### PR TITLE
Add diagnostics for SSH workspace navigation lag

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4392,11 +4392,20 @@ where
         // Run shared per-tick housekeeping (async messages, timers, auto-save, etc.)
         {
             let _span = tracing::info_span!("editor_tick").entered();
+            // DIAGNOSTIC (ssh-workspace-nav-lag): time editor_tick so a slow
+            // tick (e.g. a synchronous remote op in the polls / plugin-command
+            // processing) shows up as an `input_lag` WARN even if it never
+            // goes through the agent channel's blocking helpers.
+            let tick_start = std::time::Instant::now();
             if fresh::app::editor_tick(editor, || {
                 terminal.clear()?;
                 Ok(())
             })? {
                 needs_render = true;
+            }
+            let tick_ms = tick_start.elapsed().as_millis();
+            if tick_ms > 40 {
+                tracing::warn!(target: "input_lag", phase = "editor_tick", elapsed_ms = tick_ms);
             }
         }
 
@@ -4566,7 +4575,23 @@ where
             ),
             _ => None,
         };
-        if editor.handle_input_event(event)? {
+        // DIAGNOSTIC (ssh-workspace-nav-lag): time raw input dispatch so a
+        // slow keystroke (cursor move firing a synchronous remote/plugin op)
+        // shows up as an `input_lag` WARN with the key that triggered it.
+        // `event` is moved into the dispatch, so capture a descriptor first.
+        let ev_dbg = format!("{event:?}");
+        let input_start = std::time::Instant::now();
+        let input_needs_render = editor.handle_input_event(event)?;
+        let input_ms = input_start.elapsed().as_millis();
+        if input_ms > 40 {
+            tracing::warn!(
+                target: "input_lag",
+                phase = "handle_input_event",
+                elapsed_ms = input_ms,
+                event = ev_dbg,
+            );
+        }
+        if input_needs_render {
             needs_render = true;
         }
     }

--- a/crates/fresh-editor/src/services/remote/channel.rs
+++ b/crates/fresh-editor/src/services/remote/channel.rs
@@ -15,6 +15,32 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 
+/// DIAGNOSTIC (ssh-workspace-nav-lag): emit a `remote_block` WARN when a
+/// synchronous agent round-trip blocks its calling thread for longer than
+/// this. 30ms is below a single keystroke's frame budget but well above a
+/// local round-trip, so on a laggy SSH link any per-keystroke blocking call
+/// crosses it and is logged once per keystroke.
+const REMOTE_BLOCK_WARN_THRESHOLD_MS: u128 = 30;
+
+/// DIAGNOSTIC (ssh-workspace-nav-lag): log a blocking agent round-trip that
+/// exceeded the warn threshold, naming the method, the elapsed time, and the
+/// thread it blocked. The thread name pinpoints whether the stall is on the
+/// UI/main thread (felt as input lag) or a background poller (harmless).
+/// Filter with `RUST_LOG=remote_block=warn` or grep the warnings log for
+/// `remote_block`.
+fn log_blocking_roundtrip(method: &str, started: std::time::Instant) {
+    let elapsed_ms = started.elapsed().as_millis();
+    if elapsed_ms > REMOTE_BLOCK_WARN_THRESHOLD_MS {
+        tracing::warn!(
+            target: "remote_block",
+            method,
+            elapsed_ms,
+            thread = std::thread::current().name().unwrap_or("unnamed"),
+            "blocking agent round-trip"
+        );
+    }
+}
+
 /// Default capacity for the per-request streaming data channel.
 const DEFAULT_DATA_CHANNEL_CAPACITY: usize = 64;
 
@@ -513,7 +539,16 @@ impl AgentChannel {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, ChannelError> {
-        self.runtime_handle.block_on(self.request(method, params))
+        // DIAGNOSTIC (ssh-workspace-nav-lag): time every synchronous agent
+        // round-trip and warn when one blocks the calling thread for a
+        // noticeable stretch. On a laggy SSH link, a per-keystroke blocking
+        // call shows up here as one WARN per keystroke, naming the method and
+        // the thread it blocked (the UI/main thread is the one that matters).
+        // Grep the warnings log for the `remote_block` target.
+        let started = std::time::Instant::now();
+        let result = self.runtime_handle.block_on(self.request(method, params));
+        log_blocking_roundtrip(method, started);
+        result
     }
 
     /// Send a request and collect all streaming data along with the final result
@@ -568,8 +603,13 @@ impl AgentChannel {
         method: &str,
         params: serde_json::Value,
     ) -> Result<(Vec<serde_json::Value>, serde_json::Value), ChannelError> {
-        self.runtime_handle
-            .block_on(self.request_with_data(method, params))
+        // DIAGNOSTIC (ssh-workspace-nav-lag): see `request_blocking`.
+        let started = std::time::Instant::now();
+        let result = self
+            .runtime_handle
+            .block_on(self.request_with_data(method, params));
+        log_blocking_roundtrip(method, started);
+        result
     }
 
     /// Send a streaming request synchronously, returning receivers for


### PR DESCRIPTION
## Summary
This PR adds comprehensive diagnostic logging to identify and track input lag issues when working with remote SSH workspaces. The changes instrument both the agent communication layer and the main event loop to detect and report blocking operations that exceed acceptable latency thresholds.

## Key Changes

- **Remote agent channel diagnostics**: Added `log_blocking_roundtrip()` function and timing instrumentation to `request_blocking()` and `request_with_data_blocking()` methods to detect when synchronous agent round-trips block the calling thread for longer than 30ms. These are logged to the `remote_block` target.

- **Main event loop diagnostics**: Added timing instrumentation to two critical paths in the editor's main loop:
  - `editor_tick()`: Detects slow ticks (>40ms) that may indicate synchronous remote operations during polling or plugin command processing
  - `handle_input_event()`: Detects slow keystroke handling (>40ms) and logs which key triggered the lag
  - Both log to the `input_lag` target with phase information and elapsed time

- **Diagnostic logging design**: The thresholds and targets are chosen to:
  - Use 30ms for remote operations (below a single keystroke's frame budget but well above typical local round-trips)
  - Use 40ms for main loop operations (approximately one frame at 24fps)
  - Log to separate targets (`remote_block` and `input_lag`) for easy filtering
  - Include thread names to distinguish UI/main thread stalls (user-visible) from background thread stalls (harmless)
  - Include event descriptors and method names to correlate lag with specific user actions

## Implementation Details

- All timing uses `std::time::Instant` for precision
- Logging uses structured tracing with named fields for easy filtering and analysis
- Comments explain the diagnostic purpose and how to filter/grep the logs
- The instrumentation is minimal and non-invasive, only logging when thresholds are exceeded

https://claude.ai/code/session_01SWGkSrXSbN83vK42EEeXYD