### PR TITLE
fix(indent): indent braceless control-flow bodies in TS/JS (#2492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **Auto-indent**: a braceless control-flow body (`if (…)`, `for (…)`, `while (…)` with no `{`) now indents one level in TypeScript and JavaScript, matching the C-family behavior (#2492).
 * **Regex search**: `^` / `$` now anchor per line in multi-line `Ctrl+F` search (#2495).
 * **Splits**: closing a buffer shown in two splits no longer desyncs the surviving cursor (#2496).
 * **Terminal**: a terminal restores its live/scrollback mode on refocus, and the last split is no longer left read-only after closing a second terminal (#2485).

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -1093,11 +1093,32 @@ impl IndentCalculator {
             return Some(line_indent.saturating_sub(tab_size));
         }
 
-        // When the current line ends with a token captured as @dedent (`}`,
-        // `end`, `fi`, `done`, …), keep the new line at the same indent as
-        // the closing token. The grammar has already placed that token at the
-        // correct column matching its opener; the next line continues at the
-        // enclosing scope's indent.
+        // A line ending in `)` is ambiguous to the indent counter — and doubly
+        // so mid-edit, when the enclosing block is still unclosed and the parse
+        // window yields only ERROR nodes. The trailing `)` may close a braceless
+        // control head's condition (`if (a)`, `for (…)`, `while (…)` — the body
+        // must indent one level), a call/group on its own line (`foo(a)` — no
+        // indent), or a multi-line argument list. The per-language regex rules
+        // tier resolves this deterministically from the line text (its
+        // `indent_next_line` pattern encodes exactly which keywords open a
+        // braceless body), so decline here and let the public `calculate_indent`
+        // defer to it. This also restores parity with the C-family languages
+        // that have no bundled grammar and already use that tier (issue #2492).
+        let last_nonws_is_close_paren = last_nonws_offset
+            .and_then(|p| source.get(p))
+            .is_some_and(|&b| b == b')');
+        if last_nonws_is_dedent_capture && last_nonws_is_close_paren {
+            tracing::debug!(
+                "Cursor line ends with ')', deferring to the regex rules tier (issue #2492)"
+            );
+            return None;
+        }
+
+        // When the current line ends with another token captured as @dedent
+        // (`}`, `]`, `end`, `fi`, `done`, …), keep the new line at the same
+        // indent as the closing token. These are unambiguous block closers: the
+        // grammar has already placed the token at the correct column matching
+        // its opener; the next line continues at the enclosing scope's indent.
         if last_nonws_is_dedent_capture {
             let line_indent = Self::get_current_line_indent(buffer, position, tab_size);
             tracing::debug!(
@@ -1531,6 +1552,74 @@ mod tests {
         let indent = calc.calculate_indent(&buffer, position, &Language::CSharp, 4);
         // Should fall back to previous line indent (4 spaces)
         assert_eq!(indent, Some(4));
+    }
+
+    // ========================================================================
+    // Issue #2492: a braceless control-flow head (`if (a)`, `for (…)`,
+    // `while (…)`) in a *bundled* tree-sitter language (TypeScript / JavaScript)
+    // must indent the body one level — matching the C-family languages that use
+    // the regex rules tier. The bug was that the condition's closing `)` is
+    // captured as @dedent, which short-circuited to "maintain indent" (0)
+    // before the braceless-body indent could apply.
+    //
+    // Cursor sits at end of the head line (where Enter is pressed), with no
+    // trailing newline.
+    // ========================================================================
+
+    #[test]
+    fn test_typescript_braceless_control_head_indents() {
+        let mut calc = IndentCalculator::new();
+        for code in ["if (a)", "for (x of y)", "while (a)"] {
+            let buffer = Buffer::from_str_test(code);
+            let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+            assert_eq!(
+                indent,
+                Some(4),
+                "braceless `{code}` should indent its body one level (got {indent:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_javascript_braceless_control_head_indents() {
+        let mut calc = IndentCalculator::new();
+        for code in ["if (a)", "for (x of y)", "while (a)"] {
+            let buffer = Buffer::from_str_test(code);
+            let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::JavaScript, 4);
+            assert_eq!(
+                indent,
+                Some(4),
+                "braceless `{code}` should indent its body one level (got {indent:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_typescript_braceless_head_indents_when_nested() {
+        // The body indents relative to the head's own column, not column 0.
+        let mut calc = IndentCalculator::new();
+        let buffer = Buffer::from_str_test("function f() {\n    if (a)");
+        let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+        assert_eq!(indent, Some(8), "got {indent:?}");
+    }
+
+    #[test]
+    fn test_typescript_complete_one_line_constructs_do_not_over_indent() {
+        // Regression guard for the #2492 fix: lines that both open and close on
+        // themselves must NOT gain a level. A bare `function foo()` needs a
+        // brace body (it does not indent on its own, matching VS Code / the C
+        // family), an empty-bodied `if (a) {}` is complete, and an array
+        // literal is not a block head.
+        let mut calc = IndentCalculator::new();
+        for code in ["function foo()", "if (a) {}", "const a = [1, 2]"] {
+            let buffer = Buffer::from_str_test(code);
+            let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+            assert_eq!(
+                indent,
+                Some(0),
+                "`{code}` should not indent the next line (got {indent:?})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2492. Pressing Enter after a **braceless** control-flow head (`if (a)`, `for (…)`, `while (…)` with no `{`) in **TypeScript** or **JavaScript** left the body at column 0, while the same edit in a C-family file indented one level correctly.

```
if (a)
body        ← was: column 0 (bug)
    body    ← now: indented one level (matches C / VS Code / Prettier)
```

## Root cause

TS and JS have **bundled tree-sitter grammars**, so they use the AST indent path (`calculate_indent_tree_sitter`); the C-family languages without a bundled grammar use the regex rules tier, which already handles braceless heads via its `indent_next_line` pattern.

In the AST path, a braceless head's closing `)` is captured as `@dedent`. The "line ends with a closing token → maintain indent" short-circuit fired before the braceless-body indent could apply, so it returned the head's own indent (0). Mid-edit the enclosing block is still unclosed (its `}` is past the ~2000-byte parse window), so `if (a)` frequently parses as an `ERROR` node with no `if_statement` — which makes a purely structural fix unreliable.

## Fix

A line ending in `)` is genuinely ambiguous to the indent counter: it may close a braceless control head (indent one level), a call/group on its own line (`foo(a)` — no indent), or a multi-line argument list. The per-language regex rules tier already encodes exactly which keywords open a braceless body, so the AST path now **declines on a trailing `)` and defers to that tier** — restoring parity with the non-bundled C-family languages. Other closers (`}`, `]`, …) are unambiguous block closers and keep the maintain-indent behavior.

## Testing

New unit tests in `indent.rs`:
- `test_typescript_braceless_control_head_indents` / `test_javascript_braceless_control_head_indents` — `if (a)`, `for (x of y)`, `while (a)` → indent 4.
- `test_typescript_braceless_head_indents_when_nested` — body indents relative to the head's own column (→ 8).
- `test_typescript_complete_one_line_constructs_do_not_over_indent` — `function foo()`, `if (a) {}`, `const a = [1, 2]` must **not** gain a level (→ 0).

Full `fresh-editor` lib suite (2904 tests) and the auto-indent e2e suite pass. Manually validated in a real editor session (tmux):
- top-level `if (a)` + Enter → body at column 4
- `foo(a)` + Enter → next line at column 0 (no over-indent)
- nested `if (a)` inside a function + Enter → body at column 8

> Note: the `auto_indent` e2e suite has a pre-existing parallel-test race on the global `USER_RULES` (the config-driven tests call `clear_user_rules()`); it flakes on `master` as well and is unrelated to this change. The suite passes single-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014w7ADVZ9P7Ejq37gLGsM5C)_