### PR TITLE
fix(terminal): make auto-revert per-buffer, force it off for terminal buffers

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1332,21 +1332,25 @@ impl Editor {
         const DEBOUNCE_WINDOW: Duration = Duration::from_secs(10);
         const RAPID_REVERT_THRESHOLD: u32 = 10; // Require 10 reverts in 10 seconds to disable
 
-        // Skip if auto-revert is disabled
-        if !self.active_window().auto_revert_enabled {
-            return false;
-        }
-
         let path_buf = PathBuf::from(&path);
 
-        // Only track events for files that are actually open in the editor
-        let is_file_open = self
-            .buffers()
-            .iter()
-            .any(|(_, state)| state.buffer.file_path() == Some(&path_buf));
+        // Only track events for files that have an open buffer opted into
+        // auto-revert. Auto-revert is a per-buffer property, so a change to a
+        // terminal backing file (or a streaming buffer's file) is ignored
+        // here rather than driving a reload/redraw.
+        let is_revertible_open = {
+            let window = self.active_window();
+            window.buffers.iter().any(|(id, state)| {
+                state.buffer.file_path() == Some(&path_buf)
+                    && window.buffer_auto_revert_enabled(*id)
+            })
+        };
 
-        if !is_file_open {
-            tracing::trace!("Ignoring file change event for non-open file: {}", path);
+        if !is_revertible_open {
+            tracing::trace!(
+                "Ignoring file change event for non-revertible file: {}",
+                path
+            );
             return false;
         }
 
@@ -1390,7 +1394,22 @@ impl Editor {
                 .insert(path_buf.clone(), (now, 1));
         }
         if should_disable {
-            self.active_window_mut().auto_revert_enabled = false;
+            // Disable auto-revert only for the offending file's buffer(s),
+            // not the whole window — auto-revert is a per-buffer property.
+            let ids: Vec<BufferId> = {
+                let window = self.active_window();
+                window
+                    .buffers
+                    .iter()
+                    .filter(|(_, state)| state.buffer.file_path() == Some(&path_buf))
+                    .map(|(id, _)| *id)
+                    .collect()
+            };
+            for id in ids {
+                if let Some(meta) = self.active_window_mut().buffer_metadata.get_mut(&id) {
+                    meta.auto_revert_enabled = false;
+                }
+            }
             self.active_window_mut().status_message = Some(format!(
                 "Auto-revert disabled: {} is updating too frequently (use Ctrl+Shift+R to re-enable)",
                 path_buf.file_name().unwrap_or_default().to_string_lossy()

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -21,7 +21,15 @@ use super::Editor;
 
 impl crate::app::window::Window {
     /// Resolve the effective line_wrap setting for a buffer, considering language overrides.
-    pub(crate) fn resolve_line_wrap_for_buffer(&self, buffer_id: BufferId) -> bool {
+    pub fn resolve_line_wrap_for_buffer(&self, buffer_id: BufferId) -> bool {
+        // Terminal buffers never wrap. Their content is column-formatted (ANSI,
+        // aligned output), so wrapping is wrong — and wrapping a large scrollback
+        // makes the scrollbar's visual-row index an O(all-lines) scan on every
+        // frame, freezing the UI (fresh#2608). Forced off here so no global
+        // toggle, language override, or per-buffer pin can turn it on.
+        if self.is_terminal_buffer(buffer_id) {
+            return false;
+        }
         match self.buffers.get(&buffer_id) {
             Some(state) => buffer_config_resolve::line_wrap(&state.language, self.config()),
             None => self.config().editor.line_wrap,

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -527,17 +527,32 @@ impl Editor {
         Ok(true)
     }
 
-    /// Toggle auto-revert mode
+    /// Toggle auto-revert for the active buffer. Auto-revert is a per-buffer
+    /// property, so this only affects the buffer in the focused split.
     pub fn toggle_auto_revert(&mut self) {
-        self.active_window_mut().auto_revert_enabled = !self.active_window().auto_revert_enabled;
+        let buffer_id = self.active_buffer();
 
-        if self.active_window().auto_revert_enabled {
-            self.active_window_mut().status_message =
-                Some(t!("status.auto_revert_enabled").to_string());
-        } else {
+        // Terminal-backed buffers never auto-revert (their backing file is
+        // PTY-streamed), so the toggle can't enable it for them.
+        if self.active_window().is_terminal_buffer(buffer_id) {
             self.active_window_mut().status_message =
                 Some(t!("status.auto_revert_disabled").to_string());
+            return;
         }
+
+        let enabled = match self.active_window_mut().buffer_metadata.get_mut(&buffer_id) {
+            Some(meta) => {
+                meta.auto_revert_enabled = !meta.auto_revert_enabled;
+                meta.auto_revert_enabled
+            }
+            None => return,
+        };
+
+        self.active_window_mut().status_message = Some(if enabled {
+            t!("status.auto_revert_enabled").to_string()
+        } else {
+            t!("status.auto_revert_disabled").to_string()
+        });
     }
 
     /// Poll for file changes (called from main loop)
@@ -549,11 +564,6 @@ impl Editor {
     /// thread. This method launches a poll if the interval has elapsed and no
     /// poll is already in flight, then checks for results from a prior poll.
     pub fn poll_file_changes(&mut self) -> bool {
-        // Skip if auto-revert is disabled
-        if !self.active_window().auto_revert_enabled {
-            return false;
-        }
-
         // Check for results from a previous background poll
         let mut any_changed = false;
         if let Some(ref rx) = self.active_window_mut().pending_file_poll_rx {
@@ -588,8 +598,20 @@ impl Editor {
         }
         self.active_window_mut().last_auto_revert_poll = self.time_source.now();
 
-        // Collect paths of open files that need checking
-        let files_to_check: Vec<PathBuf> = self.buffers().paths();
+        // Collect paths of open files that need checking. Auto-revert is a
+        // per-buffer property, so only poll files whose buffer opts in — this
+        // keeps terminal backing files (append-streamed by the PTY reader)
+        // out of the poll set entirely, so their constant growth never fires
+        // a reload or redraw (fresh#2608).
+        let files_to_check: Vec<PathBuf> = {
+            let window = self.active_window();
+            window
+                .buffers
+                .iter()
+                .filter(|(id, _)| window.buffer_auto_revert_enabled(**id))
+                .filter_map(|(_, state)| state.buffer.file_path().map(PathBuf::from))
+                .collect()
+        };
 
         if files_to_check.is_empty() {
             return any_changed;
@@ -1180,26 +1202,13 @@ impl Editor {
         }
 
         for buffer_id in buffer_ids {
-            // Skip terminal buffers - they manage their own content via PTY streaming
-            // and should not be auto-reverted (which would reset editing_disabled and line_numbers)
-            if self
-                .active_window()
-                .terminal_buffers
-                .contains_key(&buffer_id)
-            {
+            // Auto-revert is a per-buffer property, forced off for terminal
+            // buffers and opt-out streaming buffers (`openFileStreaming`).
+            // Reverting a buffer whose owner is actively writing the file
+            // (PTY reader / `extend_streaming`) would wipe the piece tree
+            // mid-stream and snap the cursor back to byte 0.
+            if !self.active_window().buffer_auto_revert_enabled(buffer_id) {
                 continue;
-            }
-
-            // Skip buffers that have opted out of auto-revert. The
-            // typical caller is `openFileStreaming`, which manages
-            // appends itself via `extend_streaming`; an auto-revert
-            // here would race with those appends, wiping the piece
-            // tree mid-stream and snapping the cursor back to byte 0
-            // on every kernel write notification.
-            if let Some(meta) = self.active_window().buffer_metadata.get(&buffer_id) {
-                if !meta.auto_revert_enabled {
-                    continue;
-                }
             }
 
             let state = match self
@@ -1246,8 +1255,9 @@ impl Editor {
                 continue;
             }
 
-            // Auto-revert if enabled and buffer is not modified
-            if self.active_window().auto_revert_enabled {
+            // The buffer is unmodified and opted into auto-revert (gated at
+            // the top of the loop) — reload it to match disk.
+            {
                 // Optimistic concurrency: re-check mtime before reverting.
                 // A save may have completed between our first check and now,
                 // updating file_mod_times. If so, skip the revert.

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -64,6 +64,7 @@ impl Editor {
 
         for window in self.windows.values_mut() {
             window.sync_terminal_titles();
+            window.enforce_terminal_no_wrap();
         }
 
         // Carve a full-height left column for a docked floating panel

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2303,6 +2303,29 @@ impl Window {
         self.terminal_buffer(buffer_id).is_some()
     }
 
+    /// Terminal buffers never line-wrap (see `resolve_line_wrap_for_buffer`):
+    /// their content is column-formatted, and wrapping a large scrollback turns
+    /// the scrollbar's visual-row index into an O(all-lines) scan every frame,
+    /// freezing the UI (fresh#2608). Heal any per-buffer viewport a global
+    /// line-wrap toggle (or restored state) left enabled — cheap enough to run
+    /// each frame, and a no-op when the window has no terminals.
+    pub(crate) fn enforce_terminal_no_wrap(&mut self) {
+        let terminals = &self.terminal_buffers;
+        if terminals.is_empty() {
+            return;
+        }
+        let Some(vs_map) = self.buffers.split_view_states_mut() else {
+            return;
+        };
+        for vs in vs_map.values_mut() {
+            for (buffer_id, buffer_state) in vs.keyed_states.iter_mut() {
+                if terminals.contains_key(buffer_id) {
+                    buffer_state.viewport.line_wrap_enabled = false;
+                }
+            }
+        }
+    }
+
     /// Whether auto-revert (reload on external file change) applies to
     /// `buffer_id`. Auto-revert is a per-buffer property: it honours the
     /// buffer's metadata flag, and is always forced off for terminal-backed

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -567,10 +567,6 @@ pub struct Window {
     /// when it's showing a buffer view.
     pub overlay_preview_state: Option<crate::app::types::OverlayPreviewState>,
 
-    /// Whether auto-revert (poll-based file-mtime watching) is enabled
-    /// for buffers in this window.
-    pub auto_revert_enabled: bool,
-
     /// Tracks rapid file-change events for debouncing the auto-revert
     /// reload trigger.
     pub file_rapid_change_counts: HashMap<PathBuf, (std::time::Instant, u32)>,
@@ -1922,7 +1918,6 @@ impl Window {
             pending_search_range: None,
             live_grep_last_state: None,
             overlay_preview_state: None,
-            auto_revert_enabled: true,
             file_rapid_change_counts: HashMap::new(),
             goto_line_preview: None,
             pending_async_prompt_callback: None,
@@ -2306,6 +2301,21 @@ impl Window {
     /// Check if a buffer is a terminal buffer (in this window).
     pub fn is_terminal_buffer(&self, buffer_id: BufferId) -> bool {
         self.terminal_buffer(buffer_id).is_some()
+    }
+
+    /// Whether auto-revert (reload on external file change) applies to
+    /// `buffer_id`. Auto-revert is a per-buffer property: it honours the
+    /// buffer's metadata flag, and is always forced off for terminal-backed
+    /// buffers. A terminal's backing file is append-streamed by the PTY
+    /// reader every write; reverting it fights that stream and rebuilds the
+    /// whole scrollback's visual-row index on each change (fresh#2608).
+    pub fn buffer_auto_revert_enabled(&self, buffer_id: BufferId) -> bool {
+        if self.is_terminal_buffer(buffer_id) {
+            return false;
+        }
+        self.buffer_metadata
+            .get(&buffer_id)
+            .is_none_or(|meta| meta.auto_revert_enabled)
     }
 
     /// Get the terminal ID for a buffer (if it's a terminal buffer in

--- a/crates/fresh-editor/tests/e2e/auto_revert.rs
+++ b/crates/fresh-editor/tests/e2e/auto_revert.rs
@@ -466,3 +466,71 @@ fn test_auto_revert_with_temp_rename_save() {
         harness.assert_buffer_content(&new_content);
     }
 }
+
+/// Auto-revert is a per-buffer property: disabling it on one buffer must not
+/// disable it for the rest of the window. Regression test for fresh#2608,
+/// where auto-revert was a single window-wide flag.
+#[test]
+#[cfg_attr(target_os = "macos", ignore)] // mtime granularity / FSEvents timing
+fn test_auto_revert_disable_is_per_buffer() {
+    let mut harness = EditorTestHarness::with_temp_project(80, 24).unwrap();
+    let project_dir = harness.project_dir().unwrap();
+
+    let file_a = project_dir.join("a.txt");
+    let file_b = project_dir.join("b.txt");
+    write_and_sync(&file_a, "a0");
+    write_and_sync(&file_b, "b0");
+
+    // Open b first, then a — so `a` is the active buffer that the toggle hits.
+    harness.open_file(&file_b).unwrap();
+    let id_b = harness.editor().active_buffer();
+    harness.open_file(&file_a).unwrap();
+    let id_a = harness.editor().active_buffer();
+    assert_ne!(id_a, id_b, "the two files should open as distinct buffers");
+
+    // Disable auto-revert for the active buffer (a) only.
+    harness.editor_mut().toggle_auto_revert();
+
+    // Change both files on disk.
+    harness.sleep(FILE_CHANGE_DELAY);
+    write_and_sync(&file_a, "a1");
+    write_and_sync(&file_b, "b1");
+
+    // The buffer that kept auto-revert enabled (b) must still reload. Without
+    // the per-buffer fix, the toggle was window-wide and this never fires.
+    harness
+        .wait_until(|h| h.editor().get_buffer_content(id_b).as_deref() == Some("b1"))
+        .expect("auto-revert must still fire for the buffer that kept it enabled");
+
+    // The buffer we disabled (a) must NOT have reverted — its opt-out is
+    // independent of buffer b.
+    assert_eq!(
+        harness.editor().get_buffer_content(id_a).as_deref(),
+        Some("a0"),
+        "disabling auto-revert on one buffer must not revert it (and must not \
+         have been a window-wide toggle)"
+    );
+}
+
+/// Terminal-backed buffers force auto-revert off: their backing file is
+/// append-streamed by the PTY reader, so reverting it on every write fights
+/// the stream and rebuilds the whole scrollback index (fresh#2608).
+#[test]
+fn test_auto_revert_forced_off_for_terminal_buffers() {
+    let mut harness = EditorTestHarness::with_temp_project(80, 24).unwrap();
+
+    harness.editor_mut().open_terminal();
+    let term_id = harness.editor().active_buffer();
+
+    assert!(
+        harness.editor().active_window().is_terminal_buffer(term_id),
+        "open_terminal should make a terminal buffer active"
+    );
+    assert!(
+        !harness
+            .editor()
+            .active_window()
+            .buffer_auto_revert_enabled(term_id),
+        "terminal-backed buffers must have auto-revert forced off"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4237,3 +4237,24 @@ fn test_terminal_mode_hides_scrollbar_and_reclaims_width() {
         "live PTY width should span the scrollbar column the scrollback view reserves"
     );
 }
+
+/// Terminal buffers must never line-wrap, even with global line wrap enabled.
+/// Wrapping a large terminal scrollback turns the scrollbar's visual-row index
+/// into an O(all-lines) scan on every frame, freezing the UI (fresh#2608).
+#[test]
+fn test_terminal_buffers_never_line_wrap() {
+    let mut harness = harness_or_return!(80, 24);
+    harness.editor_mut().open_terminal();
+    let term_id = harness.editor().active_buffer();
+
+    // Global line wrap on: a regular buffer would wrap; a terminal must not.
+    harness.editor_mut().config_mut().editor.line_wrap = true;
+
+    assert!(
+        !harness
+            .editor()
+            .active_window()
+            .resolve_line_wrap_for_buffer(term_id),
+        "terminal buffers must never resolve to line-wrap even when global line wrap is on"
+    );
+}


### PR DESCRIPTION
Fixes #2608.

Split-terminal scrolling with a continuously-updating pane froze the UI and pinned a CPU core. There were **two independent root causes**, fixed in two commits.

## 1. Auto-revert reload storm (per-buffer auto-revert)

A terminal's scrollback is a read-only buffer backed by the terminal's on-disk file, which the PTY reader appends to on every write. Auto-revert was a single **window-wide** flag, so the growing file was polled and each append reloaded the buffer. Fix: make auto-revert a genuine **per-buffer** property, forced off for terminal-backed buffers, and only poll files whose buffer opts in — so terminal backing files are never stat-polled.

## 2. Whole-buffer line-wrap in the render hot path

Even after that, profiling the live editor showed each frame spending ~2.5s in whole-buffer word-wrap. With line-wrap enabled, the scrollbar's visual-row index walks **every line** to count wrapped rows — O(all-lines) — and the streaming pane retriggers renders constantly. Terminal content is column-formatted, so wrapping it is both wrong and pathologically slow, yet a global line-wrap toggle applied to every split including terminals. Fix: **force wrap off for terminal buffers** (`resolve_line_wrap_for_buffer` returns false; `enforce_terminal_no_wrap` heals any already-wrapped terminal viewport each frame). The scrollbar then takes the O(log n) logical-line path.

**Verified in a live terminal scrollback:** toggling global wrap on now leaves the terminal unwrapped; renders drop from **~2500ms / 98% CPU** to **~50ms / 6%**.

## Tests

- `test_auto_revert_disable_is_per_buffer` — disabling auto-revert on one buffer must not affect another (fails without the fix: the window-wide toggle stopped the other buffer reverting).
- `test_auto_revert_forced_off_for_terminal_buffers` — terminal buffers report auto-revert off.
- `test_terminal_buffers_never_line_wrap` — terminal buffers never resolve to line-wrap even with global line wrap on.

Existing `auto_revert` and terminal e2e tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)