### PR TITLE
fix(vi): make i"/a" quote text-objects search forward on the line (#2439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Regex search**: `^` / `$` now anchor per line in multi-line `Ctrl+F` search (#2495).
 * **Splits**: closing a buffer shown in two splits no longer desyncs the surviving cursor (#2496).
 * **Terminal**: a terminal restores its live/scrollback mode on refocus, and the last split is no longer left read-only after closing a second terminal (#2485).
+* **Vi mode**: `cw` on a non-blank now changes up to the end of the word like Vim (matching `ce`) instead of swallowing the trailing whitespace (#2437).
 * **Per-language indentation rules** are now actually applied — previously custom patterns were ignored (#2314).
 * **Brackets** are no longer highlighted inside comments and strings (#2405, reported by @TakemiSora).
 * **Quick-open `#` buffer switcher** now lists virtual buffers (#2373).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **Vi mode**: quote text objects `i"`/`a"` (and `'`/`` ` ``) now search forward on the line, so `ci"`/`di"` work from before the quotes — e.g. from the start of the line — instead of only when the cursor is already inside them (#2439).
 * **Cursor column** is preserved on vertical moves that used to drift it - indented soft-wrapped lines, off-screen up/down over short lines (#2565), and blank lines with indentation guides (#2564).
 * **LSP args** - an empty `args` list now overrides a built-in server's defaults, so you can use one that takes no arguments (e.g. markdown-oxide for marksman) (#2549, reported by @alex-ball).
 * **Settings icons** now render on all terminals by default - standard Unicode symbols replace the Nerd Font glyphs that showed as `?`; opt back in with `editor.nerd_font_icons` (#2032).

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -751,6 +751,43 @@ function endWORDIndex(text: string, startIndex: number): number {
   return index;
 }
 
+// Word-class helpers for the `cw` special case (lowercase `w`, which — unlike
+// the whitespace-delimited WORD motions above — treats a run of word characters
+// and a run of punctuation as separate words).
+
+// Return the string index of the last character of the same-class (word or
+// punctuation) run that `index` is in. `index` must point at a non-whitespace
+// character.
+function tokenRunEnd(text: string, index: number): number {
+  const startIsWord = isWordChar(charAtStringIndex(text, index));
+  while (true) {
+    const next = nextStringIndex(text, index);
+    if (next >= text.length || isWhitespaceAt(text, next)) {
+      break;
+    }
+    if (isWordChar(charAtStringIndex(text, next)) !== startIsWord) {
+      break;
+    }
+    index = next;
+  }
+  return index;
+}
+
+// Vim `e`-style advance: from `index`, move forward one character, skip any
+// whitespace, then return the last character of the next word. Used for the
+// trailing words of a `cNw` change. Returns `index` unchanged if there is no
+// further word.
+function viWordEndAdvance(text: string, index: number): number {
+  let next = nextStringIndex(text, index);
+  while (next < text.length && isWhitespaceAt(text, next)) {
+    next = nextStringIndex(text, next);
+  }
+  if (next >= text.length) {
+    return index;
+  }
+  return tokenRunEnd(text, next);
+}
+
 function computeWORDMotionTargetIndex(text: string, startIndex: number, kind: WORDMotionKind, count: number): number {
   let index = startIndex;
   for (let i = 0; i < Math.max(1, count); i++) {
@@ -944,6 +981,36 @@ async function computeWORDOperatorRange(
   }
 
   return { start, end, cursorAfter };
+}
+
+// Compute the change range for `cw` / `cNw`. Vim treats `cw` like `ce` when the
+// cursor is on a non-blank: it changes only up to the end of the word and does
+// NOT consume the trailing whitespace (`:help cw`). Returns null when the cursor
+// is on a blank (or past EOF), in which case the caller falls back to plain `w`
+// (i.e. `dw`-style) semantics.
+async function computeWordChangeRange(count: number): Promise<{ start: number; end: number } | null> {
+  const start = editor.getCursorPosition();
+  if (start === null) {
+    return null;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const startIndex = byteOffsetToStringIndex(bufferText, start);
+  if (startIndex >= bufferText.length || isWhitespaceAt(bufferText, startIndex)) {
+    return null;
+  }
+
+  // First word: stop at the end of the current word (no forward advance, so the
+  // cursor sitting on a word's last character changes only that character).
+  // Each additional count behaves like Vim's `e` motion.
+  let endIndex = tokenRunEnd(bufferText, startIndex);
+  for (let i = 1; i < Math.max(1, count); i++) {
+    endIndex = viWordEndAdvance(bufferText, endIndex);
+  }
+
+  const endTarget = stringIndexToByteOffset(bufferText, endIndex);
+  return { start, end: endTarget + byteLengthOfCharAt(bufferText, endIndex) };
 }
 
 async function applyWORDOperatorMotion(
@@ -1732,6 +1799,20 @@ async function vi_repeat() : Promise<void> {
     case "operator-motion": {
       // Operator + motion like dw, cw, d$
       if (change.operator && change.motion) {
+        if (change.motion === "vi_word_change") {
+          // `cw`/`cNw` special case — recompute the change range at the current
+          // cursor position (mirrors the WORD `cW` repeat path).
+          const range = await computeWordChangeRange(count);
+          if (range !== null) {
+            await applyOperatorWithRange("d", range.start, range.end);
+          } else {
+            await applyOperatorWithMotion("d", "move_word_right", count);
+          }
+          if (change.insertedText) {
+            editor.insertAtCursor(change.insertedText);
+          }
+          break;
+        }
         const WORDKind = WORDMotionKindFromRepeatMotion(change.motion);
         if (change.operator === "c") {
           if (WORDKind) {
@@ -2766,6 +2847,21 @@ async function vi_op_right(): Promise<void> {
 registerHandler("vi_op_right", vi_op_right);
 
 async function vi_op_word(): Promise<void> {
+  // Vim special case (`:help cw`): when changing (`c`) with the cursor on a
+  // non-blank character, `cw` behaves like `ce` — it changes only up to the end
+  // of the word and does NOT consume the trailing whitespace. Plain `dw`/`yw`
+  // and `cw` on a blank keep the regular word-forward semantics.
+  if (state.pendingOperator === "c") {
+    const count = consumeCount();
+    const range = await computeWordChangeRange(count);
+    if (range !== null) {
+      state.lastChange = { type: "operator-motion", operator: "c", motion: "vi_word_change", count };
+      await applyOperatorWithRange("c", range.start, range.end);
+      return;
+    }
+    await applyOperatorWithMotion("c", "move_word_right", count);
+    return;
+  }
   await handleMotionWithOperator("move_word_right");
 }
 registerHandler("vi_op_word", vi_op_word);

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -2475,27 +2475,32 @@ async function applyTextObject(objectType: string): Promise<void> {
       const line = text.substring(lineStart, lineEnd);
       const colInLine = posInChunk - lineStart;
 
-      // Find quote pair containing cursor
+      // Find the quote pair to operate on. Vim's rule for i"/a" is to use the
+      // pair the cursor is inside, or — when the cursor is before the quotes on
+      // the line — to search forward on the current line for the next pair. We
+      // therefore pick the first complete pair whose closing quote is at or
+      // after the cursor (covers both "inside" and "before" the quotes), which
+      // makes ci"/di" work from the start of a line (the common case).
       let quoteStart = -1;
       let quoteEnd = -1;
-      let inQuote = false;
+      let openIdx = -1;
 
       for (let i = 0; i < line.length; i++) {
-        if (line[i] === objectType) {
-          if (!inQuote) {
-            quoteStart = i;
-            inQuote = true;
-          } else {
+        if (line[i] !== objectType) continue;
+        if (openIdx === -1) {
+          openIdx = i; // opening quote of a candidate pair
+        } else {
+          // Completed a pair [openIdx, i].
+          if (colInLine <= i) {
+            quoteStart = openIdx;
             quoteEnd = i;
-            if (colInLine >= quoteStart && colInLine <= quoteEnd) {
-              break; // Found the pair containing cursor
-            }
-            inQuote = false;
+            break; // first pair at/after the cursor wins (forward search)
           }
+          openIdx = -1; // pair is entirely before the cursor; keep searching
         }
       }
 
-      if (quoteStart !== -1 && quoteEnd !== -1 && colInLine >= quoteStart && colInLine <= quoteEnd) {
+      if (quoteStart !== -1 && quoteEnd !== -1) {
         if (isInner) {
           selectStart = startOffset + lineStart + quoteStart + 1;
           selectEnd = startOffset + lineStart + quoteEnd;
@@ -2584,6 +2589,9 @@ async function applyTextObject(objectType: string): Promise<void> {
         editor.setClipboard(deletedText);
       }
       editor.deleteRange(bufferId, selectStart, selectEnd);
+      // Land the cursor where the text object was, even if it was forward of the
+      // cursor on the line (e.g. di" from before the quotes).
+      editor.setBufferCursor(bufferId, selectStart);
       state.lastYankWasLinewise = false;
       break;
     }
@@ -2593,6 +2601,9 @@ async function applyTextObject(objectType: string): Promise<void> {
         editor.setClipboard(deletedText);
       }
       editor.deleteRange(bufferId, selectStart, selectEnd);
+      // Insert at the deletion point so ci" works even when the quoted string
+      // was forward of the cursor on the line (not just when already inside it).
+      editor.setBufferCursor(bufferId, selectStart);
       state.lastYankWasLinewise = false;
       switchMode("insert");
       return;

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -398,6 +398,105 @@ fn test_vi_vim_compat_repeat_change_word_keeps_change_semantics() {
     harness.wait_for_buffer_content("X X four.five\n").unwrap();
 }
 
+// `cw` on a non-blank must behave like `ce` (Vim `:help cw`): change up to the
+// end of the word WITHOUT consuming the trailing whitespace. Regression test for
+// issue #2437, where `cw` ate the following space like `dw`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_keeps_following_space() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo bar\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    // Cursor starts on `h` of `hello`. `cw` should change only `hello`, keeping
+    // the space before `world`.
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X world foo bar\n");
+}
+
+// Unlike the whitespace-delimited `cW`, lowercase `cw` stops at punctuation:
+// `cw` on `one.two` changes only `one`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_stops_at_punctuation() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X.two three\n");
+}
+
+// `cNw` honors the count and still keeps the trailing whitespace: `c2w` on
+// `hello world foo` changes `hello world`, leaving the space before `foo`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_honors_count() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'c');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '2');
+    send_vi_key(&mut harness, 'w');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-insert".to_string()))
+        .unwrap();
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X foo\n");
+}
+
+// `.` repeat of `cw` replays the change semantics (keep trailing space), not a
+// `dw`-style delete.
+#[test]
+fn test_vi_vim_compat_repeat_change_lower_word_keeps_change_semantics() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo bar\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    harness.assert_buffer_content("X world foo bar\n");
+
+    // `w` moves to the start of `world` (byte 2), then `.` repeats `cw`.
+    send_vi_key(&mut harness, 'w');
+    harness.wait_until(|h| h.cursor_position() == 2).unwrap();
+    send_vi_key(&mut harness, '.');
+
+    harness.wait_for_buffer_content("X X foo bar\n").unwrap();
+}
+
 #[test]
 fn test_vi_vim_compat_repeat_uses_original_operator_count() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1040,3 +1040,77 @@ fn test_vi_bug_2442_goal_column_preserved_through_short_line() {
     send_key(&mut harness, 'j');
     harness.wait_until(|h| h.cursor_position() == 40).unwrap();
 }
+
+// =============================================================================
+// Bug #2439: quote text-objects i"/a" don't search forward on the line
+// =============================================================================
+
+/// Helper: send an operator + inner/around text-object (e.g. `di"`).
+fn send_operator_text_object(
+    harness: &mut EditorTestHarness,
+    op: char,
+    modifier: char,
+    object: char,
+) {
+    send_key(harness, op);
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_key(harness, modifier);
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-text-object".to_string()))
+        .unwrap();
+    send_key(harness, object);
+}
+
+/// `di"` from the start of a line (before the opening quote) should, like Vim,
+/// search forward on the current line and delete the contents of the quoted
+/// string — `the "quick" brown fox` → `the "" brown fox`.
+///
+/// BUG: the quote text object only selected the pair the cursor was already
+/// *inside*, so `di"`/`ci"` were silent no-ops when the cursor sat before the
+/// quotes (the common case, e.g. right after `0`).
+#[test]
+fn test_vi_bug_di_quote_searches_forward_on_line() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "the \"quick\" brown fox\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Cursor is at column 0 (before the opening quote).
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
+
+    // di" should delete inside the forward quoted string.
+    send_operator_text_object(&mut harness, 'd', 'i', '"');
+
+    harness
+        .wait_for_buffer_content("the \"\" brown fox\n")
+        .unwrap();
+}
+
+/// `ci"` from before the quotes should delete inside the quoted string, enter
+/// insert mode, and let you type the replacement — same forward-search rule as
+/// `di"`.
+#[test]
+fn test_vi_bug_ci_quote_searches_forward_on_line() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "the \"quick\" brown fox\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
+
+    // ci" should clear inside the quotes and drop into insert mode.
+    send_operator_text_object(&mut harness, 'c', 'i', '"');
+    wait_insert(&mut harness);
+
+    harness.type_text("WXYZ").unwrap();
+    harness.render().unwrap();
+    escape(&mut harness);
+
+    harness
+        .wait_for_buffer_content("the \"WXYZ\" brown fox\n")
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

Fixes #2439. In vi mode, the quote text objects `i"` / `a"` (and `'` / `` ` ``) only matched the quote pair the cursor was already **inside**. Vim's actual rule is to *search forward on the current line* when the cursor is before the quotes, so `ci"` / `di"` from the start of a line (the common case, e.g. right after `0`) were silent no-ops.

## Root cause

In `applyTextObject` (`crates/fresh-editor/plugins/vi_mode.ts`), the quote case scanned the line for a pair containing the cursor and bailed out with no selection when the cursor was before the quotes.

A second, related issue surfaced once forward search worked: the `c`/`d` text-object operators relied on the cursor already being inside the deleted range, so after deleting they left the cursor at its original column. With forward search the cursor is *before* the range, so `ci"` from column 0 inserted text at the start of the line instead of between the quotes.

## Fix

- Pick the first complete quote pair whose closing quote is at or after the cursor — this covers both "inside" and "before" the quotes (Vim's forward-search rule), and still resolves to the containing pair when the cursor is inside one.
- After the change/delete text-object operators, pin the cursor to the deletion point (`selectStart`), so `ci"`/`di"` land correctly regardless of where the cursor started on the line.

## Testing

Added two e2e reproductions in `vi_mode_bugs.rs` that drive keys and assert on buffer content, both starting with the cursor at column 0:

- `di"` on `the "quick" brown fox` → `the "" brown fox`
- `ci"` then typing → `the "WXYZ" brown fox`

Both fail (time out / wrong output) without the fix and pass with it.

Validation run in a tmux session:

- New tests: `2 passed; 0 failed`
- Full vi suite (`e2e_tests vi_`): `103 passed; 0 failed; 5 ignored` — no regressions
- `cargo fmt -- --check` clean; `cargo clippy --tests` clean (only pre-existing, unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdMpos2dBVKwAyqzJoc2fg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdMpos2dBVKwAyqzJoc2fg)_