### PR TITLE
Fix indentation guides to continue through soft-wrap continuation rows

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -333,21 +333,31 @@ impl CellPass<'_, '_, '_> {
     }
 
     /// Whether the current leading-whitespace cell should render as an
-    /// indentation guide. Guides are visual-only replacements for existing
-    /// source whitespace cells, so they preserve byte mappings and do not draw
-    /// through code or synthetic/injected content.
+    /// indentation guide. Guides are visual-only replacements for leading
+    /// whitespace cells, so they preserve byte mappings and do not draw through
+    /// code or injected content. On a normal row that whitespace is real source
+    /// text; on a soft-wrap continuation row it is the synthetic wrap-indent
+    /// padding (which maps to no source byte), so guides keep running through the
+    /// padding and the staircase stays unbroken across the wrap.
     fn is_indentation_guide_cell(&self, ch: char, byte_pos: Option<usize>) -> bool {
-        if matches!(self.input.indentation_guide, IndentationGuideMode::None)
-            || ch != ' '
-            || byte_pos.is_none()
-        {
+        if matches!(self.input.indentation_guide, IndentationGuideMode::None) || ch != ' ' {
             return false;
         }
 
+        // Plugin-injected continuation rows never carry guides.
         if matches!(
             self.input.view_line.line_start,
-            LineStart::AfterBreak | LineStart::AfterInjectedNewline
+            LineStart::AfterInjectedNewline
         ) {
+            return false;
+        }
+
+        // A soft-wrap continuation's leading cells are byte-less wrap-indent
+        // padding; every other row's are real source whitespace. Requiring the
+        // matching byte-mapping for each case keeps guides off injected/virtual
+        // content on normal rows and off the real wrapped text on continuations.
+        let is_wrap_continuation = matches!(self.input.view_line.line_start, LineStart::AfterBreak);
+        if byte_pos.is_none() != is_wrap_continuation {
             return false;
         }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -276,7 +276,24 @@ impl GuideColumnScanner {
                 let cut = self.stack.partition_point(|&w| w < level);
                 fill_guide_columns(&self.stack[..cut], level, tab_size, out);
             }
-            // Continuation / injected row: no guides, staircase untouched.
+            // Soft-wrap continuation row: it carries no indent of its own, but
+            // its wrap-indent padding aligns under the parent line's leading
+            // whitespace. Replay the parent content row's guides through that
+            // padding so the staircase runs unbroken across the wrap. The padding
+            // width is the row's leading run of byte-less cells (empty when
+            // `wrap_indent` is off, which correctly yields no guides). Computed
+            // against the open ancestors without mutating the staircase — a
+            // continuation opens no block.
+            None if matches!(line.line_start, LineStart::AfterBreak) => {
+                let pad_width = line
+                    .char_source_bytes
+                    .iter()
+                    .take_while(|b| b.is_none())
+                    .count();
+                let cut = self.stack.partition_point(|&w| w < pad_width);
+                fill_guide_columns(&self.stack[..cut], pad_width, tab_size, out);
+            }
+            // Injected / source-less row: no guides, staircase untouched.
             None => out.clear(),
         }
     }

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -161,3 +161,97 @@ fn indentation_guide_renders_independently_of_line_numbers() {
         );
     }
 }
+
+#[test]
+fn indentation_guide_all_mode_continues_through_wrapped_line() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_wrap.rs");
+    // A doubly-nested line long enough to soft-wrap at the narrow viewport. Its
+    // wrapped continuation rows align under the original indent (`wrap_indent`)
+    // and must keep the guides of the two enclosing blocks rather than leaving a
+    // gap in the vertical lines.
+    std::fs::write(
+        &file_path,
+        "fn main() {\n    if flag {\n        let s = \"aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk\";\n    }\n}\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+    // line_wrap / wrap_indent are on by default; pin them so the test is
+    // explicit about the configuration it exercises.
+    config.editor.line_wrap = true;
+    config.editor.wrap_indent = true;
+
+    // A narrow viewport forces the long `let` line to wrap onto continuation rows.
+    let mut harness =
+        EditorTestHarness::create(40, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+
+    // First visual row of the `let` line: guides at the two enclosing levels
+    // (columns 0 and 4) — "┊   ┊   let s = ...".
+    let let_row = lines
+        .iter()
+        .position(|line| line.contains("┊   ┊   let s ="))
+        .unwrap_or_else(|| panic!("expected a guided 'let' row\n{screen}"));
+
+    // The wrapped continuation row sits directly below and must carry the same
+    // two guides; the only `┊` glyphs on it are guides (the wrapped text has none).
+    let cont_row = lines[let_row + 1];
+    assert!(
+        cont_row.contains("┊   ┊"),
+        "indent guides should continue through the wrapped continuation row\ncont row: {cont_row:?}\n{screen}"
+    );
+}
+
+#[test]
+fn indentation_guide_active_mode_continues_through_wrapped_line() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_wrap_active.rs");
+    std::fs::write(
+        &file_path,
+        "fn main() {\n    if flag {\n        let s = \"aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk\";\n    }\n}\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::Active;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+    config.editor.line_wrap = true;
+    config.editor.wrap_indent = true;
+
+    let mut harness =
+        EditorTestHarness::create(40, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    // Move the cursor onto the wrapped `let` line so its enclosing `if` block
+    // becomes the single active guide.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+
+    // The `let` line carries the single active guide of the enclosing block.
+    let let_row = lines
+        .iter()
+        .position(|line| line.contains("┊") && line.contains("let s ="))
+        .unwrap_or_else(|| panic!("expected an active-guided 'let' row\n{screen}"));
+    let guide_col = lines[let_row]
+        .find('┊')
+        .expect("expected the active guide glyph on the 'let' row");
+
+    // Its wrapped continuation row must carry the same active guide at the same
+    // column instead of leaving a gap.
+    let cont_row = lines[let_row + 1];
+    assert_eq!(
+        cont_row.find('┊'),
+        Some(guide_col),
+        "active indent guide should continue through the wrapped continuation row\ncont row: {cont_row:?}\n{screen}"
+    );
+}


### PR DESCRIPTION
## Summary
This PR fixes indentation guides to properly continue through soft-wrap continuation rows, maintaining unbroken vertical guide lines when long lines wrap at narrow viewports.

## Key Changes

- **Updated guide rendering logic** (`cells.rs`): Modified `is_indentation_guide_cell()` to allow guides on soft-wrap continuation rows by recognizing that their leading cells are byte-less wrap-indent padding (not real source whitespace). This preserves the byte-mapping invariant while enabling guides through the padding.

- **Enhanced guide column scanning** (`mod.rs`): Added special handling in `GuideColumnScanner` for soft-wrap continuation rows (`LineStart::AfterBreak`). The scanner now replays parent block guides through the wrap-indent padding width, keeping the indentation staircase unbroken across line wraps.

- **Added comprehensive test coverage**: Two new e2e tests verify the fix works correctly:
  - `indentation_guide_all_mode_continues_through_wrapped_line`: Tests that all guides continue through wrapped lines
  - `indentation_guide_active_mode_continues_through_wrapped_line`: Tests that the active guide (for the current cursor context) continues through wrapped lines

## Implementation Details

The fix distinguishes between three row types:
1. **Normal rows**: Leading cells are real source whitespace with byte mappings
2. **Soft-wrap continuations**: Leading cells are synthetic wrap-indent padding with no byte mapping
3. **Injected rows**: Virtual content with no source bytes (guides disabled)

By checking the relationship between byte-mapping presence and row type, guides are correctly rendered only on appropriate cells while maintaining the visual continuity of indentation guides across line wraps.

https://claude.ai/code/session_01Tx4JDV1qdV1jdaUeEGHJCx