### PR TITLE
Fix language settings field edits: keep committed values, Esc cancels

### DIFF
--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -141,6 +141,26 @@ pub struct EntryDialogState {
     /// with no global fallback) it's labelled `[Clear]`, since null just unsets
     /// the value rather than inheriting one. Empty means "nothing inherits".
     pub inheritable_fields: HashSet<String>,
+    /// Snapshot of the field being text-edited, captured the moment editing
+    /// begins (before `start_editing` mutates the control). Esc restores it so
+    /// an in-progress edit is discarded — the platform convention where Enter
+    /// and Tab commit a field while Esc cancels it. `None` whenever no edit is
+    /// in flight.
+    edit_snapshot: Option<FieldEditSnapshot>,
+}
+
+/// Pre-edit state of a single dialog field, used to revert an abandoned edit.
+/// Cloning the whole control covers every editable kind uniformly (Text,
+/// Number, TextList, Json) — each restores its exact text/value, cursor, and
+/// buffers. `is_null` and the dialog-level `user_edited` flag are captured too
+/// so reverting also undoes the "field is now set / dialog is dirty" side
+/// effects that typing triggered via `mark_field_edited`.
+#[derive(Debug, Clone)]
+struct FieldEditSnapshot {
+    item_index: usize,
+    control: SettingControl,
+    is_null: bool,
+    user_edited: bool,
 }
 
 impl EntryDialogState {
@@ -246,6 +266,7 @@ impl EntryDialogState {
             user_edited: false,
             field_button_focus: None,
             inheritable_fields: HashSet::new(),
+            edit_snapshot: None,
         };
         // Pre-focus the first item in any ObjectArray controls so pressing
         // Enter opens the item editor instead of "Add new".
@@ -326,6 +347,7 @@ impl EntryDialogState {
             user_edited: false,
             field_button_focus: None,
             inheritable_fields: HashSet::new(),
+            edit_snapshot: None,
         }
     }
 
@@ -1217,6 +1239,30 @@ impl EntryDialogState {
 
     /// Start text editing mode for the current control
     pub fn start_editing(&mut self) {
+        // Snapshot the field *before* mutating it, so Esc can revert an
+        // abandoned edit to exactly what it was. Only the editable text
+        // controls below enter edit mode, so only those are worth snapshotting.
+        if !self.focus_on_buttons {
+            if let Some(item) = self.items.get(self.selected_item) {
+                if item.read_only {
+                    return;
+                }
+                if matches!(
+                    item.control,
+                    SettingControl::Text(_)
+                        | SettingControl::TextList(_)
+                        | SettingControl::Number(_)
+                        | SettingControl::Json(_)
+                ) {
+                    self.edit_snapshot = Some(FieldEditSnapshot {
+                        item_index: self.selected_item,
+                        control: item.control.clone(),
+                        is_null: item.is_null,
+                        user_edited: self.user_edited,
+                    });
+                }
+            }
+        }
         if let Some(item) = self.current_item_mut() {
             // Don't allow editing read-only fields
             if item.read_only {
@@ -1254,33 +1300,52 @@ impl EntryDialogState {
         }
     }
 
-    /// Stop text editing mode
+    /// Commit text editing mode. This is the *accept* path — Enter, Tab, and
+    /// clicking away (blur) all land here, following the platform convention
+    /// that those gestures keep the typed value. Esc takes `revert_editing`
+    /// instead.
     pub fn stop_editing(&mut self) {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
-                // Enter/Tab/Esc all *accept* the field in this dialog (see the
-                // input handler), exactly like a Text field keeps its typed
-                // value. A number's typed digits live in a separate edit buffer
-                // that only flushes into `value` on confirm; cancelling here
-                // dropped them, so every tab-size / page-width edit reverted to
-                // the old value on commit. Confirm so the typed value sticks.
+                // A number's typed digits live in a separate edit buffer that
+                // only flushes into `value` on confirm; without this every
+                // tab-size / page-width edit reverted to the old value on
+                // commit. Confirm so the typed value sticks.
                 SettingControl::Number(state) => state.confirm_editing(),
                 SettingControl::Text(state) => state.editing = false,
-                // Cancelling on a pending list row (the trailing
-                // [+] add-new slot) discards whatever the user typed
-                // and collapses the row back to `[+] Add new`. Without
-                // this, Esc was a silent no-op that left the draft
-                // text dangling until the user committed or cleared it
-                // manually.
+                // On the trailing `[+] Add new` slot the pending draft has
+                // already been flushed to the list by the Enter/Tab handler;
+                // collapse the slot back to `[+] Add new`.
                 SettingControl::TextList(state) if state.focused_item.is_none() => {
                     state.cancel_pending();
                 }
-                // If the user opened a JSON field but didn't type
-                // anything (or deleted everything), put the `null`
-                // sentinel back so the value still round-trips as JSON.
+                // If the user opened a JSON field but didn't type anything (or
+                // deleted everything), put the `null` sentinel back so the
+                // value still round-trips as JSON.
                 SettingControl::Json(state) => state.restore_unset_if_empty(),
                 _ => {}
             }
+        }
+        // The edit was accepted — there is nothing left to revert.
+        self.edit_snapshot = None;
+        self.editing_text = false;
+    }
+
+    /// Cancel text editing mode, discarding the in-progress edit and restoring
+    /// the field to its pre-edit state. This is the Esc path — matching the
+    /// Windows/macOS/web convention where Esc reverts an edit while Enter and
+    /// Tab commit it. If no snapshot was captured (e.g. a control that mutates
+    /// nothing until commit), this still exits edit mode cleanly.
+    pub fn revert_editing(&mut self) {
+        if let Some(snap) = self.edit_snapshot.take() {
+            if let Some(item) = self.items.get_mut(snap.item_index) {
+                item.control = snap.control;
+                item.is_null = snap.is_null;
+            }
+            // Restore the dialog's dirty flag to what it was before this edit,
+            // so reverting the *only* change also drops the "unsaved" state
+            // while preserving edits made to other fields earlier.
+            self.user_edited = snap.user_edited;
         }
         self.editing_text = false;
     }
@@ -2088,5 +2153,209 @@ mod tests {
             &HashMap::new(),
         );
         assert_eq!(no_delete_dialog.button_count(), 2); // Save, Cancel (no Delete)
+    }
+
+    // ---- Esc-reverts / Enter-commits field editing --------------------------
+
+    /// Build a single-property schema whose one field has the given type, so a
+    /// dialog can be driven straight to that control.
+    fn prop_schema(path: &str, name: &str, ty: SettingType) -> SettingSchema {
+        SettingSchema {
+            path: "/test".to_string(),
+            name: "Test".to_string(),
+            description: None,
+            setting_type: SettingType::Object {
+                properties: vec![SettingSchema {
+                    path: path.to_string(),
+                    name: name.to_string(),
+                    description: None,
+                    setting_type: ty,
+                    default: None,
+                    read_only: false,
+                    section: None,
+                    order: None,
+                    nullable: false,
+                    enum_from: None,
+                    dual_list_sibling: None,
+                    dynamically_extendable_status_bar_elements: false,
+                }],
+            },
+            default: None,
+            read_only: false,
+            section: None,
+            order: None,
+            nullable: false,
+            enum_from: None,
+            dual_list_sibling: None,
+            dynamically_extendable_status_bar_elements: false,
+        }
+    }
+
+    /// Focus the field at `path` (leaving button focus), returning its index.
+    fn select_field(dialog: &mut EntryDialogState, path: &str) -> usize {
+        let idx = dialog
+            .items
+            .iter()
+            .position(|it| it.path == path)
+            .expect("field should exist");
+        dialog.selected_item = idx;
+        dialog.focus_on_buttons = false;
+        idx
+    }
+
+    /// Esc reverts a Text field to its original string; the edit is discarded.
+    #[test]
+    fn esc_reverts_text_field() {
+        let schema = prop_schema("/grammar", "Grammar", SettingType::String);
+        let mut dialog = EntryDialogState::from_schema(
+            "k".to_string(),
+            &serde_json::json!({ "grammar": "typescript" }),
+            &schema,
+            "/test",
+            false,
+            false,
+            &HashMap::new(),
+        );
+        let idx = select_field(&mut dialog, "/grammar");
+
+        dialog.start_editing();
+        dialog.insert_char('X');
+        dialog.insert_char('Y');
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!("typescriptXY"),
+            "sanity: the edit is applied live before reverting"
+        );
+
+        dialog.revert_editing();
+        assert!(!dialog.editing_text, "revert exits edit mode");
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!("typescript"),
+            "Esc must restore the original text"
+        );
+    }
+
+    /// Esc reverts a Number field to its original value (typed digits dropped).
+    #[test]
+    fn esc_reverts_number_field() {
+        let schema = prop_schema(
+            "/tab_size",
+            "Tab Size",
+            SettingType::Integer {
+                minimum: None,
+                maximum: None,
+            },
+        );
+        let mut dialog = EntryDialogState::from_schema(
+            "k".to_string(),
+            &serde_json::json!({ "tab_size": 4 }),
+            &schema,
+            "/test",
+            false,
+            false,
+            &HashMap::new(),
+        );
+        let idx = select_field(&mut dialog, "/tab_size");
+
+        dialog.start_editing();
+        dialog.insert_char('9'); // replaces the selected "4" in the edit buffer
+        dialog.revert_editing();
+
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!(4),
+            "Esc must restore the original number"
+        );
+    }
+
+    /// Esc reverts an in-place edit of an existing TextList item — the case the
+    /// old accept-on-Esc path silently kept.
+    #[test]
+    fn esc_reverts_textlist_item_edit() {
+        let schema = prop_schema("/extensions", "Extensions", SettingType::StringArray);
+        let mut dialog = EntryDialogState::from_schema(
+            "k".to_string(),
+            &serde_json::json!({ "extensions": ["ts", "tsx"] }),
+            &schema,
+            "/test",
+            false,
+            false,
+            &HashMap::new(),
+        );
+        let idx = select_field(&mut dialog, "/extensions");
+
+        // Put the control into "editing the first existing item" state.
+        if let SettingControl::TextList(state) = &mut dialog.items[idx].control {
+            state.focused_item = Some(0);
+            state.cursor = state.items[0].len();
+        }
+        dialog.start_editing();
+        dialog.insert_char('Z'); // "ts" -> "tsZ"
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!(["tsZ", "tsx"]),
+            "sanity: the item is mutated live before reverting"
+        );
+
+        dialog.revert_editing();
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!(["ts", "tsx"]),
+            "Esc must restore the original list items"
+        );
+    }
+
+    /// Esc reverts a JSON/object field (a language `formatter`) to its original.
+    #[test]
+    fn esc_reverts_json_field() {
+        let schema = prop_schema("/formatter", "Formatter", SettingType::Complex);
+        let mut dialog = EntryDialogState::from_schema(
+            "k".to_string(),
+            &serde_json::json!({ "formatter": { "command": "prettier" } }),
+            &schema,
+            "/test",
+            false,
+            false,
+            &HashMap::new(),
+        );
+        let idx = select_field(&mut dialog, "/formatter");
+
+        dialog.start_editing();
+        dialog.insert_char('X'); // corrupt the JSON text in the editor
+        dialog.revert_editing();
+
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!({ "command": "prettier" }),
+            "Esc must restore the original JSON value"
+        );
+    }
+
+    /// The commit path is unchanged: Enter/Tab (via `stop_editing`) keep the
+    /// typed value, so the two keys are genuinely distinct.
+    #[test]
+    fn stop_editing_commits_text_field() {
+        let schema = prop_schema("/grammar", "Grammar", SettingType::String);
+        let mut dialog = EntryDialogState::from_schema(
+            "k".to_string(),
+            &serde_json::json!({ "grammar": "typescript" }),
+            &schema,
+            "/test",
+            false,
+            false,
+            &HashMap::new(),
+        );
+        let idx = select_field(&mut dialog, "/grammar");
+
+        dialog.start_editing();
+        dialog.insert_char('X');
+        dialog.stop_editing();
+
+        assert_eq!(
+            control_to_value(&dialog.items[idx].control),
+            serde_json::json!("typescriptX"),
+            "Enter/Tab must keep the typed value"
+        );
     }
 }

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -1258,7 +1258,13 @@ impl EntryDialogState {
     pub fn stop_editing(&mut self) {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
-                SettingControl::Number(state) => state.cancel_editing(),
+                // Enter/Tab/Esc all *accept* the field in this dialog (see the
+                // input handler), exactly like a Text field keeps its typed
+                // value. A number's typed digits live in a separate edit buffer
+                // that only flushes into `value` on confirm; cancelling here
+                // dropped them, so every tab-size / page-width edit reverted to
+                // the old value on commit. Confirm so the typed value sticks.
+                SettingControl::Number(state) => state.confirm_editing(),
                 SettingControl::Text(state) => state.editing = false,
                 // Cancelling on a pending list row (the trailing
                 // [+] add-new slot) discards whatever the user typed

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -1069,7 +1069,16 @@ impl SettingsState {
 
         match event.code {
             KeyCode::Esc => {
-                // Check if current text field requires JSON validation
+                // A plain Text field: Esc cancels the in-progress edit and
+                // restores the pre-edit value (platform convention: Enter/Tab
+                // commit, Esc reverts). Previously Esc called stop_editing(),
+                // which *accepted* the edit, so there was no way to back out.
+                if self.is_editing_plain_text() {
+                    self.revert_editing();
+                    return InputResult::Consumed;
+                }
+                // Other editable controls (TextList/Map) keep their prior
+                // dismiss semantics; the JSON-validity gate only matters here.
                 if !self.can_exit_text_editing() {
                     return InputResult::Consumed;
                 }
@@ -1077,7 +1086,21 @@ impl SettingsState {
                 InputResult::Consumed
             }
             KeyCode::Enter => {
-                self.text_add_item();
+                // A plain Text field: Enter accepts the typed value and exits
+                // edit mode (platform convention, matching the footer's "Enter"
+                // hint). Previously Enter ran text_add_item — a no-op for Text —
+                // so the user was trapped in edit mode with the following
+                // Tab/Esc/arrows appearing dead. TextList/Map keep Enter = add
+                // a row and stay in edit mode so the user can keep adding.
+                if self.is_editing_plain_text() {
+                    if self.can_exit_text_editing() {
+                        self.commit_text_edit();
+                        self.stop_editing();
+                    }
+                    // Invalid text stays in edit mode until fixed or Esc.
+                } else {
+                    self.text_add_item();
+                }
                 InputResult::Consumed
             }
             KeyCode::Char(c) => {

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -137,20 +137,17 @@ impl SettingsState {
             .map(|d| d.is_editing_json())
             .unwrap_or(false);
 
-        // Check validation first before borrowing dialog mutably
-        let can_exit = self.entry_dialog_can_exit_text_editing();
-
         let Some(dialog) = self.entry_dialog_mut() else {
             return InputResult::Consumed;
         };
 
         match event.code {
             KeyCode::Esc => {
-                // Escape accepts changes (same as Tab) - exit editing mode
-                if !can_exit {
-                    // If validation fails, just stop editing anyway (accept whatever is there)
-                }
-                dialog.stop_editing();
+                // Escape cancels the in-progress field edit and restores the
+                // pre-edit value — the platform convention (Enter/Tab commit,
+                // Esc reverts). JSON validity doesn't matter here: we're
+                // throwing the edit away regardless.
+                dialog.revert_editing();
             }
             KeyCode::Enter => {
                 if is_editing_json {

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -755,20 +755,6 @@ impl SettingsState {
             .unwrap_or(true)
     }
 
-    /// Check if entry dialog's current text field can be exited (valid JSON if required)
-    pub fn entry_dialog_can_exit_text_editing(&self) -> bool {
-        self.entry_dialog()
-            .and_then(|dialog| dialog.current_item())
-            .map(|item| {
-                if let SettingControl::Text(state) = &item.control {
-                    state.is_valid()
-                } else {
-                    true
-                }
-            })
-            .unwrap_or(true)
-    }
-
     /// Initialize map focus when entering a Map control.
     /// `from_above`: true = start at first entry, false = start at add-new field
     fn init_map_focus(&mut self, from_above: bool) {

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -198,6 +198,34 @@ pub struct SettingsState {
     /// and scrolling the body updates this so Up/Down resumes from the
     /// section the user is actually looking at.
     pub tree_cursor_section: Option<usize>,
+    /// Snapshot of a plain `Text` control taken when its edit began, so Esc
+    /// can revert an abandoned edit to exactly what it was. `None` whenever a
+    /// Text edit is not in progress. See [`Self::start_editing`] /
+    /// [`Self::revert_editing`].
+    text_edit_snapshot: Option<TextEditSnapshot>,
+}
+
+/// Pre-edit state of a plain `Text` setting, captured by `start_editing` and
+/// restored by `revert_editing` (the Esc path). Enter/Tab commit instead and
+/// clear it. Reverting has to undo not just the control's typed buffer but also
+/// the pending-change bookkeeping, since a mid-edit `on_value_changed` (e.g.
+/// from Delete) can flush the buffer into `pending_changes` before Esc.
+#[derive(Debug)]
+struct TextEditSnapshot {
+    /// JSON pointer of the edited setting (`current_item().path`).
+    path: String,
+    /// The control exactly as it was before the first keystroke.
+    control: SettingControl,
+    /// `item.modified` before the edit.
+    modified: bool,
+    /// `item.layer_source` before the edit.
+    layer_source: ConfigLayer,
+    /// `item.is_null` before the edit.
+    is_null: bool,
+    /// The `pending_changes` entry for `path` before the edit (`None` = absent).
+    pending: Option<serde_json::Value>,
+    /// Whether `path` was in `pending_deletions` before the edit.
+    was_pending_deletion: bool,
 }
 
 /// One row of the left-panel tree. Either a top-level category, or a section
@@ -325,6 +353,7 @@ impl SettingsState {
             expanded_categories: std::collections::HashSet::new(),
             categories_scroll: ScrollablePanel::new(),
             tree_cursor_section: None,
+            text_edit_snapshot: None,
         })
     }
 
@@ -2154,6 +2183,36 @@ impl SettingsState {
     }
 
     pub fn start_editing(&mut self) {
+        // Snapshot a plain Text field before mutating it, so Esc can revert an
+        // abandoned edit to its pre-edit value (Enter/Tab commit, Esc cancels).
+        // Only plain Text gets this treatment; TextList/Map/Json/DualList keep
+        // their own in-place dismiss semantics.
+        self.text_edit_snapshot = None;
+        let text_snap = self.current_item().and_then(|item| {
+            matches!(item.control, SettingControl::Text(_)).then(|| {
+                (
+                    item.path.clone(),
+                    item.control.clone(),
+                    item.modified,
+                    item.layer_source,
+                    item.is_null,
+                )
+            })
+        });
+        if let Some((path, control, modified, layer_source, is_null)) = text_snap {
+            let pending = self.pending_changes.get(&path).cloned();
+            let was_pending_deletion = self.pending_deletions.contains(&path);
+            self.text_edit_snapshot = Some(TextEditSnapshot {
+                path,
+                control,
+                modified,
+                layer_source,
+                is_null,
+                pending,
+                was_pending_deletion,
+            });
+        }
+
         if let Some(item) = self.current_item() {
             if matches!(
                 item.control,
@@ -2207,9 +2266,12 @@ impl SettingsState {
         is_text
     }
 
-    /// Stop text editing mode
+    /// Stop text editing mode. This is the *accept* path — Enter, Tab, and
+    /// clicking away all land here and keep the typed value, so any pending
+    /// revert snapshot is dropped.
     pub fn stop_editing(&mut self) {
         self.editing_text = false;
+        self.text_edit_snapshot = None;
         if let Some(item) = self.current_item_mut() {
             match item.control {
                 SettingControl::DualList(ref mut dl) => {
@@ -2220,6 +2282,51 @@ impl SettingsState {
                 }
                 _ => {}
             }
+        }
+    }
+
+    /// True while editing a plain single-line `Text` field (not a
+    /// TextList/Map/Json/DualList). These get the platform edit convention:
+    /// Enter/Tab commit the typed value, Esc reverts it.
+    pub fn is_editing_plain_text(&self) -> bool {
+        self.editing_text
+            && matches!(
+                self.current_item().map(|item| &item.control),
+                Some(SettingControl::Text(_))
+            )
+    }
+
+    /// Cancel a plain `Text` edit, discarding what was typed and restoring the
+    /// field to its pre-edit state — the Esc path, matching the Windows/macOS/
+    /// web convention where Esc reverts an edit while Enter/Tab commit it.
+    /// Restores both the control's buffer and the pending-change bookkeeping
+    /// (in case a mid-edit `on_value_changed` already flushed the buffer). With
+    /// no snapshot (a non-Text control), this just exits edit mode cleanly.
+    pub fn revert_editing(&mut self) {
+        self.editing_text = false;
+        let Some(snap) = self.text_edit_snapshot.take() else {
+            return;
+        };
+        if let Some(item) = self.current_item_mut() {
+            item.control = snap.control;
+            item.modified = snap.modified;
+            item.layer_source = snap.layer_source;
+            item.is_null = snap.is_null;
+        }
+        // Restore pending_changes / pending_deletions for this path to exactly
+        // what they were before the edit began.
+        match snap.pending {
+            Some(value) => {
+                self.pending_changes.insert(snap.path.clone(), value);
+            }
+            None => {
+                self.pending_changes.remove(&snap.path);
+            }
+        }
+        if snap.was_pending_deletion {
+            self.pending_deletions.insert(snap.path);
+        } else {
+            self.pending_deletions.remove(&snap.path);
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/language_dialog_esc_cancels_edit.rs
+++ b/crates/fresh-editor/tests/e2e/language_dialog_esc_cancels_edit.rs
@@ -1,0 +1,190 @@
+//! E2E: in the language entry dialog (Settings → Languages → <lang>), the
+//! platform-standard edit convention holds for every editable field type —
+//! **Enter/Tab commit** the typed value, **Esc reverts** it to what it was
+//! before the edit began. This matches Windows, macOS, and the web, where Esc
+//! cancels an in-progress edit rather than accepting it.
+//!
+//! Pre-change the dialog treated Esc the same as Tab (accept), so these Esc
+//! assertions fail without the fix. Tests drive only keyboard events and assert
+//! on rendered output, per CONTRIBUTING.md ("E2E Tests Observe, Not Inspect").
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+/// A config with a single `typescript` language entry so the Settings
+/// "Languages" map is deterministic to navigate.
+fn typescript_only_config() -> Config {
+    let mut config = Config::default();
+    config.languages.retain(|name, _| name == "typescript");
+    assert!(
+        config.languages.contains_key("typescript"),
+        "precondition: typescript ships as a built-in language"
+    );
+    config
+}
+
+/// Return the full text of the first rendered row that contains `needle`.
+fn row_with(harness: &EditorTestHarness, needle: &str) -> String {
+    harness
+        .screen_to_string()
+        .lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// True when the row showing `label` carries the dialog's focus marker (`>`).
+fn row_is_focused(harness: &EditorTestHarness, label: &str) -> bool {
+    let row = row_with(harness, label);
+    row.split(label).next().unwrap_or("").contains('>')
+}
+
+/// Open the single language entry's Edit Value dialog. Leaves it open.
+fn open_language_dialog(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    for _ in 0..60 {
+        if harness.screen_to_string().contains("[Enter to edit]") {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(
+        harness.screen_to_string().contains("[Enter to edit]"),
+        "language map row should be focused with an edit affordance"
+    );
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("Edit Value"),
+        "language entry dialog should open; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Walk the dialog's field focus down until `label`'s row is the focused one.
+fn focus_field(harness: &mut EditorTestHarness, label: &str) {
+    for _ in 0..80 {
+        if row_is_focused(harness, label) {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    panic!(
+        "could not focus the {label:?} field; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Esc while editing a number field (Tab Size) discards the typed digits and
+/// restores the inherited value — including the `(Inherited)` badge, proving the
+/// field's whole pre-edit state came back, not just the number.
+#[test]
+fn esc_reverts_number_field_edit() {
+    let mut harness = EditorTestHarness::with_config(140, 40, typescript_only_config()).unwrap();
+    harness.render().unwrap();
+
+    open_language_dialog(&mut harness);
+    focus_field(&mut harness, "Tab Size");
+    assert!(
+        row_with(&harness, "Tab Size").contains("(Inherited)"),
+        "precondition: Tab Size starts inherited; row: {:?}",
+        row_with(&harness, "Tab Size")
+    );
+
+    // Type a new value...
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("8").unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Tab Size").contains("8 ]"),
+        "the edit buffer should show the typed 8; row: {:?}",
+        row_with(&harness, "Tab Size")
+    );
+
+    // ...then Esc — it must revert to the inherited 0, badge and all.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let row = row_with(&harness, "Tab Size");
+    assert!(
+        row.contains("0 ]") && !row.contains("8"),
+        "Esc must revert the number to inherited 0; row: {:?}",
+        row
+    );
+    assert!(
+        row.contains("(Inherited)") && !row.contains("[Inherit]"),
+        "Esc must restore the inherited state (badge, not override); row: {:?}",
+        row
+    );
+}
+
+/// Esc while editing a text field (Grammar) discards the typed characters and
+/// restores the original string.
+#[test]
+fn esc_reverts_text_field_edit() {
+    let mut harness = EditorTestHarness::with_config(140, 40, typescript_only_config()).unwrap();
+    harness.render().unwrap();
+
+    open_language_dialog(&mut harness);
+    focus_field(&mut harness, "Grammar");
+    assert!(
+        row_with(&harness, "Grammar").contains("typescript"),
+        "precondition: Grammar reads 'typescript'; row: {:?}",
+        row_with(&harness, "Grammar")
+    );
+
+    // Append junk to the grammar name...
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("ZZZ").unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Grammar").contains("typescriptZZZ"),
+        "the edit buffer should show the appended text; row: {:?}",
+        row_with(&harness, "Grammar")
+    );
+
+    // ...then Esc — the junk must be gone and the original restored.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let row = row_with(&harness, "Grammar");
+    assert!(
+        row.contains("typescript") && !row.contains("ZZZ"),
+        "Esc must revert the text field to its original value; row: {:?}",
+        row
+    );
+}
+
+/// The contrast case: Enter still *commits* a text edit (it is not reverted),
+/// so the convention genuinely distinguishes the two keys.
+#[test]
+fn enter_commits_text_field_edit() {
+    let mut harness = EditorTestHarness::with_config(140, 40, typescript_only_config()).unwrap();
+    harness.render().unwrap();
+
+    open_language_dialog(&mut harness);
+    focus_field(&mut harness, "Grammar");
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("ZZZ").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Grammar").contains("typescriptZZZ"),
+        "Enter must keep the typed value; row: {:?}",
+        row_with(&harness, "Grammar")
+    );
+}

--- a/crates/fresh-editor/tests/e2e/language_dialog_tab_size.rs
+++ b/crates/fresh-editor/tests/e2e/language_dialog_tab_size.rs
@@ -1,0 +1,132 @@
+//! E2E reproducer: editing a language's **Tab Size** through
+//! View → Settings → General → Languages → <lang> must keep the typed value.
+//!
+//! The language entry dialog accepts a number field's digits into a separate
+//! edit buffer that only flushes into the control's `value` on *confirm*. The
+//! dialog's commit path (Enter / Tab / Esc all "accept" the field, like a Text
+//! field does) used to *cancel* the number edit instead of confirming it, so
+//! every Tab Size / Page Width edit reverted to its previous value the instant
+//! the user committed the field. This test drives only keyboard events and
+//! asserts on rendered output, per CONTRIBUTING.md ("E2E Tests Observe, Not
+//! Inspect").
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+/// A config with a single `typescript` language entry so the Settings
+/// "Languages" map is deterministic to navigate.
+fn typescript_only_config() -> Config {
+    let mut config = Config::default();
+    config.languages.retain(|name, _| name == "typescript");
+    assert!(
+        config.languages.contains_key("typescript"),
+        "precondition: typescript ships as a built-in language"
+    );
+    config
+}
+
+/// Return the full text of the first rendered row that contains `needle`.
+fn row_with(harness: &EditorTestHarness, needle: &str) -> String {
+    harness
+        .screen_to_string()
+        .lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// True when the row showing `label` carries the dialog's focus marker (`>`),
+/// which the renderer draws before the focused field's text.
+fn row_is_focused(harness: &EditorTestHarness, label: &str) -> bool {
+    let row = row_with(harness, label);
+    row.split(label).next().unwrap_or("").contains('>')
+}
+
+/// From a freshly opened Settings panel, focus the right-hand list, walk down
+/// to the single language map entry, and open its Edit Value dialog. Leaves the
+/// dialog open. (Mirrors the helper in `issue_2345_language_settings.rs`.)
+fn open_language_dialog(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    for _ in 0..60 {
+        if harness.screen_to_string().contains("[Enter to edit]") {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(
+        harness.screen_to_string().contains("[Enter to edit]"),
+        "language map row should be focused with an edit affordance"
+    );
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("Edit Value"),
+        "language entry dialog should open; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Walk the dialog's field focus down until the Tab Size row is the focused one.
+/// (Tab Size sits near the bottom of a tall dialog, so it scrolls into view as
+/// the focus walks toward it.)
+fn focus_tab_size(harness: &mut EditorTestHarness) {
+    for _ in 0..80 {
+        if row_is_focused(harness, "Tab Size") {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    panic!(
+        "could not focus the Tab Size field; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Typing a new Tab Size and committing the field must keep the typed value.
+/// Pre-fix the commit cancelled the number edit, so the field snapped back to
+/// its inherited `0`.
+#[test]
+fn language_tab_size_edit_survives_commit() {
+    let mut harness = EditorTestHarness::with_config(140, 40, typescript_only_config()).unwrap();
+    harness.render().unwrap();
+
+    open_language_dialog(&mut harness);
+    focus_tab_size(&mut harness);
+
+    // Inherited to start with: the value reads 0 and offers the (Inherited) badge.
+    assert!(
+        row_with(&harness, "Tab Size").contains("0 ]"),
+        "precondition: Tab Size starts inherited at 0; row: {:?}",
+        row_with(&harness, "Tab Size")
+    );
+
+    // Enter edit mode, replace the value with 8, and commit the field with Tab.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("8").unwrap();
+    harness.render().unwrap();
+    // While editing, the edit buffer shows the typed digit.
+    assert!(
+        row_with(&harness, "Tab Size").contains("8 ]"),
+        "typed digit should show in the edit buffer; row: {:?}",
+        row_with(&harness, "Tab Size")
+    );
+
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // After committing, the value must still be 8 — not reverted to 0.
+    assert!(
+        row_with(&harness, "Tab Size").contains("8 ]"),
+        "committed Tab Size must persist as 8, not revert to 0; row: {:?}",
+        row_with(&harness, "Tab Size")
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -83,6 +83,7 @@ pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
+pub mod language_dialog_esc_cancels_edit;
 pub mod language_dialog_tab_size;
 pub mod suspend_process;
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -83,6 +83,7 @@ pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
+pub mod language_dialog_tab_size;
 pub mod suspend_process;
 
 pub mod close_buffer_shared_split_cursor;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -206,6 +206,7 @@ pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
 pub mod settings_save_error_popup;
 pub mod settings_scrolled_list_click;
+pub mod settings_text_field_esc_cancels;
 pub mod settings_text_input_focus;
 pub mod settings_tree_view;
 pub mod settings_ui_usability;

--- a/crates/fresh-editor/tests/e2e/settings_text_field_esc_cancels.rs
+++ b/crates/fresh-editor/tests/e2e/settings_text_field_esc_cancels.rs
@@ -1,0 +1,167 @@
+//! E2E: in the main Settings view (not the entry dialog), editing a plain
+//! `Text` field follows the platform-standard edit convention —
+//! **Enter commits** the typed value and leaves edit mode, and **Esc reverts**
+//! it to what it was before the edit began. This matches Windows, macOS, and
+//! the web, where Esc cancels an in-progress edit rather than accepting it.
+//!
+//! The reproducer field is Terminal → Command (`/terminal/shell/command`), the
+//! same one reported as broken. Pre-change, Enter was a no-op on a Text field
+//! (trapping the user in edit mode) and Esc *accepted* the edit, so both
+//! assertions below fail without the fix. Tests drive only keyboard events and
+//! assert on rendered output, per CONTRIBUTING.md ("E2E Tests Observe, Not
+//! Inspect").
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, TerminalShellConfig};
+
+/// Return the full text of the first rendered row that contains `needle`.
+fn row_with(harness: &EditorTestHarness, needle: &str) -> String {
+    harness
+        .screen_to_string()
+        .lines()
+        .find(|line| line.contains(needle))
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Open Settings and focus the Terminal → Command text field via search.
+/// Leaves the field focused in the Settings panel (not yet in edit mode).
+fn focus_terminal_command(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    // Search by the field's unique description phrase and jump to it.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("Executable to launch").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(harness, "Command").contains('['),
+        "precondition: the Command value cell should be visible; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Enter commits the typed value AND exits edit mode. Proven on screen: after
+/// Enter, a plain (non-navigation) keystroke no longer lands in the field, so
+/// the value is unchanged — which only holds if Enter left edit mode.
+#[test]
+fn enter_commits_and_exits_text_field() {
+    let mut harness = EditorTestHarness::with_config(140, 40, Config::default()).unwrap();
+    harness.render().unwrap();
+
+    focus_terminal_command(&mut harness);
+
+    // Enter edit mode and type a value.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("bashrc").unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Command").contains("bashrc"),
+        "the edit buffer should show the typed value; row: {:?}",
+        row_with(&harness, "Command")
+    );
+
+    // Enter must commit and leave edit mode.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // A plain letter now that we're out of edit mode is not text input — if
+    // Enter had trapped us in edit mode (the bug), this 'X' would append.
+    harness
+        .send_key(KeyCode::Char('X'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    let row = row_with(&harness, "Command");
+    assert!(
+        row.contains("bashrc") && !row.contains("bashrcX") && !row.contains("bashrcx"),
+        "Enter must commit the value and exit edit mode (no stray 'X'); row: {:?}",
+        row
+    );
+}
+
+/// Esc discards an in-progress edit and restores the field's previous value —
+/// here the empty default. Without the fix Esc accepts the edit, so the typed
+/// text survives on screen.
+#[test]
+fn esc_reverts_text_field_to_empty() {
+    let mut harness = EditorTestHarness::with_config(140, 40, Config::default()).unwrap();
+    harness.render().unwrap();
+
+    focus_terminal_command(&mut harness);
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("hello").unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Command").contains("hello"),
+        "the edit buffer should show the typed text; row: {:?}",
+        row_with(&harness, "Command")
+    );
+
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert!(
+        !row_with(&harness, "Command").contains("hello"),
+        "Esc must revert the field to its empty pre-edit value; row: {:?}",
+        row_with(&harness, "Command")
+    );
+}
+
+/// Esc reverts to a *non-empty* prior value too, and clears the "modified"
+/// bookkeeping the edit triggered: a field whose committed value came from
+/// config returns to that value with no modified marker after Esc.
+#[test]
+fn esc_reverts_text_field_to_prior_value() {
+    let mut config = Config::default();
+    config.terminal.shell = Some(TerminalShellConfig {
+        command: "bash".to_string(),
+        args: Vec::new(),
+    });
+    let mut harness = EditorTestHarness::with_config(140, 40, config).unwrap();
+    harness.render().unwrap();
+
+    focus_terminal_command(&mut harness);
+    assert!(
+        row_with(&harness, "Command").contains("bash"),
+        "precondition: Command starts as the configured 'bash'; row: {:?}",
+        row_with(&harness, "Command")
+    );
+
+    // Edit: the first keystroke replaces the value (select-all-on-type).
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("zsh").unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_with(&harness, "Command").contains("zsh"),
+        "the edit buffer should show the replacement 'zsh'; row: {:?}",
+        row_with(&harness, "Command")
+    );
+
+    // Esc reverts to 'bash' and drops the modified state.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let row = row_with(&harness, "Command");
+    assert!(
+        row.contains("bash") && !row.contains("zsh"),
+        "Esc must restore the prior 'bash' value; row: {:?}",
+        row
+    );
+    assert!(
+        !row.contains('●') && !row.to_lowercase().contains("modified"),
+        "Esc must clear the modified marker when restoring the original; row: {:?}",
+        row
+    );
+}


### PR DESCRIPTION
## Summary

Two related fixes to editing fields in the language entry dialog (Settings → Languages → `<lang>`), plus a cleanup:

1. **Committed values are no longer discarded.** Editing a numeric field (Tab Size, Page Width) and confirming it dropped the typed digits — the value reverted to what it was before. Number fields keep a separate edit buffer that only flushes on confirm, but the dialog's commit path was cancelling the edit instead, so the buffer was thrown away.

2. **Esc now cancels an in-progress edit** instead of accepting it. This matches the platform convention shared by Windows, macOS, and the web: **Enter / Tab / click-away commit** a field's typed value, while **Esc abandons** the edit and restores what was there before. Previously the dialog treated Esc the same as Tab, so there was no way to back out of a change once typing started.

## Changes

- **entry_dialog.rs** — In `stop_editing()` (the commit path), `SettingControl::Number` now calls `confirm_editing()` instead of `cancel_editing()`, matching text fields so typed digits are kept.
- **entry_dialog.rs / input.rs** — Added a uniform revert path for every editable control (Text, Number, TextList, Json): `start_editing` snapshots the focused field (control clone plus its `is_null` / `user_edited` flags) before mutating it, and the new `revert_editing` restores that snapshot. Esc in the dialog's text-editing handler routes to `revert_editing`; Enter/Tab/blur stay on `stop_editing` (commit). Reverting restores the field's whole pre-edit state, so an abandoned edit also drops the "field is now set / dialog is dirty" side effects typing triggered — e.g. a reverted Tab Size returns to its `(Inherited)` badge.
- **state.rs** — Removed `entry_dialog_can_exit_text_editing`, now dead: its only caller was the old accept-on-Esc path, and reverting discards the edit regardless of JSON validity.

## Tests

All new tests fail on the pre-change behaviour (verified by reverting the fix). E2E tests drive only keyboard events and assert on rendered output, per CONTRIBUTING.md ("E2E Tests Observe, Not Inspect").

- **language_dialog_tab_size.rs** — typed Tab Size (8) survives commit instead of reverting to 0.
- **language_dialog_esc_cancels_edit.rs** — Esc reverts a Number field (back to inherited 0 + badge) and a Text field (Grammar); a contrast case asserts Enter still commits.
- **entry_dialog.rs** unit tests — revert for Text, Number, TextList (in-place item edit) and Json.

## Verification

Locally green before pushing: `issue_2345` (8), `language_dialog` (4), `settings` (138), `tab_config` (20), `entry_dialog` unit (15), plus the LSP / quicklsp / text-input / paste entry-dialog suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMbwvH9MWztBKb4t3rXHKe