### PR TITLE
fix(indent): re-indent dedent keywords as they are typed (#2582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **Auto-indent**: typing a dedent keyword now re-indents the line as you type it, matching the "electric" dedent already applied to closing brackets. Python `else:`/`elif`/`except`/`finally`/`case`, Ruby/Lua/Fish/Pascal `end`, Bash `fi`/`done`/`esac`, and any language's custom `decrease_indent_pattern` token snap one level shallower instead of staying over-indented until the next save (#2582).
 * **Cursor column** is preserved on vertical moves that used to drift it - indented soft-wrapped lines, off-screen up/down over short lines (#2565), and blank lines with indentation guides (#2564).
 * **LSP args** - an empty `args` list now overrides a built-in server's defaults, so you can use one that takes no arguments (e.g. markdown-oxide for marksman) (#2549, reported by @alex-ball).
 * **Settings icons** now render on all terminals by default - standard Unicode symbols replace the Nerd Font glyphs that showed as `?`; opt back in with `editor.nerd_font_icons` (#2032).

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -731,6 +731,23 @@ fn rules_dedent(state: &EditorState, position: usize, ch: char, tab_size: usize)
     })
 }
 
+/// Keyword variant of [`rules_dedent`]: when typing `ch` at `cursor` completes
+/// a dedent keyword (Python `else:`, Ruby/Lua `end`, Bash `fi`/`done`, …) on
+/// the line starting at `line_start`, returns the visual indent the line
+/// should snap to. Returns `None` when the language has no matching rule.
+fn rules_typed_dedent(
+    state: &EditorState,
+    ch: char,
+    cursor: usize,
+    line_start: usize,
+    tab_size: usize,
+) -> Option<usize> {
+    let rules = buffer_indent_rules(state)?;
+    rules.calculate_dedent_for_typed_char(&state.buffer, line_start, cursor, ch, tab_size, |b| {
+        byte_is_code(state, b)
+    })
+}
+
 /// Calculate the correct indent for a closing delimiter.
 ///
 /// Tiering mirrors the Enter-indent path: a language with a *bundled*
@@ -899,6 +916,74 @@ fn handle_auto_dedent(
         text,
         cursor_id,
     });
+}
+
+/// Handle keyword dedent-on-type: when the just-typed character `ch` completes
+/// a dedent keyword on the current line (e.g. Python `else:`, Ruby/Lua `end`),
+/// re-indent the line one level shallower — the same "electric" correction the
+/// editor already applies for a typed closing bracket, extended to the keyword
+/// triggers of `decrease_indent_pattern`.
+///
+/// Returns `true` when it handled the character (emitting the re-indent plus
+/// the inserted `ch`), so the caller skips the normal insertion. Returns
+/// `false` to leave the character to the normal path — including the no-op case
+/// where the line is already at the correct indent, which keeps the correction
+/// idempotent (no redundant undo step on every following keystroke).
+fn handle_typed_keyword_dedent(
+    state: &mut EditorState,
+    events: &mut Vec<Event>,
+    cursor_id: CursorId,
+    ch: char,
+    insert_position: usize,
+    line_start: usize,
+    tab_size: usize,
+) -> bool {
+    let Some(target_indent) = rules_typed_dedent(state, ch, insert_position, line_start, tab_size)
+    else {
+        return false;
+    };
+
+    // Current visual indent of the line (tabs count as tab_size columns).
+    let mut current_indent = 0;
+    let mut content_start = line_start;
+    while content_start < insert_position {
+        match state
+            .buffer
+            .slice_bytes(content_start..content_start + 1)
+            .first()
+        {
+            Some(&b' ') => current_indent += 1,
+            Some(&b'\t') => current_indent += tab_size,
+            _ => break,
+        }
+        content_start += 1;
+    }
+
+    if current_indent == target_indent {
+        // Already correctly indented — let the character insert normally.
+        return false;
+    }
+
+    // Replace the line's leading whitespace with the corrected indent, keeping
+    // the already-typed keyword text and appending the triggering character.
+    let leading = state.get_text_range(line_start, insert_position);
+    events.push(Event::Delete {
+        range: line_start..insert_position,
+        deleted_text: leading.clone(),
+        cursor_id,
+    });
+
+    let content = leading.trim_start_matches([' ', '\t']);
+    let use_tabs = state.buffer_settings.use_tabs;
+    let mut text = indent_to_string(target_indent, use_tabs, tab_size);
+    text.push_str(content);
+    text.push(ch);
+    events.push(Event::Insert {
+        position: line_start,
+        text,
+        cursor_id,
+    });
+    true
 }
 
 /// Check if auto-close should happen based on character after cursor.
@@ -1109,6 +1194,7 @@ fn insert_char_events(
         }
 
         // Delete selection if present
+        let had_selection = data.selection.is_some();
         if let (Some(range), Some(text)) = (data.selection, data.deleted_text) {
             events.push(Event::Delete {
                 range,
@@ -1174,6 +1260,33 @@ fn insert_char_events(
                 handle_auto_close(events, data.cursor_id, ch, close_char, data.insert_position);
                 continue;
             }
+        }
+
+        // Keyword dedent-on-type: if this character completes a dedent keyword
+        // (`else`, `end`, `fi`, …) on the current line, snap the line one level
+        // shallower — the electric-dedent counterpart to the closing-bracket
+        // handling above. Gated to the common, unambiguous case: no active
+        // selection, and the cursor at the end of the line's content (nothing
+        // but the whitespace/newline that a fresh auto-indented line carries
+        // after it). Restricting to end-of-line typing keeps the correction
+        // from firing while the user edits inside an existing line, and matches
+        // how the reported keywords are actually typed (`else:` / `end` at the
+        // tail of a freshly indented line).
+        let at_line_end = matches!(data.char_after, None | Some(b'\n'));
+        if auto_indent
+            && !had_selection
+            && at_line_end
+            && handle_typed_keyword_dedent(
+                state,
+                events,
+                data.cursor_id,
+                ch,
+                data.insert_position,
+                data.line_start,
+                tab_size,
+            )
+        {
+            continue;
         }
 
         // Normal character insertion
@@ -5416,6 +5529,141 @@ mod tests {
 
         assert_eq!(state.buffer.to_string().unwrap(), "\"\"");
         assert_eq!(cursors.primary().position, 1);
+    }
+
+    /// Type `text` one character at a time through the production insert path
+    /// (`Action::InsertChar`), applying the resulting events after each key.
+    fn type_chars(state: &mut EditorState, cursors: &mut Cursors, text: &str) {
+        for ch in text.chars() {
+            let events = action_to_events(
+                state,
+                cursors,
+                Action::InsertChar(ch),
+                4,
+                true, // auto_indent
+                true, // auto_close
+                true, // auto_surround
+                80,
+                24,
+            )
+            .unwrap();
+            for event in events {
+                state.apply(cursors, &event);
+            }
+        }
+    }
+
+    /// Issue #2582: typing a dedent-trigger keyword must re-indent the line as
+    /// it is typed, the same live correction the editor already did for `}`.
+    /// A private language id carries a Python-like rule set so the resolver
+    /// (`buffer_indent_rules`) finds it without a syntect grammar, exercising
+    /// the full typing pipeline end to end.
+    #[test]
+    fn typed_keyword_dedent_reindents_line() {
+        let _guard = crate::primitives::indent_rules::USER_RULES_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::primitives::indent_rules::set_user_rule(
+            "zz_dedent_py",
+            Some(r":\s*$"),
+            Some(r"^\s*(elif|else|except|finally|case)\b"),
+            None,
+            None,
+            None,
+        );
+
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+        state.language = "zz_dedent_py".to_string();
+
+        // Post-Enter state: an auto-indented blank line under `if a:`.
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: "if a:\n    x = 1\n    ".to_string(),
+                cursor_id: CursorId(0),
+            },
+        );
+
+        // Typing `else:` snaps the line back to column 0.
+        type_chars(&mut state, &mut cursors, "else:");
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\nelse:",
+            "typing `else:` should dedent the line to column 0"
+        );
+        // Cursor stays right after the typed text.
+        assert_eq!(cursors.primary().position, "if a:\n    x = 1\nelse:".len());
+
+        // Pressing Enter now indents the body relative to the corrected `else:`
+        // (column 4), not the pre-dedent column 8 — the bug's compounding drift.
+        let events = action_to_events(
+            &mut state,
+            &mut cursors,
+            Action::InsertNewline,
+            4,
+            true,
+            true,
+            true,
+            80,
+            24,
+        )
+        .unwrap();
+        for event in events {
+            state.apply(&mut cursors, &event);
+        }
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\nelse:\n    ",
+            "body after a corrected `else:` indents to column 4"
+        );
+
+        crate::primitives::indent_rules::clear_user_rules();
+    }
+
+    /// An ordinary statement (no decrease-rule match) keeps its indent when
+    /// typed — the electric dedent must not touch non-keyword lines.
+    #[test]
+    fn typed_ordinary_line_keeps_indent() {
+        let _guard = crate::primitives::indent_rules::USER_RULES_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::primitives::indent_rules::set_user_rule(
+            "zz_dedent_py2",
+            Some(r":\s*$"),
+            Some(r"^\s*(elif|else|except|finally|case)\b"),
+            None,
+            None,
+            None,
+        );
+
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+        state.language = "zz_dedent_py2".to_string();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: "if a:\n    ".to_string(),
+                cursor_id: CursorId(0),
+            },
+        );
+
+        type_chars(&mut state, &mut cursors, "y = 2");
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    y = 2");
+
+        crate::primitives::indent_rules::clear_user_rules();
     }
 
     #[test]

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -243,6 +243,51 @@ impl IndentRules {
         Some(indent.saturating_sub(unit))
     }
 
+    /// Indent for a line whose leading content — after typing `typed` at
+    /// `cursor` — matches the `decrease` rule (a dedent keyword such as
+    /// Python `else:`, Ruby/Lua `end`, Bash `fi`/`done`). This is the
+    /// keyword counterpart of [`calculate_dedent_for_delimiter`]: the closing
+    /// *bracket* path handles `}`/`]`/`)`, this handles alphabetic dedent
+    /// triggers that a user types rather than Enter-splits onto their own line.
+    ///
+    /// `cursor` is the byte offset of the character about to be inserted (end
+    /// of the current line's leading content); `line_start` is the start of
+    /// that line. The candidate leading text is the code view of
+    /// `[line_start, cursor)` with `typed` appended.
+    ///
+    /// Returns `None` when the language has no `decrease` rule, when the
+    /// resulting leading text does not match it, or when there is no reference
+    /// line above to align to — so the caller leaves indentation untouched.
+    pub fn calculate_dedent_for_typed_char<F: Fn(usize) -> bool>(
+        &self,
+        buffer: &Buffer,
+        line_start: usize,
+        cursor: usize,
+        typed: char,
+        tab_size: usize,
+        is_code: F,
+    ) -> Option<usize> {
+        // The line's leading content as it will read once `typed` lands.
+        // (`matches` is false when the language has no `decrease` rule, so an
+        // explicit rule-presence check would be redundant.)
+        let mut leading = code_view(buffer, line_start, cursor, &is_code);
+        leading.push(typed);
+        if !matches(&self.decrease, &leading) {
+            return None;
+        }
+        let unit = tab_size.max(1);
+        let reference = prev_nonblank_line(buffer, line_start)?;
+        let base = visual_indent(buffer, reference.start, reference.end, tab_size);
+        let ref_code = code_view(buffer, reference.start, reference.end, &is_code);
+
+        let mut indent = base;
+        if self.increases(&ref_code) {
+            indent += unit;
+        }
+        // The keyword dedents one level back toward its opener.
+        Some(indent.saturating_sub(unit))
+    }
+
     /// `increase` matches and the line does not also self-close.
     fn increases(&self, code: &str) -> bool {
         matches(&self.increase, code) && !matches(&self.self_close, code)
@@ -359,6 +404,13 @@ static FAMILY_RULES: Lazy<HashMap<Family, Arc<IndentRules>>> = Lazy::new(|| {
 /// [`clear_user_rules`] + [`set_user_rule`] whenever config is (re)loaded.
 static USER_RULES: Lazy<RwLock<HashMap<String, Arc<IndentRules>>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Serializes tests that mutate the global [`USER_RULES`] table so they can't
+/// race each other (or observe a concurrent [`clear_user_rules`]). Any test
+/// that calls [`set_user_rule`] / [`clear_user_rules`] — in this module or in
+/// callers like the editor's typing tests — must hold this first.
+#[cfg(test)]
+pub(crate) static USER_RULES_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Drop all user overrides. Call before re-applying config so removed blocks
 /// stop taking effect.
@@ -684,6 +736,112 @@ mod tests {
         assert_eq!(dedent, Some(0));
     }
 
+    /// Dedent target for typing `typed` at the end of `content` (cursor at
+    /// end of buffer), no scope masking. Mirrors the editor calling
+    /// `calculate_dedent_for_typed_char` on each keystroke.
+    fn typed_dedent(id: &str, content: &str, typed: char, tab: usize) -> Option<usize> {
+        let b = buf(content);
+        let line_start = content.rfind('\n').map(|i| i + 1).unwrap_or(0);
+        rules_for_id(id).unwrap().calculate_dedent_for_typed_char(
+            &b,
+            line_start,
+            content.len(),
+            typed,
+            tab,
+            |_| true,
+        )
+    }
+
+    #[test]
+    fn python_else_dedents_when_typed() {
+        // The user has typed "els" on an over-indented line; typing the final
+        // "e" completes `else` and should pull the line back one level.
+        assert_eq!(
+            typed_dedent("python", "if a:\n    x = 1\n    els", 'e', 4),
+            Some(0)
+        );
+        // Nested: `else` aligns with the inner `if`, not column 0.
+        assert_eq!(
+            typed_dedent(
+                "python",
+                "if a:\n    if b:\n        x = 1\n        els",
+                'e',
+                4
+            ),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn python_except_finally_case_dedent_when_typed() {
+        assert_eq!(
+            typed_dedent("python", "try:\n    x = 1\n    excep", 't', 4),
+            Some(0)
+        );
+        assert_eq!(
+            typed_dedent("python", "try:\n    x = 1\n    finall", 'y', 4),
+            Some(0)
+        );
+        assert_eq!(
+            typed_dedent(
+                "python",
+                "match v:\n    case 1:\n        y\n        cas",
+                'e',
+                4
+            ),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn ruby_end_dedents_when_typed() {
+        // `def foo` opens a block (indent 2); typing `end` on the body line
+        // dedents back to the def's column.
+        assert_eq!(
+            typed_dedent("ruby", "def foo\n  x = 1\n  en", 'd', 2),
+            Some(0)
+        );
+        // Midblock `else` in Ruby.
+        assert_eq!(typed_dedent("ruby", "if x\n  a\n  els", 'e', 2), Some(0));
+    }
+
+    #[test]
+    fn lua_and_bash_keyword_dedent_when_typed() {
+        assert_eq!(
+            typed_dedent("lua", "function f()\n    x = 1\n    en", 'd', 4),
+            Some(0)
+        );
+        assert_eq!(
+            typed_dedent("bash", "if true; then\n    x=1\n    f", 'i', 4),
+            Some(0)
+        );
+        assert_eq!(
+            typed_dedent("bash", "for x in a; do\n    y\n    don", 'e', 4),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn non_dedent_word_leaves_indent_untouched() {
+        // A plain identifier that merely starts with a dedent keyword's letters
+        // must not trigger: `elsewhere` isn't `else\b`.
+        assert_eq!(
+            typed_dedent("python", "if a:\n    x = 1\n    elsewher", 'e', 4),
+            None
+        );
+        // An ordinary statement doesn't match the decrease rule at all.
+        assert_eq!(typed_dedent("python", "if a:\n    retur", 'n', 4), None);
+        // Curly-brace languages have a bracket-only decrease rule, so typing a
+        // keyword never triggers this path (their `}` is handled elsewhere).
+        assert_eq!(typed_dedent("rust", "fn f() {\n    els", 'e', 4), None);
+    }
+
+    #[test]
+    fn typed_dedent_needs_reference_line() {
+        // First line of the buffer: nothing above to align to → leave it.
+        assert_eq!(typed_dedent("python", "els", 'e', 4), None);
+    }
+
     // ---- Anti-glitch corpus (the headline cases) --------------------------
 
     #[test]
@@ -919,6 +1077,9 @@ mod tests {
     // other (read-only) tests under the parallel runner.
     #[test]
     fn user_overrides_register_and_merge() {
+        let _guard = USER_RULES_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         clear_user_rules();
 
         // Full override for a language with no built-in family: config can add


### PR DESCRIPTION
Fixes #2582.

## Problem

Live "electric" dedent only fired for closing brackets (`}`). Typing a keyword that matches a language's `decrease_indent_pattern` — Python `else:`/`elif`/`except`/`finally`/`case`, Ruby/Lua/Fish/Pascal `end`, Bash `fi`/`done`/`esac`, or a user's custom token — left the line stuck at its inherited indent:

```
if a:
    x = 1
    else:      ← stays over-indented
```

The error then compounded: pressing Enter after the mis-indented `else:` indented the next line another level deeper, so the whole block drifted right. Dedent rules were applied only when Enter split text onto a new line, never when the keyword was typed — even though Fresh already gave `}` this treatment, and the docs' own `decrease_indent_pattern` examples (`end`, `CLOSE`) are tokens you *type* at the end of a block, never Enter-split.

## Fix

- Add `IndentRules::calculate_dedent_for_typed_char` in `indent_rules.rs` — the keyword counterpart of the existing `calculate_dedent_for_delimiter` (which handles brackets). It matches the line's leading content (after the just-typed char) against the language's `decrease` rule and returns the target indent, aligned to the reference line one level up.
- Hook it into the character-insert path (`insert_char_events`) so a completed dedent keyword snaps the line one level shallower, mirroring the existing closing-bracket `handle_auto_dedent`.

The hook is deliberately conservative:
- only when there's **no active selection** and the **cursor is at the end of the line's content** (the way these keywords are actually typed), so it never fires while editing mid-line;
- **idempotent** — it no-ops when the line is already at the correct indent, so it adds no redundant undo step on subsequent keystrokes.

Only the per-language regex rules tier is touched; curly-brace languages keep their bracket-only decrease rule (their `}` is handled by the existing path), so nothing changes for them.

## Testing

- **Unit tests** (`indent_rules.rs`): `else`/`except`/`finally`/`case` (Python, incl. nested), `end` (Ruby/Lua), `fi`/`done` (Bash); plus negatives — an identifier like `elsewhere`, an ordinary statement, a curly-brace language, and a first line with no reference above.
- **End-to-end typing tests** (`actions.rs`): drive the production `Action::InsertChar` pipeline key-by-key; verify `else:` dedents to column 0 and that the following Enter indents the body to column 4 (not the old drifted 8).
- **Manual validation**: ran the built `fresh` binary in tmux on a Python file, typed `else:`, and confirmed via `capture-pane` that the line dedents to column 0 and its body lands at column 4.
- `cargo fmt`, `cargo clippy`, and `cargo check --all-targets` all clean; existing indent / auto-pair / auto-indent scenario suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvjnQtGxsMn3UKywougFDd

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvjnQtGxsMn3UKywougFDd)_