### PR TITLE
fix(git-explorer): decorate nested sub-repos when the workspace root is a repo (#2592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Whitespace indicators** - the master toggle (**Toggle Whitespace Indicators**) now turns indicators back **on**, restoring your configured visibility (e.g. space indicators) instead of the built-in default; previously toggling off then on only brought back tab indicators, so a restart was needed to see configured space indicators again (#2579).
 * **File Explorer context menu** now grabs the keyboard while open, like the tab context menu and "+" popup: keys no longer leak into the tree's type-ahead find underneath, which could silently retarget which file a menu action operated on (#2587).
 * **Git Grep** - a search with no matches is now reported as a plain "No matches" instead of logging an error and raising the status-bar warning badge; `git grep` exits 1 when nothing matches, which was wrongly treated as a failure, so every fruitless search looked like a plugin crash (#2591).
+* **File Explorer git decorations** now show a nested sub-repo's own status even when the workspace root is itself a git repo (the monorepo-with-vendored-repo layout): files inside the nested repo previously had no decoration while the gutter, blame, and Review Diff all resolved it correctly (#2592).
 
 ### Internals
 

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -165,27 +165,36 @@ async function refreshGitExplorerDecorations() {
     // (a bare startsWith(root) mis-groups sibling repos that share a prefix,
     // e.g. project-a vs project-a-extra).
     const repoGroups: Array<{ root: string; decorations: Decoration[] }> = [];
+    // Guard against decorating the same repo twice — e.g. the workspace root
+    // repo and a discovered sub-repo path that resolves back to it.
+    const seenRoots = new Set<string>();
 
-    if (rootResult.exit_code === 0 && rootResult.stdout.trim()) {
-      // cwd is inside a git repo — single-repo mode
-      const repoRoot = rootResult.stdout.trim();
+    // Run `git status` in `repoRoot` and record its decorations, skipping any
+    // repo already collected.
+    const addRepoGroup = async (repoRoot: string): Promise<void> => {
+      if (!repoRoot || seenRoots.has(repoRoot)) return;
+      seenRoots.add(repoRoot);
       const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
       if (statusResult.exit_code === 0) {
         repoGroups.push({ root: repoRoot, decorations: parseStatusOutput(statusResult.stdout, repoRoot) });
       }
-    } else {
-      // cwd is not a git repo — discover sub-repos (monorepo/multi-repo)
-      const subRepos = discoverSubRepos(editor, cwd);
-      for (const subDir of subRepos) {
-        const subRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], subDir);
-        if (subRootResult.exit_code !== 0) continue;
-        const repoRoot = subRootResult.stdout.trim();
-        if (!repoRoot) continue;
-        const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
-        if (statusResult.exit_code === 0) {
-          repoGroups.push({ root: repoRoot, decorations: parseStatusOutput(statusResult.stdout, repoRoot) });
-        }
-      }
+    };
+
+    // Decorate the workspace root's own repo when it is one.
+    if (rootResult.exit_code === 0 && rootResult.stdout.trim()) {
+      await addRepoGroup(rootResult.stdout.trim());
+    }
+    // Always also discover nested sub-repos below cwd. A monorepo whose root
+    // is *itself* a repo can still vendor independent git repos; those files
+    // must be decorated from their own repo's status, not left blank because
+    // the outer `git status` (which only sees the sub-repo dir as untracked)
+    // stops at the boundary (#2592). When the root is not a repo this is the
+    // sole discovery path (plain monorepo/multi-repo layout).
+    const subRepos = discoverSubRepos(editor, cwd);
+    for (const subDir of subRepos) {
+      const subRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], subDir);
+      if (subRootResult.exit_code !== 0) continue;
+      await addRepoGroup(subRootResult.stdout.trim());
     }
 
     const allDecorations = repoGroups.flatMap(g => g.decorations);

--- a/crates/fresh-editor/src/app/git_index.rs
+++ b/crates/fresh-editor/src/app/git_index.rs
@@ -85,10 +85,12 @@ impl Editor {
     }
 }
 
-/// Resolve the paths to every `.git/index` reachable from `working_dir`. In a
-/// normal repo this returns a single entry; in a monorepo (working dir is not
-/// itself a git repo) it BFS-scans subdirectories up to 3 levels deep and
-/// returns one entry per discovered sub-repo so that *all* indexes are watched.
+/// Resolve the paths to every `.git/index` reachable from `working_dir`:
+/// the workspace root's own index when it is a repo, plus every nested
+/// sub-repo's index found by BFS-scanning subdirectories up to 3 levels deep.
+/// The two are additive so a monorepo whose root is *itself* a repo still has
+/// its vendored sub-repos watched (#2592); a plain multi-repo workspace (root
+/// not a repo) is covered by the same scan.
 ///
 /// Uses the `ProcessSpawner` so it works transparently on both local and
 /// remote (SSH) filesystems. Takes owned handles (no `&self`) so it can run on
@@ -99,37 +101,27 @@ fn resolve_git_indexes_blocking(
     working_dir: PathBuf,
     rt: Arc<tokio::runtime::Runtime>,
 ) -> Vec<PathBuf> {
-    let cwd = working_dir.to_string_lossy().to_string();
+    let mut indexes: Vec<PathBuf> = Vec::new();
 
-    let result = rt.block_on(spawner.spawn(
-        "git".to_string(),
-        vec!["rev-parse".to_string(), "--git-dir".to_string()],
-        Some(cwd),
-    ));
-
-    if let Ok(ref output) = result {
-        if output.exit_code == 0 {
-            let git_dir = output.stdout.trim();
-            let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
-                PathBuf::from(git_dir)
-            } else {
-                working_dir.join(git_dir)
-            };
-            return vec![git_dir_path.join("index")];
-        }
+    // Watch the workspace root's own index when it is itself a repo.
+    if let Some(index) = git_dir_index(&spawner, &working_dir, &rt) {
+        indexes.push(index);
     }
 
-    // Working dir is not a git repo — scan subdirectories to find all
-    // sub-repos' .git/index (monorepo). `MAX_DEPTH` levels below the working
-    // dir are scanned (level 1 = direct children). This MUST match the levels
-    // scanned by the TypeScript `discoverSubRepos` (lib/git_history.ts) — the
-    // two walks are expected to discover the same repos.
+    // Always also scan subdirectories for nested sub-repos' .git/index. A
+    // monorepo whose root is *itself* a repo can still vendor independent git
+    // repos, and their indexes must be watched too so the explorer refreshes
+    // when they change (#2592) — mirroring the TypeScript `discoverSubRepos`
+    // (lib/git_repo.ts), which now discovers sub-repos in both cases. When the
+    // root is not a repo this is the sole discovery path (plain monorepo).
+    // `MAX_DEPTH` levels below the working dir are scanned (level 1 = direct
+    // children); this MUST match the levels the TypeScript walk scans — the two
+    // are expected to discover the same repos.
     use std::collections::VecDeque;
     const MAX_DEPTH: u32 = 3;
     // Queue entries are (dir_to_scan, level_of_that_dir's_children).
     let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
     queue.push_back((working_dir, 1));
-    let mut indexes = Vec::new();
 
     while let Some((dir, level)) = queue.pop_front() {
         let entries = match fs.read_dir(&dir) {
@@ -147,21 +139,9 @@ fn resolve_git_indexes_blocking(
 
             let dot_git = entry.path.join(".git");
             if fs.exists(&dot_git) {
-                let sub_cwd = entry.path.to_string_lossy().to_string();
-                let sub_result = rt.block_on(spawner.spawn(
-                    "git".to_string(),
-                    vec!["rev-parse".to_string(), "--git-dir".to_string()],
-                    Some(sub_cwd),
-                ));
-                if let Ok(ref output) = sub_result {
-                    if output.exit_code == 0 {
-                        let git_dir = output.stdout.trim();
-                        let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
-                            PathBuf::from(git_dir)
-                        } else {
-                            entry.path.join(git_dir)
-                        };
-                        indexes.push(git_dir_path.join("index"));
+                if let Some(index) = git_dir_index(&spawner, &entry.path, &rt) {
+                    if !indexes.contains(&index) {
+                        indexes.push(index);
                     }
                 }
             } else if level < MAX_DEPTH {
@@ -171,4 +151,31 @@ fn resolve_git_indexes_blocking(
     }
 
     indexes
+}
+
+/// Resolve the `.git/index` path for the repo rooted at (or containing) `dir`,
+/// or `None` when `dir` is not inside a git repo. Shared by the workspace-root
+/// probe and the nested sub-repo scan so both resolve the index the same way.
+fn git_dir_index(
+    spawner: &Arc<dyn crate::services::remote::ProcessSpawner>,
+    dir: &std::path::Path,
+    rt: &Arc<tokio::runtime::Runtime>,
+) -> Option<PathBuf> {
+    let cwd = dir.to_string_lossy().to_string();
+    let result = rt.block_on(spawner.spawn(
+        "git".to_string(),
+        vec!["rev-parse".to_string(), "--git-dir".to_string()],
+        Some(cwd),
+    ));
+    let output = result.ok()?;
+    if output.exit_code != 0 {
+        return None;
+    }
+    let git_dir = output.stdout.trim();
+    let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
+        PathBuf::from(git_dir)
+    } else {
+        dir.join(git_dir)
+    };
+    Some(git_dir_path.join("index"))
 }

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -4222,3 +4222,94 @@ fn test_file_explorer_git_decorations_monorepo_subrepos() {
         "project-b should show git status decorations in monorepo layout.\nScreen:\n{screen}"
     );
 }
+
+/// Regression test for #2592: git status decorations must appear for files in a
+/// nested sub-repo even when the workspace root is *itself* a git repo (the
+/// classic monorepo-with-vendored-repo layout). Previously the explorer only
+/// ran `git status` in the outer repo, which sees the nested repo as a single
+/// untracked directory and never reports the inner file's real status — so the
+/// inner file rendered with no decoration while gutter/blame/Review Diff all
+/// resolved the nested repo correctly.
+///
+/// Layout:
+///   /tmp/outer/            (git repo; outer.py modified)
+///     vendored/            (nested git repo; inner.py modified)
+#[test]
+#[cfg_attr(windows, ignore)] // Git plugin tests are flaky on Windows CI
+fn test_file_explorer_git_decorations_nested_subrepo_under_repo_root() {
+    use crate::common::git_test_helper::git_command;
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use tempfile::TempDir;
+
+    let outer_dir = TempDir::new().expect("Failed to create outer dir");
+    let outer = outer_dir.path();
+
+    // Outer repo with a committed-then-modified tracked file.
+    let output = git_command(outer).arg("init").output().unwrap();
+    assert!(output.status.success(), "git init outer failed");
+    fs::write(outer.join("outer.py"), "outer_var = 1\n").unwrap();
+    git_command(outer).args(["add", "."]).output().unwrap();
+    git_command(outer)
+        .args(["commit", "-m", "outer"])
+        .output()
+        .unwrap();
+    fs::write(outer.join("outer.py"), "outer_var = 1\nouter_var2 = 2\n").unwrap();
+
+    // Nested repo inside the outer repo, with its own modified tracked file.
+    let vendored = outer.join("vendored");
+    fs::create_dir_all(&vendored).unwrap();
+    let output = git_command(&vendored).arg("init").output().unwrap();
+    assert!(output.status.success(), "git init vendored failed");
+    fs::write(vendored.join("inner.py"), "inner_a = 1\ninner_b = 2\n").unwrap();
+    git_command(&vendored).args(["add", "."]).output().unwrap();
+    git_command(&vendored)
+        .args(["commit", "-m", "inner"])
+        .output()
+        .unwrap();
+    fs::write(
+        vendored.join("inner.py"),
+        "inner_a = 1\ninner_b = 2\ninner_c = 3\n",
+    )
+    .unwrap();
+
+    // Install the git_explorer plugin into the workspace.
+    let plugins_dir = outer.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "git_explorer");
+    copy_plugin_lib(&plugins_dir);
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 40, outer.to_path_buf()).unwrap();
+
+    // Open the nested file first, then reveal it in the explorer: Ctrl+B
+    // auto-expands the tree down to the current file (issue #1569), so the
+    // `inner.py` row appears without relying on ordering-sensitive keyboard
+    // navigation into the `vendored` folder.
+    harness.open_file(&vendored.join("inner.py")).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // The `inner.py` *tree row* (a panel-body line starting with the `│`
+    // border, not the tab strip whose header row starts with `┌`) must pick up
+    // an `M` badge from the *nested* repo's own status. Before the fix the
+    // explorer only ran `git status` in the outer repo, which reports the
+    // sub-repo as a single untracked directory and never sees inner.py, so the
+    // row rendered with no decoration.
+    let is_inner_tree_row =
+        |line: &str| line.starts_with('│') && line.contains("inner.py") && line.contains('M');
+    harness
+        .wait_until(|h| h.screen_to_string().lines().any(is_inner_tree_row))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Nested sub-repo under repo root:\n{screen}");
+    let inner_line = screen
+        .lines()
+        .find(|l| l.starts_with('│') && l.contains("inner.py"))
+        .unwrap_or("");
+    assert!(
+        inner_line.contains('M'),
+        "inner.py tree row should show a modified (M) decoration from its own nested repo. Line: '{inner_line}'"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2592.

The File Explorer git decorations only ran `git status` in the workspace root's own repo when the root was **itself** a git repository. An embedded (vendored) sub-repo appears there as a single untracked directory (`?? vendored/`), so files inside it received **no decoration at all** — while Live Diff, Git Blame, and Review Diff all resolved the nested repo correctly for the same file. The file tree therefore contradicted the editor: the gutter showed a file modified while the explorer showed it clean/unknown.

## Root cause

`plugins/git_explorer.ts` used an `if/else`: if the workspace root was a repo it ran a single `git status` there and **never** discovered nested sub-repos; only the "root is not a repo" branch called `discoverSubRepos`. The parallel Rust index watcher (`app/git_index.rs`), which the two are contracted to keep in sync, had the same single-repo short-circuit.

## Fix

- **`git_explorer.ts`**: always discover nested sub-repos below the workspace root and decorate each from its own `git status`, in addition to the root repo when the root is one. Repos already collected are deduped via a `seenRoots` set.
- **`git_index.rs`**: watch the root's index **and** every nested sub-repo's index (shared `git_dir_index` helper), so changes inside a nested repo still trigger an explorer auto-refresh. This keeps the Rust and TypeScript sub-repo walks in sync as their shared `MONOREPO_MAX_DEPTH` contract requires.

## Testing

- New e2e regression test `test_file_explorer_git_decorations_nested_subrepo_under_repo_root`: an outer repo with a modified file plus a vendored nested repo with its own modified file; asserts the inner file's `M` badge renders in the explorer tree. It times out without the fix and passes with it.
- Existing decoration tests still pass: `test_file_explorer_git_decorations_monorepo_subrepos`, `test_file_explorer_git_change_indicator`, `test_nested_folder_shows_modified_indicator`.
- Manually validated in a real `fresh` session (tmux): opening `vendored/inner.py` in the explorer now shows `M` on the inner file, whereas before it was undecorated.
- `cargo fmt`, `cargo clippy -p fresh-editor --tests`, and the plugin type-check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1tLWaCFoijpztQEQEcUat)_