### PR TITLE
Fix compiler warnings without masking real behavior

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -582,7 +582,7 @@
           "x-section": "Display"
         },
         "indentation_guide": {
-          "description": "Vertical indentation guide rendering mode.\nGuides are drawn at indentation levels derived from the active buffer's\ntab size. They replace existing leading whitespace cells visually only;\nbuffer text, cursor positions, and mouse mappings are unchanged.\nModes:\n- `none`: disable indentation guides.\n- `all`: draw every indentation level in leading whitespace.\n- `active`: draw only the innermost guide for the cursor's current\n  indentation block.\nDefault: none",
+          "description": "Vertical indentation guide rendering mode.\nGuides are drawn at indentation levels derived from the active buffer's\ntab size. They replace existing leading whitespace cells visually only;\nbuffer text, cursor positions, and mouse mappings are unchanged.\nModes:\n- `none`: disable indentation guides.\n- `all`: draw every indentation level in leading whitespace.\n- `active`: draw only the innermost guide for the cursor's current\n  indentation block.\n\nDefault: none",
           "$ref": "#/$defs/IndentationGuideMode",
           "default": "none",
           "x-section": "Display"

--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -268,7 +268,7 @@ impl crate::app::window::Window {
                 .get(&active_split)
                 .unwrap()
                 .cursors;
-            let state = (&self.buffers).get(&active_buffer).unwrap();
+            let state = self.buffers.get(&active_buffer).unwrap();
             cursors
                 .iter()
                 .map(|(cursor_id, cursor)| {
@@ -491,7 +491,7 @@ impl crate::app::window::Window {
                 mappings.get(row_idx)?.line_end_byte
             };
 
-            let state = (&mut self.buffers).get_mut(&active_buffer)?;
+            let state = self.buffers.get_mut(&active_buffer)?;
             let buffer = &mut state.buffer;
             let buffer_len = buffer.len();
             if cur_row_line_end >= buffer_len {
@@ -564,7 +564,7 @@ impl crate::app::window::Window {
             // the user wouldn't expect (issue #1574, Windows-CRLF
             // variant).  For LF or a lone CR the byte arithmetic falls
             // through to a one-byte step.
-            let state = (&mut self.buffers).get_mut(&active_buffer)?;
+            let state = self.buffers.get_mut(&active_buffer)?;
             let buffer = &mut state.buffer;
             let _ = row_is_empty;
             let target_pos = step_before_line_break(buffer, cur_row_anchor);

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -103,7 +103,7 @@ impl Editor {
         let updated = crate::services::lsp::diagnostics::apply_diagnostics_to_state_cached(
             state,
             diagnostics,
-            &*self.theme.read().unwrap(),
+            &self.theme.read().unwrap(),
         );
         Some((buffer_id, updated))
     }
@@ -599,7 +599,7 @@ impl Editor {
                             state,
                             range.clone(),
                             &spans,
-                            &*self.theme.read().unwrap(),
+                            &self.theme.read().unwrap(),
                         );
                         if applied {
                             self.active_window_mut()
@@ -671,7 +671,7 @@ impl Editor {
                         crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                             state,
                             &decoded.spans,
-                            &*self.theme.read().unwrap(),
+                            &self.theme.read().unwrap(),
                         );
 
                         state.set_semantic_tokens(SemanticTokenStore {
@@ -782,7 +782,7 @@ impl Editor {
                         crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                             state,
                             &spans,
-                            &*self.theme.read().unwrap(),
+                            &self.theme.read().unwrap(),
                         );
 
                         state.set_semantic_tokens(SemanticTokenStore {

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -659,11 +659,11 @@ impl super::Editor {
         // this, retargeting only updates focus state and the panel
         // keeps drawing the prior (now-empty) buffer.
         for node in self.active_window_mut().grouped_subtrees.values_mut() {
-            if let Some(found) = node.find_mut(panel_leaf.into()) {
-                if let crate::view::split::SplitNode::Leaf { buffer_id, .. } = found {
-                    *buffer_id = new_buffer_id;
-                    break;
-                }
+            if let Some(crate::view::split::SplitNode::Leaf { buffer_id, .. }) =
+                node.find_mut(panel_leaf.into())
+            {
+                *buffer_id = new_buffer_id;
+                break;
             }
         }
 

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -691,15 +691,15 @@ impl super::Editor {
             //    still the prior id is safe.
             {
                 let buf_state = vs.ensure_buffer_state(new_buffer_id);
-                buf_state.apply_config_defaults(
-                    cfg.line_numbers,
-                    cfg.highlight_current_line,
+                buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                    line_numbers: cfg.line_numbers,
+                    highlight_current_line: cfg.highlight_current_line,
                     line_wrap,
-                    cfg.wrap_indent,
+                    wrap_indent: cfg.wrap_indent,
                     wrap_column,
-                    cfg.rulers,
-                    cfg.scroll_offset,
-                );
+                    rulers: cfg.rulers,
+                    scroll_offset: cfg.scroll_offset,
+                });
                 // Match the panel-buffer presentation set in
                 // `build_group_layout` (no line numbers, no current-
                 // line highlight inside grouped panels).

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -582,15 +582,15 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .get_mut(&active_split)
         {
-            view_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
+            view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
                 line_wrap,
-                self.config.editor.wrap_indent,
+                wrap_indent: self.config.editor.wrap_indent,
                 wrap_column,
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
         }
 
         self.active_window_mut().status_message = Some(t!("buffer.new").to_string());

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -300,7 +300,7 @@ impl Editor {
 
         // Read cursor state from split view state
         let cursors = self.active_cursors();
-        let old_cursor = cursors.primary().clone();
+        let old_cursor = *cursors.primary();
         let cursor_id = cursors.primary_id();
         let old_position = cursors.primary().position;
         let old_anchor = cursors.primary().anchor;

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1006,7 +1006,7 @@ impl Editor {
             // Sort anchors by position descending so each insertion
             // doesn't shift subsequent ones forward. The original
             // index is retained for column-mode line lookup.
-            anchor_positions.sort_by(|a, b| b.1.cmp(&a.1));
+            anchor_positions.sort_by_key(|b| std::cmp::Reverse(b.1));
 
             let total = pending.cursor_count_at_dispatch;
             let mut events = Vec::with_capacity(anchor_positions.len());

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -386,6 +386,19 @@ impl crate::app::window::Window {
     }
 }
 
+/// Fields of a `PluginCommand::CreateCompositeBuffer`, grouped so
+/// [`Editor::handle_create_composite_buffer`] takes one argument.
+#[cfg(feature = "plugins")]
+pub(crate) struct CreateCompositeBufferArgs {
+    pub name: String,
+    pub mode: String,
+    pub layout_config: fresh_core::api::CompositeLayoutConfig,
+    pub source_configs: Vec<fresh_core::api::CompositeSourceConfig>,
+    pub hunks: Option<Vec<fresh_core::api::CompositeHunk>>,
+    pub initial_focus_hunk: Option<usize>,
+    pub request_id: Option<u64>,
+}
+
 impl Editor {
     // =========================================================================
     // Layout Flush (synchronous state materialization)
@@ -1083,16 +1096,16 @@ impl Editor {
 
     /// Handle the CreateCompositeBuffer plugin command
     #[cfg(feature = "plugins")]
-    pub(crate) fn handle_create_composite_buffer(
-        &mut self,
-        name: String,
-        mode: String,
-        layout_config: fresh_core::api::CompositeLayoutConfig,
-        source_configs: Vec<fresh_core::api::CompositeSourceConfig>,
-        hunks: Option<Vec<fresh_core::api::CompositeHunk>>,
-        initial_focus_hunk: Option<usize>,
-        _request_id: Option<u64>,
-    ) {
+    pub(crate) fn handle_create_composite_buffer(&mut self, args: CreateCompositeBufferArgs) {
+        let CreateCompositeBufferArgs {
+            name,
+            mode,
+            layout_config,
+            source_configs,
+            hunks,
+            initial_focus_hunk,
+            request_id: _request_id,
+        } = args;
         use crate::model::composite_buffer::{
             CompositeLayout, DiffHunk, GutterStyle, LineAlignment, PaneStyle, SourcePane,
         };

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1284,7 +1284,7 @@ impl Editor {
         true
     }
 
-    /// Get the warning domain registry
+    // Get the warning domain registry.
     // Warning-domain accessors live on `impl Window`:
     //  - `clear_warnings` — call as `self.active_window_mut().clear_warnings()`.
     //  - Read access via `active_window().warning_domains` directly

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -927,15 +927,15 @@ impl Editor {
         let mut split_view_states = HashMap::new();
         let initial_split_id = split_manager.active_split();
         let mut initial_view_state = SplitViewState::with_buffer(width, height, buffer_id);
-        initial_view_state.apply_config_defaults(
-            config.editor.line_numbers,
-            config.editor.highlight_current_line,
-            config.editor.line_wrap,
-            config.editor.wrap_indent,
-            config.editor.wrap_column,
-            config.editor.rulers.clone(),
-            config.editor.scroll_offset,
-        );
+        initial_view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+            line_numbers: config.editor.line_numbers,
+            highlight_current_line: config.editor.highlight_current_line,
+            line_wrap: config.editor.line_wrap,
+            wrap_indent: config.editor.wrap_indent,
+            wrap_column: config.editor.wrap_column,
+            rulers: config.editor.rulers.clone(),
+            scroll_offset: config.editor.scroll_offset,
+        });
         split_view_states.insert(initial_split_id, initial_view_state);
 
         // Initialize filesystem manager for file explorer

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -1419,7 +1419,7 @@ impl Editor {
         let needs_seed: Vec<fresh_core::WindowId> = editor
             .windows
             .iter()
-            .filter(|(_, s)| s.buffers.splits().is_none() || s.buffers.len() == 0)
+            .filter(|(_, s)| s.buffers.splits().is_none() || s.buffers.is_empty())
             .map(|(id, _)| *id)
             .collect();
         for id in needs_seed {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -105,7 +105,7 @@ fn set_dot_path(root: &mut serde_json::Value, path: &str, value: serde_json::Val
 /// No-op when the plugin manager is inactive.
 #[allow(clippy::too_many_arguments)]
 fn load_startup_plugins(
-    plugin_manager: &Arc<RwLock<PluginManager>>,
+    plugin_manager: &std::rc::Rc<RwLock<PluginManager>>,
     dir_context: &DirectoryContext,
     bundle_plugin_dirs: &[std::path::PathBuf],
     config: &mut Config,
@@ -381,7 +381,7 @@ pub(super) struct EditorParts {
     // Registries / managers
     pub(super) command_registry: Arc<RwLock<CommandRegistry>>,
     pub(super) quick_open_registry: QuickOpenRegistry,
-    pub(super) plugin_manager: Arc<RwLock<PluginManager>>,
+    pub(super) plugin_manager: std::rc::Rc<RwLock<PluginManager>>,
     pub(super) recovery_service: Arc<std::sync::Mutex<RecoveryService>>,
     pub(super) key_translator: crate::input::key_translator::KeyTranslator,
     pub(super) update_checker: Option<crate::services::release_checker::PeriodicUpdateChecker>,
@@ -975,7 +975,7 @@ impl Editor {
 
         t.phase("split_quickopen_authority");
         // Initialize plugin manager (handles both enabled and disabled cases internally)
-        let plugin_manager = Arc::new(RwLock::new(PluginManager::new(
+        let plugin_manager = std::rc::Rc::new(RwLock::new(PluginManager::new(
             enable_plugins,
             Arc::clone(&command_registry),
             dir_context.clone(),
@@ -1121,7 +1121,7 @@ impl Editor {
             dir_context: dir_context.clone(),
             tokio_runtime: tokio_runtime.clone(),
             async_bridge: Some(async_bridge.clone()),
-            plugin_manager: Arc::clone(&plugin_manager),
+            plugin_manager: std::rc::Rc::clone(&plugin_manager),
             theme: Arc::clone(&theme),
             event_broadcaster: event_broadcaster.clone(),
             recovery_service: Arc::clone(&recovery_service),
@@ -1310,7 +1310,7 @@ impl Editor {
                     dir_context: dir_context.clone(),
                     tokio_runtime: tokio_runtime.clone(),
                     async_bridge: Some(async_bridge.clone()),
-                    plugin_manager: Arc::clone(&plugin_manager),
+                    plugin_manager: std::rc::Rc::clone(&plugin_manager),
                     theme: Arc::clone(&theme),
                     event_broadcaster: event_broadcaster.clone(),
                     recovery_service: Arc::clone(&recovery_service),

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -323,7 +323,7 @@ impl Editor {
         }
 
         // Sort edits by position descending (required by apply_bulk_edits)
-        edits.sort_by(|a, b| b.0.cmp(&a.0));
+        edits.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         // Convert to references for apply_bulk_edits
         let edit_refs: Vec<(usize, usize, &str)> = edits

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -43,6 +43,12 @@ impl Editor {
         self.apply_event_to_active_buffer(event);
     }
 
+    /// Apply an event to the active buffer with all cross-cutting concerns.
+    /// This is the centralized method that automatically handles:
+    /// - Event application to buffer
+    /// - Plugin hooks (after-insert, after-delete, etc.)
+    /// - LSP notifications
+    /// - Any other cross-cutting concerns
     pub fn apply_event_to_active_buffer(&mut self, event: &Event) {
         // Handle View events at Editor level - View events go to SplitViewState, not EditorState
         // This properly separates Buffer state from View state

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -1868,7 +1868,7 @@ impl crate::app::window::Window {
 
         self.file_explorer_decoration_cache =
             crate::view::file_tree::FileExplorerDecorationCache::rebuild(
-                decorations.into_iter(),
+                decorations,
                 &self.root,
                 &symlink_mappings,
             );
@@ -1897,7 +1897,7 @@ impl crate::app::window::Window {
 
         self.file_explorer_slot_override_cache =
             crate::view::file_tree::FileExplorerSlotOverrideCache::rebuild(
-                slots.into_iter(),
+                slots,
                 &self.root,
                 &symlink_mappings,
             );

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -943,7 +943,7 @@ impl Editor {
         );
     }
 
-    /// Clear the file explorer search (or multi-selection, pending cut, or transfer focus)
+    // Clear the file explorer search (or multi-selection, pending cut, or transfer focus).
     // `file_explorer_search_clear` lives on `impl Window` — call it via
     // `self.active_window_mut().file_explorer_search_clear()`.
 

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -406,15 +406,15 @@ impl Editor {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
                 line_wrap,
-                self.config.editor.wrap_indent,
+                wrap_indent: self.config.editor.wrap_indent,
                 wrap_column,
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
         }
 
         self.set_active_buffer(buffer_id);
@@ -596,15 +596,15 @@ impl Editor {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
                 line_wrap,
-                self.config.editor.wrap_indent,
+                wrap_indent: self.config.editor.wrap_indent,
                 wrap_column,
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
         }
 
         self.set_active_buffer(buffer_id);
@@ -856,15 +856,15 @@ impl Editor {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
                 line_wrap,
-                self.config.editor.wrap_indent,
+                wrap_indent: self.config.editor.wrap_indent,
                 wrap_column,
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
         }
 
         Ok(buffer_id)
@@ -1209,15 +1209,15 @@ impl crate::app::window::Window {
             view_state.add_buffer(buffer_id);
             // Initialize per-buffer view state for the new buffer with config defaults
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                cfg.line_numbers,
-                cfg.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: cfg.line_numbers,
+                highlight_current_line: cfg.highlight_current_line,
                 line_wrap,
-                cfg.wrap_indent,
+                wrap_indent: cfg.wrap_indent,
                 wrap_column,
-                cfg.rulers,
-                cfg.scroll_offset,
-            );
+                rulers: cfg.rulers,
+                scroll_offset: cfg.scroll_offset,
+            });
             // Auto-activate page view if configured for this language
             if let Some(page_width) = page_view {
                 buf_state.activate_page_view(page_width);

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -252,15 +252,15 @@ impl Editor {
         self.relayout();
     }
 
-    /// If the active split leaf carries `SplitRole::UtilityDock`,
-    /// move the active leaf back to the user's last regular editor
-    /// leaf. Called from the file-open path so that opening a file
-    /// while a utility panel holds focus doesn't turn the dock into
-    /// a tab strip for ordinary files.
-    ///
-    /// Routing falls back to the first non-dock leaf in tree order
-    /// when the user has only ever interacted with the dock — a
-    /// rare boot-state path.
+    // If the active split leaf carries `SplitRole::UtilityDock`,
+    // move the active leaf back to the user's last regular editor
+    // leaf. Called from the file-open path so that opening a file
+    // while a utility panel holds focus doesn't turn the dock into
+    // a tab strip for ordinary files.
+    //
+    // Routing falls back to the first non-dock leaf in tree order
+    // when the user has only ever interacted with the dock — a
+    // rare boot-state path.
     // `redirect_active_split_away_from_dock_if_needed` lives on
     // `impl Window` — call it via
     // `self.active_window_mut().redirect_active_split_away_from_dock_if_needed()`.
@@ -623,10 +623,10 @@ impl Editor {
         Ok(buffer_id)
     }
 
-    /// Restore global file state (cursor and scroll position) for a newly opened file
-    ///
-    /// This looks up the file's saved state from the global file states store
-    /// and applies it to both the EditorState (cursor) and SplitViewState (viewport).
+    // Restore global file state (cursor and scroll position) for a newly opened file.
+    //
+    // This looks up the file's saved state from the global file states store
+    // and applies it to both the EditorState (cursor) and SplitViewState (viewport).
     // `restore_global_file_state` and `save_file_state_on_close` live
     // on `impl Window` — call them via
     // `self.active_window_mut().restore_global_file_state(...)` and

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -3068,16 +3068,17 @@ impl Editor {
         );
         // Terminal-dedicated splits never show line numbers or current-line highlight.
         // (Mirrors the plugin-terminal split setup in `create_plugin_terminal`.)
-        view_state.apply_config_defaults(
-            false,
-            false,
-            self.active_window().resolve_line_wrap_for_buffer(buffer_id),
-            self.config.editor.wrap_indent,
-            self.active_window()
+        view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+            line_numbers: false,
+            highlight_current_line: false,
+            line_wrap: self.active_window().resolve_line_wrap_for_buffer(buffer_id),
+            wrap_indent: self.config.editor.wrap_indent,
+            wrap_column: self
+                .active_window()
                 .resolve_wrap_column_for_buffer(buffer_id),
-            self.config.editor.rulers.clone(),
-            0,
-        );
+            rulers: self.config.editor.rulers.clone(),
+            scroll_offset: 0,
+        });
         // Terminals don't wrap — keep escape sequences intact.
         view_state.viewport.line_wrap_enabled = false;
 

--- a/crates/fresh-editor/src/app/keybinding_editor_actions.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor_actions.rs
@@ -156,19 +156,19 @@ impl Editor {
         }
 
         match mouse_event.kind {
-            MouseEventKind::ScrollUp => {
-                // Scroll the viewport without touching selection. Coupling
-                // wheel to selection meant any prior scrollbar drag snapped
-                // back via `ensure_visible` on the next wheel tick. Three
-                // rows per tick matches the settings modal.
-                if editor.edit_dialog.is_none() && !editor.showing_confirm_dialog {
-                    editor.scroll.scroll_by(-3);
-                }
+            // Scroll the viewport without touching selection. Coupling
+            // wheel to selection meant any prior scrollbar drag snapped
+            // back via `ensure_visible` on the next wheel tick. Three
+            // rows per tick matches the settings modal.
+            MouseEventKind::ScrollUp
+                if editor.edit_dialog.is_none() && !editor.showing_confirm_dialog =>
+            {
+                editor.scroll.scroll_by(-3);
             }
-            MouseEventKind::ScrollDown => {
-                if editor.edit_dialog.is_none() && !editor.showing_confirm_dialog {
-                    editor.scroll.scroll_by(3);
-                }
+            MouseEventKind::ScrollDown
+                if editor.edit_dialog.is_none() && !editor.showing_confirm_dialog =>
+            {
+                editor.scroll.scroll_by(3);
             }
             MouseEventKind::Drag(MouseButton::Left) => {
                 // Continue dragging the scrollbar thumb (no selection or

--- a/crates/fresh-editor/src/app/line_scan.rs
+++ b/crates/fresh-editor/src/app/line_scan.rs
@@ -63,13 +63,9 @@ impl LineScan {
     /// Progress percent (0..=100), or 100 when there is nothing to scan.
     pub(crate) fn progress_percent(&self) -> usize {
         match &self.active {
-            Some(a) => {
-                if a.total_bytes == 0 {
-                    100
-                } else {
-                    (a.scanned_bytes * 100) / a.total_bytes
-                }
-            }
+            Some(a) => (a.scanned_bytes * 100)
+                .checked_div(a.total_bytes)
+                .unwrap_or(100),
             None => 100,
         }
     }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -2833,7 +2833,7 @@ impl Editor {
                 }
 
                 // Sort edits by position descending (required by apply_bulk_edits)
-                edits.sort_by(|a, b| b.0.cmp(&a.0));
+                edits.sort_by_key(|b| std::cmp::Reverse(b.0));
 
                 // Convert to references for apply_bulk_edits
                 let edit_refs: Vec<(usize, usize, &str)> = edits

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1081,7 +1081,7 @@ impl Editor {
         } else if is_markdown {
             parse_markdown(
                 &contents,
-                &*self.theme.read().unwrap(),
+                &self.theme.read().unwrap(),
                 Some(&self.grammar_registry),
             )
         } else {
@@ -1141,7 +1141,7 @@ impl Editor {
         let dynamic_height = (self.terminal_height * 60 / 100).clamp(15, 40);
 
         // Construct the popup with the fused content.
-        let mut popup = Popup::text(Vec::new(), &*self.theme.read().unwrap());
+        let mut popup = Popup::text(Vec::new(), &self.theme.read().unwrap());
         popup.content = PopupContent::Markdown(all_lines);
         popup.title = Some(t!("lsp.popup_hover").to_string());
         popup.transient = true;
@@ -1619,7 +1619,7 @@ impl Editor {
 
         let mut popup = Popup::markdown(
             &content,
-            &*self.theme.read().unwrap(),
+            &self.theme.read().unwrap(),
             Some(&self.grammar_registry),
         );
         popup.title = Some(t!("lsp.popup_signature").to_string());
@@ -1888,7 +1888,7 @@ impl Editor {
                 .collect()
         };
 
-        let mut popup = Popup::list(items, &*self.theme.read().unwrap());
+        let mut popup = Popup::list(items, &self.theme.read().unwrap());
         popup.kind = crate::view::popup::PopupKind::Action;
         popup.title = Some(t!("lsp.popup_code_actions").to_string());
         popup.position = PopupPosition::BelowCursor;

--- a/crates/fresh-editor/src/app/lsp_status.rs
+++ b/crates/fresh-editor/src/app/lsp_status.rs
@@ -52,14 +52,14 @@ fn centered(s: &str) -> String {
 /// in `status_bar::element_style`; the text is what's rendered inside the
 /// segment.  Priority:
 ///
-///   0. Buffer-level skip (large file, binary, per-buffer toggle)
-///                     — "LSP (n/a)",              state = OffDismissed
-///   1. Progress       — detailed progress string, state = On
-///   2. Error          — "LSP (error)",            state = Error
-///   3. Running        — "LSP (on)",               state = On
-///   4. Configured-but-not-running (either auto_start or opt-in dormant)
-///                     — "LSP (off)",              state = Off / OffDismissed
-///   5. Nothing        — empty,                    state = None
+///     0. Buffer-level skip (large file, binary, per-buffer toggle)
+///                       — "LSP (n/a)",              state = OffDismissed
+///     1. Progress       — detailed progress string, state = On
+///     2. Error          — "LSP (error)",            state = Error
+///     3. Running        — "LSP (on)",               state = On
+///     4. Configured-but-not-running (either auto_start or opt-in dormant)
+///                       — "LSP (off)",              state = Off / OffDismissed
+///     5. Nothing        — empty,                    state = None
 ///
 /// The buffer-level skip only wins over running language state: showing
 /// "LSP (on)" while LSP is actively skipping this buffer (e.g. rust-

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -78,6 +78,7 @@ mod split_actions;
 mod stdin_stream;
 mod tab_drag;
 mod terminal;
+pub use terminal::PluginTerminalSpec;
 mod terminal_input;
 mod terminal_link;
 mod terminal_mouse;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1472,14 +1472,6 @@ impl Editor {
             .unwrap_or_else(|| "[No Name]".to_string())
     }
 
-    /// Apply an event to the active buffer with all cross-cutting concerns.
-    /// This is the centralized method that automatically handles:
-    /// - Event application to buffer
-    /// - Plugin hooks (after-insert, after-delete, etc.)
-    /// - LSP notifications
-    /// - Any other cross-cutting concerns
-    ///
-
     /// Get the event log for the active buffer
     pub fn active_event_log(&self) -> &EventLog {
         self.active_window()

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -773,7 +773,7 @@ pub struct Editor {
     /// deliver_response, has_hook_handlers, …) take a read lock; the
     /// few `&mut self` methods (process_commands, check_thread_health,
     /// test_inject_command) take a write lock.
-    plugin_manager: Arc<RwLock<PluginManager>>,
+    plugin_manager: std::rc::Rc<RwLock<PluginManager>>,
 
     // `plugin_dev_workspaces` moved onto `Window` — keyed by `BufferId`,
     // and buffers are per-window, so the workspace map follows.

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1193,14 +1193,16 @@ impl Editor {
                             };
                             let slot_resolution = slot_resolver.resolve(&slot_context);
                             if let Some((slot_start, slot_end)) = crate::view::ui::file_explorer::FileExplorerRenderer::trailing_slot_screen_bounds(
-                                explorer,
-                                node_id,
-                                indent,
-                                content_width,
-                                &slot_resolution,
-                                &self.config.file_explorer.tree_indicator_collapsed,
-                                &self.config.file_explorer.tree_indicator_expanded,
-                                explorer_area,
+                                crate::view::ui::file_explorer::TrailingSlotBoundsCtx {
+                                    view: explorer,
+                                    node_id,
+                                    indent,
+                                    content_width,
+                                    slot_resolution: &slot_resolution,
+                                    tree_indicator_collapsed: &self.config.file_explorer.tree_indicator_collapsed,
+                                    tree_indicator_expanded: &self.config.file_explorer.tree_indicator_expanded,
+                                    explorer_area,
+                                },
                             ) {
                                 if col >= slot_start && col < slot_end {
                                     return Some(HoverTarget::FileExplorerStatusIndicator(

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3823,7 +3823,7 @@ impl Editor {
         }
 
         // Create popup
-        let mut popup = Popup::text(lines, &*self.theme.read().unwrap());
+        let mut popup = Popup::text(lines, &self.theme.read().unwrap());
         popup.title = Some(summary.title);
         popup.transient = true;
         popup.position = PopupPosition::Fixed { x: col, y: row + 1 };

--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -86,7 +86,7 @@ impl crate::app::window::Window {
             if opts.clear_anchor {
                 view_state.cursors.primary_mut().anchor = None;
             }
-            if let Some(state) = (&mut self.buffers).get_mut(&active_buffer) {
+            if let Some(state) = self.buffers.get_mut(&active_buffer) {
                 if let Some(pos) = state.buffer.offset_to_position(position) {
                     state.primary_cursor_line_number = LineNumber::Absolute(pos.line);
                 }

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -295,7 +295,7 @@ fn discover_sessions(
             .unwrap_or_default();
         found.push((root, label, plugin_state, authority_spec));
     }
-    found.sort_by(|a, b| canonical_key(&a.0).cmp(&canonical_key(&b.0)));
+    found.sort_by_key(|a| canonical_key(&a.0));
     found
         .into_iter()
         .enumerate()

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -41,6 +41,18 @@ fn make_search_opts(
     }
 }
 
+/// Fields of a `PluginCommand::BeginSearch`, grouped so
+/// [`Editor::handle_begin_search`] takes one argument instead of seven.
+pub(super) struct BeginSearchArgs {
+    pub pattern: String,
+    pub fixed_string: bool,
+    pub case_sensitive: bool,
+    pub max_results: usize,
+    pub whole_words: bool,
+    pub source_buffer_id: usize,
+    pub handle_id: u64,
+}
+
 impl Editor {
     // ==================== Menu Helpers ====================
 
@@ -2592,16 +2604,16 @@ impl Editor {
     /// dispatches. Aborts when the handle's `cancel` flag flips (set by
     /// `_searchHandleCancel` or by the next `BeginSearch` superseding this
     /// one).
-    pub(super) fn handle_begin_search(
-        &mut self,
-        pattern: String,
-        fixed_string: bool,
-        case_sensitive: bool,
-        max_results: usize,
-        whole_words: bool,
-        source_buffer_id: usize,
-        handle_id: u64,
-    ) {
+    pub(super) fn handle_begin_search(&mut self, args: BeginSearchArgs) {
+        let BeginSearchArgs {
+            pattern,
+            fixed_string,
+            case_sensitive,
+            max_results,
+            whole_words,
+            source_buffer_id,
+            handle_id,
+        } = args;
         // Look up the handle the plugin pre-registered. If it's missing
         // (registry races with a unit test), drop the request — there's no
         // observer to deliver results to.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1383,13 +1383,15 @@ impl Editor {
                 request_id,
             } => {
                 self.handle_create_composite_buffer(
-                    name,
-                    mode,
-                    layout,
-                    sources,
-                    hunks,
-                    initial_focus_hunk,
-                    request_id,
+                    crate::app::composite_buffer_actions::CreateCompositeBufferArgs {
+                        name,
+                        mode,
+                        layout_config: layout,
+                        source_configs: sources,
+                        hunks,
+                        initial_focus_hunk,
+                        request_id,
+                    },
                 );
             }
             PluginCommand::UpdateCompositeAlignment { buffer_id, hunks } => {
@@ -1521,7 +1523,7 @@ impl Editor {
                 source_buffer_id,
                 handle_id,
             } => {
-                self.handle_begin_search(
+                self.handle_begin_search(crate::app::plugin_commands::BeginSearchArgs {
                     pattern,
                     fixed_string,
                     case_sensitive,
@@ -1529,7 +1531,7 @@ impl Editor {
                     whole_words,
                     source_buffer_id,
                     handle_id,
-                );
+                });
             }
 
             PluginCommand::ReplaceInBuffer {
@@ -3731,15 +3733,15 @@ impl Editor {
                 .windows
                 .get_mut(&target_id)
                 .expect("target window present (existence checked above)");
-            target.create_plugin_terminal(
-                cwd_buf,
-                split_direction,
+            target.create_plugin_terminal(crate::app::terminal::PluginTerminalSpec {
+                cwd: cwd_buf,
+                direction: split_direction,
                 ratio,
-                focus.unwrap_or(true),
+                focus: focus.unwrap_or(true),
                 persistent,
                 command,
-                title.filter(|t| !t.is_empty()),
-            )
+                title: title.filter(|t| !t.is_empty()),
+            })
         };
         match result {
             Ok((terminal_id, buffer_id, created_split_id)) => {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3220,18 +3220,19 @@ impl Editor {
                     self.terminal_height,
                     buffer_id,
                 );
-                view_state.apply_config_defaults(
-                    self.config.editor.line_numbers,
-                    self.config.editor.highlight_current_line,
-                    line_wrap.unwrap_or_else(|| {
+                view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                    line_numbers: self.config.editor.line_numbers,
+                    highlight_current_line: self.config.editor.highlight_current_line,
+                    line_wrap: line_wrap.unwrap_or_else(|| {
                         self.active_window().resolve_line_wrap_for_buffer(buffer_id)
                     }),
-                    self.config.editor.wrap_indent,
-                    self.active_window()
+                    wrap_indent: self.config.editor.wrap_indent,
+                    wrap_column: self
+                        .active_window()
                         .resolve_wrap_column_for_buffer(buffer_id),
-                    self.config.editor.rulers.clone(),
-                    self.config.editor.scroll_offset,
-                );
+                    rulers: self.config.editor.rulers.clone(),
+                    scroll_offset: self.config.editor.scroll_offset,
+                });
                 view_state.ensure_buffer_state(buffer_id).show_line_numbers = show_line_numbers;
                 self.windows
                     .get_mut(&self.active_window)

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4014,7 +4014,7 @@ impl Editor {
                 // Synthetic, window-derived request id (well clear of the
                 // low-numbered JS callback ids) so the in-flight/cancel
                 // tracking works and a repeated switch doesn't double-connect.
-                let request_id = u64::MAX - window_id.0 as u64;
+                let request_id = u64::MAX - window_id.0;
                 if self.remote_attach_inflight.contains(&request_id) {
                     return;
                 }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -38,7 +38,7 @@ fn hard_wrap(text: &str, width: usize) -> Vec<String> {
     let mut cur = String::new();
     let mut cur_w = 0usize;
 
-    let mut push_word =
+    let push_word =
         |word: &str, lines: &mut Vec<String>, cur: &mut String, cur_w: &mut usize| {
             for c in word.chars() {
                 let w = ch_width(c);

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -38,18 +38,17 @@ fn hard_wrap(text: &str, width: usize) -> Vec<String> {
     let mut cur = String::new();
     let mut cur_w = 0usize;
 
-    let push_word =
-        |word: &str, lines: &mut Vec<String>, cur: &mut String, cur_w: &mut usize| {
-            for c in word.chars() {
-                let w = ch_width(c);
-                if *cur_w + w > width && !cur.is_empty() {
-                    lines.push(std::mem::take(cur));
-                    *cur_w = 0;
-                }
-                cur.push(c);
-                *cur_w += w;
+    let push_word = |word: &str, lines: &mut Vec<String>, cur: &mut String, cur_w: &mut usize| {
+        for c in word.chars() {
+            let w = ch_width(c);
+            if *cur_w + w > width && !cur.is_empty() {
+                lines.push(std::mem::take(cur));
+                *cur_w = 0;
             }
-        };
+            cur.push(c);
+            *cur_w += w;
+        }
+    };
 
     for word in text.split(' ') {
         let word_w: usize = word.chars().map(ch_width).sum();

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2782,16 +2782,17 @@ impl Editor {
                 self.terminal_height,
                 buffer_id,
             );
-            view_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
-                self.active_window().resolve_line_wrap_for_buffer(buffer_id),
-                self.config.editor.wrap_indent,
-                self.active_window()
+            view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
+                line_wrap: self.active_window().resolve_line_wrap_for_buffer(buffer_id),
+                wrap_indent: self.config.editor.wrap_indent,
+                wrap_column: self
+                    .active_window()
                     .resolve_wrap_column_for_buffer(buffer_id),
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
             let mut loaded_buffers = std::collections::HashSet::new();
             // Whether this *first* preview buffer was newly loaded.
             // The pre-existing case skips the `was_open` branch so

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1677,10 +1677,10 @@ impl Editor {
                                         level = WarningLevel::Error;
                                         break;
                                     }
-                                    LspServerStatus::Starting | LspServerStatus::Initializing => {
-                                        if level != WarningLevel::Error {
-                                            level = WarningLevel::Warning;
-                                        }
+                                    LspServerStatus::Starting | LspServerStatus::Initializing
+                                        if level != WarningLevel::Error =>
+                                    {
+                                        level = WarningLevel::Warning;
                                     }
                                     _ => {}
                                 }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1407,14 +1407,16 @@ impl Editor {
             Some(
                 crate::view::workspace_trust_dialog::render_workspace_trust_dialog(
                     frame,
-                    size,
-                    selected,
-                    &path,
-                    &triggers,
-                    &secondary_label,
-                    self.workspace_trust_scroll,
-                    theme_clone,
-                    draw_trust,
+                    crate::view::workspace_trust_dialog::TrustDialogParams {
+                        area: size,
+                        selected,
+                        path: &path,
+                        triggers: &triggers,
+                        secondary_label: &secondary_label,
+                        scroll: self.workspace_trust_scroll,
+                        theme: theme_clone,
+                        draw: draw_trust,
+                    },
                 ),
             )
         } else {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1553,7 +1553,7 @@ impl Editor {
                 &files_with_unsaved_changes,
                 &keybindings,
                 key_context_clone,
-                &*self.theme.read().unwrap(),
+                &self.theme.read().unwrap(),
                 close_button_hovered,
                 remote_connection.as_deref(),
                 cut_paths,
@@ -1836,7 +1836,7 @@ impl Editor {
                     frame,
                     chrome_area,
                     settings_state,
-                    &*self.theme.read().unwrap(),
+                    &self.theme.read().unwrap(),
                 );
                 self.active_chrome_mut().settings_layout = Some(settings_layout);
             }
@@ -1852,7 +1852,7 @@ impl Editor {
                     frame,
                     chrome_area,
                     wizard,
-                    &*self.theme.read().unwrap(),
+                    &self.theme.read().unwrap(),
                 );
             }
         }
@@ -1870,7 +1870,7 @@ impl Editor {
                     frame,
                     chrome_area,
                     kb_editor,
-                    &*self.theme.read().unwrap(),
+                    &self.theme.read().unwrap(),
                 );
             }
         }
@@ -1884,7 +1884,7 @@ impl Editor {
                     frame,
                     chrome_area,
                     debug,
-                    &*self.theme.read().unwrap(),
+                    &self.theme.read().unwrap(),
                 );
             }
         }
@@ -1917,7 +1917,7 @@ impl Editor {
                 &all_menus,
                 &self.menu_state,
                 &keybindings,
-                &*self.theme.read().unwrap(),
+                &self.theme.read().unwrap(),
                 hover_target.as_ref(),
                 menu_bar_mnemonics,
                 Some(&mut crate::app::types::CellThemeRecorder::new(
@@ -2357,7 +2357,7 @@ impl Editor {
             frame,
             suggestions_area,
             prompt,
-            &*self.theme.read().unwrap(),
+            &self.theme.read().unwrap(),
             self.active_window().mouse_state.hover_target.as_ref(),
             true,
             !self.suppress_chrome_cells,
@@ -2382,7 +2382,7 @@ impl Editor {
                 height: hints_height,
             };
             frame.render_widget(ratatui::widgets::Clear, hints_area);
-            Self::render_quick_open_hints(frame, hints_area, &*self.theme.read().unwrap());
+            Self::render_quick_open_hints(frame, hints_area, &self.theme.read().unwrap());
         }
     }
 
@@ -5019,7 +5019,7 @@ fn paint_text_property_entry(
         let span_w = crate::primitives::display_width::str_width(&slice) as u16;
         if let Some((map, sw, region)) = recorder.as_mut() {
             record_entry_span_cells(
-                map, *sw, *region, y, col_cursor, span_w, x, width, &fg_key, &bg_key,
+                map, *sw, region, y, col_cursor, span_w, x, width, &fg_key, &bg_key,
             );
         }
         col_cursor = col_cursor.saturating_add(span_w);
@@ -5034,7 +5034,7 @@ fn paint_text_property_entry(
             record_entry_span_cells(
                 map,
                 *sw,
-                *region,
+                region,
                 y,
                 col_cursor,
                 row_end - col_cursor,

--- a/crates/fresh-editor/src/app/scan_orchestrators.rs
+++ b/crates/fresh-editor/src/app/scan_orchestrators.rs
@@ -116,8 +116,7 @@ impl Editor {
                     .get(&active_id)
                     .expect("active window present")
                     .line_scan
-                    .leaves()[chunk.leaf_index]
-                    .clone();
+                    .leaves()[chunk.leaf_index];
                 let leaf = &leaf;
 
                 let win = self.windows.get(&active_id).expect("active window present");

--- a/crates/fresh-editor/src/app/scrollbar_math.rs
+++ b/crates/fresh-editor/src/app/scrollbar_math.rs
@@ -23,8 +23,8 @@ use crate::view::line_wrap_cache::CacheViewMode;
 use crate::view::visual_row_index::{ensure_built, VisualRowIndexKey};
 
 /// Width estimate of the gutter, used to build the wrap config. Kept in
-/// sync with the real gutter sizing in the render path (indicator + digits
-/// + separator) — see `Viewport::gutter_width`, which uses the same
+/// sync with the real gutter sizing in the render path (indicator +
+/// digits + separator) — see `Viewport::gutter_width`, which uses the same
 /// formula with `MIN_LINE_NUMBER_DIGITS` as the floor.  Returns 0 when
 /// `show_line_numbers` is false (compose mode etc.) — the renderer's
 /// `state.margins.left_total_width()` returns 0 there too, and any

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -618,20 +618,17 @@ impl Editor {
             }
         };
 
-        match control_type {
-            // Number inc/dec removed — direct typing only. Action still
-            // exists for Dropdown cycling.
-            Some("dropdown") => {
-                if let Some(ref mut state) = self.settings_state {
-                    if let Some(item) = state.current_item_mut() {
-                        if let SettingControl::Dropdown(ref mut dropdown_state) = item.control {
-                            dropdown_state.select_next();
-                        }
+        // Number inc/dec removed — direct typing only. Action still
+        // exists for Dropdown cycling.
+        if let Some("dropdown") = control_type {
+            if let Some(ref mut state) = self.settings_state {
+                if let Some(item) = state.current_item_mut() {
+                    if let SettingControl::Dropdown(ref mut dropdown_state) = item.control {
+                        dropdown_state.select_next();
                     }
-                    state.on_value_changed();
                 }
+                state.on_value_changed();
             }
-            _ => {}
         }
     }
 
@@ -676,20 +673,17 @@ impl Editor {
             }
         };
 
-        match control_type {
-            // Number inc/dec removed — direct typing only. Action still
-            // exists for Dropdown cycling.
-            Some("dropdown") => {
-                if let Some(ref mut state) = self.settings_state {
-                    if let Some(item) = state.current_item_mut() {
-                        if let SettingControl::Dropdown(ref mut dropdown_state) = item.control {
-                            dropdown_state.select_prev();
-                        }
+        // Number inc/dec removed — direct typing only. Action still
+        // exists for Dropdown cycling.
+        if let Some("dropdown") = control_type {
+            if let Some(ref mut state) = self.settings_state {
+                if let Some(item) = state.current_item_mut() {
+                    if let SettingControl::Dropdown(ref mut dropdown_state) = item.control {
+                        dropdown_state.select_prev();
                     }
-                    state.on_value_changed();
                 }
+                state.on_value_changed();
             }
-            _ => {}
         }
     }
 

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -500,7 +500,7 @@ impl Editor {
                     crate::services::lsp::diagnostics::apply_diagnostics_to_state_cached(
                         state,
                         &diagnostics,
-                        &*self.theme.read().unwrap(),
+                        &self.theme.read().unwrap(),
                     );
                 }
             }
@@ -530,7 +530,7 @@ impl Editor {
                     crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                         state,
                         &tokens,
-                        &*self.theme.read().unwrap(),
+                        &self.theme.read().unwrap(),
                     );
                 }
             }

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -625,7 +625,7 @@ impl Editor {
         // Find the index of the current keybinding map
         let current_index = all_maps
             .iter()
-            .position(|name| name.to_string() == current_map)
+            .position(|name| *name == current_map)
             .unwrap_or(0);
 
         let suggestions: Vec<crate::input::commands::Suggestion> = all_maps

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -84,17 +84,19 @@ impl Editor {
                     self.terminal_height,
                     current_buffer_id,
                 );
-                view_state.apply_config_defaults(
-                    self.config.editor.line_numbers,
-                    self.config.editor.highlight_current_line,
-                    self.active_window()
+                view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                    line_numbers: self.config.editor.line_numbers,
+                    highlight_current_line: self.config.editor.highlight_current_line,
+                    line_wrap: self
+                        .active_window()
                         .resolve_line_wrap_for_buffer(current_buffer_id),
-                    self.config.editor.wrap_indent,
-                    self.active_window()
+                    wrap_indent: self.config.editor.wrap_indent,
+                    wrap_column: self
+                        .active_window()
                         .resolve_wrap_column_for_buffer(current_buffer_id),
-                    self.config.editor.rulers.clone(),
-                    self.config.editor.scroll_offset,
-                );
+                    rulers: self.config.editor.rulers.clone(),
+                    scroll_offset: self.config.editor.scroll_offset,
+                });
 
                 // Copy keyed states from source split for OTHER buffers (not the active one).
                 // The active buffer gets a fresh cursor in the new split.

--- a/crates/fresh-editor/src/app/tab_drag.rs
+++ b/crates/fresh-editor/src/app/tab_drag.rs
@@ -482,16 +482,17 @@ impl Editor {
                 let (width, height) = (self.terminal_width, self.terminal_height);
                 let mut new_view_state =
                     crate::view::split::SplitViewState::with_buffer(width, height, buffer_id);
-                new_view_state.apply_config_defaults(
-                    self.config.editor.line_numbers,
-                    self.config.editor.highlight_current_line,
-                    self.active_window().resolve_line_wrap_for_buffer(buffer_id),
-                    self.config.editor.wrap_indent,
-                    self.active_window()
+                new_view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                    line_numbers: self.config.editor.line_numbers,
+                    highlight_current_line: self.config.editor.highlight_current_line,
+                    line_wrap: self.active_window().resolve_line_wrap_for_buffer(buffer_id),
+                    wrap_indent: self.config.editor.wrap_indent,
+                    wrap_column: self
+                        .active_window()
                         .resolve_wrap_column_for_buffer(buffer_id),
-                    self.config.editor.rulers.clone(),
-                    self.config.editor.scroll_offset,
-                );
+                    rulers: self.config.editor.rulers.clone(),
+                    scroll_offset: self.config.editor.scroll_offset,
+                });
 
                 // Copy cursor position from source split's view state
                 if let Some(source_vs) = self

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -458,8 +458,17 @@ impl Window {
                             // is independent.
                             let _ = line_numbers;
                             let _ = highlight_current_line;
-                            view_state
-                                .apply_config_defaults(false, false, false, false, None, rulers, 0);
+                            view_state.apply_config_defaults(
+                                crate::view::split::ViewConfigDefaults {
+                                    line_numbers: false,
+                                    highlight_current_line: false,
+                                    line_wrap: false,
+                                    wrap_indent: false,
+                                    wrap_column: None,
+                                    rulers,
+                                    scroll_offset: 0,
+                                },
+                            );
                             // Terminal output is ANSI-sequenced and
                             // assumes a fixed column count; wrapping
                             // would mangle cursor positioning.
@@ -1057,16 +1066,17 @@ impl Editor {
             SplitViewState::with_buffer(self.terminal_width, self.terminal_height, buffer_id);
         // Terminal-dedicated splits never show line numbers or current-line
         // highlight (mirrors the dock + plugin-terminal split setup).
-        view_state.apply_config_defaults(
-            false,
-            false,
-            self.active_window().resolve_line_wrap_for_buffer(buffer_id),
-            self.config.editor.wrap_indent,
-            self.active_window()
+        view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+            line_numbers: false,
+            highlight_current_line: false,
+            line_wrap: self.active_window().resolve_line_wrap_for_buffer(buffer_id),
+            wrap_indent: self.config.editor.wrap_indent,
+            wrap_column: self
+                .active_window()
                 .resolve_wrap_column_for_buffer(buffer_id),
-            self.config.editor.rulers.clone(),
-            0,
-        );
+            rulers: self.config.editor.rulers.clone(),
+            scroll_offset: 0,
+        });
         // Terminals don't wrap — keep escape sequences intact.
         view_state.viewport.line_wrap_enabled = false;
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -85,6 +85,19 @@ fn combine_terminal_title(pty: Option<&str>, osc: Option<&str>) -> Option<String
     }
 }
 
+/// Spawn options for [`Window::create_plugin_terminal`], grouped so the
+/// call takes one argument instead of seven.
+pub struct PluginTerminalSpec {
+    pub cwd: Option<PathBuf>,
+    pub direction: Option<crate::model::event::SplitDirection>,
+    pub ratio: Option<f32>,
+    /// Split focus: whether the new terminal becomes the active leaf.
+    pub focus: bool,
+    pub persistent: bool,
+    pub command: Option<Vec<String>>,
+    pub title: Option<String>,
+}
+
 impl Window {
     /// Resolve the terminal wrapper used to spawn a new integrated
     /// terminal in this window, applying the `terminal.shell` config
@@ -366,14 +379,17 @@ impl Window {
     /// seeding a fresh layout in a never-activated window).
     pub fn create_plugin_terminal(
         &mut self,
-        cwd: Option<PathBuf>,
-        direction: Option<crate::model::event::SplitDirection>,
-        ratio: Option<f32>,
-        focus: bool,
-        persistent: bool,
-        command: Option<Vec<String>>,
-        title: Option<String>,
+        spec: PluginTerminalSpec,
     ) -> Result<(TerminalId, BufferId, Option<LeafId>), String> {
+        let PluginTerminalSpec {
+            cwd,
+            direction,
+            ratio,
+            focus,
+            persistent,
+            command,
+            title,
+        } = spec;
         // Derive the auto-title from the command's executable name
         // (basename of argv[0]). The host writes this into the
         // terminal buffer's `BufferMetadata::name` so the tab reads

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -137,15 +137,15 @@ impl Editor {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: self.config.editor.line_numbers,
+                highlight_current_line: self.config.editor.highlight_current_line,
                 line_wrap,
-                self.config.editor.wrap_indent,
+                wrap_indent: self.config.editor.wrap_indent,
                 wrap_column,
-                self.config.editor.rulers.clone(),
-                self.config.editor.scroll_offset,
-            );
+                rulers: self.config.editor.rulers.clone(),
+                scroll_offset: self.config.editor.scroll_offset,
+            });
         }
 
         self.set_active_buffer(buffer_id);
@@ -389,27 +389,27 @@ impl crate::app::window::Window {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                cfg.line_numbers,
-                cfg.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: cfg.line_numbers,
+                highlight_current_line: cfg.highlight_current_line,
                 line_wrap,
-                cfg.wrap_indent,
+                wrap_indent: cfg.wrap_indent,
                 wrap_column,
-                cfg.rulers.clone(),
-                cfg.scroll_offset,
-            );
+                rulers: cfg.rulers.clone(),
+                scroll_offset: cfg.scroll_offset,
+            });
         } else {
             let mut view_state =
                 SplitViewState::with_buffer(terminal_width, terminal_height, buffer_id);
-            view_state.apply_config_defaults(
-                cfg.line_numbers,
-                cfg.highlight_current_line,
+            view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: cfg.line_numbers,
+                highlight_current_line: cfg.highlight_current_line,
                 line_wrap,
-                cfg.wrap_indent,
+                wrap_indent: cfg.wrap_indent,
                 wrap_column,
-                cfg.rulers,
-                cfg.scroll_offset,
-            );
+                rulers: cfg.rulers,
+                scroll_offset: cfg.scroll_offset,
+            });
             self.split_view_states_mut()
                 .expect("active window must have a populated split layout")
                 .insert(active_split, view_state);

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -66,8 +66,7 @@ impl Editor {
             self.active_buffer()
         } else {
             // Create new buffer ID
-            let id = self.alloc_buffer_id();
-            id
+            self.alloc_buffer_id()
         };
 
         // Get file size for status message before loading

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -275,23 +275,22 @@ impl Editor {
         self.stdin_stream.is_active()
     }
 
-    /// Create a new virtual buffer (not backed by a file)
-    ///
-    /// # Arguments
-    /// * `name` - Display name (e.g., "*Diagnostics*")
-    /// * `mode` - Buffer mode for keybindings (e.g., "diagnostics-list")
-    /// * `read_only` - Whether the buffer should be read-only
-    ///
-    /// # Returns
-    /// The BufferId of the created virtual buffer
-    ///
-    /// Like [`Self::create_virtual_buffer`] but does **not** add the
-    /// new buffer to any split's tab list. Use this when the caller
-    /// is going to seed a freshly-created split (e.g. the Utility
-    /// Dock leaf) with the new buffer directly — without it, the
-    /// buffer would briefly appear as a phantom tab in whatever the
-    /// previously-active split was, requiring a separate cleanup
-    /// pass to remove it.
+    // Create a new virtual buffer (not backed by a file).
+    //
+    // Arguments:
+    // * `name` - Display name (e.g., "*Diagnostics*")
+    // * `mode` - Buffer mode for keybindings (e.g., "diagnostics-list")
+    // * `read_only` - Whether the buffer should be read-only
+    //
+    // Returns the BufferId of the created virtual buffer.
+    //
+    // Like [`Self::create_virtual_buffer`] but does **not** add the
+    // new buffer to any split's tab list. Use this when the caller
+    // is going to seed a freshly-created split (e.g. the Utility
+    // Dock leaf) with the new buffer directly — without it, the
+    // buffer would briefly appear as a phantom tab in whatever the
+    // previously-active split was, requiring a separate cleanup
+    // pass to remove it.
     // `create_virtual_buffer_detached` and `create_virtual_buffer` live
     // on `impl Window` — call them via
     // `self.active_window_mut().create_virtual_buffer*(...)`.

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -654,7 +654,8 @@ impl Editor {
                     // would do). Falls back to `activate` for trees
                     // that aren't checkable, or rows that don't have
                     // a checkbox glyph (`checked: None`).
-                    if !self.fire_tree_toggle_if_checkable(panel_key, &focus_key) {
+                    let toggled = self.fire_tree_toggle_if_checkable(panel_key, &focus_key);
+                    if !toggled {
                         self.fire_tree_activate(panel_key, &focus_key);
                     }
                 }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -581,12 +581,11 @@ impl Editor {
                 }
                 _ => {}
             },
-            "Backspace" | "Delete" | "Home" | "End" => match widget {
-                Some(fresh_core::api::WidgetSpec::Text { .. }) => {
+            "Backspace" | "Delete" | "Home" | "End" => {
+                if let Some(fresh_core::api::WidgetSpec::Text { .. }) = widget {
                     self.handle_widget_text_key(panel_key, key);
                 }
-                _ => {}
-            },
+            }
             "Enter" => match widget {
                 Some(fresh_core::api::WidgetSpec::Button { .. })
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -352,7 +352,7 @@ impl Editor {
                 out_pieces.focus_key,
                 out_pieces.tabbable,
             )
-            .is_err()
+            .is_none()
         {
             tracing::warn!("rerender_widget_panel({}) lost panel mid-call", panel_key);
             return;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -1750,12 +1750,10 @@ impl Editor {
         &self,
         buffer_id: crate::model::event::BufferId,
     ) -> Option<crate::widgets::PanelKey> {
-        for panel_key in self.widget_registry.panels_for_buffer(buffer_id) {
-            if self.panel_focused_widget_is_text(&panel_key) {
-                return Some(panel_key);
-            }
-        }
-        None
+        self.widget_registry
+            .panels_for_buffer(buffer_id)
+            .into_iter()
+            .find(|panel_key| self.panel_focused_widget_is_text(panel_key))
     }
 
     /// True when `panel_key`'s currently-focused widget is a `Text`

--- a/crates/fresh-editor/src/app/window/buffers.rs
+++ b/crates/fresh-editor/src/app/window/buffers.rs
@@ -53,6 +53,10 @@ impl WindowBuffers {
         self.map.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, BufferId, EditorState> {
         self.map.iter()
     }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2823,15 +2823,15 @@ impl Window {
         {
             view_state.add_buffer(buffer_id);
             let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                cfg.line_numbers,
-                cfg.highlight_current_line,
+            buf_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                line_numbers: cfg.line_numbers,
+                highlight_current_line: cfg.highlight_current_line,
                 line_wrap,
-                cfg.wrap_indent,
+                wrap_indent: cfg.wrap_indent,
                 wrap_column,
-                cfg.rulers,
-                cfg.scroll_offset,
-            );
+                rulers: cfg.rulers,
+                scroll_offset: cfg.scroll_offset,
+            });
         }
 
         self.set_active_buffer(buffer_id);

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -62,7 +62,7 @@ impl crate::app::Editor {
             dir_context: self.dir_context.clone(),
             tokio_runtime: self.tokio_runtime.clone(),
             async_bridge: self.async_bridge.clone(),
-            plugin_manager: std::sync::Arc::clone(&self.plugin_manager),
+            plugin_manager: std::rc::Rc::clone(&self.plugin_manager),
             theme: std::sync::Arc::clone(&self.theme),
             event_broadcaster: self.event_broadcaster.clone(),
             recovery_service: std::sync::Arc::clone(&self.recovery_service),

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -313,15 +313,15 @@ impl crate::app::Editor {
                 .windows
                 .get_mut(&id)
                 .expect("just-inserted window must be present");
-            target.create_plugin_terminal(
-                cwd.or_else(|| Some(root.clone())),
-                None, // no split direction — let the no-layout branch seed
-                None,
-                true,  // focus — newly spawned terminal is the seed
-                false, // ephemeral by default; orchestrator owns persistence
+            target.create_plugin_terminal(crate::app::terminal::PluginTerminalSpec {
+                cwd: cwd.or_else(|| Some(root.clone())),
+                direction: None, // no split direction — let the no-layout branch seed
+                ratio: None,
+                focus: true,       // newly spawned terminal is the seed
+                persistent: false, // ephemeral by default; orchestrator owns persistence
                 command,
-                title.filter(|t| !t.is_empty()),
-            )
+                title: title.filter(|t| !t.is_empty()),
+            })
         };
 
         let (terminal_id, buffer_id, _split_id) = match spawn_result {

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -713,7 +713,7 @@ impl crate::app::Editor {
         if !self
             .windows
             .get(&id)
-            .is_some_and(|s| s.buffers.splits().is_none() || s.buffers.len() == 0)
+            .is_some_and(|s| s.buffers.splits().is_none() || s.buffers.is_empty())
         {
             return None;
         }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -17,6 +17,18 @@ use fresh_core::WindowId;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Seed state for a freshly-built window layout: the base buffer plus the
+/// editor/metadata/event-log/split scaffolding returned by
+/// [`Editor::build_fresh_layout_if_needed`].
+type FreshLayoutSeed = (
+    fresh_core::BufferId,
+    crate::state::EditorState,
+    crate::app::types::BufferMetadata,
+    crate::model::event::EventLog,
+    SplitManager,
+    HashMap<crate::model::event::LeafId, SplitViewState>,
+);
+
 impl crate::app::Editor {
     /// Snapshot the editor-global resources every new `Window` needs.
     /// All fields are cheap clones (`Arc` increments or `Clone`-by-value
@@ -697,17 +709,7 @@ impl crate::app::Editor {
     /// Factored out of `set_active_window` so other call sites that
     /// need to populate an inert window shell can share the same
     /// seed-construction logic.
-    pub(crate) fn build_fresh_layout_if_needed(
-        &mut self,
-        id: WindowId,
-    ) -> Option<(
-        fresh_core::BufferId,
-        crate::state::EditorState,
-        crate::app::types::BufferMetadata,
-        crate::model::event::EventLog,
-        SplitManager,
-        HashMap<crate::model::event::LeafId, SplitViewState>,
-    )> {
+    pub(crate) fn build_fresh_layout_if_needed(&mut self, id: WindowId) -> Option<FreshLayoutSeed> {
         if !self
             .windows
             .get(&id)

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -165,11 +165,13 @@ pub struct WindowResources {
     pub async_bridge: Option<crate::services::async_bridge::AsyncBridge>,
 
     /// Plugin manager (single QuickJS instance), wrapped in
-    /// `Arc<RwLock<>>` so windows can fire hooks and read state
+    /// `Rc<RwLock<>>` so windows can fire hooks and read state
     /// without going through `Editor`. Reads take a read lock; the
     /// few `&mut self` methods (process_commands, check_thread_health,
-    /// test_inject_command) take a write lock.
-    pub plugin_manager: Arc<RwLock<crate::services::plugins::manager::PluginManager>>,
+    /// test_inject_command) take a write lock. `Rc` rather than `Arc`:
+    /// `PluginManager` is not `Sync` and never leaves the UI thread, so
+    /// atomic refcounting would buy nothing.
+    pub plugin_manager: std::rc::Rc<RwLock<crate::services::plugins::manager::PluginManager>>,
 
     /// Active resolved theme, mirrored from `Editor.theme`. Each
     /// `set_theme` / theme-reload pushes the new value into this

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1114,15 +1114,19 @@ impl crate::app::window::Window {
                             self.terminal_height,
                             second_buffer_id,
                         );
-                        view_state.apply_config_defaults(
-                            self.resources.config.editor.line_numbers,
-                            self.resources.config.editor.highlight_current_line,
-                            self.resolve_line_wrap_for_buffer(second_buffer_id),
-                            self.resources.config.editor.wrap_indent,
-                            self.resolve_wrap_column_for_buffer(second_buffer_id),
-                            self.resources.config.editor.rulers.clone(),
-                            self.resources.config.editor.scroll_offset,
-                        );
+                        view_state.apply_config_defaults(crate::view::split::ViewConfigDefaults {
+                            line_numbers: self.resources.config.editor.line_numbers,
+                            highlight_current_line: self
+                                .resources
+                                .config
+                                .editor
+                                .highlight_current_line,
+                            line_wrap: self.resolve_line_wrap_for_buffer(second_buffer_id),
+                            wrap_indent: self.resources.config.editor.wrap_indent,
+                            wrap_column: self.resolve_wrap_column_for_buffer(second_buffer_id),
+                            rulers: self.resources.config.editor.rulers.clone(),
+                            scroll_offset: self.resources.config.editor.scroll_offset,
+                        });
                         self.buffers
                             .split_view_states_mut()
                             .expect("active window must have a populated split layout")

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -496,7 +496,7 @@ impl Editor {
         let populated = self
             .windows
             .get(&id)
-            .map(|w| w.buffers.splits().is_some() && w.buffers.len() > 0)
+            .map(|w| w.buffers.splits().is_some() && !w.buffers.is_empty())
             .unwrap_or(false);
 
         let session = self.session_name.clone();
@@ -1814,7 +1814,7 @@ impl crate::app::window::Window {
     /// layout, if it doesn't already have a populated layout. Mirrors
     /// `Editor::build_fresh_layout_if_needed`, rooted on `self`.
     pub(crate) fn seed_initial_layout(&mut self) {
-        if self.buffers.splits().is_some() && self.buffers.len() > 0 {
+        if self.buffers.splits().is_some() && !self.buffers.is_empty() {
             return;
         }
         let buf = self.alloc_buffer_id();

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1176,9 +1176,7 @@ impl crate::app::window::Window {
         let active_buffer_id = self
             .buffers
             .with_all_mut(|__buffers_mut, _mgr, vs_map| {
-                let Some(view_state) = vs_map.get_mut(&current_split_id) else {
-                    return None;
-                };
+                let view_state = vs_map.get_mut(&current_split_id)?;
                 let mut active_buffer_id: Option<BufferId> = None;
                 if !split_state.open_tabs.is_empty() {
                     // Clear pre-existing open_buffers (e.g. the initial empty buffer

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1205,6 +1205,7 @@ pub struct EditorConfig {
     /// - `all`: draw every indentation level in leading whitespace.
     /// - `active`: draw only the innermost guide for the cursor's current
     ///   indentation block.
+    ///
     /// Default: none
     #[serde(default)]
     #[schemars(extend("x-section" = "Display"))]

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -161,11 +161,9 @@ fn find_changed_paths_recursive(
                 find_changed_paths_recursive(old_val, new_val, path, changed);
             }
         }
-        (old_val, new_val) if old_val != new_val => {
-            // Leaf values differ - mark as changed
-            if !prefix.is_empty() {
-                changed.insert(prefix);
-            }
+        // Leaf values differ - mark as changed (skip the empty root prefix)
+        (old_val, new_val) if old_val != new_val && !prefix.is_empty() => {
+            changed.insert(prefix);
         }
         _ => {} // Values are equal, no change
     }

--- a/crates/fresh-editor/src/input/fuzzy/mod.rs
+++ b/crates/fresh-editor/src/input/fuzzy/mod.rs
@@ -187,7 +187,7 @@ where
         .collect();
 
     // Sort by score descending (best matches first)
-    results.sort_by(|a, b| b.1.score.cmp(&a.1.score));
+    results.sort_by_key(|b| std::cmp::Reverse(b.1.score));
 
     results
 }

--- a/crates/fresh-editor/src/input/quick_open/providers.rs
+++ b/crates/fresh-editor/src/input/quick_open/providers.rs
@@ -946,7 +946,7 @@ impl QuickOpenProvider for FileProvider {
             }
         }
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.1));
         scored.truncate(max_results);
 
         let mut suggestions: Vec<Suggestion> = scored

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3165,11 +3165,10 @@ fn forward_to_session(session: &str, files: &[String]) -> AnyhowResult<bool> {
         loop {
             match conn.read_control() {
                 Ok(Some(line)) => {
-                    if let Ok(msg) = serde_json::from_str::<ServerControl>(&line) {
-                        match msg {
-                            ServerControl::WaitComplete | ServerControl::Quit { .. } => break,
-                            _ => {}
-                        }
+                    if let Ok(ServerControl::WaitComplete | ServerControl::Quit { .. }) =
+                        serde_json::from_str::<ServerControl>(&line)
+                    {
+                        break;
                     }
                 }
                 Ok(None) => break, // parent closed the connection

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -107,8 +107,6 @@ impl Default for BufferConfig {
     }
 }
 
-/// Line ending format used in the file
-
 /// Represents a line number (simplified for new implementation)
 /// Legacy enum kept for backwards compatibility - always Absolute now
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -2188,7 +2188,7 @@ impl TextBuffer {
         let mut tree = pristine;
 
         // Apply deletions from HIGH to LOW offset so earlier offsets stay valid.
-        deletions.sort_by(|a, b| b.0.cmp(&a.0));
+        deletions.sort_by_key(|b| std::cmp::Reverse(b.0));
         for &(offset, len) in &deletions {
             tree.delete(offset, len, &self.buffers);
         }

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -3016,7 +3016,7 @@ impl TextBuffer {
         }
 
         // Get some text before pos
-        let start = pos.saturating_sub(256).max(0);
+        let start = pos.saturating_sub(256);
         let Some(bytes) = self.get_text_range(start, pos - start) else {
             // Data unloaded, return pos as fallback
             return pos;

--- a/crates/fresh-editor/src/model/buffer/search.rs
+++ b/crates/fresh-editor/src/model/buffer/search.rs
@@ -66,11 +66,9 @@ impl ChunkedSearchState {
 
     /// Progress as a percentage (0–100).
     pub fn progress_percent(&self) -> usize {
-        if self.total_bytes > 0 {
-            (self.scanned_bytes * 100) / self.total_bytes
-        } else {
-            100
-        }
+        (self.scanned_bytes * 100)
+            .checked_div(self.total_bytes)
+            .unwrap_or(100)
     }
 }
 

--- a/crates/fresh-editor/src/model/piece_tree.rs
+++ b/crates/fresh-editor/src/model/piece_tree.rs
@@ -1717,11 +1717,7 @@ impl PieceTree {
                     };
                     let doc_line = lines_before + lines_in_partial;
                     // Column estimate: offset_in_piece modulo average bytes per line
-                    let avg_bytes_per_line = if lf_count > 0 {
-                        piece_bytes / lf_count
-                    } else {
-                        80
-                    };
+                    let avg_bytes_per_line = piece_bytes.checked_div(lf_count).unwrap_or(80);
                     let column = if avg_bytes_per_line > 0 {
                         offset_in_piece % avg_bytes_per_line
                     } else {

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -1392,7 +1392,7 @@ impl GrammarRegistry {
                 short_name: entry.short_name.clone(),
             })
             .collect();
-        result.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        result.sort_by_key(|a| a.name.to_lowercase());
         result
     }
 

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -84,10 +84,7 @@ impl IndentCalculator {
             // languages are no longer bundled (they use syntect highlighting +
             // the regex indent-rules tier), so this bails to the caller's
             // fallback for them. See fresh_languages::Language::ts_language.
-            let ts_language: fresh_languages::tree_sitter::Language = match language.ts_language() {
-                Some(l) => l,
-                None => return None,
-            };
+            let ts_language: fresh_languages::tree_sitter::Language = language.ts_language()?;
             let (lang_name, query_str) = match language {
                 Language::Rust => ("rust", include_str!("../../queries/rust/indents.scm")),
                 Language::Python => ("python", include_str!("../../queries/python/indents.scm")),

--- a/crates/fresh-editor/src/primitives/visual_layout.rs
+++ b/crates/fresh-editor/src/primitives/visual_layout.rs
@@ -336,7 +336,9 @@ pub fn wrap_str_to_width(text: &str, wrap_width: usize) -> Vec<Range<usize>> {
         return Vec::new();
     }
     if wrap_width == 0 {
-        return vec![0..text.len()];
+        // A single chunk spanning the whole string (one `Range` element,
+        // not a range collected into individual indices).
+        return std::iter::once(0..text.len()).collect();
     }
 
     use unicode_segmentation::UnicodeSegmentation;

--- a/crates/fresh-editor/src/primitives/visual_layout.rs
+++ b/crates/fresh-editor/src/primitives/visual_layout.rs
@@ -411,7 +411,7 @@ pub fn wrap_str_to_width(text: &str, wrap_width: usize) -> Vec<Range<usize>> {
         if text_len > chunk_start_byte
             && text_len >= floor_byte
             && text_len <= slice_end_hard
-            && best_target_byte.map_or(true, |b| text_len > b)
+            && best_target_byte.is_none_or(|b| text_len > b)
         {
             best_target_byte = Some(text_len);
         }

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -118,8 +118,11 @@ pub fn start() -> std::io::Result<&'static str> {
 struct BoundControl {
     req_rx: Receiver<LocalControlRequest>,
     waiters: Arc<Mutex<HashMap<u64, Sender<()>>>>,
-    /// Set to stop the accept thread. Held by the caller so the socket and
-    /// its thread live exactly as long as needed.
+    /// Set to stop the accept thread. Production (`start`) drops this and lets
+    /// the socket live for the whole process; only the tests hold it to shut
+    /// the accept thread down deterministically, so it reads as dead outside
+    /// `cfg(test)`.
+    #[cfg_attr(not(test), allow(dead_code))]
     shutdown: Arc<AtomicBool>,
 }
 

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -807,10 +807,11 @@ fn build_docker_exec_prefix(
 /// [`RemoteAgentSpec`]) verbatim so there is no new backend vocabulary and
 /// `fresh-core` stays backend-opaque. Externally tagged so it round-trips
 /// through JSON robustly and additively.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub enum SessionAuthoritySpec {
     /// Host-local backend. The default for a brand-new session and for any
     /// session with no persisted spec (back-compat).
+    #[default]
     Local,
     /// A backend installed via `editor.setAuthority(...)` — devcontainer /
     /// docker. Reconnecting it is the owning plugin's job (only it can run
@@ -819,12 +820,6 @@ pub enum SessionAuthoritySpec {
     /// A born-attached remote agent (SSH / Kubernetes). Reconnectable from
     /// core via `connect_ssh_authority` / `connect_kube_authority`.
     RemoteAgent(RemoteAgentSpec),
-}
-
-impl Default for SessionAuthoritySpec {
-    fn default() -> Self {
-        Self::Local
-    }
 }
 
 impl SessionAuthoritySpec {

--- a/crates/fresh-editor/src/services/completion/buffer_words.rs
+++ b/crates/fresh-editor/src/services/completion/buffer_words.rs
@@ -208,7 +208,7 @@ impl CompletionProvider for BufferWordProvider {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         let candidates = scored
             .into_iter()

--- a/crates/fresh-editor/src/services/fs/manager.rs
+++ b/crates/fresh-editor/src/services/fs/manager.rs
@@ -230,7 +230,7 @@ impl FsManager {
         let metadata_results = self.get_metadata(paths).await;
 
         // Attach metadata to entries
-        for (entry, metadata_result) in entries.iter_mut().zip(metadata_results.into_iter()) {
+        for (entry, metadata_result) in entries.iter_mut().zip(metadata_results) {
             if let Ok(metadata) = metadata_result {
                 entry.metadata = Some(metadata);
             }

--- a/crates/fresh-editor/src/services/recovery/storage.rs
+++ b/crates/fresh-editor/src/services/recovery/storage.rs
@@ -585,7 +585,7 @@ impl RecoveryStorage {
         }
 
         // Sort by update time (newest first)
-        entries.sort_by(|a, b| b.metadata.updated_at.cmp(&a.metadata.updated_at));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.metadata.updated_at));
 
         Ok(entries)
     }

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -521,8 +521,7 @@ async fn read_ssh_stderr(stderr: Option<ChildStderr>) -> Option<String> {
     buf.trim()
         .lines()
         .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .next_back()
+        .rfind(|line| !line.is_empty())
         .map(str::to_string)
 }
 

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -263,6 +263,18 @@ pub struct EditorState {
     pub coord_map: crate::model::coord_map::CoordMap,
 }
 
+/// The fields of an [`Event::AddOverlay`], grouped so
+/// [`EditorState::apply_add_overlay`] takes one argument instead of seven.
+struct AddOverlaySpec<'a> {
+    namespace: &'a Option<crate::view::overlay::OverlayNamespace>,
+    range: &'a Range<usize>,
+    face: &'a EventOverlayFace,
+    priority: i32,
+    message: &'a Option<String>,
+    extend_to_line_end: bool,
+    url: &'a Option<String>,
+}
+
 impl EditorState {
     /// Create a new editor state with an empty buffer
     ///
@@ -693,15 +705,15 @@ impl EditorState {
                 message,
                 extend_to_line_end,
                 url,
-            } => self.apply_add_overlay(
+            } => self.apply_add_overlay(AddOverlaySpec {
                 namespace,
                 range,
                 face,
-                *priority,
+                priority: *priority,
                 message,
-                *extend_to_line_end,
+                extend_to_line_end: *extend_to_line_end,
                 url,
-            ),
+            }),
 
             Event::RemoveOverlay { handle } => {
                 tracing::trace!("RemoveOverlay: handle={:?}", handle);
@@ -864,23 +876,18 @@ impl EditorState {
     }
 
     /// Materialize an `AddOverlay` event into a tracked [`Overlay`].
-    fn apply_add_overlay(
-        &mut self,
-        namespace: &Option<crate::view::overlay::OverlayNamespace>,
-        range: &Range<usize>,
-        face: &EventOverlayFace,
-        priority: i32,
-        message: &Option<String>,
-        extend_to_line_end: bool,
-        url: &Option<String>,
-    ) {
-        let overlay_face = convert_event_face_to_overlay_face(face);
-        let mut overlay =
-            Overlay::with_priority(&mut self.marker_list, range.clone(), overlay_face, priority);
-        overlay.namespace = namespace.clone();
-        overlay.message = message.clone();
-        overlay.extend_to_line_end = extend_to_line_end;
-        overlay.url = url.clone();
+    fn apply_add_overlay(&mut self, spec: AddOverlaySpec) {
+        let overlay_face = convert_event_face_to_overlay_face(spec.face);
+        let mut overlay = Overlay::with_priority(
+            &mut self.marker_list,
+            spec.range.clone(),
+            overlay_face,
+            spec.priority,
+        );
+        overlay.namespace = spec.namespace.clone();
+        overlay.message = spec.message.clone();
+        overlay.extend_to_line_end = spec.extend_to_line_end;
+        overlay.url = spec.url.clone();
         self.overlays.add(overlay);
     }
 

--- a/crates/fresh-editor/src/test_api.rs
+++ b/crates/fresh-editor/src/test_api.rs
@@ -136,6 +136,19 @@ impl Caret {
 
 /// The single observation surface for semantic theorem tests.
 ///
+/// A virtual line to seed via [`EditorTestApi::seed_virtual_line`]:
+/// `text` with optional fg/bg colors (each `Option<(r,g,b)>`), placement
+/// (`"above"` or `"below"`), namespace, and priority.
+pub struct VirtualLineSpec<'a> {
+    pub byte_offset: usize,
+    pub text: &'a str,
+    pub fg: Option<(u8, u8, u8)>,
+    pub bg: Option<(u8, u8, u8)>,
+    pub placement: &'a str,
+    pub namespace: &'a str,
+    pub priority: i32,
+}
+
 /// Implemented by `crate::app::Editor`. Tests obtain a
 /// `&mut dyn EditorTestApi` from the test harness and never see the
 /// underlying `Editor` type directly.
@@ -353,16 +366,7 @@ pub trait EditorTestApi {
     /// Inject a virtual line at the marker for `byte_offset` with
     /// `text`, fg/bg colors (each as `Option<(r,g,b)>`), placement
     /// (`"above"` or `"below"`), namespace, and priority.
-    fn seed_virtual_line(
-        &mut self,
-        byte_offset: usize,
-        text: &str,
-        fg: Option<(u8, u8, u8)>,
-        bg: Option<(u8, u8, u8)>,
-        placement: &str,
-        namespace: &str,
-        priority: i32,
-    );
+    fn seed_virtual_line(&mut self, spec: VirtualLineSpec);
 
     /// Total count of virtual texts on the active state.
     fn virtual_text_count(&self) -> usize;
@@ -802,16 +806,16 @@ impl EditorTestApi for crate::app::Editor {
         self.get_status_message().cloned()
     }
 
-    fn seed_virtual_line(
-        &mut self,
-        byte_offset: usize,
-        text: &str,
-        fg: Option<(u8, u8, u8)>,
-        bg: Option<(u8, u8, u8)>,
-        placement: &str,
-        namespace: &str,
-        priority: i32,
-    ) {
+    fn seed_virtual_line(&mut self, spec: VirtualLineSpec) {
+        let VirtualLineSpec {
+            byte_offset,
+            text,
+            fg,
+            bg,
+            placement,
+            namespace,
+            priority,
+        } = spec;
         use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
         use ratatui::style::{Color, Style};
         let pos = match placement {

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -451,14 +451,14 @@ enum PState {
     Sinking,
 }
 
-/// One painted cell turned into a physics particle. `home` is its original
-/// screen cell (area-local float coords); `pos`/`vel` evolve once its word
-/// is struck by the wave. `cell` carries the full visual (glyph, fg, bg,
-/// modifier) so chrome colors fly along with the text. `word` indexes the
-/// run of characters it belongs to — the unit that launches together.
+/// One painted cell turned into a physics particle. `home_x` is its original
+/// area-local column, kept for the surface/sway calculations; `pos`/`vel`
+/// evolve once its word is struck by the wave. `cell` carries the full visual
+/// (glyph, fg, bg, modifier) so chrome colors fly along with the text. `word`
+/// indexes the run of characters it belongs to — the unit that launches
+/// together.
 struct WaveParticle {
     home_x: f32,
-    home_y: f32,
     x: f32,
     y: f32,
     vx: f32,
@@ -588,7 +588,7 @@ impl WaveEffect {
         self.words.clear();
         for dy in 0..area.height {
             let mut run: Vec<usize> = Vec::new();
-            let mut close_run = |run: &mut Vec<usize>,
+            let close_run = |run: &mut Vec<usize>,
                                  particles: &mut Vec<WaveParticle>,
                                  words: &mut Vec<Word>| {
                 if run.is_empty() {
@@ -617,7 +617,6 @@ impl WaveEffect {
                 }
                 self.particles.push(WaveParticle {
                     home_x: dx as f32,
-                    home_y: dy as f32,
                     x: dx as f32,
                     y: dy as f32,
                     vx: 0.0,

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -346,7 +346,7 @@ impl FrameEffect for CursorJump {
         // Trail length scales with the path so short jumps don't get an
         // oversized tail. Min 2 keeps a hint of motion even on tiny jumps.
         let path_cells = dx.abs().max(dy.abs()).round() as i32;
-        let trail_len = (path_cells.min(8).max(2)) as usize;
+        let trail_len = path_cells.clamp(2, 8) as usize;
 
         for i in 0..trail_len {
             // Trail samples behind the head: i=0 is the head (alpha=1, full
@@ -589,8 +589,8 @@ impl WaveEffect {
         for dy in 0..area.height {
             let mut run: Vec<usize> = Vec::new();
             let close_run = |run: &mut Vec<usize>,
-                                 particles: &mut Vec<WaveParticle>,
-                                 words: &mut Vec<Word>| {
+                             particles: &mut Vec<WaveParticle>,
+                             words: &mut Vec<Word>| {
                 if run.is_empty() {
                     return;
                 }

--- a/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
+++ b/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
@@ -409,7 +409,7 @@ impl BracketHighlightOverlay {
         viewport_end: usize,
         skip_ranges: &[Range<usize>],
     ) -> bool {
-        if viewport_start >= viewport_end || buffer.len() == 0 {
+        if viewport_start >= viewport_end || buffer.is_empty() {
             return self.clear_colorization(overlays, marker_list);
         }
 

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -201,11 +201,7 @@ impl FileTreeView {
         }
         let mut prefix = Vec::new();
         let mut cur = anchor;
-        loop {
-            let cur_node = match self.tree.get_node(cur) {
-                Some(n) => n,
-                None => break,
-            };
+        while let Some(cur_node) = self.tree.get_node(cur) {
             let parent_id = match cur_node.parent {
                 Some(p) => p,
                 None => break,
@@ -293,11 +289,7 @@ impl FileTreeView {
     fn count_absorbed_ancestors(&self, id: NodeId) -> usize {
         let mut count = 0usize;
         let mut cur = id;
-        loop {
-            let parent_id = match self.tree.get_node(cur).and_then(|n| n.parent) {
-                Some(p) => p,
-                None => break,
-            };
+        while let Some(parent_id) = self.tree.get_node(cur).and_then(|n| n.parent) {
             if self.is_absorbed(parent_id) {
                 count += 1;
             }

--- a/crates/fresh-editor/src/view/keybinding_editor.rs
+++ b/crates/fresh-editor/src/view/keybinding_editor.rs
@@ -1600,27 +1600,23 @@ fn handle_edit_dialog_input(
                     dialog.focus_area = 1;
                     dialog.mode = EditMode::EditingAction;
                 }
-                (KeyCode::Left, _) => {
-                    if dialog.context_option_index > 0 {
-                        dialog.context_option_index -= 1;
-                        dialog.context =
-                            dialog.context_options[dialog.context_option_index].clone();
-                        // Update conflicts
-                        if let Some(key_code) = dialog.key_code {
-                            dialog.conflicts =
-                                editor.find_conflicts(key_code, dialog.modifiers, &dialog.context);
-                        }
+                (KeyCode::Left, _) if dialog.context_option_index > 0 => {
+                    dialog.context_option_index -= 1;
+                    dialog.context = dialog.context_options[dialog.context_option_index].clone();
+                    // Update conflicts
+                    if let Some(key_code) = dialog.key_code {
+                        dialog.conflicts =
+                            editor.find_conflicts(key_code, dialog.modifiers, &dialog.context);
                     }
                 }
-                (KeyCode::Right, _) => {
-                    if dialog.context_option_index + 1 < dialog.context_options.len() {
-                        dialog.context_option_index += 1;
-                        dialog.context =
-                            dialog.context_options[dialog.context_option_index].clone();
-                        if let Some(key_code) = dialog.key_code {
-                            dialog.conflicts =
-                                editor.find_conflicts(key_code, dialog.modifiers, &dialog.context);
-                        }
+                (KeyCode::Right, _)
+                    if dialog.context_option_index + 1 < dialog.context_options.len() =>
+                {
+                    dialog.context_option_index += 1;
+                    dialog.context = dialog.context_options[dialog.context_option_index].clone();
+                    if let Some(key_code) = dialog.key_code {
+                        dialog.conflicts =
+                            editor.find_conflicts(key_code, dialog.modifiers, &dialog.context);
                     }
                 }
                 (KeyCode::Enter, _) => {
@@ -1657,15 +1653,11 @@ fn handle_edit_dialog_input(
                     dialog.focus_area = 2;
                     dialog.mode = EditMode::EditingContext;
                 }
-                (KeyCode::Left, _) => {
-                    if dialog.selected_button > 0 {
-                        dialog.selected_button -= 1;
-                    }
+                (KeyCode::Left, _) if dialog.selected_button > 0 => {
+                    dialog.selected_button -= 1;
                 }
-                (KeyCode::Right, _) => {
-                    if dialog.selected_button < 1 {
-                        dialog.selected_button += 1;
-                    }
+                (KeyCode::Right, _) if dialog.selected_button < 1 => {
+                    dialog.selected_button += 1;
                 }
                 (KeyCode::Enter, _) => {
                     if dialog.selected_button == 0 {

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -449,6 +449,7 @@ impl WrapGeometry {
 ///   2. `apply_soft_breaks` (Compose mode, when any soft breaks overlap)
 ///   3. `apply_conceal_ranges` (Compose mode, when any conceals overlap)
 ///   4. `apply_wrapping_transform`
+///
 /// followed by `ViewLineIterator::collect()` to materialise the
 /// `Vec<ViewLine>`.
 ///

--- a/crates/fresh-editor/src/view/markdown.rs
+++ b/crates/fresh-editor/src/view/markdown.rs
@@ -515,11 +515,11 @@ pub fn parse_markdown(
                         style_stack
                             .push(current.add_modifier(Modifier::UNDERLINED).fg(Color::Cyan));
                     }
-                    Tag::List(_) | Tag::Item => {
-                        // Start list items on new line
-                        if !lines.last().map(|l| l.spans.is_empty()).unwrap_or(true) {
-                            lines.push(StyledLine::new());
-                        }
+                    // Start list items on a new line
+                    Tag::List(_) | Tag::Item
+                        if !lines.last().map(|l| l.spans.is_empty()).unwrap_or(true) =>
+                    {
+                        lines.push(StyledLine::new());
                     }
                     Tag::Paragraph => {
                         // Start paragraphs on new line if we have any prior content.

--- a/crates/fresh-editor/src/view/prompt.rs
+++ b/crates/fresh-editor/src/view/prompt.rs
@@ -663,7 +663,7 @@ impl Prompt {
             })
             .collect();
 
-        filtered.sort_by(|a, b| b.1.cmp(&a.1));
+        filtered.sort_by_key(|b| std::cmp::Reverse(b.1));
         self.suggestions = filtered.into_iter().map(|(s, _)| s).collect();
         self.selected_suggestion = if self.suggestions.is_empty() {
             None

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -702,15 +702,11 @@ impl SettingsState {
     /// Buttons: 0 = Keep editing (default), 1 = Discard.
     fn handle_entry_discard_confirm_input(&mut self, event: &KeyEvent) -> InputResult {
         match event.code {
-            KeyCode::Left | KeyCode::BackTab => {
-                if self.entry_discard_confirm_selection > 0 {
-                    self.entry_discard_confirm_selection -= 1;
-                }
+            KeyCode::Left | KeyCode::BackTab if self.entry_discard_confirm_selection > 0 => {
+                self.entry_discard_confirm_selection -= 1;
             }
-            KeyCode::Right | KeyCode::Tab => {
-                if self.entry_discard_confirm_selection < 1 {
-                    self.entry_discard_confirm_selection += 1;
-                }
+            KeyCode::Right | KeyCode::Tab if self.entry_discard_confirm_selection < 1 => {
+                self.entry_discard_confirm_selection += 1;
             }
             KeyCode::Enter => {
                 match self.entry_discard_confirm_selection {
@@ -743,15 +739,11 @@ impl SettingsState {
     /// Buttons: 0 = Cancel (default), 1 = Delete.
     fn handle_entry_delete_confirm_input(&mut self, event: &KeyEvent) -> InputResult {
         match event.code {
-            KeyCode::Left | KeyCode::BackTab => {
-                if self.entry_delete_confirm_selection > 0 {
-                    self.entry_delete_confirm_selection -= 1;
-                }
+            KeyCode::Left | KeyCode::BackTab if self.entry_delete_confirm_selection > 0 => {
+                self.entry_delete_confirm_selection -= 1;
             }
-            KeyCode::Right | KeyCode::Tab => {
-                if self.entry_delete_confirm_selection < 1 {
-                    self.entry_delete_confirm_selection += 1;
-                }
+            KeyCode::Right | KeyCode::Tab if self.entry_delete_confirm_selection < 1 => {
+                self.entry_delete_confirm_selection += 1;
             }
             KeyCode::Enter => match self.entry_delete_confirm_selection {
                 0 => {

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -392,13 +392,9 @@ impl SettingControl {
                 (base + expanded_height) as u16
             }
             // Dropdown needs extra height when open to show options
-            Self::Dropdown(state) => {
-                if state.open {
-                    // 1 for label/button + number of options (max 8 visible)
-                    1 + state.options.len().min(8) as u16
-                } else {
-                    1
-                }
+            Self::Dropdown(state) if state.open => {
+                // 1 for label/button + number of options (max 8 visible)
+                1 + state.options.len().min(8) as u16
             }
             // KeybindingList needs: 1 label + bindings + 1 add-new row
             Self::ObjectArray(state) => {

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -2324,15 +2324,13 @@ impl SettingsState {
             match &mut item.control {
                 SettingControl::TextList(state) => state.backspace(),
                 SettingControl::Text(state) => state.backspace(),
-                SettingControl::Map(state) => {
-                    if state.cursor > 0 {
-                        let mut char_start = state.cursor - 1;
-                        while char_start > 0 && !state.new_key_text.is_char_boundary(char_start) {
-                            char_start -= 1;
-                        }
-                        state.new_key_text.remove(char_start);
-                        state.cursor = char_start;
+                SettingControl::Map(state) if state.cursor > 0 => {
+                    let mut char_start = state.cursor - 1;
+                    while char_start > 0 && !state.new_key_text.is_char_boundary(char_start) {
+                        char_start -= 1;
                     }
+                    state.new_key_text.remove(char_start);
+                    state.cursor = char_start;
                 }
                 SettingControl::Json(state) => state.backspace(),
                 _ => {}
@@ -2346,14 +2344,12 @@ impl SettingsState {
             match &mut item.control {
                 SettingControl::TextList(state) => state.move_left(),
                 SettingControl::Text(state) => state.move_left(),
-                SettingControl::Map(state) => {
-                    if state.cursor > 0 {
-                        let mut new_pos = state.cursor - 1;
-                        while new_pos > 0 && !state.new_key_text.is_char_boundary(new_pos) {
-                            new_pos -= 1;
-                        }
-                        state.cursor = new_pos;
+                SettingControl::Map(state) if state.cursor > 0 => {
+                    let mut new_pos = state.cursor - 1;
+                    while new_pos > 0 && !state.new_key_text.is_char_boundary(new_pos) {
+                        new_pos -= 1;
                     }
+                    state.cursor = new_pos;
                 }
                 SettingControl::Json(state) => state.move_left(),
                 _ => {}
@@ -2367,16 +2363,14 @@ impl SettingsState {
             match &mut item.control {
                 SettingControl::TextList(state) => state.move_right(),
                 SettingControl::Text(state) => state.move_right(),
-                SettingControl::Map(state) => {
-                    if state.cursor < state.new_key_text.len() {
-                        let mut new_pos = state.cursor + 1;
-                        while new_pos < state.new_key_text.len()
-                            && !state.new_key_text.is_char_boundary(new_pos)
-                        {
-                            new_pos += 1;
-                        }
-                        state.cursor = new_pos;
+                SettingControl::Map(state) if state.cursor < state.new_key_text.len() => {
+                    let mut new_pos = state.cursor + 1;
+                    while new_pos < state.new_key_text.len()
+                        && !state.new_key_text.is_char_boundary(new_pos)
+                    {
+                        new_pos += 1;
                     }
+                    state.cursor = new_pos;
                 }
                 SettingControl::Json(state) => state.move_right(),
                 _ => {}

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -196,6 +196,20 @@ pub struct BufferViewState {
     pub folds: FoldManager,
 }
 
+/// Editor display settings applied to a fresh [`BufferViewState`] via
+/// [`BufferViewState::apply_config_defaults`]. Grouping the flags into one
+/// struct keeps the call under the argument-count limit and names each
+/// boolean at every call site.
+pub struct ViewConfigDefaults {
+    pub line_numbers: bool,
+    pub highlight_current_line: bool,
+    pub line_wrap: bool,
+    pub wrap_indent: bool,
+    pub wrap_column: Option<usize>,
+    pub rulers: Vec<usize>,
+    pub scroll_offset: usize,
+}
+
 impl BufferViewState {
     /// Resolve fold ranges and ensure the primary cursor is visible.
     ///
@@ -239,16 +253,16 @@ impl BufferViewState {
     /// `wrap_column`, and `rulers` from the given config values. Call this after
     /// creating a new `BufferViewState` (via `new()` or `ensure_buffer_state()`)
     /// to ensure the view respects the user's settings.
-    pub fn apply_config_defaults(
-        &mut self,
-        line_numbers: bool,
-        highlight_current_line: bool,
-        line_wrap: bool,
-        wrap_indent: bool,
-        wrap_column: Option<usize>,
-        rulers: Vec<usize>,
-        scroll_offset: usize,
-    ) {
+    pub fn apply_config_defaults(&mut self, defaults: ViewConfigDefaults) {
+        let ViewConfigDefaults {
+            line_numbers,
+            highlight_current_line,
+            line_wrap,
+            wrap_indent,
+            wrap_column,
+            rulers,
+            scroll_offset,
+        } = defaults;
         self.show_line_numbers = line_numbers;
         self.highlight_current_line = highlight_current_line;
         self.viewport.line_wrap_enabled = line_wrap;
@@ -2203,15 +2217,15 @@ mod tests {
             "default scroll_offset should be 3"
         );
 
-        view_state.apply_config_defaults(
-            true,   // line_numbers
-            true,   // highlight_current_line
-            false,  // line_wrap
-            false,  // wrap_indent
-            None,   // wrap_column
-            vec![], // rulers
-            7,      // scroll_offset
-        );
+        view_state.apply_config_defaults(ViewConfigDefaults {
+            line_numbers: true,
+            highlight_current_line: true,
+            line_wrap: false,
+            wrap_indent: false,
+            wrap_column: None,
+            rulers: vec![],
+            scroll_offset: 7,
+        });
         assert_eq!(
             view_state.viewport.scroll_offset, 7,
             "apply_config_defaults should set scroll_offset on the viewport"

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -32,6 +32,19 @@ pub struct ExplorerDecorations<'a> {
 
 pub struct FileExplorerRenderer;
 
+/// Inputs to [`FileExplorerRenderer::trailing_slot_screen_bounds`], grouped
+/// so the call takes one argument instead of eight.
+pub(crate) struct TrailingSlotBoundsCtx<'a> {
+    pub view: &'a FileTreeView,
+    pub node_id: NodeId,
+    pub indent: usize,
+    pub content_width: usize,
+    pub slot_resolution: &'a ExplorerSlotResolution,
+    pub tree_indicator_collapsed: &'a str,
+    pub tree_indicator_expanded: &'a str,
+    pub explorer_area: Rect,
+}
+
 impl FileExplorerRenderer {
     /// Check if a directory contains any modified files
     fn folder_has_modified_files(
@@ -520,16 +533,17 @@ impl FileExplorerRenderer {
         Line::from(spans)
     }
 
-    pub(crate) fn trailing_slot_screen_bounds(
-        view: &FileTreeView,
-        node_id: NodeId,
-        indent: usize,
-        content_width: usize,
-        slot_resolution: &ExplorerSlotResolution,
-        tree_indicator_collapsed: &str,
-        tree_indicator_expanded: &str,
-        explorer_area: Rect,
-    ) -> Option<(u16, u16)> {
+    pub(crate) fn trailing_slot_screen_bounds(ctx: TrailingSlotBoundsCtx) -> Option<(u16, u16)> {
+        let TrailingSlotBoundsCtx {
+            view,
+            node_id,
+            indent,
+            content_width,
+            slot_resolution,
+            tree_indicator_collapsed,
+            tree_indicator_expanded,
+            explorer_area,
+        } = ctx;
         let trailing_slot = slot_resolution.trailing.as_ref()?;
         let node = view.tree().get_node(node_id).expect("Node should exist");
 
@@ -893,16 +907,16 @@ mod tests {
         let area = Rect::new(0, 0, 40, 10);
         let content_width = area.width.saturating_sub(3) as usize;
 
-        let bounds = FileExplorerRenderer::trailing_slot_screen_bounds(
-            &view,
-            schema_id,
-            2,
+        let bounds = FileExplorerRenderer::trailing_slot_screen_bounds(TrailingSlotBoundsCtx {
+            view: &view,
+            node_id: schema_id,
+            indent: 2,
             content_width,
-            &slot_resolution,
-            ">",
-            "▼",
-            area,
-        )
+            slot_resolution: &slot_resolution,
+            tree_indicator_collapsed: ">",
+            tree_indicator_expanded: "▼",
+            explorer_area: area,
+        })
         .expect("modified file should render a trailing slot");
 
         assert_eq!(bounds.1, area.x + area.width.saturating_sub(1));

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -212,8 +212,8 @@ pub(super) fn fold_indicators_for_viewport(
 
                 let mut subsequent_lines = Vec::new();
                 let lookahead_limit = (i + 1 + max_lookahead).min(view_lines.len());
-                for j in i..lookahead_limit {
-                    subsequent_lines.push(view_lines[j].text.as_bytes());
+                for line in &view_lines[i..lookahead_limit] {
+                    subsequent_lines.push(line.text.as_bytes());
                 }
 
                 if indent_folding::is_line_foldable_in_bytes(&subsequent_lines, tab_size) {

--- a/crates/fresh-editor/src/view/ui/split_rendering/style.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/style.rs
@@ -177,7 +177,7 @@ pub(super) fn create_wrapped_virtual_lines(
             if text.is_empty() {
                 Vec::new()
             } else {
-                vec![0..text.len()]
+                std::iter::once(0..text.len()).collect()
             }
         }
     };

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -219,10 +219,9 @@ struct RenderedElement {
 /// - `On`            — at least one server for this language is running
 /// - `Off`           — configured servers exist for this language, none are running
 /// - `OffDismissed`  — like `Off`, but the user clicked "Disable" from the
-///                     popup; rendered with a muted style so it stops
-///                     shouting for attention while remaining clickable
-///                     (so the user can still open the popup to re-enable
-///                     or see install help).
+///   popup; rendered with a muted style so it stops shouting for
+///   attention while remaining clickable (so the user can still open the
+///   popup to re-enable or see install help).
 /// - `Error`         — at least one server for this language is in the Error state
 /// - `None`          — no LSP configured or running for this language
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1489,10 +1488,10 @@ impl StatusBarRenderer {
     }
 
     /// The clickable identity of an element kind, or `None` for static
-    /// (non-interactive) elements. This single mapping is what makes the click
-    /// + hover rail generic: it's the *only* place that decides whether a
-    /// built-in element is clickable. Plugin tokens are handled separately
-    /// (they dispatch a hook, not a core `Action`).
+    /// (non-interactive) elements. This single mapping is what makes the
+    /// click + hover rail generic: it's the *only* place that decides
+    /// whether a built-in element is clickable. Plugin tokens are handled
+    /// separately (they dispatch a hook, not a core `Action`).
     fn clickable_for_kind(kind: ElementKind) -> Option<StatusBarClickable> {
         match kind {
             ElementKind::LineEnding => Some(StatusBarClickable::LineEnding),

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1242,15 +1242,13 @@ impl StatusBarRenderer {
                 })
             }
             StatusBarElement::CustomToken(key) => {
-                if let Some(value) = ctx.dynamic_status_bar_elements.get(key) {
-                    Some(RenderedElement {
+                ctx.dynamic_status_bar_elements
+                    .get(key)
+                    .map(|value| RenderedElement {
                         text: value.clone(),
                         kind: ElementKind::Custom,
                         token_key: Some(key.clone()),
                     })
-                } else {
-                    None // Skip rendering if no value set
-                }
             }
         }
     }

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -459,6 +459,14 @@ fn tab_styles(
     (base_style, close_style)
 }
 
+/// Output of [`build_tab_spans`]: `(spans, ranges, rendered_targets)`. See the
+/// function's own docs for the per-field meaning.
+type TabSpanLayout = (
+    Vec<(Span<'static>, usize)>,
+    Vec<(usize, usize, usize)>,
+    Vec<TabTarget>,
+);
+
 /// Build the styled `(name, close-button)` spans for every resolvable tab.
 ///
 /// Returns `(spans, ranges, rendered_targets)` where `spans` holds two entries
@@ -479,11 +487,7 @@ fn build_tab_spans(
     preview_buffer: Option<BufferId>,
     is_active_split: bool,
     theme: &crate::view::theme::Theme,
-) -> (
-    Vec<(Span<'static>, usize)>,
-    Vec<(usize, usize, usize)>,
-    Vec<TabTarget>,
-) {
+) -> TabSpanLayout {
     let mut all_tab_spans: Vec<(Span<'static>, usize)> = Vec::new();
     let mut tab_ranges: Vec<(usize, usize, usize)> = Vec::new();
     let mut rendered_targets: Vec<TabTarget> = Vec::new();

--- a/crates/fresh-editor/src/view/visual_row_index.rs
+++ b/crates/fresh-editor/src/view/visual_row_index.rs
@@ -19,11 +19,12 @@
 //!     prefix_sums[N] = total visual rows
 //!     line_starts[N] = buffer length (sentinel)
 //!
-//! Population: derived from `LineWrapCache`. Each entry `prefix_sums[i+1]
-//! - prefix_sums[i]` equals `cache_entry.len()` for line `i`. On a miss
-//! the build path falls through to `compute_line_layout` (same miss
-//! handler the per-line cache uses), so the row counts always match the
-//! pipeline output. No second wrap implementation; no drift.
+//! Population: derived from `LineWrapCache`. Each entry
+//! `prefix_sums[i+1] - prefix_sums[i]` equals `cache_entry.len()` for
+//! line `i`. On a miss the build path falls through to
+//! `compute_line_layout` (same miss handler the per-line cache uses),
+//! so the row counts always match the pipeline output. No second wrap
+//! implementation; no drift.
 //!
 //! Invalidation: keyed on the same pipeline-input version + geometry
 //! that determines per-line row counts. Any version bump or width /

--- a/crates/fresh-editor/src/view/workspace_trust_dialog.rs
+++ b/crates/fresh-editor/src/view/workspace_trust_dialog.rs
@@ -61,26 +61,43 @@ pub struct TrustDialogLayout {
     pub max_scroll: u16,
 }
 
-/// Render the workspace-trust prompt centered in `area`, with `selected`
-/// (0=Trust, 1=Restricted, 2=Block) marked. `triggers` is a comma-separated
-/// list of the marker files/dirs that caused the prompt (shown as a "Detected:"
-/// line; pass "" to omit). `secondary_label` is the right-hand button text
-/// (e.g. "Quit (Ctrl+Q)" at startup, "Cancel (Esc)" from the palette). Returns
-/// the click layout.
+/// Inputs to [`render_workspace_trust_dialog`] other than the frame.
+pub struct TrustDialogParams<'a> {
+    pub area: Rect,
+    /// Selected button: 0=Trust, 1=Restricted, 2=Block.
+    pub selected: usize,
+    pub path: &'a str,
+    /// Comma-separated marker files/dirs that caused the prompt (shown as a
+    /// "Detected:" line; pass `""` to omit).
+    pub triggers: &'a str,
+    /// Right-hand button text (e.g. "Quit (Ctrl+Q)" at startup, "Cancel (Esc)"
+    /// from the palette).
+    pub secondary_label: &'a str,
+    pub scroll: u16,
+    pub theme: &'a Theme,
+    /// When false, compute + return the click layout (rects) but paint no cells
+    /// — the frontend renders this modal natively from `trust_dialog_view`. The
+    /// TUI always passes `true`.
+    pub draw: bool,
+}
+
+/// Render the workspace-trust prompt centered in `params.area`, with
+/// `params.selected` (0=Trust, 1=Restricted, 2=Block) marked. Returns the
+/// click layout.
 pub fn render_workspace_trust_dialog(
     frame: &mut Frame,
-    area: Rect,
-    selected: usize,
-    path: &str,
-    triggers: &str,
-    secondary_label: &str,
-    scroll: u16,
-    theme: &Theme,
-    // When false, compute + return the click layout (rects) but paint no cells —
-    // the frontend renders this modal natively from `trust_dialog_view`. The TUI
-    // always passes `true`.
-    draw: bool,
+    params: TrustDialogParams,
 ) -> TrustDialogLayout {
+    let TrustDialogParams {
+        area,
+        selected,
+        path,
+        triggers,
+        secondary_label,
+        scroll,
+        theme,
+        draw,
+    } = params;
     let width = DIALOG_WIDTH.min(area.width.saturating_sub(4));
     let inner_w = width.saturating_sub(2);
     let bg = theme.popup_bg;

--- a/crates/fresh-editor/src/webui/mod.rs
+++ b/crates/fresh-editor/src/webui/mod.rs
@@ -418,10 +418,10 @@ fn cells_json(buf: &Buffer, r: Rect) -> Value {
         let mut cur_bg: Option<String> = None;
         let mut cur_mods = Modifier::empty();
         let flush = |runs: &mut Vec<Value>,
-                         text: &mut String,
-                         fg: &Option<String>,
-                         bg: &Option<String>,
-                         m: Modifier| {
+                     text: &mut String,
+                     fg: &Option<String>,
+                     bg: &Option<String>,
+                     m: Modifier| {
             if !text.is_empty() {
                 runs.push(json!({
                     "t": text,

--- a/crates/fresh-editor/src/webui/mod.rs
+++ b/crates/fresh-editor/src/webui/mod.rs
@@ -417,7 +417,7 @@ fn cells_json(buf: &Buffer, r: Rect) -> Value {
         let mut cur_fg: Option<String> = None;
         let mut cur_bg: Option<String> = None;
         let mut cur_mods = Modifier::empty();
-        let mut flush = |runs: &mut Vec<Value>,
+        let flush = |runs: &mut Vec<Value>,
                          text: &mut String,
                          fg: &Option<String>,
                          bg: &Option<String>,

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -359,17 +359,13 @@ impl WidgetRegistry {
         instance_states: HashMap<String, WidgetInstanceState>,
         focus_key: String,
         tabbable: Vec<String>,
-    ) -> Result<BufferId, ()> {
-        match self.panels.get_mut(panel_key) {
-            Some(state) => {
-                state.hits = hits;
-                state.instance_states = instance_states;
-                state.focus_key = focus_key;
-                state.tabbable = tabbable;
-                Ok(state.buffer_id)
-            }
-            None => Err(()),
-        }
+    ) -> Option<BufferId> {
+        let state = self.panels.get_mut(panel_key)?;
+        state.hits = hits;
+        state.instance_states = instance_states;
+        state.focus_key = focus_key;
+        state.tabbable = tabbable;
+        Some(state.buffer_id)
     }
 
     /// Borrow the current spec + return the buffer id. Companion to

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1488,10 +1488,10 @@ fn collect_list(
         // scroll.
         let mut emitted = 0u32;
         let last = if end < total as usize { end + 1 } else { end };
-        'cards: for i in start..last {
+        'cards: for (offset, card) in rendered_cards[start..last].iter().enumerate() {
+            let i = start + offset;
             let is_selected = i as i32 == effective_sel;
             let item_key = item_keys.get(i).cloned().unwrap_or_default();
-            let card = &rendered_cards[i];
             for r in 0..item_height as usize {
                 if emitted >= avail_rows {
                     break 'cards;

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -2546,12 +2546,11 @@ fn render_completion_bottom_border(total_cols: usize) -> TextPropertyEntry {
     }
 }
 
-/// Overlay variant of `render_completion_item`. Same body
-/// (leading space + candidate text + optional scrollbar glyph
-/// + trailing pad), but wrapped with the popup's own
-/// `│ ... │` chrome since overlay rows paint at the panel
-/// width directly without going through a `LabeledSection`'s
-/// row wrapper.
+/// Overlay variant of `render_completion_item`. Same body (leading
+/// space + candidate text + optional scrollbar glyph + trailing pad),
+/// but wrapped with the popup's own `│ ... │` chrome since overlay rows
+/// paint at the panel width directly without going through a
+/// `LabeledSection`'s row wrapper.
 fn render_completion_item_overlay(
     item: &str,
     kind: Option<&str>,

--- a/crates/fresh-editor/tests/common/scenario/layout_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/layout_scenario.rs
@@ -21,7 +21,7 @@ use crate::common::scenario::failure::ScenarioFailure;
 use crate::common::scenario::input_event::InputEvent;
 use crate::common::scenario::observable::Observable;
 use crate::common::scenario::render_snapshot::{RenderSnapshot, RenderSnapshotExpect};
-use fresh::test_api::{Action, EditorTestApi};
+use fresh::test_api::{Action, EditorTestApi, VirtualLineSpec};
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct LayoutScenario {
@@ -575,15 +575,15 @@ pub fn check_layout_scenario(s: LayoutScenario) -> Result<(), ScenarioFailure> {
                 });
             }
         };
-        harness.api_mut().seed_virtual_line(
-            spec.byte_offset,
-            &spec.text,
-            spec.fg,
-            spec.bg,
+        harness.api_mut().seed_virtual_line(VirtualLineSpec {
+            byte_offset: spec.byte_offset,
+            text: &spec.text,
+            fg: spec.fg,
+            bg: spec.bg,
             placement,
-            &spec.namespace,
-            spec.priority,
-        );
+            namespace: &spec.namespace,
+            priority: spec.priority,
+        });
     }
 
     // Declarative margin-annotation seeding. Mirrors

--- a/crates/fresh-editor/tests/common/scenario/modal_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/modal_scenario.rs
@@ -21,7 +21,7 @@ use crate::common::scenario::context::PromptKind;
 use crate::common::scenario::failure::ScenarioFailure;
 use crate::common::scenario::input_event::InputEvent;
 use crate::common::scenario::observable::{ModalState, Observable, PopupSnapshot};
-use fresh::test_api::{Action, EditorTestApi};
+use fresh::test_api::Action;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ModalScenario {

--- a/crates/fresh-editor/tests/e2e/markdown_compose_table_border.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_table_border.rs
@@ -845,7 +845,7 @@ fn test_wide_table_not_corrupted_by_rapid_delete_above() {
     let raw_pipe_lines = |s: &str| s.lines().filter(|l| l.contains('|')).count();
     let mut worst = 0usize;
     let mut worst_frame = String::new();
-    let mut record = |h: &EditorTestHarness, worst: &mut usize, wf: &mut String| {
+    let record = |h: &EditorTestHarness, worst: &mut usize, wf: &mut String| {
         let s = h.screen_to_string();
         let c = raw_pipe_lines(&s);
         if c > *worst {

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -11,7 +11,6 @@
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh_core::api::PluginCommand;
-use fresh_core::WindowId;
 use serde_json::Value;
 use std::path::Path;
 

--- a/crates/fresh-editor/tests/e2e/restored_agent_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/restored_agent_terminal.rs
@@ -47,15 +47,15 @@ fn session_config() -> Config {
 fn spawn_agent_terminal(window: &mut fresh::app::window::Window, argv: &[&str]) {
     let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
     let (terminal_id, _buffer_id, _leaf) = window
-        .create_plugin_terminal(
-            None,
-            None, // no split direction — seed/attach in the active split
-            None,
-            true,  // focus — the agent terminal is the seed
-            false, // ephemeral — exactly the Orchestrator agent case
-            Some(argv.clone()),
-            None,
-        )
+        .create_plugin_terminal(fresh::app::PluginTerminalSpec {
+            cwd: None,
+            direction: None, // no split direction — seed/attach in the active split
+            ratio: None,
+            focus: true,       // the agent terminal is the seed
+            persistent: false, // ephemeral — exactly the Orchestrator agent case
+            command: Some(argv.clone()),
+            title: None,
+        })
         .expect("agent terminal should spawn");
     // create_window_with_terminal records this marker; mirror it here so the
     // ephemeral terminal is recognised as a restorable session terminal.
@@ -73,7 +73,15 @@ fn spawn_resumable_agent_terminal(
     let launch: Vec<String> = launch.iter().map(|s| s.to_string()).collect();
     let resume: Vec<String> = resume.iter().map(|s| s.to_string()).collect();
     let (terminal_id, _buffer_id, _leaf) = window
-        .create_plugin_terminal(None, None, None, true, false, Some(launch.clone()), None)
+        .create_plugin_terminal(fresh::app::PluginTerminalSpec {
+            cwd: None,
+            direction: None,
+            ratio: None,
+            focus: true,
+            persistent: false,
+            command: Some(launch.clone()),
+            title: None,
+        })
         .expect("agent terminal should spawn");
     window.terminal_commands.insert(terminal_id, launch);
     window.terminal_resume_commands.insert(terminal_id, resume);

--- a/crates/fresh-editor/tests/e2e/terminal_link.rs
+++ b/crates/fresh-editor/tests/e2e/terminal_link.rs
@@ -48,15 +48,15 @@ fn open_terminal_with_output(
     let (terminal_id, buffer_id, _leaf) = harness
         .editor_mut()
         .active_window_mut()
-        .create_plugin_terminal(
-            None,  // cwd: default to window root (working_dir)
-            None,  // direction: attach as a tab in the active split
-            None,  // ratio
-            true,  // focus
-            false, // persistent
-            Some(vec!["sleep".into(), "30".into()]),
-            None, // title
-        )
+        .create_plugin_terminal(fresh::app::PluginTerminalSpec {
+            cwd: None,       // default to window root (working_dir)
+            direction: None, // attach as a tab in the active split
+            ratio: None,
+            focus: true,
+            persistent: false,
+            command: Some(vec!["sleep".into(), "30".into()]),
+            title: None,
+        })
         .expect("spawn sleep terminal");
     harness.editor_mut().enter_terminal_mode();
     // Feed program output directly into the grid (no PTY/prompt race).

--- a/crates/fresh-editor/tests/orchestrator_bringup_characterization.rs
+++ b/crates/fresh-editor/tests/orchestrator_bringup_characterization.rs
@@ -31,8 +31,14 @@ use tempfile::TempDir;
 /// is what `DirectoryContext::for_testing` is rooted at; the editor's
 /// data dir is therefore `data_root/data`.
 struct Scenario {
+    // Held purely for their `Drop` guard: these `TempDir`s keep the on-disk
+    // directories alive for the test's lifetime. The tests navigate via the
+    // canonicalized paths below, so the handles themselves are never read.
+    #[allow(dead_code)]
     project: TempDir,
+    #[allow(dead_code)]
     worktree: TempDir,
+    #[allow(dead_code)]
     other: TempDir,
     data_root: TempDir,
     project_canon: PathBuf,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1502,8 +1502,7 @@ impl JsEditorApi {
         } else {
             HashMap::new()
         };
-        let res = self.services.translate(&plugin_name, &key, &args_map);
-        res
+        self.services.translate(&plugin_name, &key, &args_map)
     }
 
     // === Buffer Queries (additional) ===

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5944,6 +5944,11 @@ impl JsEditorApi {
 
     /// Mount a declarative widget panel as a centered floating
     /// overlay (not bound to any virtual buffer).
+    // The argument list is the JS-facing binding: rquickjs maps each
+    // parameter positionally to a `mountFloatingWidget(...)` call argument,
+    // so it can't be collapsed into a params struct without changing the
+    // plugin API.
+    #[allow(clippy::too_many_arguments)]
     #[qjs(rename = "mountFloatingWidget")]
     pub fn mount_floating_widget<'js>(
         &self,
@@ -6372,6 +6377,11 @@ impl JsEditorApi {
         js_name = "beginSearch",
         ts_raw = "beginSearch(pattern: string, opts?: { fixedString?: boolean; caseSensitive?: boolean; maxResults?: number; wholeWords?: boolean; sourceBufferId?: number }): SearchHandle"
     )]
+    // The argument list is the JS-facing binding (see the `ts_raw`
+    // signature above): rquickjs maps each parameter positionally to the
+    // `beginSearch(...)` call, so it can't be collapsed into a params
+    // struct without changing the plugin API.
+    #[allow(clippy::too_many_arguments)]
     #[qjs(rename = "_beginSearch")]
     pub fn begin_search(
         &self,


### PR DESCRIPTION
Address all unused-mut, dead-code, and unused-import warnings surfaced by
`cargo build` (and `cargo build --tests`) in fresh-editor:

- Drop needless `mut` on three by-value-param closures (popup_dialogs
  word wrap, webui run flush, animation close_run) — they never mutate
  captured state.
- Remove the write-only `home_y` field from `WaveParticle`; launch/sink
  physics reads the word-level `home_y` and the particle's `home_x`, never
  the particle's own `home_y`. Doc comment updated to match.
- Scope the `BoundControl::shutdown` dead-code allow to `not(test)`. Only
  the tests read it (to stop the accept thread deterministically);
  production drops it and lets the socket live for the whole process. The
  lint stays active under cfg(test) where the field is genuinely used.
- Keep the `TempDir` guard fields (`project`/`worktree`/`other`) in the
  orchestrator bring-up characterization Scenario — they are load-bearing
  Drop guards that keep the on-disk dirs alive; annotate rather than
  delete, since removing them would delete the temp dirs mid-test.
- Remove genuinely unused test imports and one unused `mut`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YUBrkPBEyHj3cuVdmaTK97