### PR TITLE
fix(lsp): range-format the active selection instead of the whole file (#2605)

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -2146,6 +2146,12 @@ impl Editor {
     }
 
     /// Request document formatting from LSP.
+    ///
+    /// When the primary cursor has an active selection and the server
+    /// advertises range formatting, only the selected range is formatted
+    /// (`textDocument/rangeFormatting`) — mirroring VS Code's "Format
+    /// Selection". Otherwise the whole document is formatted
+    /// (`textDocument/formatting`).
     pub(crate) fn request_formatting(&mut self) {
         let buffer_id = self.active_buffer();
         let metadata = match self.active_window().buffer_metadata.get(&buffer_id) {
@@ -2176,6 +2182,16 @@ impl Editor {
         let tab_size = self.config.editor.tab_size as u32;
         let insert_spaces = !self.config.editor.use_tabs;
 
+        // Convert the active selection (if any) to LSP positions so we can
+        // ask the server to format just that range.
+        let selection_range = self.active_cursors().primary().selection_range();
+        let selection_lsp = selection_range.map(|range| {
+            let buffer = &self.active_state().buffer;
+            let (s_line, s_char) = buffer.position_to_lsp_position(range.start);
+            let (e_line, e_char) = buffer.position_to_lsp_position(range.end);
+            (s_line as u32, s_char as u32, e_line as u32, e_char as u32)
+        });
+
         self.active_window_mut().next_lsp_request_id += 1;
         let request_id = self.active_window_mut().next_lsp_request_id;
 
@@ -2183,18 +2199,58 @@ impl Editor {
 
         if let Some(lsp) = self.windows.get_mut(&__active_id).map(|w| &mut w.lsp) {
             if let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::Format) {
-                if let Err(e) = sh.handle.document_formatting(
-                    request_id,
-                    uri.as_uri().clone(),
-                    tab_size,
-                    insert_spaces,
-                ) {
+                // Prefer range formatting when a selection is active and the
+                // server supports it; otherwise format the whole document.
+                let result = match selection_lsp {
+                    Some((sl, sc, el, ec)) if sh.capabilities.document_range_formatting => {
+                        sh.handle.document_range_formatting(
+                            request_id,
+                            uri.as_uri().clone(),
+                            sl,
+                            sc,
+                            el,
+                            ec,
+                            tab_size,
+                            insert_spaces,
+                        )
+                    }
+                    _ => sh.handle.document_formatting(
+                        request_id,
+                        uri.as_uri().clone(),
+                        tab_size,
+                        insert_spaces,
+                    ),
+                };
+                if let Err(e) = result {
                     tracing::warn!("Failed to request formatting: {}", e);
                 }
             } else {
                 self.set_status_message("Formatting not supported by LSP server".to_string());
             }
         }
+    }
+
+    /// Whether the active buffer's LSP server advertises range formatting
+    /// (`textDocument/rangeFormatting`). Used to decide whether an active
+    /// selection can be range-formatted instead of falling back to a
+    /// whole-file external format.
+    pub(crate) fn active_lsp_supports_range_formatting(&self) -> bool {
+        let buffer_id = self.active_buffer();
+        let lsp_enabled = self
+            .active_window()
+            .buffer_metadata
+            .get(&buffer_id)
+            .map(|m| m.lsp_enabled)
+            .unwrap_or(false);
+        if !lsp_enabled {
+            return false;
+        }
+        let language = self.active_state().language.clone();
+        self.active_window()
+            .lsp
+            .handle_for_feature(&language, LspFeature::Format)
+            .map(|sh| sh.capabilities.document_range_formatting)
+            .unwrap_or(false)
     }
 
     /// Handle find references response from LSP

--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -128,6 +128,18 @@ impl Editor {
         // Get language from buffer's stored state
         let language = self.active_state().language.clone();
 
+        // An active selection means the user wants to reformat only that
+        // region (as in VS Code's "Format Selection"). External formatters can
+        // only rewrite the whole file, so when a selection is active and the
+        // language server supports range formatting, route through LSP range
+        // formatting instead of silently reformatting the entire buffer.
+        if self.active_cursors().primary().selection_range().is_some()
+            && self.active_lsp_supports_range_formatting()
+        {
+            self.request_formatting();
+            return Ok(());
+        }
+
         // Get formatter for this language
         let formatter = self
             .config

--- a/crates/fresh-editor/tests/e2e/issue_2605_format_selection_range.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2605_format_selection_range.rs
@@ -1,0 +1,283 @@
+//! Tests for issue #2605: "Format Buffer" ignores the active selection and
+//! reformats the whole file — the documented LSP range formatting was
+//! unreachable when a (default) external formatter existed.
+//!
+//! Root cause (pre-fix): `format_buffer` always ran the configured external
+//! formatter first, and that formatter can only rewrite the whole file. The
+//! LSP fallback (`request_formatting`) was only reached when no formatter was
+//! set, and even then it always sent `textDocument/formatting` (whole
+//! document), never `textDocument/rangeFormatting`. A selection was therefore
+//! silently ignored and the entire buffer was reformatted.
+//!
+//! Fix: when a selection is active and the language server advertises range
+//! formatting, `format_buffer` routes through LSP `textDocument/rangeFormatting`
+//! for just that range — bypassing the whole-file external formatter — matching
+//! VS Code's "Format Selection". Without a selection, the existing whole-file
+//! behavior is preserved.
+//!
+//! These tests use a bash fake LSP, so they are skipped on Windows.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// A fake LSP server that advertises both whole-document and range formatting.
+///
+/// - `textDocument/rangeFormatting` returns an edit that reformats *only* the
+///   first line (`local a=1` -> `local a = 1`) and logs the request.
+/// - `textDocument/formatting` (whole document) logs the request and returns an
+///   edit that also touches line 2 — so if it is ever called by mistake the
+///   out-of-selection line changes and the test fails.
+fn create_range_formatting_lsp_script(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = r##"#!/bin/bash
+
+LOG_FILE="${1:-/tmp/fake_lsp_range_log.txt}"
+> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    echo "METHOD:$method" >> "$LOG_FILE"
+    echo "---" >> "$LOG_FILE"
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"textDocumentSync":2,"documentFormattingProvider":true,"documentRangeFormattingProvider":true,"diagnosticProvider":{"interFileDependencies":false,"workspaceDiagnostics":false}}}}'
+            ;;
+        "textDocument/rangeFormatting")
+            echo "RANGE_BODY:$msg" >> "$LOG_FILE"
+            echo "---" >> "$LOG_FILE"
+            # Reformat only line 0: "local a=1" -> "local a = 1".
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":9}},"newText":"local a = 1"}]}'
+            ;;
+        "textDocument/formatting")
+            echo "FORMAT_BODY:$msg" >> "$LOG_FILE"
+            echo "---" >> "$LOG_FILE"
+            # Whole-document: also touches line 1 so a wrong call is visible.
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[{"range":{"start":{"line":0,"character":0},"end":{"line":1,"character":9}},"newText":"local a = 1\nlocal b = 2"}]}'
+            ;;
+        "textDocument/diagnostic")
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[]}}'
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+            break
+            ;;
+    esac
+done
+"##;
+
+    let script_path = dir.join("fake_lsp_range_formatting.sh");
+    std::fs::write(&script_path, script).expect("Failed to write fake LSP script");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    script_path
+}
+
+/// An external formatter that appends a sentinel line. It stands in for a
+/// default formatter like rustfmt: it can only rewrite the whole file. If
+/// `format_buffer` runs it, the sentinel appears in the buffer and the test
+/// fails — proving whether the selection routed to the external formatter or
+/// to LSP range formatting.
+fn create_sentinel_formatter(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = "#!/bin/sh\ncat\nprintf '%s\\n' '-- EXTERNAL_FORMATTER_RAN'\n";
+    let path = dir.join("sentinel_fmt.sh");
+    std::fs::write(&path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+    }
+    path
+}
+
+fn setup(
+    temp_dir: &tempfile::TempDir,
+    log_file: &std::path::Path,
+    with_external_formatter: bool,
+) -> anyhow::Result<(EditorTestHarness, std::path::PathBuf)> {
+    let script_path = create_range_formatting_lsp_script(temp_dir.path());
+    let test_file = temp_dir.path().join("test.lua");
+    std::fs::write(&test_file, "local a=1\nlocal b=2\nlocal c=3\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "lua".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    if with_external_formatter {
+        let fmt = create_sentinel_formatter(temp_dir.path());
+        let entry = config
+            .languages
+            .entry("lua".to_string())
+            .or_insert_with(fresh::config::LanguageConfig::default);
+        entry.formatter = Some(fresh::config::FormatterConfig {
+            command: fmt.to_string_lossy().to_string(),
+            args: vec![],
+            stdin: true,
+            timeout_ms: 10_000,
+        });
+    }
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the LSP to be reported ready (capabilities received).
+    harness.wait_for_screen_contains("LSP (on)")?;
+
+    Ok((harness, test_file))
+}
+
+fn run_format_buffer(harness: &mut EditorTestHarness) -> anyhow::Result<()> {
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.render()?;
+    harness.type_text("Format Buffer")?;
+    harness.wait_for_screen_contains("Format Buffer")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.render()?;
+    Ok(())
+}
+
+/// With an active selection and an external formatter configured, Format Buffer
+/// must range-format only the selection via LSP — not run the whole-file
+/// external formatter.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_selection_routes_to_lsp_range_formatting() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("fresh=debug")
+        .try_init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let log_file = temp_dir.path().join("range_log.txt");
+    let (mut harness, _f) = setup(&temp_dir, &log_file, /*with_external_formatter=*/ true)?;
+
+    // Select the whole first line: from (0,0) down to (1,0).
+    harness.send_key(KeyCode::Down, KeyModifiers::SHIFT)?;
+    harness.render()?;
+    assert!(
+        harness.has_selection(),
+        "precondition: a selection should be active"
+    );
+
+    run_format_buffer(&mut harness)?;
+
+    // The server must receive a range-formatting request.
+    harness.wait_until(|_| {
+        std::fs::read_to_string(&log_file)
+            .unwrap_or_default()
+            .contains("METHOD:textDocument/rangeFormatting")
+    })?;
+
+    // And the range edit must be applied: line 0 reformatted, lines 1-2 intact.
+    harness.wait_until(|h| {
+        h.get_buffer_content().as_deref() == Some("local a = 1\nlocal b=2\nlocal c=3\n")
+    })?;
+
+    let log = std::fs::read_to_string(&log_file).unwrap_or_default();
+    assert!(
+        !log.contains("METHOD:textDocument/formatting"),
+        "whole-document formatting must not be requested when a selection is active; log:\n{log}"
+    );
+
+    let content = harness.get_buffer_content().unwrap_or_default();
+    assert!(
+        !content.contains("EXTERNAL_FORMATTER_RAN"),
+        "the whole-file external formatter must not run for a selection; buffer:\n{content}"
+    );
+
+    Ok(())
+}
+
+/// Without a selection, Format Buffer keeps the existing whole-file behavior:
+/// the configured external formatter runs and rewrites the whole buffer.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_no_selection_uses_whole_file_external_formatter() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("fresh=debug")
+        .try_init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let log_file = temp_dir.path().join("range_log_nosel.txt");
+    let (mut harness, _f) = setup(&temp_dir, &log_file, /*with_external_formatter=*/ true)?;
+
+    assert!(
+        !harness.has_selection(),
+        "precondition: no selection should be active"
+    );
+
+    run_format_buffer(&mut harness)?;
+
+    // The external formatter appends its sentinel to the whole buffer.
+    harness.wait_until(|h| {
+        h.get_buffer_content()
+            .unwrap_or_default()
+            .contains("EXTERNAL_FORMATTER_RAN")
+    })?;
+
+    let log = std::fs::read_to_string(&log_file).unwrap_or_default();
+    assert!(
+        !log.contains("METHOD:textDocument/rangeFormatting"),
+        "range formatting must not be requested without a selection; log:\n{log}"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -82,6 +82,7 @@ pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_2566_env_detector_labels;
+pub mod issue_2605_format_selection_range;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod language_dialog_esc_cancels_edit;

--- a/docs/features/lsp.md
+++ b/docs/features/lsp.md
@@ -7,7 +7,7 @@ Fresh has native support for the Language Server Protocol (LSP), providing featu
 *   **Code actions:** Quick fixes, refactorings, and server-initiated file create/rename/delete, all through a single popup that merges actions from every configured server.
 *   **Navigation:** Go to Definition (`F12`), Find References (`Shift+F12`), and Go to Implementation (`Ctrl+F12`).
 *   **Hover, rename, and signature help.**
-*   **Formatting:** "Format Buffer" from the command palette uses the configured external formatter, falling back to LSP formatting (including range formatting) when none is set.
+*   **Formatting:** "Format Buffer" from the command palette formats the whole file with the configured external formatter, falling back to LSP formatting when none is set. With an active selection it formats only that range via the language server's range formatting (`textDocument/rangeFormatting`) when the server supports it, matching VS Code's "Format Selection".
 
 All LSP operations are available as palette commands (search for "LSP"). Use the [Keybinding Editor](./keybinding-editor.md) to see or change the keys bound to each one.
 


### PR DESCRIPTION
Fixes #2605.

## Problem

"Format Buffer" silently reformatted the **entire** file even when a selection was active, so selecting a region before formatting (to avoid polluting a diff in a legacy/vendored file) didn't restrict the scope. Two gaps caused this:

1. `request_formatting` always sent `textDocument/formatting` (whole document) and never `textDocument/rangeFormatting`, so a selection was ignored on the LSP path.
2. `format_buffer` always ran the configured external formatter first, and external formatters can only rewrite the whole file. Every language shipping a **default** formatter (Rust/JS/TS/Python/C/C++/Go) therefore never reached the LSP range-formatting fallback documented in `docs/features/lsp.md` — making a selection-scoped format unreachable.

## Fix

When the primary cursor has an active selection **and** the language server advertises range formatting, Format Buffer now routes through LSP `textDocument/rangeFormatting` for just that range — bypassing the whole-file external formatter — matching VS Code's *Format Selection*. Without a selection, or when the server can't range-format, the existing whole-file behavior (external formatter → LSP `textDocument/formatting` fallback) is preserved unchanged.

All the range-formatting plumbing (`document_range_formatting`, response routing via `AsyncMessage::LspFormatting`, `apply_formatting_edits`, and the advertised client capability) already existed; this wiring just makes it reachable.

### Design note (precedence)

This gives the single `Format Buffer` command VS-Code-like semantics: **with a selection → format the selection (via LSP), without a selection → format the whole buffer**. External whole-file formatters intentionally take a back seat only when a selection is active and the server can do a true range format; otherwise nothing about the current behavior changes. Happy to adjust the precedence if a different policy is preferred.

## Changes

- `crates/fresh-editor/src/app/lsp_requests.rs` — `request_formatting` prefers `rangeFormatting` for an active selection; new `active_lsp_supports_range_formatting` helper.
- `crates/fresh-editor/src/app/on_save_actions.rs` — `format_buffer` routes a selection to the LSP range path instead of the whole-file external formatter.
- `docs/features/lsp.md` — document the selection → range-formatting behavior.
- `crates/fresh-editor/tests/e2e/issue_2605_format_selection_range.rs` — new e2e tests.

## Testing

Validated end-to-end through the e2e harness (real `Editor`, real LSP client protocol, driven via the command palette) with a fake LSP that advertises range formatting:

- `test_selection_routes_to_lsp_range_formatting` — with a selection **and** an external formatter configured, only the selection is range-formatted via LSP; the whole-file external formatter does **not** run, and `textDocument/formatting` is **not** requested.
- `test_no_selection_uses_whole_file_external_formatter` — without a selection, the whole-file external formatter still runs and no range request is sent (regression guard for the preserved path).

Both new tests pass; the pre-existing `issue_1573_format_buffer` and `test_format_buffer_via_lsp` tests still pass. `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kKTu39XJub5sm8suHbMGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014kKTu39XJub5sm8suHbMGY)_