### PR TITLE
fix(lsp): keep error diagnostics after dismissing a hover popup (#2601)

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1066,31 +1066,22 @@ impl Editor {
                 self.apply_event_to_active_buffer(&remove_event);
             }
 
-            // Add overlay to highlight the hovered symbol
-            let event = crate::model::event::Event::AddOverlay {
-                namespace: None,
-                range: start_byte..end_byte,
-                face: crate::model::event::OverlayFace::Background {
+            // Add an overlay to highlight the hovered symbol and remember its
+            // handle so it can be removed when the hover is dismissed. The
+            // handle comes straight from the add — recovering it via
+            // `overlays.all().last()` would grab the highest-priority overlay
+            // (an error diagnostic at priority 100) instead, so dismissing the
+            // hover would then remove the error's overlay (#2601).
+            let handle = self.add_overlay(
+                None,
+                start_byte..end_byte,
+                crate::model::event::OverlayFace::Background {
                     color: (80, 80, 120), // Subtle highlight for hovered symbol
                 },
-                priority: 90, // Below rename (100) but above syntax (lower)
-                message: None,
-                extend_to_line_end: false,
-                url: None,
-            };
-            self.apply_event_to_active_buffer(&event);
-            // Store the handle for later removal
-            if let Some(state) = self
-                .windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-                .get(&self.active_buffer())
-            {
-                if let Some(handle) = state.overlays.all().last().map(|o| o.handle.clone()) {
-                    self.active_window_mut().hover.set_symbol_overlay(handle);
-                }
-            }
+                90, // Below rename (100) but above syntax (lower)
+                None,
+            );
+            self.active_window_mut().hover.set_symbol_overlay(handle);
         } else {
             // No range provided by LSP - compute word boundaries at hover position
             // This prevents the popup from following the mouse within the same word

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -23,7 +23,17 @@ use super::Editor;
 impl Editor {
     // === Overlay Management (Event-Driven) ===
 
-    /// Add an overlay for decorations (underlines, highlights, etc.)
+    /// Add a decoration overlay (underline, highlight, etc.) to the active
+    /// buffer and return its handle for later removal.
+    ///
+    /// Decoration overlays are ephemeral and not part of the undo history, and
+    /// `AddOverlay` fires no plugin hook, so this adds directly to the buffer's
+    /// overlay manager rather than round-tripping through an `AddOverlay` event
+    /// — which would discard the handle. The handle comes straight from the add
+    /// (via [`EditorState::add_overlay`]); recovering it from
+    /// `overlays.all().last()` would be wrong, since overlays are
+    /// priority-sorted and `.last()` is the highest-priority overlay (e.g. an
+    /// error diagnostic at priority 100), not the one just added.
     pub fn add_overlay(
         &mut self,
         namespace: Option<crate::view::overlay::OverlayNamespace>,
@@ -32,24 +42,8 @@ impl Editor {
         priority: i32,
         message: Option<String>,
     ) -> crate::view::overlay::OverlayHandle {
-        let event = Event::AddOverlay {
-            namespace,
-            range,
-            face,
-            priority,
-            message,
-            extend_to_line_end: false,
-            url: None,
-        };
-        self.apply_event_to_active_buffer(&event);
-        // Return the handle of the last added overlay
-        let state = self.active_state();
-        state
-            .overlays
-            .all()
-            .last()
-            .map(|o| o.handle.clone())
-            .unwrap_or_default()
+        self.active_state_mut()
+            .add_overlay(namespace, range, face, priority, message, false, None)
     }
 
     /// Remove an overlay by handle

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -952,18 +952,45 @@ impl EditorState {
 
     /// Materialize an `AddOverlay` event into a tracked [`Overlay`].
     fn apply_add_overlay(&mut self, spec: AddOverlaySpec) {
-        let overlay_face = convert_event_face_to_overlay_face(spec.face);
-        let mut overlay = Overlay::with_priority(
-            &mut self.marker_list,
+        self.add_overlay(
+            spec.namespace.clone(),
             spec.range.clone(),
-            overlay_face,
+            spec.face.clone(),
             spec.priority,
+            spec.message.clone(),
+            spec.extend_to_line_end,
+            spec.url.clone(),
         );
-        overlay.namespace = spec.namespace.clone();
-        overlay.message = spec.message.clone();
-        overlay.extend_to_line_end = spec.extend_to_line_end;
-        overlay.url = spec.url.clone();
-        self.overlays.add(overlay);
+    }
+
+    /// Add an overlay to this buffer's overlay manager and return its handle.
+    ///
+    /// This is the shared materialization point for both the `AddOverlay`
+    /// event (via [`apply_add_overlay`](Self::apply_add_overlay)) and direct
+    /// callers that need the handle back for later removal — e.g. the hover /
+    /// rename symbol highlights. Returning the handle from the add itself is
+    /// what `OverlayManager::add` already provides; callers must **not** try to
+    /// recover it via `overlays.all().last()`, which returns the
+    /// highest-priority overlay (priority-sorted), not the one just added.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_overlay(
+        &mut self,
+        namespace: Option<crate::view::overlay::OverlayNamespace>,
+        range: Range<usize>,
+        face: EventOverlayFace,
+        priority: i32,
+        message: Option<String>,
+        extend_to_line_end: bool,
+        url: Option<String>,
+    ) -> crate::view::overlay::OverlayHandle {
+        let overlay_face = convert_event_face_to_overlay_face(&face);
+        let mut overlay =
+            Overlay::with_priority(&mut self.marker_list, range, overlay_face, priority);
+        overlay.namespace = namespace;
+        overlay.message = message;
+        overlay.extend_to_line_end = extend_to_line_end;
+        overlay.url = url;
+        self.overlays.add(overlay)
     }
 
     /// Show a popup synthesized from replayed [`PopupData`].

--- a/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
@@ -1335,3 +1335,107 @@ done
 
     Ok(())
 }
+
+/// Regression test for #2601: dismissing a hover popup must not remove an
+/// error diagnostic elsewhere in the buffer.
+///
+/// Root cause: while showing a hover, the editor adds a subtle symbol-highlight
+/// overlay (priority 90) and remembers its handle for removal on dismiss. That
+/// handle was captured via `overlays.all().last()` — but overlays are
+/// priority-sorted, so `.last()` returns the *highest-priority* overlay, which
+/// is an error diagnostic (priority 100), not the just-added hover highlight.
+/// Dismissing the hover then removed the error's overlay, dropping it from the
+/// status-bar severity count, the gutter marker, and `F8` navigation (while the
+/// Diagnostics panel, which reads `stored_diagnostics`, still listed it) until
+/// the next save re-published.
+///
+/// The hover here is requested on `x` (line 1, char 8), *away* from the error
+/// range (chars 17-24), so the hover highlight does not overlap the diagnostic —
+/// exactly the reporter's scenario of hovering at an unrelated position.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
+fn test_dismissing_hover_preserves_error_diagnostic_2601() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("fresh=debug")
+        .try_init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let script_path = create_hover_plus_diagnostic_server_script(temp_dir.path());
+    let log_file = temp_dir.path().join("hover_dismiss_diag_log.txt");
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(
+        &test_file,
+        "fn main() {\n    let x: i32 = \"hello\";\n    println!(\"{}\", x);\n}\n",
+    )?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the error diagnostic to be published and shown (E:1).
+    harness.wait_until(|_| {
+        let log = std::fs::read_to_string(&log_file).unwrap_or_default();
+        log.contains("SENT: publishDiagnostics")
+    })?;
+    harness.wait_until(|h| h.screen_to_string().contains("E:1"))?;
+
+    // Move the cursor onto `x` (line 1, char 8) — away from the error range
+    // (chars 17-24) — and request a hover there. The fake server answers with a
+    // hover body plus a range at char 8-9, so the editor adds its symbol
+    // highlight overlay there.
+    use crossterm::event::{KeyCode, KeyModifiers};
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    for _ in 0..8 {
+        harness.send_key(KeyCode::Right, KeyModifiers::NONE)?;
+    }
+    harness.editor_mut().request_hover()?;
+    harness.wait_until(|h| h.editor().active_state().popups.is_visible())?;
+    harness.render()?;
+
+    // Sanity: the error is still shown while the hover popup is open.
+    assert!(
+        harness.screen_to_string().contains("E:1"),
+        "Error diagnostic should be visible while the hover popup is open.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Dismiss the hover popup (Escape), matching the reporter's steps.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE)?;
+    harness.wait_until(|h| !h.editor().active_state().popups.is_visible())?;
+    harness.render()?;
+
+    // The error must survive the dismissal: still counted in the status bar.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("E:1"),
+        "Dismissing the hover popup must NOT drop the error diagnostic (#2601).\nScreen:\n{}",
+        screen
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #2601. Dismissing a hover popup silently removed an **error** diagnostic elsewhere in the buffer from the status-bar severity count, the gutter marker, and `F8` navigation — while the Diagnostics panel still listed it — until the next save re-published.

## Root cause

While a hover is shown, the editor adds a subtle symbol-highlight overlay (priority **90**) and remembers its handle so it can remove it when the hover is dismissed. That handle was captured with:

```rust
state.overlays.all().last().map(|o| o.handle.clone())
```

But `OverlayManager` keeps overlays **priority-sorted**, so `.last()` returns the *highest-priority* overlay — an error diagnostic (priority **100**) whenever one exists anywhere in the buffer — not the hover highlight just added. On dismiss, `hide_popup()` removed *that* handle, deleting the error's overlay.

This precisely matches the report:
- Only **errors** vanish (priority 100 is the max; warnings/info at 50/30 are never `.last()`).
- It happens hovering **anywhere**, since the wrong handle is grabbed regardless of hover position.
- The **panel still shows it** — the panel reads `stored_diagnostics`, which is untouched; only the overlay (which feeds the status count / gutter / `F8`) was removed.
- **Re-saving restores it** — check-on-save re-publishes and re-adds the overlays.

## Fix

Return the handle from the add itself. `OverlayManager::add` already yields the handle — the loss happened only because the decoration was routed through an `AddOverlay` **event**, whose application discarded the return value, forcing callers to guess it back from `all().last()`.

- Add a shared `EditorState::add_overlay(...) -> OverlayHandle` materialization point; the `AddOverlay` event path (`apply_add_overlay`) now delegates to it.
- The `Editor::add_overlay` helper adds directly through it and returns the real handle. `AddOverlay` fires no plugin hook and isn't logged, so a direct add is behavior-preserving.
- The hover symbol highlight (and the rename highlight, which shares the helper) now get the correct handle with no fragile read-back.

## Testing

- New e2e regression test `test_dismissing_hover_preserves_error_diagnostic_2601`: publishes an error diagnostic, hovers an unrelated symbol (`x`, away from the error range), dismisses the popup with `Esc`, and asserts the status bar still shows `E:1`. Verified it **fails** against the pre-fix `all().last()` logic and **passes** with the fix.
- `cargo test -p fresh-editor --lib overlay::` — 28 passed.
- `cargo test -p fresh-editor --test e2e_tests lsp_diagnostic_flow` — 8 passed (incl. the existing hover-fusion tests that exercise the same overlay path).
- `cargo fmt` / `cargo clippy -p fresh-editor --tests` — clean on the touched files.

Rebased on latest `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft3NHxRR24aKUNG8qhHG12