### PR TITLE
Sort Project Search & Replace results in natural path order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Improvements
 
+* **Project Search & Replace** lists files with matches in natural path order (so `file2` precedes `file10`) instead of the random order the parallel project walk produced, making it easy to track progress while reviewing matches (#2435, requested by @mandolyte).
 * **Open Terminal to the Right / Below** — open a new terminal in a fresh split beside or below the active pane.
 * **File Open: reveal hidden files** when the filter starts with `.` (#2407, requested by @dragonfyre13).
 * **Vim compatibility options** for vi mode — extra compatibility motions and word search (#2398, by @NihilDigit).

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -341,6 +341,39 @@ function getFileExtBadge(path: string): string {
   return ext.slice(0, 2);
 }
 
+/** Natural ("human") ordering of two display paths (#2435). Splits each
+ *  string into alternating non-digit / digit runs and compares digit
+ *  runs by numeric value so `file2` sorts before `file10` rather than
+ *  after it. Non-digit runs compare case-insensitively first (so `B`
+ *  doesn't jump ahead of `a`) with a case-sensitive tiebreak to keep
+ *  the order total and stable. Path separators are ordinary characters,
+ *  which keeps each directory's files grouped together. */
+function naturalCompare(a: string, b: string): number {
+  const re = /\d+|\D+/g;
+  const ap = a.match(re) ?? [];
+  const bp = b.match(re) ?? [];
+  const n = Math.min(ap.length, bp.length);
+  for (let i = 0; i < n; i++) {
+    const x = ap[i];
+    const y = bp[i];
+    const xNum = x.charCodeAt(0) >= 48 && x.charCodeAt(0) <= 57;
+    const yNum = y.charCodeAt(0) >= 48 && y.charCodeAt(0) <= 57;
+    if (xNum && yNum) {
+      const dx = parseInt(x, 10);
+      const dy = parseInt(y, 10);
+      if (dx !== dy) return dx < dy ? -1 : 1;
+      // Equal value but different width (leading zeros): shorter first.
+      if (x.length !== y.length) return x.length - y.length;
+    } else {
+      const xl = x.toLowerCase();
+      const yl = y.toLowerCase();
+      if (xl !== yl) return xl < yl ? -1 : 1;
+      if (x !== y) return x < y ? -1 : 1;
+    }
+  }
+  return ap.length - bp.length;
+}
+
 function buildFileGroups(results: SearchResult[]): FileGroup[] {
   const map = new Map<string, SearchResult[]>();
   const order: string[] = [];
@@ -352,12 +385,42 @@ function buildFileGroups(results: SearchResult[]): FileGroup[] {
     }
     map.get(key)!.push(r);
   }
-  return order.map(absPath => ({
+  const groups = order.map(absPath => ({
     relPath: getRelativePath(absPath),
     absPath,
     expanded: true,
     matches: map.get(absPath)!,
   }));
+  groups.sort((a, b) => naturalCompare(a.relPath, b.relPath));
+  return groups;
+}
+
+/** Re-order `panel.fileGroups` into natural path order in place,
+ *  preserving each file's expansion state across the re-index. The
+ *  streaming search path appends files in completion order (the project
+ *  walk runs them through a parallel pool, so arrival order is
+ *  effectively random); call this once a search finishes so the
+ *  reviewer sees a stable, sorted list (#2435). Expansion keys are
+ *  positional (`file:<index>`), so the set is rebuilt from the files
+ *  that were expanded before the sort. */
+function sortFileGroups(): void {
+  if (!panel) return;
+  const expandedPaths = new Set<string>();
+  for (let i = 0; i < panel.fileGroups.length; i++) {
+    if (panel.expandedFileKeys.has(`file:${i}`)) {
+      expandedPaths.add(panel.fileGroups[i].absPath);
+    }
+  }
+  panel.fileGroups.sort((a, b) => naturalCompare(a.relPath, b.relPath));
+  panel.expandedFileKeys.clear();
+  panel.knownFileKeys.clear();
+  for (let i = 0; i < panel.fileGroups.length; i++) {
+    const key = `file:${i}`;
+    panel.knownFileKeys.add(key);
+    if (expandedPaths.has(panel.fileGroups[i].absPath)) {
+      panel.expandedFileKeys.add(key);
+    }
+  }
 }
 
 interface FlatItem {
@@ -1494,10 +1557,15 @@ async function rerunSearch(): Promise<void> {
         // Cheap: the tree is empty (no per-node serialization cost).
         updatePanelContent();
       } else {
-        // Only one tiny mutation needed: refresh matchStats since it
-        // depends on the busy flag and searchPerformed. The tree's
-        // nodes already reflect the final state — no full re-emit.
-        panel.widgetPanel.setRawEntries("matchStats", buildMatchStatsEntries());
+        // The tree was built incrementally in file-arrival order while
+        // streaming. Now that the search is finished, re-order the file
+        // groups into natural path order and re-emit once so the
+        // reviewer sees a stable, sorted list (#2435). This is the only
+        // full re-emit of the run — it happens after streaming has
+        // stopped and the user is about to start reviewing, so it
+        // doesn't compete with input the way per-batch re-emits would.
+        sortFileGroups();
+        updatePanelContent();
       }
     }
   }

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -2116,6 +2116,62 @@ fn test_widget_text_shift_right_copy_paste_duplicates_substring() {
         .unwrap();
 }
 
+/// Result file groups are presented in natural (human) path order once
+/// a search finishes, not in the random file-arrival order the parallel
+/// project walk produces (#2435). `item2.txt` must sort before
+/// `item10.txt` — plain lexicographic order would place `item10.txt`
+/// second, so this also guards against an accidental string sort.
+#[test]
+fn test_search_replace_natural_sort_order() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    // The searched files (each holds one match). Created in an order
+    // that is neither natural nor lexicographic so the rendered order
+    // can only come from an explicit sort.
+    for name in ["item10.txt", "item1.txt", "item2.txt"] {
+        fs::write(project_root.join(name), "needle here\n").unwrap();
+    }
+    // A start buffer with no match, so the searched names appear only in
+    // the matches section (not in the tab bar, which would offset the
+    // first-occurrence lookups below).
+    let start_file = project_root.join("start.txt");
+    fs::write(&start_file, "nothing to find\n").unwrap();
+
+    // A tall window so the results split has room for all six tree rows
+    // (3 file rows + 3 match rows) without scrolling.
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 60, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("needle").unwrap();
+    harness.render().unwrap();
+
+    // The natural sort is applied once the search finishes and the tree
+    // is re-emitted. Wait for the terminal state: all three file rows
+    // present, in natural order (item1 < item2 < item10). Without the
+    // sort the final order is the random file-arrival order, so this
+    // condition never settles and the test fails.
+    let row_of =
+        |s: &str, needle: &str| -> Option<usize> { s.lines().position(|l| l.contains(needle)) };
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            match (
+                row_of(&s, "item1.txt"),
+                row_of(&s, "item2.txt"),
+                row_of(&s, "item10.txt"),
+            ) {
+                (Some(r1), Some(r2), Some(r10)) => r1 < r2 && r2 < r10,
+                _ => false,
+            }
+        })
+        .unwrap();
+}
+
 /// Shift+Right twice selects two chars; Backspace deletes the
 /// whole selection, not just one char. Regression test for the
 /// pre-unification behaviour where the widget framework had no


### PR DESCRIPTION
## Summary

Closes #2435.

Files with matches in **Project Search & Replace** were listed in the order the project walk happened to finish reading them. Because the host walks files through a parallel pool (`Semaphore(8)` in `handle_begin_search`), that order is effectively random, so a reviewer scanning a large result set (the reporter had ~150 matches) had no sense of how far along they were.

This change presents the file groups in **natural ("human") path order** — e.g. `file2.txt` precedes `file10.txt` rather than following it.

## What changed

- **`naturalCompare(a, b)`** — a small, dependency-free comparator that splits each path into alternating non-digit / digit runs and compares digit runs numerically. Non-digit runs compare case-insensitively first (with a case-sensitive tiebreak) so the order is total and stable; path separators are ordinary characters, so each directory's files stay grouped.
- **`buildFileGroups`** (the non-streaming / post-replace path) now returns groups sorted by `relPath`.
- **`sortFileGroups`** re-orders the live `panel.fileGroups` in place and rebuilds the positional `file:<index>` expansion keys so collapse/expand state survives the re-index.
- The **streaming** search still appends files live in arrival order for responsiveness; the sort is applied **once, when the search completes**, via a single panel re-emit in `rerunSearch`. That re-emit is the only full re-emit of the run and happens after streaming stops and the user is about to start reviewing — so it doesn't compete with input the way the deliberately-avoided per-batch re-emits would.

## Design notes

The host walk is intentionally parallel, so sorting host-side would mean buffering every result before showing anything and would defeat streaming. Keeping the sort plugin-side and deferring it to completion preserves the existing streaming/perf behavior while delivering the requested ordering.

## Testing

- New e2e test `test_search_replace_natural_sort_order`: creates `item1.txt`, `item2.txt`, `item10.txt` (written in a non-sorted order), runs a project search, and asserts the rendered rows settle into `item1 < item2 < item10`. The `item2`/`item10` pair also guards against an accidental plain lexicographic sort (which would place `item10` second). Verified the test fails (never settles) without the plugin change and passes with it.
- Full `search_replace` e2e suite passes (36 passed).
- Plugin type-checks clean (`check-types.sh search_replace.ts`).
- Manually validated in a real `fresh` session via tmux: a mix of `file3/file20/file100` and `item1/item2/item3/item10` renders in correct natural order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoUCfHb4wLjRNrmpPKJZEv)_