### PR TITLE
Settings: portable ASCII category icons by default, Nerd Font icons behind a config toggle

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -74,6 +74,7 @@
         "show_vertical_scrollbar": true,
         "show_horizontal_scrollbar": false,
         "show_tilde": true,
+        "nerd_font_icons": false,
         "use_terminal_bg": false,
         "set_window_title": true,
         "terminal_auto_title": true,
@@ -544,6 +545,12 @@
           "description": "Show tilde (~) markers on lines after the end of the file.\nThese vim-style markers indicate lines that are not part of the file content.\nDefault: true",
           "type": "boolean",
           "default": true,
+          "x-section": "Display"
+        },
+        "nerd_font_icons": {
+          "description": "Use Nerd Font icons for decorative UI glyphs (e.g. the settings\ncategory icons). Nerd Font glyphs live in the Unicode private-use\narea and only render correctly when the terminal uses a patched\n\"Nerd Font\"; on any other font they show up as `?` or empty boxes.\nWhen disabled, portable ASCII symbols are used instead.\nDefault: false",
+          "type": "boolean",
+          "default": false,
           "x-section": "Display"
         },
         "use_terminal_bg": {

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -548,7 +548,7 @@
           "x-section": "Display"
         },
         "nerd_font_icons": {
-          "description": "Use Nerd Font icons for decorative UI glyphs (e.g. the settings\ncategory icons). Nerd Font glyphs live in the Unicode private-use\narea and only render correctly when the terminal uses a patched\n\"Nerd Font\"; on any other font they show up as `?` or empty boxes.\nWhen disabled, portable ASCII symbols are used instead.\nDefault: false",
+          "description": "Use Nerd Font icons for decorative UI glyphs (e.g. the settings\ncategory icons). Nerd Font glyphs live in the Unicode private-use\narea and only render correctly when the terminal uses a patched\n\"Nerd Font\"; on any other font they show up as `?` or empty boxes.\nWhen disabled, standard Unicode symbols (covered by normal\nterminal font fallback) are used instead.\nDefault: false",
           "type": "boolean",
           "default": false,
           "x-section": "Display"

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1155,6 +1155,16 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub show_tilde: bool,
 
+    /// Use Nerd Font icons for decorative UI glyphs (e.g. the settings
+    /// category icons). Nerd Font glyphs live in the Unicode private-use
+    /// area and only render correctly when the terminal uses a patched
+    /// "Nerd Font"; on any other font they show up as `?` or empty boxes.
+    /// When disabled, portable ASCII symbols are used instead.
+    /// Default: false
+    #[serde(default = "default_false")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub nerd_font_icons: bool,
+
     /// Use the terminal's default background color instead of the theme's editor background.
     /// When enabled, the editor background inherits from the terminal emulator,
     /// allowing transparency or custom terminal backgrounds to show through.
@@ -1804,6 +1814,7 @@ impl Default for EditorConfig {
             show_vertical_scrollbar: true,
             show_horizontal_scrollbar: false,
             show_tilde: true,
+            nerd_font_icons: false,
             use_terminal_bg: false,
             set_window_title: true,
             terminal_auto_title: true,

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1159,7 +1159,8 @@ pub struct EditorConfig {
     /// category icons). Nerd Font glyphs live in the Unicode private-use
     /// area and only render correctly when the terminal uses a patched
     /// "Nerd Font"; on any other font they show up as `?` or empty boxes.
-    /// When disabled, portable ASCII symbols are used instead.
+    /// When disabled, standard Unicode symbols (covered by normal
+    /// terminal font fallback) are used instead.
     /// Default: false
     #[serde(default = "default_false")]
     #[schemars(extend("x-section" = "Display"))]

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -214,6 +214,7 @@ pub struct PartialEditorConfig {
     pub show_vertical_scrollbar: Option<bool>,
     pub show_horizontal_scrollbar: Option<bool>,
     pub show_tilde: Option<bool>,
+    pub nerd_font_icons: Option<bool>,
     pub use_terminal_bg: Option<bool>,
     pub set_window_title: Option<bool>,
     pub terminal_auto_title: Option<bool>,
@@ -333,6 +334,7 @@ impl Merge for PartialEditorConfig {
         self.show_horizontal_scrollbar
             .merge_from(&other.show_horizontal_scrollbar);
         self.show_tilde.merge_from(&other.show_tilde);
+        self.nerd_font_icons.merge_from(&other.nerd_font_icons);
         self.use_terminal_bg.merge_from(&other.use_terminal_bg);
         self.set_window_title.merge_from(&other.set_window_title);
         self.terminal_auto_title
@@ -651,6 +653,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             show_vertical_scrollbar: Some(cfg.show_vertical_scrollbar),
             show_horizontal_scrollbar: Some(cfg.show_horizontal_scrollbar),
             show_tilde: Some(cfg.show_tilde),
+            nerd_font_icons: Some(cfg.nerd_font_icons),
             use_terminal_bg: Some(cfg.use_terminal_bg),
             set_window_title: Some(cfg.set_window_title),
             terminal_auto_title: Some(cfg.terminal_auto_title),
@@ -822,6 +825,7 @@ impl PartialEditorConfig {
                 .show_horizontal_scrollbar
                 .unwrap_or(defaults.show_horizontal_scrollbar),
             show_tilde: self.show_tilde.unwrap_or(defaults.show_tilde),
+            nerd_font_icons: self.nerd_font_icons.unwrap_or(defaults.nerd_font_icons),
             use_terminal_bg: self.use_terminal_bg.unwrap_or(defaults.use_terminal_bg),
             set_window_title: self.set_window_title.unwrap_or(defaults.set_window_title),
             terminal_auto_title: self

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -501,20 +501,45 @@ fn render_categories_horizontal(
     }
 }
 
-/// Get an icon for a settings category name (Nerd Font icons)
-fn category_icon(name: &str) -> &'static str {
-    match name.to_lowercase().as_str() {
-        "general" => "\u{f013} ",       //
-        "editor" => "\u{f044} ",        //
-        "clipboard" => "\u{f328} ",     //
-        "file browser" => "\u{f07b} ",  //
-        "file explorer" => "\u{f07c} ", //
-        "packages" => "\u{f487} ",      //
-        "plugins" => "\u{f1e6} ",       //
-        "terminal" => "\u{f120} ",      //
-        "warnings" => "\u{f071} ",      //
-        "keybindings" => "\u{f11c} ",   //
-        _ => "\u{f111} ",               //  (dot circle as fallback)
+/// Get an icon for a settings category name.
+///
+/// Two sets are available. The Nerd Font set uses private-use-area
+/// codepoints that require a patched "Nerd Font" in the terminal — on
+/// any other font they render as `?` or empty boxes (issue #2032). The
+/// default set sticks to plain ASCII so it renders everywhere; it's
+/// used unless `editor.nerd_font_icons` is enabled.
+fn category_icon(name: &str, nerd_fonts: bool) -> &'static str {
+    let name = name.to_lowercase();
+    if nerd_fonts {
+        return match name.as_str() {
+            "general" => "\u{f013} ",       //
+            "editor" => "\u{f044} ",        //
+            "clipboard" => "\u{f328} ",     //
+            "file browser" => "\u{f07b} ",  //
+            "file explorer" => "\u{f07c} ", //
+            "packages" => "\u{f487} ",      //
+            "plugins" => "\u{f1e6} ",       //
+            "terminal" => "\u{f120} ",      //
+            "warnings" => "\u{f071} ",      //
+            "keybindings" => "\u{f11c} ",   //
+            _ => "\u{f111} ",               //  (dot circle as fallback)
+        };
+    }
+    if name.starts_with("plugin: ") {
+        return "+ ";
+    }
+    match name.as_str() {
+        "general" => "* ",
+        "editor" => "~ ",
+        "clipboard" => "= ",
+        "file browser" => "/ ",
+        "file explorer" => "/ ",
+        "packages" => "@ ",
+        "plugins" => "+ ",
+        "terminal" => "$ ",
+        "warnings" => "! ",
+        "keybindings" => "^ ",
+        _ => "- ",
     }
 }
 
@@ -563,6 +588,7 @@ fn render_categories(
         label: String,
         icon: Option<&'static str>,
     }
+    let nerd_fonts = state.nerd_font_icons_enabled();
     let row_data: Vec<RowData> = rows
         .iter()
         .map(|row| match *row {
@@ -593,7 +619,7 @@ fn render_categories(
                     cat_idx: Some(idx),
                     section_idx: None,
                     label: page.name.clone(),
-                    icon: Some(category_icon(&page.name)),
+                    icon: Some(category_icon(&page.name, nerd_fonts)),
                 }
             }
             TreeRow::Section {

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -504,10 +504,14 @@ fn render_categories_horizontal(
 /// Get an icon for a settings category name.
 ///
 /// Two sets are available. The Nerd Font set uses private-use-area
-/// codepoints that require a patched "Nerd Font" in the terminal — on
-/// any other font they render as `?` or empty boxes (issue #2032). The
-/// default set sticks to plain ASCII so it renders everywhere; it's
-/// used unless `editor.nerd_font_icons` is enabled.
+/// codepoints that require a patched "Nerd Font" in the terminal — PUA
+/// glyphs have no system-font fallback, so on any other font they
+/// render as `?` or empty boxes (issue #2032). The default set uses
+/// standard BMP codepoints (default text presentation, width 1) from
+/// the same compatibility class as the `▶`/`✓`/`●` glyphs the UI
+/// already relies on, so terminal font fallback can always supply
+/// them. The Nerd Font set is used only when `editor.nerd_font_icons`
+/// is enabled.
 fn category_icon(name: &str, nerd_fonts: bool) -> &'static str {
     let name = name.to_lowercase();
     if nerd_fonts {
@@ -526,20 +530,20 @@ fn category_icon(name: &str, nerd_fonts: bool) -> &'static str {
         };
     }
     if name.starts_with("plugin: ") {
-        return "+ ";
+        return "\u{271a} "; // ✚ heavy plus (add-on)
     }
     match name.as_str() {
-        "general" => "* ",
-        "editor" => "~ ",
-        "clipboard" => "= ",
-        "file browser" => "/ ",
-        "file explorer" => "/ ",
-        "packages" => "@ ",
-        "plugins" => "+ ",
-        "terminal" => "$ ",
-        "warnings" => "! ",
-        "keybindings" => "^ ",
-        _ => "- ",
+        "general" => "\u{2699} ",       // ⚙ gear
+        "editor" => "\u{270e} ",        // ✎ pencil
+        "clipboard" => "\u{2702} ",     // ✂ scissors (cut/copy)
+        "file browser" => "\u{25a4} ",  // ▤ square with lines (document)
+        "file explorer" => "\u{25a6} ", // ▦ square with grid (tree)
+        "packages" => "\u{25c6} ",      // ◆ diamond
+        "plugins" => "\u{271a} ",       // ✚ heavy plus (add-on)
+        "terminal" => "\u{00bb} ",      // » prompt chevron
+        "warnings" => "\u{26a0} ",      // ⚠ warning sign
+        "keybindings" => "\u{2328} ",   // ⌨ keyboard
+        _ => "\u{2022} ",               // • bullet as fallback
     }
 }
 

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -369,6 +369,20 @@ impl SettingsState {
         self.focus.current().unwrap_or_default()
     }
 
+    /// Whether Nerd Font icons are enabled (`editor.nerd_font_icons`).
+    ///
+    /// Checks the unsaved pending value first so toggling the setting
+    /// inside the Settings dialog previews immediately, then falls back
+    /// to the value the dialog was opened with.
+    pub fn nerd_font_icons_enabled(&self) -> bool {
+        const PATH: &str = "/editor/nerd_font_icons";
+        self.pending_changes
+            .get(PATH)
+            .or_else(|| self.original_config.pointer(PATH))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
     /// Show the settings panel
     pub fn show(&mut self) {
         self.visible = true;


### PR DESCRIPTION
Addresses the settings-tree part of #2032 (Nerd Font private-use-area glyphs rendering as `?` on terminals without a patched font — reported on macOS terminals and reproduced on WSL2/Windows Terminal with Consolas/Courier New). PUA codepoints have no system-font fallback, so no font switch can fix them; standard BMP symbols do get fallback on modern terminals — the same compatibility class as the `▶`/`✓`/`●` glyphs the UI already relies on.

## What changed

**Full list of settings category symbols** (from `category_icon` in `crates/fresh-editor/src/view/settings/render.rs`):

| Category | Nerd Font (PUA) | New default (standard Unicode) |
|---|---|---|
| General | `U+F013` (gear) | `⚙` U+2699 gear |
| Editor | `U+F044` (pencil) | `✎` U+270E pencil |
| Clipboard | `U+F328` (clipboard) | `✂` U+2702 scissors |
| File Browser | `U+F07B` (folder) | `▤` U+25A4 square with lines |
| File Explorer | `U+F07C` (folder-open) | `▦` U+25A6 square with grid |
| Packages | `U+F487` (package) | `◆` U+25C6 diamond |
| Plugins | `U+F1E6` (plug) | `✚` U+271A heavy plus |
| Terminal | `U+F120` (terminal) | `»` U+00BB prompt chevron |
| Warnings | `U+F071` (warning) | `⚠` U+26A0 warning sign |
| Keybindings | `U+F11C` (keyboard) | `⌨` U+2328 keyboard |
| Plugin: &lt;name&gt; | `U+F111` (fallback dot) | `✚` U+271A heavy plus |
| (fallback) | `U+F111` (dot circle) | `•` U+2022 bullet |

All default-set codepoints are BMP, width 1, and have default *text* presentation (no VS16), so they don't trigger emoji rendering.

**New config setting**: `editor.nerd_font_icons` (bool, default `false`, under Editor → Display). When disabled (default), the standard-Unicode set is used; enabling it restores the original Nerd Font glyphs for users whose terminal font supports them. Toggling it inside the Settings dialog previews immediately (the pending unsaved value is read first).

Files touched:
- `config.rs` — new `EditorConfig::nerd_font_icons` field
- `partial_config.rs` — mirror field in `PartialEditorConfig` (merge/from/resolve)
- `view/settings/render.rs` — `category_icon` now takes the flag and carries both symbol sets
- `view/settings/state.rs` — `SettingsState::nerd_font_icons_enabled()` accessor (pending value → original config → default false)
- `plugins/config-schema.json` — regenerated via `./scripts/gen_schema.sh`

## Notes

- The other glyphs listed in #2032 (`▶`/`▼` chevrons, `←→` hints, box-drawing borders, `✓`) are standard Unicode, not PUA — they're out of scope here but the new flag is a natural gate for an ASCII fallback for those too, if needed.
- A per-category override map (e.g. `editor.settings_category_icons`) would be a straightforward follow-up if finer customization is wanted.

Verified with `cargo build -p fresh-editor` and `cargo fmt --check` (tests intentionally not run per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rB9Vmw6iGgts2Q5Yrk9T