### PR TITLE
fix(build): silence spurious ts-rs serde-attribute parse warnings (#2519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* **Build**: `cargo install` / `cargo build` no longer emits spurious `failed to parse serde attribute` warnings from ts-rs for `#[serde(transparent)]` and `#[serde(serialize_with = …)]` attributes it intentionally ignores (#2519).
 * **Settings UI**: committing a text field with `Tab` now persists the typed value on Save, matching `Enter`. Previously the row showed as modified but Save wrote an empty value (#2515).
 
 ## 0.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ crossterm = "0.29"
 winit = "0.30"
 wgpu = "28.0"
 lsp-types = "0.97"
-ts-rs = { version = "12.0", features = ["serde_json"] }
+ts-rs = { version = "12.0", features = ["serde_json", "no-serde-warnings"] }
 # Add more as needed during refactor
 
 [profile.release]


### PR DESCRIPTION
## Summary

Fixes #2519.

`cargo install` / `cargo build` of `fresh-core` emitted three spurious warnings:

```
warning: failed to parse serde attribute
  | transparent
  = note: ts-rs failed to parse this attribute. It will be ignored.
warning: failed to parse serde attribute
  | serialize_with = "serialize_path"
  ...
warning: failed to parse serde attribute
  | serialize_with = "serialize_ranges_as_tuples"
  ...
```

## Root cause

ts-rs 12's `serde-compat` scans every `#[serde(...)]` attribute and prints a
`failed to parse serde attribute` warning for any attribute it doesn't
recognize. Three of our attributes trip it:

- `#[serde(transparent)]` on `BufferId` (`crates/fresh-core/src/lib.rs`)
- `#[serde(serialize_with = "serialize_path")]` (`crates/fresh-core/src/api.rs`)
- `#[serde(serialize_with = "serialize_ranges_as_tuples")]` (`crates/fresh-core/src/api.rs`)

ts-rs ignoring these is the correct behavior — they are serialization-only
concerns, and the affected types already carry explicit `#[ts(type = ...)]`
annotations. So the warnings are pure noise.

## Fix

Enable ts-rs's purpose-built `no-serde-warnings` feature on the workspace
dependency. It suppresses these benign warnings while keeping the default
`serde-compat` feature active, so `rename_all` / `tag` / etc. continue to be
honored by ts-rs.

```diff
-ts-rs = { version = "12.0", features = ["serde_json"] }
+ts-rs = { version = "12.0", features = ["serde_json", "no-serde-warnings"] }
```

## Testing / validation

These are compile-time proc-macro diagnostics with no runtime behavior, so the
build output is itself the reproducer. Verified by a clean rebuild of the
affected crates:

| | `failed to parse serde attribute` warnings |
|---|---|
| before | 3 |
| after | 0 |

```
$ cargo build -p fresh-core -p fresh-plugin-runtime
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 29s
# 0 serde-attribute warnings, 0 compiler warnings
```

CHANGELOG updated under *Unreleased → Bug Fixes*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wP8UPDATsywv8KNqTxiFD

---
_Generated by [Claude Code](https://claude.ai/code/session_016wP8UPDATsywv8KNqTxiFD)_