### PR TITLE
Orchestrator dock: commit failed dormant-SSH dives to an empty disconnected shell, badge dormant remote rows (fixes #2570)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -436,10 +436,35 @@ pub struct WindowInfo {
     #[ts(type = "boolean")]
     #[serde(skip_serializing_if = "is_false_field", default)]
     pub shared_worktree: bool,
+    /// Remote backend identity when this session's backend is not
+    /// host-local (SSH / Kubernetes). Carried for live remote windows
+    /// *and* for dormant (not-yet-connected / disconnected) sessions, so
+    /// the dock can badge a restored SSH session before any connection
+    /// exists. `None` for local sessions and plugin-managed backends
+    /// (devcontainer), whose facet the owning plugin supplies itself.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remote: Option<RemoteBackendInfo>,
 }
 
 fn is_false_field(b: &bool) -> bool {
     !b
+}
+
+/// Backend identity of a non-local session, as surfaced to plugins on
+/// [`WindowInfo`]. Mirrors the persisted `SessionAuthoritySpec::RemoteAgent`
+/// transport, reduced to what the dock renders.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct RemoteBackendInfo {
+    /// Backend kind: `"ssh"` or `"kubernetes"`.
+    pub kind: String,
+    /// Short human identity for the row (e.g. `deploy@build-01`,
+    /// `ns/pod`).
+    pub detail: String,
+    /// `true` when the backend connection is currently live; `false` for a
+    /// dormant session (restored from disk, not yet connected, or whose
+    /// last connect failed).
+    pub connected: bool,
 }
 
 /// Information about a buffer

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -497,6 +497,32 @@ type WindowInfo = {
 	* emitted when false.
 	*/
 	shared_worktree?: boolean;
+	/**
+	* Remote backend identity when this session's backend is not
+	* host-local (SSH / Kubernetes). Carried for live remote windows
+	* *and* for dormant (not-yet-connected / disconnected) sessions, so
+	* the dock can badge a restored SSH session before any connection
+	* exists. `None` for local sessions and plugin-managed backends
+	* (devcontainer), whose facet the owning plugin supplies itself.
+	*/
+	remote?: RemoteBackendInfo | null;
+};
+type RemoteBackendInfo = {
+	/**
+	* Backend kind: `"ssh"` or `"kubernetes"`.
+	*/
+	kind: string;
+	/**
+	* Short human identity for the row (e.g. `deploy@build-01`,
+	* `ns/pod`).
+	*/
+	detail: string;
+	/**
+	* `true` when the backend connection is currently live; `false` for a
+	* dormant session (restored from disk, not yet connected, or whose
+	* last connect failed).
+	*/
+	connected: boolean;
 };
 type JsDiagnostic = {
 	/**

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -677,6 +677,21 @@ const OPEN_MODE = "orchestrator-open";
 // Session-list reconciliation
 // =============================================================================
 
+// Remote facet derived from the host's `WindowInfo.remote` backend identity.
+// Present for SSH/Kubernetes sessions — including *dormant* ones restored
+// from disk that have never connected this run — so their dock rows carry
+// the backend glyph + detail and a disconnected ("stopped") state instead of
+// masquerading as local sessions. Plugin-managed backends (devcontainer)
+// carry no host facet; theirs still arrives via `pendingRemoteFacet`.
+function backendFacet(info: WindowInfo): AgentSession["remote"] | undefined {
+  if (!info.remote) return undefined;
+  return {
+    kind: info.remote.kind as SessionBackend,
+    detail: info.remote.detail,
+    state: info.remote.connected ? "running" : "stopped",
+  };
+}
+
 function reconcileSessions(): void {
   const editorSessions = editor.listWindows();
   const seen = new Set<number>();
@@ -707,13 +722,27 @@ function reconcileSessions(): void {
         state: "idle",
         lastOutputAt: null,
         createdAt: Date.now(),
-        remote,
+        remote: remote ?? backendFacet(s),
       });
     } else {
       existing.label = s.label;
       existing.root = s.root;
       existing.projectPath = s.project_path;
       if (s.shared_worktree != null) existing.sharedWorktree = s.shared_worktree;
+      // Keep the backend facet in step with the host's view: adopt it when
+      // missing (a dormant session that predates the facet, or one whose
+      // plugin-side record was created before the snapshot carried it), and
+      // track the connected/disconnected flip so a promoted or dropped
+      // backend re-badges the row. A plugin-owned lifecycle state
+      // ("starting") is left alone — it resolves through its own path.
+      const facet = backendFacet(s);
+      if (facet) {
+        if (!existing.remote) {
+          existing.remote = facet;
+        } else if (existing.remote.state !== "starting") {
+          existing.remote.state = facet.state;
+        }
+      }
     }
   }
   // Live windows live in the positive id space; their absence from

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1258,9 +1258,11 @@ impl Editor {
                 // selection and active window agree again — issue #2570).
                 // The session stays dormant behind the shell; diving again
                 // (or the indicator's Retry) reconnects, and a success
-                // replaces the shell with the fully-restored window.
+                // replaces the shell with the fully-restored window. The
+                // failure message is posted *after* the activation so the
+                // switch machinery can't clear it off the status line.
+                self.activate_failed_dormant_placeholder(window_id, reason.clone());
                 self.set_status_message(format!("Connection failed: {reason}"));
-                self.activate_failed_dormant_placeholder(window_id, reason);
             } else {
                 // The session was closed while the connect was in flight —
                 // nothing to attach the failure to; just surface it.

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1251,11 +1251,19 @@ impl Editor {
                 // `tracing::warn!` above, which lights the warning indicator);
                 // the reason itself is surfaced in the remote-indicator popup.
                 w.remote_reconnect_error = Some(reason);
+            } else if self.dormant_remote.contains_key(&window_id) {
+                // A dive-triggered connect of a dormant session failed. The
+                // user asked for that workspace, so commit the switch: build
+                // an empty disconnected shell for it and activate it (dock
+                // selection and active window agree again — issue #2570).
+                // The session stays dormant behind the shell; diving again
+                // (or the indicator's Retry) reconnects, and a success
+                // replaces the shell with the fully-restored window.
+                self.set_status_message(format!("Connection failed: {reason}"));
+                self.activate_failed_dormant_placeholder(window_id, reason);
             } else {
-                // A dormant session's connect failed: it has no
-                // window (we never built one without the backend), so
-                // surface the reason on the status line. The session
-                // stays dormant in the dock; diving again retries.
+                // The session was closed while the connect was in flight —
+                // nothing to attach the failure to; just surface it.
                 self.set_status_message(format!("Connection failed: {reason}"));
             }
         }

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1245,12 +1245,21 @@ impl Editor {
         if let Some(window_id) = reconnect_window {
             let reason = error.lines().next().unwrap_or(&error).to_string();
             if let Some(w) = self.windows.get_mut(&window_id) {
-                // An already-live remote window whose reconnect failed: record
-                // the reason on the window. The status-bar indicator renders a
-                // short "Disconnected" from this (the full error went to the
-                // `tracing::warn!` above, which lights the warning indicator);
-                // the reason itself is surfaced in the remote-indicator popup.
-                w.remote_reconnect_error = Some(reason);
+                // An already-live remote window whose reconnect failed — or a
+                // dormant session's shell the dive committed into while this
+                // connect ran: record the reason on the window. The status-bar
+                // indicator renders a short "Disconnected" from this (the full
+                // error went to the `tracing::warn!` above, which lights the
+                // warning indicator); the reason itself is surfaced in the
+                // remote-indicator popup. No activation here — the user may
+                // have switched away while the connect was in flight, and a
+                // background failure must not steal focus.
+                w.remote_reconnect_error = Some(reason.clone());
+                // For a dormant session's shell, ALSO surface the reason on
+                // the status line, as the window-less path always did.
+                if self.dormant_remote.contains_key(&window_id) {
+                    self.set_status_message(format!("Connection failed: {reason}"));
+                }
             } else if self.dormant_remote.contains_key(&window_id) {
                 // A dive-triggered connect of a dormant session failed. The
                 // user asked for that workspace, so commit the switch: build

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1256,9 +1256,11 @@ impl Editor {
                 // background failure must not steal focus.
                 w.remote_reconnect_error = Some(reason.clone());
                 // For a dormant session's shell, ALSO surface the reason on
-                // the status line, as the window-less path always did.
+                // the status line, as the window-less path always did —
+                // on the SHELL's own status line (messages are per-window;
+                // the user may be looking at another workspace by now).
                 if self.dormant_remote.contains_key(&window_id) {
-                    self.set_status_message(format!("Connection failed: {reason}"));
+                    w.set_status_message(format!("Connection failed: {reason}"));
                 }
             } else if self.dormant_remote.contains_key(&window_id) {
                 // A dive-triggered connect of a dormant session failed. The

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -57,7 +57,7 @@ fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
 /// facet the dock renders (`None` for local sessions, and for plugin-managed
 /// backends whose facet the owning plugin supplies itself). The `kind`
 /// strings match the plugin API's `SessionBackend` values.
-fn remote_backend_info(
+pub(crate) fn remote_backend_info(
     spec: &crate::services::authority::SessionAuthoritySpec,
     connected: bool,
 ) -> Option<fresh_core::api::RemoteBackendInfo> {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -53,37 +53,6 @@ fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
     path
 }
 
-/// Reduce a session's persisted backend spec to the [`RemoteBackendInfo`]
-/// facet the dock renders (`None` for local sessions, and for plugin-managed
-/// backends whose facet the owning plugin supplies itself). The `kind`
-/// strings match the plugin API's `SessionBackend` values.
-pub(crate) fn remote_backend_info(
-    spec: &crate::services::authority::SessionAuthoritySpec,
-    connected: bool,
-) -> Option<fresh_core::api::RemoteBackendInfo> {
-    use crate::services::authority::{RemoteTransportSpec, SessionAuthoritySpec};
-    let SessionAuthoritySpec::RemoteAgent(agent) = spec else {
-        return None;
-    };
-    let (kind, detail) = match &agent.transport {
-        RemoteTransportSpec::Ssh { user, host, .. } => (
-            "ssh",
-            match user.as_deref().filter(|u| !u.is_empty()) {
-                Some(user) => format!("{user}@{host}"),
-                None => host.clone(),
-            },
-        ),
-        RemoteTransportSpec::KubectlExec { namespace, pod, .. } => {
-            ("kubernetes", format!("{namespace}/{pod}"))
-        }
-    };
-    Some(fresh_core::api::RemoteBackendInfo {
-        kind: kind.to_string(),
-        detail,
-        connected,
-    })
-}
-
 #[cfg(windows)]
 fn canonicalize_deepest_existing(path: &std::path::Path) -> std::path::PathBuf {
     if let Ok(c) = path.canonicalize() {
@@ -309,7 +278,7 @@ impl Editor {
                     shared_worktree: d.shared_worktree,
                     // Never connected (or its window would exist) — the dock
                     // badges it as its real backend, disconnected.
-                    remote: remote_backend_info(&d.authority_spec, false),
+                    remote: d.authority_spec.remote_backend_info(false),
                 }
             });
         let mut session_infos: Vec<fresh_core::api::WindowInfo> = self
@@ -341,10 +310,9 @@ impl Editor {
                     shared_worktree,
                     // A parked keepalive is what distinguishes a live remote
                     // window from a dormant one's disconnected shell.
-                    remote: remote_backend_info(
-                        &s.authority_spec,
-                        self.session_keepalives.contains_key(&s.id),
-                    ),
+                    remote: s
+                        .authority_spec
+                        .remote_backend_info(self.session_keepalives.contains_key(&s.id)),
                 }
             })
             .collect();

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -53,6 +53,37 @@ fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
     path
 }
 
+/// Reduce a session's persisted backend spec to the [`RemoteBackendInfo`]
+/// facet the dock renders (`None` for local sessions, and for plugin-managed
+/// backends whose facet the owning plugin supplies itself). The `kind`
+/// strings match the plugin API's `SessionBackend` values.
+fn remote_backend_info(
+    spec: &crate::services::authority::SessionAuthoritySpec,
+    connected: bool,
+) -> Option<fresh_core::api::RemoteBackendInfo> {
+    use crate::services::authority::{RemoteTransportSpec, SessionAuthoritySpec};
+    let SessionAuthoritySpec::RemoteAgent(agent) = spec else {
+        return None;
+    };
+    let (kind, detail) = match &agent.transport {
+        RemoteTransportSpec::Ssh { user, host, .. } => (
+            "ssh",
+            match user.as_deref().filter(|u| !u.is_empty()) {
+                Some(user) => format!("{user}@{host}"),
+                None => host.clone(),
+            },
+        ),
+        RemoteTransportSpec::KubectlExec { namespace, pod, .. } => {
+            ("kubernetes", format!("{namespace}/{pod}"))
+        }
+    };
+    Some(fresh_core::api::RemoteBackendInfo {
+        kind: kind.to_string(),
+        detail,
+        connected,
+    })
+}
+
 #[cfg(windows)]
 fn canonicalize_deepest_existing(path: &std::path::Path) -> std::path::PathBuf {
     if let Ok(c) = path.canonicalize() {
@@ -250,28 +281,37 @@ impl Editor {
         // deterministic order — `next_window_id` is monotonic
         // so this is "creation order".
         // Dormant remote sessions (SSH / kube discovered at boot, not yet
-        // connected) have no `Window` — they live in `dormant_remote` as
-        // authority-less descriptors. They must still appear in the dock, so
-        // fold them into the snapshot alongside the live windows. A dive
-        // promotes one to a real window (removing it from `dormant_remote`), so
-        // the two collections are disjoint and never double-list a session.
-        let dormant_infos = self.dormant_remote.values().map(|d| {
-            let slot = d.plugin_state.get("orchestrator");
-            let project_path = slot
-                .and_then(|m| m.get("project_path"))
-                .and_then(|v| v.as_str())
-                .filter(|p| !p.is_empty())
-                .map(std::path::PathBuf::from)
-                .or_else(|| d.project_path.clone())
-                .unwrap_or_else(|| d.root.clone());
-            fresh_core::api::WindowInfo {
-                id: fresh_core::WindowId(d.id),
-                label: d.label.clone(),
-                root: normalize_plugin_path(d.root.clone()),
-                project_path: normalize_plugin_path(project_path),
-                shared_worktree: d.shared_worktree,
-            }
-        });
+        // connected) usually have no `Window` — they live in `dormant_remote`
+        // as authority-less descriptors. They must still appear in the dock,
+        // so fold them into the snapshot alongside the live windows. A dive
+        // promotes one to a real window (removing it from `dormant_remote`);
+        // a *failed* dive leaves the descriptor AND a disconnected shell
+        // window at the same id, so descriptors shadowed by a window are
+        // skipped to keep the list one-row-per-session.
+        let dormant_infos = self
+            .dormant_remote
+            .iter()
+            .filter(|(id, _)| !self.windows.contains_key(id))
+            .map(|(_, d)| {
+                let slot = d.plugin_state.get("orchestrator");
+                let project_path = slot
+                    .and_then(|m| m.get("project_path"))
+                    .and_then(|v| v.as_str())
+                    .filter(|p| !p.is_empty())
+                    .map(std::path::PathBuf::from)
+                    .or_else(|| d.project_path.clone())
+                    .unwrap_or_else(|| d.root.clone());
+                fresh_core::api::WindowInfo {
+                    id: fresh_core::WindowId(d.id),
+                    label: d.label.clone(),
+                    root: normalize_plugin_path(d.root.clone()),
+                    project_path: normalize_plugin_path(project_path),
+                    shared_worktree: d.shared_worktree,
+                    // Never connected (or its window would exist) — the dock
+                    // badges it as its real backend, disconnected.
+                    remote: remote_backend_info(&d.authority_spec, false),
+                }
+            });
         let mut session_infos: Vec<fresh_core::api::WindowInfo> = self
             .windows
             .values()
@@ -299,6 +339,12 @@ impl Editor {
                     root: normalize_plugin_path(s.root.clone()),
                     project_path: normalize_plugin_path(project_path),
                     shared_worktree,
+                    // A parked keepalive is what distinguishes a live remote
+                    // window from a dormant one's disconnected shell.
+                    remote: remote_backend_info(
+                        &s.authority_spec,
+                        self.session_keepalives.contains_key(&s.id),
+                    ),
                 }
             })
             .collect();
@@ -889,6 +935,13 @@ impl Editor {
                 // than activating a placeholder — see `bring_dormant_remote_online`.
                 if self.dormant_remote.contains_key(&id) {
                     self.bring_dormant_remote_online(id);
+                    // A previous failed connect left this session with a
+                    // disconnected shell window — land the dive in it (empty
+                    // editor, error indicator) while the retry connects,
+                    // instead of staying on the previous workspace.
+                    if self.windows.contains_key(&id) {
+                        self.set_active_window(id);
+                    }
                 } else {
                     self.set_active_window(id);
                 }
@@ -896,6 +949,11 @@ impl Editor {
             PluginCommand::SetActiveWindowAnimated { id, from_edge } => {
                 if self.dormant_remote.contains_key(&id) {
                     self.bring_dormant_remote_online(id);
+                    // See `SetActiveWindow`: a failed earlier connect left a
+                    // disconnected shell — the dive lands there.
+                    if self.windows.contains_key(&id) {
+                        self.set_active_window_animated(id, &from_edge);
+                    }
                 } else {
                     self.set_active_window_animated(id, &from_edge);
                 }
@@ -4044,6 +4102,14 @@ impl Editor {
         // to an already-connected window must not tear down and rebuild it. A
         // local session has nothing to reconnect.
         if self.session_keepalives.contains_key(&window_id) {
+            return;
+        }
+        // A session still descriptor-backed in `dormant_remote` (its window,
+        // when present, is the disconnected shell a failed connect built)
+        // connects through the dive gate (`bring_dormant_remote_online`) or
+        // the indicator's explicit Retry. Re-firing here would start a second
+        // connect on the very activation that surfaces a failure.
+        if self.dormant_remote.contains_key(&window_id) {
             return;
         }
         self.start_remote_reconnect(window_id);

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -930,30 +930,30 @@ impl Editor {
                 );
             }
             PluginCommand::SetActiveWindow { id } => {
-                // Diving into a dormant remote session connects its backend and
-                // promotes it to a real window (born with that authority) rather
-                // than activating a placeholder — see `bring_dormant_remote_online`.
+                // Diving into a dormant remote session starts its backend
+                // connect AND commits the switch immediately: the dive lands
+                // in the session's empty shell (status: Connecting…) rather
+                // than leaving the editor on the previous workspace while the
+                // dock already selected this one — a dead host can keep the
+                // connect in flight for minutes (issue #2570). A success
+                // promotes the shell to the fully-restored window
+                // (`promote_dormant_remote`); a failure records the reason on
+                // it (Disconnected + Retry).
                 if self.dormant_remote.contains_key(&id) {
                     self.bring_dormant_remote_online(id);
-                    // A previous failed connect left this session with a
-                    // disconnected shell window — land the dive in it (empty
-                    // editor, error indicator) while the retry connects,
-                    // instead of staying on the previous workspace.
-                    if self.windows.contains_key(&id) {
-                        self.set_active_window(id);
-                    }
+                    self.ensure_dormant_shell(id);
+                    self.set_active_window(id);
                 } else {
                     self.set_active_window(id);
                 }
             }
             PluginCommand::SetActiveWindowAnimated { id, from_edge } => {
+                // See `SetActiveWindow`: the dive commits into the session's
+                // shell while its backend connects.
                 if self.dormant_remote.contains_key(&id) {
                     self.bring_dormant_remote_online(id);
-                    // See `SetActiveWindow`: a failed earlier connect left a
-                    // disconnected shell — the dive lands there.
-                    if self.windows.contains_key(&id) {
-                        self.set_active_window_animated(id, &from_edge);
-                    }
+                    self.ensure_dormant_shell(id);
+                    self.set_active_window_animated(id, &from_edge);
                 } else {
                     self.set_active_window_animated(id, &from_edge);
                 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -940,9 +940,13 @@ impl Editor {
                 // (`promote_dormant_remote`); a failure records the reason on
                 // it (Disconnected + Retry).
                 if self.dormant_remote.contains_key(&id) {
-                    self.bring_dormant_remote_online(id);
                     self.ensure_dormant_shell(id);
                     self.set_active_window(id);
+                    // Start (or join) the backend connect AFTER the switch:
+                    // status messages are per-window, so its "Connecting
+                    // to …" lands on the now-active shell rather than on
+                    // the workspace we just left.
+                    self.bring_dormant_remote_online(id);
                 } else {
                     self.set_active_window(id);
                 }
@@ -951,9 +955,11 @@ impl Editor {
                 // See `SetActiveWindow`: the dive commits into the session's
                 // shell while its backend connects.
                 if self.dormant_remote.contains_key(&id) {
-                    self.bring_dormant_remote_online(id);
                     self.ensure_dormant_shell(id);
                     self.set_active_window_animated(id, &from_edge);
+                    // See `SetActiveWindow`: connect starts after the
+                    // switch so its status lands on the shell.
+                    self.bring_dormant_remote_online(id);
                 } else {
                     self.set_active_window_animated(id, &from_edge);
                 }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -490,7 +490,10 @@ impl Editor {
             || self.active_window().terminal_mode
             || self.dock.as_ref().is_some_and(|d| d.focused)
             || settings_visible
-            || self.keybinding_editor.is_some();
+            || self.keybinding_editor.is_some()
+            // A dormant remote session's shell renders as a placeholder
+            // page (no editable buffer), so no text cursor either.
+            || self.dormant_remote.contains_key(&self.active_window);
 
         // Convert HoverTarget to tab hover info for rendering
         let hovered_tab = match &self.active_window_mut().mouse_state.hover_target {
@@ -631,6 +634,16 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .active_split();
         self.maybe_start_cursor_jump_animation(pending_hardware_cursor, active_split);
+
+        // A dormant remote session's shell shows a placeholder page instead
+        // of an (empty, uneditable) buffer: nothing can be shown or edited
+        // until the backend connects, so painting a tab bar and a "[No
+        // Name]" scratch buffer misrepresents the state. Painted over the
+        // content area after the split renderer so it composes with the
+        // chrome (menu, dock, status bar) without forking the render flow.
+        if self.dormant_remote.contains_key(&self.active_window) {
+            self.render_dormant_shell_page(frame, editor_content_area);
+        }
 
         // Detect viewport changes and fire hooks
         // Compare against previous frame's viewport state (stored in self.active_window().previous_viewports)
@@ -1483,6 +1496,97 @@ impl Editor {
     /// into the given rect and makes no layout decisions. A no-op when the
     /// explorer isn't materialised (mid-sync the rect stays reserved but
     /// blank).
+    /// Placeholder page for a dormant remote session's shell: the workspace
+    /// cannot show (or edit) anything until its backend connects, so instead
+    /// of a tab bar + empty scratch buffer the content area is a blank page
+    /// with the session's backend identity and live connection state —
+    /// Connecting… while the dive's connect is in flight, the failure reason
+    /// once it failed. The dock stays the way to switch away or retry.
+    fn render_dormant_shell_page(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
+        use ratatui::style::{Modifier, Style};
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let active_id = self.active_window;
+        let window = self.windows.get(&active_id).expect("active window exists");
+        let label = window.label.clone();
+        let detail =
+            crate::app::plugin_dispatch::remote_backend_info(&window.authority_spec, false)
+                .map(|r| {
+                    let glyph = if r.kind == "kubernetes" { "⎈" } else { "⇅" };
+                    format!("{glyph} {label} — {}", r.detail)
+                })
+                .unwrap_or_else(|| format!("⇅ {label}"));
+        let connecting = self
+            .remote_attach_inflight
+            .contains(&(u64::MAX - active_id.0));
+        let state_line = if connecting {
+            "Connecting…".to_string()
+        } else if let Some(reason) = &window.remote_reconnect_error {
+            format!("Disconnected — {reason}")
+        } else {
+            "Not connected".to_string()
+        };
+        let hint = "This workspace is unavailable until its connection is established.";
+        let retry_hint = "Select it again in the dock (or use the status-bar indicator) to retry.";
+
+        let (bg, fg, dim) = {
+            let theme = self.theme.read().unwrap();
+            (theme.editor_bg, theme.editor_fg, theme.line_number_fg)
+        };
+        let buf = frame.buffer_mut();
+        // Blank the whole content area — over the tab bar and scratch buffer
+        // the split renderer just painted.
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if let Some(cell) = buf.cell_mut(ratatui::layout::Position::new(x, y)) {
+                    cell.set_symbol(" ");
+                    cell.set_style(Style::default().bg(bg));
+                }
+            }
+        }
+        // Centered message block.
+        let lines: [(&str, Style); 5] = [
+            (
+                detail.as_str(),
+                Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
+            ),
+            ("", Style::default().bg(bg)),
+            (state_line.as_str(), Style::default().fg(fg).bg(bg)),
+            ("", Style::default().bg(bg)),
+            (hint, Style::default().fg(dim).bg(bg)),
+        ];
+        let block_height = lines.len() as u16 + 1;
+        let top = area.top() + area.height.saturating_sub(block_height) / 2;
+        let draw_centered =
+            |buf: &mut ratatui::buffer::Buffer, y: u16, text: &str, style: Style| {
+                if y >= area.bottom() || text.is_empty() {
+                    return;
+                }
+                // Truncate to the area (char-boundary safe) with an ellipsis.
+                let max = area.width.saturating_sub(2) as usize;
+                let truncated: String = if text.chars().count() > max {
+                    let mut t: String = text.chars().take(max.saturating_sub(1)).collect();
+                    t.push('…');
+                    t
+                } else {
+                    text.to_string()
+                };
+                let w = truncated.chars().count() as u16;
+                let x = area.left() + area.width.saturating_sub(w) / 2;
+                buf.set_string(x, y, &truncated, style);
+            };
+        for (i, (text, style)) in lines.iter().enumerate() {
+            draw_centered(buf, top + i as u16, text, *style);
+        }
+        draw_centered(
+            buf,
+            top + lines.len() as u16,
+            retry_hint,
+            Style::default().fg(dim).bg(bg),
+        );
+    }
+
     fn render_file_explorer(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
         // Get connection string before mutable borrow of file_explorer.
         let remote_connection = self.connection_display_string();

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1510,13 +1510,14 @@ impl Editor {
         let active_id = self.active_window;
         let window = self.windows.get(&active_id).expect("active window exists");
         let label = window.label.clone();
-        let detail =
-            crate::app::plugin_dispatch::remote_backend_info(&window.authority_spec, false)
-                .map(|r| {
-                    let glyph = if r.kind == "kubernetes" { "⎈" } else { "⇅" };
-                    format!("{glyph} {label} — {}", r.detail)
-                })
-                .unwrap_or_else(|| format!("⇅ {label}"));
+        let detail = window
+            .authority_spec
+            .remote_backend_info(false)
+            .map(|r| {
+                let glyph = if r.kind == "kubernetes" { "⎈" } else { "⇅" };
+                format!("{glyph} {label} — {}", r.detail)
+            })
+            .unwrap_or_else(|| format!("⇅ {label}"));
         let connecting = self
             .remote_attach_inflight
             .contains(&(u64::MAX - active_id.0));
@@ -1527,8 +1528,19 @@ impl Editor {
         } else {
             "Not connected".to_string()
         };
-        let hint = "This workspace is unavailable until its connection is established.";
-        let retry_hint = "Select it again in the dock (or use the status-bar indicator) to retry.";
+        // Soft, state-appropriate hints: while connecting the workspace may
+        // open at any moment; only a recorded failure suggests retrying.
+        let (hint, retry_hint) = if connecting || window.remote_reconnect_error.is_none() {
+            (
+                "The workspace will open as soon as the connection is established.",
+                "",
+            )
+        } else {
+            (
+                "The workspace could not be loaded without its connection.",
+                "Select it again in the dock (or use the status-bar indicator) to reconnect.",
+            )
+        };
 
         let (bg, fg, dim) = {
             let theme = self.theme.read().unwrap();

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1709,6 +1709,13 @@ impl Editor {
             // Active window's last failed-reconnect error (drives a core
             // FailedAttach indicator for a dormant remote workspace).
             let remote_reconnect_error = self.active_window().remote_reconnect_error.clone();
+            // The active window is a remote session whose window-derived
+            // connect (dive / retry; see `start_remote_reconnect`'s request-id
+            // scheme) is still in flight — its shell shows `Connecting`.
+            let remote_connecting = self
+                .remote_attach_inflight
+                .contains(&(u64::MAX - self.active_window_id().0))
+                && self.active_window().authority_spec.is_remote();
 
             // Get session name for display (only in session mode)
             let session_name = self.session_name().map(|s| s.to_string());
@@ -1774,6 +1781,7 @@ impl Editor {
                         read_only: is_read_only,
                         remote_state_override: self.remote_indicator_override.as_ref(),
                         remote_reconnect_error: remote_reconnect_error.as_deref(),
+                        remote_connecting,
                         is_synthetic_placeholder,
                         // Filled in by `render_status` from the user's
                         // status_bar config; the value here is just a

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -1092,6 +1092,14 @@ impl crate::app::Editor {
         // session as its real (not-yet-connected) backend and a retry knows
         // what to reconnect to — never downgraded to local.
         window.authority_spec = descriptor.authority_spec.clone();
+        // The shell renders as a placeholder page (see
+        // `render_dormant_shell_page`), not as an editable buffer — nothing
+        // can be meaningfully edited before the backend connects. Seed the
+        // layout here (so the renderer has a populated `splits`) and lock
+        // its scratch buffer.
+        window.seed_initial_layout();
+        let seed_buffer = window.active_buffer();
+        window.mark_buffer_read_only(seed_buffer, true);
         self.windows.insert(id, window);
     }
 

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -806,10 +806,15 @@ impl crate::app::Editor {
     ///
     /// Returns `true` on success, `false` on rejection.
     pub fn close_window(&mut self, id: WindowId) -> bool {
-        // A dormant remote session has no `Window` and no live connection —
-        // closing it just drops its descriptor so it leaves the dock. (It can
-        // never be the active window, and isn't the "last window".)
-        if self.dormant_remote.remove(&id).is_some() {
+        // A dormant remote session usually has no `Window` and no live
+        // connection — closing it just drops its descriptor so it leaves the
+        // dock. (Without a window it can never be active, and isn't the
+        // "last window".) A dormant session that DOES have a window — the
+        // disconnected shell a failed reconnect leaves behind — falls through
+        // to the normal close path below (which honours the active/last-window
+        // guards) and drops its descriptor together with the window.
+        if self.dormant_remote.contains_key(&id) && !self.windows.contains_key(&id) {
+            self.dormant_remote.remove(&id);
             self.plugin_manager
                 .read()
                 .unwrap()
@@ -831,6 +836,9 @@ impl crate::app::Editor {
             tracing::warn!("close_window: unknown session id {id}");
             return false;
         }
+        // Closing a dormant session's disconnected shell drops the whole
+        // session: the descriptor must leave the dock with the window.
+        self.dormant_remote.remove(&id);
         // Tear down a born-attached remote session's connection (carrier +
         // reconnect/heartbeat + runtime) when its window closes. No-op for
         // local windows, which never have an entry.
@@ -924,6 +932,12 @@ impl crate::app::Editor {
         if self.remote_attach_inflight.contains(&request_id) {
             return; // a connect for this session is already in flight
         }
+        // A prior failed connect may have left a disconnected shell window
+        // for this session — clear its recorded failure so the indicator
+        // shows "Connecting" (not a stale error) while this retry runs.
+        if let Some(w) = self.windows.get_mut(&id) {
+            w.remote_reconnect_error = None;
+        }
         // `start_remote_connect` posts a "Connecting to …" status and, on
         // success, emits `RemoteAttachReady` in `Reconnect { window_id: id }`
         // mode — which `promote_dormant_remote` turns into the live window. The
@@ -1000,14 +1014,89 @@ impl crate::app::Editor {
         window.terminal_height = self.terminal_height;
         window.plugin_state = descriptor.plugin_state.clone();
         window.authority_spec = descriptor.authority_spec.clone();
+        // Captured before the insert below swaps the active window's
+        // authority out from under `self.authority()` — only meaningful for
+        // the already-active case, where it is the disconnected shell's
+        // placeholder label.
+        let previous_authority_label = self.authority().display_label.clone();
+        let already_active = self.active_window == id;
         self.windows.insert(id, window);
         self.session_keepalives.insert(id, keepalive);
 
-        // Activate through the normal switch path: nothing to materialize
-        // (already restored), no reconnect re-trigger (keepalive now parked),
-        // and it adopts the new authority into the editor caches, fires
-        // `active_window_changed`, and relayouts.
-        self.set_active_window(id);
+        if already_active {
+            // The restored window replaced this session's disconnected shell
+            // (a failed earlier connect committed the switch), which was
+            // already the active window — `set_active_window` would no-op.
+            // Run the switch tail it would have run: adopt the connected
+            // authority into the editor caches, refresh the plugin snapshot,
+            // re-sync terminal mode for the restored active buffer, and
+            // relayout.
+            self.adopt_active_window_authority(&previous_authority_label);
+            #[cfg(feature = "plugins")]
+            self.update_plugin_state_snapshot();
+            self.sync_terminal_mode_to_active_buffer();
+            self.relayout();
+        } else {
+            // Activate through the normal switch path: nothing to materialize
+            // (already restored), no reconnect re-trigger (keepalive now
+            // parked), and it adopts the new authority into the editor
+            // caches, fires `active_window_changed`, and relayouts.
+            self.set_active_window(id);
+        }
         self.set_status_message(format!("Connected: {}", descriptor.label));
+    }
+
+    /// A dormant remote session's dive-triggered connect **failed**: commit
+    /// the switch anyway, into an **empty disconnected shell** for that
+    /// workspace, instead of silently staying on the previous window (which
+    /// left the dock claiming a workspace the editor never entered —
+    /// issue #2570).
+    ///
+    /// The shell is a real `Window` on a local placeholder authority with
+    /// nothing restored into it: its persisted workspace can only be restored
+    /// through the connected backend, so it stays on disk, authoritative
+    /// (`save_workspace_for` skips descriptor-backed ids). The descriptor is
+    /// deliberately **kept** in `dormant_remote`, so a later dive retries the
+    /// connect and a success still lands in `promote_dormant_remote` — which
+    /// replaces this shell with the fully-restored window. The recorded
+    /// `reason` drives the status bar's disconnected indicator (and its
+    /// Retry popup) while the shell is active.
+    pub(crate) fn activate_failed_dormant_placeholder(&mut self, id: WindowId, reason: String) {
+        let Some(descriptor) = self.dormant_remote.get(&id) else {
+            return;
+        };
+        let root = descriptor.root.clone();
+        // Same per-session local scope a boot-discovered local shell gets:
+        // its own trust + env handles, never a clone of the previous
+        // window's.
+        let authority = crate::services::authority::Authority::local_scoped(
+            crate::services::authority::SessionScope::for_root(
+                &root,
+                &self.dir_context.project_state_dir(&root),
+            ),
+        );
+        let mut window = Window::new(
+            id,
+            descriptor.label.clone(),
+            root,
+            authority,
+            self.window_resources(),
+        );
+        window.terminal_width = self.terminal_width;
+        window.terminal_height = self.terminal_height;
+        window.plugin_state = descriptor.plugin_state.clone();
+        // Keep the backend identity so the status bar / dock present the
+        // session as its real (disconnected) backend and a retry knows what
+        // to reconnect to — never downgraded to local.
+        window.authority_spec = descriptor.authority_spec.clone();
+        window.remote_reconnect_error = Some(reason);
+        self.windows.insert(id, window);
+        // The normal switch path seeds the empty layout and fires
+        // `active_window_changed`, so the dock keeps this session selected
+        // as the (now genuinely) active one. Its reconnect re-trigger is a
+        // no-op here: `reconnect_dormant_session_if_needed` skips
+        // descriptor-backed sessions, whose connects are owned by the dive
+        // gate (`bring_dormant_remote_online`).
+        self.set_active_window(id);
     }
 }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -1046,22 +1046,25 @@ impl crate::app::Editor {
         self.set_status_message(format!("Connected: {}", descriptor.label));
     }
 
-    /// A dormant remote session's dive-triggered connect **failed**: commit
-    /// the switch anyway, into an **empty disconnected shell** for that
-    /// workspace, instead of silently staying on the previous window (which
-    /// left the dock claiming a workspace the editor never entered —
-    /// issue #2570).
+    /// Ensure a dormant remote session has its **empty shell** `Window`, so a
+    /// dive can commit the switch immediately — before (and regardless of
+    /// whether) its backend connect resolves (issue #2570: the dock must
+    /// never select a workspace the editor didn't actually enter, and a dead
+    /// host can keep the connect in flight for minutes).
     ///
     /// The shell is a real `Window` on a local placeholder authority with
     /// nothing restored into it: its persisted workspace can only be restored
     /// through the connected backend, so it stays on disk, authoritative
     /// (`save_workspace_for` skips descriptor-backed ids). The descriptor is
-    /// deliberately **kept** in `dormant_remote`, so a later dive retries the
+    /// deliberately **kept** in `dormant_remote`, so diving again retries the
     /// connect and a success still lands in `promote_dormant_remote` — which
-    /// replaces this shell with the fully-restored window. The recorded
-    /// `reason` drives the status bar's disconnected indicator (and its
-    /// Retry popup) while the shell is active.
-    pub(crate) fn activate_failed_dormant_placeholder(&mut self, id: WindowId, reason: String) {
+    /// replaces this shell with the fully-restored window. While the shell is
+    /// active, the status bar presents the in-flight connect as `Connecting`
+    /// and a recorded failure as `Disconnected` (with the Retry popup).
+    pub(crate) fn ensure_dormant_shell(&mut self, id: WindowId) {
+        if self.windows.contains_key(&id) {
+            return;
+        }
         let Some(descriptor) = self.dormant_remote.get(&id) else {
             return;
         };
@@ -1086,11 +1089,26 @@ impl crate::app::Editor {
         window.terminal_height = self.terminal_height;
         window.plugin_state = descriptor.plugin_state.clone();
         // Keep the backend identity so the status bar / dock present the
-        // session as its real (disconnected) backend and a retry knows what
-        // to reconnect to — never downgraded to local.
+        // session as its real (not-yet-connected) backend and a retry knows
+        // what to reconnect to — never downgraded to local.
         window.authority_spec = descriptor.authority_spec.clone();
-        window.remote_reconnect_error = Some(reason);
         self.windows.insert(id, window);
+    }
+
+    /// A dormant remote session's dive-triggered connect **failed** while the
+    /// session has no window yet: commit the switch into its empty shell and
+    /// record the reason (drives the `Disconnected` indicator + Retry popup).
+    /// With dives committing the switch up front this is a fallback — it only
+    /// fires when a connect was started without the shell (or the shell was
+    /// closed while the connect was in flight).
+    pub(crate) fn activate_failed_dormant_placeholder(&mut self, id: WindowId, reason: String) {
+        if !self.dormant_remote.contains_key(&id) {
+            return;
+        }
+        self.ensure_dormant_shell(id);
+        if let Some(w) = self.windows.get_mut(&id) {
+            w.remote_reconnect_error = Some(reason);
+        }
         // The normal switch path seeds the empty layout and fires
         // `active_window_changed`, so the dock keeps this session selected
         // as the (now genuinely) active one. Its reconnect re-trigger is a

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -414,6 +414,14 @@ impl Editor {
     /// snapshots via `Window::capture_workspace`, and injects the
     /// editor-global `plugin_global_state`.
     pub fn save_workspace_for(&mut self, id: fresh_core::WindowId) -> Result<(), WorkspaceError> {
+        // A session still descriptor-backed in `dormant_remote` never had its
+        // workspace restored: its window, when present, is only the empty
+        // disconnected shell a failed reconnect built. The on-disk workspace —
+        // written by the last *connected* session — is authoritative; saving
+        // the shell would clobber the real layout (and its terminals).
+        if self.dormant_remote.contains_key(&id) {
+            return Ok(());
+        }
         let Some(win) = self.windows.get(&id) else {
             return Ok(());
         };

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -828,6 +828,37 @@ impl SessionAuthoritySpec {
     pub fn is_remote(&self) -> bool {
         !matches!(self, Self::Local)
     }
+
+    /// Reduce this backend spec to the [`fresh_core::api::RemoteBackendInfo`]
+    /// facet the dock and the dormant-shell page render (`None` for local
+    /// sessions, and for plugin-managed backends whose facet the owning
+    /// plugin supplies itself). The `kind` strings match the plugin API's
+    /// `SessionBackend` values.
+    pub fn remote_backend_info(
+        &self,
+        connected: bool,
+    ) -> Option<fresh_core::api::RemoteBackendInfo> {
+        let Self::RemoteAgent(agent) = self else {
+            return None;
+        };
+        let (kind, detail) = match &agent.transport {
+            RemoteTransportSpec::Ssh { user, host, .. } => (
+                "ssh",
+                match user.as_deref().filter(|u| !u.is_empty()) {
+                    Some(user) => format!("{user}@{host}"),
+                    None => host.clone(),
+                },
+            ),
+            RemoteTransportSpec::KubectlExec { namespace, pod, .. } => {
+                ("kubernetes", format!("{namespace}/{pod}"))
+            }
+        };
+        Some(fresh_core::api::RemoteBackendInfo {
+            kind: kind.to_string(),
+            detail,
+            connected,
+        })
+    }
 }
 
 /// Plugin payload for `editor.attachRemoteAgent(...)`. Names a transport

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -274,6 +274,12 @@ pub struct StatusBarContext<'a> {
     /// override, but scoped to the active window so a failed SSH/kube reconnect
     /// can't bleed onto another window's indicator.
     pub remote_reconnect_error: Option<&'a str>,
+    /// True when the active window is a dormant remote session's shell whose
+    /// backend connect is currently in flight — the dive committed the switch
+    /// while the SSH/kube handshake is still pending. Renders the `{remote}`
+    /// indicator as `Connecting` instead of the placeholder authority's
+    /// misleading "Local".
+    pub remote_connecting: bool,
     /// True when the active buffer is the synthesized placeholder kept
     /// alive by the close path with `auto_create_empty_buffer_on_last_buffer_close`
     /// disabled. Buffer-specific elements (filename, cursor, line ending,
@@ -1196,6 +1202,13 @@ impl StatusBarRenderer {
                 // derived states synthesize one from `remote_connection`.
                 let (text, state) = if let Some(over) = ctx.remote_state_override {
                     (over.label(), over.state())
+                } else if ctx.remote_connecting {
+                    // The active window is a dormant remote session's shell
+                    // whose backend connect is in flight (dive-committed
+                    // switch / retry). Without this the shell — which runs
+                    // on a local placeholder authority — would claim
+                    // "Local" while the status message says Connecting.
+                    ("Connecting…".to_string(), RemoteIndicatorState::Connecting)
                 } else if ctx.remote_reconnect_error.is_some() {
                     // A reconnect of the active window's remote workspace failed.
                     // Keep the indicator short — just "Disconnected" — rather

--- a/crates/fresh-editor/tests/common/dormant_ssh.rs
+++ b/crates/fresh-editor/tests/common/dormant_ssh.rs
@@ -1,0 +1,115 @@
+//! Shared scaffolding for the issue-#2570 dormant-SSH-workspace reproducers
+//! (`orchestrator_dock_failed_reconnect.rs`,
+//! `orchestrator_dock_dormant_ssh_badge.rs`).
+//!
+//! Persistence isolation: `Workspace::save`/`load` live under the *global*
+//! `$XDG_DATA_HOME/fresh`, while the harness's boot discovery reads the
+//! `DirectoryContext` it is built with. [`isolated_dir_context`] points BOTH
+//! at the same per-test temp tree so phase-1 saves are what phase-2 discovery
+//! finds — and nothing touches the real user data dir. Setting the env var is
+//! process-global, so each test binary using this module must hold a single
+//! test (the same constraint `remote_restore_terminal_e2e.rs` documents).
+
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+
+use fresh::config_io::DirectoryContext;
+use fresh::services::authority::{RemoteAgentSpec, RemoteTransportSpec, SessionAuthoritySpec};
+
+use super::harness::{EditorTestHarness, HarnessOptions};
+
+static PATH_INIT: Once = Once::new();
+
+/// Prepend the fake-ssh fixtures dir to PATH once, so `Command::new("ssh")`
+/// resolves to the always-failing shim (`tests/fixtures/fake-ssh`) — a
+/// deterministic "unreachable host" with no network involved. `Once` keeps
+/// the process-global env mutation from racing across tests in a binary.
+pub fn ensure_fake_ssh_on_path() {
+    PATH_INIT.call_once(|| {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-ssh");
+        assert!(
+            dir.join("ssh").exists(),
+            "fake ssh shim missing at {}",
+            dir.display()
+        );
+        let old = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{old}", dir.display()));
+    });
+}
+
+/// Isolate ALL editor persistence into `base`: `$XDG_DATA_HOME/fresh` is
+/// where workspace save/load live, and the returned `DirectoryContext`'s
+/// `data_dir` is the SAME path — so phase-1 saves, boot discovery, and any
+/// later save all agree, inside the test's temp tree.
+pub fn isolated_dir_context(base: &Path) -> DirectoryContext {
+    let xdg_data = base.join("xdg-data");
+    std::fs::create_dir_all(&xdg_data).unwrap();
+    std::env::set_var("XDG_DATA_HOME", &xdg_data);
+    DirectoryContext {
+        data_dir: xdg_data.join("fresh"),
+        config_dir: base.join("config"),
+        home_dir: Some(base.join("home")),
+        documents_dir: None,
+        downloads_dir: None,
+    }
+}
+
+/// An SSH `authority_spec` for a host the fake shim "fails to reach".
+pub fn dead_ssh_spec(remote_path: &Path) -> SessionAuthoritySpec {
+    SessionAuthoritySpec::RemoteAgent(RemoteAgentSpec {
+        transport: RemoteTransportSpec::Ssh {
+            user: Some("root".to_string()),
+            host: "dead-host".to_string(),
+            port: Some(2222),
+            identity_file: None,
+            remote_path: Some(remote_path.to_string_lossy().into_owned()),
+            extra_args: Vec::new(),
+        },
+        base_env: Vec::new(),
+        window: true,
+        label: Some("ssh-dead".to_string()),
+        command: None,
+    })
+}
+
+pub fn canonical_mkdir(base: &Path, name: &str) -> PathBuf {
+    let p = base.join(name);
+    std::fs::create_dir_all(&p).unwrap();
+    p.canonicalize().unwrap_or(p)
+}
+
+/// The "previous session" both reproducers restart from: it leaves behind a
+/// local project workspace (with `local_marker.txt` open) and a persisted
+/// SSH workspace labelled `ssh-dead` (with `remote_notes.txt` open and a
+/// `RemoteAgent` backend spec).
+pub fn persist_previous_session(
+    dir_context: &DirectoryContext,
+    project: &Path,
+    remote_root: &Path,
+    with_plugins: bool,
+) {
+    let mut opts = HarnessOptions::new()
+        .with_working_dir(project.to_path_buf())
+        .with_shared_dir_context(dir_context.clone());
+    if !with_plugins {
+        opts = opts.with_empty_plugins_dir();
+    }
+    let mut h = EditorTestHarness::create(120, 36, opts).unwrap();
+
+    std::fs::write(project.join("local_marker.txt"), "LOCAL MARKER\n").unwrap();
+    h.open_file(&project.join("local_marker.txt")).unwrap();
+
+    // The remote session: give it real content so its on-disk workspace has
+    // something a stray save could clobber, then tag it remote. The spec is
+    // set *after* the content so nothing tries to connect in this phase.
+    std::fs::write(remote_root.join("remote_notes.txt"), "REMOTE NOTES\n").unwrap();
+    let a = h
+        .editor_mut()
+        .create_window_at(remote_root.to_path_buf(), "ssh-dead".to_string());
+    h.editor_mut().set_active_window(a);
+    h.open_file(&remote_root.join("remote_notes.txt")).unwrap();
+    h.editor_mut()
+        .set_session_authority_spec(a, dead_ssh_spec(remote_root));
+
+    h.editor_mut().save_all_windows_workspaces().unwrap();
+}

--- a/crates/fresh-editor/tests/common/dormant_ssh.rs
+++ b/crates/fresh-editor/tests/common/dormant_ssh.rs
@@ -25,16 +25,29 @@ static PATH_INIT: Once = Once::new();
 /// deterministic "unreachable host" with no network involved. `Once` keeps
 /// the process-global env mutation from racing across tests in a binary.
 pub fn ensure_fake_ssh_on_path() {
-    PATH_INIT.call_once(|| {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-ssh");
-        assert!(
-            dir.join("ssh").exists(),
-            "fake ssh shim missing at {}",
-            dir.display()
-        );
-        let old = std::env::var("PATH").unwrap_or_default();
-        std::env::set_var("PATH", format!("{}:{old}", dir.display()));
-    });
+    PATH_INIT.call_once(|| prepend_shim_dir("tests/fixtures/fake-ssh"));
+}
+
+static HANG_PATH_INIT: Once = Once::new();
+
+/// Like [`ensure_fake_ssh_on_path`], but the shim **hangs** instead of
+/// failing (`tests/fixtures/fake-ssh-hang`): a host that accepts the TCP
+/// connection and never completes the SSH handshake, so the connect stays
+/// in-flight for the whole test — the "shut-down host that drops packets"
+/// shape, which never produces a prompt failure.
+pub fn ensure_hanging_fake_ssh_on_path() {
+    HANG_PATH_INIT.call_once(|| prepend_shim_dir("tests/fixtures/fake-ssh-hang"));
+}
+
+fn prepend_shim_dir(rel: &str) {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    assert!(
+        dir.join("ssh").exists(),
+        "fake ssh shim missing at {}",
+        dir.display()
+    );
+    let old = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{old}", dir.display()));
 }
 
 /// Isolate ALL editor persistence into `base`: `$XDG_DATA_HOME/fresh` is

--- a/crates/fresh-editor/tests/common/mod.rs
+++ b/crates/fresh-editor/tests/common/mod.rs
@@ -5,6 +5,9 @@
 pub mod blog_showcase;
 #[cfg(test)]
 #[allow(dead_code)]
+pub mod dormant_ssh;
+#[cfg(test)]
+#[allow(dead_code)]
 pub mod fake_lsp;
 #[cfg(test)]
 #[allow(dead_code)]

--- a/crates/fresh-editor/tests/fixtures/fake-ssh-hang/ssh
+++ b/crates/fresh-editor/tests/fixtures/fake-ssh-hang/ssh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Fake `ssh` for tests: models a connect that HANGS — a host that accepts the
+# TCP connection but never completes the SSH handshake (or silently drops
+# packets). It drains stdin (so the parent's agent-bootstrap write doesn't
+# block) and then sleeps far past any test horizon without ever printing the
+# agent-ready line or exiting, exactly like `ssh` against a dead-but-routed
+# endpoint. The parent kills it via kill-on-drop when the connect future is
+# dropped.
+cat >/dev/null 2>&1 &
+sleep 600

--- a/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
@@ -95,7 +95,8 @@ fn dive_commits_switch_while_connect_is_still_pending() {
     h.assert_screen_not_contains("remote_notes.txt");
     h.wait_until(|h| {
         let scr = h.screen_to_string();
-        scr.contains("This workspace is unavailable") && !scr.contains("[No Name]")
+        scr.contains("will open as soon as the connection is established")
+            && !scr.contains("[No Name]")
     })
     .unwrap();
     // Nothing is editable before the connection exists: typing must be

--- a/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
@@ -89,8 +89,24 @@ fn dive_commits_switch_while_connect_is_still_pending() {
     );
     h.wait_until(|h| h.screen_to_string().contains("Connecting"))
         .unwrap();
-    // The shell is EMPTY — nothing restored without the backend.
+    // The shell is EMPTY — nothing restored without the backend — and it
+    // renders as a placeholder page, not as an editable scratch buffer: no
+    // "[No Name]" tab, a message instead.
     h.assert_screen_not_contains("remote_notes.txt");
+    h.wait_until(|h| {
+        let scr = h.screen_to_string();
+        scr.contains("This workspace is unavailable") && !scr.contains("[No Name]")
+    })
+    .unwrap();
+    // Nothing is editable before the connection exists: typing must be
+    // swallowed by the read-only placeholder, not land in a hidden buffer.
+    h.type_text("XYZ").unwrap();
+    h.process_async_and_render().unwrap();
+    assert!(
+        !h.get_buffer_content().unwrap_or_default().contains("XYZ"),
+        "typing into the placeholder page must not edit anything"
+    );
+    h.assert_screen_not_contains("XYZ");
 
     // The user is not trapped in the pending shell: switching back to the
     // local workspace works while the connect is still in flight.

--- a/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_connecting_commit.rs
@@ -1,0 +1,101 @@
+//! Reproducer for issue #2570's *connecting-limbo* variant (user report on
+//! PR #2575): diving onto a dormant SSH workspace whose host **hangs** —
+//! accepts the TCP connection but never completes the SSH handshake, the
+//! shape of a shut-down host that drops packets — used to leave the editor
+//! on the previous workspace for the whole (potentially minutes-long)
+//! connect attempt, while the dock had already highlighted the SSH row and
+//! the status bar said "Connecting…".
+//!
+//! Now the dive **commits the switch immediately**: the SSH session's empty
+//! shell becomes the active window while the connect is still in flight, so
+//! the dock's selection and the editor view always agree (an empty/progress
+//! page counts; the previous workspace on screen does not).
+//!
+//! The hang is deterministic via the `tests/fixtures/fake-ssh-hang` shim —
+//! no network involved. Single test in this binary: the persistence
+//! isolation sets the process-global `XDG_DATA_HOME` (see
+//! `common::dormant_ssh::isolated_dir_context`), and the PATH shim is
+//! likewise process-global.
+//!
+//! Plugins-gated: the dormant-session dive only connects with the plugin
+//! runtime present. Linux-gated like the sibling reproducers (XDG-based
+//! isolation, Unix shell shim).
+#![cfg(all(target_os = "linux", feature = "plugins"))]
+
+mod common;
+
+use common::dormant_ssh::{
+    canonical_mkdir, ensure_hanging_fake_ssh_on_path, isolated_dir_context,
+    persist_previous_session,
+};
+use common::harness::{EditorTestHarness, HarnessOptions};
+use fresh_core::api::PluginCommand;
+
+/// While the connect is still pending, the dive must already have switched
+/// the editor into the SSH workspace's empty shell — Connecting state on
+/// screen, previous workspace's buffers gone — and switching back must work
+/// without waiting for the connect to resolve.
+#[test]
+fn dive_commits_switch_while_connect_is_still_pending() {
+    common::tracing::init_tracing_from_env();
+    ensure_hanging_fake_ssh_on_path();
+    fresh::i18n::set_locale("en");
+
+    let base = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(base.path());
+    let project = canonical_mkdir(base.path(), "project");
+    let remote_root = canonical_mkdir(base.path(), "remote-root");
+
+    persist_previous_session(&dir_context, &project, &remote_root, false);
+
+    let mut h = EditorTestHarness::create(
+        120,
+        36,
+        HarnessOptions::new()
+            .with_working_dir(project.clone())
+            .with_shared_dir_context(dir_context.clone())
+            .with_empty_plugins_dir(),
+    )
+    .unwrap();
+    // A visible buffer in the local workspace — the thing that must LEAVE
+    // the screen the moment the dive commits.
+    h.open_file(&project.join("local_marker.txt")).unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+    let local_id = h.editor().active_window_id();
+
+    let dormant = h.editor().dormant_remote_sessions_for_test();
+    let ssh_id = dormant
+        .iter()
+        .find(|(_, l)| l == "ssh-dead")
+        .map(|(id, _)| *id)
+        .expect("the SSH session must come back as a dormant descriptor");
+
+    // Dive, exactly as the dock's click/live-switch does. The fake ssh hangs
+    // forever, so nothing below is reachable by waiting for the connect to
+    // resolve — the switch has to happen up front.
+    h.editor_mut()
+        .handle_plugin_command(PluginCommand::SetActiveWindow { id: ssh_id })
+        .unwrap();
+
+    // The switch is committed immediately: the previous workspace's buffer
+    // leaves the screen and the SSH session's shell is the active window,
+    // presenting itself as Connecting.
+    h.wait_until(|h| !h.screen_to_string().contains("local_marker.txt"))
+        .unwrap();
+    assert_eq!(
+        h.editor().active_window_id(),
+        ssh_id,
+        "the dive must land in the tried workspace while the connect is pending"
+    );
+    h.wait_until(|h| h.screen_to_string().contains("Connecting"))
+        .unwrap();
+    // The shell is EMPTY — nothing restored without the backend.
+    h.assert_screen_not_contains("remote_notes.txt");
+
+    // The user is not trapped in the pending shell: switching back to the
+    // local workspace works while the connect is still in flight.
+    h.editor_mut()
+        .handle_plugin_command(PluginCommand::SetActiveWindow { id: local_id })
+        .unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+}

--- a/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
@@ -25,6 +25,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
 fn dock_lists_dormant_ssh_session_with_backend_badge_and_dive_commits() {
+    common::tracing::init_tracing_from_env();
     ensure_fake_ssh_on_path();
     fresh::i18n::set_locale("en");
 
@@ -63,6 +64,10 @@ fn dock_lists_dormant_ssh_session_with_backend_badge_and_dive_commits() {
             .any(|c| c.get_localized_name() == "Orchestrator: Toggle Dock")
     })
     .unwrap();
+    // A visible buffer in the local workspace — the thing that must LEAVE
+    // the screen when the dive commits. (Opened explicitly: the harness's
+    // `create` doesn't run the production foreground-workspace restore.)
+    h.open_file(&project.join("local_marker.txt")).unwrap();
     h.wait_for_screen_contains("local_marker.txt").unwrap();
 
     // Open the dock via the command palette.
@@ -75,10 +80,12 @@ fn dock_lists_dormant_ssh_session_with_backend_badge_and_dive_commits() {
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
 
     // The dormant SSH session is listed — WITHOUT flipping "show empty" —
-    // and badged as a (disconnected) SSH backend: glyph + `user@host` detail.
+    // and badged as a (disconnected) SSH backend: glyph + `user@host` detail
+    // (the detail may be ellipsis-truncated on a narrow card, so match its
+    // prefix).
     h.wait_until(|h| {
         let scr = h.screen_to_string();
-        scr.contains("ssh-dead") && scr.contains("⇅") && scr.contains("root@dead-host")
+        scr.contains("ssh-dead") && scr.contains("⇅") && scr.contains("root@")
     })
     .unwrap();
 

--- a/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
@@ -1,0 +1,104 @@
+//! Dock-level reproducer for issue #2570's display gaps: a dormant SSH
+//! session restored from disk must be *presented* as a remote (disconnected)
+//! workspace.
+//!
+//! Before the fix the dormant row carried no backend facet, so it rendered
+//! exactly like a local session AND was swallowed by the dock's default
+//! "hide trivial" filter — the user had to toggle "show empty" to even see
+//! it. Driven end-to-end through the real dock UI (orchestrator plugin):
+//! toggle the dock, see the badged row, arrow onto it, and observe the failed
+//! dive land in the (empty) SSH workspace with the dock still listing the
+//! session.
+//!
+//! Single test in this binary: the persistence isolation sets the
+//! process-global `XDG_DATA_HOME` (see
+//! `common::dormant_ssh::isolated_dir_context`).
+
+mod common;
+
+use common::dormant_ssh::{
+    canonical_mkdir, ensure_fake_ssh_on_path, isolated_dir_context, persist_previous_session,
+};
+use common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
+fn dock_lists_dormant_ssh_session_with_backend_badge_and_dive_commits() {
+    ensure_fake_ssh_on_path();
+    fresh::i18n::set_locale("en");
+
+    let base = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(base.path());
+    let project = canonical_mkdir(base.path(), "project");
+    let remote_root = canonical_mkdir(base.path(), "remote-root");
+
+    // The orchestrator plugin drives the dock; it lives in the launch
+    // project's plugins dir.
+    let plugins_dir = project.join("plugins");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    persist_previous_session(&dir_context, &project, &remote_root, true);
+
+    // Animations off so the dock's live-switch slide completes instantly
+    // under the test clock (same as the dock showcase test).
+    let mut cfg = fresh::config::Config::default();
+    cfg.editor.animations = false;
+    cfg.editor.cursor_jump_animation = false;
+    let mut h = EditorTestHarness::create(
+        140,
+        40,
+        HarnessOptions::new()
+            .with_config(cfg)
+            .with_working_dir(project.clone())
+            .with_shared_dir_context(dir_context.clone()),
+    )
+    .unwrap();
+    h.wait_until(|h| {
+        let reg = h.editor().command_registry().read().unwrap();
+        reg.get_all()
+            .iter()
+            .any(|c| c.get_localized_name() == "Orchestrator: Toggle Dock")
+    })
+    .unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+
+    // Open the dock via the command palette.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+
+    // The dormant SSH session is listed — WITHOUT flipping "show empty" —
+    // and badged as a (disconnected) SSH backend: glyph + `user@host` detail.
+    h.wait_until(|h| {
+        let scr = h.screen_to_string();
+        scr.contains("ssh-dead") && scr.contains("⇅") && scr.contains("root@dead-host")
+    })
+    .unwrap();
+
+    // Arrow onto the SSH row: the dock live-switches, the connect fails, and
+    // the switch still commits — the editor lands in the (empty) SSH
+    // workspace instead of silently staying on the local one.
+    let local_root = h.editor().active_window().root.clone();
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.editor().active_window().root != local_root)
+        .unwrap();
+    h.wait_until(|h| {
+        let scr = h.screen_to_string();
+        scr.contains("Connection failed") && !scr.contains("local_marker.txt")
+    })
+    .unwrap();
+    assert_eq!(
+        h.editor().active_window().root,
+        remote_root,
+        "the dive must commit to the SSH workspace"
+    );
+    // The dock still lists the session (it must not vanish on failure).
+    h.assert_screen_contains("ssh-dead");
+}

--- a/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_dormant_ssh_badge.rs
@@ -13,6 +13,13 @@
 //! Single test in this binary: the persistence isolation sets the
 //! process-global `XDG_DATA_HOME` (see
 //! `common::dormant_ssh::isolated_dir_context`).
+//!
+//! Plugins-gated: the dock is the orchestrator plugin's UI, and the dormant
+//! dive it drives only connects with the plugin runtime present. Linux-gated
+//! like `remote_restore_terminal_e2e.rs`, which shares the same scaffolding
+//! constraints: persistence isolation rides `XDG_DATA_HOME` (ignored by the
+//! macOS/Windows data dirs) and the fake `ssh` is a Unix shell script.
+#![cfg(all(target_os = "linux", feature = "plugins"))]
 
 mod common;
 
@@ -23,7 +30,6 @@ use common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOp
 use crossterm::event::{KeyCode, KeyModifiers};
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
 fn dock_lists_dormant_ssh_session_with_backend_badge_and_dive_commits() {
     common::tracing::init_tracing_from_env();
     ensure_fake_ssh_on_path();

--- a/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
@@ -105,8 +105,16 @@ fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
         "the tried workspace must be the active window after the failed connect"
     );
     // The shell is EMPTY: nothing of the persisted workspace can be restored
-    // without its backend, so its file must not appear.
+    // without its backend, so its file must not appear — and it renders as a
+    // placeholder page (no "[No Name]" tab) showing the disconnected state.
     h.assert_screen_not_contains("remote_notes.txt");
+    h.wait_until(|h| {
+        let scr = h.screen_to_string();
+        scr.contains("Disconnected —")
+            && scr.contains("This workspace is unavailable")
+            && !scr.contains("[No Name]")
+    })
+    .unwrap();
 
     // Quit-style save: the disconnected shell must not clobber the real
     // on-disk workspace with its empty layout.

--- a/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
@@ -111,7 +111,7 @@ fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
     h.wait_until(|h| {
         let scr = h.screen_to_string();
         scr.contains("Disconnected —")
-            && scr.contains("This workspace is unavailable")
+            && scr.contains("could not be loaded")
             && !scr.contains("[No Name]")
     })
     .unwrap();

--- a/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
@@ -32,6 +32,7 @@ use fresh_core::api::PluginCommand;
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
 fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
+    common::tracing::init_tracing_from_env();
     ensure_fake_ssh_on_path();
     fresh::i18n::set_locale("en");
 
@@ -65,6 +66,10 @@ fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
             .with_empty_plugins_dir(),
     )
     .unwrap();
+    // A visible buffer in the local workspace — the thing that must LEAVE
+    // the screen when the dive commits. (Opened explicitly: the harness's
+    // `create` doesn't run the production foreground-workspace restore.)
+    h.open_file(&project.join("local_marker.txt")).unwrap();
     h.wait_for_screen_contains("local_marker.txt").unwrap();
     let local_id = h.editor().active_window_id();
 

--- a/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
@@ -1,0 +1,123 @@
+//! Reproducer for issue #2570: switching to a persisted (dormant) SSH
+//! workspace whose backend can no longer be reached.
+//!
+//! Before the fix, the dock's dive (`SetActiveWindow` on a dormant remote
+//! session) kicked off the reconnect and, when it failed, left the editor on
+//! the *previous* workspace while the dock had already moved its selection —
+//! the UI claimed the SSH workspace was current, but the previous session's
+//! buffers stayed on screen. Now a failed connect **commits the switch**: the
+//! session gets an empty disconnected shell window (nothing restored — its
+//! on-disk workspace stays authoritative), the shell becomes the active
+//! window, and diving again retries the connect.
+//!
+//! The SSH failure is deterministic: the fake `ssh` shim in
+//! `tests/fixtures/fake-ssh` fails instantly like an unreachable host, so no
+//! network (or real ssh binary) is involved. Single test in this binary: the
+//! persistence isolation sets the process-global `XDG_DATA_HOME` (see
+//! `common::dormant_ssh::isolated_dir_context`).
+
+mod common;
+
+use common::dormant_ssh::{
+    canonical_mkdir, ensure_fake_ssh_on_path, isolated_dir_context, persist_previous_session,
+};
+use common::harness::{EditorTestHarness, HarnessOptions};
+use fresh_core::api::PluginCommand;
+
+/// Diving into a dormant SSH workspace whose connect fails must land the
+/// editor in that workspace — as an empty disconnected shell — not leave it
+/// sitting on the previous workspace while the dock claims otherwise. The
+/// shell must never overwrite the session's on-disk workspace, and a later
+/// dive must still work (retry, and switching back and forth).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
+fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
+    ensure_fake_ssh_on_path();
+    fresh::i18n::set_locale("en");
+
+    let base = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(base.path());
+    let project = canonical_mkdir(base.path(), "project");
+    let remote_root = canonical_mkdir(base.path(), "remote-root");
+
+    persist_previous_session(&dir_context, &project, &remote_root, false);
+
+    // The persisted SSH workspace file — must survive the whole test
+    // unchanged (the disconnected shell has nothing real to save).
+    let ws_file = dir_context.data_dir.join("workspaces").join(format!(
+        "{}.json",
+        fresh::workspace::encode_path_for_filename(&remote_root)
+    ));
+    let ws_before = std::fs::read_to_string(&ws_file).expect("persisted remote workspace");
+    assert!(
+        ws_before.contains("remote_notes.txt") && ws_before.contains("RemoteAgent"),
+        "sanity: the persisted remote workspace carries its content + backend spec"
+    );
+
+    // ---- The session under test: relaunch locally, dive into the dead
+    //      SSH workspace. ----
+    let mut h = EditorTestHarness::create(
+        120,
+        36,
+        HarnessOptions::new()
+            .with_working_dir(project.clone())
+            .with_shared_dir_context(dir_context.clone())
+            .with_empty_plugins_dir(),
+    )
+    .unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+    let local_id = h.editor().active_window_id();
+
+    let dormant = h.editor().dormant_remote_sessions_for_test();
+    let ssh_id = dormant
+        .iter()
+        .find(|(_, l)| l == "ssh-dead")
+        .map(|(id, _)| *id)
+        .expect("the SSH session must come back as a dormant descriptor");
+
+    // Dive, exactly as the dock's live-switch does.
+    h.editor_mut()
+        .handle_plugin_command(PluginCommand::SetActiveWindow { id: ssh_id })
+        .unwrap();
+
+    // The connect fails (fake ssh) and the failure is surfaced...
+    h.wait_until(|h| h.screen_to_string().contains("Connection failed"))
+        .unwrap();
+    // ...and the switch is COMMITTED: the previous workspace's buffer is no
+    // longer on screen (before the fix the editor stayed on it forever).
+    h.wait_until(|h| !h.screen_to_string().contains("local_marker.txt"))
+        .unwrap();
+    assert_eq!(
+        h.editor().active_window_id(),
+        ssh_id,
+        "the tried workspace must be the active window after the failed connect"
+    );
+    // The shell is EMPTY: nothing of the persisted workspace can be restored
+    // without its backend, so its file must not appear.
+    h.assert_screen_not_contains("remote_notes.txt");
+
+    // Quit-style save: the disconnected shell must not clobber the real
+    // on-disk workspace with its empty layout.
+    h.editor_mut().save_all_windows_workspaces().unwrap();
+    let ws_after = std::fs::read_to_string(&ws_file).unwrap();
+    assert_eq!(
+        ws_before, ws_after,
+        "a disconnected shell must never overwrite the session's persisted workspace"
+    );
+
+    // Switching back to the local workspace still works...
+    h.editor_mut()
+        .handle_plugin_command(PluginCommand::SetActiveWindow { id: local_id })
+        .unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+
+    // ...and diving into the SSH workspace again retries + lands in the
+    // shell again (the session stayed dormant behind it).
+    h.editor_mut()
+        .handle_plugin_command(PluginCommand::SetActiveWindow { id: ssh_id })
+        .unwrap();
+    h.wait_until(|h| h.editor().active_window_id() == ssh_id)
+        .unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("local_marker.txt"))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_failed_reconnect.rs
@@ -15,6 +15,14 @@
 //! network (or real ssh binary) is involved. Single test in this binary: the
 //! persistence isolation sets the process-global `XDG_DATA_HOME` (see
 //! `common::dormant_ssh::isolated_dir_context`).
+//!
+//! Plugins-gated: the dormant-session dive (`bring_dormant_remote_online` →
+//! `start_remote_connect`) is a no-op without the plugin runtime, and the
+//! `handle_plugin_command` entry point only exists with it. Linux-gated like
+//! `remote_restore_terminal_e2e.rs`, which shares the same scaffolding
+//! constraints: persistence isolation rides `XDG_DATA_HOME` (ignored by the
+//! macOS/Windows data dirs) and the fake `ssh` is a Unix shell script.
+#![cfg(all(target_os = "linux", feature = "plugins"))]
 
 mod common;
 
@@ -30,7 +38,6 @@ use fresh_core::api::PluginCommand;
 /// shell must never overwrite the session's on-disk workspace, and a later
 /// dive must still work (retry, and switching back and forth).
 #[test]
-#[cfg_attr(target_os = "windows", ignore)] // fake-ssh shim is a Unix shell script
 fn failed_dormant_reconnect_commits_switch_to_empty_shell() {
     common::tracing::init_tracing_from_env();
     ensure_fake_ssh_on_path();

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -10337,6 +10337,7 @@ mod tests {
                     root: std::path::PathBuf::from("/repo"),
                     project_path: std::path::PathBuf::from("/repo"),
                     shared_worktree: false,
+                    remote: None,
                 },
                 fresh_core::api::WindowInfo {
                     id: fresh_core::WindowId(2),
@@ -10344,6 +10345,7 @@ mod tests {
                     root: std::path::PathBuf::from("/wt/feat-auth"),
                     project_path: std::path::PathBuf::from("/wt/feat-auth"),
                     shared_worktree: false,
+                    remote: None,
                 },
             ];
             state.active_window_id = fresh_core::WindowId(2);

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -22,10 +22,10 @@ use fresh_core::api::{
     CreateVirtualBufferOptions, CursorInfo, DirEntry, FormatterPackConfig, GrammarInfoSnapshot,
     GrepMatch, JsDiagnostic, JsPosition, JsRange, JsTextPropertyEntry, KeyEventPayload,
     LanguagePackConfig, LayoutHints, LspServerPackConfig, OverlayColorSpec, OverlayOptions,
-    PluginAnimationEdge, PluginAnimationKind, ProcessLimitsPackConfig, ReplaceResult, ScreenSize,
-    SearchTakeResult, SpawnResult, SplitSnapshot, TerminalResult, TextPropertiesAtCursor,
-    TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire, ViewTokenWireKind, ViewportInfo,
-    VirtualBufferResult, WindowInfo,
+    PluginAnimationEdge, PluginAnimationKind, ProcessLimitsPackConfig, RemoteBackendInfo,
+    ReplaceResult, ScreenSize, SearchTakeResult, SpawnResult, SplitSnapshot, TerminalResult,
+    TextPropertiesAtCursor, TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire,
+    ViewTokenWireKind, ViewportInfo, VirtualBufferResult, WindowInfo,
 };
 use fresh_core::command::Suggestion;
 use fresh_core::file_explorer::{
@@ -51,6 +51,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         // Core types
         "BufferInfo" => Some(BufferInfo::decl(&cfg)),
         "WindowInfo" => Some(WindowInfo::decl(&cfg)),
+        "RemoteBackendInfo" => Some(RemoteBackendInfo::decl(&cfg)),
         "CursorInfo" => Some(CursorInfo::decl(&cfg)),
         "ViewportInfo" => Some(ViewportInfo::decl(&cfg)),
         "ScreenSize" => Some(ScreenSize::decl(&cfg)),
@@ -317,6 +318,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "DirEntry",                        // Used by plugins for directory entries
     "BufferInfo",                      // Used by listBuffers, getBufferInfo
     "WindowInfo",                      // Used by listWindows
+    "RemoteBackendInfo",               // Used by WindowInfo.remote
     "JsDiagnostic",                    // Used by getAllDiagnostics
     "JsRange",                         // Used by JsDiagnostic
     "JsPosition",                      // Used by JsRange
@@ -861,6 +863,7 @@ mod tests {
         let expected_types = vec![
             "BufferInfo",
             "WindowInfo",
+            "RemoteBackendInfo",
             "CursorInfo",
             "ViewportInfo",
             "ScreenSize",


### PR DESCRIPTION
Fixes #2570.

## Summary

Switching to a persisted SSH workspace via the Orchestrator dock when its host is unreachable used to leave the UI lying: the dock moved its selection to the SSH row, but the reconnect failed silently and the editor stayed on the previous workspace — its buffers still on screen under a dock claiming the SSH session was current. The dormant SSH row also rendered exactly like a local session (no backend badge) and was hidden by the default "hide trivial" filter.

Now a failed dive **commits the switch**: the session gets an **empty disconnected shell** window that becomes the active window — dock selection and editor agree — with the status bar showing `Disconnected` plus the connection-failure reason (and its Retry popup). Dormant remote rows are badged with their backend glyph and `user@host` detail, and are always listed.

## Behavior

- Dive onto a dormant SSH/Kubernetes row whose connect fails → the editor lands in an empty shell for that workspace (`[No Name]`, nothing restored); the previous workspace's buffers leave the screen.
- The shell **never** overwrites the session's persisted workspace — the on-disk file (written by the last connected session) stays authoritative; quit-save skips descriptor-backed sessions.
- The session stays dormant behind the shell: re-diving (or the remote indicator's Retry) reconnects, and a success replaces the shell with the fully-restored workspace via `promote_dormant_remote` — including when the shell is already the active window (the switch tail runs explicitly since `set_active_window` would no-op).
- Closing the shell closes the whole session (descriptor + window leave the dock together).
- Dock rows for dormant remote sessions carry a new `WindowInfo.remote` facet (`kind`, `detail`, `connected`), so they render as disconnected SSH/Kubernetes sessions and are exempt from the "hide trivial" filter, like live remote rows.

## Implementation notes

- `activate_failed_dormant_placeholder` (window_actions.rs) builds the shell: local scoped authority (own trust/env handles), empty seed layout, preserved `authority_spec` + `plugin_state`, `remote_reconnect_error` recorded for the indicator.
- `reconnect_dormant_session_if_needed` skips descriptor-backed sessions — their connects are owned by the dive gate (`bring_dormant_remote_online`) or explicit Retry, so the failure-path activation can't fire a second connect.
- The failure status message is posted *after* activation so the switch machinery can't clear it off the status line.
- `WindowInfo.remote` is populated from the persisted `SessionAuthoritySpec::RemoteAgent` for both dormant descriptors (`connected: false`) and live windows (`connected` = parked keepalive); the orchestrator plugin adopts it as the row facet. `fresh.d.ts` regenerated.

## Tests & verification

- Two reproducers (Linux + plugins gated, deterministic via the always-failing `tests/fixtures/fake-ssh` shim — no network):
  - `orchestrator_dock_failed_reconnect` — core dive path: failure commits the switch to an empty shell, on-disk workspace survives byte-identical, switch-back and re-dive retry work.
  - `orchestrator_dock_dormant_ssh_badge` — real dock UI: dormant row listed with ⇅ badge without "show empty", arrow-dive lands in the SSH workspace with the row still listed.
  - Both verified RED against the pre-fix base (core: stuck on the old workspace with "Connection failed" in the status bar; dock: SSH row never appears) and GREEN with the fix.
- Manually verified in tmux against a real user-space `sshd`: connect, quit, stop sshd, relaunch locally, dock dive → empty disconnected shell, selected row, `Disconnected` indicator; round-trip switching works.
- `cargo check --all-targets`, the no-plugins CI check command, fmt, and clippy are clean; plugin type-check introduces no new errors.

https://claude.ai/code/session_01CaM2DeB6Cpe9p88TNSZc7Y