### PR TITLE
test: de-flake three e2e tests (git-log, current-line highlight, review-diff staging)

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
@@ -92,10 +92,18 @@ fn git_log_file_opened_at_commit_shows_indentation_guides() {
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
+    // Wait for the detail pane's diff body to finish rendering — not just the
+    // commit list — before navigating. The `+++ b/indented.rs` header is emitted
+    // by `git show` and is exactly the line git_log scans back for, so its
+    // presence proves the diff the cursor is about to enter is on screen. Keying
+    // only on the commit list (as before) let the `Down`/`Enter` keys race the
+    // async `git show`, landing the cursor on unloaded content.
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("switch pane") && s.contains("Add indented file")
+            s.contains("switch pane")
+                && s.contains("Add indented file")
+                && s.contains("+++ b/indented.rs")
         })
         .unwrap();
 
@@ -110,9 +118,18 @@ fn git_log_file_opened_at_commit_shows_indentation_guides() {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
 
-    // The file-at-commit view opens; its indented body must carry guides.
+    // Wait for the file-at-commit view itself, not merely a code line that also
+    // appears in the diff. git_log titles that tab `*<hash>:indented.rs*`, so the
+    // `:indented.rs` marker is unique to the opened view — the diff pane shows
+    // `b/indented.rs`, never `:indented.rs`. The old wait keyed on `let x = 1`,
+    // which the diff pane already renders as `+    let x = 1;`; it could pass
+    // without the view ever opening and then fail the guide assertion, because
+    // the git-log diff pane intentionally renders no guides.
     harness
-        .wait_until(|h| h.screen_to_string().contains("let x = 1"))
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(":indented.rs") && s.contains("let x = 1")
+        })
         .unwrap();
     let screen = harness.screen_to_string();
     assert!(

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -402,13 +402,30 @@ fn test_review_visual_stage_line_in_second_file() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Hunk navigation + focus-mode repaint are async: focus mode only paints the
-    // focused file's body, so `+ADDED_B` isn't on screen until the jump to the
-    // second file completes. `diff_line_of` renders just once and panics if the
-    // row is missing, so wait for the second file's body to render first.
+    // Hunk navigation + focus-mode repaint are async *and multi-phase*: focus
+    // mode only paints the focused file's body, and after `+ADDED_B` first
+    // appears the plugin can still reflow the panel. `diff_line_of` maps a
+    // *screen* row to a diff-buffer line against a fixed panel offset
+    // (`CENTER_FIRST_ROW`), so sampling a mid-reflow frame yields a wrong target:
+    // the cursor lands off `+ADDED_B`, `s` stages nothing, and the wait below
+    // hangs until the external timeout. Wait for the body to appear *and* for the
+    // async plugin pipeline to go quiet, so the row→line mapping is read from a
+    // converged frame.
     harness.wait_for_screen_contains("+ADDED_B").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let bravo_added = diff_line_of(&mut harness, "+ADDED_B");
     move_cursor_to_line(&mut harness, bravo_added);
+
+    // Fail fast if the cursor didn't land on the `+ADDED_B` row. Without this a
+    // mis-mapped target degrades into an opaque 180s timeout on the indefinite
+    // wait below instead of a clear diagnostic (CONTRIBUTING.md §16: don't let a
+    // wrong state hide behind an unbounded wait).
+    assert_eq!(
+        diff_line_of(&mut harness, "+ADDED_B"),
+        bravo_added,
+        "cursor line {bravo_added} must still map to the +ADDED_B row before staging; screen:\n{}",
+        harness.screen_to_string()
+    );
 
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)

--- a/crates/fresh-editor/tests/e2e/rendering.rs
+++ b/crates/fresh-editor/tests/e2e/rendering.rs
@@ -606,11 +606,18 @@ fn test_current_line_highlight_spans_full_width() {
     let file_path = temp_dir.path().join("highlight_test.txt");
     std::fs::write(&file_path, "abc\ndef\nghi\n").unwrap();
 
-    // Default config has highlight_current_line = true and dark theme
-    let config = Config {
+    // Default config has highlight_current_line = true and dark theme.
+    // Disable frame-buffer animations: this test inspects a single settled
+    // frame, but the harness only force-disables animations when *no* config is
+    // passed (see EditorTestHarness). Because we pass one for the dark theme,
+    // the default `animations: true` would otherwise leak in, and a mid-slide
+    // open frame could show a not-yet-settled current-line background — an
+    // intermittent failure of the assertions below.
+    let mut config = Config {
         theme: "dark".into(),
         ..Default::default()
     };
+    config.editor.animations = false;
     let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
     harness.open_file(&file_path).unwrap();
     harness.render().unwrap();


### PR DESCRIPTION
Fixes three intermittently-failing e2e tests. All are test-only changes — no product code is touched. Each maps to CONTRIBUTING.md §3 (semantic waiting, no time-sensitive frames) and §16 (a wait that passes/hangs vacuously proves nothing).

## 1. `git_log_file_opened_at_commit_shows_indentation_guides`

`FAIL` on its `▏` assertion. It navigated the detail pane (`Tab`, 40×`Down`, `Enter`) after waiting only for the commit list, so keys could race the async `git show`; and it then waited on `screen.contains("let x = 1")`, which is **not unique to the file-at-commit view** — the diff pane already renders it as `+    let x = 1;`, so the wait could pass while still showing the guideless diff pane.

Fix: gate navigation on the diff body (`+++ b/indented.rs`), and wait on a signal unique to the opened view — git_log titles that tab `*<hash>:indented.rs*`, so `:indented.rs` only appears once the file-at-commit buffer is open (existing tests key on tab titles the same way).

## 2. `test_current_line_highlight_spans_full_width`

`FAIL` on its current-line-background assertions. It inspects a single settled frame but passes a `Config` only to set the dark theme — and the harness force-disables animations **only when no config is provided**, while `Config::default()` has `animations: true`. So animations leaked in and a mid-slide open frame showed a not-yet-settled background. The harness explicitly documents this hazard.

Fix: set `config.editor.animations = false`, matching the harness's contract for single-frame inspection tests.

## 3. `test_review_visual_stage_line_in_second_file`

`TIMEOUT [180s]`. Jumping into the second file (`n`,`n`) triggers an async, multi-phase focus-mode repaint. The test waited only for `+ADDED_B` to appear, then called `diff_line_of`, which maps a screen row to a diff-buffer line against a **fixed panel offset**. Sampling a mid-reflow frame produced a wrong target, so the cursor landed off `+ADDED_B`, `s` staged nothing, and the (correctly unbounded) terminal `wait_until` spun until the external timeout.

Fix: `wait_for_async_quiescence` before reading the row→line mapping, so the target comes from a converged frame; and assert the cursor still maps to the `+ADDED_B` row before staging, so a future mis-map fails fast with a diagnostic instead of hanging.

## Testing

`cargo fmt` clean; the `e2e_tests` target compiles (`--no-run`, exit 0). Per the requests that prompted these changes, I did **not** run the flaky tests themselves to avoid reproducing them; the fixes are static hardening of wait/config conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)