### PR TITLE
fix(vi): clamp j/k onto a shorter line to its last character (#2442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **Vi mode**: moving with `j` / `k` onto a shorter line now clamps the cursor to that line's last character (like Vim) instead of parking it one past the end, so a following `x` deletes a character rather than the newline and joins lines. The desired column is still remembered for the next vertical move (#2442).
 * **Regex search**: `^` / `$` now anchor per line in multi-line `Ctrl+F` search (#2495).
 * **Splits**: closing a buffer shown in two splits no longer desyncs the surviving cursor (#2496).
 * **Terminal**: a terminal restores its live/scrollback mode on refocus, and the last split is no longer left read-only after closing a second terminal (#2485).

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -1081,12 +1081,15 @@ function vi_left() : void {
 registerHandler("vi_left", vi_left);
 
 function vi_down() : void {
-  executeWithCount("move_down");
+  // vi_move_down clamps the caret to the destination line's last char (Vim
+  // never lets the cursor rest past it in NORMAL mode), while still
+  // remembering the goal column for the next vertical move.
+  executeWithCount("vi_move_down");
 }
 registerHandler("vi_down", vi_down);
 
 function vi_up() : void {
-  executeWithCount("move_up");
+  executeWithCount("vi_move_up");
 }
 registerHandler("vi_up", vi_up);
 

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -854,10 +854,10 @@ impl Editor {
             }
 
             // Cursor movement (without selection)
-            Action::MoveDown => {
+            Action::MoveDown | Action::ViMoveDown => {
                 self.handle_cursor_movement_action(split_id, buffer_id, CursorMovement::Down, false)
             }
-            Action::MoveUp => {
+            Action::MoveUp | Action::ViMoveUp => {
                 self.handle_cursor_movement_action(split_id, buffer_id, CursorMovement::Up, false)
             }
             Action::MoveLeft => {

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -56,6 +56,23 @@ fn content_len_without_line_ending(content: &str) -> usize {
     content.trim_end_matches(LINE_ENDING_CHARS).len()
 }
 
+/// In vi NORMAL mode the caret may not rest past a line's last character.
+///
+/// Given a destination line (its start offset and full content, line ending
+/// included) and a tentative byte position on that line, clamp the position to
+/// the start of the line's last character — or to the line start for an empty
+/// line. Used by the vi-aware vertical motions so `j`/`k` onto a shorter line
+/// land on the last char (like Vim) instead of one past it.
+fn clamp_to_last_char_on_line(line_start: usize, line_content: &str, pos: usize) -> usize {
+    let line_len = content_len_without_line_ending(line_content);
+    let last_char_pos = line_content[..line_len]
+        .char_indices()
+        .next_back()
+        .map(|(i, _)| line_start + i)
+        .unwrap_or(line_start);
+    pos.min(last_char_pos)
+}
+
 fn find_paragraph_up(buffer: &mut Buffer, pos: usize, estimated_line_length: usize) -> usize {
     let mut iter = buffer.line_iterator(pos, estimated_line_length);
     let mut found_pos = None;
@@ -1500,6 +1517,7 @@ fn handle_vertical_up(
     events: &mut Vec<Event>,
     estimated_line_length: usize,
     extend_selection: bool,
+    clamp_to_last_char: bool,
 ) {
     for (cursor_id, cursor) in cursors.iter() {
         let from_pos = if !extend_selection && cursor.deselect_on_move {
@@ -1523,7 +1541,10 @@ fn handle_vertical_up(
         if let Some((prev_line_start, prev_line_content)) = iter.prev() {
             let prev_line_text = prev_line_content.trim_end_matches('\n');
             let byte_offset = byte_offset_at_visual_column(prev_line_text, goal_visual_column);
-            let new_pos = prev_line_start + byte_offset;
+            let mut new_pos = prev_line_start + byte_offset;
+            if clamp_to_last_char {
+                new_pos = clamp_to_last_char_on_line(prev_line_start, &prev_line_content, new_pos);
+            }
 
             let new_anchor = if extend_selection {
                 Some(cursor.anchor.unwrap_or(cursor.position))
@@ -1554,6 +1575,7 @@ fn handle_vertical_down(
     events: &mut Vec<Event>,
     estimated_line_length: usize,
     extend_selection: bool,
+    clamp_to_last_char: bool,
 ) {
     for (cursor_id, cursor) in cursors.iter() {
         let from_pos = if !extend_selection && cursor.deselect_on_move {
@@ -1579,7 +1601,10 @@ fn handle_vertical_down(
         if let Some((next_line_start, next_line_content)) = iter.next_line() {
             let next_line_text = next_line_content.trim_end_matches('\n');
             let byte_offset = byte_offset_at_visual_column(next_line_text, goal_visual_column);
-            let new_pos = next_line_start + byte_offset;
+            let mut new_pos = next_line_start + byte_offset;
+            if clamp_to_last_char {
+                new_pos = clamp_to_last_char_on_line(next_line_start, &next_line_content, new_pos);
+            }
 
             let new_anchor = if extend_selection {
                 Some(cursor.anchor.unwrap_or(cursor.position))
@@ -2405,11 +2430,50 @@ pub fn action_to_events(
         }
 
         Action::MoveUp => {
-            handle_vertical_up(state, cursors, &mut events, estimated_line_length, false);
+            handle_vertical_up(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                false,
+                false,
+            );
         }
 
         Action::MoveDown => {
-            handle_vertical_down(state, cursors, &mut events, estimated_line_length, false);
+            handle_vertical_down(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                false,
+                false,
+            );
+        }
+
+        // Vi NORMAL-mode `k`/`j`: like MoveUp/MoveDown but the caret is clamped
+        // to the destination line's last character (it may never rest past it),
+        // while the goal column is still remembered for the next vertical move.
+        Action::ViMoveUp => {
+            handle_vertical_up(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                false,
+                true,
+            );
+        }
+
+        Action::ViMoveDown => {
+            handle_vertical_down(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                false,
+                true,
+            );
         }
 
         Action::MoveLineStart => {
@@ -2541,11 +2605,25 @@ pub fn action_to_events(
         }
 
         Action::SelectUp => {
-            handle_vertical_up(state, cursors, &mut events, estimated_line_length, true);
+            handle_vertical_up(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                true,
+                false,
+            );
         }
 
         Action::SelectDown => {
-            handle_vertical_down(state, cursors, &mut events, estimated_line_length, true);
+            handle_vertical_down(
+                state,
+                cursors,
+                &mut events,
+                estimated_line_length,
+                true,
+                false,
+            );
         }
 
         Action::SelectToParagraphUp => {

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -373,6 +373,8 @@ pub enum Action {
     MoveRight,
     MoveUp,
     MoveDown,
+    ViMoveUp,   // Vim 'k' - move up, clamping the caret to the line's last char
+    ViMoveDown, // Vim 'j' - move down, clamping the caret to the line's last char
     MoveWordLeft,
     MoveWordRight,
     MoveWordEnd,     // Move to end of current word (Ctrl+Right style, past the end)
@@ -935,6 +937,8 @@ impl Action {
             "move_right" => MoveRight,
             "move_up" => MoveUp,
             "move_down" => MoveDown,
+            "vi_move_up" => ViMoveUp,
+            "vi_move_down" => ViMoveDown,
             "move_word_left" => MoveWordLeft,
             "move_word_right" => MoveWordRight,
             "move_word_end" => MoveWordEnd,
@@ -1453,6 +1457,8 @@ impl Action {
                 | Action::MoveRight
                 | Action::MoveUp
                 | Action::MoveDown
+                | Action::ViMoveUp
+                | Action::ViMoveDown
                 | Action::MoveWordLeft
                 | Action::MoveWordRight
                 | Action::MoveWordEnd
@@ -2457,6 +2463,8 @@ impl KeybindingResolver {
             Action::MoveRight => t!("action.move_right"),
             Action::MoveUp => t!("action.move_up"),
             Action::MoveDown => t!("action.move_down"),
+            Action::ViMoveUp => t!("action.move_up"),
+            Action::ViMoveDown => t!("action.move_down"),
             Action::MoveWordLeft => t!("action.move_word_left"),
             Action::MoveWordRight => t!("action.move_word_right"),
             Action::MoveWordEnd => t!("action.move_word_end"),

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -630,7 +630,10 @@ fn test_vi_vim_compat_search_count_does_not_leak_to_next_motion() {
     harness.wait_for_screen_contains("Ln 1, Col 19").unwrap();
 
     send_vi_key(&mut harness, 'j');
-    harness.wait_for_screen_contains("Ln 2, Col 4").unwrap();
+    // The count must not leak into `j`: the cursor moves down exactly one line
+    // (to line 2, not line 4). The column clamps to the last char of the shorter
+    // line "one" (Col 3, like Vim) rather than resting one past it.
+    harness.wait_for_screen_contains("Ln 2, Col 3").unwrap();
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -936,3 +936,107 @@ fn test_vi_bug_d_percent_ignored() {
 
     harness.wait_for_buffer_content("foobaz\n").unwrap();
 }
+
+// =============================================================================
+// Bug #2442: j/k onto a shorter line park the cursor one past the last char,
+// so `x` deletes the newline and joins lines.
+// =============================================================================
+
+/// In NORMAL mode the cursor must never rest past the last character of a line.
+/// Moving down (`j`) from a long line onto a *shorter* line must clamp the
+/// cursor to the shorter line's last character — like Vim — not the insert
+/// position one past it. Otherwise `x` deletes the line-ending newline and
+/// joins the following line (silent corruption from navigate-then-delete).
+#[test]
+fn test_vi_bug_2442_j_onto_shorter_line_then_x_joins_lines() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new(
+        "motions.txt",
+        "hello world foo bar baz\nshort\na longer line with many words here\n",
+    )
+    .unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // $ -> last char of line 1 (the 'z'). j -> down onto "short".
+    send_key(&mut harness, '$');
+    let pos_eol = harness.cursor_position();
+    send_key(&mut harness, 'j');
+    harness
+        .wait_until(|h| h.cursor_position() > pos_eol)
+        .unwrap();
+
+    // x deletes one character. In Vim the cursor sits on the 't' of "short",
+    // so x gives "shor" and never joins line 3.
+    send_key(&mut harness, 'x');
+
+    harness
+        .wait_for_buffer_content(
+            "hello world foo bar baz\nshor\na longer line with many words here\n",
+        )
+        .unwrap();
+}
+
+/// Same off-by-one for upward motion (`k`) onto a shorter line.
+#[test]
+fn test_vi_bug_2442_k_onto_shorter_line_then_x_joins_lines() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new(
+        "motions.txt",
+        "hello world foo bar baz\nshort\na longer line with many words here\n",
+    )
+    .unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Go to line 3, end of line, then k up onto "short".
+    send_key(&mut harness, 'j');
+    send_key(&mut harness, 'j');
+    send_key(&mut harness, '$');
+    let pos_eol = harness.cursor_position();
+    send_key(&mut harness, 'k');
+    harness
+        .wait_until(|h| h.cursor_position() < pos_eol)
+        .unwrap();
+
+    send_key(&mut harness, 'x');
+
+    harness
+        .wait_for_buffer_content(
+            "hello world foo bar baz\nshor\na longer line with many words here\n",
+        )
+        .unwrap();
+}
+
+/// The desired (goal) column must survive the clamp: long -> short -> long
+/// returns to the original column, matching Vim's remembered column.
+#[test]
+fn test_vi_bug_2442_goal_column_preserved_through_short_line() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    // Column 10 (0-indexed byte 10) is 'd' of "world" on line 1 and 'l' of
+    // "longer" on line 3; line 2 "short" is only 5 chars.
+    let fixture = TestFixture::new(
+        "motions.txt",
+        "hello world foo bar baz\nshort\na longer line with many words here\n",
+    )
+    .unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Move to byte column 10 on line 1 via 10 'l' presses.
+    for _ in 0..10 {
+        send_key(&mut harness, 'l');
+    }
+    harness.wait_until(|h| h.cursor_position() == 10).unwrap();
+
+    // j onto "short" clamps to its last char ('t', byte 4 on the line ->
+    // absolute byte 24+4 = 28), then j onto line 3 must restore column 10
+    // (absolute byte 24 + 6 + 10 = 40).
+    send_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 28).unwrap();
+    send_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 40).unwrap();
+}


### PR DESCRIPTION
Fixes #2442.

## Problem

In vi mode, moving with `j` / `k` from a long line onto a **shorter** line parked the cursor **one column past the last character** (the insert position) instead of clamping it to the last character like Vim. Because the cursor then sat on the line-ending boundary, pressing `x` deleted the **newline** and joined the following line — silent corruption from an ordinary navigate-then-delete.

```
$ on line 1 → j onto "short" → status showed "Col 6" on a 5-char line
x → deleted the newline, joining the next line onto "short"
```

Horizontal clamping (`l`, `$`) was already correct (they use the vi-aware `move_*_in_line` actions); only the **vertical** motions went through the generic `move_down`/`move_up`, which legitimately land at end-of-line for a normal editor but not for vi NORMAL mode.

## Fix

Add vi-aware native vertical motions `ViMoveUp` / `ViMoveDown` (alongside the existing `ViMoveWordEnd`). They reuse the same vertical-motion logic — so the **goal column is still remembered** for the next vertical move (a long→short→long traversal returns to the original column, as in Vim) — but clamp the final position to the destination line's last character via a small `clamp_to_last_char_on_line` helper. The `vi_mode` plugin routes normal-mode `j`/`k` (and the Down/Up arrows) to these actions.

`MoveUp` / `MoveDown` / `SelectUp` / `SelectDown` are byte-for-byte unchanged (they pass `clamp = false`), so non-vi navigation and selection are unaffected.

## Why not clamp in the plugin

A plugin-side corrective move (e.g. `move_left` after `move_down`) would work for the join bug but resets `sticky_column` to 0, wiping the remembered goal column and regressing long→short→long navigation. Clamping inside the native vertical motion keeps the goal column intact, so the fix is done there.

## Tests

- New e2e reproductions in `vi_mode_bugs.rs` (drive real keystrokes, assert on buffer content / cursor position; fail/time-out without the fix):
  - `j` onto a shorter line then `x` → deletes a char, **does not** join lines
  - same for upward `k`
  - goal column survives a long→short→long traversal
- Updated `test_vi_vim_compat_search_count_does_not_leak_to_next_motion`, which had recorded the buggy off-by-one column (`Col 4` on a 3-char line) — now asserts the Vim-correct `Col 3`. Its actual intent (the search count not leaking into the next `j`) is unchanged.

All 109 vi-mode e2e tests pass; `cargo fmt`, `cargo clippy`, and `cargo check --all-targets` are clean. Manually validated in a tmux session: `$` → `j` onto `short` lands on `Col 5` and `x` yields `shor` without joining the line below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCqVXtGtd7VyaLFFFVq9tC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCqVXtGtd7VyaLFFFVq9tC)_