### PR TITLE
Add x-display-field to EnvDetector for Settings UI labels

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -2052,7 +2052,8 @@
         "markers",
         "kind",
         "snippet"
-      ]
+      ],
+      "x-display-field": "/name"
     },
     "EnvKind": {
       "description": "Activation risk class for an environment — decides whether activating it\nneeds a trust prompt first.",

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -502,6 +502,7 @@ pub enum EnvKind {
 /// One environment detector: which marker files/dirs identify it, how risky
 /// activation is, how to activate it, and what to call it.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(extend("x-display-field" = "/name"))]
 pub struct EnvDetector {
     /// Short label shown in the status pill (e.g. ".venv", "direnv", "mise").
     pub name: String,

--- a/crates/fresh-editor/tests/e2e/issue_2566_env_detector_labels.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2566_env_detector_labels.rs
@@ -1,0 +1,74 @@
+//! E2E reproducer for issue #2566 — "Settings › Env: detector entries all
+//! display as (no action)".
+//!
+//! The Settings **Env** section renders its **Detectors** list with the shared
+//! ObjectArray/KeybindingList control, which shows each entry's
+//! `x-display-field`. `EnvDetector` never declared one, so every row fell back
+//! to the placeholder `(no action)` — the detectors were indistinguishable in
+//! the list. With `x-display-field = /name` each row shows the detector's name
+//! (`.venv`, `direnv`, …) instead.
+//!
+//! Drives only keyboard events and asserts on rendered output, per
+//! CONTRIBUTING.md ("E2E Tests Observe, Not Inspect").
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+/// Open Settings and walk the category sidebar down to the **Env** section,
+/// whose right pane is uniquely identified by the `Detectors:` list label.
+fn open_env_settings(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    // Sidebar starts focused on the first category; step down until the Env
+    // section's Detectors list is on screen. Bounded so a regression that never
+    // reaches Env fails instead of looping forever.
+    for _ in 0..40 {
+        if harness.screen_to_string().contains("Detectors:") {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(
+        harness.screen_to_string().contains("Detectors:"),
+        "should reach the Env section's Detectors list; screen was:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Issue #2566: each detector row shows its name, not the `(no action)`
+/// placeholder. The default detectors include `.venv` and `direnv`.
+#[test]
+fn issue_2566_env_detectors_show_names_not_placeholder() {
+    // Default config carries the built-in env detectors (.venv, venv, direnv,
+    // mise, pipenv, poetry).
+    let config = Config::default();
+    assert!(
+        !config.env.detectors.is_empty(),
+        "precondition: default config ships env detectors"
+    );
+
+    let mut harness = EditorTestHarness::with_config(120, 40, config).unwrap();
+    harness.render().unwrap();
+
+    open_env_settings(&mut harness);
+
+    let screen = harness.screen_to_string();
+    // Pre-fix, every detector row rendered as the fallback placeholder.
+    assert!(
+        !screen.contains("(no action)"),
+        "detector rows must not render as the `(no action)` placeholder; screen was:\n{}",
+        screen
+    );
+    // Post-fix, rows are labeled by the detector `name`.
+    assert!(
+        screen.contains(".venv"),
+        "detector rows should show their name (e.g. `.venv`); screen was:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains("direnv"),
+        "detector rows should show their name (e.g. `direnv`); screen was:\n{}",
+        screen
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -81,6 +81,7 @@ pub mod issue_2362_replace_toolbar_theme;
 pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;
+pub mod issue_2566_env_detector_labels;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod language_dialog_esc_cancels_edit;


### PR DESCRIPTION
## Summary
Fixes issue #2566 where environment detector entries in the Settings › Env section all displayed as "(no action)" placeholder text instead of showing their actual names.

## Changes
- **config-schema.json**: Added `"x-display-field": "/name"` to the `EnvDetector` schema definition, instructing the UI to display the detector's `name` field in list views
- **src/config.rs**: Added `#[schemars(extend("x-display-field" = "/name"))]` attribute to the `EnvDetector` struct to propagate the display field configuration through schema generation
- **tests/e2e/issue_2566_env_detector_labels.rs**: Added comprehensive E2E test that verifies detector entries display their names (e.g., ".venv", "direnv") instead of the placeholder text

## Implementation Details
The `EnvDetector` struct is rendered in the Settings UI using a shared ObjectArray/KeybindingList control that displays each entry's `x-display-field`. Without this field declared, the control fell back to showing "(no action)" for all rows, making detectors indistinguishable. By setting `x-display-field` to `/name`, each detector row now displays its human-readable name, improving usability and clarity in the Settings interface.

The test uses keyboard navigation to reach the Env settings section and verifies that the rendered output contains detector names rather than the placeholder text.

https://claude.ai/code/session_01RGv5WqkKCyWYQs7bgg7iYg