### PR TITLE
fix(indent-guides): gate on buffer kind + per-buffer override, not layout

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2463,6 +2463,12 @@ pub enum PluginCommand {
     /// Enable/disable line numbers for a buffer
     SetLineNumbers { buffer_id: BufferId, enabled: bool },
 
+    /// Enable/disable indentation guides for a buffer, overriding the global
+    /// `editor.indentation_guide` default. Used by tool views (e.g. the Git Log
+    /// commit-detail diff) that show non-editable content where the guides are
+    /// noise.
+    SetIndentationGuide { buffer_id: BufferId, enabled: bool },
+
     /// Set the view mode for a buffer ("source" or "compose")
     SetViewMode { buffer_id: BufferId, mode: String },
 

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3018,6 +3018,11 @@ pub enum PluginCommand {
         /// it has just set, which keeps the UTF-8 byte math on the host
         /// side.
         initial_cursor_line: Option<u32>,
+        /// Optional per-buffer indentation-guide override. `None` keeps the
+        /// default (virtual buffers show no guides); `Some(true)` forces guides
+        /// on for a virtual buffer that shows real source (e.g. git log's
+        /// file-at-commit view).
+        indentation_guide: Option<bool>,
         /// Optional request ID for async response
         request_id: Option<u64>,
     },
@@ -4466,6 +4471,12 @@ pub struct CreateVirtualBufferOptions {
     #[serde(default, rename = "initialCursorLine")]
     #[ts(optional, rename = "initialCursorLine")]
     pub initial_cursor_line: Option<u32>,
+    /// Override indentation-guide visibility for this buffer (default: follows
+    /// the global setting, but virtual buffers show none). Set `true` when the
+    /// buffer displays real source — e.g. a file opened at a past commit.
+    #[serde(default, rename = "indentationGuide")]
+    #[ts(optional, rename = "indentationGuide")]
+    pub indentation_guide: Option<bool>,
 }
 
 /// Options for createVirtualBufferInSplit
@@ -5306,6 +5317,7 @@ impl PluginApi {
             editing_disabled: false,
             hidden_from_tabs: false,
             initial_cursor_line: None,
+            indentation_guide: None,
             request_id: None,
         })
     }

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -1155,6 +1155,10 @@ async function git_log_detail_open_file(): Promise<void> {
     readOnly: true,
     editingDisabled: true,
     showLineNumbers: true,
+    // This view shows real source (highlighted from the filename), so keep
+    // indentation guides — virtual buffers default off, but a historical file
+    // view is code the user is reading.
+    indentationGuide: true,
     entries,
     initialCursorLine: Math.max(0, line - 1),
   });

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -589,6 +589,10 @@ async function showCommitInDetail(commit: GitCommit, cwd: string): Promise<void>
   // wrap on (long minified lines unreadable in the 40% panel).
   editor.setBufferShowCursors(bufferId, true);
   editor.setLineWrap(bufferId, null, true);
+  // The detail panel is a file-backed buffer (a `git show` dump), so it
+  // escapes the virtual-buffer default that keeps guides out of the commit
+  // list. Disable them explicitly: a diff isn't an editable indented document.
+  editor.setIndentationGuide(bufferId, false);
   // Land at the top of the diff every time we (re-)visit a commit.
   editor.setBufferCursor(bufferId, 0);
 }

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1589,6 +1589,12 @@ type CreateVirtualBufferOptions = {
 	* plugin would otherwise have to navigate.
 	*/
 	initialCursorLine?: number;
+	/**
+	* Override indentation-guide visibility for this buffer (default: follows
+	* the global setting, but virtual buffers show none). Set `true` when the
+	* buffer displays real source — e.g. a file opened at a past commit.
+	*/
+	indentationGuide?: boolean;
 };
 type GrepMatch = {
 	/**

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2990,6 +2990,12 @@ interface EditorAPI {
 	*/
 	setLineNumbers(bufferId: number, enabled: boolean): boolean;
 	/**
+	* Enable or disable indentation guides for a buffer, overriding the global
+	* `editor.indentation_guide` setting. Tool views that render non-editable
+	* content (e.g. the Git Log commit-detail diff) disable them.
+	*/
+	setIndentationGuide(bufferId: number, enabled: boolean): boolean;
+	/**
 	* Set the view mode for a buffer ("source" or "compose")
 	*/
 	setViewMode(bufferId: number, mode: string): boolean;

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1703,6 +1703,24 @@ impl Editor {
         }
     }
 
+    /// Handle SetIndentationGuide command
+    ///
+    /// Records a per-buffer override for indentation-guide visibility. Unlike
+    /// line numbers (which are per-split), this lives on the buffer's
+    /// `EditorState`, so it follows the buffer wherever it's shown — including a
+    /// buffer-group detail panel that isn't the focused split, and across the
+    /// panel's per-commit buffer retargets.
+    pub(super) fn handle_set_indentation_guide(&mut self, buffer_id: BufferId, enabled: bool) {
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .expect("active window present")
+            .buffer_state_mut(buffer_id)
+        {
+            state.indentation_guide_override = Some(enabled);
+        }
+    }
+
     /// Handle SetLineWrap command
     pub(super) fn handle_set_line_wrap(
         &mut self,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1070,6 +1070,7 @@ impl Editor {
                 editing_disabled,
                 hidden_from_tabs,
                 initial_cursor_line,
+                indentation_guide,
                 request_id,
             } => {
                 self.handle_create_virtual_buffer_with_content(
@@ -1082,6 +1083,7 @@ impl Editor {
                     editing_disabled,
                     hidden_from_tabs,
                     initial_cursor_line,
+                    indentation_guide,
                     request_id,
                 );
             }
@@ -1809,6 +1811,7 @@ impl Editor {
         show_line_numbers: bool,
         show_cursors: bool,
         editing_disabled: bool,
+        indentation_guide: Option<bool>,
     ) {
         if let Some(state) = self
             .windows
@@ -1820,6 +1823,12 @@ impl Editor {
             state.margins.configure_for_line_numbers(show_line_numbers);
             state.show_cursors = show_cursors;
             state.editing_disabled = editing_disabled;
+            // `None` leaves the default (virtual buffers get no guides); a
+            // plugin that shows real source in a virtual buffer (e.g. git log's
+            // file-at-commit view) passes `Some(true)` to keep them.
+            if let Some(enabled) = indentation_guide {
+                state.indentation_guide_override = Some(enabled);
+            }
         }
     }
 
@@ -1847,7 +1856,13 @@ impl Editor {
         let buffer_id =
             self.active_window_mut()
                 .create_virtual_buffer(name.clone(), mode, read_only);
-        self.configure_vbuf_display(buffer_id, show_line_numbers, show_cursors, editing_disabled);
+        self.configure_vbuf_display(
+            buffer_id,
+            show_line_numbers,
+            show_cursors,
+            editing_disabled,
+            None,
+        );
         if let Some(pid) = panel_id {
             self.panel_ids_mut().insert(pid.to_string(), buffer_id);
         }
@@ -2867,6 +2882,7 @@ impl Editor {
         editing_disabled: bool,
         hidden_from_tabs: bool,
         initial_cursor_line: Option<u32>,
+        indentation_guide: Option<bool>,
         request_id: Option<u64>,
     ) {
         // Hidden-from-tabs buffers (e.g. composite source panes) must NOT be
@@ -2896,7 +2912,13 @@ impl Editor {
         // margins each frame via configure_for_line_numbers(), making the margin
         // setting here effectively write-only. Consider removing the margin call
         // and only setting BufferViewState.show_line_numbers.
-        self.configure_vbuf_display(buffer_id, show_line_numbers, show_cursors, editing_disabled);
+        self.configure_vbuf_display(
+            buffer_id,
+            show_line_numbers,
+            show_cursors,
+            editing_disabled,
+            indentation_guide,
+        );
         if !hidden_from_tabs {
             let active_split = self.split_manager().active_split();
             if let Some(view_state) = self
@@ -3083,7 +3105,13 @@ impl Editor {
             buffer_id
         );
 
-        self.configure_vbuf_display(buffer_id, show_line_numbers, show_cursors, editing_disabled);
+        self.configure_vbuf_display(
+            buffer_id,
+            show_line_numbers,
+            show_cursors,
+            editing_disabled,
+            None,
+        );
 
         if let Some(pid) = panel_id {
             self.panel_ids_mut().insert(pid, buffer_id);
@@ -3228,7 +3256,13 @@ impl Editor {
             buffer_id
         );
 
-        self.configure_vbuf_display(buffer_id, show_line_numbers, show_cursors, editing_disabled);
+        self.configure_vbuf_display(
+            buffer_id,
+            show_line_numbers,
+            show_cursors,
+            editing_disabled,
+            None,
+        );
 
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries) {
             tracing::error!("Failed to set virtual buffer content: {}", e);

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -567,6 +567,9 @@ impl Editor {
             PluginCommand::SetLineNumbers { buffer_id, enabled } => {
                 self.handle_set_line_numbers(buffer_id, enabled);
             }
+            PluginCommand::SetIndentationGuide { buffer_id, enabled } => {
+                self.handle_set_indentation_guide(buffer_id, enabled);
+            }
             PluginCommand::SetViewMode { buffer_id, mode } => {
                 self.handle_set_view_mode(buffer_id, &mode);
             }

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -197,6 +197,15 @@ pub struct EditorState {
     /// wheel is ignored and no scrollbar is drawn.
     pub scrollable: bool,
 
+    /// Explicit per-buffer override for indentation-guide visibility.
+    /// `None` = follow the default (the global `editor.indentation_guide`,
+    /// except virtual buffers which default off — guides are a source-code aid,
+    /// like the column rulers). `Some(false)` = force off; `Some(true)` = force
+    /// on using the global mode. Set via the `setIndentationGuide` plugin API so
+    /// a file-backed tool view that the virtual-buffer default can't catch — the
+    /// Git Log commit-detail diff is the motivating case — can opt out.
+    pub indentation_guide_override: Option<bool>,
+
     /// Per-buffer user settings (tab size, indentation style, etc.)
     /// These settings are preserved across file reloads (auto-revert)
     pub buffer_settings: BufferSettings,
@@ -295,6 +304,7 @@ impl EditorState {
             cursor_visibility_locked: false,
             editing_disabled: false,
             scrollable: true,
+            indentation_guide_override: None,
             buffer_settings: BufferSettings::default(),
             reference_highlighter: ReferenceHighlighter::new(),
             is_composite_buffer: false,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -441,6 +441,23 @@ pub(crate) fn render_content(
                 &view_prefs.rulers
             };
 
+            // Indentation guides are a source-code editing aid, like the column
+            // rulers above. Resolve the effective mode per buffer: an explicit
+            // plugin override (`setIndentationGuide`) wins; otherwise virtual
+            // buffers (grep results, *Diagnostics*, the Git Log commit list, …)
+            // default off because they aren't code, while ordinary file buffers
+            // follow the global setting. A file-backed tool view the virtual
+            // default can't catch — the Git Log commit-detail diff — opts out via
+            // the override. This is independent of the line-number gutter, so an
+            // ordinary buffer keeps its guides with line numbers turned off.
+            let mut style = style;
+            style.cfg.indentation_guide = match state.indentation_guide_override {
+                Some(true) => style.cfg.indentation_guide,
+                Some(false) => IndentationGuideMode::None,
+                None if is_virtual_buffer => IndentationGuideMode::None,
+                None => style.cfg.indentation_guide,
+            };
+
             let mut empty_folds = FoldManager::new();
             let folds = split_view_states
                 .as_deref_mut()

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -791,6 +791,7 @@ fn test_next_buffer_skips_hidden_buffers() {
         editing_disabled: true,
         hidden_from_tabs: true, // <-- This makes it hidden
         initial_cursor_line: None,
+        indentation_guide: None,
         request_id: None,
     };
     harness

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -134,3 +134,30 @@ fn indentation_guide_all_mode_continues_through_blank_line_in_editor_flow() {
         "indentation guide should resume on the line after the blank\n{screen}"
     );
 }
+
+#[test]
+fn indentation_guide_renders_independently_of_line_numbers() {
+    // Indentation guides and the line-number gutter are independent preferences:
+    // turning line numbers off must NOT take the guides with it. A user can want
+    // a chrome-free gutter and still rely on the guides to read code structure.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_no_line_numbers.rs");
+    std::fs::write(&file_path, "fn main() {\n    let child = 1;\n}\n").unwrap();
+
+    for line_numbers in [true, false] {
+        let mut config = Config::default();
+        config.editor.indentation_guide = IndentationGuideMode::All;
+        config.editor.line_numbers = line_numbers;
+
+        let mut harness =
+            EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+        harness.open_file(&file_path).unwrap();
+        harness.render().unwrap();
+
+        let screen = harness.screen_to_string();
+        assert!(
+            screen.contains("▏   let child = 1;"),
+            "indentation guide should render with line_numbers={line_numbers}\n{screen}"
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
@@ -61,3 +61,62 @@ fn git_log_view_does_not_render_indentation_guides() {
         "Git Log panels must not render indentation guides (`▏`).\nScreen:\n{screen}"
     );
 }
+
+// Pressing Enter on a diff line opens that file at the commit version — a
+// read-only *virtual* buffer showing real source. Virtual buffers default to
+// no guides, but this one is code the user is reading, so git_log opts it back
+// in via `createVirtualBuffer({ indentationGuide: true })`. The guides must
+// render there (regression: they didn't, because the virtual default hid them).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn git_log_file_opened_at_commit_shows_indentation_guides() {
+    let repo = GitTestRepo::new();
+    repo.create_file("indented.rs", "fn main() {\n    let x = 1;\n}\n");
+    repo.git_add(&["indented.rs"]);
+    repo.git_commit("Add indented file");
+    repo.setup_git_log_plugin();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, config, repo.path.clone()).unwrap();
+    harness.open_file(&repo.path.join("indented.rs")).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane") && s.contains("Add indented file")
+        })
+        .unwrap();
+
+    // Focus the detail pane, then move down into the diff body so the cursor
+    // sits inside indented.rs's `+++ b/…` section (git_log derives the file to
+    // open by scanning backward from the cursor for that header).
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    for _ in 0..40 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // The file-at-commit view opens; its indented body must carry guides.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("let x = 1"))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains('▏'),
+        "a file opened at a commit version should render indentation guides (`▏`).\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
@@ -1,0 +1,63 @@
+//! Regression test: indentation guides must not leak into the Git Log view.
+//!
+//! The Git Log command opens a magit-style buffer group — a commit list beside
+//! a commit-detail diff — rendered as inner group-leaf panels with no
+//! code-editing chrome. With `editor.indentation_guide = "all"` the global
+//! setting used to apply to those panels too, painting a stray `▏` into column
+//! 0 of the commit list and over the four-space-indented commit-message lines
+//! in the diff. Indentation guides are a source-code editing aid; they don't
+//! belong in a tool view. This opens the log with guides enabled and asserts no
+//! guide glyph renders — independent of line numbers (a separate preference).
+
+use crate::common::git_test_helper::GitTestRepo;
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, IndentationGuideMode};
+
+// TODO: git command output differs on Windows; the other git_log tests skip it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn git_log_view_does_not_render_indentation_guides() {
+    let repo = GitTestRepo::new();
+    // An indented source file: `git show`'s commit message is itself indented
+    // four spaces, so the commit-detail panel carries column-0 guide bait
+    // regardless of the diff body.
+    repo.create_file("indented.rs", "fn main() {\n    let x = 1;\n}\n");
+    repo.git_add(&["indented.rs"]);
+    repo.git_commit("Add indented file");
+    repo.setup_git_log_plugin();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, config, repo.path.clone()).unwrap();
+
+    // Anchor on a real file tab, then open the full-repo Git Log.
+    harness.open_file(&repo.path.join("indented.rs")).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Both panels have painted once the toolbar hint ("switch pane") and the
+    // commit-detail diff (the selected commit's `Author:` line) are on screen.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane") && s.contains("Author:")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains('▏'),
+        "Git Log panels must not render indentation guides (`▏`).\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -35,6 +35,7 @@ pub mod file_explorer_slots;
 pub mod find_file;
 pub mod git;
 pub mod git_log_current_file;
+pub mod git_log_indent_guide;
 pub mod git_log_split_tab_focus;
 pub mod git_statusbar;
 pub mod goto_with_selection;

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -6164,6 +6164,7 @@ impl Editor {
                 editing_disabled,
                 hidden_from_tabs,
                 initial_cursor_line: _,
+                indentation_guide: _,
                 request_id,
             } => {
                 let buffer_id = self.create_virtual_buffer(name.clone(), mode.clone(), read_only);

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -33,6 +33,7 @@ fn reproduce_cursor_panic() {
         editing_disabled: false,
         hidden_from_tabs: false,
         initial_cursor_line: None,
+        indentation_guide: None,
         request_id: None,
     };
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5380,6 +5380,7 @@ impl JsEditorApi {
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 hidden_from_tabs: opts.hidden_from_tabs.unwrap_or(false),
                 initial_cursor_line: opts.initial_cursor_line,
+                indentation_guide: opts.indentation_guide,
                 request_id: Some(id),
             });
         Ok(id)

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4914,6 +4914,18 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Enable or disable indentation guides for a buffer, overriding the global
+    /// `editor.indentation_guide` setting. Tool views that render non-editable
+    /// content (e.g. the Git Log commit-detail diff) disable them.
+    pub fn set_indentation_guide(&self, buffer_id: u32, enabled: bool) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetIndentationGuide {
+                buffer_id: BufferId(buffer_id as usize),
+                enabled,
+            })
+            .is_ok()
+    }
+
     /// Set the view mode for a buffer ("source" or "compose")
     pub fn set_view_mode(&self, buffer_id: u32, mode: String) -> bool {
         self.command_sender

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1400,6 +1400,7 @@ mod tests {
             "setLineIndicator",
             "clearLineIndicators",
             "setLineNumbers",
+            "setIndentationGuide",
             "setViewMode",
             "setViewState",
             "getViewState",


### PR DESCRIPTION
## Problem

Indentation guides were drawn for every buffer straight from the global `editor.indentation_guide` setting, so they leaked into tool views. Most visibly, the **Git Log** buffer group showed a guide glyph (`▏`) in column 0 of the commit list and over git's four-space-indented commit-message lines in the commit-detail diff — a read-only summary view with no indentation model.

## Approach

Indentation guides are a source-code editing aid, so the decision follows the *nature of the buffer*, not where it happens to be laid out. (An earlier iteration keyed off `is_inner_group_leaf` — "is this buffer in a buffer group" — but that couples a content decision to a layout primitive: a plugin grouping ordinary code files would silently lose its guides.)

The effective mode is resolved **per buffer**, mirroring how the column rulers a few lines above are already suppressed for virtual buffers:

- **Virtual buffers** (grep results, `*Diagnostics*`, the Git Log commit list, …) default **off** — they aren't code.
- **Ordinary file buffers** follow the global setting, **independent of the line-number gutter** — turning line numbers off keeps guides in real code.
- A per-buffer override lets a view opt in/out explicitly, mirroring `setLineNumbers`:
  - **`setIndentationGuide(bufferId, enabled)`** for an existing buffer — the Git Log **detail** panel (a file-backed `git show` dump) opts *out*.
  - **`createVirtualBuffer({ indentationGuide })`** at creation (parallel to `showLineNumbers`) — the Git Log **file-at-commit** view (`RET` on a diff line opens a read-only virtual buffer of real source) opts *in*, so it keeps its guides.

## Changes

- `EditorState::indentation_guide_override: Option<bool>` (per-buffer); render resolves `override → virtual-default → global`.
- `PluginCommand::SetIndentationGuide` + `setIndentationGuide` binding; `indentationGuide` option on `createVirtualBuffer` (threaded through `CreateVirtualBufferWithContent` → `configure_vbuf_display`); regenerated `fresh.d.ts`.
- `git_log.ts`: detail diff → guides off; file-at-commit view → guides on.

## Testing

- `git_log_view_does_not_render_indentation_guides` — no guide glyph in the log view (fails without the change).
- `git_log_file_opened_at_commit_shows_indentation_guides` — opening a file at a commit from the log renders guides (fails without the `indentationGuide` option).
- `indentation_guide_renders_independently_of_line_numbers` — guides render with line numbers on **and** off in an ordinary buffer.
- Existing indentation-guide / git-log / buffer-lifecycle e2e suites and split-rendering unit tests pass; `cargo fmt --check`, `cargo clippy --all-targets` (0 errors), `cargo check --all-targets`, and the `fresh.d.ts` regen test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnnKmUM2dmnEhtCULfpkss