### PR TITLE
test(git-log): de-flake file-at-commit indentation-guide test

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_indent_guide.rs
@@ -92,10 +92,18 @@ fn git_log_file_opened_at_commit_shows_indentation_guides() {
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
+    // Wait for the detail pane's diff body to finish rendering — not just the
+    // commit list — before navigating. The `+++ b/indented.rs` header is emitted
+    // by `git show` and is exactly the line git_log scans back for, so its
+    // presence proves the diff the cursor is about to enter is on screen. Keying
+    // only on the commit list (as before) let the `Down`/`Enter` keys race the
+    // async `git show`, landing the cursor on unloaded content.
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("switch pane") && s.contains("Add indented file")
+            s.contains("switch pane")
+                && s.contains("Add indented file")
+                && s.contains("+++ b/indented.rs")
         })
         .unwrap();
 
@@ -110,9 +118,18 @@ fn git_log_file_opened_at_commit_shows_indentation_guides() {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
 
-    // The file-at-commit view opens; its indented body must carry guides.
+    // Wait for the file-at-commit view itself, not merely a code line that also
+    // appears in the diff. git_log titles that tab `*<hash>:indented.rs*`, so the
+    // `:indented.rs` marker is unique to the opened view — the diff pane shows
+    // `b/indented.rs`, never `:indented.rs`. The old wait keyed on `let x = 1`,
+    // which the diff pane already renders as `+    let x = 1;`; it could pass
+    // without the view ever opening and then fail the guide assertion, because
+    // the git-log diff pane intentionally renders no guides.
     harness
-        .wait_until(|h| h.screen_to_string().contains("let x = 1"))
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(":indented.rs") && s.contains("let x = 1")
+        })
         .unwrap();
     let screen = harness.screen_to_string();
     assert!(


### PR DESCRIPTION
## Summary

`git_log_file_opened_at_commit_shows_indentation_guides` intermittently fails its `▏` assertion. The fix is test-only — no product code changes.

## Root cause

Two timing hazards let the test observe the wrong state:

1. **Racy navigation.** It drives the detail pane (`Tab`, 40×`Down`, `Enter`) after waiting only for the **commit list** to appear. The keystrokes could therefore race the async `git show`, landing the cursor on a not-yet-rendered diff so `Enter` had no diff line to resolve a file from.
2. **Ambiguous final wait.** It then waited on `screen.contains("let x = 1")` before asserting the guide glyph. That line is **not unique** to the file-at-commit view — the diff pane already renders it as `+    let x = 1;`. So the wait could pass while the screen still showed the diff pane, which *intentionally* draws no guides, and the `▏` assertion would fail.

## Fix

- **Gate the navigation** on the diff body being on screen — wait for `+++ b/indented.rs`, the exact header git_log scans backward for, so the cursor enters loaded content.
- **Wait on a signal unique to the opened view.** git_log titles that tab `*<hash>:indented.rs*`, so `:indented.rs` appears only once the file-at-commit buffer is actually open (the diff pane shows `b/indented.rs`, never `:indented.rs`).

Both waits stay semantic and unbounded, per the contributing guidelines (`§3` semantic waiting, `§16` no vacuously-passing waits).

## Testing

Test-only change; `cargo fmt` clean and the `e2e_tests` target compiles. Per the request that prompted this, I did **not** run the flaky test itself to "reproduce" it — the change is a targeted correction of the wait/navigation signals identified by static analysis of the test and the `git_log.ts` plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tx4JDV1qdV1jdaUeEGHJCx)_