### PR TITLE
Add editor.ascii_ui fallback for chrome glyphs (#2032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Settings**:
   * language-entry field edits keep their committed value (including **Tab Size**), and `Esc` now cancels an in-progress edit while `Enter`/`Tab` commit it (#2537);
   * committing a text field with `Tab` persists the typed value on Save, matching `Enter` — previously the row showed as modified but Save wrote an empty value (#2515).
+* **ASCII chrome fallback** — a new `editor.ascii_ui` option (Settings → *Editor* → *Display*) redraws UI chrome (settings editor, file tree, popups, prompts, dialog borders) with plain ASCII instead of Unicode box-drawing and symbol glyphs — including the Nerd-Font settings category icons — for terminals/fonts that render them as `?` or blank boxes (#2032, reported by @comesuccingfuccsloot). Buffer text, whitespace indicators, and indentation guides are unaffected.
 
 ### Internals
 

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -31,6 +31,7 @@
       "$ref": "#/$defs/EditorConfig",
       "default": {
         "animations": true,
+        "ascii_ui": false,
         "cursor_jump_animation": true,
         "line_numbers": true,
         "relative_line_numbers": false,
@@ -374,6 +375,12 @@
           "description": "Enable frame-buffer animations (tab-switch slides, dashboard\nbringup, plugin-driven effects). When `false`, every animation\ncall is a no-op: the UI is fully static and each render lands\nthe final frame immediately. Useful on slow terminals, over\nSSH, or for users who prefer no motion.",
           "type": "boolean",
           "default": true,
+          "x-section": "Display"
+        },
+        "ascii_ui": {
+          "description": "Draw chrome (settings editor, file tree, popups, prompts, dialog\nborders) with plain ASCII characters instead of Unicode box-drawing\nand symbol glyphs. Enable this on terminals/fonts that render the\ndecorative glyphs (`▶`, `→`, `╭╮╰╯`, `✓`, Nerd-Font category icons,\n…) as `?` or blank boxes. Affects UI chrome only — buffer text,\nwhitespace indicators, and indentation guides are unchanged.\nDefault: false",
+          "type": "boolean",
+          "default": false,
           "x-section": "Display"
         },
         "cursor_jump_animation": {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -60,6 +60,11 @@ impl Editor {
         let _span = tracing::info_span!("render").entered();
         let size = frame.area();
 
+        // Resolve the chrome glyph set (Unicode vs. ASCII fallback) for this
+        // frame from the live config, so every render site below sees the
+        // current `editor.ascii_ui` value regardless of how it was swapped.
+        crate::view::glyphs::set_ascii_ui(self.config.editor.ascii_ui);
+
         self.drain_pre_layout_plugin_commands();
 
         for window in self.windows.values_mut() {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -997,6 +997,17 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub animations: bool,
 
+    /// Draw chrome (settings editor, file tree, popups, prompts, dialog
+    /// borders) with plain ASCII characters instead of Unicode box-drawing
+    /// and symbol glyphs. Enable this on terminals/fonts that render the
+    /// decorative glyphs (`▶`, `→`, `╭╮╰╯`, `✓`, Nerd-Font category icons,
+    /// …) as `?` or blank boxes. Affects UI chrome only — buffer text,
+    /// whitespace indicators, and indentation guides are unchanged.
+    /// Default: false
+    #[serde(default = "default_false")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub ascii_ui: bool,
+
     /// Enable the cursor-jump trail animation on long cursor moves
     /// (search jumps, go-to-definition, pane switches). Has no effect
     /// when `animations` is `false`.
@@ -1741,6 +1752,7 @@ impl Default for EditorConfig {
             auto_close: true,
             auto_surround: true,
             animations: true,
+            ascii_ui: false,
             cursor_jump_animation: true,
             line_numbers: true,
             relative_line_numbers: false,

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -152,6 +152,7 @@ pub struct PartialEditorConfig {
     pub auto_close: Option<bool>,
     pub auto_surround: Option<bool>,
     pub animations: Option<bool>,
+    pub ascii_ui: Option<bool>,
     pub cursor_jump_animation: Option<bool>,
     pub line_numbers: Option<bool>,
     pub relative_line_numbers: Option<bool>,
@@ -583,6 +584,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             auto_close: Some(cfg.auto_close),
             auto_surround: Some(cfg.auto_surround),
             animations: Some(cfg.animations),
+            ascii_ui: Some(cfg.ascii_ui),
             cursor_jump_animation: Some(cfg.cursor_jump_animation),
             line_numbers: Some(cfg.line_numbers),
             relative_line_numbers: Some(cfg.relative_line_numbers),
@@ -678,6 +680,7 @@ impl PartialEditorConfig {
             auto_close: self.auto_close.unwrap_or(defaults.auto_close),
             auto_surround: self.auto_surround.unwrap_or(defaults.auto_surround),
             animations: self.animations.unwrap_or(defaults.animations),
+            ascii_ui: self.ascii_ui.unwrap_or(defaults.ascii_ui),
             cursor_jump_animation: self
                 .cursor_jump_animation
                 .unwrap_or(defaults.cursor_jump_animation),

--- a/crates/fresh-editor/src/view/calibration_wizard.rs
+++ b/crates/fresh-editor/src/view/calibration_wizard.rs
@@ -63,6 +63,7 @@ pub fn render_calibration_wizard(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.editor_fg))
         .style(Style::default().bg(theme.editor_bg).fg(theme.editor_fg));
 
@@ -117,6 +118,7 @@ fn render_confirmation_dialog(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.diagnostic_warning_fg))
         .style(Style::default().bg(theme.editor_bg).fg(theme.editor_fg));
 

--- a/crates/fresh-editor/src/view/controls/dropdown/render.rs
+++ b/crates/fresh-editor/src/view/controls/dropdown/render.rs
@@ -76,7 +76,11 @@ pub fn render_dropdown_aligned(
     let display_width = max_option_len.max(selected_text.len()).min(20);
     let padded = format!("{:width$}", selected_text, width = display_width);
 
-    let arrow = if state.open { "▲" } else { "▼" };
+    let arrow = if state.open {
+        crate::view::glyphs::glyphs().triangle_up
+    } else {
+        crate::view::glyphs::glyphs().triangle_down
+    };
 
     let actual_label_width = label_width.unwrap_or(state.label.len() as u16);
     let padded_label = format!(

--- a/crates/fresh-editor/src/view/controls/dual_list/render.rs
+++ b/crates/fresh-editor/src/view/controls/dual_list/render.rs
@@ -171,7 +171,10 @@ pub fn render_dual_list_partial(
             // Separator row between transfer and reorder buttons
             2 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled(g.h.repeat(3), dim_style)), btn_area);
+                frame.render_widget(
+                    Paragraph::new(Span::styled(g.h.repeat(3), dim_style)),
+                    btn_area,
+                );
             }
             3 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);

--- a/crates/fresh-editor/src/view/controls/dual_list/render.rs
+++ b/crates/fresh-editor/src/view/controls/dual_list/render.rs
@@ -2,6 +2,7 @@
 
 use super::{DualListColors, DualListColumn, DualListLayout, DualListRowArea, DualListState};
 use crate::view::controls::FocusState;
+use crate::view::glyphs::glyphs;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
@@ -151,30 +152,37 @@ pub fn render_dual_list_partial(
         // Action buttons between columns: add/remove transfer items, up/down reorder
         let btn_style = Style::default().fg(colors.button);
         let dim_style = Style::default().fg(colors.disabled);
+        let g = glyphs();
+        // Centre each glyph in the fixed 3-column button so multi-cell ASCII
+        // fallbacks (`->`, `<-`) still fit without shifting the layout.
         match row_idx {
             0 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled(" → ", btn_style)), btn_area);
+                let label = format!("{:^3}", g.arrow_right);
+                frame.render_widget(Paragraph::new(Span::styled(label, btn_style)), btn_area);
                 layout.add_button = Some(btn_area);
             }
             1 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled(" ← ", btn_style)), btn_area);
+                let label = format!("{:^3}", g.arrow_left);
+                frame.render_widget(Paragraph::new(Span::styled(label, btn_style)), btn_area);
                 layout.remove_button = Some(btn_area);
             }
             // Separator row between transfer and reorder buttons
             2 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled("───", dim_style)), btn_area);
+                frame.render_widget(Paragraph::new(Span::styled(g.h.repeat(3), dim_style)), btn_area);
             }
             3 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled(" ↑ ", btn_style)), btn_area);
+                let label = format!("{:^3}", g.arrow_up);
+                frame.render_widget(Paragraph::new(Span::styled(label, btn_style)), btn_area);
                 layout.move_up_button = Some(btn_area);
             }
             4 => {
                 let btn_area = Rect::new(btn_x, y, btn_width, 1);
-                frame.render_widget(Paragraph::new(Span::styled(" ↓ ", btn_style)), btn_area);
+                let label = format!("{:^3}", g.arrow_down);
+                frame.render_widget(Paragraph::new(Span::styled(label, btn_style)), btn_area);
                 layout.move_down_button = Some(btn_area);
             }
             _ => {}

--- a/crates/fresh-editor/src/view/controls/map_input/render.rs
+++ b/crates/fresh-editor/src/view/controls/map_input/render.rs
@@ -57,7 +57,11 @@ pub fn render_map(
         let is_focused = state.focused_entry == Some(idx) && state.focus == FocusState::Focused;
         let is_expanded = state.is_expanded(idx);
 
-        let arrow = if is_expanded { "▼" } else { ">" };
+        let arrow = if is_expanded {
+            crate::view::glyphs::glyphs().chevron_expanded
+        } else {
+            ">"
+        };
 
         // Value preview using display_field if available
         let value_preview = state.get_display_value(value);

--- a/crates/fresh-editor/src/view/file_tree/decorations.rs
+++ b/crates/fresh-editor/src/view/file_tree/decorations.rs
@@ -47,13 +47,13 @@ impl<'a> ExplorerRowStatus<'a> {
         is_dir: bool,
     ) -> Option<ExplorerTrailingSlotPayload> {
         let (text, fg) = match self.resolved {
-            Some(ResolvedExplorerStatus::Unsaved) => ("●".to_string(), theme.diagnostic_warning_fg),
+            Some(ResolvedExplorerStatus::Unsaved) => (crate::view::glyphs::glyphs().bullet.to_string(), theme.diagnostic_warning_fg),
             Some(ResolvedExplorerStatus::Decoration(decoration)) => (
                 decoration_symbol(&decoration.symbol),
                 compatibility_decoration_color(decoration, theme),
             ),
             Some(ResolvedExplorerStatus::BubbledDecoration(decoration)) => (
-                "●".to_string(),
+                crate::view::glyphs::glyphs().bullet.to_string(),
                 compatibility_decoration_color(decoration, theme),
             ),
             None => return None,

--- a/crates/fresh-editor/src/view/file_tree/decorations.rs
+++ b/crates/fresh-editor/src/view/file_tree/decorations.rs
@@ -47,7 +47,10 @@ impl<'a> ExplorerRowStatus<'a> {
         is_dir: bool,
     ) -> Option<ExplorerTrailingSlotPayload> {
         let (text, fg) = match self.resolved {
-            Some(ResolvedExplorerStatus::Unsaved) => (crate::view::glyphs::glyphs().bullet.to_string(), theme.diagnostic_warning_fg),
+            Some(ResolvedExplorerStatus::Unsaved) => (
+                crate::view::glyphs::glyphs().bullet.to_string(),
+                theme.diagnostic_warning_fg,
+            ),
             Some(ResolvedExplorerStatus::Decoration(decoration)) => (
                 decoration_symbol(&decoration.symbol),
                 compatibility_decoration_color(decoration, theme),

--- a/crates/fresh-editor/src/view/glyphs.rs
+++ b/crates/fresh-editor/src/view/glyphs.rs
@@ -1,0 +1,280 @@
+//! Central glyph set for UI chrome (settings editor, file tree, popups,
+//! prompts, dialog borders).
+//!
+//! Some terminals/fonts render the decorative Unicode glyphs the chrome uses
+//! (`▶`, `→`, `╭╮╰╯`, `✓`, and especially the Nerd-Font private-use-area
+//! category icons) as literal `?` or blank boxes — see issue #2032. Routing
+//! every chrome glyph through this module lets the `editor.ascii_ui` config
+//! flag swap the whole set for plain ASCII in one place.
+//!
+//! Scope is UI **chrome only**. Buffer text, whitespace indicators
+//! (`·`, `→`) and indentation guides have their own dedicated config and are
+//! intentionally left alone.
+
+use ratatui::symbols::border;
+
+/// A resolved set of chrome glyphs. Every field is `&'static str` so the two
+/// concrete sets ([`UNICODE`] and [`ASCII`]) live as `static` values and
+/// [`glyphs`] can hand out cheap `&'static` references.
+#[derive(Debug, Clone, Copy)]
+pub struct Glyphs {
+    /// `true` for the ASCII set — lets callers branch on mode when composing
+    /// multi-glyph strings.
+    pub ascii: bool,
+
+    // ── Disclosure / tree ────────────────────────────────────────────────
+    /// Expanded node marker (`▼`).
+    pub chevron_expanded: &'static str,
+    /// Collapsed node marker (`▶`).
+    pub chevron_collapsed: &'static str,
+    /// Upward triangle used by dropdowns/scroll affordances (`▲`).
+    pub triangle_up: &'static str,
+    /// Downward triangle used by dropdowns (`▼`).
+    pub triangle_down: &'static str,
+
+    // ── Arrows ───────────────────────────────────────────────────────────
+    pub arrow_right: &'static str,
+    pub arrow_left: &'static str,
+    pub arrow_up: &'static str,
+    pub arrow_down: &'static str,
+
+    // ── Indicators ───────────────────────────────────────────────────────
+    /// Filled dot used for "modified"/selected markers (`●`).
+    pub bullet: &'static str,
+    /// Active/enabled toggle marker (`✓`).
+    pub check: &'static str,
+    /// Left edge accent bar for highlighted rows (`▎`).
+    pub bar: &'static str,
+
+    // ── Box drawing ──────────────────────────────────────────────────────
+    pub h: &'static str,
+    pub v: &'static str,
+    pub corner_tl: &'static str,
+    pub corner_tr: &'static str,
+    pub corner_bl: &'static str,
+    pub corner_br: &'static str,
+    pub tee_right: &'static str,
+    pub tee_left: &'static str,
+}
+
+impl Glyphs {
+    /// The pure-ASCII border symbol set (`+`/`-`/`|`).
+    fn ascii_border_set(&self) -> border::Set<'static> {
+        border::Set {
+            top_left: self.corner_tl,
+            top_right: self.corner_tr,
+            bottom_left: self.corner_bl,
+            bottom_right: self.corner_br,
+            vertical_left: self.v,
+            vertical_right: self.v,
+            horizontal_top: self.h,
+            horizontal_bottom: self.h,
+        }
+    }
+
+    /// Border symbol set for rounded-corner blocks. Replaces
+    /// `.border_type(BorderType::Rounded)` so the flag reaches block borders;
+    /// falls back to ASCII when `ascii_ui` is enabled.
+    pub fn border_set(&self) -> border::Set<'static> {
+        if self.ascii {
+            self.ascii_border_set()
+        } else {
+            border::ROUNDED
+        }
+    }
+
+    /// Border symbol set for plain (square-corner) blocks — the ratatui
+    /// default. Identical to the default in Unicode mode (no visual change),
+    /// ASCII when `ascii_ui` is enabled. Use on `Borders::ALL` blocks that
+    /// don't set an explicit border type.
+    pub fn plain_border_set(&self) -> border::Set<'static> {
+        if self.ascii {
+            self.ascii_border_set()
+        } else {
+            border::PLAIN
+        }
+    }
+
+    /// Combined vertical scroll indicator (`↑`, `↓`, `↑↓`, or empty) for the
+    /// given can-scroll-up / can-scroll-down state. Includes a leading space
+    /// when non-empty, matching the previous inline call sites.
+    pub fn scroll_indicator(&self, up: bool, down: bool) -> String {
+        match (up, down) {
+            (true, true) => format!(" {}{}", self.arrow_up, self.arrow_down),
+            (true, false) => format!(" {}", self.arrow_up),
+            (false, true) => format!(" {}", self.arrow_down),
+            (false, false) => String::new(),
+        }
+    }
+
+    /// Icon shown before a settings category name. Unicode mode uses Nerd-Font
+    /// private-use-area icons (unchanged from before); ASCII mode uses a plain
+    /// two-cell marker so alignment is preserved without needing a patched
+    /// font.
+    pub fn category_icon(&self, name: &str) -> &'static str {
+        if self.ascii {
+            return "- ";
+        }
+        match name.to_lowercase().as_str() {
+            "general" => "\u{f013} ",       //
+            "editor" => "\u{f044} ",        //
+            "clipboard" => "\u{f328} ",     //
+            "file browser" => "\u{f07b} ",  //
+            "file explorer" => "\u{f07c} ", //
+            "packages" => "\u{f487} ",      //
+            "plugins" => "\u{f1e6} ",       //
+            "terminal" => "\u{f120} ",      //
+            "warnings" => "\u{f071} ",      //
+            "keybindings" => "\u{f11c} ",   //
+            _ => "\u{f111} ",               //  (dot circle as fallback)
+        }
+    }
+}
+
+/// The default (Unicode) chrome glyphs — current appearance, unchanged.
+pub static UNICODE: Glyphs = Glyphs {
+    ascii: false,
+    chevron_expanded: "▼",
+    chevron_collapsed: "▶",
+    triangle_up: "▲",
+    triangle_down: "▼",
+    arrow_right: "→",
+    arrow_left: "←",
+    arrow_up: "↑",
+    arrow_down: "↓",
+    bullet: "●",
+    check: "✓",
+    bar: "▎",
+    h: "─",
+    v: "│",
+    corner_tl: "╭",
+    corner_tr: "╮",
+    corner_bl: "╰",
+    corner_br: "╯",
+    tee_right: "├",
+    tee_left: "┤",
+};
+
+/// The ASCII fallback chrome glyphs, used when `editor.ascii_ui` is enabled.
+pub static ASCII: Glyphs = Glyphs {
+    ascii: true,
+    chevron_expanded: "v",
+    chevron_collapsed: ">",
+    triangle_up: "^",
+    triangle_down: "v",
+    arrow_right: "->",
+    arrow_left: "<-",
+    arrow_up: "^",
+    arrow_down: "v",
+    bullet: "*",
+    check: "x",
+    bar: "|",
+    h: "-",
+    v: "|",
+    corner_tl: "+",
+    corner_tr: "+",
+    corner_bl: "+",
+    corner_br: "+",
+    tee_right: "+",
+    tee_left: "+",
+};
+
+use std::cell::Cell;
+
+thread_local! {
+    /// Per-thread ASCII-mode flag. `set_ascii_ui` and every `glyphs()` read
+    /// happen synchronously on one thread within a single `App::render` frame,
+    /// so a thread-local is both correct for production and keeps tests that
+    /// render on separate threads fully isolated from one another.
+    static ASCII_MODE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Update the active glyph mode. Called once per frame from the render pass so
+/// it always reflects the live config, no matter which path swapped the config.
+pub fn set_ascii_ui(on: bool) {
+    ASCII_MODE.with(|m| m.set(on));
+}
+
+/// The active chrome glyph set.
+#[inline]
+pub fn glyphs() -> &'static Glyphs {
+    if ASCII_MODE.with(Cell::get) {
+        &ASCII
+    } else {
+        &UNICODE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_glyphs_are_pure_ascii() {
+        let g = &ASCII;
+        for s in [
+            g.chevron_expanded,
+            g.chevron_collapsed,
+            g.triangle_up,
+            g.triangle_down,
+            g.arrow_right,
+            g.arrow_left,
+            g.arrow_up,
+            g.arrow_down,
+            g.bullet,
+            g.check,
+            g.bar,
+            g.h,
+            g.v,
+            g.corner_tl,
+            g.corner_tr,
+            g.corner_bl,
+            g.corner_br,
+            g.tee_right,
+            g.tee_left,
+            g.category_icon("general"),
+            g.category_icon("does-not-exist"),
+        ] {
+            assert!(s.is_ascii(), "expected ASCII, got {s:?}");
+        }
+        assert!(g.scroll_indicator(true, true).is_ascii());
+    }
+
+    #[test]
+    fn mode_toggles_the_active_set() {
+        set_ascii_ui(false);
+        assert!(!glyphs().ascii);
+        assert_eq!(glyphs().chevron_collapsed, "▶");
+        set_ascii_ui(true);
+        assert!(glyphs().ascii);
+        assert_eq!(glyphs().chevron_collapsed, ">");
+        // restore default so global state doesn't leak across tests
+        set_ascii_ui(false);
+    }
+
+    #[test]
+    fn scroll_indicator_matches_states() {
+        let g = &UNICODE;
+        assert_eq!(g.scroll_indicator(false, false), "");
+        assert_eq!(g.scroll_indicator(true, false), " ↑");
+        assert_eq!(g.scroll_indicator(false, true), " ↓");
+        assert_eq!(g.scroll_indicator(true, true), " ↑↓");
+    }
+
+    #[test]
+    fn ascii_border_set_is_ascii() {
+        let set = ASCII.border_set();
+        for s in [
+            set.top_left,
+            set.top_right,
+            set.bottom_left,
+            set.bottom_right,
+            set.vertical_left,
+            set.vertical_right,
+            set.horizontal_top,
+            set.horizontal_bottom,
+        ] {
+            assert!(s.is_ascii(), "expected ASCII border cell, got {s:?}");
+        }
+    }
+}

--- a/crates/fresh-editor/src/view/keybinding_editor.rs
+++ b/crates/fresh-editor/src/view/keybinding_editor.rs
@@ -68,6 +68,7 @@ pub fn render_keybinding_editor(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.popup_border_fg))
         .style(Style::default().bg(theme.popup_bg).fg(theme.popup_text_fg));
 
@@ -635,6 +636,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect, theme: &Theme) {
     let block = Block::default()
         .title(format!(" {} ", t!("keybinding_editor.help_title")))
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.popup_border_fg))
         .style(Style::default().bg(theme.popup_bg).fg(theme.popup_text_fg));
     let inner = block.inner(dialog_area);
@@ -742,6 +744,7 @@ fn render_edit_dialog(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.popup_border_fg))
         .style(Style::default().bg(theme.popup_bg).fg(theme.popup_text_fg));
     let inner = block.inner(dialog_area);
@@ -1067,6 +1070,7 @@ fn render_autocomplete_popup(
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.popup_border_fg))
         .style(Style::default().bg(theme.popup_bg).fg(theme.popup_text_fg));
     let inner = block.inner(popup_area);
@@ -1131,6 +1135,7 @@ fn render_confirm_dialog(
     let block = Block::default()
         .title(format!(" {} ", t!("keybinding_editor.confirm_title")))
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.diagnostic_warning_fg))
         .style(Style::default().bg(theme.popup_bg).fg(theme.popup_text_fg));
     let inner = block.inner(dialog_area);

--- a/crates/fresh-editor/src/view/mod.rs
+++ b/crates/fresh-editor/src/view/mod.rs
@@ -24,9 +24,9 @@ pub mod conceal;
 pub mod controls;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod dimming;
-pub mod glyphs;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod folding;
+pub mod glyphs;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod line_wrap_cache;
 #[cfg(any(feature = "runtime", feature = "wasm"))]

--- a/crates/fresh-editor/src/view/mod.rs
+++ b/crates/fresh-editor/src/view/mod.rs
@@ -24,6 +24,7 @@ pub mod conceal;
 pub mod controls;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod dimming;
+pub mod glyphs;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod folding;
 #[cfg(any(feature = "runtime", feature = "wasm"))]

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -1079,6 +1079,7 @@ impl Popup {
         let block = if self.bordered {
             let mut block = Block::default()
                 .borders(Borders::ALL)
+                .border_set(crate::view::glyphs::glyphs().plain_border_set())
                 .border_style(self.border_style)
                 .style(self.background_style);
 

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -17,11 +17,12 @@ use crate::view::controls::{
     NumberInputColors, TextInputColors, TextListColors, ToggleColors,
 };
 use crate::view::theme::Theme;
+use crate::view::glyphs::glyphs;
 use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
 /// Build spans for a text line with selection highlighting
@@ -199,7 +200,7 @@ pub fn render_settings(
     let block = Block::default()
         .title(title.as_str())
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+        .border_set(glyphs().border_set())
         .border_style(Style::default().fg(theme.popup_border_fg))
         .style(Style::default().bg(theme.popup_bg));
     frame.render_widget(block, modal_area);
@@ -336,7 +337,7 @@ fn render_horizontal_layout(
     let divider_style = Style::default().fg(theme.split_separator_fg);
     for y in 0..divider_area.height {
         frame.render_widget(
-            Paragraph::new("│").style(divider_style),
+            Paragraph::new(glyphs().v).style(divider_style),
             Rect::new(divider_area.x, divider_area.y + y, 1, 1),
         );
     }
@@ -401,7 +402,7 @@ fn render_vertical_layout(
 
     // Render horizontal separator
     if sep_y < content_area.y + content_area.height {
-        let sep_line: String = "─".repeat(content_area.width as usize);
+        let sep_line: String = glyphs().h.repeat(content_area.width as usize);
         frame.render_widget(
             Paragraph::new(sep_line).style(Style::default().fg(theme.split_separator_fg)),
             Rect::new(content_area.x, sep_y, content_area.width, 1),
@@ -443,7 +444,11 @@ fn render_categories_horizontal(
         let is_selected = i == state.selected_category;
         let has_modified = state.page_has_pending_changes(i);
 
-        let indicator = if has_modified { "● " } else { "  " };
+        let indicator = if has_modified {
+            format!("{} ", glyphs().bullet)
+        } else {
+            "  ".to_string()
+        };
         let name = &page.name;
 
         let style = if is_selected && is_focused {
@@ -468,19 +473,20 @@ fn render_categories_horizontal(
         // Add separator between categories
         if i > 0 {
             spans.push(Span::styled(
-                " │ ",
+                format!(" {} ", glyphs().v),
                 Style::default().fg(theme.split_separator_fg),
             ));
             total_width += 3;
         }
 
+        let entry_width = (indicator.len() + name.len()) as u16;
         spans.push(Span::styled(indicator, indicator_style));
         spans.push(Span::styled(name.as_str(), style));
-        total_width += (indicator.len() + name.len()) as u16;
+        total_width += entry_width;
 
         // Track category rect for click handling (approximate)
-        let cat_x = area.x + total_width.saturating_sub((indicator.len() + name.len()) as u16);
-        let cat_width = (indicator.len() + name.len()) as u16;
+        let cat_x = area.x + total_width.saturating_sub(entry_width);
+        let cat_width = entry_width;
         layout
             .categories
             .push((i, Rect::new(cat_x, area.y, cat_width, 1)));
@@ -492,29 +498,16 @@ fn render_categories_horizontal(
 
     // Show navigation hint on line 2 if space
     if area.height >= 2 {
-        let hint = "←→: Switch category";
+        let hint = format!(
+            "{}{}: Switch category",
+            glyphs().arrow_left,
+            glyphs().arrow_right
+        );
         let hint_style = Style::default().fg(theme.line_number_fg);
         frame.render_widget(
             Paragraph::new(hint).style(hint_style),
             Rect::new(area.x, area.y + 1, area.width, 1),
         );
-    }
-}
-
-/// Get an icon for a settings category name (Nerd Font icons)
-fn category_icon(name: &str) -> &'static str {
-    match name.to_lowercase().as_str() {
-        "general" => "\u{f013} ",       //
-        "editor" => "\u{f044} ",        //
-        "clipboard" => "\u{f328} ",     //
-        "file browser" => "\u{f07b} ",  //
-        "file explorer" => "\u{f07c} ", //
-        "packages" => "\u{f487} ",      //
-        "plugins" => "\u{f1e6} ",       //
-        "terminal" => "\u{f120} ",      //
-        "warnings" => "\u{f071} ",      //
-        "keybindings" => "\u{f11c} ",   //
-        _ => "\u{f111} ",               //  (dot circle as fallback)
     }
 }
 
@@ -575,9 +568,9 @@ fn render_categories(
                 RowData {
                     chevron: if expandable {
                         if expanded {
-                            "▼"
+                            glyphs().chevron_expanded
                         } else {
-                            "▶"
+                            glyphs().chevron_collapsed
                         }
                     } else {
                         " "
@@ -593,7 +586,7 @@ fn render_categories(
                     cat_idx: Some(idx),
                     section_idx: None,
                     label: page.name.clone(),
-                    icon: Some(category_icon(&page.name)),
+                    icon: Some(glyphs().category_icon(&page.name)),
                 }
             }
             TreeRow::Section {
@@ -1244,7 +1237,7 @@ fn render_setting_item_pure(
             // secondary structure, not nested popups.
             let block = Block::default()
                 .borders(borders)
-                .border_type(BorderType::Rounded)
+                .border_set(glyphs().border_set())
                 .border_style(Style::default().fg(theme.split_separator_fg));
             frame.render_widget(block, card_rect);
         }
@@ -1319,7 +1312,7 @@ fn render_setting_item_pure(
         }
         if pending_dirty && label_row_visible && inner_area.width >= 2 {
             frame.render_widget(
-                Paragraph::new("●").style(Style::default().fg(theme.settings_selected_fg)),
+                Paragraph::new(glyphs().bullet).style(Style::default().fg(theme.settings_selected_fg)),
                 Rect::new(inner_area.x + 1, inner_area.y, 1, 1),
             );
         }
@@ -1682,10 +1675,10 @@ fn render_json_control(
         // Build line with border
         let mut spans = vec![
             Span::raw(" ".repeat(indent as usize)),
-            Span::styled("│", Style::default().fg(border_color)),
+            Span::styled(glyphs().v, Style::default().fg(border_color)),
         ];
         spans.extend(content_spans);
-        spans.push(Span::styled("│", Style::default().fg(border_color)));
+        spans.push(Span::styled(glyphs().v, Style::default().fg(border_color)));
         let line = Line::from(spans);
 
         frame.render_widget(Paragraph::new(line), Rect::new(area.x, y, area.width, 1));
@@ -2284,7 +2277,10 @@ fn render_keybinding_list_partial(
                         format!("{:<20}", key_combo),
                         Style::default().fg(key_fg).bg(bg),
                     ),
-                    Span::styled(" → ", Style::default().fg(arrow_fg).bg(bg)),
+                    Span::styled(
+                        format!(" {} ", glyphs().arrow_right),
+                        Style::default().fg(arrow_fg).bg(bg),
+                    ),
                     Span::styled(action, Style::default().fg(action_fg).bg(bg)),
                 ])
             };
@@ -2435,7 +2431,7 @@ fn render_footer(
     if footer_y > modal_area.y {
         let sep_y = footer_y.saturating_sub(1);
         let sep_area = Rect::new(modal_area.x + 1, sep_y, footer_width, 1);
-        let sep_line: String = "─".repeat(sep_area.width as usize);
+        let sep_line: String = glyphs().h.repeat(sep_area.width as usize);
         frame.render_widget(
             Paragraph::new(sep_line).style(Style::default().fg(theme.split_separator_fg)),
             sep_area,
@@ -2709,7 +2705,7 @@ fn render_footer_vertical(
     // Draw top separator
     let sep_y = footer_y;
     if sep_y > modal_area.y {
-        let sep_line: String = "─".repeat(footer_width as usize);
+        let sep_line: String = glyphs().h.repeat(footer_width as usize);
         frame.render_widget(
             Paragraph::new(sep_line).style(Style::default().fg(theme.split_separator_fg)),
             Rect::new(modal_area.x + 1, sep_y, footer_width, 1),
@@ -2891,12 +2887,7 @@ fn render_search_header(frame: &mut Frame, area: Rect, state: &SettingsState, th
     // Add scroll indicators
     let has_more_above = state.search_scroll_offset > 0;
     let has_more_below = state.search_scroll_offset + state.search_max_visible < result_count;
-    let scroll_indicator = match (has_more_above, has_more_below) {
-        (true, true) => " ↑↓",
-        (true, false) => " ↑",
-        (false, true) => " ↓",
-        (false, false) => "",
-    };
+    let scroll_indicator = glyphs().scroll_indicator(has_more_above, has_more_below);
 
     let count_style = Style::default().fg(theme.line_number_fg);
     let indicator_style = Style::default()
@@ -3067,7 +3058,11 @@ fn render_search_result_item(
     };
 
     // Build name with match highlighting, prefixed with selection indicator
-    let indicator = if is_selected { "▸ " } else { "  " };
+    let indicator = if is_selected {
+        format!("{} ", glyphs().chevron_collapsed)
+    } else {
+        "  ".to_string()
+    };
     let indicator_style = if is_selected {
         Style::default()
             .fg(theme.settings_selected_fg)
@@ -3191,7 +3186,7 @@ fn centered_dialog_frame(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+        .border_set(glyphs().border_set())
         .border_style(Style::default().fg(border_fg))
         .style(Style::default().bg(theme.popup_bg));
     frame.render_widget(block, dialog_area);
@@ -3375,7 +3370,7 @@ fn render_confirm_dialog(
     let button_y = dialog_area.y + dialog_area.height - 3;
 
     // Draw separator
-    let sep_line: String = "─".repeat(inner.width as usize);
+    let sep_line: String = glyphs().h.repeat(inner.width as usize);
     frame.render_widget(
         Paragraph::new(sep_line).style(Style::default().fg(theme.split_separator_fg)),
         Rect::new(inner.x, button_y - 1, inner.width, 1),
@@ -3399,7 +3394,7 @@ fn render_confirm_dialog(
         frame,
         inner,
         button_y,
-        "←/→/Tab: Select   Enter: Confirm   Esc: Cancel",
+        &format!("{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
         theme,
     );
 }
@@ -3435,7 +3430,7 @@ fn render_reset_dialog(frame: &mut Frame, parent_area: Rect, state: &SettingsSta
     let button_y = dialog_area.y + dialog_area.height - 3;
 
     // Draw separator
-    let sep_line: String = "─".repeat(inner.width as usize);
+    let sep_line: String = glyphs().h.repeat(inner.width as usize);
     frame.render_widget(
         Paragraph::new(sep_line).style(Style::default().fg(theme.split_separator_fg)),
         Rect::new(inner.x, button_y - 1, inner.width, 1),
@@ -3455,7 +3450,7 @@ fn render_reset_dialog(frame: &mut Frame, parent_area: Rect, state: &SettingsSta
         frame,
         inner,
         button_y,
-        "←/→/Tab: Select   Enter: Confirm   Esc: Cancel",
+        &format!("{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
         theme,
     );
 }
@@ -3502,7 +3497,7 @@ fn render_entry_discard_confirm(
         frame,
         inner,
         button_y,
-        "Tab/←→: Select   Enter: Confirm   Esc: Keep editing",
+        &format!("Tab/{}{}: Select   Enter: Confirm   Esc: Keep editing", glyphs().arrow_left, glyphs().arrow_right),
         theme,
     );
 }
@@ -3593,7 +3588,7 @@ fn render_entry_delete_confirm(
         frame,
         inner,
         button_y,
-        "Tab/←→: Select   Enter: Confirm   Esc: Cancel",
+        &format!("Tab/{}{}: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
         theme,
     );
 }
@@ -3641,7 +3636,7 @@ fn render_entry_items(
                 && content_y >= scroll_offset
             {
                 let sep_style = Style::default().fg(theme.line_number_fg);
-                let separator_line = "─".repeat(inner.width.saturating_sub(2) as usize);
+                let separator_line = glyphs().h.repeat(inner.width.saturating_sub(2) as usize);
                 frame.render_widget(
                     Paragraph::new(separator_line).style(sep_style),
                     Rect::new(inner.x + 1, screen_y, inner.width.saturating_sub(2), 1),
@@ -3758,7 +3753,7 @@ fn render_entry_items(
         if item.modified && skip_rows == 0 {
             let modified_style = Style::default().fg(theme.settings_selected_fg);
             frame.render_widget(
-                Paragraph::new("●").style(modified_style),
+                Paragraph::new(glyphs().bullet).style(modified_style),
                 Rect::new(inner.x + 1, screen_y, 1, 1),
             );
         }
@@ -3981,18 +3976,21 @@ fn render_entry_footer(
             if let SettingControl::TextList(state) = &it.control {
                 if state.focused_item.is_none() {
                     return Some(if !state.pending_active && state.new_item_text.is_empty() {
-                        "Press Enter (or type) to add a new item; ↓/Tab to leave"
+                        format!(
+                            "Press Enter (or type) to add a new item; {}/Tab to leave",
+                            glyphs().arrow_down
+                        )
                     } else if state.new_item_text.is_empty() {
-                        "Type the new item — Enter to add, Esc to cancel"
+                        "Type the new item — Enter to add, Esc to cancel".to_string()
                     } else {
-                        "Editing new item — Enter to add, Esc to cancel"
+                        "Editing new item — Enter to add, Esc to cancel".to_string()
                     });
                 }
             }
             None
         });
 
-        let text: Option<String> = pending_list_caption.map(String::from).or_else(|| {
+        let text: Option<String> = pending_list_caption.or_else(|| {
             dialog
                 .current_item()
                 .and_then(|it| it.description.as_deref())
@@ -4036,30 +4034,37 @@ fn render_entry_footer(
         1,
     );
 
-    let (text, style) = if has_invalid_json && !is_json_control {
+    let g = glyphs();
+    let (text, style): (String, Style) = if has_invalid_json && !is_json_control {
         (
-            "⚠ Invalid JSON - fix before leaving field",
+            "⚠ Invalid JSON - fix before leaving field".to_string(),
             Style::default().fg(theme.diagnostic_warning_fg),
         )
     } else if has_invalid_json {
         (
-            "⚠ Invalid JSON",
+            "⚠ Invalid JSON".to_string(),
             Style::default().fg(theme.diagnostic_warning_fg),
         )
     } else if is_json_control {
         (
-            "↑↓←→:Move  Enter:Newline  Tab/Esc:Exit",
+            format!(
+                "{}{}{}{}:Move  Enter:Newline  Tab/Esc:Exit",
+                g.arrow_up, g.arrow_down, g.arrow_left, g.arrow_right
+            ),
             Style::default().fg(theme.line_number_fg),
         )
     } else if dialog.editing_text {
         (
-            "Enter/Tab:Commit field  Esc:Cancel",
+            "Enter/Tab:Commit field  Esc:Cancel".to_string(),
             Style::default().fg(theme.line_number_fg),
         )
     } else {
         // The `●:modified` legend is the only place that explains the row-indicator.
         (
-            "↑↓:Navigate  Tab:Fields/Buttons  Enter:Edit/Apply  Ctrl+S:Save  Esc:Cancel  ●:modified",
+            format!(
+                "{}{}:Navigate  Tab:Fields/Buttons  Enter:Edit/Apply  Ctrl+S:Save  Esc:Cancel  {}:modified",
+                g.arrow_up, g.arrow_down, g.bullet
+            ),
             Style::default().fg(theme.line_number_fg),
         )
     };
@@ -4095,7 +4100,7 @@ fn render_entry_dialog_inner(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+        .border_set(glyphs().border_set())
         .border_style(Style::default().fg(border_color))
         .style(Style::default().bg(theme.popup_bg));
     frame.render_widget(block, dialog_area);
@@ -4141,11 +4146,12 @@ fn render_entry_dialog_inner(
 /// Render the help overlay showing keyboard shortcuts
 fn render_help_overlay(frame: &mut Frame, parent_area: Rect, theme: &Theme) {
     // Define the help content
+    let up_down = format!("{} / {}", glyphs().arrow_up, glyphs().arrow_down);
     let help_items = [
         (
             "Navigation",
             vec![
-                ("↑ / ↓", "Move up/down"),
+                (up_down.as_str(), "Move up/down"),
                 ("Tab", "Switch between categories and settings"),
                 ("Enter", "Activate/toggle setting"),
             ],
@@ -4155,7 +4161,7 @@ fn render_help_overlay(frame: &mut Frame, parent_area: Rect, theme: &Theme) {
             vec![
                 ("/", "Start search"),
                 ("Esc", "Cancel search"),
-                ("↑ / ↓", "Navigate results"),
+                (up_down.as_str(), "Navigate results"),
                 ("Enter", "Jump to result"),
             ],
         ),
@@ -4184,7 +4190,7 @@ fn render_help_overlay(frame: &mut Frame, parent_area: Rect, theme: &Theme) {
     let block = Block::default()
         .title(" Keyboard Shortcuts ")
         .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+        .border_set(glyphs().border_set())
         .border_style(Style::default().fg(theme.menu_highlight_fg))
         .style(Style::default().bg(theme.popup_bg));
     frame.render_widget(block, dialog_area);

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -16,8 +16,8 @@ use crate::view::controls::{
     render_text_input_aligned, render_toggle_aligned, DropdownColors, DualListColors, MapColors,
     NumberInputColors, TextInputColors, TextListColors, ToggleColors,
 };
-use crate::view::theme::Theme;
 use crate::view::glyphs::glyphs;
+use crate::view::theme::Theme;
 use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -1312,7 +1312,8 @@ fn render_setting_item_pure(
         }
         if pending_dirty && label_row_visible && inner_area.width >= 2 {
             frame.render_widget(
-                Paragraph::new(glyphs().bullet).style(Style::default().fg(theme.settings_selected_fg)),
+                Paragraph::new(glyphs().bullet)
+                    .style(Style::default().fg(theme.settings_selected_fg)),
                 Rect::new(inner_area.x + 1, inner_area.y, 1, 1),
             );
         }
@@ -3394,7 +3395,11 @@ fn render_confirm_dialog(
         frame,
         inner,
         button_y,
-        &format!("{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
+        &format!(
+            "{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel",
+            glyphs().arrow_left,
+            glyphs().arrow_right
+        ),
         theme,
     );
 }
@@ -3450,7 +3455,11 @@ fn render_reset_dialog(frame: &mut Frame, parent_area: Rect, state: &SettingsSta
         frame,
         inner,
         button_y,
-        &format!("{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
+        &format!(
+            "{}/{}/Tab: Select   Enter: Confirm   Esc: Cancel",
+            glyphs().arrow_left,
+            glyphs().arrow_right
+        ),
         theme,
     );
 }
@@ -3497,7 +3506,11 @@ fn render_entry_discard_confirm(
         frame,
         inner,
         button_y,
-        &format!("Tab/{}{}: Select   Enter: Confirm   Esc: Keep editing", glyphs().arrow_left, glyphs().arrow_right),
+        &format!(
+            "Tab/{}{}: Select   Enter: Confirm   Esc: Keep editing",
+            glyphs().arrow_left,
+            glyphs().arrow_right
+        ),
         theme,
     );
 }
@@ -3588,7 +3601,11 @@ fn render_entry_delete_confirm(
         frame,
         inner,
         button_y,
-        &format!("Tab/{}{}: Select   Enter: Confirm   Esc: Cancel", glyphs().arrow_left, glyphs().arrow_right),
+        &format!(
+            "Tab/{}{}: Select   Enter: Confirm   Esc: Cancel",
+            glyphs().arrow_left,
+            glyphs().arrow_right
+        ),
         theme,
     );
 }

--- a/crates/fresh-editor/src/view/ui/file_browser.rs
+++ b/crates/fresh-editor/src/view/ui/file_browser.rs
@@ -80,6 +80,7 @@ impl FileBrowserRenderer {
         // Create the popup block with border
         let block = Block::default()
             .borders(Borders::ALL)
+            .border_set(crate::view::glyphs::glyphs().plain_border_set())
             .border_style(Style::default().fg(theme.popup_border_fg))
             .style(Style::default().bg(theme.popup_bg))
             .title(title_line);
@@ -233,7 +234,7 @@ impl FileBrowserRenderer {
 
         // Separator between checkboxes
         checkbox_spans.push(Span::styled(
-            " │ ",
+            format!(" {} ", crate::view::glyphs::glyphs().v),
             Style::default()
                 .fg(theme.help_separator_fg)
                 .bg(theme.popup_bg),
@@ -341,7 +342,7 @@ impl FileBrowserRenderer {
 
             if idx < state.shortcuts.len() - 1 {
                 nav_spans.push(Span::styled(
-                    " │ ",
+                    format!(" {} ", crate::view::glyphs::glyphs().v),
                     Style::default()
                         .fg(theme.help_separator_fg)
                         .bg(theme.popup_bg),
@@ -397,7 +398,11 @@ impl FileBrowserRenderer {
             .add_modifier(Modifier::BOLD);
 
         // Sort indicator
-        let sort_arrow = if state.sort_ascending { "▲" } else { "▼" };
+        let sort_arrow = if state.sort_ascending {
+            crate::view::glyphs::glyphs().triangle_up
+        } else {
+            crate::view::glyphs::glyphs().triangle_down
+        };
 
         let mut spans = Vec::new();
 

--- a/crates/fresh-editor/src/view/workspace_trust_dialog.rs
+++ b/crates/fresh-editor/src/view/workspace_trust_dialog.rs
@@ -162,6 +162,7 @@ pub fn render_workspace_trust_dialog(
 
     let block = Block::default()
         .borders(Borders::ALL)
+        .border_set(crate::view::glyphs::glyphs().plain_border_set())
         .border_style(Style::default().fg(theme.popup_border_fg).bg(bg))
         .style(Style::default().bg(bg).fg(fg));
     let inner = block.inner(dialog);
@@ -230,7 +231,7 @@ pub fn render_workspace_trust_dialog(
                 frame,
                 r,
                 Line::from(Span::styled(
-                    "─".repeat(iw as usize),
+                    crate::view::glyphs::glyphs().h.repeat(iw as usize),
                     Style::default().fg(theme.popup_border_fg).bg(bg),
                 )),
             ),

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,6 +58,27 @@ echo $COLORTERM
 
 If something outside Fresh scribbles over the TUI — a stray shell message, an external program's output, a paste with unbalanced escape sequences, or a terminal that got wedged during a resize — the screen can end up with ghost text or misaligned cells. Run **Redraw Screen** from the command palette (`Ctrl+P`) to clear the terminal and repaint the UI from scratch.
 
+## Chrome Glyphs Show as `?` or Blank Boxes
+
+If the settings editor, file tree, popups, or dialog borders render decorative
+symbols (`▶`, `→`, `╭╮╰╯`, `✓`, or the settings category icons) as literal `?`
+characters or empty boxes, your terminal font can't render those glyphs and
+isn't falling back to one that can. The settings category icons in particular
+use [Nerd Font](https://www.nerdfonts.com/) icons, which require a
+Nerd-Font-patched font.
+
+Two fixes:
+
+1. **Switch to ASCII chrome.** Enable `editor.ascii_ui` (Settings UI →
+   *Editor* → *Display*, or `"editor": { "ascii_ui": true }` in `config.toml`).
+   This swaps every chrome glyph for a plain-ASCII equivalent (`>`/`v` for
+   chevrons, `->` for arrows, `+`/`-`/`|` for borders, `[x]` markers, …). It
+   affects UI chrome only — buffer text, whitespace indicators, and indentation
+   guides are unchanged.
+2. **Use a font that has the glyphs.** A Nerd-Font-patched monospace font
+   (e.g. a Nerd Font build of JetBrains Mono, Hack, or Fira Code), or on macOS
+   a font like Menlo/SF Mono, renders the Unicode set correctly.
+
 ## Advanced Topics
 
 ### Visual Regression Testing


### PR DESCRIPTION
On terminals/fonts that lack the decorative Unicode and Nerd-Font glyphs
the UI chrome uses, the settings editor, file tree, popups, and dialog
borders render symbols as literal `?` or blank boxes. The worst offender
is the settings category icons, which use Nerd-Font private-use-area
codepoints and break on any non-patched font.

Introduce a central chrome glyph set (view/glyphs.rs) with a Unicode set
(current appearance, unchanged) and an ASCII fallback set, selected per
frame from a new `editor.ascii_ui` config flag. Route the chrome glyph
sites through it: settings editor (chevrons, category icons, arrows,
bullets, separators, rounded/dialog borders, hints), file tree status
dot, file browser (sort arrow, separators, popup border), the
dropdown/dual-list/map-input controls, and the popup/keybinding-editor/
calibration-wizard/workspace-trust dialog borders.

Buffer text, whitespace indicators, indentation guides, and the
already-configurable file-explorer tree indicators are left untouched —
they have their own dedicated config. Regenerate config-schema.json so
the flag appears in the Settings UI, and document the option in
troubleshooting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QtFiKHF9rWPgFQUcPwHrkv