### PR TITLE
fix(git-grep): treat "no matches" (exit 1) as empty, not an error (#2591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Settings fields** - language-entry edits (incl. **Tab Size**) keep their committed value, with `Esc` to cancel and `Enter`/`Tab` to commit (#2537, #2515); the search filter gains full cursor editing and ignores `Ctrl`/`Alt` chords; the **Env** list labels rows by name instead of `(no action)`.
 * **Whitespace indicators** - the master toggle (**Toggle Whitespace Indicators**) now turns indicators back **on**, restoring your configured visibility (e.g. space indicators) instead of the built-in default; previously toggling off then on only brought back tab indicators, so a restart was needed to see configured space indicators again (#2579).
 * **File Explorer context menu** now grabs the keyboard while open, like the tab context menu and "+" popup: keys no longer leak into the tree's type-ahead find underneath, which could silently retarget which file a menu action operated on (#2587).
+* **Git Grep** - a search with no matches is now reported as a plain "No matches" instead of logging an error and raising the status-bar warning badge; `git grep` exits 1 when nothing matches, which was wrongly treated as a failure, so every fruitless search looked like a plugin crash (#2591).
 
 ### Internals
 

--- a/crates/fresh-editor/plugins/git_grep.ts
+++ b/crates/fresh-editor/plugins/git_grep.ts
@@ -62,7 +62,14 @@ async function searchWithGitGrep(query: string): Promise<GrepMatch[]> {
     query,
   ]);
 
-  if (result.exit_code === 0) {
+  // git grep's exit codes: 0 = matches found, 1 = no matches (a normal,
+  // successful search — NOT a failure), >=2 = a real error (bad pattern,
+  // broken repo, …). Treating exit 1 as an error made every fruitless search
+  // log an ERROR and raise the status-bar warning badge, so an ordinary
+  // "nothing matched" looked like a plugin crash (issue #2591). Mirror
+  // live_grep's git-grep provider: accept 0 and 1, error only on a real
+  // failure.
+  if (result.exit_code === 0 || result.exit_code === 1) {
     const matches = parseGrepOutput(
       result.stdout,
       100,
@@ -72,8 +79,12 @@ async function searchWithGitGrep(query: string): Promise<GrepMatch[]> {
     // selecting a result opens the right file regardless of the workspace cwd.
     return matches.map((m) => ({ ...m, abs: toAbsInRepo(editor, repo, m.file) }));
   }
-  editor.error(`[git_grep] process exited with code ${result.exit_code}: ${result.stderr}`);
-  editor.setStatus(`git grep failed (exit ${result.exit_code})`);
+  // A negative exit code means the search was superseded/killed as the user
+  // kept typing (the Finder cancels the in-flight git) — stay quiet for that.
+  if (result.exit_code > 1) {
+    editor.error(`[git_grep] process exited with code ${result.exit_code}: ${result.stderr}`);
+    editor.setStatus(`git grep failed (exit ${result.exit_code})`);
+  }
   return [];
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -309,6 +309,58 @@ fn test_git_grep_cancel() {
     harness.assert_screen_not_contains("Git grep: ");
 }
 
+/// Regression test for issue #2591 (papercut): a query with no matches must be
+/// handled as an ordinary empty result ("No matches"), NOT as a plugin error.
+/// `git grep` exits 1 when nothing matches; the plugin used to log that as an
+/// ERROR and raise the status-bar warning badge, so every fruitless search
+/// looked like a crash. Here we search for a token that appears nowhere in the
+/// fixture and assert the editor reports "No matches" and never surfaces a
+/// git-grep failure.
+#[test]
+fn test_git_grep_no_matches_is_graceful() {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    repo.setup_git_plugins();
+
+    // Change to repo directory so git commands work correctly
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    // Trigger git grep
+    trigger_git_grep(&mut harness);
+
+    // Search for a token that is guaranteed absent from the fixture.
+    harness
+        .type_text("zzz_definitely_absent_token_qypq")
+        .unwrap();
+
+    // The finder reports the empty result set as "No matches".
+    harness
+        .wait_until(|h| h.screen_to_string().contains("No matches"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Git grep no-match screen:\n{screen}");
+
+    // The prompt stays open and usable — a fruitless search is not fatal.
+    assert!(
+        screen.contains("Git grep:"),
+        "grep prompt should stay open after a no-match query"
+    );
+    // Crucially, the "no matches" case must NOT be presented as a failure:
+    // no plugin error status and no in-overlay search-error render.
+    harness.assert_screen_not_contains("git grep failed");
+    harness.assert_screen_not_contains("Search error");
+}
+
 /// Test git find file basic functionality
 #[test]
 fn test_git_find_file_shows_results() {


### PR DESCRIPTION
## Summary

Fixes the remaining **"papercut"** reported in #2591: the standalone **Git Grep** command logs an `ERROR` and raises the status-bar `[⚠]` warning badge on any search that finds nothing, so an ordinary "nothing matched" looks like a plugin crash.

`git grep` exits **1** when a pattern matches nothing — a normal, successful search — and `>= 2` only on a real failure (bad pattern, broken repo). `searchWithGitGrep` treated *any* non-zero exit as an error:

```ts
if (result.exit_code === 0) { …return matches… }
editor.error(`[git_grep] process exited with code ${result.exit_code}: …`); // fired on exit 1 too
editor.setStatus(`git grep failed (exit ${result.exit_code})`);
```

## The fix

Accept exit codes **0 and 1** as success (exit 1 produces an empty result the Finder already shows as "No matches"), and surface an error only for a genuine git failure (`exit_code > 1`). A negative code means the in-flight git was superseded as the user kept typing, so it stays quiet too. This mirrors `live_grep.ts`'s git-grep provider, which already documents and handles exit 1 this way (*"git grep exits 1 when no matches — treat as empty, not error"*).

## Scope note

The monorepo/multi-repo **repo-resolution** half of #2591 (Scenarios 1 & 2) was already fixed by the merged #2585, which routed Git Grep through `lib/git_repo.ts`. This PR closes out the remaining papercut the same issue calls out.

## Changes

- `crates/fresh-editor/plugins/git_grep.ts` — accept exit 0/1 as success; error only on `exit_code > 1`.
- `crates/fresh-editor/tests/e2e/plugins/git.rs` — new `test_git_grep_no_matches_is_graceful` regression test.
- `CHANGELOG.md` — Bug Fixes entry.

## Verification

- ✅ `cargo test -p fresh-editor --test e2e_tests test_git_grep` — all 9 git-grep tests pass, including the new one.
- ✅ Plugin `tsc` typecheck: no new errors in `git_grep.ts`.
- ✅ `cargo fmt` / `cargo clippy` clean for the touched files.
- ✅ **Manual TUI validation (tmux)** against the issue's Scenario 1 monorepo fixture (`/tmp/mono` non-repo root, `app/` sub-repo):
  - No-match query (`zzz_absent_qypq`) → status bar shows **"No matches"** and **no `[⚠]` badge** (previously raised the badge).
  - Matching query (`VERSION`) → still returns `main.py:1  version = "VERSION-TWO"`, confirming repo resolution is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZcAtWM9TE2K8UwiDubexv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZcAtWM9TE2K8UwiDubexv)_