### PR TITLE
fix(vi): bind visual-block > / < indent operators (#2606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
-* **Vi mode**: the indent operators `>>` / `<<` (with counts and motions like `>j`) and visual-mode `>` / `<` now shift lines by one level instead of doing nothing; `.` repeats them (#2438).
+* **Vi mode**: the indent operators `>>` / `<<` (with counts and motions like `>j`) and visual, visual-line, and visual-block `>` / `<` now shift lines by one level instead of doing nothing; `.` repeats them (#2438, #2606).
 * **Vi mode**: quote text objects `i"`/`a"` (and `'`/`` ` ``) now search forward on the line, so `ci"`/`di"` work from before the quotes — e.g. from the start of the line — instead of only when the cursor is already inside them (#2439).
 * **Cursor column** is preserved on vertical moves that used to drift it - indented soft-wrapped lines, off-screen up/down over short lines (#2565), and blank lines with indentation guides (#2564).
 * **LSP args** - an empty `args` list now overrides a built-in server's defaults, so you can use one that takes no arguments (e.g. markdown-oxide for marksman) (#2549, reported by @alex-ball).

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -2352,6 +2352,21 @@ function vi_vblock_toggle_line() : void {
 }
 registerHandler("vi_vblock_toggle_line", vi_vblock_toggle_line);
 
+// Visual block > / < — Vim shifts every line the block touches by one
+// shiftwidth (whole lines, not just the selected columns) and returns to
+// normal mode. The block selection is the same live per-line selection that
+// vi_vblock_delete/yank act on, so applyVisualIndent (which drives the
+// editor's selection-aware indent/dedent) does exactly the right thing here.
+async function vi_vblock_indent() : Promise<void> {
+  await applyVisualIndent(">");
+}
+registerHandler("vi_vblock_indent", vi_vblock_indent);
+
+async function vi_vblock_dedent() : Promise<void> {
+  await applyVisualIndent("<");
+}
+registerHandler("vi_vblock_dedent", vi_vblock_dedent);
+
 // Visual mode motions - these extend the selection
 function vi_vis_left() : void {
   clearComputedVisualRange();
@@ -3723,6 +3738,8 @@ editor.defineMode("vi-visual-block", [
   ["c", "vi_vblock_change"],
   ["s", "vi_vblock_change"],
   ["y", "vi_vblock_yank"],
+  [">", "vi_vblock_indent"],
+  ["<", "vi_vblock_dedent"],
 
   // Exit
   ["Escape", "vi_vblock_escape"],

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1312,6 +1312,72 @@ fn test_vi_visual_line_indent_stops_at_selection() {
 }
 
 // =============================================================================
+// Bug #2606: visual-block (Ctrl+V) indent operators >/< do nothing
+// =============================================================================
+//
+// `>`/`<` were bound in visual and visual-line mode (bug #2438) but never in
+// visual-block mode, so the keys were silently swallowed and the editor stayed
+// stuck in `-- VISUAL BLOCK --`. Like Vim, they now shift every line the block
+// touches by one shiftwidth and return to normal mode.
+
+/// Visual-block `>` indents every line the block spans and returns to normal.
+#[test]
+fn test_vi_visual_block_indent() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbeta\ngamma\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Ctrl+V enters visual block, j extends it down to the second line.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual-block".to_string()))
+        .unwrap();
+    send_key(&mut harness, 'j');
+    send_key(&mut harness, '>');
+
+    // Both spanned lines shift right by one 4-space level; gamma is untouched.
+    harness
+        .wait_for_buffer_content("    alpha\n    beta\ngamma\n")
+        .unwrap();
+    // Returns to normal mode after the operation (Vim behavior).
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+}
+
+/// Visual-block `<` dedents every line the block spans and returns to normal.
+#[test]
+fn test_vi_visual_block_dedent() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "    alpha\n    beta\ngamma\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual-block".to_string()))
+        .unwrap();
+    send_key(&mut harness, 'j');
+    send_key(&mut harness, '<');
+
+    harness
+        .wait_for_buffer_content("alpha\nbeta\ngamma\n")
+        .unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+}
+
+// =============================================================================
 // Bug #2441: find-char motions (f/t/F/T) broken with operators and ; / , repeat
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #2606. In vi mode, the indent operators `>` / `<` were bound in visual and visual-line mode (the #2438 fix family) but **never in visual-block mode** (`Ctrl+V`). The keys were silently swallowed and the editor stayed stuck in `-- VISUAL BLOCK --`.

## Root cause

`editor.defineMode("vi-visual-block", …)` bound the block operators `d`/`x`/`c`/`s`/`y` but had no entries for `>` / `<`, and no `vi_vblock_indent` / `vi_vblock_dedent` handlers existed. So the keys hit nothing and were consumed.

## Fix

The visual-block selection is the same live per-line selection that `vi_vblock_delete` and `vi_vblock_yank` already operate on, so the two new handlers simply reuse `applyVisualIndent` — the existing helper that drives the editor's selection-aware indent/dedent for the other visual modes. Like Vim (`:help v_b_>`), `>` / `<` now shift every line the block touches by one shiftwidth and return to normal mode.

- `plugins/vi_mode.ts`: add `vi_vblock_indent` / `vi_vblock_dedent` handlers and bind `>` / `<` in the `vi-visual-block` mode.
- `CHANGELOG.md`: extend the existing #2438 bullet to note visual-block coverage.

## Testing

Added two e2e tests in `vi_mode_bugs.rs` that drive `Ctrl+V`, `j`, then `>` / `<` and assert on rendered buffer content and the return to normal mode:

- `test_vi_visual_block_indent`
- `test_vi_visual_block_dedent`

Reproducer contract verified: with the keybindings removed (bug present) both tests hang (keys unbound, buffer never changes) until externally killed; with the fix both pass in 0.21s. Plugin type-check shows no new errors introduced by this change.

```
running 2 tests
test e2e::vi_mode_bugs::test_vi_visual_block_dedent ... ok
test e2e::vi_mode_bugs::test_vi_visual_block_indent ... ok
test result: ok. 2 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCUMtMUFwRsUqe8MdfTfdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCUMtMUFwRsUqe8MdfTfdC)_