### PR TITLE
fix(settings): make the search filter a real text input

### DIFF
--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -1476,7 +1476,7 @@ impl Editor {
             ],
             footer_selected: st.footer_button_index,
             search_active: st.search_active,
-            search_query: st.search_query.clone(),
+            search_query: st.search_query().to_string(),
             search_results: st
                 .search_results
                 .iter()

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -810,7 +810,15 @@ impl SettingsState {
                 self.search_delete();
                 InputResult::Consumed
             }
-            KeyCode::Char(c) => {
+            // Only plain (or Shift-modified) chars type into the filter.
+            // Ctrl/Alt chords — Ctrl+A/C/V/X etc. — must NOT insert their
+            // letter; they fall through to the modal consume below so they
+            // no-op instead of corrupting the query. (Selection and
+            // clipboard aren't wired for this field.)
+            KeyCode::Char(c)
+                if !event.modifiers.contains(KeyModifiers::CONTROL)
+                    && !event.modifiers.contains(KeyModifiers::ALT) =>
+            {
                 self.search_insert_char(c);
                 InputResult::Consumed
             }
@@ -1716,12 +1724,12 @@ mod tests {
         state.handle_key_event(&key(KeyCode::Char('t')), &mut ctx);
         state.handle_key_event(&key(KeyCode::Char('a')), &mut ctx);
         state.handle_key_event(&key(KeyCode::Char('b')), &mut ctx);
-        assert_eq!(state.search_query, "tab");
+        assert_eq!(state.search_query(), "tab");
 
         // Escape cancels search
         state.handle_key_event(&key(KeyCode::Esc), &mut ctx);
         assert!(!state.search_active);
-        assert!(state.search_query.is_empty());
+        assert!(state.search_query().is_empty());
     }
 
     /// The settings filter used to only append/backspace at the end: arrow
@@ -1742,33 +1750,74 @@ mod tests {
         for c in "theme".chars() {
             state.handle_key_event(&key(KeyCode::Char(c)), &mut ctx);
         }
-        assert_eq!(state.search_query, "theme");
-        assert_eq!(state.search_cursor, 5);
+        assert_eq!(state.search_query(), "theme");
+        assert_eq!(state.search_cursor(), 5);
 
         // Left twice, then insert 'X' -> lands mid-string, not at the end
         state.handle_key_event(&key(KeyCode::Left), &mut ctx);
         state.handle_key_event(&key(KeyCode::Left), &mut ctx);
-        assert_eq!(state.search_cursor, 3);
+        assert_eq!(state.search_cursor(), 3);
         state.handle_key_event(&key(KeyCode::Char('X')), &mut ctx);
-        assert_eq!(state.search_query, "theXme");
-        assert_eq!(state.search_cursor, 4);
+        assert_eq!(state.search_query(), "theXme");
+        assert_eq!(state.search_cursor(), 4);
 
         // Home jumps to start; Backspace at start is a no-op
         state.handle_key_event(&key(KeyCode::Home), &mut ctx);
-        assert_eq!(state.search_cursor, 0);
+        assert_eq!(state.search_cursor(), 0);
         state.handle_key_event(&key(KeyCode::Backspace), &mut ctx);
-        assert_eq!(state.search_query, "theXme");
+        assert_eq!(state.search_query(), "theXme");
 
         // Delete removes the char at the cursor (the leading 't')
         state.handle_key_event(&key(KeyCode::Delete), &mut ctx);
-        assert_eq!(state.search_query, "heXme");
-        assert_eq!(state.search_cursor, 0);
+        assert_eq!(state.search_query(), "heXme");
+        assert_eq!(state.search_cursor(), 0);
 
         // End jumps to the end; Backspace removes the trailing char
         state.handle_key_event(&key(KeyCode::End), &mut ctx);
-        assert_eq!(state.search_cursor, state.search_query.len());
+        assert_eq!(state.search_cursor(), state.search_query().len());
         state.handle_key_event(&key(KeyCode::Backspace), &mut ctx);
-        assert_eq!(state.search_query, "heXm");
+        assert_eq!(state.search_query(), "heXm");
+    }
+
+    /// Ctrl/Alt chords must not type their letter into the filter. The
+    /// `Char` arm used to match regardless of modifiers, so Ctrl+A/C/V
+    /// inserted a literal `a`/`c`/`v` instead of no-op'ing.
+    #[test]
+    fn test_search_ignores_ctrl_and_alt_chords() {
+        let schema = include_str!("../../../plugins/config-schema.json");
+        let config = crate::config::Config::default();
+        let mut state = SettingsState::new(schema, &config).unwrap();
+        state.visible = true;
+
+        let mut ctx = InputContext::new();
+
+        state.handle_key_event(&key(KeyCode::Char('/')), &mut ctx);
+        for c in "hello".chars() {
+            state.handle_key_event(&key(KeyCode::Char(c)), &mut ctx);
+        }
+        assert_eq!(state.search_query(), "hello");
+
+        // Ctrl+A / Ctrl+C / Ctrl+V / Ctrl+X leave the query untouched
+        for c in ['a', 'c', 'v', 'x'] {
+            state.handle_key_event(
+                &KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL),
+                &mut ctx,
+            );
+        }
+        // Alt chord too
+        state.handle_key_event(
+            &KeyEvent::new(KeyCode::Char('a'), KeyModifiers::ALT),
+            &mut ctx,
+        );
+        assert_eq!(state.search_query(), "hello");
+
+        // A plain char still types; Shift+char types uppercase
+        state.handle_key_event(&key(KeyCode::Char('!')), &mut ctx);
+        state.handle_key_event(
+            &KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::SHIFT),
+            &mut ctx,
+        );
+        assert_eq!(state.search_query(), "hello!Z");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -786,12 +786,36 @@ impl SettingsState {
                 self.search_next();
                 InputResult::Consumed
             }
+            // Cursor movement within the query text. Up/Down are reserved
+            // for navigating the result list (above), so Left/Right/Home/End
+            // edit the query — matching the Command Palette, where the same
+            // split makes the filter feel like a real text input.
+            KeyCode::Left => {
+                self.search_cursor_left();
+                InputResult::Consumed
+            }
+            KeyCode::Right => {
+                self.search_cursor_right();
+                InputResult::Consumed
+            }
+            KeyCode::Home => {
+                self.search_cursor_home();
+                InputResult::Consumed
+            }
+            KeyCode::End => {
+                self.search_cursor_end();
+                InputResult::Consumed
+            }
+            KeyCode::Delete => {
+                self.search_delete();
+                InputResult::Consumed
+            }
             KeyCode::Char(c) => {
-                self.search_push_char(c);
+                self.search_insert_char(c);
                 InputResult::Consumed
             }
             KeyCode::Backspace => {
-                self.search_pop_char();
+                self.search_backspace();
                 InputResult::Consumed
             }
             _ => InputResult::Consumed, // Modal: consume all
@@ -1698,6 +1722,53 @@ mod tests {
         state.handle_key_event(&key(KeyCode::Esc), &mut ctx);
         assert!(!state.search_active);
         assert!(state.search_query.is_empty());
+    }
+
+    /// The settings filter used to only append/backspace at the end: arrow
+    /// keys did nothing within the text (unlike the Command Palette). It now
+    /// tracks a cursor, so Left/Right/Home/End move the caret and edits land
+    /// at the cursor — matching the palette.
+    #[test]
+    fn test_search_arrow_keys_edit_within_query() {
+        let schema = include_str!("../../../plugins/config-schema.json");
+        let config = crate::config::Config::default();
+        let mut state = SettingsState::new(schema, &config).unwrap();
+        state.visible = true;
+
+        let mut ctx = InputContext::new();
+
+        // Start search and type "theme"
+        state.handle_key_event(&key(KeyCode::Char('/')), &mut ctx);
+        for c in "theme".chars() {
+            state.handle_key_event(&key(KeyCode::Char(c)), &mut ctx);
+        }
+        assert_eq!(state.search_query, "theme");
+        assert_eq!(state.search_cursor, 5);
+
+        // Left twice, then insert 'X' -> lands mid-string, not at the end
+        state.handle_key_event(&key(KeyCode::Left), &mut ctx);
+        state.handle_key_event(&key(KeyCode::Left), &mut ctx);
+        assert_eq!(state.search_cursor, 3);
+        state.handle_key_event(&key(KeyCode::Char('X')), &mut ctx);
+        assert_eq!(state.search_query, "theXme");
+        assert_eq!(state.search_cursor, 4);
+
+        // Home jumps to start; Backspace at start is a no-op
+        state.handle_key_event(&key(KeyCode::Home), &mut ctx);
+        assert_eq!(state.search_cursor, 0);
+        state.handle_key_event(&key(KeyCode::Backspace), &mut ctx);
+        assert_eq!(state.search_query, "theXme");
+
+        // Delete removes the char at the cursor (the leading 't')
+        state.handle_key_event(&key(KeyCode::Delete), &mut ctx);
+        assert_eq!(state.search_query, "heXme");
+        assert_eq!(state.search_cursor, 0);
+
+        // End jumps to the end; Backspace removes the trailing char
+        state.handle_key_event(&key(KeyCode::End), &mut ctx);
+        assert_eq!(state.search_cursor, state.search_query.len());
+        state.handle_key_event(&key(KeyCode::Backspace), &mut ctx);
+        assert_eq!(state.search_query, "heXm");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -2872,7 +2872,7 @@ fn render_search_header(frame: &mut Frame, area: Rect, state: &SettingsState, th
 
     // Show result count and scroll position inline after cursor
     let result_count = state.search_results.len();
-    let count_text = if state.search_query.is_empty() {
+    let count_text = if state.search_query().is_empty() {
         String::new()
     } else if result_count == 0 {
         " (no results)".to_string()
@@ -2904,12 +2904,13 @@ fn render_search_header(frame: &mut Frame, area: Rect, state: &SettingsState, th
         .add_modifier(Modifier::BOLD);
 
     // Render the query as a block cursor sitting on the character at
-    // `search_cursor` (or a trailing space when the cursor is at the end),
-    // so the caret reflects Left/Right/Home/End movement.
-    let cursor = state.search_cursor.min(state.search_query.len());
-    let before = &state.search_query[..cursor];
+    // the caret (or a trailing space when the cursor is at the end),
+    // so it reflects Left/Right/Home/End movement.
+    let query = state.search_query();
+    let cursor = state.search_cursor().min(query.len());
+    let before = &query[..cursor];
     let (under, after) = {
-        let rest = &state.search_query[cursor..];
+        let rest = &query[cursor..];
         match rest.chars().next() {
             Some(c) => (c.to_string(), &rest[c.len_utf8()..]),
             None => (" ".to_string(), ""),

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -2903,10 +2903,24 @@ fn render_search_header(frame: &mut Frame, area: Rect, state: &SettingsState, th
         .fg(theme.menu_active_fg)
         .add_modifier(Modifier::BOLD);
 
+    // Render the query as a block cursor sitting on the character at
+    // `search_cursor` (or a trailing space when the cursor is at the end),
+    // so the caret reflects Left/Right/Home/End movement.
+    let cursor = state.search_cursor.min(state.search_query.len());
+    let before = &state.search_query[..cursor];
+    let (under, after) = {
+        let rest = &state.search_query[cursor..];
+        match rest.chars().next() {
+            Some(c) => (c.to_string(), &rest[c.len_utf8()..]),
+            None => (" ".to_string(), ""),
+        }
+    };
+
     let spans = vec![
         Span::styled("> ", search_style),
-        Span::styled(&state.search_query, search_style),
-        Span::styled(" ", cursor_style), // Cursor
+        Span::styled(before, search_style),
+        Span::styled(under, cursor_style), // Cursor
+        Span::styled(after, search_style),
         Span::styled(count_text, count_style),
         Span::styled(scroll_indicator, indicator_style),
     ];

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -10,6 +10,7 @@ use super::schema::{parse_schema, SettingCategory, SettingSchema};
 use super::search::{search_settings, DeepMatch, SearchResult};
 use crate::config::Config;
 use crate::config_io::ConfigLayer;
+use crate::view::controls::text_input::TextInputState;
 use crate::view::controls::FocusState;
 use crate::view::ui::{FocusManager, ScrollItem, ScrollablePanel};
 use std::collections::HashMap;
@@ -96,13 +97,13 @@ pub struct SettingsState {
     original_config: serde_json::Value,
     /// Whether the settings panel is visible
     pub visible: bool,
-    /// Current search query
-    pub search_query: String,
-    /// Cursor position within the search query, as a byte offset into
-    /// `search_query`. Always kept on a char boundary. Lets the filter
-    /// behave like a normal text input (arrow keys, Home/End, mid-string
-    /// insert/delete) instead of only appending at the end.
-    pub search_cursor: usize,
+    /// The search filter's text field. Backed by the same `TextInputState`
+    /// control the rest of the Settings dialog uses, so the filter gets
+    /// grapheme-aware cursor movement (arrow keys, Home/End, mid-string
+    /// insert/delete) for free instead of the old append-only string.
+    /// Read the text via [`SettingsState::search_query`] and the caret via
+    /// [`SettingsState::search_cursor`].
+    pub search_input: TextInputState,
     /// Whether search is active
     pub search_active: bool,
     /// Current search results
@@ -324,8 +325,7 @@ impl SettingsState {
             pending_changes: HashMap::new(),
             original_config: config_value,
             visible: false,
-            search_query: String::new(),
-            search_cursor: 0,
+            search_input: TextInputState::new("").with_focus(FocusState::Focused),
             search_active: false,
             search_results: Vec::new(),
             selected_search_result: 0,
@@ -464,8 +464,7 @@ impl SettingsState {
     pub fn hide(&mut self) {
         self.visible = false;
         self.search_active = false;
-        self.search_query.clear();
-        self.search_cursor = 0;
+        self.search_input.clear();
     }
 
     /// Get the current entry dialog (top of stack), if any
@@ -1387,11 +1386,21 @@ impl SettingsState {
         }
     }
 
+    /// The current search filter text.
+    pub fn search_query(&self) -> &str {
+        &self.search_input.value
+    }
+
+    /// The search caret position, as a byte offset into
+    /// [`SettingsState::search_query`] (always on a grapheme boundary).
+    pub fn search_cursor(&self) -> usize {
+        self.search_input.cursor
+    }
+
     /// Start search mode
     pub fn start_search(&mut self) {
         self.search_active = true;
-        self.search_query.clear();
-        self.search_cursor = 0;
+        self.search_input.clear();
         self.search_results.clear();
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
@@ -1400,8 +1409,7 @@ impl SettingsState {
     /// Cancel search mode
     pub fn cancel_search(&mut self) {
         self.search_active = false;
-        self.search_query.clear();
-        self.search_cursor = 0;
+        self.search_input.clear();
         self.search_results.clear();
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
@@ -1409,29 +1417,25 @@ impl SettingsState {
 
     /// Update search query and refresh results
     pub fn set_search_query(&mut self, query: String) {
-        self.search_query = query;
-        self.search_cursor = self.search_query.len();
-        self.search_results = search_settings(&self.pages, &self.search_query);
-        self.selected_search_result = 0;
-        self.search_scroll_offset = 0;
+        self.search_input.set_value(query);
+        self.refresh_search_results();
     }
 
     /// Recompute results after the query text changed and reset the
     /// results selection/scroll to the top.
     fn refresh_search_results(&mut self) {
-        self.search_results = search_settings(&self.pages, &self.search_query);
+        self.search_results = search_settings(&self.pages, &self.search_input.value);
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
     }
 
     /// Insert a character at the cursor position in the search query.
     pub fn search_insert_char(&mut self, c: char) {
-        self.search_query.insert(self.search_cursor, c);
-        self.search_cursor += c.len_utf8();
+        self.search_input.insert(c);
         self.refresh_search_results();
     }
 
-    /// Add a character to the search query (appends at the cursor).
+    /// Add a character to the search query.
     ///
     /// Kept for backwards compatibility; delegates to `search_insert_char`.
     pub fn search_push_char(&mut self, c: char) {
@@ -1440,13 +1444,7 @@ impl SettingsState {
 
     /// Delete the grapheme cluster before the cursor (Backspace).
     pub fn search_backspace(&mut self) {
-        if self.search_cursor == 0 {
-            return;
-        }
-        let start =
-            crate::primitives::grapheme::prev_grapheme_boundary(&self.search_query, self.search_cursor);
-        self.search_query.replace_range(start..self.search_cursor, "");
-        self.search_cursor = start;
+        self.search_input.backspace();
         self.refresh_search_results();
     }
 
@@ -1459,46 +1457,32 @@ impl SettingsState {
 
     /// Delete the grapheme cluster at the cursor (Delete key).
     pub fn search_delete(&mut self) {
-        if self.search_cursor >= self.search_query.len() {
-            return;
-        }
-        let end =
-            crate::primitives::grapheme::next_grapheme_boundary(&self.search_query, self.search_cursor);
-        self.search_query.replace_range(self.search_cursor..end, "");
+        self.search_input.delete();
         self.refresh_search_results();
     }
 
     /// Move the search cursor left by one grapheme cluster.
     ///
-    /// Uses grapheme boundaries (like the Command Palette) so combining
-    /// marks — Thai diacritics, emoji modifiers — move as a single unit.
+    /// Movement is grapheme-aware (via the shared control) so combining
+    /// marks — Thai diacritics, emoji modifiers — move as a single unit,
+    /// matching the Command Palette.
     pub fn search_cursor_left(&mut self) {
-        if self.search_cursor > 0 {
-            self.search_cursor = crate::primitives::grapheme::prev_grapheme_boundary(
-                &self.search_query,
-                self.search_cursor,
-            );
-        }
+        self.search_input.move_left();
     }
 
     /// Move the search cursor right by one grapheme cluster.
     pub fn search_cursor_right(&mut self) {
-        if self.search_cursor < self.search_query.len() {
-            self.search_cursor = crate::primitives::grapheme::next_grapheme_boundary(
-                &self.search_query,
-                self.search_cursor,
-            );
-        }
+        self.search_input.move_right();
     }
 
     /// Move the search cursor to the start of the query.
     pub fn search_cursor_home(&mut self) {
-        self.search_cursor = 0;
+        self.search_input.move_home();
     }
 
     /// Move the search cursor to the end of the query.
     pub fn search_cursor_end(&mut self) {
-        self.search_cursor = self.search_query.len();
+        self.search_input.move_end();
     }
 
     /// Navigate to previous search result
@@ -4087,34 +4071,34 @@ mod tests {
         for c in "aที่b".chars() {
             state.search_insert_char(c);
         }
-        let end = state.search_query.len();
-        assert_eq!(state.search_cursor, end);
+        let end = state.search_query().len();
+        assert_eq!(state.search_cursor(), end);
 
         // Left: past 'b' (1 byte)
         state.search_cursor_left();
-        assert_eq!(state.search_cursor, end - 1);
+        assert_eq!(state.search_cursor(), end - 1);
 
         // Left: skip the whole Thai cluster in one step (9 bytes)
         state.search_cursor_left();
-        assert_eq!(state.search_cursor, 1);
+        assert_eq!(state.search_cursor(), 1);
 
         // Left: before 'a'
         state.search_cursor_left();
-        assert_eq!(state.search_cursor, 0);
+        assert_eq!(state.search_cursor(), 0);
 
         // Backspace at start is a no-op; the query is untouched
         state.search_backspace();
-        assert_eq!(state.search_query, "aที่b");
+        assert_eq!(state.search_query(), "aที่b");
 
         // Delete at the start removes the leading 'a' only
         state.search_delete();
-        assert_eq!(state.search_query, "ที่b");
-        assert_eq!(state.search_cursor, 0);
+        assert_eq!(state.search_query(), "ที่b");
+        assert_eq!(state.search_cursor(), 0);
 
         // One Right skips the Thai cluster; Delete then removes the 'b'
         state.search_cursor_right();
-        assert_eq!(state.search_cursor, "ที่".len());
+        assert_eq!(state.search_cursor(), "ที่".len());
         state.search_delete();
-        assert_eq!(state.search_query, "ที่");
+        assert_eq!(state.search_query(), "ที่");
     }
 }

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -98,6 +98,11 @@ pub struct SettingsState {
     pub visible: bool,
     /// Current search query
     pub search_query: String,
+    /// Cursor position within the search query, as a byte offset into
+    /// `search_query`. Always kept on a char boundary. Lets the filter
+    /// behave like a normal text input (arrow keys, Home/End, mid-string
+    /// insert/delete) instead of only appending at the end.
+    pub search_cursor: usize,
     /// Whether search is active
     pub search_active: bool,
     /// Current search results
@@ -320,6 +325,7 @@ impl SettingsState {
             original_config: config_value,
             visible: false,
             search_query: String::new(),
+            search_cursor: 0,
             search_active: false,
             search_results: Vec::new(),
             selected_search_result: 0,
@@ -459,6 +465,7 @@ impl SettingsState {
         self.visible = false;
         self.search_active = false;
         self.search_query.clear();
+        self.search_cursor = 0;
     }
 
     /// Get the current entry dialog (top of stack), if any
@@ -1384,6 +1391,7 @@ impl SettingsState {
     pub fn start_search(&mut self) {
         self.search_active = true;
         self.search_query.clear();
+        self.search_cursor = 0;
         self.search_results.clear();
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
@@ -1393,6 +1401,7 @@ impl SettingsState {
     pub fn cancel_search(&mut self) {
         self.search_active = false;
         self.search_query.clear();
+        self.search_cursor = 0;
         self.search_results.clear();
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
@@ -1401,25 +1410,95 @@ impl SettingsState {
     /// Update search query and refresh results
     pub fn set_search_query(&mut self, query: String) {
         self.search_query = query;
+        self.search_cursor = self.search_query.len();
         self.search_results = search_settings(&self.pages, &self.search_query);
         self.selected_search_result = 0;
         self.search_scroll_offset = 0;
     }
 
-    /// Add a character to the search query
+    /// Recompute results after the query text changed and reset the
+    /// results selection/scroll to the top.
+    fn refresh_search_results(&mut self) {
+        self.search_results = search_settings(&self.pages, &self.search_query);
+        self.selected_search_result = 0;
+        self.search_scroll_offset = 0;
+    }
+
+    /// Insert a character at the cursor position in the search query.
+    pub fn search_insert_char(&mut self, c: char) {
+        self.search_query.insert(self.search_cursor, c);
+        self.search_cursor += c.len_utf8();
+        self.refresh_search_results();
+    }
+
+    /// Add a character to the search query (appends at the cursor).
+    ///
+    /// Kept for backwards compatibility; delegates to `search_insert_char`.
     pub fn search_push_char(&mut self, c: char) {
-        self.search_query.push(c);
-        self.search_results = search_settings(&self.pages, &self.search_query);
-        self.selected_search_result = 0;
-        self.search_scroll_offset = 0;
+        self.search_insert_char(c);
     }
 
-    /// Remove the last character from the search query
+    /// Delete the grapheme cluster before the cursor (Backspace).
+    pub fn search_backspace(&mut self) {
+        if self.search_cursor == 0 {
+            return;
+        }
+        let start =
+            crate::primitives::grapheme::prev_grapheme_boundary(&self.search_query, self.search_cursor);
+        self.search_query.replace_range(start..self.search_cursor, "");
+        self.search_cursor = start;
+        self.refresh_search_results();
+    }
+
+    /// Remove the grapheme cluster before the cursor.
+    ///
+    /// Kept for backwards compatibility; delegates to `search_backspace`.
     pub fn search_pop_char(&mut self) {
-        self.search_query.pop();
-        self.search_results = search_settings(&self.pages, &self.search_query);
-        self.selected_search_result = 0;
-        self.search_scroll_offset = 0;
+        self.search_backspace();
+    }
+
+    /// Delete the grapheme cluster at the cursor (Delete key).
+    pub fn search_delete(&mut self) {
+        if self.search_cursor >= self.search_query.len() {
+            return;
+        }
+        let end =
+            crate::primitives::grapheme::next_grapheme_boundary(&self.search_query, self.search_cursor);
+        self.search_query.replace_range(self.search_cursor..end, "");
+        self.refresh_search_results();
+    }
+
+    /// Move the search cursor left by one grapheme cluster.
+    ///
+    /// Uses grapheme boundaries (like the Command Palette) so combining
+    /// marks — Thai diacritics, emoji modifiers — move as a single unit.
+    pub fn search_cursor_left(&mut self) {
+        if self.search_cursor > 0 {
+            self.search_cursor = crate::primitives::grapheme::prev_grapheme_boundary(
+                &self.search_query,
+                self.search_cursor,
+            );
+        }
+    }
+
+    /// Move the search cursor right by one grapheme cluster.
+    pub fn search_cursor_right(&mut self) {
+        if self.search_cursor < self.search_query.len() {
+            self.search_cursor = crate::primitives::grapheme::next_grapheme_boundary(
+                &self.search_query,
+                self.search_cursor,
+            );
+        }
+    }
+
+    /// Move the search cursor to the start of the query.
+    pub fn search_cursor_home(&mut self) {
+        self.search_cursor = 0;
+    }
+
+    /// Move the search cursor to the end of the query.
+    pub fn search_cursor_end(&mut self) {
+        self.search_cursor = self.search_query.len();
     }
 
     /// Navigate to previous search result
@@ -3993,5 +4072,49 @@ mod tests {
         // TEST_SCHEMA has no DualList items, so all calls should return None
         let result = state.with_dual_list_mut(0, |_| ());
         assert!(result.is_none());
+    }
+
+    /// The search filter moves by grapheme cluster (like the Command
+    /// Palette), so a single Left crosses a multi-codepoint Thai cluster
+    /// rather than landing between its combining marks.
+    #[test]
+    fn test_search_cursor_moves_by_grapheme_cluster() {
+        let config = test_config();
+        let mut state = SettingsState::new(TEST_SCHEMA, &config).unwrap();
+
+        // "aที่b": 'a' (1 byte) + Thai cluster "ที่" (9 bytes) + 'b' (1 byte)
+        state.start_search();
+        for c in "aที่b".chars() {
+            state.search_insert_char(c);
+        }
+        let end = state.search_query.len();
+        assert_eq!(state.search_cursor, end);
+
+        // Left: past 'b' (1 byte)
+        state.search_cursor_left();
+        assert_eq!(state.search_cursor, end - 1);
+
+        // Left: skip the whole Thai cluster in one step (9 bytes)
+        state.search_cursor_left();
+        assert_eq!(state.search_cursor, 1);
+
+        // Left: before 'a'
+        state.search_cursor_left();
+        assert_eq!(state.search_cursor, 0);
+
+        // Backspace at start is a no-op; the query is untouched
+        state.search_backspace();
+        assert_eq!(state.search_query, "aที่b");
+
+        // Delete at the start removes the leading 'a' only
+        state.search_delete();
+        assert_eq!(state.search_query, "ที่b");
+        assert_eq!(state.search_cursor, 0);
+
+        // One Right skips the Thai cluster; Delete then removes the 'b'
+        state.search_cursor_right();
+        assert_eq!(state.search_cursor, "ที่".len());
+        state.search_delete();
+        assert_eq!(state.search_query, "ที่");
     }
 }

--- a/crates/fresh-editor/tests/e2e/unicode_cursor.rs
+++ b/crates/fresh-editor/tests/e2e/unicode_cursor.rs
@@ -887,15 +887,20 @@ fn test_file_open_prompt_grapheme_movement() {
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
 }
 
-/// Test grapheme cluster movement in settings search box
+/// Test grapheme cluster movement in settings search box.
 ///
-/// Note: The settings search box is a simple filter field that doesn't support
-/// cursor movement (Left/Right arrows) - it only supports typing at the end
-/// and backspace. This is a limitation of the simple filter design, not a bug.
+/// The settings filter now supports full cursor movement (Left/Right/Home/End,
+/// mid-string insert/delete) with grapheme-cluster granularity, matching the
+/// Command Palette. That behavior is unit-tested at the state level in
+/// `view::settings::input::tests::test_search_arrow_keys_edit_within_query`.
 ///
-/// This test is marked ignore since cursor movement isn't supported in this field.
+/// This end-to-end variant stays ignored because it asserts on the *hardware*
+/// terminal cursor via `screen_cursor_position()`, but the settings dialog —
+/// like all of its controls — paints a styled block cursor into the frame
+/// rather than moving the hardware cursor, so `screen_cursor_position()` can't
+/// observe the caret here.
 #[test]
-#[ignore = "Settings search is a simple filter without cursor movement support"]
+#[ignore = "settings dialog paints a styled block cursor, not the hardware cursor screen_cursor_position() reads"]
 fn test_settings_search_grapheme_movement() {
     let mut harness = EditorTestHarness::new(120, 40).unwrap();
     harness.render().unwrap();


### PR DESCRIPTION
## Problem

The Settings dialog filter behaved differently from every other text input in the app. Arrow keys, `Home`/`End`, and mid-string editing did nothing — the query was a bare string that only appended on type and backspaced from the end. So you couldn't fix a typo in the middle of a filter without deleting everything after it, and the caret was painted at the end regardless of where you were. The Command Palette, by contrast, has full cursor navigation, which is exactly the inconsistency the report called out ("arrow keys work in the Command Palette, but not in the Settings dialog filter").

While driving it interactively I also hit a latent bug: the `Char` arm matched regardless of modifiers, so **`Ctrl+A`/`C`/`V`/`X` inserted a literal `a`/`c`/`v`/`x`** into the query instead of no-op'ing.

## What changed

- **Real caret, grapheme-aware.** The filter now moves by grapheme cluster (`Left`/`Right`/`Home`/`End`), inserts and deletes at the cursor (`Delete` included), and combining marks — Thai diacritics, emoji modifiers — move as a single unit. `Up`/`Down` stay bound to result-list navigation, mirroring the palette's split. The search header paints its block cursor at the caret position instead of always at the end.
- **Backed by the shared control.** Rather than a parallel implementation, the filter is now backed by `TextInputState` — the same control every other text field in the Settings dialog uses — read via `search_query()` / `search_cursor()` accessors. One fewer text-input variant to maintain.
- **Ctrl/Alt chords no longer corrupt the query.** The `Char` arm is guarded on `CONTROL`/`ALT`, so those chords fall through to the modal consume (no-op) while plain and `Shift`+char input types normally. Ranged selection and clipboard are intentionally *not* wired for this field (the shared control has no selection model yet).

## Testing

- Unit tests: mid-string edits, grapheme-cluster movement over multibyte input, and that Ctrl/Alt chords leave the query untouched.
- Verified the full editing set interactively in a real terminal (type, `Home`/`End`, `Left`/`Right`, mid-string insert, `Backspace`, `Delete`-at-cursor, `aXあB` cluster crossing, and Ctrl+A/C/V/X being inert).
- The ignored e2e grapheme test's stale rationale is updated: the behavior is now supported and unit-tested; it stays ignored only because it asserts on the hardware cursor, which the Settings dialog never sets (all its controls render a styled block cursor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMu4rF1qgDpwdCfXGt3noH