### PR TITLE
fix(file-explorer): grab the keyboard while the context menu is open (#2587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Indentation guides** continue through soft-wrapped rows (#2538), respect per-buffer overrides and buffer kind (#2523), and stay visible when opening a file at a commit from **Git Log**.
 * **Settings fields** - language-entry edits (incl. **Tab Size**) keep their committed value, with `Esc` to cancel and `Enter`/`Tab` to commit (#2537, #2515); the search filter gains full cursor editing and ignores `Ctrl`/`Alt` chords; the **Env** list labels rows by name instead of `(no action)`.
 * **Whitespace indicators** - the master toggle (**Toggle Whitespace Indicators**) now turns indicators back **on**, restoring your configured visibility (e.g. space indicators) instead of the built-in default; previously toggling off then on only brought back tab indicators, so a restart was needed to see configured space indicators again (#2579).
+* **File Explorer context menu** now grabs the keyboard while open, like the tab context menu and "+" popup: keys no longer leak into the tree's type-ahead find underneath, which could silently retarget which file a menu action operated on (#2587).
 
 ### Internals
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3624,8 +3624,18 @@ impl Editor {
         Some(Ok(()))
     }
 
-    /// Handle keyboard navigation for the file explorer context menu.
-    /// Returns `Some` if the key was consumed, `None` to let normal dispatch continue.
+    /// Handle keyboard input for the file explorer right-click context menu.
+    ///
+    /// Modal like [`handle_tab_context_menu_key`]: while the menu is open it
+    /// **grabs the keyboard**. Up/Down navigate, Enter activates the
+    /// highlighted item, Esc dismisses, and every other key — printable
+    /// characters, Backspace, modified chords — is swallowed so it can't leak
+    /// into the tree's type-ahead find underneath and silently retarget the
+    /// selection the menu acts on (#2587). This mirrors the 0.4.2 keyboard
+    /// grab already applied to the tab context menu and the "+" new-tab popup.
+    ///
+    /// Returns `Some` whenever the menu is open, `None` only when there is no
+    /// menu so normal dispatch continues.
     pub(super) fn handle_file_explorer_context_menu_key(
         &mut self,
         code: crossterm::event::KeyCode,
@@ -3634,41 +3644,50 @@ impl Editor {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyModifiers;
 
-        if modifiers != KeyModifiers::NONE {
-            return None;
+        // Only act while the menu is actually open; otherwise fall through to
+        // normal dispatch.
+        self.active_window().file_explorer_context_menu.as_ref()?;
+
+        // Navigation/activation keys act only when unmodified.
+        if modifiers == KeyModifiers::NONE {
+            match code {
+                KeyCode::Up => {
+                    if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu
+                    {
+                        menu.prev_item();
+                    }
+                    return Some(Ok(()));
+                }
+                KeyCode::Down => {
+                    if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu
+                    {
+                        menu.next_item();
+                    }
+                    return Some(Ok(()));
+                }
+                KeyCode::Enter => {
+                    let item = {
+                        let menu = self
+                            .active_window_mut()
+                            .file_explorer_context_menu
+                            .as_ref()?;
+                        menu.items()[menu.highlighted]
+                    };
+                    self.active_window_mut().file_explorer_context_menu = None;
+                    self.execute_file_explorer_context_menu_action(item);
+                    return Some(Ok(()));
+                }
+                KeyCode::Esc => {
+                    self.active_window_mut().file_explorer_context_menu = None;
+                    return Some(Ok(()));
+                }
+                _ => {}
+            }
         }
 
-        match code {
-            KeyCode::Up => {
-                if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
-                    menu.prev_item();
-                }
-                Some(Ok(()))
-            }
-            KeyCode::Down => {
-                if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
-                    menu.next_item();
-                }
-                Some(Ok(()))
-            }
-            KeyCode::Enter => {
-                let item = {
-                    let menu = self
-                        .active_window_mut()
-                        .file_explorer_context_menu
-                        .as_ref()?;
-                    menu.items()[menu.highlighted]
-                };
-                self.active_window_mut().file_explorer_context_menu = None;
-                self.execute_file_explorer_context_menu_action(item);
-                Some(Ok(()))
-            }
-            KeyCode::Esc => {
-                self.active_window_mut().file_explorer_context_menu = None;
-                Some(Ok(()))
-            }
-            _ => None,
-        }
+        // Modal: swallow every other key while the menu is open so nothing
+        // leaks into the type-ahead find beneath it.
+        Some(Ok(()))
     }
 
     /// Handle left-click on the file explorer context menu

--- a/crates/fresh-editor/tests/e2e/explorer_context_menu.rs
+++ b/crates/fresh-editor/tests/e2e/explorer_context_menu.rs
@@ -453,6 +453,50 @@ fn test_keyboard_down_wraps() {
     );
 }
 
+// ── keyboard grab (#2587) ─────────────────────────────────────────────────────
+
+/// While the context menu is open it grabs the keyboard: printable keys must
+/// not leak into the tree's type-ahead find underneath. Without the grab,
+/// typing activates the explorer search — the title renders ` /<query> ` —
+/// and silently retargets the selection the menu's actions operate on.
+#[test]
+fn test_context_menu_grabs_keyboard_printable_keys() {
+    let mut h = EditorTestHarness::with_temp_project(100, 30).unwrap();
+    let root = h.project_dir().unwrap();
+    fs::write(root.join("alpha.txt"), "a").unwrap();
+    fs::create_dir(root.join("subdir")).unwrap();
+
+    h.editor_mut().focus_file_explorer();
+    h.wait_for_file_explorer().unwrap();
+    h.wait_for_file_explorer_item("alpha.txt").unwrap();
+
+    // Open the context menu on a file row.
+    h.mouse_right_click(EXPLORER_COL, 3).unwrap();
+    assert!(context_menu_visible(&h), "context menu should open");
+
+    // Type printable characters while the menu is open.
+    for c in ['s', 'u', 'b'] {
+        h.send_key(KeyCode::Char(c), KeyModifiers::NONE).unwrap();
+    }
+    h.render().unwrap();
+
+    let screen = h.screen_to_string();
+    // The type-ahead find renders its query as ` /<query> ` in the explorer
+    // title — it must be absent, since the keys were aimed at the open menu.
+    assert!(
+        !screen.contains(" /sub"),
+        "typing while the context menu is open must not activate the explorer \
+         type-ahead find. Screen:\n{}",
+        screen
+    );
+    // The menu is still up and usable.
+    assert!(
+        context_menu_visible(&h),
+        "context menu should stay open after printable keys. Screen:\n{}",
+        screen
+    );
+}
+
 // ── hover highlight ──────────────────────────────────────────────────────────
 
 /// Hovering over context menu items updates the highlighted item without


### PR DESCRIPTION
## Summary

Fixes #2587. The File Explorer right-click context menu did not grab the keyboard while open: printable keys and Backspace leaked past it into the tree's **type-ahead find** underneath, which moved the tree selection behind the menu. Because menu actions act on the *current* selection, a stray keypress could silently retarget which file a menu action operated on.

This is the exact leak class the 0.4.2 release fixed for the sibling **tab context menu** and **"+" new-tab popup** (see CHANGELOG 0.4.2: *"…grab the keyboard while open, so keys no longer leak into the buffer underneath."*). The explorer context menu was the odd one out.

## Root cause

`handle_file_explorer_context_menu_key` (`crates/fresh-editor/src/app/mouse_input.rs`) returned `None` for any key other than Up/Down/Enter/Esc, and bailed out entirely (`return None`) on any modifier. A `None` return lets normal dispatch continue, where the active `FileExplorer` key context routes `InsertChar(c)` into `file_explorer_search_push_char` — the type-ahead. The sibling tab handlers instead swallow every other key (`_ => {}` then `Some(Ok(()))`).

## Fix

While the menu is open the handler now **grabs the keyboard**: it runs navigation only for unmodified Up/Down/Enter/Esc and returns `Some(Ok(()))` for every other key, so nothing reaches the type-ahead beneath it — mirroring the tab context menu / "+" popup behavior.

## Testing

- New e2e reproducer `test_context_menu_grabs_keyboard_printable_keys`: opens the menu, types printable characters, and asserts (observe-only) the type-ahead title (` /<query> `) never appears and the menu stays open. **Fails on the old handler, passes with the grab.**
- Full `explorer_context_menu` e2e suite passes (28 tests), including the existing keyboard-navigation cases (Up/Down/Enter/Esc still work).
- `cargo check --all-targets -p fresh-editor`, `cargo fmt --check`, and `cargo clippy` are clean for the changed code.

### Manual validation (tmux)

In a project with `alpha.txt` / `beta.txt` / `subdir/`: opened the explorer, right-clicked `alpha.txt`, then typed `sub` with the menu open. The sidebar title stayed **File Explorer** (no `/sub` type-ahead), the selection marker stayed on `alpha.txt`, and choosing **Copy Relative Path** reported **`Copied path: alpha.txt`** — the right-clicked file, not a retargeted node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3nc8iMoA2ykMpiycPgRGf)_