### PR TITLE
fix(vi): include trailing whitespace in the a" text object (#2604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 * **Vi mode**: the indent operators `>>` / `<<` (with counts and motions like `>j`) and visual-mode `>` / `<` now shift lines by one level instead of doing nothing; `.` repeats them (#2438).
 * **Vi mode**: quote text objects `i"`/`a"` (and `'`/`` ` ``) now search forward on the line, so `ci"`/`di"` work from before the quotes — e.g. from the start of the line — instead of only when the cursor is already inside them (#2439).
+* **Vi mode**: the `a"` text object (and `'`/`` ` ``) now includes the trailing whitespace after the closing quote — falling back to leading whitespace when there is none — matching Vim's `:help aquote`, so `da"` on `the "quick" brown fox` leaves `the brown fox` instead of a stray double space (#2604).
 * **Cursor column** is preserved on vertical moves that used to drift it - indented soft-wrapped lines, off-screen up/down over short lines (#2565), and blank lines with indentation guides (#2564).
 * **LSP args** - an empty `args` list now overrides a built-in server's defaults, so you can use one that takes no arguments (e.g. markdown-oxide for marksman) (#2549, reported by @alex-ball).
 * **Settings icons** now render on all terminals by default - standard Unicode symbols replace the Nerd Font glyphs that showed as `?`; opt back in with `editor.nerd_font_icons` (#2032).

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -2758,8 +2758,22 @@ async function applyTextObject(objectType: string): Promise<void> {
           selectStart = startOffset + lineStart + quoteStart + 1;
           selectEnd = startOffset + lineStart + quoteEnd;
         } else {
-          selectStart = startOffset + lineStart + quoteStart;
-          selectEnd = startOffset + lineStart + quoteEnd + 1;
+          // `a"` includes the quotes plus surrounding whitespace, matching Vim
+          // (`:help aquote`): trailing whitespace after the closing quote is
+          // included; if there is none, leading whitespace before the opening
+          // quote is included instead.
+          let aStart = quoteStart;
+          let aEnd = quoteEnd + 1; // exclusive, just past the closing quote
+          const isBlank = (c: string) => c === " " || c === "\t";
+          let trailingEnd = aEnd;
+          while (trailingEnd < line.length && isBlank(line[trailingEnd])) trailingEnd++;
+          if (trailingEnd > aEnd) {
+            aEnd = trailingEnd;
+          } else {
+            while (aStart > 0 && isBlank(line[aStart - 1])) aStart--;
+          }
+          selectStart = startOffset + lineStart + aStart;
+          selectEnd = startOffset + lineStart + aEnd;
         }
       }
       break;

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1115,6 +1115,46 @@ fn test_vi_bug_ci_quote_searches_forward_on_line() {
         .unwrap();
 }
 
+/// Bug #2604: `da"` should also delete the trailing whitespace after the
+/// closing quote, like Vim (`:help aquote`): `the "quick" brown fox` →
+/// `the brown fox` (single space), not `the  brown fox` (double space).
+#[test]
+fn test_vi_bug_da_quote_includes_trailing_whitespace() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "the \"quick\" brown fox\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Cursor is at column 0 (before the opening quote).
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
+
+    // da" deletes `"quick"` plus the trailing space.
+    send_operator_text_object(&mut harness, 'd', 'a', '"');
+
+    harness.wait_for_buffer_content("the brown fox\n").unwrap();
+}
+
+/// Bug #2604 (leading-whitespace fallback): when there is no trailing
+/// whitespace after the closing quote, `da"` includes the leading whitespace
+/// before the opening quote instead — `foo "bar"` → `foo`.
+#[test]
+fn test_vi_bug_da_quote_falls_back_to_leading_whitespace() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "foo \"bar\"\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
+
+    // No trailing whitespace after the closing quote, so the leading space is
+    // consumed instead.
+    send_operator_text_object(&mut harness, 'd', 'a', '"');
+
+    harness.wait_for_buffer_content("foo\n").unwrap();
+}
+
 // =============================================================================
 // Bug #2438: vi mode indent operators >>/<< (and visual >/<) do nothing
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #2604. Fresh's vi-mode `a"` text object did not match Vim: `da"` on `the "quick" brown fox` left a stray double space (`the  brown fox`) instead of `the brown fox`, because the `around` object selected only the quotes and never the surrounding whitespace.

Per Vim's `:help aquote`, `a"` selects the quoted string **including the quotes** plus **trailing whitespace** after the closing quote — and, when there is no trailing whitespace, **leading whitespace** before the opening quote instead.

## Changes

- `crates/fresh-editor/plugins/vi_mode.ts` — the `around` branch of the quote text object (`"`, `'`, `` ` ``) now extends the range over trailing blanks after the closing quote, falling back to leading blanks before the opening quote when there is no trailing whitespace. Inner (`i"`) behavior is unchanged.
- `crates/fresh-editor/tests/e2e/vi_mode_bugs.rs` — two e2e regression tests: the trailing-whitespace case (`the "quick" brown fox` → `the brown fox`) and the leading-whitespace fallback (`foo "bar"` → `foo`).
- `CHANGELOG.md` — entry under 0.4.3 Bug Fixes.

## Validation

Built with the embedded plugin (`embed-plugins`) and ran the e2e suite in a tmux session:

- Both new tests pass.
- All 15 existing quote-related e2e tests pass (including the `di"`/`ci"` forward-search tests from #2439) — no regressions.

```
test e2e::vi_mode_bugs::test_vi_bug_da_quote_includes_trailing_whitespace ... ok
test e2e::vi_mode_bugs::test_vi_bug_da_quote_falls_back_to_leading_whitespace ... ok
test result: ok. 15 passed; 0 failed; ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Zrw9FZ5tesgkxo76ftgFd

---
_Generated by [Claude Code](https://claude.ai/code/session_014Zrw9FZ5tesgkxo76ftgFd)_