### PR TITLE
fix(orchestrator): focus activated window when clicking a dock row

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -3262,6 +3262,43 @@ function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
   })();
 }
 
+// A click on a dock row is a deliberate "open this session" gesture, so
+// it both switches the active window *and* hands keyboard focus to the
+// editor — exactly like pressing Enter (`dock_activate`). This differs
+// from arrow-nav, which only live-switches and keeps focus on the dock
+// so you can keep arrowing. The switch is done synchronously here (the
+// 30 ms debounce in `scheduleDockSwitch` exists only to absorb held
+// arrow keys; a click has no such stream) and the pending debounce token
+// is bumped so any in-flight arrow switch can't clobber this one.
+function diveDockSelectionFromClick(fromEdge: "top" | "bottom" | null): void {
+  if (!openDialog || !openPanel || !dockMode) return;
+  dockSwitchToken++;
+  const id = openDialog.filteredIds[openDialog.selectedIndex];
+  if (typeof id !== "number") return;
+  const sess = orchestratorSessions.get(id);
+  // A discovered (on-disk) worktree has no live window — attach a fresh
+  // session and dive in (attachToWorktree hands focus to the editor).
+  if (sess?.discovered) {
+    void attachToWorktree({
+      root: sess.root,
+      projectPath: sess.projectPath ?? sess.root,
+      label: sess.label,
+      branch: sess.branch,
+      discoveredId: sess.id,
+      dive: true,
+    });
+    return;
+  }
+  if (id > 0 && id !== editor.activeWindow()) {
+    if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
+    else editor.setActiveWindow(id);
+  }
+  // Hand keyboard focus to the activated window (mirror `dock_activate`).
+  dockBlurred = true;
+  editor.floatingPanelControl(openPanel.id(), "blur", 0);
+  editor.setEditorMode(null);
+}
+
 // Toggle command (bind to a key of choice; reachable as
 // "Orchestrator: Toggle Dock" in the command palette). Simple
 // 2-state: visible → hide, hidden → show + focus. (A blurred-but-
@@ -7044,15 +7081,19 @@ editor.on("widget_event", (e) => {
         clearDialogError();
         if (dockMode) {
           // The editor to the dock's right is the preview: arrowing the
-          // list (or clicking a row) switches the active window live
-          // (debounced), wiping down when moving down and up when moving
-          // up. A discovered (on-disk) worktree has no window to switch
-          // to, so `scheduleDockSwitch` opens it as the active session
-          // instead — both click and arrow land there the same way.
+          // list switches the active window live (debounced), wiping down
+          // when moving down and up when moving up, and keeps focus on the
+          // dock so you can keep arrowing. A *click* is a deliberate "open
+          // this" gesture, so it also hands keyboard focus to the activated
+          // window (dive in) like Enter — otherwise keys keep going to the
+          // dock while the editor shows the switched session. A discovered
+          // (on-disk) worktree has no window to switch to, so both paths
+          // attach a fresh session to it instead.
           openPanel.update(buildDockSpec());
           openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
           const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
-          scheduleDockSwitch(fromEdge);
+          if (payload.via === "click") diveDockSelectionFromClick(fromEdge);
+          else scheduleDockSwitch(fromEdge);
           return;
         }
         // Update preview pane.

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1371,6 +1371,62 @@ fn click_un_dive_switches_to_clicked_session() {
         .unwrap();
 }
 
+/// Regression: clicking a session row in a *focused* dock must switch to
+/// that session AND hand keyboard focus to the activated window — exactly
+/// like pressing Enter. The `select` handler in `orchestrator.ts` used to
+/// treat a click identically to arrow-nav: it live-switched the active
+/// window but left focus on the dock, so the editor showed the clicked
+/// session while keystrokes still drove the dock. The fix routes a
+/// click (`payload.via === "click"`) through `diveDockSelectionFromClick`,
+/// which switches and blurs the dock; arrow-nav (no `via`) keeps its
+/// debounced live-switch and stays on the dock.
+///
+/// Observed through rendered output only (CONTRIBUTING §2): after the
+/// click the dock must report blurred, and a sentinel typed into the
+/// keyboard must land in the clicked session's empty buffer (proving both
+/// that focus left the dock and that the active window is the clicked one).
+#[test]
+fn click_on_focused_dock_row_dives_focus_into_session() {
+    init_tracing_from_env();
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    // The dock mounts with keyboard focus; alphaproj is the active window.
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("alphaproj") && s.contains("beta")
+    })
+    .unwrap();
+    assert!(
+        h.editor().is_dock_focused(),
+        "precondition: the dock holds keyboard focus on mount"
+    );
+
+    // Click beta's row. The fix switches the active window to beta and
+    // dives focus into it — so the dock blurs without any Enter.
+    let beta_row = row_of(&h, "beta") as u16;
+    h.mouse_click(3, beta_row).unwrap();
+    h.wait_until(|h| !h.editor().is_dock_focused()).unwrap();
+
+    // Focus now sits on beta's empty `[No Name]` buffer: a typed sentinel
+    // lands in the buffer (visible on screen) rather than being swallowed
+    // by the dock. `ZZ` avoids false matches with any chrome label.
+    h.send_key(KeyCode::Char('Z'), KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Char('Z'), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("ZZ"))
+        .unwrap();
+    assert_eq!(
+        h.editor().active_window().root,
+        root.join("wt-beta"),
+        "clicking beta's row must make it the active window"
+    );
+}
+
 #[test]
 fn dock_initial_sort_is_lex_stable_not_current_first() {
     // Smoking-gun reproducer for the dock-reorder hypothesis behind the


### PR DESCRIPTION
Clicking a session row in the orchestrator dock switched the active
window but left keyboard focus on the dock, so the editor showed the
clicked session while keystrokes kept driving the dock. The select
handler treated a click identically to arrow-nav (debounced live-switch,
focus stays on dock so you can keep arrowing).

Route a click (payload.via === "click") through a new
diveDockSelectionFromClick helper that switches synchronously and hands
keyboard focus to the activated window, mirroring Enter (dock_activate).
Arrow-nav keeps its debounced live-switch and dock focus. Discovered
on-disk worktrees attach a fresh session and dive in.

Adds a regression test asserting a click on a focused dock row blurs the
dock and lands typed input in the clicked session's buffer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hk5aHMTs3FQqYvE2bn9Hkk