### PR TITLE
Enable rquickjs bindgen feature on NetBSD

### DIFF
--- a/crates/fresh-core/Cargo.toml
+++ b/crates/fresh-core/Cargo.toml
@@ -23,6 +23,10 @@ rquickjs-serde = { workspace = true, optional = true }
 [target.'cfg(target_os = "freebsd")'.dependencies]
 rquickjs = { workspace = true, optional = true, features = ["bindgen"] }
 
+# rquickjs-sys has no pre-generated bindings for NetBSD
+[target.'cfg(target_os = "netbsd")'.dependencies]
+rquickjs = { workspace = true, optional = true, features = ["bindgen"] }
+
 [dev-dependencies]
 proptest = "1.9"
 

--- a/crates/fresh-plugin-runtime/Cargo.toml
+++ b/crates/fresh-plugin-runtime/Cargo.toml
@@ -32,3 +32,7 @@ trash = "5.2.5"
 # rquickjs-sys has no pre-generated bindings for FreeBSD
 [target.'cfg(target_os = "freebsd")'.dependencies]
 rquickjs = { workspace = true, features = ["bindgen"] }
+
+# rquickjs-sys has no pre-generated bindings for NetBSD
+[target.'cfg(target_os = "netbsd")'.dependencies]
+rquickjs = { workspace = true, features = ["bindgen"] }


### PR DESCRIPTION
## What

Add a `target_os = "netbsd"` dependency block that enables the `bindgen`
feature for `rquickjs` in the two crates that depend on it
(`fresh-core` and `fresh-plugin-runtime`), mirroring the existing
FreeBSD workaround.

## Why

`rquickjs-sys` ships pre-generated C bindings only for a handful of
platforms; NetBSD is not among them. Without the `bindgen` feature the
build fails on NetBSD because no bindings are available. Enabling
`bindgen` makes `rquickjs-sys` generate them at compile time, exactly as
already done for FreeBSD.

This lets NetBSD build `fresh` from the upstream source unmodified. It
is currently carried as a local patch in pkgsrc-wip; upstreaming it
removes the need to maintain that patch.

## Scope

Build configuration only — no behavior change on existing platforms,
since the new block is gated on `cfg(target_os = "netbsd")`.