### PR TITLE
fix(live-diff): clear stale diff after committing to git (#2503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Switch Project** re-roots the active window in place instead of restarting the editor (#2472).
 * **New Workspace (Local)** seeds its path from a local root even when the active window is remote (#2480).
 * **Markdown compose**: table cells are measured by display width (fixing emoji-row border flicker), and table borders clear when compose mode is disabled (#2475, #2478).
+* **Live Diff**: a *vs HEAD* (or *vs branch*) diff now clears itself after you commit the buffer's changes — the plugin watches the HEAD reflog and refreshes its reference on every commit/checkout/reset, instead of leaving a stale diff until a manual *Live Diff: Refresh* (#2503).
 * **Terminal scrollback**: ANSI colors survive soft-wrapped rows (#2449); the backing file stays local in remote mode, fixing a hang when toggling scrollback over SSH (#2424).
 * **Shebang language detection** now covers interpreters with no first-line regex (Fish, Lua, PowerShell, Tcl, Elixir, R, Julia, …), handling `env` indirection and versioned names; an existing extension match still wins (#2357, reported by @shemgp).
 * The asm-lsp "no `.asm-lsp.toml`" offer is scoped to its triggering buffer instead of floating over every buffer.

--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -1252,13 +1252,129 @@ async function live_diff_set_default(): Promise<void> {
 registerHandler("live_diff_set_default", live_diff_set_default);
 
 // =============================================================================
+// Git reference watching (#2503)
+// =============================================================================
+//
+// In `head` / `branch` mode the reference (left) side is the *committed* file,
+// not the working copy. Committing the buffer's changes moves HEAD so the
+// reference now matches the buffer and the diff should empty out — but a commit
+// doesn't touch the buffer, so none of the edit-driven recompute hooks fire and
+// the cached reference goes stale: the gutter keeps showing the change against
+// the pre-commit HEAD until a manual "Live Diff: Refresh".
+//
+// Fix: watch the HEAD reflog and drop the cached reference when it moves. A
+// plain `git commit` on the current branch appends to `logs/HEAD` (and updates
+// the branch ref) but leaves the bare `HEAD` file untouched, so the reflog —
+// not `HEAD` — is the file that reliably moves on every commit, checkout, reset
+// and merge (it also covers detached-HEAD commits, which rewrite `HEAD`
+// itself). `focus_gained` is a cheap fallback for the rare repo with reflogs
+// disabled, or when the watch can't be registered.
+
+let headWatchHandle: number | null = null;
+let watchedCwd: string | null = null;
+let ensureWatchInFlight: Promise<void> | null = null;
+
+// Resolve a directory inside the repo we should watch. The plugin loads each
+// reference relative to its *file's* directory (see `loadReference`), not
+// `editor.getCwd()` — the active buffer can live in a different repo than the
+// editor cwd — so we resolve the reflog the same way for consistency.
+function gitWatchCwd(): string | null {
+  const activeState = states.get(editor.getActiveBufferId());
+  if (activeState) return fileDir(activeState.filePath);
+  for (const s of states.values()) return fileDir(s.filePath);
+  return null;
+}
+
+async function discoverHeadLogPath(cwd: string): Promise<string | null> {
+  // `--absolute-git-dir` resolves the git dir (worktrees / submodules /
+  // `--git-dir` setups all included) as a normalized *absolute* path. We must
+  // not use `--git-path logs/HEAD` here: it returns a path *relative to cwd*
+  // (e.g. `../.git/logs/HEAD` when the buffer is in a sub-directory), and the
+  // file watcher compares against notify's canonical, `..`-free event paths —
+  // a `..` in the watch path means the reflog event never matches (#2503).
+  const result = await editor.spawnProcess(
+    "git", ["rev-parse", "--absolute-git-dir"], cwd,
+  );
+  if (result.exit_code !== 0) return null;
+  const gitDir = result.stdout.trim();
+  if (!gitDir) return null;
+  return `${gitDir}/logs/HEAD`;
+}
+
+async function ensureHeadWatch(): Promise<void> {
+  const cwd = gitWatchCwd();
+  if (!cwd) return;
+  if (watchedCwd === cwd && headWatchHandle !== null) return;
+  if (ensureWatchInFlight) return ensureWatchInFlight;
+
+  ensureWatchInFlight = (async () => {
+    try {
+      if (headWatchHandle !== null) {
+        editor.unwatchPath(headWatchHandle);
+        headWatchHandle = null;
+      }
+      watchedCwd = cwd;
+      const headLog = await discoverHeadLogPath(cwd);
+      if (!headLog) return;
+      try {
+        headWatchHandle = await editor.watchPath(headLog, false);
+      } catch (_e) {
+        // Watch registration failed (reflog missing in a fresh repo with no
+        // commits yet, kernel watch limit). focus_gained is the fallback.
+      }
+    } finally {
+      ensureWatchInFlight = null;
+    }
+  })();
+  return ensureWatchInFlight;
+}
+
+// Drop the cached git reference for every git-backed (head/branch) buffer and
+// recompute, so the diff re-fetches its reference and clears if the buffer now
+// matches the committed tree. `disk` mode tracks the working copy, not a
+// committed ref, so a HEAD move doesn't affect it.
+function refreshGitReferences(): void {
+  for (const state of states.values()) {
+    if (state.mode.kind === "disk") continue;
+    if (!isEnabledForBuffer(state)) continue;
+    // Re-fetch the reference (HEAD may have moved) but keep `lastHunksKey`:
+    // this path fires on every window focus, so when the diff is in fact
+    // unchanged the recompute's hunk-equality guard suppresses the repaint
+    // and there's no flicker. `lastBufferText` must still be cleared so the
+    // "same buffer text" early-return doesn't skip recomputing against the
+    // new reference.
+    state.oldText = null;
+    state.oldLines = [];
+    state.lastBufferText = null;
+    recompute(state.bufferId).catch((e) => editor.error(`live-diff: ${e}`));
+  }
+}
+
+// =============================================================================
 // Event wiring
 // =============================================================================
 
 editor.on("after_file_open", (args) => {
   const state = ensureState(args.buffer_id);
   if (!state) return true;
+  ensureHeadWatch().catch((e) => editor.error(`live-diff: ${e}`));
   recompute(args.buffer_id).catch((e) => editor.error(`live-diff: ${e}`));
+  return true;
+});
+
+// A git HEAD movement (commit, checkout, reset, merge) makes every "vs HEAD" /
+// "vs <branch>" reference potentially stale — re-fetch and repaint (#2503).
+editor.on("path_changed", (args) => {
+  if (args.handle !== headWatchHandle) return true;
+  refreshGitReferences();
+  return true;
+});
+
+// Picks up commits made while fresh was unfocused (e.g. via an external
+// terminal), and is the fallback when the reflog watch couldn't be registered.
+editor.on("focus_gained", () => {
+  ensureHeadWatch().catch((e) => editor.error(`live-diff: ${e}`));
+  refreshGitReferences();
   return true;
 });
 
@@ -1364,6 +1480,8 @@ editor.exportPluginApi("live-diff", {
 // =============================================================================
 // Initialization
 // =============================================================================
+
+ensureHeadWatch().catch((e) => editor.error(`live-diff: ${e}`));
 
 const initBid = editor.getActiveBufferId();
 if (initBid !== 0) {

--- a/crates/fresh-editor/src/services/file_watcher.rs
+++ b/crates/fresh-editor/src/services/file_watcher.rs
@@ -27,7 +27,20 @@ use notify::{
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// Allocate a process-globally-unique watch handle. The notify-callback
+/// lookup table ([`handle_map`]) is process-global, so handles must be
+/// unique across *every* [`FileWatcherManager`] in the process — not just
+/// within one. A per-manager counter (the old design) hands out `1, 2, …`
+/// in each manager, so two managers (e.g. two editor instances in one
+/// process, or two parallel tests) would collide on handle `1` and clobber
+/// each other's entry in the shared map, silently dropping events.
+fn alloc_global_handle() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Manages plugin-registered file watchers. Created on demand the
 /// first time a `WatchPath` arrives — the `notify::Watcher` is
@@ -43,7 +56,6 @@ pub struct FileWatcherManager {
     /// when notify fires events for a path that was just
     /// unwatched (rare but possible — events are queued).
     handles: HashMap<u64, (PathBuf, RecursiveMode)>,
-    next_handle: u64,
 }
 
 impl FileWatcherManager {
@@ -51,7 +63,6 @@ impl FileWatcherManager {
         Self {
             watcher: None,
             handles: HashMap::new(),
-            next_handle: 1,
         }
     }
 
@@ -84,8 +95,7 @@ impl FileWatcherManager {
         watcher
             .watch(path, mode)
             .map_err(|e| format!("watchPath({}): {}", path.display(), e))?;
-        let handle = self.next_handle;
-        self.next_handle += 1;
+        let handle = alloc_global_handle();
         self.handles.insert(handle, (path.to_path_buf(), mode));
         // The notify event callback uses a shared `handles` map
         // (set up below in `build_watcher`) to look up which

--- a/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
@@ -1039,3 +1039,64 @@ fn test_live_diff_word_highlight_on_low_similarity_removed_added_pair() {
          NOT be bold + underlined",
     );
 }
+
+/// Regression (#2503): in `vs HEAD` mode, committing the buffer's changes to
+/// git must clear the diff automatically — *without* a manual
+/// `Live Diff: Refresh`. Before the fix the plugin cached the HEAD reference
+/// for the buffer's lifetime and only re-fetched it on a mode change or an
+/// explicit refresh, so the gutter kept showing the change against the
+/// pre-commit HEAD even though HEAD now matched the buffer exactly.
+///
+/// In production the plugin notices the HEAD move via a watch on the HEAD
+/// reflog (`logs/HEAD`); `focus_gained` is the same-effect fallback (a commit
+/// made in an external terminal while fresh was unfocused). This test drives
+/// the `focus_gained` path because it's deterministic — the reflog watch is
+/// real-filesystem-notify-driven, which is timing-flaky under parallel test
+/// load — but both triggers funnel into the same reference-refresh code.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_live_diff_clears_after_commit() {
+    let repo = GitTestRepo::new();
+    repo.setup_live_diff_plugin();
+
+    // HEAD has the original two lines; the working tree adds a third so the
+    // diff shows a `+` glyph against HEAD.
+    repo.create_file("src/demo.txt", "line one\nline two\n");
+    repo.git_add(&["src/demo.txt"]);
+    repo.git_commit("init");
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    repo.modify_file("src/demo.txt", "line one\nline two\nline three ADDED\n");
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    enable_live_diff_globally(&mut harness);
+    open_file(&mut harness, &repo.path, "src/demo.txt");
+
+    // The added line shows a `+` against HEAD.
+    harness
+        .wait_until(|h| has_glyph(&h.screen_to_string(), '+'))
+        .unwrap();
+
+    // Commit the working-tree change so HEAD now matches the buffer exactly.
+    repo.git_add_all();
+    repo.git_commit("commit the added line");
+
+    // Refocus (as if returning from the terminal where the commit ran): the
+    // plugin re-fetches its HEAD reference and, finding it identical to the
+    // buffer, clears the diff. Before the fix the cached reference stayed put
+    // and the `+` persisted until a manual refresh.
+    harness.editor_mut().focus_gained();
+
+    harness
+        .wait_until(|h| !has_glyph(&h.screen_to_string(), '+'))
+        .unwrap();
+}

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -7010,6 +7010,7 @@ const EDITOR_PROMISE_BOOTSTRAP: &str = r#"
                 editor.spawnBackgroundProcess = _wrapAsyncThenable("_spawnBackgroundProcessStart", "spawnBackgroundProcess");
                 editor.httpFetch = _wrapAsyncThenable("_httpFetchStart", "httpFetch");
                 editor.spawnProcessWait = _wrapAsync("_spawnProcessWaitStart", "spawnProcessWait");
+                editor.watchPath = _wrapAsync("_watchPathStart", "watchPath");
                 editor.getBufferText = _wrapAsync("_getBufferTextStart", "getBufferText");
                 editor.createCompositeBuffer = _wrapAsync("_createCompositeBufferStart", "createCompositeBuffer");
                 editor.getCompositeCursorInfo = _wrapAsync("_getCompositeCursorInfoStart", "getCompositeCursorInfo");


### PR DESCRIPTION
Fixes #2503.

## Symptom

With Live Diff in **vs HEAD** mode, committing the buffer's changes to git left the diff unchanged — the gutter kept showing the old `+`/`-`/`~` markers and virtual old-content lines against the *pre-commit* HEAD, even though HEAD now matched the buffer exactly. It only cleared after a manual **Live Diff: Refresh**.

## Root cause

In `head`/`branch` mode the reference (left) side is the *committed* file, not the working copy. The plugin loaded that reference once and cached it for the buffer's lifetime, re-fetching only on a mode change or explicit refresh. A `git commit` moves HEAD but doesn't touch the buffer, so none of the edit-driven recompute hooks (`after_insert`/`after_delete`/`lines_changed`) fired, and the cached reference went stale.

## Fix

The plugin now watches the **HEAD reflog** (`logs/HEAD`) and re-fetches its reference when it moves. A plain `git commit` on the current branch appends to `logs/HEAD` (and updates the branch ref) but leaves the bare `HEAD` file untouched — so the reflog, not `HEAD`, is the file that reliably moves on every commit, checkout, reset and merge (it also covers detached-HEAD commits). `focus_gained` is a fallback for commits made while fresh was unfocused, or when the watch can't be registered. Both triggers funnel into one reference-refresh that re-fetches HEAD and repaints only when the diff actually changed (no focus flicker).

The git dir is resolved with `git rev-parse --absolute-git-dir` so the watched path is absolute and `..`-free — a relative path (from `--git-path`) never matches notify's canonical event paths.

### Two supporting fixes were needed to make plugin file-watching actually work

- **`editor.watchPath` was never wired into the plugin runtime.** Only the native `_watchPathStart` existed; the JS `_wrapAsync` binding was missing, so every `editor.watchPath(...)` call threw *"not a function"* and silently fell back. Added the binding. This also activates `git_statusbar`'s HEAD-file watch, which had the same latent no-op.
- **File-watch handles collided across editor instances.** Handles were allocated per-`FileWatcherManager` (`1, 2, …`) while the notify-callback lookup table is process-global, so two editors (or two parallel tests) collided on handle `1` and clobbered each other's map entry, dropping events. Handles now come from a process-global atomic counter.

## Testing

- Added e2e regression `test_live_diff_clears_after_commit`: opens a file with a `+` diff against HEAD, commits so HEAD matches the buffer, and asserts the diff clears on refocus. It drives the deterministic `focus_gained` path (the reflog watch is real-notify-driven and timing-flaky under parallel load), exercising the shared refresh code.
- Verified the reflog-watch path end-to-end manually (watch registers, `path_changed` fires on commit, diff clears).
- `live_diff` (12), `watch_path`, `git_statusbar`, `auto_revert` + `git` plugin e2e (54), and the `fresh-plugin-runtime` unit tests (112) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxC4hqczJXKxgJoKRKwDdS)_