### PR TITLE
fix(vi): support find-char motions (f/t/F/T) with operators (#2441)

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -28,7 +28,7 @@ type WordSearchDirection = "forward" | "backward";
 type WordSearchTarget = { start: number; end: number; text: string; wholeWord: boolean };
 
 // Types for tracking repeatable changes
-type ChangeType = "simple" | "operator-motion" | "operator-textobj" | "insert" | "line-op";
+type ChangeType = "simple" | "operator-motion" | "operator-textobj" | "operator-find-char" | "insert" | "line-op";
 
 interface LastChange {
   type: ChangeType;
@@ -36,6 +36,8 @@ interface LastChange {
   operator?: string;         // For operator+motion/textobj: "d", "c", "y"
   motion?: string;           // For operator+motion: the motion action
   textObject?: { modifier: TextObjectType; object: string }; // For operator+textobj
+  findType?: FindCharType;   // For operator+find-char (df/dt/cf/ct): the f/t/F/T variant
+  findCharTarget?: string;   // For operator+find-char: the target character
   count?: number;            // Count used with the command
   insertedText?: string;     // Text inserted during insert mode
 }
@@ -202,7 +204,8 @@ async function captureInsertedText(): Promise<void> {
         insertedText: text,
       };
     } else if (state.lastChange.type === "simple" || state.lastChange.type === "operator-motion" ||
-               state.lastChange.type === "operator-textobj" || state.lastChange.type === "line-op") {
+               state.lastChange.type === "operator-textobj" || state.lastChange.type === "operator-find-char" ||
+               state.lastChange.type === "line-op") {
       // A change command (c, s, etc.) was used - append the inserted text
       state.lastChange.insertedText = text;
     }
@@ -2044,6 +2047,22 @@ async function vi_repeat() : Promise<void> {
       break;
     }
 
+    case "operator-find-char": {
+      // Operator + find-char like dfx, dtx, cfx
+      if (change.operator && change.findType && change.findCharTarget) {
+        if (change.operator === "c") {
+          // Replay change as delete-then-insert so '.' doesn't block on input.
+          await executeFindCharOperator("d", change.findType, change.findCharTarget, count);
+          if (change.insertedText) {
+            editor.insertAtCursor(change.insertedText);
+          }
+        } else {
+          await executeFindCharOperator(change.operator, change.findType, change.findCharTarget, count);
+        }
+      }
+      break;
+    }
+
     case "insert": {
       // Pure insert (i, a, o, O)
       if (change.insertedText) {
@@ -2954,6 +2973,75 @@ async function enterFindCharMode(findType: FindCharType): Promise<void> {
   switchMode("normal");
 }
 
+// Extract the current cursor line as a string plus the cursor's column index
+// within it. Returns null if the buffer text can't be read. Used by both the
+// pure find-char motion and the operator-pending find-char paths.
+async function getFindCharLineContext(
+  bufferId: number,
+  cursorPos: number,
+): Promise<{ lineText: string; col: number } | null> {
+  // Read up to 10KB before and after cursor for context.
+  const windowSize = 10000;
+  const startOffset = Math.max(0, cursorPos - windowSize);
+  const bufLen = editor.getBufferLength(bufferId);
+  const endOffset = Math.min(bufLen, cursorPos + windowSize);
+
+  const text = await editor.getBufferText(bufferId, startOffset, endOffset);
+  if (!text) return null;
+
+  const posInChunk = cursorPos - startOffset;
+
+  // Find line start (last newline before cursor, or start of chunk).
+  let lineStart = 0;
+  for (let i = posInChunk - 1; i >= 0; i--) {
+    if (text[i] === '\n') {
+      lineStart = i + 1;
+      break;
+    }
+  }
+
+  // Find line end (next newline after cursor, or end of chunk).
+  let lineEnd = text.length;
+  for (let i = posInChunk; i < text.length; i++) {
+    if (text[i] === '\n') {
+      lineEnd = i;
+      break;
+    }
+  }
+
+  return { lineText: text.substring(lineStart, lineEnd), col: posInChunk - lineStart };
+}
+
+// Compute the landing column for a find-char motion on a single line.
+// `count` selects the Nth occurrence (1-based). Returns the target column
+// within `lineText`, or -1 if the target isn't found.
+function computeFindCharTargetCol(
+  findType: FindCharType,
+  char: string,
+  lineText: string,
+  col: number,
+  count: number,
+): number {
+  let remaining = Math.max(1, count);
+
+  if (findType === "f" || findType === "t") {
+    // Search forward on the line.
+    for (let i = col + 1; i < lineText.length; i++) {
+      if (lineText[i] === char && --remaining === 0) {
+        return findType === "f" ? i : i - 1;
+      }
+    }
+  } else {
+    // Search backward (F/T).
+    for (let i = col - 1; i >= 0; i--) {
+      if (lineText[i] === char && --remaining === 0) {
+        return findType === "F" ? i : i + 1;
+      }
+    }
+  }
+  return -1;
+}
+
 // Execute find char motion (async because getBufferText is async)
 async function executeFindChar(findType: FindCharType, char: string): Promise<void> {
   if (!findType) return;
@@ -2965,61 +3053,11 @@ async function executeFindChar(findType: FindCharType, char: string): Promise<vo
     return;
   }
 
-  // Get text around cursor to find line boundaries
-  // Read up to 10KB before and after cursor for context
-  const windowSize = 10000;
-  const startOffset = Math.max(0, cursorPos - windowSize);
-  const bufLen = editor.getBufferLength(bufferId);
-  const endOffset = Math.min(bufLen, cursorPos + windowSize);
+  const ctx = await getFindCharLineContext(bufferId, cursorPos);
+  if (!ctx) return;
+  const { lineText, col } = ctx;
 
-  // Get buffer text around cursor
-  const text = await editor.getBufferText(bufferId, startOffset, endOffset);
-  if (!text) return;
-
-  // Calculate position within this text chunk
-  const posInChunk = cursorPos - startOffset;
-
-  // Find line start (last newline before cursor, or start of chunk)
-  let lineStart = 0;
-  for (let i = posInChunk - 1; i >= 0; i--) {
-    if (text[i] === '\n') {
-      lineStart = i + 1;
-      break;
-    }
-  }
-
-  // Find line end (next newline after cursor, or end of chunk)
-  let lineEnd = text.length;
-  for (let i = posInChunk; i < text.length; i++) {
-    if (text[i] === '\n') {
-      lineEnd = i;
-      break;
-    }
-  }
-
-  // Extract line text and calculate column
-  const lineText = text.substring(lineStart, lineEnd);
-  const col = posInChunk - lineStart;
-
-  let targetCol = -1;
-
-  if (findType === "f" || findType === "t") {
-    // Search forward on the line
-    for (let i = col + 1; i < lineText.length; i++) {
-      if (lineText[i] === char) {
-        targetCol = findType === "f" ? i : i - 1;
-        break;
-      }
-    }
-  } else {
-    // Search backward (F/T)
-    for (let i = col - 1; i >= 0; i--) {
-      if (lineText[i] === char) {
-        targetCol = findType === "F" ? i : i + 1;
-        break;
-      }
-    }
-  }
+  const targetCol = computeFindCharTargetCol(findType, char, lineText, col, 1);
 
   if (targetCol >= 0 && targetCol !== col) {
     // Move to target column
@@ -3032,6 +3070,78 @@ async function executeFindChar(findType: FindCharType, char: string): Promise<vo
     // Save for ; and , repeat
     state.lastFindChar = { type: findType, char };
   }
+}
+
+// Apply a pending operator (d/c/y) over a find-char motion (df/dt/cf/ct/dF/dT…).
+// In vim these are *inclusive* motions: the found character is part of the
+// affected range. Forward (f/t) deletes from the cursor up to and including the
+// landing column; backward (F/T) deletes from the landing column up to (but not
+// including) the cursor.
+async function executeFindCharOperator(
+  operator: string,
+  findType: FindCharType,
+  char: string,
+  count: number,
+): Promise<void> {
+  if (!findType) {
+    switchMode("normal");
+    return;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = editor.getCursorPosition();
+  if (cursorPos === null || (cursorPos === 0 && (findType === "F" || findType === "T"))) {
+    switchMode("normal");
+    return;
+  }
+
+  const ctx = await getFindCharLineContext(bufferId, cursorPos);
+  if (!ctx) {
+    switchMode("normal");
+    return;
+  }
+  const { lineText, col } = ctx;
+
+  const targetCol = computeFindCharTargetCol(findType, char, lineText, col, count);
+  if (targetCol < 0 || targetCol === col) {
+    // Target not found on the line: vim leaves the buffer unchanged and cancels
+    // the operator. Do NOT consume the operator as a different motion.
+    switchMode("normal");
+    return;
+  }
+
+  // Save for ; and , repeat (vim records the find even in operator form).
+  state.lastFindChar = { type: findType, char };
+
+  // Convert the cursor→target column span into a byte range. Column indices are
+  // measured in the line string; byte offsets are derived from the live cursor
+  // byte offset plus the UTF-8 length of the intervening text.
+  let start: number;
+  let end: number;
+  if (targetCol > col) {
+    // Forward: include the landing character.
+    const between = editor.utf8ByteLength(lineText.substring(col, targetCol));
+    start = cursorPos;
+    end = cursorPos + between + byteLengthOfCharAt(lineText, targetCol);
+  } else {
+    // Backward: from the landing column up to the cursor.
+    const between = editor.utf8ByteLength(lineText.substring(targetCol, col));
+    start = cursorPos - between;
+    end = cursorPos;
+  }
+
+  // Record for '.' repeat (delete/change only, matching operator-motion).
+  if (operator === "d" || operator === "c") {
+    state.lastChange = {
+      type: "operator-find-char",
+      operator,
+      findType,
+      findCharTarget: char,
+      count,
+    };
+  }
+
+  await applyOperatorWithRange(operator, start, end);
 }
 
 // Commands to enter find-char mode (async; await getNextKey internally)
@@ -3066,6 +3176,51 @@ async function vi_find_char_repeat_reverse(): Promise<void> {
   }
 }
 registerHandler("vi_find_char_repeat_reverse", vi_find_char_repeat_reverse);
+
+// Enter find-char mode with a pending operator (df/dt/cf/ct/dF/dT/…). Awaits the
+// target keypress, then applies the operator over the find-char range. Mirrors
+// enterFindCharMode but preserves the pending operator across the await and
+// dispatches to the operator-aware executor.
+async function enterFindCharOperatorMode(findType: FindCharType): Promise<void> {
+  if (!state.pendingOperator) {
+    switchMode("normal");
+    return;
+  }
+  const operator = state.pendingOperator;
+  // Consume any count now (e.g. d2fx); the find-char await must not lose it.
+  const count = consumeCountOrDefault(1);
+
+  state.pendingFindChar = findType;
+  state.mode = "find-char";
+  editor.setEditorMode("vi-find-char");
+  editor.setStatus(getModeIndicator("find-char"));
+
+  editor.beginKeyCapture();
+  try {
+    const ev = await editor.getNextKey();
+    state.pendingFindChar = null;
+    if (ev.key.length === 1) {
+      await executeFindCharOperator(operator, findType, ev.key, count);
+    } else {
+      // Escape (or any non-character key) cancels the operator.
+      switchMode("normal");
+    }
+  } finally {
+    editor.endKeyCapture();
+  }
+}
+
+async function vi_op_find_char_f(): Promise<void> { return enterFindCharOperatorMode("f"); }
+registerHandler("vi_op_find_char_f", vi_op_find_char_f);
+
+async function vi_op_find_char_t(): Promise<void> { return enterFindCharOperatorMode("t"); }
+registerHandler("vi_op_find_char_t", vi_op_find_char_t);
+
+async function vi_op_find_char_F(): Promise<void> { return enterFindCharOperatorMode("F"); }
+registerHandler("vi_op_find_char_F", vi_op_find_char_F);
+
+async function vi_op_find_char_T(): Promise<void> { return enterFindCharOperatorMode("T"); }
+registerHandler("vi_op_find_char_T", vi_op_find_char_T);
 
 // ============================================================================
 // Operator-Pending Mode Commands
@@ -3376,6 +3531,12 @@ editor.defineMode("vi-operator-pending", [
   ["%", "vi_op_matching_bracket"],
   ["{", "vi_op_paragraph_up"],
   ["}", "vi_op_paragraph_down"],
+
+  // Find-char motions (df/dt/cf/ct and backward dF/dT) — inclusive motions
+  ["f", "vi_op_find_char_f"],
+  ["t", "vi_op_find_char_t"],
+  ["F", "vi_op_find_char_F"],
+  ["T", "vi_op_find_char_T"],
 
   // Text objects
   ["i", "vi_text_object_inner"],

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1310,3 +1310,135 @@ fn test_vi_visual_line_indent_stops_at_selection() {
         .wait_for_buffer_content("    one\n    two\n    three\nfour\n")
         .unwrap();
 }
+
+// =============================================================================
+// Bug #2441: find-char motions (f/t/F/T) broken with operators and ; / , repeat
+// =============================================================================
+
+/// `dfr` should delete from the cursor up to and including the first `r`,
+/// leaving "ld foo bar baz". BUG: stuck in operator-pending, nothing deleted.
+#[test]
+fn test_vi_bug_2441_dfr_deletes_through_target() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'd');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_key(&mut harness, 'f');
+    send_key(&mut harness, 'r');
+
+    harness.wait_for_buffer_content("ld foo bar baz\n").unwrap();
+}
+
+/// `dfw` should delete up to and including the first `w` ("hello w"),
+/// leaving "orld foo bar baz". BUG: `f` is dropped and `w` runs as a plain
+/// word motion, so `dfw` silently degrades to `dw`.
+#[test]
+fn test_vi_bug_2441_dfw_target_is_motion_key() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'd');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_key(&mut harness, 'f');
+    send_key(&mut harness, 'w');
+
+    harness
+        .wait_for_buffer_content("orld foo bar baz\n")
+        .unwrap();
+}
+
+/// `dtr` (till) should delete up to but NOT including the first `r`,
+/// leaving "rld foo bar baz".
+#[test]
+fn test_vi_bug_2441_dtr_deletes_until_target() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'd');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_key(&mut harness, 't');
+    send_key(&mut harness, 'r');
+
+    harness
+        .wait_for_buffer_content("rld foo bar baz\n")
+        .unwrap();
+}
+
+/// `cfr` should delete up to and including the first `r` and enter insert mode,
+/// then typed text replaces it. Leaves "Xld foo bar baz".
+#[test]
+fn test_vi_bug_2441_cfr_changes_through_target() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'c');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_key(&mut harness, 'f');
+    send_key(&mut harness, 'r');
+    wait_insert(&mut harness);
+    harness.type_text("X").unwrap();
+    harness.render().unwrap();
+    escape(&mut harness);
+
+    harness
+        .wait_for_buffer_content("Xld foo bar baz\n")
+        .unwrap();
+}
+
+/// `;` should repeat the last `f`/`t`. After `fo` (lands on first 'o', col 4),
+/// `;` should advance to the next 'o' (col 7). BUG: `;` is a no-op.
+#[test]
+fn test_vi_bug_2441_semicolon_repeats_find() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'f');
+    send_key(&mut harness, 'o');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+
+    send_key(&mut harness, ';');
+    harness.wait_until(|h| h.cursor_position() == 7).unwrap();
+}
+
+/// `,` should repeat the last find in the opposite direction. After `fo;`
+/// (cursor at col 7), `,` should move back to the previous 'o' (col 4).
+#[test]
+fn test_vi_bug_2441_comma_repeats_find_reverse() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "hello world foo bar baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'f');
+    send_key(&mut harness, 'o');
+    send_key(&mut harness, ';');
+    harness.wait_until(|h| h.cursor_position() == 7).unwrap();
+
+    send_key(&mut harness, ',');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+}


### PR DESCRIPTION
Fixes #2441.

## Problem

In vi mode the find-char motions (`f`/`t`/`F`/`T`) worked as pure cursor motions but were **unbound in operator-pending mode**. The reported symptoms:

- **A — hang:** `dfr` (and `cf`/`ct`/`dt`, backward `dF`/`dT`) left the editor stuck in `-- OPERATOR (d) --` indefinitely, swallowing all keys until `Esc`. The `f` key did nothing while pending, and the target char was not a motion, so nothing resolved the operator.
- **B — silent mis-delete:** when the find target was itself a motion key, e.g. `dfw`, the dropped `f` left `w` to run as a plain word motion, so `dfw` degraded to `dw` and deleted the wrong span.

(The issue also listed `;`/`,` repeat as a no-op — that part was already fixed on `master` since v0.4.1; this PR adds regression coverage for it.)

## Fix

Bind `f`/`t`/`F`/`T` in operator-pending mode to a new operator-aware find-char path that, after capturing the target character, converts the cursor→target span into a byte range and applies the pending operator via the existing `applyOperatorWithRange`:

- Find-char operators are **inclusive** motions in vim: forward `f`/`t` include the landing character; backward `F`/`T` delete from the landing column up to (but not including) the cursor.
- A **missing target** on the line cancels the operator and leaves the buffer unchanged, instead of being consumed as a different motion.
- Wired into `.` repeat (new `operator-find-char` change type) and into `;`/`,` repeat, with a count so `d2fx` targets the Nth occurrence.
- The line-context lookup and target search are factored into shared helpers reused by the existing pure-motion path, so cursor-only `f`/`t`/`F`/`T` behavior is unchanged.

## Testing

- New e2e reproductions in `vi_mode_bugs.rs` — `dfr`, `dfw`, `dtr`, `cfr` — which **hang without this change** and pass with it; plus `;`/`,` regression tests.
- Full `vi_mode` e2e suite passes (107 passed, 0 failed).
- `cargo fmt` clean; the TypeScript plugin introduces no new `tsc` errors (the 4 pre-existing `ActionSpec` errors are unrelated).
- Manually validated in a real terminal (tmux): `dfr` → `ld foo bar baz`, `dtr` → `rld foo bar baz`, and `cfr` then typing `XYZ` → `XYZld foo bar baz`, each returning cleanly to NORMAL/INSERT instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4ofi1eeqzb96bkpgc9tri

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4ofi1eeqzb96bkpgc9tri)_