### PR TITLE
fix(whitespace): restore configured indicators when master toggle turns back on (#2579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Remote workspaces (SSH)** (#2525) - file explorer appears immediately when toggled (#2522), a boot hang is fixed with idle-based read timeouts, and per-keystroke lag on very long lines is gone (#2529).
 * **Indentation guides** continue through soft-wrapped rows (#2538), respect per-buffer overrides and buffer kind (#2523), and stay visible when opening a file at a commit from **Git Log**.
 * **Settings fields** - language-entry edits (incl. **Tab Size**) keep their committed value, with `Esc` to cancel and `Enter`/`Tab` to commit (#2537, #2515); the search filter gains full cursor editing and ignores `Ctrl`/`Alt` chords; the **Env** list labels rows by name instead of `(no action)`.
+* **Whitespace indicators** - the master toggle (**Toggle Whitespace Indicators**) now turns indicators back **on**, restoring your configured visibility (e.g. space indicators) instead of the built-in default; previously toggling off then on only brought back tab indicators, so a restart was needed to see configured space indicators again (#2579).
 
 ### Internals
 

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1840,6 +1840,11 @@ impl Editor {
             }
             Action::ToggleTabIndicators | Action::ToggleWhitespaceIndicators => {
                 let __buffer_id = self.active_buffer();
+                // Resolve the buffer's configured visibility up front so turning
+                // the master toggle back on restores the indicators the user
+                // actually enabled (e.g. space indicators), rather than the
+                // hard-coded default. Fixes #2579.
+                let restore = self.configured_whitespace_visibility(__buffer_id);
                 if let Some(state) = self
                     .windows
                     .get_mut(&self.active_window)
@@ -1847,7 +1852,7 @@ impl Editor {
                     .expect("active window present")
                     .get_mut(&__buffer_id)
                 {
-                    state.buffer_settings.whitespace.toggle_all();
+                    state.buffer_settings.whitespace.toggle_all(restore);
                     let status = if state.buffer_settings.whitespace.any_visible() {
                         t!("toggle.whitespace_indicators_shown")
                     } else {

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -375,6 +375,31 @@ impl Editor {
         self.set_status_message(status.to_string());
     }
 
+    /// Resolve the whitespace-indicator visibility a buffer would get from the
+    /// current config: the flat editor config, refined by the buffer language's
+    /// `show_whitespace_tabs` override. This is the same resolution used when a
+    /// file is opened, so callers can restore a buffer to its "configured"
+    /// visibility (e.g. when the whitespace master toggle is switched back on).
+    pub fn configured_whitespace_visibility(
+        &self,
+        buffer_id: fresh_core::BufferId,
+    ) -> crate::config::WhitespaceVisibility {
+        use crate::config::WhitespaceVisibility;
+        let mut whitespace = WhitespaceVisibility::from_editor_config(&self.config.editor);
+        if let Some(state) = self
+            .windows
+            .get(&self.active_window)
+            .map(|w| &w.buffers)
+            .and_then(|buffers| buffers.get(&buffer_id))
+        {
+            if let Some(lang_config) = self.config.languages.get(&state.language) {
+                whitespace =
+                    whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
+            }
+        }
+        whitespace
+    }
+
     /// Reset buffer settings (tab_size, use_tabs, auto_close, whitespace visibility) to config defaults
     pub fn reset_buffer_settings(&mut self) {
         use crate::config::WhitespaceVisibility;

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -730,19 +730,31 @@ impl WhitespaceVisibility {
         self.any_spaces() || self.any_tabs()
     }
 
+    /// All indicators disabled — the "hidden" state of the master toggle.
+    pub fn hidden() -> Self {
+        Self {
+            spaces_leading: false,
+            spaces_inner: false,
+            spaces_trailing: false,
+            tabs_leading: false,
+            tabs_inner: false,
+            tabs_trailing: false,
+        }
+    }
+
     /// Toggle all whitespace indicators on/off (master switch).
-    /// When turning off, all positions are disabled.
-    /// When turning on, restores to default visibility (tabs all on, spaces all off).
-    pub fn toggle_all(&mut self) {
+    ///
+    /// When turning off, all positions are disabled. When turning back on,
+    /// visibility is restored to `restore` — the user's configured, per-buffer
+    /// resolved visibility — so indicators the user actually enabled (e.g. space
+    /// indicators) reappear, not just the hard-coded default. If `restore` has
+    /// nothing visible (config hides whitespace entirely), fall back to the
+    /// built-in default so the master toggle always shows *something*.
+    pub fn toggle_all(&mut self, restore: WhitespaceVisibility) {
         if self.any_visible() {
-            *self = Self {
-                spaces_leading: false,
-                spaces_inner: false,
-                spaces_trailing: false,
-                tabs_leading: false,
-                tabs_inner: false,
-                tabs_trailing: false,
-            };
+            *self = Self::hidden();
+        } else if restore.any_visible() {
+            *self = restore;
         } else {
             *self = Self::default();
         }

--- a/crates/fresh-editor/tests/e2e/buffer_settings_commands.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_settings_commands.rs
@@ -134,6 +134,61 @@ fn test_toggle_tab_indicators_command() {
     );
 }
 
+/// Regression test for #2579: the whitespace master toggle could turn indicators
+/// off but not visibly back on. Turning back on restored the hard-coded default
+/// (tabs on / spaces off) instead of the user's configured visibility, so a user
+/// who enabled space indicators saw nothing return on a space-indented file
+/// (a restart re-resolved from config, which is why it "worked again").
+#[test]
+fn test_toggle_whitespace_indicators_restores_configured_spaces() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+
+    // Leading spaces so the space indicator (·) has something to mark.
+    std::fs::write(&file_path, "    hello\n").unwrap();
+
+    // User configures space indicators on, tab indicators off.
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_spaces_leading = true;
+    config.editor.whitespace_spaces_inner = false;
+    config.editor.whitespace_spaces_trailing = false;
+    config.editor.whitespace_tabs_leading = false;
+    config.editor.whitespace_tabs_inner = false;
+    config.editor.whitespace_tabs_trailing = false;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Configured space indicators are visible on open.
+    let screen_initial = harness.screen_to_string();
+    assert!(
+        screen_initial.contains('·'),
+        "Space indicators should be visible on open. Screen:\n{}",
+        screen_initial
+    );
+
+    // Toggle off — indicators disappear.
+    run_command(&mut harness, "Toggle Whitespace Indicators");
+    let screen_off = harness.screen_to_string();
+    assert!(
+        !screen_off.contains('·'),
+        "After toggling off, space indicators should be hidden. Screen:\n{}",
+        screen_off
+    );
+
+    // Toggle back on — the *configured* space indicators must return, not the
+    // hard-coded default (which shows only tab indicators, invisible here).
+    run_command(&mut harness, "Toggle Whitespace Indicators");
+    let screen_on = harness.screen_to_string();
+    assert!(
+        screen_on.contains('·'),
+        "After toggling back on, configured space indicators should return. Screen:\n{}",
+        screen_on
+    );
+}
+
 /// Test that "Set Tab Size" command changes tab rendering width
 #[test]
 fn test_set_tab_size_command() {


### PR DESCRIPTION
Fixes #2579.

## Problem

The **Toggle Whitespace Indicators** master toggle could turn indicators *off* but not visibly back *on*. The reporter noted that a restart brought the indicators back, so "the Ctrl+P toggle can only turn it off, not back on."

## Root cause

When turning back on, `WhitespaceVisibility::toggle_all` restored the hard-coded `Self::default()` — tab indicators on, **space indicators off** — instead of the buffer's configured visibility. A user who had enabled *space* indicators saw only tab indicators return, which are invisible on space-indented code. Opening a file re-resolves visibility from config, which is why a restart appeared to fix it.

## Fix

- `WhitespaceVisibility::toggle_all(restore)` now takes the buffer's configured (config- + language-resolved) visibility and restores *that* when switching on. It falls back to the built-in default only when the config hides whitespace entirely, so the toggle still shows something in that case.
- Added `App::configured_whitespace_visibility(buffer_id)`, which mirrors the resolution already used when a file is opened (flat editor config refined by the language's `show_whitespace_tabs` override). The toggle handler resolves the restore state through it.
- Added `WhitespaceVisibility::hidden()` for the all-off state (previously duplicated inline).

## Testing

- **New e2e regression test** `test_toggle_whitespace_indicators_restores_configured_spaces`: with space indicators configured, it asserts the `·` markers are visible on open, gone after toggling off, and **restored** after toggling back on. Verified it **fails without the fix** (exit 101) and passes with it.
- Full `buffer_settings_commands` e2e module (6 tests, incl. the existing tab-indicator and reset tests) passes.
- `cargo check` / `cargo clippy` clean for the touched files; `cargo fmt` applied.
- **Manual validation** in a tmux session driving the real `fresh` binary: opened a space-indented file (`·` shown), ran the palette toggle off (`·` gone), then on again — `·` indicators restored, matching the initial render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ouKtTEVkSJfhnNAGw9RMn

---
_Generated by [Claude Code](https://claude.ai/code/session_014ouKtTEVkSJfhnNAGw9RMn)_