### PR TITLE
fix(lsp): let an explicit empty args override a default server's args (#2549)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -1677,12 +1677,15 @@
           "x-order": 3
         },
         "args": {
-          "description": "Arguments to pass to the server",
-          "type": "array",
+          "description": "Arguments to pass to the server.\n\n`None` (field omitted) inherits the default server's args, while an\nexplicit list — including an empty `[]` — replaces them. This lets a\nuser swap a default server that takes args (e.g. `marksman server`)\nfor one that takes none (e.g. `markdown-oxide`) by setting `\"args\": []`.",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": null,
           "x-order": 4
         },
         "auto_start": {

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2430,7 +2430,7 @@ impl Editor {
         };
         let lsp_config = crate::types::LspServerConfig {
             command: config.command,
-            args: config.args,
+            args: Some(config.args),
             enabled: true, // Explicitly enable - Default::default() gives false
             auto_start: config.auto_start.unwrap_or(true),
             initialization_options: config.initialization_options,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -930,7 +930,7 @@ pub(crate) fn configure_lsp_servers(
         tracing::info!("Detected Deno project (deno.json found), using deno lsp for JS/TS");
         let deno_config = LspServerConfig {
             command: "deno".to_string(),
-            args: vec!["lsp".to_string()],
+            args: Some(vec!["lsp".to_string()]),
             enabled: true,
             auto_start: false,
             process_limits: ProcessLimits::default(),

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -6175,7 +6175,7 @@ impl Config {
             "quicklsp".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "quicklsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: false,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6214,7 +6214,7 @@ impl Config {
             "rust".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "rust-analyzer".to_string(),
-                args: vec!["--log-file".to_string(), ra_log_path],
+                args: Some(vec!["--log-file".to_string(), ra_log_path]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::unlimited(),
@@ -6237,7 +6237,7 @@ impl Config {
             "python".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "pylsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6264,7 +6264,7 @@ impl Config {
             "gdscript".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "nc".to_string(),
-                args: vec!["127.0.0.1".to_string(), "6005".to_string()],
+                args: Some(vec!["127.0.0.1".to_string(), "6005".to_string()]),
                 enabled: false,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6284,7 +6284,7 @@ impl Config {
             "javascript".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "typescript-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6309,7 +6309,7 @@ impl Config {
             "typescript".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "typescript-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6336,7 +6336,7 @@ impl Config {
             "html".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vscode-html-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6355,7 +6355,7 @@ impl Config {
             "css".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vscode-css-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6374,7 +6374,7 @@ impl Config {
             "c".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "clangd".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6396,7 +6396,7 @@ impl Config {
             "cpp".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "clangd".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6420,7 +6420,7 @@ impl Config {
             "go".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "gopls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6443,7 +6443,7 @@ impl Config {
             "json".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vscode-json-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6464,7 +6464,7 @@ impl Config {
             "jsonc".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vscode-json-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6483,7 +6483,7 @@ impl Config {
             "csharp".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "csharp-ls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6507,7 +6507,7 @@ impl Config {
             "odin".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "ols".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6527,7 +6527,7 @@ impl Config {
             "zig".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "zls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6547,7 +6547,7 @@ impl Config {
             "c3".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "c3lsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6568,7 +6568,7 @@ impl Config {
             "slang".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "slangd".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6588,7 +6588,7 @@ impl Config {
             "java".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "jdtls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6613,7 +6613,7 @@ impl Config {
             "latex".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "texlab".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6633,7 +6633,7 @@ impl Config {
             "markdown".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "marksman".to_string(),
-                args: vec!["server".to_string()],
+                args: Some(vec!["server".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6653,7 +6653,7 @@ impl Config {
             "templ".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "templ".to_string(),
-                args: vec!["lsp".to_string()],
+                args: Some(vec!["lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6673,7 +6673,7 @@ impl Config {
             "typst".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "tinymist".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6692,7 +6692,7 @@ impl Config {
             "bash".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "bash-language-server".to_string(),
-                args: vec!["start".to_string()],
+                args: Some(vec!["start".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6712,7 +6712,7 @@ impl Config {
             "lua".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "lua-language-server".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6737,7 +6737,7 @@ impl Config {
             "ruby".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "solargraph".to_string(),
-                args: vec!["stdio".to_string()],
+                args: Some(vec!["stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6761,7 +6761,7 @@ impl Config {
             "php".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "phpactor".to_string(),
-                args: vec!["language-server".to_string()],
+                args: Some(vec!["language-server".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6780,7 +6780,7 @@ impl Config {
             "yaml".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "yaml-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6800,7 +6800,7 @@ impl Config {
             "toml".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "taplo".to_string(),
-                args: vec!["lsp".to_string(), "stdio".to_string()],
+                args: Some(vec!["lsp".to_string(), "stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6820,7 +6820,7 @@ impl Config {
             "dart".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "dart".to_string(),
-                args: vec!["language-server".to_string(), "--protocol=lsp".to_string()],
+                args: Some(vec!["language-server".to_string(), "--protocol=lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6840,7 +6840,7 @@ impl Config {
             "nushell".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "nu".to_string(),
-                args: vec!["--lsp".to_string()],
+                args: Some(vec!["--lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6860,7 +6860,7 @@ impl Config {
             "solidity".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "nomicfoundation-solidity-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6882,7 +6882,7 @@ impl Config {
             "terraform".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "terraform-ls".to_string(),
-                args: vec!["serve".to_string()],
+                args: Some(vec!["serve".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6906,7 +6906,7 @@ impl Config {
             "cmake".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "cmake-language-server".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6926,7 +6926,7 @@ impl Config {
             "protobuf".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "buf".to_string(),
-                args: vec!["beta".to_string(), "lsp".to_string()],
+                args: Some(vec!["beta".to_string(), "lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6946,7 +6946,7 @@ impl Config {
             "graphql".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "graphql-lsp".to_string(),
-                args: vec!["server".to_string(), "-m".to_string(), "stream".to_string()],
+                args: Some(vec!["server".to_string(), "-m".to_string(), "stream".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6966,7 +6966,7 @@ impl Config {
             "sql".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "sqls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6987,7 +6987,7 @@ impl Config {
             "vue".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vue-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7006,7 +7006,7 @@ impl Config {
             "svelte".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "svelteserver".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7025,7 +7025,7 @@ impl Config {
             "astro".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "astro-ls".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7044,7 +7044,7 @@ impl Config {
             "tailwindcss".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "tailwindcss-language-server".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7066,7 +7066,7 @@ impl Config {
             "nix".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "nil".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7086,7 +7086,7 @@ impl Config {
             "kotlin".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "kotlin-language-server".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7105,7 +7105,7 @@ impl Config {
             "swift".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "sourcekit-lsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7125,7 +7125,7 @@ impl Config {
             "scala".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "metals".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7145,7 +7145,7 @@ impl Config {
             "elixir".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "elixir-ls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7164,7 +7164,7 @@ impl Config {
             "erlang".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "erlang_ls".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7184,7 +7184,7 @@ impl Config {
             "haskell".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "haskell-language-server-wrapper".to_string(),
-                args: vec!["--lsp".to_string()],
+                args: Some(vec!["--lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7204,7 +7204,7 @@ impl Config {
             "ocaml".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "ocamllsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7224,7 +7224,7 @@ impl Config {
             "clojure".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "clojure-lsp".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7244,11 +7244,11 @@ impl Config {
             "r".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "R".to_string(),
-                args: vec![
+                args: Some(vec![
                     "--vanilla".to_string(),
                     "-e".to_string(),
                     "languageserver::run()".to_string(),
-                ],
+                ]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7268,12 +7268,12 @@ impl Config {
             "julia".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "julia".to_string(),
-                args: vec![
+                args: Some(vec![
                     "--startup-file=no".to_string(),
                     "--history-file=no".to_string(),
                     "-e".to_string(),
                     "using LanguageServer; runserver()".to_string(),
-                ],
+                ]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7293,7 +7293,7 @@ impl Config {
             "perl".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "perlnavigator".to_string(),
-                args: vec!["--stdio".to_string()],
+                args: Some(vec!["--stdio".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7313,7 +7313,7 @@ impl Config {
             "nim".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "nimlangserver".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7332,7 +7332,7 @@ impl Config {
             "gleam".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "gleam".to_string(),
-                args: vec!["lsp".to_string()],
+                args: Some(vec!["lsp".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7352,7 +7352,7 @@ impl Config {
             "racket".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "racket-langserver".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7372,7 +7372,7 @@ impl Config {
             "fsharp".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "fsautocomplete".to_string(),
-                args: vec!["--adaptive-lsp-server-enabled".to_string()],
+                args: Some(vec!["--adaptive-lsp-server-enabled".to_string()]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -7391,7 +7391,7 @@ impl Config {
         // Handles both Verilog and SystemVerilog; configured per-project via .svls.toml.
         let svls_config = LspServerConfig {
             command: "svls".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: ProcessLimits::default(),
@@ -7424,7 +7424,7 @@ impl Config {
         // Pushed diagnostics are unaffected by the feature filter.
         let asm_lsp_config = LspServerConfig {
             command: "asm-lsp".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: ProcessLimits::default(),
@@ -8317,7 +8317,7 @@ mod tests {
         let config = Config::default();
         let server = &config.lsp["gdscript"].as_slice()[0];
         assert_eq!(server.command, "nc");
-        assert_eq!(server.args, vec!["127.0.0.1", "6005"]);
+        assert_eq!(server.args, Some(vec!["127.0.0.1".to_string(), "6005".to_string()]));
         assert!(!server.enabled);
         assert_eq!(server.name.as_deref(), Some("Godot GDScript"));
     }

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -6820,7 +6820,10 @@ impl Config {
             "dart".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "dart".to_string(),
-                args: Some(vec!["language-server".to_string(), "--protocol=lsp".to_string()]),
+                args: Some(vec![
+                    "language-server".to_string(),
+                    "--protocol=lsp".to_string(),
+                ]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -6946,7 +6949,11 @@ impl Config {
             "graphql".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "graphql-lsp".to_string(),
-                args: Some(vec!["server".to_string(), "-m".to_string(), "stream".to_string()]),
+                args: Some(vec![
+                    "server".to_string(),
+                    "-m".to_string(),
+                    "stream".to_string(),
+                ]),
                 enabled: true,
                 auto_start: false,
                 process_limits: ProcessLimits::default(),
@@ -8317,7 +8324,10 @@ mod tests {
         let config = Config::default();
         let server = &config.lsp["gdscript"].as_slice()[0];
         assert_eq!(server.command, "nc");
-        assert_eq!(server.args, Some(vec!["127.0.0.1".to_string(), "6005".to_string()]));
+        assert_eq!(
+            server.args,
+            Some(vec!["127.0.0.1".to_string(), "6005".to_string()])
+        );
         assert!(!server.enabled);
         assert_eq!(server.name.as_deref(), Some("Godot GDScript"));
     }

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -2471,7 +2471,10 @@ mod tests {
         );
         assert_eq!(
             rust_analyzer.args,
-            vec!["--log-file", "/tmp/rust-analyzer-{pid}.log"],
+            Some(vec![
+                "--log-file".to_string(),
+                "/tmp/rust-analyzer-{pid}.log".to_string()
+            ]),
             "rust-analyzer args should be preserved"
         );
 
@@ -2555,7 +2558,10 @@ mod tests {
         let reloaded_ra = &reloaded.lsp["rust-analyzer"].as_slice()[0];
         assert_eq!(
             reloaded_ra.args,
-            vec!["--log-file", "/tmp/rust-analyzer-{pid}.log"],
+            Some(vec![
+                "--log-file".to_string(),
+                "/tmp/rust-analyzer-{pid}.log".to_string()
+            ]),
             "BUG #806: Custom args should survive save/reload cycle"
         );
     }

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -48,7 +48,18 @@ fn strip_empty_defaults(value: Value) -> Option<Value> {
         Value::Object(map) => {
             let filtered: serde_json::Map<String, Value> = map
                 .into_iter()
-                .filter_map(|(k, v)| strip_empty_defaults(v).map(|v| (k, v)))
+                .filter_map(|(k, v)| {
+                    // An empty `args` array is a *meaningful* override for an LSP
+                    // server: it means "launch with no arguments", as opposed to an
+                    // omitted `args` which inherits the default server's arguments
+                    // (e.g. marksman's `server`). Stripping it as a redundant empty
+                    // default would make it impossible to replace a default server
+                    // that takes args with one that takes none (#2549), so keep it.
+                    if k == "args" && matches!(&v, Value::Array(a) if a.is_empty()) {
+                        return Some((k, v));
+                    }
+                    strip_empty_defaults(v).map(|v| (k, v))
+                })
                 .collect();
             if filtered.is_empty() {
                 None
@@ -1285,6 +1296,65 @@ mod tests {
             "saving an unrelated field must not drop the commented tab_size"
         );
         assert!(!reloaded.editor.line_numbers);
+        drop(temp);
+    }
+
+    #[test]
+    fn clearing_default_lsp_args_persists_empty_and_survives_reload() {
+        // Regression for #2549: replacing a default LSP server that takes args
+        // (markdown → `marksman server`) with no arguments. The Settings UI
+        // records the edited entry as a pending change with an empty `args`
+        // array; saving it must (a) persist `"args": []` to disk rather than
+        // stripping it as an empty default, and (b) resolve back to no args
+        // instead of re-inheriting marksman's `server`.
+        let (temp, resolver) = create_test_resolver();
+
+        // Sanity: the default really does carry the `server` argument.
+        let defaults = resolver.resolve().unwrap();
+        assert_eq!(
+            defaults.lsp["markdown"].as_slice()[0].args,
+            Some(vec!["server".to_string()]),
+            "precondition: default markdown LSP is `marksman server`"
+        );
+
+        // Simulate the Settings UI save: the markdown entry with args cleared.
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(
+            "/lsp/markdown".to_string(),
+            serde_json::json!([{
+                "command": "markdown-oxide",
+                "enabled": true,
+                "auto_start": false,
+                "args": [],
+            }]),
+        );
+        resolver
+            .save_changes_to_layer(
+                &changes,
+                &std::collections::HashSet::new(),
+                ConfigLayer::User,
+            )
+            .unwrap();
+
+        // (a) The empty args array must be written to disk, not stripped.
+        let saved = std::fs::read_to_string(resolver.user_config_path()).unwrap();
+        let saved_json: serde_json::Value = serde_json::from_str(&saved).unwrap();
+        assert_eq!(
+            saved_json.pointer("/lsp/markdown/0/args"),
+            Some(&serde_json::json!([])),
+            "explicit empty args must be persisted, not dropped. File: {saved}"
+        );
+
+        // (b) On reload the server runs with no arguments, not the default.
+        let reloaded = resolver.resolve().unwrap();
+        let server = &reloaded.lsp["markdown"].as_slice()[0];
+        assert_eq!(server.command, "markdown-oxide");
+        assert_eq!(
+            server.args,
+            Some(vec![]),
+            "cleared args must not re-inherit the default `server` argument"
+        );
+        assert!(server.args().is_empty());
         drop(temp);
     }
 

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -1295,7 +1295,7 @@ impl LspManager {
             match LspHandle::spawn(
                 &runtime,
                 &config.command,
-                &config.args,
+                config.args(),
                 config.env.clone(),
                 LanguageScope::single(language),
                 server_name.clone(),
@@ -1411,7 +1411,7 @@ impl LspManager {
             match LspHandle::spawn(
                 &runtime,
                 &config.command,
-                &config.args,
+                config.args(),
                 config.env.clone(),
                 LanguageScope::all(),
                 server_name.clone(),
@@ -1738,7 +1738,7 @@ impl LspManager {
         match LspHandle::spawn(
             &runtime,
             &config.command,
-            &config.args,
+            config.args(),
             config.env.clone(),
             scope,
             server_name.to_string(),
@@ -2144,7 +2144,7 @@ mod tests {
         let config = LspServerConfig {
             enabled: true,
             command: "rust-analyzer".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
             auto_start: false,
             initialization_options: None,
@@ -2173,7 +2173,7 @@ mod tests {
             LspServerConfig {
                 enabled: true,
                 command: "rust-analyzer".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
                 auto_start: false,
                 initialization_options: None,
@@ -2218,7 +2218,7 @@ mod tests {
             LspServerConfig {
                 enabled: false,
                 command: String::new(), // command not required when disabled
-                args: vec![],
+                args: Some(vec![]),
                 process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
                 auto_start: false,
                 initialization_options: None,
@@ -2253,7 +2253,7 @@ mod tests {
             LspServerConfig {
                 enabled: false,
                 command: String::new(),
-                args: vec![],
+                args: Some(vec![]),
                 process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
                 auto_start: false,
                 initialization_options: None,
@@ -2285,7 +2285,7 @@ mod tests {
             LspServerConfig {
                 enabled: true,
                 command: "rust-analyzer".to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
                 auto_start: true,
                 initialization_options: None,

--- a/crates/fresh-editor/src/services/packages.rs
+++ b/crates/fresh-editor/src/services/packages.rs
@@ -322,7 +322,7 @@ impl LspManifestConfig {
 
         LspServerConfig {
             command: self.command.clone(),
-            args: self.args.clone(),
+            args: Some(self.args.clone()),
             enabled: true,
             auto_start: self.auto_start.unwrap_or(true),
             initialization_options: self.initialization_options.clone(),
@@ -593,7 +593,7 @@ mod tests {
 
         let lsp = fresh.lsp.unwrap();
         assert_eq!(lsp.command, "hare-lsp");
-        assert_eq!(lsp.args, vec!["--stdio"]);
+        assert_eq!(lsp.args, vec!["--stdio".to_string()]);
         assert_eq!(lsp.auto_start, Some(true));
 
         // Verify conversion to LspServerConfig

--- a/crates/fresh-editor/src/types.rs
+++ b/crates/fresh-editor/src/types.rs
@@ -285,10 +285,15 @@ pub struct LspServerConfig {
     #[schemars(extend("x-order" = 3))]
     pub name: Option<String>,
 
-    /// Arguments to pass to the server
+    /// Arguments to pass to the server.
+    ///
+    /// `None` (field omitted) inherits the default server's args, while an
+    /// explicit list — including an empty `[]` — replaces them. This lets a
+    /// user swap a default server that takes args (e.g. `marksman server`)
+    /// for one that takes none (e.g. `markdown-oxide`) by setting `"args": []`.
     #[serde(default)]
     #[schemars(extend("x-order" = 4))]
-    pub args: Vec<String>,
+    pub args: Option<Vec<String>>,
 
     /// Whether to auto-start this LSP server when opening matching files.
     /// Defaults to true: a server you configure is normally one you want
@@ -374,6 +379,14 @@ impl LspServerConfig {
         FeatureFilter::from_config(&self.only_features, &self.except_features)
     }
 
+    /// The arguments to launch this server with, treating an omitted
+    /// (`None`) list as no arguments. Use this at spawn time; use the
+    /// `args` field directly only when the unset-vs-empty distinction
+    /// matters (e.g. merging user config with defaults).
+    pub fn args(&self) -> &[String] {
+        self.args.as_deref().unwrap_or(&[])
+    }
+
     /// Merge this config with defaults, using default values for empty/unset fields.
     ///
     /// This is used when loading configs where fields like `command` may be empty
@@ -386,11 +399,11 @@ impl LspServerConfig {
             } else {
                 self.command
             },
-            args: if self.args.is_empty() {
-                defaults.args.clone()
-            } else {
-                self.args
-            },
+            // Inherit the default args only when the user omitted the field
+            // entirely (`None`). An explicit list — including an empty `[]` —
+            // is respected as-is, so a replacement server can opt out of the
+            // default's arguments.
+            args: self.args.or_else(|| defaults.args.clone()),
             enabled: self.enabled,
             auto_start: self.auto_start,
             process_limits: self.process_limits,
@@ -509,5 +522,69 @@ mod tests {
     fn test_feature_filter_default() {
         let filter = FeatureFilter::default();
         assert!(matches!(filter, FeatureFilter::All));
+    }
+
+    /// A default server (e.g. `marksman server`) that a user replaces with a
+    /// command taking a different set of args.
+    fn marksman_default() -> LspServerConfig {
+        LspServerConfig {
+            command: "marksman".to_string(),
+            args: Some(vec!["server".to_string()]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_merge_omitted_args_inherits_default() {
+        // User omits `args` entirely (deserializes to None): inherit the
+        // default server's args.
+        let user = LspServerConfig {
+            command: "marksman".to_string(),
+            args: None,
+            ..Default::default()
+        };
+        let merged = user.merge_with_defaults(&marksman_default());
+        assert_eq!(merged.args, Some(vec!["server".to_string()]));
+        assert_eq!(merged.args(), ["server".to_string()]);
+    }
+
+    #[test]
+    fn test_merge_explicit_empty_args_overrides_default() {
+        // Regression for #2549: a user replacing marksman with a server that
+        // takes no arguments sets `"args": []`. This must NOT fall back to the
+        // default `["server"]` — the server should be launched with no args.
+        let user = LspServerConfig {
+            command: "markdown-oxide".to_string(),
+            args: Some(vec![]),
+            ..Default::default()
+        };
+        let merged = user.merge_with_defaults(&marksman_default());
+        assert_eq!(merged.command, "markdown-oxide");
+        assert_eq!(merged.args, Some(vec![]));
+        assert!(merged.args().is_empty());
+    }
+
+    #[test]
+    fn test_merge_explicit_args_replaces_default() {
+        let user = LspServerConfig {
+            command: "markdown-oxide".to_string(),
+            args: Some(vec!["--stdio".to_string()]),
+            ..Default::default()
+        };
+        let merged = user.merge_with_defaults(&marksman_default());
+        assert_eq!(merged.args, Some(vec!["--stdio".to_string()]));
+    }
+
+    #[test]
+    fn test_args_deserializes_missing_as_none_and_empty_as_some() {
+        // The unset-vs-empty distinction hinges on serde: an omitted field is
+        // None, while an explicit empty array is Some([]).
+        let omitted: LspServerConfig =
+            serde_json::from_str(r#"{"command":"markdown-oxide"}"#).unwrap();
+        assert_eq!(omitted.args, None);
+
+        let empty: LspServerConfig =
+            serde_json::from_str(r#"{"command":"markdown-oxide","args":[]}"#).unwrap();
+        assert_eq!(empty.args, Some(vec![]));
     }
 }

--- a/crates/fresh-editor/tests/e2e/action_popup_global.rs
+++ b/crates/fresh-editor/tests/e2e/action_popup_global.rs
@@ -429,7 +429,7 @@ editor.on("action_popup_result", "devmock_on_result");
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "rust-analyzer".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/folding.rs
+++ b/crates/fresh-editor/tests/e2e/folding.rs
@@ -545,7 +545,7 @@ fn test_folded_gutter_line_numbers_match_content_during_scroll() -> anyhow::Resu
             command: FakeLspServer::folding_ranges_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/hot_exit_recovery_lsp_sync.rs
+++ b/crates/fresh-editor/tests/e2e/hot_exit_recovery_lsp_sync.rs
@@ -116,7 +116,7 @@ fn rust_lsp_config(script: &std::path::Path, log_file: &std::path::Path) -> Conf
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -804,7 +804,7 @@ fn test_lsp_waiting_indicator() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -877,7 +877,7 @@ fn test_semantic_tokens_version_gating() -> anyhow::Result<()> {
             command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -978,7 +978,7 @@ fn test_semantic_tokens_range_preserves_overlays_on_edit() -> anyhow::Result<()>
             command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1077,7 +1077,7 @@ fn test_semantic_tokens_persist_on_enter_key() -> anyhow::Result<()> {
             command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1177,7 +1177,7 @@ fn test_semantic_tokens_overlays_shift_on_edit() -> anyhow::Result<()> {
             command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1285,7 +1285,7 @@ fn test_semantic_tokens_range_only_viewport_highlighting() -> anyhow::Result<()>
             command: FakeLspServer::semantic_tokens_range_only_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1456,7 +1456,7 @@ fn test_lsp_completion_canceled_on_cursor_move() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1529,7 +1529,7 @@ fn test_lsp_cursor_animation() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1605,7 +1605,7 @@ fn test_lsp_completion_canceled_on_text_edit() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -2196,7 +2196,7 @@ fn test_lsp_diagnostics_non_blocking() -> anyhow::Result<()> {
             command: FakeLspServer::blocking_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -2356,10 +2356,10 @@ fn test_rust_analyzer_rename_real_scenario() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "rust-analyzer".to_string(),
-            args: vec![
+            args: Some(vec![
                 "--log-file".to_string(),
                 ra_log_file.to_string_lossy().to_string(),
-            ],
+            ]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -2972,7 +2972,7 @@ fn test_lsp_progress_status_display() -> anyhow::Result<()> {
             command: FakeLspServer::progress_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -3139,7 +3139,7 @@ fn test_lsp_crash_detection_and_restart() -> anyhow::Result<()> {
             command: FakeLspServer::crashing_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -3438,7 +3438,7 @@ fn test_pull_diagnostics_auto_trigger_after_open() -> anyhow::Result<()> {
             command: FakeLspServer::pull_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -3522,7 +3522,7 @@ fn test_pull_diagnostics_result_id_tracking() -> anyhow::Result<()> {
             command: FakeLspServer::pull_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -3844,7 +3844,7 @@ fn test_stopped_lsp_does_not_auto_restart_on_edit() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true, // Auto-start so it starts when we open the file
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -4180,7 +4180,7 @@ fn test_hover_popup_persists_within_symbol_and_popup() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -4280,7 +4280,7 @@ fn test_hover_popup_persists_through_click_after_outside_move() -> anyhow::Resul
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -4380,7 +4380,7 @@ fn test_hover_popup_does_not_accumulate_across_hovers() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6009,7 +6009,7 @@ fn test_hover_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false, // This is the key setting - LSP should NOT auto-start
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6102,7 +6102,7 @@ fn test_typing_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false, // This is the key setting - LSP should NOT auto-start
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6183,7 +6183,7 @@ fn test_completion_triggered_on_trigger_character() -> anyhow::Result<()> {
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6270,7 +6270,7 @@ fn test_completion_triggered_on_word_char_with_quick_suggestions() -> anyhow::Re
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6355,7 +6355,7 @@ fn test_completion_not_triggered_on_word_char_without_quick_suggestions() -> any
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6442,7 +6442,7 @@ fn test_completion_not_triggered_on_non_word_char() -> anyhow::Result<()> {
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6591,7 +6591,7 @@ fn test_completion_no_auto_show_by_default() -> anyhow::Result<()> {
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6675,7 +6675,7 @@ fn test_completion_auto_show_when_enabled() -> anyhow::Result<()> {
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -6828,7 +6828,7 @@ fn test_hover_popup_follows_mouse_when_lsp_returns_no_range() -> anyhow::Result<
             command: FakeLspServer::no_range_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -7065,7 +7065,7 @@ fn test_hover_does_not_trigger_past_end_of_line() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -7172,7 +7172,7 @@ fn test_hover_does_not_trigger_on_empty_line() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -7265,7 +7265,7 @@ fn test_hover_suppressed_while_lsp_status_popup_open() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -7373,7 +7373,7 @@ fn test_hover_no_duplicate_popup_when_moving_within_symbol() -> anyhow::Result<(
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -8139,7 +8139,7 @@ log("STOPPED")
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::types::LspServerConfig {
             command: "python3".to_string(),
-            args: vec![script_path.to_string_lossy().to_string()],
+            args: Some(vec![script_path.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::types::ProcessLimits::default(),
@@ -8459,7 +8459,7 @@ log("STOPPED")
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::types::LspServerConfig {
             command: "python3".to_string(),
-            args: vec![script_path.to_string_lossy().to_string()],
+            args: Some(vec![script_path.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::types::ProcessLimits::default(),
@@ -8764,7 +8764,7 @@ log("STOPPED")
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::types::LspServerConfig {
             command: "python3".to_string(),
-            args: vec![script_path.to_string_lossy().to_string()],
+            args: Some(vec![script_path.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::types::ProcessLimits::default(),
@@ -8953,7 +8953,7 @@ done
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9111,7 +9111,7 @@ done
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9376,7 +9376,7 @@ done
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9565,7 +9565,7 @@ done
         "lua".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false, // KEY: must be manually started to exercise manual_restart
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9666,7 +9666,7 @@ fn test_restart_lsp_prompt_shows_suggestions() -> anyhow::Result<()> {
         fresh::types::LspLanguageConfig::Multi(vec![
             fresh::services::lsp::LspServerConfig {
                 command: script.clone(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9680,7 +9680,7 @@ fn test_restart_lsp_prompt_shows_suggestions() -> anyhow::Result<()> {
             },
             fresh::services::lsp::LspServerConfig {
                 command: script,
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9769,7 +9769,7 @@ fn test_restart_lsp_prompt_restarts_stopped_server() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9857,7 +9857,7 @@ fn test_stop_lsp_via_prompt_no_warning() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -9977,7 +9977,7 @@ fn lsp_spawn_failure_writes_stub_log_for_view_log_popup() -> anyhow::Result<()> 
         "pascal".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: bogus.clone(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_autostart_selective.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_autostart_selective.rs
@@ -129,7 +129,7 @@ fn build_server_config(
 ) -> fresh::services::lsp::LspServerConfig {
     fresh::services::lsp::LspServerConfig {
         command: script.to_string_lossy().to_string(),
-        args: vec![log_path.to_string_lossy().to_string(), severity.to_string()],
+        args: Some(vec![log_path.to_string_lossy().to_string(), severity.to_string()]),
         enabled,
         auto_start,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -483,7 +483,7 @@ fn test_universal_lsp_spawned_once_across_languages() -> anyhow::Result<()> {
         "test-universal".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![spawn_log.to_string_lossy().to_string()],
+            args: Some(vec![spawn_log.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             name: Some("TestUniversal".to_string()),

--- a/crates/fresh-editor/tests/e2e/lsp_autostart_selective.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_autostart_selective.rs
@@ -129,7 +129,10 @@ fn build_server_config(
 ) -> fresh::services::lsp::LspServerConfig {
     fresh::services::lsp::LspServerConfig {
         command: script.to_string_lossy().to_string(),
-        args: Some(vec![log_path.to_string_lossy().to_string(), severity.to_string()]),
+        args: Some(vec![
+            log_path.to_string_lossy().to_string(),
+            severity.to_string(),
+        ]),
         enabled,
         auto_start,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_bulk_edit_undo_desync.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_bulk_edit_undo_desync.rs
@@ -141,7 +141,7 @@ fn test_code_action_undo_sends_did_change() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_diagnostic_context.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_diagnostic_context.rs
@@ -43,7 +43,7 @@ fn test_code_action_request_includes_overlapping_diagnostic() -> anyhow::Result<
             command: FakeLspServer::diagnostic_gated_code_actions_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
@@ -37,7 +37,7 @@ fn test_code_action_number_key_selects_and_applies() -> anyhow::Result<()> {
             command: FakeLspServer::code_actions_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -138,7 +138,7 @@ fn test_code_action_arrow_enter_applies() -> anyhow::Result<()> {
             command: FakeLspServer::code_actions_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_resolve_and_commands.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_resolve_and_commands.rs
@@ -134,7 +134,7 @@ fn setup_editor(
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_entries_1514.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_entries_1514.rs
@@ -142,7 +142,7 @@ fn test_completion_popup_has_no_duplicates_after_second_request_1514() -> anyhow
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_completion_dynamic_registration.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_dynamic_registration.rs
@@ -44,7 +44,7 @@ fn test_completion_works_when_registered_dynamically_with_string_id() -> anyhow:
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_completion_resolve_and_formatting.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_resolve_and_formatting.rs
@@ -119,7 +119,7 @@ fn setup_editor(
         language.to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_config.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_config.rs
@@ -35,7 +35,7 @@ fn test_start_lsp_command_works_when_config_disabled() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: false, // KEY: LSP is disabled in config
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -130,7 +130,7 @@ fn test_settings_ui_lsp_enabled_change_takes_effect() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: false,   // KEY: LSP is disabled in config initially
             auto_start: true, // auto_start=true so it will start when enabled
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -269,7 +269,7 @@ fn test_lsp_manager_config_updated_via_set_lsp_config() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: false,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -311,7 +311,7 @@ fn test_lsp_manager_config_updated_via_set_lsp_config() -> anyhow::Result<()> {
         command: FakeLspServer::script_path(temp_dir.path())
             .to_string_lossy()
             .to_string(),
-        args: vec![],
+        args: Some(vec![]),
         enabled: true, // Changed to true
         auto_start: false,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_crash_loop.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_crash_loop.rs
@@ -77,7 +77,7 @@ fn test_crash_loop_is_bounded() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_cross_language_diagnostic_pull.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_cross_language_diagnostic_pull.rs
@@ -160,7 +160,7 @@ fn test_workspace_diagnostic_refresh_pulls_only_same_language_buffers() -> anyho
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -388,7 +388,7 @@ fn test_quiescent_inlay_hint_burst_only_for_same_language_buffers() -> anyhow::R
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
@@ -200,7 +200,7 @@ fn test_rust_analyzer_push_diagnostics_displayed() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -293,7 +293,7 @@ fn test_rust_analyzer_diagnostics_cleared_after_fix() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -555,7 +555,7 @@ fn test_edit_save_edit_save_diagnostic_flow() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -702,7 +702,7 @@ fn test_workspace_diagnostic_refresh_handled() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -914,7 +914,7 @@ fn test_stale_diagnostics_dropped_during_rapid_typing() -> anyhow::Result<()> {
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1116,7 +1116,7 @@ fn test_hover_popup_fuses_overlapping_diagnostic() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -1278,7 +1278,7 @@ done
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_env.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_env.rs
@@ -32,7 +32,7 @@ fn test_lsp_env_vars_passed_to_server() -> anyhow::Result<()> {
             command: FakeLspServer::env_echo_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
@@ -109,7 +109,7 @@ fn build_server_config(
 ) -> fresh::services::lsp::LspServerConfig {
     fresh::services::lsp::LspServerConfig {
         command: script.to_string_lossy().to_string(),
-        args: vec![log_path.to_string_lossy().to_string(), severity.to_string()],
+        args: Some(vec![log_path.to_string_lossy().to_string(), severity.to_string()]),
         enabled: true,
         auto_start: true,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
@@ -109,7 +109,10 @@ fn build_server_config(
 ) -> fresh::services::lsp::LspServerConfig {
     fresh::services::lsp::LspServerConfig {
         command: script.to_string_lossy().to_string(),
-        args: Some(vec![log_path.to_string_lossy().to_string(), severity.to_string()]),
+        args: Some(vec![
+            log_path.to_string_lossy().to_string(),
+            severity.to_string(),
+        ]),
         enabled: true,
         auto_start: true,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_goto_definition_readonly.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_goto_definition_readonly.rs
@@ -161,7 +161,7 @@ done
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_goto_implementation.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_goto_implementation.rs
@@ -134,7 +134,7 @@ done
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
@@ -154,7 +154,7 @@ fn config_with_rust_lsp(command: &str) -> fresh::config::Config {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: command.to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -429,7 +429,7 @@ fn issue_3_external_kill_leaves_popup_state_stale() -> anyhow::Result<()> {
     let mut config = config_with_rust_lsp(&script.to_string_lossy());
     if let Some(lsp_cfg) = config.lsp.get_mut("rust") {
         for c in lsp_cfg.as_mut_slice() {
-            c.args = vec![log.to_string_lossy().to_string()];
+            c.args = Some(vec![log.to_string_lossy().to_string()]);
         }
     }
 
@@ -521,7 +521,7 @@ fn issue_4_disable_lsp_does_not_stop_running_server() -> anyhow::Result<()> {
     let mut config = config_with_rust_lsp(&script.to_string_lossy());
     if let Some(lsp_cfg) = config.lsp.get_mut("rust") {
         for c in lsp_cfg.as_mut_slice() {
-            c.args = vec![log.to_string_lossy().to_string()];
+            c.args = Some(vec![log.to_string_lossy().to_string()]);
         }
     }
 
@@ -621,7 +621,7 @@ fn issue_5_spinner_has_no_auto_redraw_schedule() -> anyhow::Result<()> {
     let mut config = config_with_rust_lsp(&script.to_string_lossy());
     if let Some(lsp_cfg) = config.lsp.get_mut("rust") {
         for c in lsp_cfg.as_mut_slice() {
-            c.args = vec![log.to_string_lossy().to_string()];
+            c.args = Some(vec![log.to_string_lossy().to_string()]);
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/lsp_indicator_click_to_open.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_indicator_click_to_open.rs
@@ -22,7 +22,7 @@ fn make_config_with_dormant_rust_lsp() -> fresh::config::Config {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "rust-analyzer".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_inlay_hints_capability.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_inlay_hints_capability.rs
@@ -33,7 +33,7 @@ fn test_inlay_hint_skipped_when_server_does_not_advertise_capability() -> anyhow
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_lifecycle_visibility.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_lifecycle_visibility.rs
@@ -119,7 +119,7 @@ fn test_dormant_lsp_renders_off_indicator_on_status_bar() -> anyhow::Result<()> 
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![marker.to_string_lossy().to_string()],
+            args: Some(vec![marker.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: false, // configured but dormant
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -191,7 +191,7 @@ fn test_dormant_lsp_count_reflects_configured_servers() -> anyhow::Result<()> {
 
     let build = |name: &str, marker: &std::path::Path| fresh::services::lsp::LspServerConfig {
         command: script.to_string_lossy().to_string(),
-        args: vec![marker.to_string_lossy().to_string()],
+        args: Some(vec![marker.to_string_lossy().to_string()]),
         enabled: true,
         auto_start: false,
         process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -309,7 +309,7 @@ fn test_dormant_indicator_refreshes_on_buffer_switch() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![marker.to_string_lossy().to_string()],
+            args: Some(vec![marker.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -28,7 +28,7 @@ fn make_config_with_missing_rust_lsp() -> fresh::config::Config {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "this-binary-definitely-does-not-exist-xyz123".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -260,7 +260,7 @@ fn test_popup_offers_enable_when_config_already_disabled() -> anyhow::Result<()>
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "rust-analyzer".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: false,
             auto_start: false,
             name: Some("rust-analyzer".to_string()),

--- a/crates/fresh-editor/tests/e2e/lsp_multi_semantic_tokens.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_multi_semantic_tokens.rs
@@ -31,7 +31,7 @@ fn test_multi_lsp_semantic_tokens_capability_mismatch() -> anyhow::Result<()> {
                 command: FakeLspServer::no_semantic_tokens_script_path(temp_dir.path())
                     .to_string_lossy()
                     .to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 name: Some("no-semtok".to_string()),
@@ -48,7 +48,7 @@ fn test_multi_lsp_semantic_tokens_capability_mismatch() -> anyhow::Result<()> {
                 command: FakeLspServer::script_path(temp_dir.path())
                     .to_string_lossy()
                     .to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 name: Some("with-semtok".to_string()),

--- a/crates/fresh-editor/tests/e2e/lsp_order.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_order.rs
@@ -45,7 +45,7 @@ fn test_did_open_sent_before_hover() -> anyhow::Result<()> {
             command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_publish_diagnostics_capability.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_publish_diagnostics_capability.rs
@@ -303,7 +303,7 @@ fn test_strict_server_sends_diagnostics_with_capability() -> anyhow::Result<()> 
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -373,7 +373,7 @@ fn test_permissive_server_sends_diagnostics_without_capability() -> anyhow::Resu
         "c".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_server_lifecycle_cleanup.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_server_lifecycle_cleanup.rs
@@ -237,7 +237,7 @@ fn test_stopping_server_clears_diagnostics() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -310,7 +310,7 @@ fn test_two_servers_both_receive_didopen_and_publish_diagnostics() -> anyhow::Re
         fresh::types::LspLanguageConfig::Multi(vec![
             fresh::services::lsp::LspServerConfig {
                 command: error_script.to_string_lossy().to_string(),
-                args: vec![error_log.to_string_lossy().to_string()],
+                args: Some(vec![error_log.to_string_lossy().to_string()]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -324,7 +324,7 @@ fn test_two_servers_both_receive_didopen_and_publish_diagnostics() -> anyhow::Re
             },
             fresh::services::lsp::LspServerConfig {
                 command: warning_script.to_string_lossy().to_string(),
-                args: vec![warning_log.to_string_lossy().to_string()],
+                args: Some(vec![warning_log.to_string_lossy().to_string()]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_stop_stale_indicator.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_stop_stale_indicator.rs
@@ -116,7 +116,7 @@ fn test_stop_lsp_server_clears_stale_on_indicator() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -287,7 +287,7 @@ fn test_stop_lsp_server_clears_stale_progress_spinner() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_toggle_desync.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_toggle_desync.rs
@@ -174,7 +174,7 @@ fn test_lsp_toggle_off_edit_toggle_on_causes_desync() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -302,7 +302,7 @@ fn test_lsp_toggle_off_sends_did_close() -> anyhow::Result<()> {
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_unified_code_actions.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_unified_code_actions.rs
@@ -39,7 +39,7 @@ fn test_code_actions_merged_from_two_servers() -> anyhow::Result<()> {
                 command: FakeLspServer::code_actions_script_path(temp_dir.path())
                     .to_string_lossy()
                     .to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -55,7 +55,7 @@ fn test_code_actions_merged_from_two_servers() -> anyhow::Result<()> {
                 command: FakeLspServer::code_actions_b_script_path(temp_dir.path())
                     .to_string_lossy()
                     .to_string(),
-                args: vec![],
+                args: Some(vec![]),
                 enabled: true,
                 auto_start: true,
                 process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/lsp_unresponsive_capability_does_not_block.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_unresponsive_capability_does_not_block.rs
@@ -40,7 +40,7 @@ fn test_completion_works_when_server_silently_drops_semantic_tokens() -> anyhow:
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/markdown_compose_diagnostics.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_diagnostics.rs
@@ -132,7 +132,7 @@ fn test_compose_mode_keeps_diagnostic_gutter() -> anyhow::Result<()> {
         "markdown".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/orchestrator_window_lsp.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_window_lsp.rs
@@ -103,7 +103,7 @@ fn config_with_fake_rust_lsp(
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![log.to_string_lossy().to_string()],
+            args: Some(vec![log.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -336,7 +336,7 @@ fn goto_definition_translates_uris_between_host_and_container() {
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "fake-pylsp".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -606,7 +606,7 @@ fn arrange_attached_session_with_open_main_py() -> (
         "python".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: "fake-pylsp".to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
@@ -46,7 +46,7 @@ fn setup_harness(temp_dir: &tempfile::TempDir) -> (EditorTestHarness, std::path:
             command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_jump.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_jump.rs
@@ -53,7 +53,7 @@ fn test_diagnostics_panel_enter_does_not_jump() {
             command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -205,7 +205,7 @@ fn test_diagnostics_panel_cursor_move_scrolls_editor() {
             command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/lsp_find_references.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/lsp_find_references.rs
@@ -123,7 +123,7 @@ done
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true, // Auto-start so LSP starts when file is opened
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/lsp_navigation.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/lsp_navigation.rs
@@ -90,7 +90,7 @@ fn setup_lsp_test() -> anyhow::Result<(EditorTestHarness, tempfile::TempDir)> {
         "typescript".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/plugins/plugin.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin.rs
@@ -319,7 +319,7 @@ fn test_diagnostics_panel_plugin_loads() {
             command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -751,7 +751,7 @@ fn test_clangd_plugin_file_status_notification() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: ProcessLimits::default(),
@@ -829,7 +829,7 @@ fn test_clangd_plugin_switch_source_header() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: ProcessLimits::default(),
@@ -1064,7 +1064,7 @@ editor.setStatus("Test diagnostics plugin loaded");
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/popup_selection.rs
+++ b/crates/fresh-editor/tests/e2e/popup_selection.rs
@@ -30,7 +30,7 @@ fn test_lsp_hover_popup_text_selection_copy() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/theme.rs
+++ b/crates/fresh-editor/tests/e2e/theme.rs
@@ -766,7 +766,7 @@ fn test_diagnostic_overlay_colors_update_on_theme_change() -> anyhow::Result<()>
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script.to_string_lossy().to_string(),
-            args: vec![log_file.to_string_lossy().to_string()],
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
             enabled: true,
             auto_start: true,
             process_limits: Default::default(),

--- a/crates/fresh-editor/tests/e2e/theme_screenshots.rs
+++ b/crates/fresh-editor/tests/e2e/theme_screenshots.rs
@@ -1053,7 +1053,7 @@ fn scene_lsp_status(s: &mut BlogShowcase, theme_token: &str, theme_json: &str) {
             command: FakeLspServer::script_path(lsp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/universal_lsp.rs
+++ b/crates/fresh-editor/tests/e2e/universal_lsp.rs
@@ -154,7 +154,7 @@ done
         "test-universal".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
             command: script_path.to_string_lossy().to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),

--- a/crates/fresh-editor/tests/e2e/warning_indicators.rs
+++ b/crates/fresh-editor/tests/e2e/warning_indicators.rs
@@ -130,7 +130,7 @@ fn test_lsp_popup_shows_start_for_stopped_server() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: false,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -211,7 +211,7 @@ fn test_lsp_indicator_on_shows_server_actions() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),


### PR DESCRIPTION
## Summary

Fixes #2549 — you couldn't replace a default LSP server that passes `args` with one that takes none.

Each language's pre-configured LSP may set `args` (e.g. Markdown's **marksman** is launched as `marksman server`). Swapping it for a server that runs in LSP mode with **no** arguments — such as [markdown-oxide](https://github.com/Feel-ix-343/markdown-oxide) — was impossible:

- An omitted `args` and an explicit `"args": []` both deserialized to an empty `Vec<String>`.
- `LspServerConfig::merge_with_defaults` treated "empty" as "unset" and re-inserted the default's `server` argument.
- Fresh then ran `markdown-oxide server`, which exits with an error.

## Fix

Make `LspServerConfig::args` an `Option<Vec<String>>` so the config loader can distinguish:

- **`None`** (field omitted) → inherit the default server's args.
- **`Some(list)`** (an explicit array, including `[]`) → use it verbatim, replacing the default.

This mirrors how other override-able fields (`name`, `only_features`, `except_features`, …) already use `Option` to tell "unset" from "explicitly set".

Details:
- Merge is now `args: self.args.or_else(|| defaults.args.clone())`.
- Added `LspServerConfig::args() -> &[String]` used at spawn sites, treating `None` as no arguments.
- Default server definitions, package-manifest conversion, and Deno auto-detection wrap their args in `Some(...)`.

With this, the config from the issue works as expected:

```json
"lsp": {
  "markdown": { "command": "markdown-oxide", "args": [], "enabled": true }
}
```

## Testing

- New regression tests in `types.rs` cover the three merge cases (omitted → inherit, explicit `[]` → empty, explicit list → replace) and the serde `None`-vs-`Some([])` distinction.
- The existing #806 config save/reload round-trip tests and the gdscript-args test were updated for the new type and still pass.
- Full `cargo test -p fresh-editor --lib` suite: **2932 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df9atLQQjWXXcv1MUzxxDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df9atLQQjWXXcv1MUzxxDH)_