### PR TITLE
fix(mouse): single shared source of truth for mouse capture (#2504)

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -383,6 +383,7 @@ pub(super) struct EditorParts {
     pub(super) quick_open_registry: QuickOpenRegistry,
     pub(super) plugin_manager: std::rc::Rc<RwLock<PluginManager>>,
     pub(super) recovery_service: Arc<std::sync::Mutex<RecoveryService>>,
+    pub(super) mouse_capture: Arc<std::sync::atomic::AtomicBool>,
     pub(super) key_translator: crate::input::key_translator::KeyTranslator,
     pub(super) update_checker: Option<crate::services::release_checker::PeriodicUpdateChecker>,
 
@@ -590,6 +591,7 @@ impl Editor {
             lsp_uri_schemes: std::collections::HashSet::new(),
             plugin_manager: parts.plugin_manager,
             recovery_service: parts.recovery_service,
+            mouse_capture: parts.mouse_capture,
             time_source: parts.time_source,
             color_capability: parts.color_capability,
             update_checker: parts.update_checker,
@@ -1237,6 +1239,14 @@ impl Editor {
             )))
         };
 
+        // The single source of truth for terminal mouse capture, shared by
+        // every window (mouse capture is one global terminal property, not a
+        // per-window setting). Defaults to enabled, matching the always-on
+        // capture that `TerminalModes::enable` turns on at startup; the real
+        // TUI seeds it from the live terminal state right after construction
+        // (see `Editor::set_mouse_capture`). #2504
+        let mouse_capture = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+
         // Build the resource bundle every `Window` gets a clone of. The
         // base window receives one clone here; subsequent windows
         // (created via `Editor::create_window_at` or first-dive seeding
@@ -1260,6 +1270,7 @@ impl Editor {
             theme: Arc::clone(&theme),
             event_broadcaster: event_broadcaster.clone(),
             recovery_service: Arc::clone(&recovery_service),
+            mouse_capture: Arc::clone(&mouse_capture),
         };
 
         // Build the active window — the one that holds the seed
@@ -1420,6 +1431,7 @@ impl Editor {
             quick_open_registry,
             plugin_manager,
             recovery_service,
+            mouse_capture,
             key_translator,
             update_checker,
             time_source: time_source.clone(),

--- a/crates/fresh-editor/src/app/menu_context.rs
+++ b/crates/fresh-editor/src/app/menu_context.rs
@@ -71,7 +71,9 @@ impl Editor {
         let page_view = self.active_window().is_page_view();
         let file_explorer_visible = self.file_explorer_visible();
         let file_explorer_focused = self.active_window().is_file_explorer_focused();
-        let mouse_capture = self.active_window_mut().mouse_enabled;
+        let mouse_capture = self
+            .mouse_capture
+            .load(std::sync::atomic::Ordering::Relaxed);
         let mouse_hover = self.config.editor.mouse_hover_enabled;
         let inlay_hints = self.config.editor.enable_inlay_hints;
         // True for any real buffer; false when the active buffer is the

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -671,8 +671,10 @@ pub struct Editor {
     // `file_explorer_clipboard` moved onto `Window`.
 
     // `menu_bar_visible`, `menu_bar_auto_shown`, `tab_bar_visible`,
-    // `status_bar_visible`, `prompt_line_visible`, `mouse_enabled`
-    // moved onto `Window` — per-window UI toggles.
+    // `status_bar_visible`, `prompt_line_visible` moved onto `Window` —
+    // per-window UI toggles. (Mouse capture is the exception: it is one
+    // global terminal property, so it lives on `Editor.mouse_capture`,
+    // shared into every window — see that field.)
 
     // `same_buffer_scroll_sync` moved onto `Window` — per-window UX
     // toggle, since the split tree it controls is per-window.
@@ -911,6 +913,16 @@ pub struct Editor {
     /// `WindowResources` so per-window restore / auto-save can reach it
     /// without an active-window flip.
     recovery_service: std::sync::Arc<std::sync::Mutex<RecoveryService>>,
+
+    /// Live terminal mouse-capture state — the single source of truth for
+    /// the **View → Mouse Support** toggle. Mouse capture is a property of
+    /// the one controlling terminal, not of any individual window
+    /// (toggling it issues `Enable`/`DisableMouseCapture` on the process
+    /// stdout), so it is shared by `Arc` into every `Window` via
+    /// `WindowResources` rather than stored per-window. Seeded at startup
+    /// from the real `TerminalModes` state. Switching windows always shows
+    /// the same, accurate value (#2504).
+    pub(crate) mouse_capture: std::sync::Arc<std::sync::atomic::AtomicBool>,
 
     /// Request a full terminal clear and redraw on the next frame
     full_redraw_requested: bool,

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -421,10 +421,15 @@ impl Editor {
     /// Toggle mouse capture on/off
     pub fn toggle_mouse_capture(&mut self) {
         use std::io::stdout;
+        use std::sync::atomic::Ordering;
 
-        self.active_window_mut().mouse_enabled = !self.active_window_mut().mouse_enabled;
+        // Mouse capture is a single global terminal property, so flip the
+        // shared flag (every window observes the same value) and apply the
+        // matching terminal sequence.
+        let enabled = !self.mouse_capture.load(Ordering::Relaxed);
+        self.mouse_capture.store(enabled, Ordering::Relaxed);
 
-        if self.active_window_mut().mouse_enabled {
+        if enabled {
             // Best-effort terminal mouse capture toggle.
             #[allow(clippy::let_underscore_must_use)]
             let _ = crossterm::execute!(stdout(), crossterm::event::EnableMouseCapture);
@@ -439,7 +444,20 @@ impl Editor {
 
     /// Check if mouse capture is enabled
     pub fn is_mouse_enabled(&self) -> bool {
-        self.active_window().mouse_enabled
+        self.mouse_capture
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Seed the shared mouse-capture flag from the real terminal state.
+    ///
+    /// The authoritative state lives in `TerminalModes` (owned by the event
+    /// loop), which enables mouse capture at startup. Calling this right
+    /// after construction keeps the **View → Mouse Support** checkbox in sync
+    /// with reality instead of a constructor default (#2504). Takes `&self`
+    /// because the flag is interior-mutable (`Arc<AtomicBool>`).
+    pub fn set_mouse_capture(&self, enabled: bool) {
+        self.mouse_capture
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Toggle mouse hover for LSP on/off

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2016,7 +2016,11 @@ impl Window {
             previous_click_time: None,
             previous_click_position: None,
             click_count: 0,
-            mouse_enabled: false,
+            // Terminal mouse capture is enabled unconditionally at startup
+            // (see `services::terminal_modes`), so a window reflects that
+            // reality from the start — otherwise the View -> Mouse Support
+            // checkbox shows unticked while the mouse actually works (#2504).
+            mouse_enabled: true,
             mouse_cursor_position: None,
             gpm_active: false,
             menu_bar_visible: resources.config.editor.show_menu_bar,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -844,9 +844,6 @@ pub struct Window {
     pub previous_click_position: Option<(u16, u16)>,
     pub click_count: u8,
 
-    /// Whether mouse capture is enabled in this window.
-    pub mouse_enabled: bool,
-
     /// GPM software-cursor position for this window (when GPM is
     /// active and we draw our own cursor).
     pub mouse_cursor_position: Option<(u16, u16)>,
@@ -2016,11 +2013,6 @@ impl Window {
             previous_click_time: None,
             previous_click_position: None,
             click_count: 0,
-            // Terminal mouse capture is enabled unconditionally at startup
-            // (see `services::terminal_modes`), so a window reflects that
-            // reality from the start — otherwise the View -> Mouse Support
-            // checkbox shows unticked while the mouse actually works (#2504).
-            mouse_enabled: true,
             mouse_cursor_position: None,
             gpm_active: false,
             menu_bar_visible: resources.config.editor.show_menu_bar,

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -66,6 +66,7 @@ impl crate::app::Editor {
             theme: std::sync::Arc::clone(&self.theme),
             event_broadcaster: self.event_broadcaster.clone(),
             recovery_service: std::sync::Arc::clone(&self.recovery_service),
+            mouse_capture: std::sync::Arc::clone(&self.mouse_capture),
         }
     }
 

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -187,4 +187,12 @@ pub struct WindowResources {
     /// and is shared by every window — per-window restore and auto-save
     /// reach it directly (no active-window flip).
     pub recovery_service: Arc<std::sync::Mutex<crate::services::recovery::RecoveryService>>,
+
+    /// Live terminal mouse-capture state, mirrored from `Editor.mouse_capture`.
+    /// Mouse capture is a single global terminal property, so every window
+    /// shares the *same* `Arc<AtomicBool>` — the **View → Mouse Support**
+    /// checkbox stays consistent no matter which window is active, and a
+    /// freshly created window reflects the live state instead of a stale
+    /// default (#2504).
+    pub mouse_capture: Arc<std::sync::atomic::AtomicBool>,
 }

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -384,8 +384,8 @@ impl Editor {
     }
 
     /// Apply only the **editor-global** config overrides from a
-    /// workspace (the global `Config`). The window-local override
-    /// (`mouse_enabled`) is applied by
+    /// workspace (the global `Config`). The shared mouse-capture
+    /// override (`mouse_enabled`) is applied by
     /// `Window::apply_workspace_layout`.
     fn restore_config_overrides(&mut self, overrides: &WorkspaceConfigOverrides) {
         if let Some(line_numbers) = overrides.line_numbers {
@@ -2142,10 +2142,13 @@ impl crate::app::window::Window {
             workspace.split_states.len()
         );
 
-        // Window-local config override (the rest of the overrides mutate
-        // the editor-global `Config` and are applied by the caller).
+        // Mouse capture is a single global terminal property shared by every
+        // window (see `Editor::mouse_capture`); restoring a persisted value
+        // updates that shared flag.
         if let Some(mouse_enabled) = workspace.config_overrides.mouse_enabled {
-            self.mouse_enabled = mouse_enabled;
+            self.resources
+                .mouse_capture
+                .store(mouse_enabled, std::sync::atomic::Ordering::Relaxed);
         }
 
         self.restore_search_options(&workspace.search_options);
@@ -2351,7 +2354,11 @@ impl crate::app::window::Window {
             line_wrap: Some(cfg.line_wrap),
             syntax_highlighting: Some(cfg.syntax_highlighting),
             enable_inlay_hints: Some(cfg.enable_inlay_hints),
-            mouse_enabled: Some(self.mouse_enabled),
+            mouse_enabled: Some(
+                self.resources
+                    .mouse_capture
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ),
             menu_bar_hidden: None,
         };
 

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3980,6 +3980,12 @@ fn real_main() -> AnyhowResult<()> {
             editor.set_gpm_active(true);
         }
 
+        // Seed the shared mouse-capture flag from the real terminal state so
+        // the View -> Mouse Support checkbox matches the capture that
+        // `TerminalModes::enable` turned on above (#2504). Re-applied on every
+        // editor instance (authority-swap restarts rebuild the editor).
+        editor.set_mouse_capture(terminal_modes.mouse_capture_enabled());
+
         // Re-wire the tracing log paths into every editor instance,
         // not just the first. Status-bar click → open log, warning
         // indicator click → open log all break otherwise after the

--- a/crates/fresh-editor/tests/mouse_capture_default.rs
+++ b/crates/fresh-editor/tests/mouse_capture_default.rs
@@ -1,0 +1,80 @@
+//! Regression test for issue #2504: the **View → Mouse Support** menu item
+//! showed unticked even though the mouse actually worked.
+//!
+//! The terminal-level mouse capture is enabled unconditionally at startup
+//! (see `services::terminal_modes`), but the per-window `mouse_enabled`
+//! flag — which drives the menu checkbox via the `mouse_capture` context
+//! key — was constructed as `false`. So every freshly built window,
+//! including ones created by **Orchestrator: New Workspace**, reported the
+//! mouse as disabled while clicks still moved the cursor.
+//!
+//! The flag must default to `true` so the checkbox matches reality.
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::model::filesystem::{FileSystem, StdFileSystem};
+use std::path::Path;
+use std::sync::Arc;
+
+fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Editor {
+    let filesystem: Arc<dyn FileSystem + Send + Sync> = Arc::new(StdFileSystem);
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project.to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap()
+}
+
+#[test]
+fn initial_window_reports_mouse_enabled() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let project = sandbox.path().join("project");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    let editor = editor_in(&project, &dir_context);
+
+    assert!(
+        editor.is_mouse_enabled(),
+        "the initial window should report mouse capture as enabled, matching the \
+         terminal mouse capture that is turned on at startup",
+    );
+}
+
+#[test]
+fn new_workspace_window_reports_mouse_enabled() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let project = sandbox.path().join("project");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    let mut editor = editor_in(&project, &dir_context);
+
+    // Mirror the "Orchestrator: New Workspace" path, which spins up a brand
+    // new window via `Window::new` and makes it active.
+    let new_root = project.join("workspace");
+    std::fs::create_dir_all(&new_root).unwrap();
+    let id = editor.create_window_at(new_root, "workspace".to_string());
+    editor.set_active_window(id);
+
+    assert!(
+        editor.is_mouse_enabled(),
+        "a freshly created workspace window should report mouse capture as \
+         enabled so the View -> Mouse Support menu item is ticked",
+    );
+}

--- a/crates/fresh-editor/tests/mouse_capture_default.rs
+++ b/crates/fresh-editor/tests/mouse_capture_default.rs
@@ -1,14 +1,18 @@
 //! Regression test for issue #2504: the **View → Mouse Support** menu item
-//! showed unticked even though the mouse actually worked.
+//! showed unticked even though the mouse actually worked, and the per-window
+//! flag could desync when switching windows.
 //!
-//! The terminal-level mouse capture is enabled unconditionally at startup
-//! (see `services::terminal_modes`), but the per-window `mouse_enabled`
-//! flag — which drives the menu checkbox via the `mouse_capture` context
-//! key — was constructed as `false`. So every freshly built window,
-//! including ones created by **Orchestrator: New Workspace**, reported the
-//! mouse as disabled while clicks still moved the cursor.
+//! Mouse capture is a single global terminal property (toggling it issues
+//! `Enable`/`DisableMouseCapture` on the process stdout), so it is now backed
+//! by one shared `Arc<AtomicBool>` rather than a per-window `bool`. These
+//! tests pin two properties:
 //!
-//! The flag must default to `true` so the checkbox matches reality.
+//! 1. A freshly built editor reports mouse capture as enabled (the default,
+//!    matching the always-on terminal capture; the real TUI seeds it from the
+//!    live `TerminalModes` state at startup).
+//! 2. The state is shared across windows — toggling it in one window is
+//!    immediately reflected in another, and a newly created workspace window
+//!    sees the live value instead of a stale default.
 
 use fresh::config::Config;
 use fresh::config_io::DirectoryContext;
@@ -38,8 +42,7 @@ fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Edit
     .unwrap()
 }
 
-#[test]
-fn initial_window_reports_mouse_enabled() {
+fn test_editor() -> (tempfile::TempDir, fresh::app::Editor) {
     let sandbox = tempfile::tempdir().unwrap();
     let project = sandbox.path().join("project");
     let data_home = sandbox.path().join("data-home");
@@ -47,6 +50,12 @@ fn initial_window_reports_mouse_enabled() {
     std::fs::create_dir_all(&data_home).unwrap();
     let dir_context = DirectoryContext::for_testing(&data_home);
     let editor = editor_in(&project, &dir_context);
+    (sandbox, editor)
+}
+
+#[test]
+fn initial_window_reports_mouse_enabled() {
+    let (_sandbox, editor) = test_editor();
 
     assert!(
         editor.is_mouse_enabled(),
@@ -56,25 +65,40 @@ fn initial_window_reports_mouse_enabled() {
 }
 
 #[test]
-fn new_workspace_window_reports_mouse_enabled() {
-    let sandbox = tempfile::tempdir().unwrap();
-    let project = sandbox.path().join("project");
-    let data_home = sandbox.path().join("data-home");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir_all(&data_home).unwrap();
-    let dir_context = DirectoryContext::for_testing(&data_home);
-    let mut editor = editor_in(&project, &dir_context);
+fn mouse_capture_state_is_shared_across_windows() {
+    let (sandbox, mut editor) = test_editor();
 
-    // Mirror the "Orchestrator: New Workspace" path, which spins up a brand
-    // new window via `Window::new` and makes it active.
-    let new_root = project.join("workspace");
+    // Mirror the "Orchestrator: New Workspace" path: a brand new window via
+    // `Window::new`, then make it active.
+    let new_root = sandbox.path().join("workspace");
     std::fs::create_dir_all(&new_root).unwrap();
-    let id = editor.create_window_at(new_root, "workspace".to_string());
-    editor.set_active_window(id);
+    let workspace_id = editor.create_window_at(new_root, "workspace".to_string());
+    let initial_id = editor.active_window_id();
 
+    // The freshly created workspace window observes the live state, not a
+    // stale per-window default.
+    editor.set_active_window(workspace_id);
     assert!(
         editor.is_mouse_enabled(),
-        "a freshly created workspace window should report mouse capture as \
-         enabled so the View -> Mouse Support menu item is ticked",
+        "a freshly created workspace window should report mouse capture as enabled",
+    );
+
+    // Disabling capture from one window is visible from every other window —
+    // there is a single source of truth, so the menu checkbox can never
+    // desync when switching windows.
+    editor.set_mouse_capture(false);
+    assert!(!editor.is_mouse_enabled(), "disable should take effect");
+
+    editor.set_active_window(initial_id);
+    assert!(
+        !editor.is_mouse_enabled(),
+        "the other window must observe the same (disabled) state after switching",
+    );
+
+    editor.set_mouse_capture(true);
+    editor.set_active_window(workspace_id);
+    assert!(
+        editor.is_mouse_enabled(),
+        "re-enabling from one window is observed from the other window too",
     );
 }


### PR DESCRIPTION
## Summary

Fixes #2504 — **View → Mouse Support** showed unticked (`☐`) even though the mouse worked (most visibly in **Orchestrator: New Workspace** windows), and the checkbox could disagree with reality after switching windows.

## Root cause

Mouse capture is a property of the **one controlling terminal** — `toggle_mouse_capture` issues `Enable`/`DisableMouseCapture` on the process stdout, and `TerminalModes::enable` turns capture on unconditionally at startup. But the editor stored the state as a **per-window** `Window.mouse_enabled: bool` (read by the menu via the `mouse_capture` context key). That model is wrong in two ways:

1. **Stale on construction** — `Window::new` hardcoded `false`, so every freshly built window (initial *and* every workspace window, both via `Window::new`) reported the mouse disabled while clicks still worked.
2. **Desyncs across windows** — toggling in one window only updated that window's flag, so switching to another window showed a checkbox that no longer matched the actual terminal state.

## Fix

Replace the per-window flag with a single shared source of truth: `Editor.mouse_capture: Arc<AtomicBool>`, shared into every window via `WindowResources` (the same pattern already used for the shared `theme` handle).

- The menu context, the toggle action, and workspace capture/restore all read/write this one flag → every window always observes the same value.
- `main.rs` seeds it from the real `TerminalModes::mouse_capture_enabled()` immediately after editor construction, so the checkbox reflects the capture that was actually enabled at startup rather than a constructor default.
- `Window.mouse_enabled` is removed entirely; the per-workspace persisted `mouse_enabled` override is preserved for backward compatibility and now drives the shared flag.

## Testing

- `tests/mouse_capture_default.rs` pins both properties: the initial window reports mouse enabled, and the state stays **synchronized across windows** (toggling from one window is observed from another; a freshly created workspace window sees the live value).
- `cargo fmt` / `cargo clippy` clean; `cargo check --all-targets` and `--features gui` both build.
- `orchestrator_workspace_roundtrip` (mouse capture/restore path) passes.
- Manual validation in tmux: opened **View** menu → **☑ Mouse Support** by default; selected it → status line **"Mouse capture disabled"** and the checkbox flipped to **☐**, confirming the shared flag drives the menu live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)