### PR TITLE
fix(remote): improve SSH disconnect/reconnect UX (#2545)

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -831,6 +831,18 @@ impl Editor {
         if revived > 0 {
             let label = window.label.clone();
             self.set_status_message(format!("Reconnected: {label}"));
+            // Reactivate the focused buffer. A terminal that was focused (and in
+            // terminal input mode) when the carrier dropped had `terminal_mode`
+            // cleared by `handle_terminal_exited`; respawning the PTY doesn't
+            // restore it, so without this the reborn terminal is stranded in
+            // scrollback / Normal mode until the user clicks it. Re-deriving the
+            // flags from the active buffer's remembered (still-`Live`) mode
+            // brings it back live in place. Only the active window owns the
+            // `terminal_mode` / `key_context` input state; a background window
+            // re-syncs when the user next focuses it.
+            if window_id == self.active_window {
+                self.sync_terminal_mode_to_active_buffer();
+            }
         }
     }
 
@@ -877,6 +889,39 @@ impl Editor {
                     }
                 }
             });
+        }
+    }
+
+    /// Detect remote-connection state changes (a link dropped or came back)
+    /// across windows and report whether any changed since the last poll.
+    ///
+    /// The background reconnect task flips `is_remote_connected()` on its own
+    /// timeline: a plain drop fires no async message at all, and the eventual
+    /// settle after a flap may land between the `RemoteReconnected` events that
+    /// do fire. Neither is tied to an input event, so without this poll the
+    /// status-bar remote indicator goes stale — still reading "connected" after
+    /// a drop, or "(Disconnected)" after the link came back — until the user
+    /// happens to press a key. Called once per editor tick; when it returns
+    /// `true` the caller re-renders. Cheap: a bool load per remote window, and
+    /// no allocation at all when there are no remote windows.
+    pub(crate) fn poll_remote_connection_changes(&mut self) -> bool {
+        let current: std::collections::HashMap<fresh_core::WindowId, bool> = self
+            .windows
+            .iter()
+            .filter_map(|(id, w)| {
+                let fs = &w.authority().filesystem;
+                // Only windows with a real remote authority matter; a local
+                // filesystem's default `is_remote_connected() == true` is noise.
+                fs.remote_connection_info()
+                    .is_some()
+                    .then(|| (*id, fs.is_remote_connected()))
+            })
+            .collect();
+        if current != self.remote_connected_cache {
+            self.remote_connected_cache = current;
+            true
+        } else {
+            false
         }
     }
 
@@ -1200,9 +1245,11 @@ impl Editor {
         if let Some(window_id) = reconnect_window {
             let reason = error.lines().next().unwrap_or(&error).to_string();
             if let Some(w) = self.windows.get_mut(&window_id) {
-                // An already-live remote window whose reconnect
-                // failed: record on the window so its status-bar
-                // indicator shows FailedAttach.
+                // An already-live remote window whose reconnect failed: record
+                // the reason on the window. The status-bar indicator renders a
+                // short "Disconnected" from this (the full error went to the
+                // `tracing::warn!` above, which lights the warning indicator);
+                // the reason itself is surfaced in the remote-indicator popup.
                 w.remote_reconnect_error = Some(reason);
             } else {
                 // A dormant session's connect failed: it has no

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1237,8 +1237,8 @@ impl Editor {
         // and no plugin dialog open, so its only user-visible signal
         // is the status-bar remote indicator. Record the reason on
         // the workspace's window so the indicator renders
-        // `FailedAttach` (persistent, error-styled, with a Retry /
-        // Reopen Locally popup) until the next reconnect attempt.
+        // `FailedAttach` (persistent, error-styled, with a Retry-only
+        // popup) until the next reconnect attempt.
         // Born-attached / restart attaches carry `None` here; their
         // failure is surfaced by the launching plugin's rejected
         // promise (e.g. the New-Session dialog's inline error).

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -465,6 +465,7 @@ impl Editor {
 
             // Trivial defaults (no external dependencies):
             remote_reconnect_forwarders: std::collections::HashSet::new(),
+            remote_connected_cache: HashMap::new(),
             materialize_pending: std::collections::HashSet::new(),
             grammar_reload_pending: false,
             grammar_build_in_progress: false,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -124,6 +124,11 @@ pub fn editor_tick(
     if async_messages {
         needs_render = true;
     }
+    // Keep the status-bar remote indicator in sync with a background
+    // reconnect that never routes through an input event or async message.
+    if editor.poll_remote_connection_changes() {
+        needs_render = true;
+    }
     let pending_file_opens = {
         let _s = tracing::info_span!("process_pending_file_opens").entered();
         editor.process_pending_file_opens()
@@ -547,6 +552,15 @@ pub struct Editor {
     /// rather than polled. `ensure_remote_reconnect_forwarders` registers one
     /// lazily per remote window; this set makes that idempotent.
     remote_reconnect_forwarders: std::collections::HashSet<u64>,
+
+    /// Last-seen remote-connection state per window, so a per-tick poll can
+    /// force a re-render when a link drops or comes back. The background
+    /// reconnect task flips `is_remote_connected()` without any input event or
+    /// (on a plain drop) async message, so without this poll the status-bar
+    /// remote indicator would stay stale — showing "connected" after a drop, or
+    /// "(Disconnected)" after the link settled back — until the user happens to
+    /// press a key. Only windows with a remote authority are tracked.
+    remote_connected_cache: HashMap<fresh_core::WindowId, bool>,
 
     /// In-flight async system-clipboard reads, keyed by `request_id`.
     /// Each entry owns an anchor (`VirtualText("▍")`) in some buffer

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -805,11 +805,14 @@ impl Editor {
             }
         }
 
-        // Core-driven FailedAttach: a dormant remote workspace whose
-        // dive-triggered reconnect failed (recorded on the window, not via the
-        // plugin override). Offer a generic Retry (re-run the core reconnect)
-        // and a Dismiss that clears the error — independent of the
-        // devcontainer-specific override path above.
+        // Core-driven FailedAttach: a remote (SSH) workspace whose reconnect
+        // failed (recorded on the window, not via the plugin override). Offer a
+        // single Retry that re-runs the core reconnect — independent of the
+        // devcontainer-specific override path above. There is deliberately no
+        // "Reopen Locally" here: the SSH flow keeps its remote authority (the
+        // error clears on a successful reconnect, which also runs automatically
+        // in the background), so a local fallback would only strand the open
+        // remote buffers on a mismatched filesystem.
         let core_failed_attach = !override_handled
             && self
                 .active_window()
@@ -830,10 +833,6 @@ impl Editor {
             items.push(
                 PopupListItem::new("    Retry".to_string())
                     .with_data("retry_reconnect".to_string()),
-            );
-            items.push(
-                PopupListItem::new("    Reopen Locally".to_string())
-                    .with_data("clear_reconnect_error".to_string()),
             );
         }
 
@@ -1156,15 +1155,6 @@ impl Editor {
             // in a plugins-less build.
             #[cfg(feature = "plugins")]
             self.force_reconnect_remote_session(self.active_window);
-            return;
-        }
-        if action_key == "clear_reconnect_error" {
-            // "Reopen Locally" / dismiss: drop the failed-reconnect error so the
-            // indicator stops showing FailedAttach. The workspace keeps its
-            // remote `authority_spec`, so a later dive still retries the connect.
-            if let Some(w) = self.windows.get_mut(&self.active_window) {
-                w.remote_reconnect_error = None;
-            }
             return;
         }
         if action_key == "cancel_popup" {

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -701,7 +701,8 @@ impl Editor {
     /// - **Connected (container):** offers "Reopen Locally" (detach),
     ///   "Rebuild Container", and "Show Container Info".
     /// - **Connected (SSH):** offers "Disconnect Remote" and "Show Info".
-    /// - **Disconnected:** offers "Reconnect" (best-effort) and "Go Local".
+    /// - **Disconnected:** offers "Reconnect" (best-effort) for a remote-agent
+    ///   window; nothing else (the reconnect also runs automatically).
     ///
     /// Clicking the `{remote}` status-bar element a second time toggles
     /// the popup closed, matching the LSP-indicator affordance.
@@ -877,7 +878,13 @@ impl Editor {
                         );
                     }
                 }
-                // Disconnected — warn and offer fallbacks.
+                // Disconnected — offer a reconnect and nothing else. The old
+                // "Go Local" (`detach`) escape hatch was removed: it silently
+                // swapped the window's remote authority for the local one,
+                // stranding the open remote buffers on a mismatched filesystem —
+                // surprising behaviour with no obvious way back. Recovery from a
+                // dropped link is a reconnect, which also runs automatically in
+                // the background.
                 (Some(_), true) => {
                     title = "Remote: Disconnected".to_string();
                     // Offer Reconnect for a live remote-agent (SSH/kube) window:
@@ -896,10 +903,6 @@ impl Editor {
                                 .with_data("reconnect".to_string()),
                         );
                     }
-                    items.push(
-                        PopupListItem::new("    Go Local".to_string())
-                            .with_data("detach".to_string()),
-                    );
                 }
                 // Local authority.
                 (None, _) => {

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -284,21 +284,41 @@ impl Drop for SshConnection {
     }
 }
 
-/// Default interval between reconnection attempts.
-const DEFAULT_RECONNECT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+/// Delay before the *first* reconnection attempt after a drop, and the base the
+/// exponential backoff doubles from.
+const DEFAULT_RECONNECT_INITIAL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+/// Ceiling on the backoff delay between reconnection attempts. A host that stays
+/// down is retried at most this often rather than being hammered every few
+/// seconds forever.
+const DEFAULT_RECONNECT_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+/// How often to poll a live link for a drop.
+const DEFAULT_RECONNECT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Configuration for the reconnect task.
 pub struct ReconnectConfig {
-    /// How long to wait between reconnection attempts.
-    pub interval: std::time::Duration,
+    /// Delay before the first reconnection attempt after a drop, and the base
+    /// the exponential backoff doubles from.
+    pub initial_interval: std::time::Duration,
+    /// Upper bound on the backoff delay between successive failed attempts.
+    pub max_interval: std::time::Duration,
+    /// How often to poll `is_connected()` while the link is up, watching for a
+    /// drop.
+    pub poll_interval: std::time::Duration,
 }
 
 impl Default for ReconnectConfig {
     fn default() -> Self {
         Self {
-            interval: DEFAULT_RECONNECT_INTERVAL,
+            initial_interval: DEFAULT_RECONNECT_INITIAL_INTERVAL,
+            max_interval: DEFAULT_RECONNECT_MAX_INTERVAL,
+            poll_interval: DEFAULT_RECONNECT_POLL_INTERVAL,
         }
     }
+}
+
+/// Next backoff delay: double the current one, capped at `max`.
+fn next_backoff(current: std::time::Duration, max: std::time::Duration) -> std::time::Duration {
+    current.saturating_mul(2).min(max)
 }
 
 /// Spawn a background task that automatically reconnects when the channel
@@ -361,20 +381,23 @@ where
         loop {
             // Wait until disconnected
             while channel.is_connected() {
-                tokio::time::sleep(config.interval).await;
+                tokio::time::sleep(config.poll_interval).await;
             }
 
             tracing::info!("{label}: connection lost, attempting reconnection...");
 
-            // Retry loop
+            // Retry loop with exponential backoff. We start at `initial_interval`
+            // and double after each failed attempt up to `max_interval`, so a
+            // brief blip recovers quickly while a host that stays down settles
+            // into an unobtrusive ~max_interval retry cadence instead of a tight
+            // hammering loop.
+            let mut delay = config.initial_interval;
             loop {
-                tokio::time::sleep(config.interval).await;
+                tokio::time::sleep(delay).await;
 
-                // Check if channel was dropped (write_tx gone)
-                if !channel.is_connected() {
-                    // Still disconnected — try to reconnect
-                } else {
-                    // Something else reconnected us (e.g., manual replace_transport)
+                // Something else reconnected us (e.g., manual replace_transport)
+                // while we were sleeping — nothing left to do.
+                if channel.is_connected() {
                     break;
                 }
 
@@ -385,7 +408,11 @@ where
                         break;
                     }
                     Err(e) => {
-                        tracing::debug!("{label}: reconnection attempt failed: {e}");
+                        tracing::debug!(
+                            "{label}: reconnection attempt failed (next retry in {:?}): {e}",
+                            next_backoff(delay, config.max_interval)
+                        );
+                        delay = next_backoff(delay, config.max_interval);
                     }
                 }
             }
@@ -799,6 +826,42 @@ mod tests {
         // Empty user / empty host are still rejected.
         assert!(ConnectionParams::parse("@host").is_none());
         assert!(ConnectionParams::parse("user@").is_none());
+    }
+
+    #[test]
+    fn reconnect_backoff_doubles_and_caps() {
+        use std::time::Duration;
+
+        let max = Duration::from_secs(30);
+        // Starting from the default 1s base, the delay doubles each failed
+        // attempt: 1 → 2 → 4 → 8 → 16 → 30 (capped) → 30 …
+        let mut delay = Duration::from_secs(1);
+        let expected = [2, 4, 8, 16, 30, 30, 30];
+        for want in expected {
+            delay = next_backoff(delay, max);
+            assert_eq!(
+                delay,
+                Duration::from_secs(want),
+                "backoff should double toward, then hold at, the {max:?} cap"
+            );
+        }
+    }
+
+    #[test]
+    fn reconnect_config_default_caps_at_30s_with_backoff() {
+        use std::time::Duration;
+
+        let cfg = ReconnectConfig::default();
+        // The whole point of the backoff: a host that stays down is retried at
+        // most every 30s, not hammered on a tight fixed interval.
+        assert_eq!(cfg.max_interval, Duration::from_secs(30));
+        // And it genuinely backs off — the first attempt is sooner than the cap.
+        assert!(
+            cfg.initial_interval < cfg.max_interval,
+            "initial interval ({:?}) must be below the {:?} cap so the delay grows",
+            cfg.initial_interval,
+            cfg.max_interval
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1196,15 +1196,19 @@ impl StatusBarRenderer {
                 // derived states synthesize one from `remote_connection`.
                 let (text, state) = if let Some(over) = ctx.remote_state_override {
                     (over.label(), over.state())
-                } else if let Some(err) = ctx.remote_reconnect_error {
-                    // Core-driven FailedAttach for the active window's dormant
-                    // remote workspace whose reconnect failed. Takes precedence
-                    // over the connection-derived state (which would read
-                    // "Local", since the live authority is still the local
-                    // placeholder until a reconnect lands).
+                } else if ctx.remote_reconnect_error.is_some() {
+                    // A reconnect of the active window's remote workspace failed.
+                    // Keep the indicator short — just "Disconnected" — rather
+                    // than inlining the full SSH error, which used to swamp the
+                    // whole status bar. The detail isn't lost: it's emitted as a
+                    // `tracing::warn!` (which lights the warning indicator) and
+                    // surfaced in the remote-indicator popup. Takes precedence
+                    // over the connection-derived state (which for a dormant
+                    // workspace would read "Local", since the live authority is
+                    // still the local placeholder until a reconnect lands).
                     (
-                        format!("Reconnect failed: {err}"),
-                        RemoteIndicatorState::FailedAttach,
+                        "Disconnected".to_string(),
+                        RemoteIndicatorState::Disconnected,
                     )
                 } else {
                     match ctx.remote_connection {

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -177,6 +177,7 @@ pub mod recovery;
 pub mod remote_auto_reconnect_terminal;
 pub mod remote_fs_test;
 pub mod remote_indicator_popup;
+pub mod remote_indicator_status;
 pub mod remote_reconnect_terminal;
 pub mod rendering;
 pub mod restored_agent_terminal;

--- a/crates/fresh-editor/tests/e2e/per_session_authority.rs
+++ b/crates/fresh-editor/tests/e2e/per_session_authority.rs
@@ -420,14 +420,14 @@ fn switching_to_a_dormant_remote_session_starts_reconnect() -> anyhow::Result<()
 }
 
 #[test]
-fn a_failed_remote_reconnect_shows_failedattach_on_the_status_line() -> anyhow::Result<()> {
+fn a_failed_remote_reconnect_shows_disconnected_on_the_status_line() -> anyhow::Result<()> {
     // When a window's most recent remote reconnect fails, the `{remote}`
-    // status indicator must surface it as "Reconnect failed: <reason>" — the
-    // core, per-window counterpart to the plugin-driven FailedAttach override.
-    // Regression for the "show reconnect failures via the FailedAttach status
-    // indicator" fix: without the `remote_reconnect_error` derivation branch in
-    // `status_bar.rs` (and the value being threaded through `render.rs`), the
-    // indicator falls back to "Local" and the failure is invisible.
+    // status indicator must surface it — but as a short "Disconnected", not the
+    // full SSH error, which used to fill the whole bar. The reason is carried on
+    // the window (`remote_reconnect_error`, threaded through `render.rs`) and
+    // shown in the remote-indicator popup / warning log; the bar itself stays
+    // glanceable. Without the derivation branch in `status_bar.rs` the indicator
+    // would fall back to "Local" and the failure would be invisible.
     let temp = tempfile::tempdir()?;
     let mut harness = EditorTestHarness::create(
         120,
@@ -441,10 +441,12 @@ fn a_failed_remote_reconnect_shows_failedattach_on_the_status_line() -> anyhow::
     harness
         .editor_mut()
         .active_window_mut()
-        .remote_reconnect_error = Some("ssh connect failed".into());
+        .remote_reconnect_error =
+        Some("Agent failed to start: SSH could not connect (exit code 255)".into());
     harness.render()?;
 
-    harness.assert_screen_contains("Reconnect failed");
+    harness.assert_screen_contains("Disconnected");
+    harness.assert_screen_not_contains("Agent failed to start");
 
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
@@ -275,3 +275,85 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
         "a duplicate reconnect event does not respawn an already-live terminal"
     );
 }
+
+/// When the focused buffer is a terminal that was in terminal (input) mode at
+/// the moment the carrier dropped, an auto-reconnect must bring it back live —
+/// reactivating terminal input mode, not stranding it in scrollback/Normal.
+///
+/// The drop clears the window's `terminal_mode` (via `handle_terminal_exited`)
+/// but preserves the buffer's remembered `Live` interaction mode; respawning
+/// the PTY alone does not restore the window flags, so before the fix a
+/// reconnected terminal sat inert until the user clicked it. This drives the
+/// reconnect dispatch and asserts the input mode is restored.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Unix PTY shell
+fn auto_reconnect_reactivates_focused_terminal_in_input_mode() {
+    use fresh::input::keybindings::KeyContext;
+
+    if !pty_available() {
+        eprintln!("Skipping auto-reconnect terminal-mode test: PTY not available");
+        return;
+    }
+
+    const CHANNEL_ID: u64 = 4343;
+    let temp = tempfile::tempdir().unwrap();
+    let connected = Arc::new(AtomicBool::new(true));
+    let fs: Arc<dyn FileSystem + Send + Sync> = Arc::new(ToggleRemoteFs {
+        inner: StdFileSystem,
+        connected: connected.clone(),
+        channel_id: CHANNEL_ID,
+    });
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_working_dir(temp.path().to_path_buf())
+            .with_filesystem(fs),
+    )
+    .unwrap();
+
+    // A focused, live terminal in terminal (input) mode — the pre-disconnect
+    // state a user has when they're typing in an embedded shell.
+    let (old_id, _buffer_id) = harness
+        .editor_mut()
+        .active_window_mut()
+        .open_terminal_in_window()
+        .expect("terminal should spawn");
+    assert!(
+        harness.editor().active_window().terminal_mode,
+        "a freshly opened, focused terminal starts in input mode"
+    );
+
+    // Carrier drop: the PTY dies and `handle_terminal_exited` clears the
+    // window's `terminal_mode` (dropping to Normal) while leaving the buffer's
+    // remembered `Live` interaction mode intact for the reconnect. Reproduce
+    // exactly that state.
+    connected.store(false, Ordering::SeqCst);
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .terminal_manager
+        .close(old_id);
+    {
+        let w = harness.editor_mut().active_window_mut();
+        w.terminal_mode = false;
+        w.key_context = KeyContext::Normal;
+    }
+
+    // The link comes back: the reconnect dispatch reattaches the window,
+    // respawns the dead PTY, and must reactivate the focused terminal.
+    connected.store(true, Ordering::SeqCst);
+    harness
+        .editor_mut()
+        .test_dispatch_remote_reconnected(CHANNEL_ID);
+
+    assert!(
+        harness.editor().active_window().terminal_mode,
+        "reconnect must reactivate the focused terminal in input mode, not leave it in scrollback"
+    );
+    assert_eq!(
+        harness.editor().active_window().key_context,
+        KeyContext::Terminal,
+        "reconnect must restore the Terminal key context so keystrokes reach the PTY"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
@@ -371,8 +371,9 @@ fn test_remote_indicator_popup_failed_attach_offers_retry() -> anyhow::Result<()
 /// A *live* remote-agent (SSH/kube) window whose backend dropped its carrier
 /// must offer a working **Reconnect** in the Remote Indicator popup — the
 /// status-bar surface for rebuilding the link (re-point authority, respawn the
-/// dead terminal). The row dispatches the core reconnect (`reconnect`), distinct
-/// from "Go Local" (`detach`).
+/// dead terminal). The row dispatches the core reconnect (`reconnect`). The
+/// old "Go Local" (`detach`) row must NOT be offered — it silently swapped the
+/// window's authority for the local one, stranding the open remote buffers.
 #[test]
 fn test_remote_indicator_popup_disconnected_remote_agent_offers_reconnect() -> anyhow::Result<()> {
     let temp = tempfile::tempdir()?;
@@ -415,11 +416,13 @@ fn test_remote_indicator_popup_disconnected_remote_agent_offers_reconnect() -> a
         "Reconnect must not be disabled. Row: {reconnect:?}"
     );
 
-    // "Go Local" is still offered as the escape hatch.
+    // "Go Local" (`detach`) must no longer be offered — it stranded open
+    // remote buffers on a mismatched local filesystem.
     assert!(
-        rows.iter()
-            .any(|(t, d, _)| t.contains("Go Local") && d.as_deref() == Some("detach")),
-        "Disconnected popup must still offer 'Go Local'. Rows: {rows:#?}"
+        !rows
+            .iter()
+            .any(|(t, d, _)| t.contains("Go Local") || d.as_deref() == Some("detach")),
+        "Disconnected popup must not offer 'Go Local'/detach. Rows: {rows:#?}"
     );
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
@@ -427,6 +427,52 @@ fn test_remote_indicator_popup_disconnected_remote_agent_offers_reconnect() -> a
     Ok(())
 }
 
+/// A remote-agent (SSH) window whose reconnect failed drives the core
+/// `FailedAttach` branch via `remote_reconnect_error`. That popup must offer
+/// only **Retry** (re-run the core reconnect) and must NOT offer any
+/// "Reopen Locally" / local-fallback row: the SSH flow keeps its remote
+/// authority (the error clears on a successful reconnect, which also runs
+/// automatically), so a local fallback would strand the open remote buffers.
+/// The devcontainer FailedAttach override keeps its own "Reopen Locally"
+/// (`clear_override`) — this guard is scoped to the SSH/remote flow.
+#[test]
+fn test_remote_indicator_popup_ssh_reconnect_failed_offers_retry_only() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new().with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .remote_reconnect_error = Some("ssh connect failed (exit 255)".into());
+
+    harness.editor_mut().show_remote_indicator_popup();
+    harness.render()?;
+
+    let rows = popup_item_rows(&harness);
+    let retry = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Retry"))
+        .unwrap_or_else(|| panic!("SSH reconnect-failed popup lacks a Retry row. Rows: {rows:#?}"));
+    assert_eq!(
+        retry.1.as_deref(),
+        Some("retry_reconnect"),
+        "Retry must dispatch the core reconnect. Row: {retry:?}"
+    );
+
+    // No "Reopen Locally" / local-fallback row in the SSH flow.
+    assert!(
+        !rows.iter().any(|(t, d, _)| t.contains("Reopen Locally")
+            || d.as_deref() == Some("clear_reconnect_error")
+            || d.as_deref() == Some("detach")),
+        "SSH reconnect-failed popup must not offer a local-fallback row. Rows: {rows:#?}"
+    );
+    Ok(())
+}
+
 /// A local session's Remote Indicator popup must NOT offer Reconnect — there is
 /// no remote backend to rebuild. Guards against the Reconnect row leaking into
 /// non-remote (or container) windows.

--- a/crates/fresh-editor/tests/e2e/remote_indicator_status.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_status.rs
@@ -1,0 +1,54 @@
+//! E2E tests for the status-bar Remote Indicator's *rendered label* around a
+//! failed reconnect.
+//!
+//! A failed reconnect records the SSH failure reason on the active window
+//! (`remote_reconnect_error`). The indicator used to inline that whole sentence
+//! (`Reconnect failed: Agent failed to start: SSH could not connect to …`),
+//! which swamped the status bar. It must now render a short "Disconnected"
+//! instead — the full reason is emitted as a `tracing::warn!` and surfaced in
+//! the remote-indicator popup, not the bar.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::config::{Config, StatusBarConfig, StatusBarElement};
+
+/// The multi-line-long SSH failure a failed reconnect records — the kind of
+/// string that used to fill the status bar end to end.
+const LONG_RECONNECT_ERROR: &str = "Agent failed to start: SSH could not connect to \
+     root@localhost:2222. Check that the host is reachable, the hostname is correct, \
+     and your SSH credentials are valid (exit code 255)";
+
+#[test]
+fn test_failed_reconnect_indicator_is_short_disconnected() {
+    // A status bar that includes the {remote} indicator on the left.
+    let mut config = Config::default();
+    config.editor.status_bar = StatusBarConfig {
+        left: vec![
+            StatusBarElement::RemoteIndicator,
+            StatusBarElement::Filename,
+        ],
+        right: vec![],
+        ..StatusBarConfig::default()
+    };
+
+    let mut harness =
+        EditorTestHarness::create(160, 30, HarnessOptions::new().with_config(config)).unwrap();
+
+    // Simulate the state a failed reconnect leaves behind: the reason recorded
+    // on the active window. (The warning-log side is exercised by the reconnect
+    // dispatch itself; here we lock in the *rendered* indicator.)
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .remote_reconnect_error = Some(LONG_RECONNECT_ERROR.to_string());
+    harness.render().unwrap();
+
+    let status = harness.get_status_bar();
+    assert!(
+        status.contains("Disconnected"),
+        "Failed-reconnect indicator should read 'Disconnected'.\nStatus bar: {status}"
+    );
+    assert!(
+        !status.contains("Reconnect failed") && !status.contains("Agent failed to start"),
+        "Failed-reconnect indicator must not inline the long SSH error.\nStatus bar: {status}"
+    );
+}

--- a/crates/fresh-editor/tests/remote_channel_timeout_tests.rs
+++ b/crates/fresh-editor/tests/remote_channel_timeout_tests.rs
@@ -513,7 +513,10 @@ fn test_auto_reconnect_task() {
         channel_clone,
         connect_fn,
         ReconnectConfig {
-            interval: Duration::from_millis(100), // Fast retry for tests
+            // Fast, non-backing-off retry for tests.
+            initial_interval: Duration::from_millis(100),
+            max_interval: Duration::from_millis(100),
+            poll_interval: Duration::from_millis(100),
         },
         "test",
     );


### PR DESCRIPTION
Four related fixes to how an SSH workspace's remote indicator behaves
when the link drops and comes back. All were reproduced against a local
sshd on a user port with the editor driven interactively in tmux.

1. Short "Disconnected" label. A failed reconnect recorded the full SSH
   error on the window and the status bar inlined it
   ("Reconnect failed: Agent failed to start: SSH could not connect …"),
   swamping the whole bar. The indicator now renders a short
   "Disconnected"; the full reason still goes to the existing
   tracing::warn! (which lights the warning indicator) and the
   remote-indicator popup, so no detail is lost.

2. Reconnect backoff + live status. The auto-reconnect task retried on a
   fixed 5s interval forever; it now uses exponential backoff from 1s
   doubling up to a 30s cap, so a host that stays down settles into an
   unobtrusive cadence instead of being hammered. A plain drop (and the
   settle after a flap) fires no input event or async message, so the
   status bar went stale — showing "connected" after a drop or
   "(Disconnected)" after recovery — until a key was pressed. A cheap
   per-tick poll now re-renders when any remote window's connection
   state changes.

3. Reactivate the focused terminal on reconnect. When the carrier
   dropped, the exit handler cleared the window's terminal_mode; the
   reconnect respawned the PTY but never restored it, stranding a
   focused terminal in scrollback/Normal mode until the user clicked it.
   reattach_window now re-derives the focused buffer's mode, bringing a
   live terminal back in input mode in place.

4. Remove "Go Local" from the disconnected popup. It silently swapped
   the window's remote authority for the local one, stranding the open
   remote buffers on a mismatched filesystem with no obvious way back.
   The disconnected popup now offers only Reconnect (which also runs
   automatically in the background).

Tests: a status-bar render test for the short label, a component test
that reconnect restores terminal input mode, popup/per-session tests
updated to the new behaviour, and unit tests for the backoff schedule.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y4NTKb4RQPZFVfBB6A1wju