### PR TITLE
Fix cursor column drift in vertical movement

### DIFF
--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -482,6 +482,27 @@ impl crate::app::window::Window {
         let active_buffer = self.active_buffer();
 
         if direction > 0 {
+            // Fast path: when neither the current logical line nor the next
+            // one wraps, we can land precisely at the goal visual column
+            // instead of the conservative start-of-next-row jump below. This
+            // keeps the column stable when a batched move crosses the scroll
+            // boundary onto an off-screen row (issue #2565). Wrapped lines
+            // keep the fallback so #1574 stays fixed.
+            if let Some(text_width) = self.visual_text_width(active_split) {
+                if let Some(state) = self.buffers.get_mut(&active_buffer) {
+                    if let Some(pos) = unwrapped_neighbor_goal_pos(
+                        &mut state.buffer,
+                        from_pos,
+                        1,
+                        goal_visual_col,
+                        text_width,
+                        estimated_line_length,
+                    ) {
+                        return Some((pos, goal_visual_col));
+                    }
+                }
+            }
+
             // Find current row's end byte via cached layout — this is the
             // authoritative "end of current visual row" position that the
             // renderer itself uses.
@@ -520,6 +541,25 @@ impl crate::app::window::Window {
             let _ = estimated_line_length;
             Some((target_pos, goal_visual_col))
         } else {
+            // Fast path mirrored from the Down branch: when neither the
+            // current logical line nor the previous one wraps, land at the
+            // goal visual column on the previous line rather than the
+            // conservative end-of-previous-row jump below (issue #2565).
+            if let Some(text_width) = self.visual_text_width(active_split) {
+                if let Some(state) = self.buffers.get_mut(&active_buffer) {
+                    if let Some(pos) = unwrapped_neighbor_goal_pos(
+                        &mut state.buffer,
+                        from_pos,
+                        -1,
+                        goal_visual_col,
+                        text_width,
+                        estimated_line_length,
+                    ) {
+                        return Some((pos, goal_visual_col));
+                    }
+                }
+            }
+
             // Up-direction fallback: mirror the Down logic.  Use the
             // cached layout to locate the current visual row's "anchor"
             // byte (the row start for rows with visible content, or
@@ -572,6 +612,78 @@ impl crate::app::window::Window {
             Some((target_pos, goal_visual_col))
         }
     }
+
+    /// Width (in display columns) of the text area for `split_id` — the
+    /// number of columns a logical line's first visual row can occupy before
+    /// it wraps. Mirrors the renderer's wrap budget
+    /// (`WrapConfig::first_line_width`) so callers can tell whether a given
+    /// logical line wraps. Returns `None` if the split has no viewport yet.
+    fn visual_text_width(&self, split_id: LeafId) -> Option<usize> {
+        use crate::primitives::line_wrapping::WrapConfig;
+        let active_buffer = self.active_buffer();
+        let state = self.buffers.get(&active_buffer)?;
+        let vs = self.buffers.splits().map(|(_, vs)| vs)?.get(&split_id)?;
+        let gutter = vs.viewport.gutter_width(&state.buffer);
+        let wrap = WrapConfig::new(
+            vs.viewport.effective_width() as usize,
+            gutter,
+            true,
+            vs.viewport.wrap_indent,
+        );
+        Some(wrap.first_line_width)
+    }
+}
+
+/// Column-preserving landing spot for an off-screen vertical move when
+/// neither the current logical line nor the adjacent one (in `direction`:
+/// -1 = up, +1 = down) wraps at `text_width`.
+///
+/// The cached-layout mover (`move_visual_line`) returns `None` when the
+/// target visual row isn't in the last-rendered slice — e.g. a batched move
+/// crossed the scroll boundary. For non-wrapping lines the goal column maps
+/// straight onto the adjacent logical line, so we can land there exactly
+/// (byte offset at `goal_visual_col`) rather than falling back to the
+/// end-/start-of-row jump. Returns `None` when either line wraps, so the
+/// caller keeps that conservative fallback (issue #1574).
+fn unwrapped_neighbor_goal_pos(
+    buffer: &mut crate::model::buffer::Buffer,
+    from_pos: usize,
+    direction: i8,
+    goal_visual_col: usize,
+    text_width: usize,
+    estimated_line_length: usize,
+) -> Option<usize> {
+    use crate::primitives::display_width::{byte_offset_at_visual_column, str_width};
+
+    let line_ending: &[char] = &['\n', '\r'];
+
+    // The current logical line must not wrap, otherwise `from_pos`'s visual
+    // row may be a wrapped segment and the "adjacent" row is not the
+    // neighbour logical line.
+    let cur_content = {
+        let mut iter = buffer.line_iterator(from_pos, estimated_line_length);
+        iter.next_line()?.1
+    };
+    if str_width(cur_content.trim_end_matches(line_ending)) > text_width {
+        return None;
+    }
+
+    // The neighbour logical line, and it must not wrap either.
+    let (neighbor_start, neighbor_content) = {
+        let mut iter = buffer.line_iterator(from_pos, estimated_line_length);
+        if direction < 0 {
+            iter.prev()?
+        } else {
+            iter.next_line(); // consume the current line
+            iter.next_line()?
+        }
+    };
+    let neighbor_text = neighbor_content.trim_end_matches(line_ending);
+    if str_width(neighbor_text) > text_width {
+        return None;
+    }
+
+    Some(neighbor_start + byte_offset_at_visual_column(neighbor_text, goal_visual_col))
 }
 
 /// Advance past the line break at `pos`, matching the CRLF handling in

--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -345,8 +345,8 @@ impl crate::app::window::Window {
                         .layout_cache
                         .byte_to_visual_column(split_id, from_pos)?;
 
-                    let goal_visual_col = if sticky_column > 0 {
-                        sticky_column
+                    let goal_visual_col = if let Some(sticky) = sticky_column {
+                        sticky
                     } else {
                         current_visual_col
                     };
@@ -357,7 +357,7 @@ impl crate::app::window::Window {
                         goal_visual_col,
                         *direction,
                     ) {
-                        Some(result) => result,
+                        Some((pos, goal)) => (pos, Some(goal)),
                         None => {
                             // Target visual row is past the cached view-line
                             // mappings — the destination row isn't in the
@@ -377,7 +377,7 @@ impl crate::app::window::Window {
                                 *direction,
                                 _estimated_line_length,
                             ) {
-                                Some(result) => result,
+                                Some((pos, goal)) => (pos, Some(goal)),
                                 None => continue, // Genuinely at buffer boundary
                             }
                         }
@@ -390,7 +390,7 @@ impl crate::app::window::Window {
                         .layout_cache
                         .visual_line_end(split_id, position, allow_advance)
                     {
-                        Some(end_pos) => (end_pos, 0),
+                        Some(end_pos) => (end_pos, None),
                         None => return None,
                     }
                 }
@@ -401,7 +401,7 @@ impl crate::app::window::Window {
                         .layout_cache
                         .visual_line_start(split_id, position, allow_advance)
                     {
-                        Some(start_pos) => (start_pos, 0),
+                        Some(start_pos) => (start_pos, None),
                         None => return None,
                     }
                 }

--- a/crates/fresh-editor/src/app/bookmark_actions.rs
+++ b/crates/fresh-editor/src/app/bookmark_actions.rs
@@ -113,7 +113,7 @@ impl Editor {
             old_anchor: cursor.anchor,
             new_anchor: None,
             old_sticky_column: cursor.sticky_column,
-            new_sticky_column: 0,
+            new_sticky_column: None,
         };
 
         self.active_event_log_mut().append(event.clone());

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -1142,7 +1142,7 @@ impl Editor {
                     old_anchor,
                     new_anchor: target_anchor,
                     old_sticky_column,
-                    new_sticky_column: 0, // Reset sticky column for navigation
+                    new_sticky_column: None, // Reset sticky column for navigation
                 };
                 let split_id = self
                     .windows
@@ -1198,7 +1198,7 @@ impl Editor {
                     old_anchor,
                     new_anchor: target_anchor,
                     old_sticky_column,
-                    new_sticky_column: 0, // Reset sticky column for navigation
+                    new_sticky_column: None, // Reset sticky column for navigation
                 };
                 let split_id = self
                     .windows

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -369,7 +369,7 @@ impl Editor {
                 old_anchor,
                 new_anchor,
                 old_sticky_column,
-                new_sticky_column: target_col,
+                new_sticky_column: Some(target_col),
             };
 
             let split_id = self
@@ -457,7 +457,7 @@ impl Editor {
                 old_anchor,
                 new_anchor: Some(start_pos),
                 old_sticky_column,
-                new_sticky_column: end_col_0,
+                new_sticky_column: Some(end_col_0),
             };
 
             let split_id = self
@@ -499,7 +499,7 @@ impl Editor {
                 old_anchor,
                 new_anchor: None,
                 old_sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
 
             let split_id = self

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -377,7 +377,7 @@ impl Editor {
                             cursor.deselect_on_move,
                         )
                     })
-                    .unwrap_or((CursorId(0), 0, None, 0, true));
+                    .unwrap_or((CursorId(0), 0, None, None, true));
 
                 // Check for onClick text property at this position
                 // This enables clickable UI elements in virtual buffers
@@ -440,8 +440,7 @@ impl Editor {
             .buffers()
             .get(&buffer_id)
             .and_then(|state| state.buffer.offset_to_position(target_position))
-            .map(|pos| pos.column)
-            .unwrap_or(0);
+            .map(|pos| pos.column);
 
         let event = Event::MoveCursor {
             cursor_id: primary_cursor_id,

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1428,7 +1428,7 @@ impl Editor {
                 old_anchor: primary.anchor,
                 new_anchor: Some(range.start),
                 old_sticky_column: primary.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);
@@ -1471,7 +1471,7 @@ impl Editor {
                     old_anchor: primary.anchor,
                     new_anchor: Some(word_start),
                     old_sticky_column: primary.sticky_column,
-                    new_sticky_column: 0,
+                    new_sticky_column: None,
                 };
 
                 // Log and apply the event
@@ -1584,7 +1584,7 @@ impl Editor {
                 old_anchor: cur.anchor,
                 new_anchor: None,
                 old_sticky_column: cur.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             });
         }
 

--- a/crates/fresh-editor/src/app/diagnostic_jumps.rs
+++ b/crates/fresh-editor/src/app/diagnostic_jumps.rs
@@ -59,7 +59,7 @@ impl Editor {
                 old_anchor: cursor.anchor,
                 new_anchor: None,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);
@@ -131,7 +131,7 @@ impl Editor {
                 old_anchor: cursor.anchor,
                 new_anchor: None,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -841,7 +841,7 @@ fn create_fold(
         if in_hidden_range || anchor_in_hidden {
             cursor.position = header_byte;
             cursor.anchor = None;
-            cursor.sticky_column = 0;
+            cursor.sticky_column = None;
             cursor.selection_mode = crate::model::cursor::SelectionMode::Normal;
             cursor.block_anchor = None;
             cursor.deselect_on_move = true;

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -378,7 +378,7 @@ impl Editor {
                 old_anchor,
                 new_anchor: None,
                 old_sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
 
             let split_id = self

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -337,7 +337,7 @@ pub(crate) struct GotoLinePreviewSnapshot {
     pub cursor_id: crate::model::event::CursorId,
     pub position: usize,
     pub anchor: Option<usize>,
-    pub sticky_column: usize,
+    pub sticky_column: Option<usize>,
     pub viewport_top_byte: usize,
     pub viewport_top_view_line_offset: usize,
     pub viewport_left_column: usize,
@@ -2059,8 +2059,8 @@ mod tests {
             new_position: 6,
             old_anchor: None, // TODO: Get actual old anchor
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         // Test move up
@@ -2208,8 +2208,8 @@ mod tests {
             new_position: 0,
             old_anchor: None, // TODO: Get actual old anchor
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         let events = editor
@@ -2262,8 +2262,8 @@ mod tests {
             new_position: 0,
             old_anchor: None, // TODO: Get actual old anchor
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         let events = editor
@@ -2709,8 +2709,8 @@ mod tests {
             new_position: 10,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         assert_eq!(editor.active_cursors().primary().position, 10);
@@ -2754,8 +2754,8 @@ mod tests {
             new_position: 26,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         // Call goto_matching_bracket
@@ -2794,8 +2794,8 @@ mod tests {
             new_position: 0,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         // Call goto_matching_bracket
@@ -3113,8 +3113,8 @@ mod tests {
             new_position: 7,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         // Set bookmark '1'
@@ -3135,8 +3135,8 @@ mod tests {
             new_position: 14,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
 
         // Jump back to bookmark

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1475,8 +1475,8 @@ impl Editor {
             new_position: target_position,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         };
 
         if let Some(event_log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {
@@ -1634,8 +1634,8 @@ impl Editor {
             new_position: target_position,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         };
 
         if let Some(event_log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {
@@ -3141,7 +3141,7 @@ impl Editor {
                     cursor.sticky_column,
                 )
             })
-            .unwrap_or((CursorId(0), 0, None, 0));
+            .unwrap_or((CursorId(0), 0, None, None));
 
         let event = Event::MoveCursor {
             cursor_id: primary_cursor_id,
@@ -3150,7 +3150,7 @@ impl Editor {
             old_anchor,
             new_anchor: Some(anchor_position),
             old_sticky_column,
-            new_sticky_column: new_sticky_column.unwrap_or(old_sticky_column),
+            new_sticky_column: new_sticky_column.or(old_sticky_column),
         };
 
         if let Some(event_log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {

--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -524,7 +524,7 @@ impl Editor {
                 new_position: new_cursor_pos,
                 old_anchor: None,
                 new_anchor: old_anchor.map(|a| a.min(new_buffer_len)),
-                old_sticky_column: 0,
+                old_sticky_column: None,
                 new_sticky_column: old_sticky_column,
             };
             events.push(move_cursor_event);

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -284,7 +284,7 @@ impl Editor {
                             old_anchor: cursor.anchor,
                             new_anchor: None,
                             old_sticky_column: cursor.sticky_column,
-                            new_sticky_column: 0,
+                            new_sticky_column: None,
                         }
                     })
                     .collect();

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -1243,7 +1243,7 @@ impl Editor {
                 old_anchor,
                 new_anchor: None,
                 old_sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             },
             Event::Delete {
                 range: range.clone(),

--- a/crates/fresh-editor/src/app/shell_command.rs
+++ b/crates/fresh-editor/src/app/shell_command.rs
@@ -200,7 +200,7 @@ impl Editor {
                     new_position: new_cursor_pos,
                     old_anchor: None,
                     new_anchor: old_anchor.map(|a| a.min(new_buffer_len)),
-                    old_sticky_column: 0,
+                    old_sticky_column: None,
                     new_sticky_column: old_sticky_column,
                 };
                 events.push(move_cursor_event);

--- a/crates/fresh-editor/src/app/text_ops.rs
+++ b/crates/fresh-editor/src/app/text_ops.rs
@@ -91,7 +91,7 @@ impl Editor {
                 old_anchor: cursor.anchor,
                 new_anchor,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             });
         }
 
@@ -347,8 +347,8 @@ impl Editor {
                 new_position,
                 old_anchor: original_anchor,
                 new_anchor: Some(new_anchor),
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             });
         }
 
@@ -519,7 +519,7 @@ impl Editor {
                 old_anchor: cursor.anchor,
                 new_anchor,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: 0,
+                new_sticky_column: None,
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -277,9 +277,26 @@ impl WindowLayoutCache {
                 }
             }
         }
-        // Byte is at or past end of row - return column after last character
-        // This handles cursor positions at end of line (e.g., after last char before newline)
-        Some(row.visual_to_char.len())
+        // Byte is at or past end of row - return the column just after the last
+        // *source-backed* cell. Trailing cells that map to no source byte are
+        // purely visual (e.g. indentation guides synthesised on a blank line
+        // inside an indented block); counting them would push the cursor's
+        // column right by one per guide, so a Down onto the next line would
+        // land one column too far (issue #2564). On a normal line every cell is
+        // source-backed, so this still returns the end-of-line column.
+        let last_real_col = row
+            .visual_to_char
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, &char_idx)| {
+                row.char_source_bytes
+                    .get(char_idx)
+                    .is_some_and(|b| b.is_some())
+            })
+            .map(|(visual_col, _)| visual_col + 1)
+            .unwrap_or(0);
+        Some(last_real_col)
     }
 
     /// Move by visual line using the cached mappings

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2510,7 +2510,7 @@ impl Window {
             cursor: SerializedCursor {
                 position: primary_cursor.position,
                 anchor: primary_cursor.anchor,
-                sticky_column: primary_cursor.sticky_column,
+                sticky_column: primary_cursor.sticky_column.unwrap_or(0),
             },
             additional_cursors: buf_state
                 .cursors
@@ -2519,7 +2519,7 @@ impl Window {
                 .map(|(_, cursor)| SerializedCursor {
                     position: cursor.position,
                     anchor: cursor.anchor,
-                    sticky_column: cursor.sticky_column,
+                    sticky_column: cursor.sticky_column.unwrap_or(0),
                 })
                 .collect(),
             scroll: SerializedScroll {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1299,7 +1299,9 @@ impl crate::app::window::Window {
                     buf_state.cursors.primary_mut().position = cursor_pos;
                     buf_state.cursors.primary_mut().anchor =
                         file_state.cursor.anchor.map(|a| a.min(max_pos));
-                    buf_state.cursors.primary_mut().sticky_column = file_state.cursor.sticky_column;
+                    buf_state.cursors.primary_mut().sticky_column =
+                        (file_state.cursor.sticky_column != 0)
+                            .then_some(file_state.cursor.sticky_column);
 
                     buf_state.viewport.top_byte = file_state.scroll.top_byte.min(max_pos);
                     buf_state.viewport.top_view_line_offset =
@@ -1688,7 +1690,7 @@ impl crate::app::window::Window {
             cursor: SerializedCursor {
                 position: primary_cursor.position,
                 anchor: primary_cursor.anchor,
-                sticky_column: primary_cursor.sticky_column,
+                sticky_column: primary_cursor.sticky_column.unwrap_or(0),
             },
             additional_cursors: view_state
                 .cursors
@@ -1697,7 +1699,7 @@ impl crate::app::window::Window {
                 .map(|(_, cursor)| SerializedCursor {
                     position: cursor.position,
                     anchor: cursor.anchor,
-                    sticky_column: cursor.sticky_column,
+                    sticky_column: cursor.sticky_column.unwrap_or(0),
                 })
                 .collect(),
             scroll: SerializedScroll {
@@ -2725,7 +2727,7 @@ fn serialize_split_view_state(
                 cursor: SerializedCursor {
                     position: primary_cursor.position,
                     anchor: primary_cursor.anchor,
-                    sticky_column: primary_cursor.sticky_column,
+                    sticky_column: primary_cursor.sticky_column.unwrap_or(0),
                 },
                 additional_cursors: buf_state
                     .cursors
@@ -2734,7 +2736,7 @@ fn serialize_split_view_state(
                     .map(|(_, cursor)| SerializedCursor {
                         position: cursor.position,
                         anchor: cursor.anchor,
-                        sticky_column: cursor.sticky_column,
+                        sticky_column: cursor.sticky_column.unwrap_or(0),
                     })
                     .collect(),
                 scroll: SerializedScroll {

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -291,7 +291,7 @@ fn add_move_cursor_event(
     new_position: usize,
     old_anchor: Option<usize>,
     new_anchor: Option<usize>,
-    old_sticky_column: usize,
+    old_sticky_column: Option<usize>,
 ) {
     events.push(Event::MoveCursor {
         cursor_id,
@@ -300,7 +300,7 @@ fn add_move_cursor_event(
         old_anchor,
         new_anchor,
         old_sticky_column,
-        new_sticky_column: 0,
+        new_sticky_column: None,
     });
 }
 
@@ -433,7 +433,7 @@ fn block_select_action(
             old_anchor: cursor.anchor,
             new_anchor: Some(byte_anchor),
             old_sticky_column: cursor.sticky_column,
-            new_sticky_column: new_2d.column,
+            new_sticky_column: Some(new_2d.column),
         });
 
         // Note: We need to set block selection mode after the event is processed
@@ -742,8 +742,8 @@ fn handle_skip_over_with_dedent(
             new_position: line_start + indent_byte_len + 1,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
         return true;
     }
@@ -758,8 +758,8 @@ fn handle_skip_over(events: &mut Vec<Event>, cursor_id: CursorId, insert_positio
         new_position: insert_position + 1,
         old_anchor: None,
         new_anchor: None,
-        old_sticky_column: 0,
-        new_sticky_column: 0,
+        old_sticky_column: None,
+        new_sticky_column: None,
     });
 }
 
@@ -829,8 +829,8 @@ fn handle_auto_close(
         new_position: insert_position + 1,
         old_anchor: None,
         new_anchor: None,
-        old_sticky_column: 0,
-        new_sticky_column: 0,
+        old_sticky_column: None,
+        new_sticky_column: None,
     });
 }
 
@@ -957,8 +957,8 @@ fn insert_char_events(
                         new_position: sel_end + 2,
                         old_anchor: None,
                         new_anchor: None,
-                        old_sticky_column: 0,
-                        new_sticky_column: 0,
+                        old_sticky_column: None,
+                        new_sticky_column: None,
                     });
                     continue;
                 }
@@ -1249,7 +1249,7 @@ fn handle_insert_newline(
                     old_anchor: None, // No selection after bracket expansion
                     new_anchor: None,
                     old_sticky_column: cursor.sticky_column,
-                    new_sticky_column: cursor_line_end, // Reset sticky column
+                    new_sticky_column: Some(cursor_line_end),
                 });
             }
         }
@@ -1513,11 +1513,7 @@ fn handle_vertical_up(
 
         let (current_visual_column, _) =
             calculate_visual_column(&mut state.buffer, from_pos, estimated_line_length);
-        let goal_visual_column = if cursor.sticky_column > 0 {
-            cursor.sticky_column
-        } else {
-            current_visual_column
-        };
+        let goal_visual_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
         let mut iter = state.buffer.line_iterator(from_pos, estimated_line_length);
         if let Some((prev_line_start, prev_line_content)) = iter.prev() {
@@ -1539,7 +1535,7 @@ fn handle_vertical_up(
                 old_anchor: cursor.anchor,
                 new_anchor,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: goal_visual_column,
+                new_sticky_column: Some(goal_visual_column),
             });
         }
     }
@@ -1567,11 +1563,7 @@ fn handle_vertical_down(
 
         let (current_visual_column, _) =
             calculate_visual_column(&mut state.buffer, from_pos, estimated_line_length);
-        let goal_visual_column = if cursor.sticky_column > 0 {
-            cursor.sticky_column
-        } else {
-            current_visual_column
-        };
+        let goal_visual_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
         let mut iter = state.buffer.line_iterator(from_pos, estimated_line_length);
         iter.next_line(); // consume current line
@@ -1595,7 +1587,7 @@ fn handle_vertical_down(
                 old_anchor: cursor.anchor,
                 new_anchor,
                 old_sticky_column: cursor.sticky_column,
-                new_sticky_column: goal_visual_column,
+                new_sticky_column: Some(goal_visual_column),
             });
         }
     }
@@ -1620,11 +1612,7 @@ fn handle_page_up(
         let current_line_start = iter.current_position();
         let current_column = cursor.position - current_line_start;
 
-        let goal_column = if cursor.sticky_column > 0 {
-            cursor.sticky_column
-        } else {
-            current_column
-        };
+        let goal_column = cursor.sticky_column.unwrap_or(current_column);
 
         let mut new_pos = cursor.position;
         for _ in 0..lines_to_move {
@@ -1651,7 +1639,7 @@ fn handle_page_up(
             old_anchor: cursor.anchor,
             new_anchor,
             old_sticky_column: cursor.sticky_column,
-            new_sticky_column: goal_column,
+            new_sticky_column: Some(goal_column),
         });
     }
 }
@@ -1675,11 +1663,7 @@ fn handle_page_down(
         let current_line_start = iter.current_position();
         let current_column = cursor.position - current_line_start;
 
-        let goal_column = if cursor.sticky_column > 0 {
-            cursor.sticky_column
-        } else {
-            current_column
-        };
+        let goal_column = cursor.sticky_column.unwrap_or(current_column);
 
         iter.next_line(); // consume current line
 
@@ -1708,7 +1692,7 @@ fn handle_page_down(
             old_anchor: cursor.anchor,
             new_anchor,
             old_sticky_column: cursor.sticky_column,
-            new_sticky_column: goal_column,
+            new_sticky_column: Some(goal_column),
         });
     }
 }
@@ -2169,7 +2153,7 @@ fn handle_toggle_case(state: &mut EditorState, cursors: &Cursors, events: &mut V
             old_anchor: cursor.anchor,
             new_anchor: None,
             old_sticky_column: cursor.sticky_column,
-            new_sticky_column: 0,
+            new_sticky_column: None,
         });
     }
 }
@@ -2284,7 +2268,7 @@ fn handle_duplicate_line(
             line_end + line_ending.len()
         };
         let cursor = cursors.get(cursor_id);
-        let old_sticky = cursor.map(|c| c.sticky_column).unwrap_or(0);
+        let old_sticky = cursor.and_then(|c| c.sticky_column);
         events.push(Event::MoveCursor {
             cursor_id,
             old_position: line_end + insert_len,
@@ -2292,7 +2276,7 @@ fn handle_duplicate_line(
             old_anchor: None,
             new_anchor: None,
             old_sticky_column: old_sticky,
-            new_sticky_column: 0,
+            new_sticky_column: None,
         });
     }
 }
@@ -3168,8 +3152,8 @@ mod tests {
                 new_position: 6,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3227,8 +3211,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3308,8 +3292,8 @@ mod tests {
                 new_position: 2, // "B"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3361,8 +3345,8 @@ mod tests {
                 new_position: 0, // "A"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3414,8 +3398,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3464,8 +3448,8 @@ mod tests {
                 new_position: 2, // "B"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3514,8 +3498,8 @@ mod tests {
                 new_position: 2, // "B"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3585,8 +3569,8 @@ mod tests {
                 new_position: target_start,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3653,8 +3637,8 @@ mod tests {
                 new_position: selection_end,
                 old_anchor: None,
                 new_anchor: Some(selection_start),
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3807,8 +3791,8 @@ mod tests {
                 new_position: 3,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3840,7 +3824,8 @@ mod tests {
                 "Cursor should move to end of shorter line"
             );
             assert_eq!(
-                *new_sticky_column, 3,
+                *new_sticky_column,
+                Some(3),
                 "Sticky column should preserve original column"
             );
         } else {
@@ -3871,7 +3856,11 @@ mod tests {
         } = &events[0]
         {
             assert_eq!(*new_position, 13, "Cursor should move back to column 3");
-            assert_eq!(*new_sticky_column, 3, "Sticky column should be preserved");
+            assert_eq!(
+                *new_sticky_column,
+                Some(3),
+                "Sticky column should be preserved"
+            );
         } else {
             panic!("Expected MoveCursor event");
         }
@@ -3906,8 +3895,8 @@ mod tests {
                 new_position: 13,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -3939,7 +3928,8 @@ mod tests {
                 "Cursor should move to end of shorter line"
             );
             assert_eq!(
-                *new_sticky_column, 3,
+                *new_sticky_column,
+                Some(3),
                 "Sticky column should preserve original column"
             );
         } else {
@@ -3970,7 +3960,11 @@ mod tests {
         } = &events[0]
         {
             assert_eq!(*new_position, 3, "Cursor should move back to column 3");
-            assert_eq!(*new_sticky_column, 3, "Sticky column should be preserved");
+            assert_eq!(
+                *new_sticky_column,
+                Some(3),
+                "Sticky column should be preserved"
+            );
         } else {
             panic!("Expected MoveCursor event");
         }
@@ -4005,8 +3999,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4061,8 +4055,8 @@ mod tests {
                 new_position: 6,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4120,8 +4114,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4191,8 +4185,8 @@ mod tests {
                 new_position: 5,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4343,8 +4337,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4479,8 +4473,8 @@ mod tests {
                 new_position: target_line_start,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4557,8 +4551,8 @@ mod tests {
                 new_position: 13,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -4956,8 +4950,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5023,8 +5017,8 @@ mod tests {
                 new_position: 7, // end of "bar"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5036,8 +5030,8 @@ mod tests {
                 new_position: 3, // end of "foo"
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5093,8 +5087,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5258,8 +5252,8 @@ mod tests {
                 new_position: 0,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5400,8 +5394,8 @@ mod tests {
                 new_position: 1,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5459,8 +5453,8 @@ mod tests {
                 new_position: 1,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5514,8 +5508,8 @@ mod tests {
                 new_position: 1,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5569,8 +5563,8 @@ mod tests {
                 new_position: 1,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5625,8 +5619,8 @@ mod tests {
                 new_position: 1,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 
@@ -5681,8 +5675,8 @@ mod tests {
                 new_position: 2,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 

--- a/crates/fresh-editor/src/input/line_move.rs
+++ b/crates/fresh-editor/src/input/line_move.rs
@@ -223,19 +223,24 @@ pub(crate) fn move_lines(
     }
 
     #[allow(clippy::type_complexity)]
-    let cursor_snapshots: Vec<(CursorId, Option<Range<usize>>, usize, Option<usize>, usize)> =
-        cursors
-            .iter()
-            .map(|(cursor_id, cursor)| {
-                (
-                    cursor_id,
-                    cursor.selection_range(),
-                    cursor.position,
-                    cursor.anchor,
-                    cursor.sticky_column,
-                )
-            })
-            .collect();
+    let cursor_snapshots: Vec<(
+        CursorId,
+        Option<Range<usize>>,
+        usize,
+        Option<usize>,
+        Option<usize>,
+    )> = cursors
+        .iter()
+        .map(|(cursor_id, cursor)| {
+            (
+                cursor_id,
+                cursor.selection_range(),
+                cursor.position,
+                cursor.anchor,
+                cursor.sticky_column,
+            )
+        })
+        .collect();
 
     let ranges: Vec<LineByteRange> = {
         let buffer = &mut state.buffer;

--- a/crates/fresh-editor/src/model/cursor.rs
+++ b/crates/fresh-editor/src/model/cursor.rs
@@ -28,9 +28,12 @@ pub struct Cursor {
     /// Selection anchor (if any) for visual selection - byte offset
     pub anchor: Option<usize>,
 
-    /// Desired column for vertical navigation
-    /// When moving up/down, try to stay in this column
-    pub sticky_column: usize,
+    /// Desired *visual* column for vertical navigation.
+    /// When moving up/down, try to stay in this column. `None` means "no goal
+    /// set — derive it from the current position"; `Some(c)` pins visual
+    /// column `c`, including `Some(0)` (a real goal of column 0, which a bare
+    /// `usize` with `0`-means-unset could not represent).
+    pub sticky_column: Option<usize>,
 
     /// Selection mode (normal or block)
     pub selection_mode: SelectionMode,
@@ -50,7 +53,7 @@ impl Cursor {
         Self {
             position,
             anchor: None,
-            sticky_column: 0,
+            sticky_column: None,
             selection_mode: SelectionMode::Normal,
             block_anchor: None,
             deselect_on_move: true, // Default: movement clears selection
@@ -62,7 +65,7 @@ impl Cursor {
         Self {
             position: end,
             anchor: Some(start),
-            sticky_column: 0,
+            sticky_column: None,
             selection_mode: SelectionMode::Normal,
             block_anchor: None,
             deselect_on_move: true, // Default: movement clears selection

--- a/crates/fresh-editor/src/model/event.rs
+++ b/crates/fresh-editor/src/model/event.rs
@@ -30,8 +30,8 @@ pub enum Event {
         new_position: usize,
         old_anchor: Option<usize>,
         new_anchor: Option<usize>,
-        old_sticky_column: usize,
-        new_sticky_column: usize,
+        old_sticky_column: Option<usize>,
+        new_sticky_column: Option<usize>,
     },
 
     /// Add a new cursor
@@ -1282,8 +1282,8 @@ mod tests {
             new_position: 1,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
         assert_eq!(log.current_index(), 2);
 
@@ -1300,8 +1300,8 @@ mod tests {
             new_position: 0,
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         });
         assert!(
             log.can_redo(),

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -856,7 +856,7 @@ impl EditorState {
         cursor_id: crate::model::event::CursorId,
         new_position: usize,
         new_anchor: Option<usize>,
-        new_sticky_column: usize,
+        new_sticky_column: Option<usize>,
     ) {
         if let Some(cursor) = cursors.get_mut(cursor_id) {
             cursor.position = new_position;
@@ -1943,8 +1943,8 @@ mod tests {
                 new_position: 2,
                 old_anchor: None,
                 new_anchor: None,
-                old_sticky_column: 0,
-                new_sticky_column: 0,
+                old_sticky_column: None,
+                new_sticky_column: None,
             },
         );
 

--- a/crates/fresh-editor/tests/e2e/folding.rs
+++ b/crates/fresh-editor/tests/e2e/folding.rs
@@ -46,7 +46,7 @@ fn set_top_line(harness: &mut EditorTestHarness, line: usize) {
     let cursors = harness.editor_mut().active_cursors_mut();
     cursors.primary_mut().position = top_byte;
     cursors.primary_mut().anchor = None;
-    cursors.primary_mut().sticky_column = 0;
+    cursors.primary_mut().sticky_column = None;
 }
 
 fn set_cursor_line(harness: &mut EditorTestHarness, line: usize) {
@@ -59,7 +59,7 @@ fn set_cursor_line(harness: &mut EditorTestHarness, line: usize) {
     let cursors = harness.editor_mut().active_cursors_mut();
     cursors.primary_mut().position = pos;
     cursors.primary_mut().anchor = None;
-    cursors.primary_mut().sticky_column = 0;
+    cursors.primary_mut().sticky_column = None;
 }
 
 fn find_text_position(harness: &EditorTestHarness, needle: &str) -> (u16, u16) {
@@ -430,7 +430,7 @@ fn test_folded_viewport_inside_range_fills_lines() {
         let cursors = harness.editor_mut().active_cursors_mut();
         cursors.primary_mut().position = cursor_pos;
         cursors.primary_mut().anchor = None;
-        cursors.primary_mut().sticky_column = 0;
+        cursors.primary_mut().sticky_column = None;
     }
     harness.render().unwrap();
 

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -100,6 +100,47 @@ fn indentation_guide_keeps_subdued_color_inside_selection() {
 }
 
 #[test]
+fn indentation_guide_blank_line_does_not_shift_cursor_column_on_move_down() {
+    // Regression (issue #2564): a *genuinely empty* line inside an indented
+    // block renders synthesized indentation-guide cells that map to no source
+    // byte. The visual-column lookup used by vertical movement must ignore
+    // those virtual cells; otherwise moving Down off the blank line lands one
+    // column too far right and the shift sticks.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_blank_cursor.rs");
+    // Line 3 is genuinely empty (0 chars) between two 4-space-indented lines.
+    std::fs::write(
+        &file_path,
+        "fn main() {\n    let a = 1;\n\n    let b = 2;\n}\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Cursor starts at line 1, column 0. Step onto the first indented line and
+    // record the cursor's on-screen column there.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // -> line 2 "    let a = 1;"
+    let (x_indented, _) = harness.screen_cursor_position();
+
+    // Continue down across the blank line onto the next indented line.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // -> line 3 (blank)
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // -> line 4 "    let b = 2;"
+    let (x_after_blank, _) = harness.screen_cursor_position();
+
+    assert_eq!(
+        x_after_blank, x_indented,
+        "moving Down across a blank line inside an indented block must keep the cursor in \
+         the same column (column 0); the synthesized indentation guide shifted it right"
+    );
+}
+
+#[test]
 fn indentation_guide_all_mode_continues_through_blank_line_in_editor_flow() {
     let temp_dir = TempDir::new().unwrap();
     let file_path = temp_dir.path().join("guides_blank.rs");

--- a/crates/fresh-editor/tests/e2e/movement.rs
+++ b/crates/fresh-editor/tests/e2e/movement.rs
@@ -679,3 +679,54 @@ fn test_movement_through_multiple_empty_lines() {
         "Should be somewhere on Line 6, got position {final_pos}"
     );
 }
+
+#[test]
+fn batched_vertical_movement_across_scroll_preserves_column() {
+    // Regression (issue #2565): moving the cursor down past the bottom of the
+    // viewport and back up in BATCHES (several keys per render, as the frame
+    // loop does under fast input) must return the cursor to its starting
+    // column. When a batched move crossed the scroll boundary the off-screen
+    // wrap fallback landed the cursor at the *end* of a line instead of at the
+    // goal column, and the drift stuck.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("scroll.txt");
+    // Short lines that never wrap, but more than a screenful so the view must
+    // scroll (and moves cross rows that aren't in the last-rendered layout).
+    let mut content = String::new();
+    for i in 0..60 {
+        content.push_str(&format!("line {i}\n"));
+    }
+    std::fs::write(&file_path, &content).unwrap();
+
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Cursor starts at line 1, column 0.
+    let (start_x, _) = harness.screen_cursor_position();
+
+    // Down to the bottom then back up, five keys per render — each batch runs
+    // against a stale layout cache, the condition that triggered the drift.
+    for _ in 0..14 {
+        harness
+            .send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 5)
+            .unwrap();
+    }
+    for _ in 0..14 {
+        harness
+            .send_key_repeat(KeyCode::Up, KeyModifiers::NONE, 5)
+            .unwrap();
+    }
+
+    let (end_x, _) = harness.screen_cursor_position();
+    let status = harness.get_status_bar();
+    assert_eq!(
+        end_x, start_x,
+        "cursor column drifted after a batched down/up round trip across a scroll boundary; \
+         status: {status}"
+    );
+    assert!(
+        status.contains("Ln 1, Col 1"),
+        "expected the cursor back at Ln 1, Col 1 after the round trip, got: {status}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/movement.rs
+++ b/crates/fresh-editor/tests/e2e/movement.rs
@@ -730,3 +730,48 @@ fn batched_vertical_movement_across_scroll_preserves_column() {
         "expected the cursor back at Ln 1, Col 1 after the round trip, got: {status}"
     );
 }
+
+#[test]
+fn column_zero_preserved_descending_through_wrapped_indented_line() {
+    use crate::common::harness::HarnessOptions;
+    use fresh::config::{Config, IndentationGuideMode};
+    // Regression: with the cursor at column 0, descending past an indented
+    // line that soft-wraps must leave the cursor at column 0 on the lines
+    // below. A goal column of 0 was treated as "no goal", so the cursor
+    // snapped to the indentation width and that column stuck.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("w.rs");
+    // No trailing newline: the final line "lower two" is real content, so a
+    // drifted column persists there instead of being reset by an empty line.
+    let content =
+        "top line here\n    wrapme aaaa bbbb cccc dddd eeee ffff gg\n    lower one\n    lower two";
+    std::fs::write(&file_path, content).unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.line_wrap = true;
+    config.editor.wrap_indent = true;
+    let mut harness =
+        EditorTestHarness::create(40, 16, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Cursor at column 0 of line 1.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+
+    // Descend well past the wrapped line; the cursor ends on the last line.
+    for _ in 0..10 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+
+    // The last logical line is "    lower two". Column 0 means the cursor sits
+    // at that line's start byte, not `start + indent`.
+    let buf = harness.get_buffer_content().unwrap();
+    let last_line_start = buf.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let pos = harness.cursor_position();
+    assert_eq!(
+        pos, last_line_start,
+        "column 0 drifted after descending through a wrapped indented line: cursor at \
+         offset {pos}, expected the last line start {last_line_start} (col 0)"
+    );
+}

--- a/crates/fresh-editor/tests/integration_tests.rs
+++ b/crates/fresh-editor/tests/integration_tests.rs
@@ -371,8 +371,8 @@ fn test_cursor_within_buffer_bounds() {
             new_position: 12, // Middle of line 2
             old_anchor: None,
             new_anchor: None,
-            old_sticky_column: 0,
-            new_sticky_column: 0,
+            old_sticky_column: None,
+            new_sticky_column: None,
         },
     );
 
@@ -952,8 +952,8 @@ mod event_inverse_tests {
             new_position: 20,
             old_anchor: None,
             new_anchor: Some(15),
-            old_sticky_column: 5,
-            new_sticky_column: 10,
+            old_sticky_column: Some(5),
+            new_sticky_column: Some(10),
         };
 
         let inverse = event.inverse().expect("MoveCursor should have inverse");
@@ -973,8 +973,8 @@ mod event_inverse_tests {
                 assert_eq!(new_position, 10); // Swapped
                 assert_eq!(old_anchor, Some(15)); // Swapped
                 assert_eq!(new_anchor, None); // Swapped
-                assert_eq!(old_sticky_column, 10); // Swapped
-                assert_eq!(new_sticky_column, 5); // Swapped
+                assert_eq!(old_sticky_column, Some(10)); // Swapped
+                assert_eq!(new_sticky_column, Some(5)); // Swapped
             }
             _ => panic!("MoveCursor inverse should be MoveCursor"),
         }
@@ -1224,8 +1224,8 @@ mod event_inverse_tests {
             new_position: 20,
             old_anchor: None,
             new_anchor: Some(15),
-            old_sticky_column: 5,
-            new_sticky_column: 10,
+            old_sticky_column: Some(5),
+            new_sticky_column: Some(10),
         };
 
         let inverse = original.inverse().expect("Should have inverse");
@@ -1247,8 +1247,8 @@ mod event_inverse_tests {
                 assert_eq!(new_position, 20);
                 assert_eq!(old_anchor, None);
                 assert_eq!(new_anchor, Some(15));
-                assert_eq!(old_sticky_column, 5);
-                assert_eq!(new_sticky_column, 10);
+                assert_eq!(old_sticky_column, Some(5));
+                assert_eq!(new_sticky_column, Some(10));
             }
             _ => panic!("Double inverse should be MoveCursor"),
         }


### PR DESCRIPTION
## Summary
Fixes several cases where moving the cursor up/down failed to preserve its column. Each fix has a regression test that was confirmed to fail without the change and pass with it.

Fixes #2564
Fixes #2565

## The three fixes

1. **Indentation guides on blank lines (issue #2564).** `WindowLayoutCache::byte_to_visual_column()` now returns the column just after the last *source-backed* cell instead of counting purely synthetic cells. An empty line inside an indented block renders indentation-guide cells that map to no source byte; counting them reported the cursor one column too far right, and a Down carried that +1 onto the next line.

2. **Off-screen moves over non-wrapping lines (issue #2565).** When a batched move (several keypresses per render, as the frame loop does under fast input) crosses the scroll boundary, the target visual row isn't in the last-rendered layout, so the wrap-aware fallback takes over. It landed the cursor at the end/start of the adjacent row — fine for wrapped paragraphs (issue #1574) but wrong for short lines. Added a fast path (`unwrapped_neighbor_goal_pos` + `visual_text_width`) that lands at the goal column when neither the current nor the adjacent line wraps; wrapped lines keep the existing fallback.

3. **Column 0 through a wrapped indented line.** The goal column was a bare `usize` where `0` doubled as "no goal set" (`if sticky_column > 0 { … }`). Descending at column 0 through an indented line that soft-wraps re-derived the goal from the current position each step, and on the wrapped continuation row (whose column 0 is virtual wrap-indent) the cursor snapped to the indentation and stuck. `Cursor::sticky_column` and the `MoveCursor` event fields are now `Option<usize>` (`None` = derive from position, `Some(c)` = pin column `c`, including `Some(0)`), which removes the sentinel. Non-zero columns were never affected, which is why only column 1 misbehaved.

## Tests

- `indentation_guide_blank_line_does_not_shift_cursor_column_on_move_down`
- `batched_vertical_movement_across_scroll_preserves_column`
- `column_zero_preserved_descending_through_wrapped_indented_line`

Regression suites pass: e2e movement, integration, and the wrap / #1574 / #1147 semantic tests (678). Two unrelated tests (`test_multiple_locales_can_be_loaded`, `test_diagnostics_api_with_fake_lsp`) flake under full-parallel load and pass in isolation.

https://claude.ai/code/session_01CM2Yvt6DBhVVUhKwj7eVXj