### PR TITLE
fix: click-to-position the caret in text fields — Search & Replace, Settings, entry dialogs (#2573)

### DIFF
--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -222,7 +222,7 @@ impl Editor {
         // and the duplicate dispatch becomes a no-op.
         if let (Some(brow), Some(bcol)) = (mc_buffer_row, mc_buffer_col) {
             if let Some((panel_key, hit)) = self.widget_registry.hit_test(buffer_id, brow, bcol) {
-                self.deliver_widget_hit(&panel_key, &hit);
+                self.deliver_widget_hit(&panel_key, &hit, Some(bcol as usize));
             }
         }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -47,7 +47,7 @@ mod macro_codegen;
 mod macros;
 mod menu_actions;
 mod menu_context;
-pub(crate) mod mouse_input;
+mod mouse_input;
 mod navigation;
 mod on_save_actions;
 mod orchestrator_persistence;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -47,7 +47,7 @@ mod macro_codegen;
 mod macros;
 mod menu_actions;
 mod menu_context;
-mod mouse_input;
+pub(crate) mod mouse_input;
 mod navigation;
 mod on_save_actions;
 mod orchestrator_persistence;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4171,7 +4171,10 @@ impl Editor {
             .unwrap_or_default();
         let local_screen_col = (col - inner.x) as usize;
         let bcol = match entries.get(brow as usize) {
-            Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
+            Some(entry) => crate::primitives::display_width::grapheme_byte_at_visual_column(
+                &entry.text,
+                local_screen_col,
+            ),
             None => return false,
         };
         let (mut payload, key, kind) =
@@ -4277,7 +4280,10 @@ impl Editor {
             .unwrap_or_default();
         let local_screen_col = (col - inner.x) as usize;
         let bcol = match entries.get(brow as usize) {
-            Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
+            Some(entry) => crate::primitives::display_width::grapheme_byte_at_visual_column(
+                &entry.text,
+                local_screen_col,
+            ),
             None => return,
         };
         let (mut hit_payload, hit_event, hit_key, hit_kind, hit_byte_start) = match self
@@ -4389,100 +4395,5 @@ impl Editor {
         ms.drag_start_popup_scroll = None;
         ms.dragging_prompt_scrollbar = false;
         ms.selecting_in_popup = None;
-    }
-}
-
-/// Translate a display-column offset within a rendered line into a
-/// UTF-8 byte offset inside the entry's text. Walks the string
-/// codepoint-by-codepoint using `unicode-width` so wide glyphs
-/// (CJK, emoji) advance by their actual screen width.
-/// Translate a byte offset into a rendered widget-row (`text`) back to a
-/// byte offset into the field's *value*, undoing the field's layout: the
-/// label/`[` prefix (`byte_start` + `inner_start`) and single-line
-/// head-truncation (a `…`-prefixed tail view, `ellipsis`/`dropped`).
-///
-/// Shared by every click-to-position-cursor path — the widget hit handler
-/// and the Settings entry dialog — so the truncation arithmetic lives in
-/// one place. `row_byte` typically comes from [`screen_col_to_byte`].
-pub(crate) fn widget_row_byte_to_value_byte(
-    row_byte: usize,
-    byte_start: usize,
-    inner_start: usize,
-    dropped: usize,
-    ellipsis: usize,
-    value_len: usize,
-) -> usize {
-    let offset_in_field = row_byte.saturating_sub(byte_start);
-    // A click left of the value (label / `[` / gutter) clamps to the
-    // start; a click on the `…` ellipsis maps to the first visible byte;
-    // a click past the last character clamps to end-of-value.
-    let rel = offset_in_field.saturating_sub(inner_start);
-    if ellipsis > 0 {
-        if rel < ellipsis {
-            dropped
-        } else {
-            dropped + (rel - ellipsis)
-        }
-    } else {
-        rel
-    }
-    .min(value_len)
-}
-
-pub(crate) fn screen_col_to_byte(text: &str, target_col: usize) -> usize {
-    use unicode_segmentation::UnicodeSegmentation;
-    use unicode_width::UnicodeWidthStr;
-    let mut byte = 0;
-    let mut col = 0usize;
-    // Advance a whole grapheme cluster at a time, measuring each cluster's
-    // display width with `UnicodeWidthStr` — the same measure the renderer
-    // uses (see `split_rendering::spans`). Per-codepoint width would both
-    // mis-size clusters like emoji ZWJ sequences / flags and let the caret
-    // land between a cluster's codepoints; returning the cluster's start
-    // byte keeps it on a grapheme boundary and aligned with the glyph.
-    for cluster in text.graphemes(true) {
-        let w = UnicodeWidthStr::width(cluster);
-        if col + w > target_col {
-            return byte;
-        }
-        col += w;
-        byte += cluster.len();
-    }
-    byte
-}
-
-#[cfg(test)]
-mod screen_col_to_byte_tests {
-    use super::screen_col_to_byte;
-
-    #[test]
-    fn ascii_maps_col_to_byte_one_to_one() {
-        assert_eq!(screen_col_to_byte("abcdef", 0), 0);
-        assert_eq!(screen_col_to_byte("abcdef", 3), 3);
-        // Past the end clamps to the byte length.
-        assert_eq!(screen_col_to_byte("abcdef", 99), 6);
-    }
-
-    #[test]
-    fn wide_cjk_advances_two_columns_per_cluster() {
-        // Each CJK ideograph is 3 bytes and 2 display columns wide.
-        let s = "中文x"; // 中(0..3) 文(3..6) x(6)
-        assert_eq!(screen_col_to_byte(s, 0), 0);
-        // Column 1 is the right half of 中 — still resolves to its start.
-        assert_eq!(screen_col_to_byte(s, 1), 0);
-        assert_eq!(screen_col_to_byte(s, 2), 3); // start of 文
-        assert_eq!(screen_col_to_byte(s, 4), 6); // the 'x'
-    }
-
-    #[test]
-    fn multi_codepoint_cluster_never_splits() {
-        // Decomposed "é" (e + U+0301) is one column, one 3-byte cluster.
-        let s = "e\u{301}z"; // cluster(0..3) z(3)
-        assert_eq!(screen_col_to_byte(s, 0), 0);
-        assert_eq!(screen_col_to_byte(s, 1), 3); // never returns byte 1 (mid-cluster)
-        // Thai cluster: 9 bytes, one column.
-        let thai = "ที่z"; // cluster(0..9) z(9)
-        assert_eq!(screen_col_to_byte(thai, 0), 0);
-        assert_eq!(screen_col_to_byte(thai, 1), 9);
     }
 }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4396,17 +4396,93 @@ impl Editor {
 /// UTF-8 byte offset inside the entry's text. Walks the string
 /// codepoint-by-codepoint using `unicode-width` so wide glyphs
 /// (CJK, emoji) advance by their actual screen width.
-fn screen_col_to_byte(text: &str, target_col: usize) -> usize {
-    use unicode_width::UnicodeWidthChar;
+/// Translate a byte offset into a rendered widget-row (`text`) back to a
+/// byte offset into the field's *value*, undoing the field's layout: the
+/// label/`[` prefix (`byte_start` + `inner_start`) and single-line
+/// head-truncation (a `…`-prefixed tail view, `ellipsis`/`dropped`).
+///
+/// Shared by every click-to-position-cursor path — the widget hit handler
+/// and the Settings entry dialog — so the truncation arithmetic lives in
+/// one place. `row_byte` typically comes from [`screen_col_to_byte`].
+pub(crate) fn widget_row_byte_to_value_byte(
+    row_byte: usize,
+    byte_start: usize,
+    inner_start: usize,
+    dropped: usize,
+    ellipsis: usize,
+    value_len: usize,
+) -> usize {
+    let offset_in_field = row_byte.saturating_sub(byte_start);
+    // A click left of the value (label / `[` / gutter) clamps to the
+    // start; a click on the `…` ellipsis maps to the first visible byte;
+    // a click past the last character clamps to end-of-value.
+    let rel = offset_in_field.saturating_sub(inner_start);
+    if ellipsis > 0 {
+        if rel < ellipsis {
+            dropped
+        } else {
+            dropped + (rel - ellipsis)
+        }
+    } else {
+        rel
+    }
+    .min(value_len)
+}
+
+pub(crate) fn screen_col_to_byte(text: &str, target_col: usize) -> usize {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
     let mut byte = 0;
     let mut col = 0usize;
-    for ch in text.chars() {
-        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+    // Advance a whole grapheme cluster at a time, measuring each cluster's
+    // display width with `UnicodeWidthStr` — the same measure the renderer
+    // uses (see `split_rendering::spans`). Per-codepoint width would both
+    // mis-size clusters like emoji ZWJ sequences / flags and let the caret
+    // land between a cluster's codepoints; returning the cluster's start
+    // byte keeps it on a grapheme boundary and aligned with the glyph.
+    for cluster in text.graphemes(true) {
+        let w = UnicodeWidthStr::width(cluster);
         if col + w > target_col {
             return byte;
         }
         col += w;
-        byte += ch.len_utf8();
+        byte += cluster.len();
     }
     byte
+}
+
+#[cfg(test)]
+mod screen_col_to_byte_tests {
+    use super::screen_col_to_byte;
+
+    #[test]
+    fn ascii_maps_col_to_byte_one_to_one() {
+        assert_eq!(screen_col_to_byte("abcdef", 0), 0);
+        assert_eq!(screen_col_to_byte("abcdef", 3), 3);
+        // Past the end clamps to the byte length.
+        assert_eq!(screen_col_to_byte("abcdef", 99), 6);
+    }
+
+    #[test]
+    fn wide_cjk_advances_two_columns_per_cluster() {
+        // Each CJK ideograph is 3 bytes and 2 display columns wide.
+        let s = "中文x"; // 中(0..3) 文(3..6) x(6)
+        assert_eq!(screen_col_to_byte(s, 0), 0);
+        // Column 1 is the right half of 中 — still resolves to its start.
+        assert_eq!(screen_col_to_byte(s, 1), 0);
+        assert_eq!(screen_col_to_byte(s, 2), 3); // start of 文
+        assert_eq!(screen_col_to_byte(s, 4), 6); // the 'x'
+    }
+
+    #[test]
+    fn multi_codepoint_cluster_never_splits() {
+        // Decomposed "é" (e + U+0301) is one column, one 3-byte cluster.
+        let s = "e\u{301}z"; // cluster(0..3) z(3)
+        assert_eq!(screen_col_to_byte(s, 0), 0);
+        assert_eq!(screen_col_to_byte(s, 1), 3); // never returns byte 1 (mid-cluster)
+        // Thai cluster: 9 bytes, one column.
+        let thai = "ที่z"; // cluster(0..9) z(9)
+        assert_eq!(screen_col_to_byte(thai, 0), 0);
+        assert_eq!(screen_col_to_byte(thai, 1), 9);
+    }
 }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4280,26 +4280,26 @@ impl Editor {
             Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
             None => return,
         };
-        let (mut hit_payload, hit_event, hit_key, hit_kind) =
-            match self
-                .widget_registry
-                .hit_test(slot.buffer_id(), brow, bcol as u32)
-            {
-                Some((_, hit)) => (
-                    hit.payload.clone(),
-                    hit.event_type.to_string(),
-                    hit.widget_key.clone(),
-                    hit.widget_kind,
-                ),
-                None => {
-                    tracing::debug!(
-                        target: "fresh::dock",
-                        ?slot, col, row, brow, bcol,
-                        "handle_floating_widget_click: hit_test found no widget"
-                    );
-                    return;
-                }
-            };
+        let (mut hit_payload, hit_event, hit_key, hit_kind, hit_byte_start) = match self
+            .widget_registry
+            .hit_test(slot.buffer_id(), brow, bcol as u32)
+        {
+            Some((_, hit)) => (
+                hit.payload.clone(),
+                hit.event_type.to_string(),
+                hit.widget_key.clone(),
+                hit.widget_kind,
+                hit.byte_start,
+            ),
+            None => {
+                tracing::debug!(
+                    target: "fresh::dock",
+                    ?slot, col, row, brow, bcol,
+                    "handle_floating_widget_click: hit_test found no widget"
+                );
+                return;
+            }
+        };
         if !hit_key.is_empty() {
             let tabbable = self
                 .widget_registry
@@ -4324,6 +4324,20 @@ impl Editor {
                 hit_kind,
                 hit_event = %hit_event,
                 "handle_floating_widget_click: hit with empty key (not focusable)"
+            );
+        }
+        // Click-to-position-cursor: a click inside a text field moves the
+        // caret to the clicked column, matching every GUI text input
+        // (#2573). Focus was set just above, so the field is now the
+        // panel's focused widget; the helper maps `bcol` → value byte and
+        // fires `change` so the plugin's cursor mirror follows.
+        if hit_kind == "text" && hit_event == "focus" {
+            self.reposition_widget_text_cursor_from_click(
+                &panel_key,
+                &hit_key,
+                bcol,
+                hit_byte_start,
+                &hit_payload,
             );
         }
         let handled_specially = if hit_kind == "tree" && hit_event == "expand" {

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -2787,9 +2787,9 @@ impl Editor {
             .unwrap_or(0) as usize;
 
         // Translate the click's field byte → value byte (shared with the
-        // Settings entry dialog). `offset_in_field` already rebased the
-        // click by `hit_byte_start`, so pass `byte_start = 0` here.
-        let value_byte = crate::app::mouse_input::widget_row_byte_to_value_byte(
+        // Settings UI via `crate::widgets`). `offset_in_field` already
+        // rebased the click by `hit_byte_start`, so pass `byte_start = 0`.
+        let value_byte = crate::widgets::row_byte_to_value_byte(
             offset_in_field,
             0,
             inner_start,

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -2786,21 +2786,17 @@ impl Editor {
             .and_then(|v| v.as_u64())
             .unwrap_or(0) as usize;
 
-        // Translate the click's field byte → value byte. A click left of
-        // the value (label / `[` / gutter) clamps to the start; a click
-        // on the `…` ellipsis maps to the first visible byte; a click
-        // past the last character clamps to end-of-value.
-        let rel = offset_in_field.saturating_sub(inner_start);
-        let value_byte = if ellipsis > 0 {
-            if rel < ellipsis {
-                dropped
-            } else {
-                dropped + (rel - ellipsis)
-            }
-        } else {
-            rel
-        }
-        .min(value_len);
+        // Translate the click's field byte → value byte (shared with the
+        // Settings entry dialog). `offset_in_field` already rebased the
+        // click by `hit_byte_start`, so pass `byte_start = 0` here.
+        let value_byte = crate::app::mouse_input::widget_row_byte_to_value_byte(
+            offset_in_field,
+            0,
+            inner_start,
+            dropped,
+            ellipsis,
+            value_len,
+        );
 
         self.with_focused_text_editor(panel_key, |editor| editor.set_cursor_from_flat(value_byte));
     }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -198,6 +198,7 @@ impl Editor {
         &mut self,
         panel_key: &crate::widgets::PanelKey,
         hit: &crate::widgets::HitArea,
+        clicked_byte: Option<usize>,
     ) {
         // Click-to-focus: if the clicked widget has a stable, tabbable key, move
         // focus there before firing the event so the next render reflects it.
@@ -211,6 +212,20 @@ impl Editor {
                 self.set_panel_focus_and_notify(panel_key, hit.widget_key.clone());
             }
             self.rerender_widget_panel(panel_key);
+        }
+        // Click-to-position-cursor for buffer-mounted text fields: move
+        // the caret to the clicked column when the hit resolver knew it
+        // (#2573). Mirrors the floating-panel path in `mouse_input`.
+        if hit.widget_kind == "text" && hit.event_type == "focus" {
+            if let Some(byte) = clicked_byte {
+                self.reposition_widget_text_cursor_from_click(
+                    panel_key,
+                    &hit.widget_key,
+                    byte,
+                    hit.byte_start,
+                    &hit.payload,
+                );
+            }
         }
         // Tree disclosure click: the host owns expansion state, so toggle it
         // (the toggle handler fires its own `expand` event with the post-toggle
@@ -313,7 +328,9 @@ impl Editor {
             .get(&panel_key)
             .and_then(|p| p.hits.get(hit_index).cloned());
         if let Some(hit) = hit {
-            self.deliver_widget_hit(&panel_key, &hit);
+            // Native frontends deliver by index, without a per-cell click
+            // column, so there's no click-to-position payload to honour here.
+            self.deliver_widget_hit(&panel_key, &hit, None);
         }
     }
 
@@ -377,7 +394,7 @@ impl Editor {
                 .or_else(|| Self::synthesize_list_hit(panel, event_type, payload))
         };
         if let Some(hit) = hit {
-            self.deliver_widget_hit(&panel_key, &hit);
+            self.deliver_widget_hit(&panel_key, &hit, None);
         }
     }
 
@@ -2712,6 +2729,80 @@ impl Editor {
             serde_json::json!({ "value": after_value, "cursorByte": after_cursor as i64, }),
         );
         true
+    }
+
+    /// Reposition a just-focused Text widget's cursor to the byte under
+    /// a mouse click (#2573). `entry_byte` is the click's byte offset
+    /// within the rendered row (as resolved by `hit_test`); `payload` is
+    /// the `focus` HitArea payload, which carries the value-layout
+    /// breadcrumbs the renderer stamped on it (`valueInnerStart` and the
+    /// truncation fields). Maps the row byte back to a value byte, moves
+    /// the cursor, and fires `change` so a plugin mirroring the cursor
+    /// position (e.g. Search & Replace) stays in sync.
+    ///
+    /// A no-op for hits without the layout payload (older render paths,
+    /// non-text widgets) or when the clicked widget isn't the focused
+    /// one — the caller is expected to focus it first.
+    pub(super) fn reposition_widget_text_cursor_from_click(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: &str,
+        entry_byte: usize,
+        hit_byte_start: usize,
+        payload: &serde_json::Value,
+    ) {
+        // `valueInnerStart` is relative to the *field's own* rendered
+        // text (gutter + label + `[`). Fields can be composed
+        // horizontally into a shared row (Search + Replace live on one
+        // line), so `hit_byte_start` — the field's offset within that
+        // composed row — rebases both the click and the value origin
+        // into the same coordinate space.
+        let inner_start = match payload.get("valueInnerStart").and_then(|v| v.as_u64()) {
+            Some(v) => v as usize,
+            None => return,
+        };
+        let offset_in_field = entry_byte.saturating_sub(hit_byte_start);
+        // The cursor op below targets the panel's *focused* widget; guard
+        // that focus already landed on the clicked field so a stray call
+        // can't move an unrelated field's cursor.
+        let is_focused = self
+            .widget_registry
+            .get(panel_key)
+            .map(|p| p.focus_key == widget_key)
+            .unwrap_or(false);
+        if !is_focused {
+            return;
+        }
+        let value_len = payload
+            .get("valueLen")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let dropped = payload
+            .get("valueDropped")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let ellipsis = payload
+            .get("ellipsisBytes")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        // Translate the click's field byte → value byte. A click left of
+        // the value (label / `[` / gutter) clamps to the start; a click
+        // on the `…` ellipsis maps to the first visible byte; a click
+        // past the last character clamps to end-of-value.
+        let rel = offset_in_field.saturating_sub(inner_start);
+        let value_byte = if ellipsis > 0 {
+            if rel < ellipsis {
+                dropped
+            } else {
+                dropped + (rel - ellipsis)
+            }
+        } else {
+            rel
+        }
+        .min(value_len);
+
+        self.with_focused_text_editor(panel_key, |editor| editor.set_cursor_from_flat(value_byte));
     }
 
     /// Apply a non-printable editing key to the focused text widget

--- a/crates/fresh-editor/src/primitives/display_width.rs
+++ b/crates/fresh-editor/src/primitives/display_width.rs
@@ -56,6 +56,38 @@ pub fn byte_offset_at_visual_column(s: &str, visual_col: usize) -> usize {
     s.len()
 }
 
+/// Convert a visual column to a byte offset, resolving to the grapheme
+/// cluster whose cell **contains** the column (click semantics).
+///
+/// Differs from [`byte_offset_at_visual_column`] in two ways, both of
+/// which matter when mapping a mouse click to a caret position:
+///
+/// * It advances one **grapheme cluster** at a time (measuring each with
+///   [`str_width`], the same measure the renderer uses), so the returned
+///   offset is always on a cluster boundary — a click never lands between
+///   the codepoints of an emoji ZWJ sequence, a flag, or a Thai
+///   combining cluster.
+/// * It returns the cluster *containing* `visual_col` rather than the
+///   first cluster starting at or after it, so clicking the right half of
+///   a double-width glyph selects that glyph, not the next one.
+///
+/// Past the end of the string, returns the string's length.
+#[inline]
+pub fn grapheme_byte_at_visual_column(s: &str, visual_col: usize) -> usize {
+    use unicode_segmentation::UnicodeSegmentation;
+    let mut byte = 0;
+    let mut col = 0usize;
+    for cluster in s.graphemes(true) {
+        let w = str_width(cluster);
+        if col + w > visual_col {
+            return byte;
+        }
+        col += w;
+        byte += cluster.len();
+    }
+    byte
+}
+
 /// Visual column of a byte offset in its line, wide-char aware.
 ///
 /// Returns `None` when the offset's line can't be resolved. The offset may
@@ -130,6 +162,27 @@ mod tests {
 
         // Zero-width space
         assert_eq!(char_width('\u{200B}'), 0);
+    }
+
+    #[test]
+    fn test_grapheme_byte_at_visual_column() {
+        // ASCII: column maps to byte one-to-one; past end clamps to len.
+        assert_eq!(grapheme_byte_at_visual_column("abcdef", 0), 0);
+        assert_eq!(grapheme_byte_at_visual_column("abcdef", 3), 3);
+        assert_eq!(grapheme_byte_at_visual_column("abcdef", 99), 6);
+
+        // Wide CJK: each ideograph is 3 bytes, 2 columns. Clicking either
+        // half of 中 resolves to its start (contains-semantics).
+        let s = "中文x"; // 中(0..3) 文(3..6) x(6)
+        assert_eq!(grapheme_byte_at_visual_column(s, 0), 0);
+        assert_eq!(grapheme_byte_at_visual_column(s, 1), 0); // right half of 中
+        assert_eq!(grapheme_byte_at_visual_column(s, 2), 3); // start of 文
+        assert_eq!(grapheme_byte_at_visual_column(s, 4), 6); // the 'x'
+
+        // Multi-codepoint clusters never split: decomposed "é" (e + U+0301,
+        // 3 bytes, 1 column) and a 9-byte Thai cluster.
+        assert_eq!(grapheme_byte_at_visual_column("e\u{301}z", 1), 3);
+        assert_eq!(grapheme_byte_at_visual_column("ที่z", 1), 9);
     }
 
     #[test]

--- a/crates/fresh-editor/src/primitives/grapheme.rs
+++ b/crates/fresh-editor/src/primitives/grapheme.rs
@@ -97,6 +97,42 @@ pub fn grapheme_at(s: &str, pos: usize) -> Option<(&str, usize, usize)> {
     None
 }
 
+/// Snap a byte position **down** to the nearest grapheme-cluster
+/// boundary at or before it.
+///
+/// Unlike [`prev_grapheme_boundary`], a `pos` that already sits on a
+/// boundary is returned unchanged — this is the "don't land inside a
+/// cluster" clamp used when placing the cursor from an externally
+/// computed byte offset (e.g. a mouse click), not a movement operation.
+///
+/// # Examples
+/// ```ignore
+/// let s = "aที่b"; // 'a'(1) + Thai cluster(9) + 'b'(1)
+/// assert_eq!(snap_to_grapheme_boundary(s, 1), 1);  // already a boundary
+/// assert_eq!(snap_to_grapheme_boundary(s, 5), 1);  // inside the cluster → its start
+/// assert_eq!(snap_to_grapheme_boundary(s, 10), 10); // cluster end / 'b' start
+/// ```
+#[inline]
+pub fn snap_to_grapheme_boundary(s: &str, pos: usize) -> usize {
+    if pos == 0 || s.is_empty() {
+        return 0;
+    }
+    if pos >= s.len() {
+        return s.len();
+    }
+    let mut last_boundary = 0;
+    for (idx, _) in s.grapheme_indices(true) {
+        if idx == pos {
+            return pos;
+        }
+        if idx > pos {
+            break;
+        }
+        last_boundary = idx;
+    }
+    last_boundary
+}
+
 /// Count the number of grapheme clusters in a string.
 ///
 /// This is what users would count as "characters".
@@ -138,6 +174,23 @@ mod tests {
 
         // From middle of grapheme, prev should go to start
         assert_eq!(prev_grapheme_boundary(s, 3), 0);
+    }
+
+    #[test]
+    fn test_snap_to_grapheme_boundary() {
+        // ASCII: every byte is a boundary, so nothing moves.
+        assert_eq!(snap_to_grapheme_boundary("hello", 3), 3);
+        assert_eq!(snap_to_grapheme_boundary("hello", 0), 0);
+        assert_eq!(snap_to_grapheme_boundary("hello", 99), 5);
+
+        // Thai cluster (9 bytes) + 'x': interior offsets snap to the
+        // cluster start; the boundary at its end is preserved.
+        let s = "ที่x";
+        assert_eq!(snap_to_grapheme_boundary(s, 0), 0);
+        assert_eq!(snap_to_grapheme_boundary(s, 3), 0); // mid-cluster
+        assert_eq!(snap_to_grapheme_boundary(s, 6), 0); // mid-cluster
+        assert_eq!(snap_to_grapheme_boundary(s, 9), 9); // cluster end / 'x' start
+        assert_eq!(snap_to_grapheme_boundary(s, 10), 10); // end of string
     }
 
     #[test]

--- a/crates/fresh-editor/src/primitives/text_edit.rs
+++ b/crates/fresh-editor/src/primitives/text_edit.rs
@@ -160,9 +160,8 @@ impl TextEdit {
         for (i, line) in self.lines.iter().enumerate() {
             if remaining <= line.len() {
                 self.cursor_row = i;
-                self.cursor_col = crate::primitives::grapheme::snap_to_grapheme_boundary(
-                    line, remaining,
-                );
+                self.cursor_col =
+                    crate::primitives::grapheme::snap_to_grapheme_boundary(line, remaining);
                 return;
             }
             remaining -= line.len() + 1; // step past the line and its trailing '\n'

--- a/crates/fresh-editor/src/primitives/text_edit.rs
+++ b/crates/fresh-editor/src/primitives/text_edit.rs
@@ -148,19 +148,21 @@ impl TextEdit {
     /// Move the cursor to the position designated by a flat UTF-8 byte
     /// offset into `value()`. Clears any active selection (matching the
     /// other non-selecting cursor-move methods). Clamps to the value's
-    /// length and snaps to the nearest preceding char boundary.
+    /// length and snaps down to the nearest grapheme-cluster boundary, so
+    /// an externally computed offset (e.g. from a mouse click) can never
+    /// land the caret between the codepoints of a single cluster — Thai
+    /// combining marks, emoji ZWJ sequences, flags — matching how
+    /// `move_left`/`move_right` traverse the value.
     pub fn set_cursor_from_flat(&mut self, byte: usize) {
         self.clear_selection();
         let total = self.value().len();
         let mut remaining = byte.min(total);
         for (i, line) in self.lines.iter().enumerate() {
             if remaining <= line.len() {
-                let mut col = remaining;
-                while col > 0 && !line.is_char_boundary(col) {
-                    col -= 1;
-                }
                 self.cursor_row = i;
-                self.cursor_col = col;
+                self.cursor_col = crate::primitives::grapheme::snap_to_grapheme_boundary(
+                    line, remaining,
+                );
                 return;
             }
             remaining -= line.len() + 1; // step past the line and its trailing '\n'
@@ -765,6 +767,28 @@ mod tests {
         let mut edit = TextEdit::single_line_with_text("é");
         edit.set_cursor_from_flat(1);
         assert_eq!(edit.cursor_col, 0);
+    }
+
+    #[test]
+    fn test_set_cursor_from_flat_snaps_to_grapheme_boundary() {
+        // Decomposed "é" = 'e' + combining acute (U+0301, 2 bytes) is one
+        // grapheme cluster spanning 3 bytes. Byte 1 is a valid *char*
+        // boundary (between 'e' and the mark) but lands mid-cluster; the
+        // caret must snap back to the cluster start (0), not sit inside it.
+        let mut edit = TextEdit::single_line_with_text("e\u{301}");
+        edit.set_cursor_from_flat(1);
+        assert_eq!(edit.cursor_col, 0);
+        // Byte 3 (past the whole cluster) is the end boundary — kept as-is.
+        edit.set_cursor_from_flat(3);
+        assert_eq!(edit.cursor_col, 3);
+
+        // Thai "ที่" is a single 9-byte cluster; any interior offset snaps
+        // to its start, and the trailing 'x' stays reachable at its start.
+        let mut thai = TextEdit::single_line_with_text("ที่x");
+        thai.set_cursor_from_flat(6);
+        assert_eq!(thai.cursor_col, 0);
+        thai.set_cursor_from_flat(9);
+        assert_eq!(thai.cursor_col, 9);
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/controls/text_input/mod.rs
+++ b/crates/fresh-editor/src/view/controls/text_input/mod.rs
@@ -171,6 +171,17 @@ impl TextInputState {
         self.editor.delete();
     }
 
+    /// Position the caret at a flat byte offset in the value — used for
+    /// click-to-position (#2573). Like the arrow keys, an explicit caret
+    /// placement cancels the "next keystroke replaces the value" arm: the
+    /// user pointed at a spot, so the following keystroke must insert
+    /// there, not wipe the field. The offset is grapheme-snapped and
+    /// clamped by `TextEdit`.
+    pub fn set_cursor_from_flat(&mut self, byte: usize) {
+        self.pending_replace_on_type = false;
+        self.editor.set_cursor_from_flat(byte);
+    }
+
     /// Move cursor left
     pub fn move_left(&mut self) {
         self.pending_replace_on_type = false;

--- a/crates/fresh-editor/src/view/settings/layout.rs
+++ b/crates/fresh-editor/src/view/settings/layout.rs
@@ -279,7 +279,7 @@ impl SettingsLayout {
                             return Some(SettingsHit::ControlDropdown(item.index));
                         }
                     }
-                    ControlLayoutInfo::Text(area) => {
+                    ControlLayoutInfo::Text { area, .. } => {
                         if point_in_rect(*area, x, y) {
                             return Some(SettingsHit::ControlText(item.index));
                         }

--- a/crates/fresh-editor/src/view/settings/mouse.rs
+++ b/crates/fresh-editor/src/view/settings/mouse.rs
@@ -877,6 +877,62 @@ impl Editor {
         Ok(false)
     }
 
+    /// Map a click on a single-line `Text` control to a byte offset in
+    /// its value, so the caret lands where the user clicked (#2573).
+    ///
+    /// Rather than re-derive the field's label/bracket/truncation layout
+    /// by hand, this replays the exact widget render the dialog drew
+    /// (`setting_control_to_widget_aligned` → `render_spec_no_autofocus`)
+    /// and reads the value-layout breadcrumbs back off the field's `focus`
+    /// hit area — the same geometry inversion `render::hit_rect` uses, and
+    /// the same `screen_col_to_byte` / value-byte mapping the widget-panel
+    /// click path uses. Returns `None` for non-text controls or when the
+    /// render produced no text hit (e.g. an empty item name → no key).
+    fn entry_text_click_to_value_byte(
+        control: &SettingControl,
+        item_name: &str,
+        label_col_width: u16,
+        control_area_x: u16,
+        control_area_width: u16,
+        click_col: u16,
+    ) -> Option<usize> {
+        if !matches!(control, SettingControl::Text(_)) {
+            return None;
+        }
+        // Mirrors `render_entry_items`: the control is indented by the
+        // 3-col focus-indicator gutter, and the widget's own label column
+        // is the dialog-wide width minus that gutter.
+        const FOCUS_INDICATOR_WIDTH: u16 = 3;
+        let spec = crate::view::settings::widget_map::setting_control_to_widget_aligned(
+            item_name,
+            control,
+            Some(label_col_width.saturating_sub(FOCUS_INDICATOR_WIDTH)),
+        );
+        let out = crate::widgets::render_spec_no_autofocus(
+            &spec,
+            &std::collections::HashMap::new(),
+            "",
+            control_area_width.max(1) as u32,
+        );
+        let hit = out
+            .hits
+            .iter()
+            .find(|h| h.widget_kind == "text" && h.event_type == "focus")?;
+        let entry = out.entries.get(hit.buffer_row as usize)?;
+        let row_text = entry.text.trim_end_matches('\n');
+        let click_in_row = click_col.saturating_sub(control_area_x) as usize;
+        let row_byte = crate::app::mouse_input::screen_col_to_byte(row_text, click_in_row);
+        let field = |k: &str| hit.payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        Some(crate::app::mouse_input::widget_row_byte_to_value_byte(
+            row_byte,
+            hit.byte_start,
+            field("valueInnerStart"),
+            field("valueDropped"),
+            field("ellipsisBytes"),
+            field("valueLen"),
+        ))
+    }
+
     fn handle_entry_dialog_item_click(
         &mut self,
         col: u16,
@@ -952,12 +1008,45 @@ impl Editor {
                 if matches!(item.control, SettingControl::TextList(_)) {
                     return self.handle_text_list_click(idx, sub_row, col, layout);
                 }
+                // Click-to-position: resolve the clicked column to a value
+                // byte before mutating the dialog (the immutable `item`
+                // borrow is still live here). `label_col_width` mirrors
+                // `render_settings_entry_dialog`'s dialog-wide computation.
+                let click_byte = if matches!(item.control, SettingControl::Text(_)) {
+                    const FOCUS_INDICATOR_WIDTH: u16 = 3;
+                    let max_label_width = (layout.inner_width / 2).max(20);
+                    let label_col_width = dialog
+                        .items
+                        .iter()
+                        .map(|it| it.name.len() as u16 + 2)
+                        .filter(|&w| w <= max_label_width)
+                        .max()
+                        .unwrap_or(20)
+                        .min(max_label_width);
+                    Self::entry_text_click_to_value_byte(
+                        &item.control,
+                        &item.name,
+                        label_col_width,
+                        layout.inner_x + FOCUS_INDICATOR_WIDTH,
+                        layout.inner_width.saturating_sub(FOCUS_INDICATOR_WIDTH),
+                        col,
+                    )
+                } else {
+                    None
+                };
                 dialog.focus_on_buttons = false;
                 dialog.field_button_focus = None;
                 dialog.selected_item = idx;
                 dialog.update_focus_states();
                 if !dialog.editing_text {
                     dialog.start_editing();
+                }
+                // Place the caret after `start_editing` (which seeds the
+                // cursor at end-of-value), so the click position wins.
+                if let Some(byte) = click_byte {
+                    if let SettingControl::Text(ts) = &mut dialog.items[idx].control {
+                        ts.editor.set_cursor_from_flat(byte);
+                    }
                 }
                 return Ok(true);
             }

--- a/crates/fresh-editor/src/view/settings/mouse.rs
+++ b/crates/fresh-editor/src/view/settings/mouse.rs
@@ -8,6 +8,7 @@ use anyhow::Result as AnyhowResult;
 use rust_i18n::t;
 
 use super::items::SettingControl;
+use super::render::ControlLayoutInfo;
 use super::{FocusPanel, SettingsHit, SettingsLayout};
 use crate::view::controls::DualListColumn;
 
@@ -234,7 +235,35 @@ impl Editor {
             return Ok(false);
         };
 
+        // A click on a main-panel text field enters editing (via dispatch)
+        // AND positions the caret where the click landed (#2573). The
+        // geometry was stamped into the layout at render time; read it
+        // here, where the screen `col` is still available (the web-shared
+        // `dispatch_settings_hit` carries no column). Grab it before
+        // dispatch, since dispatch re-borrows the layout.
+        let text_click_geometry = match hit {
+            SettingsHit::ControlText(idx) => self
+                .active_chrome()
+                .settings_layout
+                .as_ref()
+                .and_then(|l| l.items.iter().find(|it| it.index == idx))
+                .and_then(|it| match &it.control {
+                    ControlLayoutInfo::Text { geometry, .. } => geometry.clone(),
+                    _ => None,
+                }),
+            _ => None,
+        };
+
         self.dispatch_settings_hit(hit, row, is_double_click);
+
+        // Position the caret after dispatch, which ran `start_editing` and
+        // seeded the caret at end-of-value; the click position wins.
+        if let Some(geometry) = text_click_geometry {
+            let byte = geometry.value_byte_at(col);
+            if let Some(state) = self.settings_state.as_mut() {
+                state.position_text_cursor(byte);
+            }
+        }
         Ok(true)
     }
 
@@ -880,14 +909,16 @@ impl Editor {
     /// Map a click on a single-line `Text` control to a byte offset in
     /// its value, so the caret lands where the user clicked (#2573).
     ///
-    /// Rather than re-derive the field's label/bracket/truncation layout
-    /// by hand, this replays the exact widget render the dialog drew
+    /// The entry dialog is a modal that recomputes its own item positions
+    /// on click, so rather than store per-item geometry it reconstructs it:
+    /// it replays the exact widget render the dialog drew
     /// (`setting_control_to_widget_aligned` → `render_spec_no_autofocus`)
     /// and reads the value-layout breadcrumbs back off the field's `focus`
-    /// hit area — the same geometry inversion `render::hit_rect` uses, and
-    /// the same `screen_col_to_byte` / value-byte mapping the widget-panel
-    /// click path uses. Returns `None` for non-text controls or when the
-    /// render produced no text hit (e.g. an empty item name → no key).
+    /// hit area via [`WidgetTextClickGeometry`] — the same type the main
+    /// settings panel stamps at render time, and the same value-byte
+    /// mapping the widget-panel click path uses. Returns `None` for
+    /// non-text controls or when the render produced no text hit (e.g. an
+    /// empty item name → no key).
     fn entry_text_click_to_value_byte(
         control: &SettingControl,
         item_name: &str,
@@ -914,23 +945,9 @@ impl Editor {
             "",
             control_area_width.max(1) as u32,
         );
-        let hit = out
-            .hits
-            .iter()
-            .find(|h| h.widget_kind == "text" && h.event_type == "focus")?;
-        let entry = out.entries.get(hit.buffer_row as usize)?;
-        let row_text = entry.text.trim_end_matches('\n');
-        let click_in_row = click_col.saturating_sub(control_area_x) as usize;
-        let row_byte = crate::app::mouse_input::screen_col_to_byte(row_text, click_in_row);
-        let field = |k: &str| hit.payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-        Some(crate::app::mouse_input::widget_row_byte_to_value_byte(
-            row_byte,
-            hit.byte_start,
-            field("valueInnerStart"),
-            field("valueDropped"),
-            field("ellipsisBytes"),
-            field("valueLen"),
-        ))
+        let geometry =
+            crate::widgets::WidgetTextClickGeometry::from_render_output(&out, control_area_x)?;
+        Some(geometry.value_byte_at(click_col))
     }
 
     fn handle_entry_dialog_item_click(
@@ -1045,7 +1062,7 @@ impl Editor {
                 // cursor at end-of-value), so the click position wins.
                 if let Some(byte) = click_byte {
                     if let SettingControl::Text(ts) = &mut dialog.items[idx].control {
-                        ts.editor.set_cursor_from_flat(byte);
+                        ts.set_cursor_from_flat(byte);
                     }
                 }
                 return Ok(true);

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -1518,7 +1518,10 @@ fn render_control(
 
         SettingControl::Text(state) => {
             if skip_rows > 0 {
-                return ControlLayoutInfo::Text(Rect::default());
+                return ControlLayoutInfo::Text {
+                    area: Rect::default(),
+                    geometry: None,
+                };
             }
             if read_only {
                 // Truly read-only fields (e.g., Key: in entry dialogs) render as plain text
@@ -1541,7 +1544,10 @@ fn render_control(
                     Paragraph::new(value.as_str()).style(value_style),
                     value_area,
                 );
-                ControlLayoutInfo::Text(Rect::default())
+                ControlLayoutInfo::Text {
+                    area: Rect::default(),
+                    geometry: None,
+                }
             } else {
                 // Editable text (and nullable-null) render through the
                 // widget framework. While editing, focus the widget (by
@@ -1560,11 +1566,20 @@ fn render_control(
                     prev,
                 );
                 let rect = hit_rect(&out, "text", "focus", area, 0);
-                ControlLayoutInfo::Text(if rect.width > 0 {
-                    rect
-                } else {
-                    Rect::new(area.x, area.y, area.width, 1)
-                })
+                // Stamp the field's click geometry from the render we just
+                // did, so a later click maps to a caret position without
+                // reverse-engineering the layout. The row is painted at
+                // `area.x` (its byte 0).
+                let geometry =
+                    crate::widgets::WidgetTextClickGeometry::from_render_output(&out, area.x);
+                ControlLayoutInfo::Text {
+                    area: if rect.width > 0 {
+                        rect
+                    } else {
+                        Rect::new(area.x, area.y, area.width, 1)
+                    },
+                    geometry,
+                }
             }
         }
 
@@ -1720,7 +1735,10 @@ fn render_control(
                 label_width,
                 prev,
             );
-            ControlLayoutInfo::Text(Rect::new(area.x, area.y, area.width, 1))
+            ControlLayoutInfo::Text {
+                area: Rect::new(area.x, area.y, area.width, 1),
+                geometry: None,
+            }
         }
 
         SettingControl::Complex { .. } => {
@@ -1766,7 +1784,16 @@ pub enum ControlLayoutInfo {
         option_areas: Vec<Rect>,
         scroll_offset: usize,
     },
-    Text(Rect),
+    Text {
+        area: Rect,
+        /// Stamped at render time for single-line editable text fields so a
+        /// click can be mapped to a caret position without reconstructing
+        /// the field's label/bracket/truncation layout (#2573). `None` for
+        /// read-only or multi-line (JSON) text. When Settings controls are
+        /// mounted as real widget panels this becomes redundant with the
+        /// registry hit path (see `widgets::WidgetTextClickGeometry`).
+        geometry: Option<crate::widgets::WidgetTextClickGeometry>,
+    },
     TextList {
         /// (data_index, screen_area) - None index means "add new" row
         rows: Vec<(Option<usize>, Rect)>,

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -2446,6 +2446,17 @@ impl SettingsState {
             .unwrap_or(false)
     }
 
+    /// Move the current single-line `Text` control's caret to a flat byte
+    /// offset in its value — used for click-to-position (#2573). No-op for
+    /// other control kinds. The byte is grapheme-snapped by `TextEdit`.
+    pub fn position_text_cursor(&mut self, byte: usize) {
+        if let Some(item) = self.current_item_mut() {
+            if let SettingControl::Text(state) = &mut item.control {
+                state.set_cursor_from_flat(byte);
+            }
+        }
+    }
+
     /// Insert a character into the current editable control
     pub fn text_insert(&mut self, c: char) {
         if let Some(item) = self.current_item_mut() {

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -17,6 +17,7 @@
 mod actions;
 mod registry;
 mod render;
+mod text_click;
 
 pub use actions::{
     append_tree_nodes_in_spec, find_widget_by_key, set_list_items_in_spec, set_raw_entries_in_spec,
@@ -32,3 +33,4 @@ pub use render::{
     wrap_index, EmbedRect, FocusCursor, OverlayRow, RenderOutput, ScrollRegion,
     DROPDOWN_VISIBLE_OPTIONS,
 };
+pub use text_click::{row_byte_to_value_byte, WidgetTextClickGeometry};

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -2458,14 +2458,27 @@ fn render_widget_text(
         // through and the field stayed unfocused (#2234 item 1). Focusing is
         // driven by the tabbable path in `handle_floating_widget_click`; the
         // `focus` event keeps the plugin's focus mirror in step.
+        //
+        // The payload carries the value-layout breadcrumbs the click
+        // handler needs to reposition the cursor to the clicked column
+        // (#2573): `valueInnerStart` is where the value's `<inner>`
+        // region begins in this row's text (after the gutter that was
+        // just prepended), and the truncation fields translate a click
+        // over a `…`-prefixed tail view back to a value byte.
         if let Some(k) = key.filter(|k| !k.is_empty()) {
+            let inner_start = marker_bytes + rendered.inner_byte_start;
             out.hits.push(HitArea {
                 widget_key: k.to_string(),
                 widget_kind: "text",
                 buffer_row: 0,
                 byte_start: 0,
                 byte_end: entry.text.len(),
-                payload: json!({}),
+                payload: json!({
+                    "valueInnerStart": inner_start,
+                    "valueDropped": rendered.value_dropped_bytes,
+                    "ellipsisBytes": rendered.ellipsis_bytes,
+                    "valueLen": rendered.value_len,
+                }),
                 event_type: "focus",
             });
         }
@@ -4467,6 +4480,22 @@ pub struct RenderedTextInput {
     /// Byte offset within `entry.text` where the cursor lands.
     /// When the input is unfocused or has no cursor, `None`.
     pub cursor_byte_in_entry: Option<usize>,
+    /// Byte offset within `entry.text` where the value's rendered
+    /// `<inner>` region begins (just after the label + `[`). Used to
+    /// map a mouse click column back to a value byte for
+    /// click-to-position-cursor.
+    pub inner_byte_start: usize,
+    /// Number of value bytes hidden off the left edge by
+    /// head-truncation (the `…`-prefixed tail view). `0` when the
+    /// whole value is visible.
+    pub value_dropped_bytes: usize,
+    /// Byte length of the leading `…` glyph within `<inner>` when the
+    /// value is head-truncated; `0` otherwise. A click landing on the
+    /// ellipsis maps to the first visible value byte.
+    pub ellipsis_bytes: usize,
+    /// Total byte length of the (untruncated) value. A click past the
+    /// last visible character clamps the cursor here (end-of-value).
+    pub value_len: usize,
 }
 
 /// Render a `TextInput`.
@@ -4521,6 +4550,12 @@ pub fn render_text_input(
     } else {
         (cursor_byte as usize).min(value.len())
     };
+
+    // Breadcrumbs for mapping a mouse click column back to a value
+    // byte (click-to-position-cursor). Set by the head-truncation
+    // branch; stay 0 when the whole value is visible.
+    let mut value_dropped_bytes = 0usize;
+    let mut ellipsis_bytes = 0usize;
 
     // Build `<inner>` plus the byte offset of the cursor *within*
     // `<inner>` (not yet including `[`/label offsets). This is the
@@ -4603,6 +4638,8 @@ pub fn render_text_input(
             } else {
                 "…".len() + (raw_cursor_byte - dropped_bytes)
             };
+            value_dropped_bytes = dropped_bytes;
+            ellipsis_bytes = "…".len();
             (s, Some(cursor_in_inner))
         }
     } else if max_visible_chars > 0 && value.chars().count() > max_visible_chars as usize {
@@ -4720,6 +4757,10 @@ pub fn render_text_input(
             truncate_to_chars: None,
         },
         cursor_byte_in_entry,
+        inner_byte_start,
+        value_dropped_bytes,
+        ellipsis_bytes,
+        value_len: value.len(),
     }
 }
 

--- a/crates/fresh-editor/src/widgets/text_click.rs
+++ b/crates/fresh-editor/src/widgets/text_click.rs
@@ -1,0 +1,189 @@
+//! Mapping a mouse click on a rendered text widget to a caret position.
+//!
+//! Every text input the widget runtime draws — plugin panels *and* the
+//! Settings controls, which render through the same [`render_spec`] path —
+//! emits a `focus` [`HitArea`] whose payload carries the value-layout
+//! breadcrumbs needed to turn a click into a byte offset in the field's
+//! *value*:
+//!
+//! * `valueInnerStart` — byte where the value's `<inner>` region begins in
+//!   the rendered row (after the gutter / label / `[`).
+//! * `valueDropped` / `ellipsisBytes` — for a single-line field whose
+//!   value is head-truncated to a `…`-prefixed tail view, the bytes hidden
+//!   off the left and the width of the `…`.
+//! * `valueLen` — the value's byte length, used to clamp.
+//!
+//! [`WidgetTextClickGeometry`] is a snapshot of that hit plus the row text
+//! and the screen column the row was painted at — everything required to
+//! answer "the user clicked screen column X; what value byte is that?".
+//! The mounted-panel path reaches the same data live through
+//! [`WidgetRegistry::hit_test`](super::WidgetRegistry::hit_test); surfaces
+//! that render widgets *without* mounting them (the Settings UI, today)
+//! stamp this geometry at render time and read it back on click. When
+//! Settings controls are eventually mounted as real panels, this snapshot
+//! and its stamping become redundant with the registry hit path.
+//!
+//! [`render_spec`]: super::render_spec
+
+use super::RenderOutput;
+use crate::primitives::display_width::grapheme_byte_at_visual_column;
+
+/// Translate a byte offset into a rendered widget row back to a byte
+/// offset into the field's *value*, undoing the field's layout: the
+/// label/`[` prefix (`byte_start` + `inner_start`) and single-line
+/// head-truncation (a `…`-prefixed tail view, `ellipsis`/`dropped`).
+///
+/// Shared by every click-to-position-cursor path — the mounted widget hit
+/// handler and the Settings UI — so the truncation arithmetic lives in one
+/// place.
+pub fn row_byte_to_value_byte(
+    row_byte: usize,
+    byte_start: usize,
+    inner_start: usize,
+    dropped: usize,
+    ellipsis: usize,
+    value_len: usize,
+) -> usize {
+    let offset_in_field = row_byte.saturating_sub(byte_start);
+    // A click left of the value (label / `[` / gutter) clamps to the
+    // start; a click on the `…` ellipsis maps to the first visible byte;
+    // a click past the last character clamps to end-of-value.
+    let rel = offset_in_field.saturating_sub(inner_start);
+    if ellipsis > 0 {
+        if rel < ellipsis {
+            dropped
+        } else {
+            dropped + (rel - ellipsis)
+        }
+    } else {
+        rel
+    }
+    .min(value_len)
+}
+
+/// A snapshot of one rendered text field's geometry, sufficient to map a
+/// screen-column click to a value byte after the fact. Built from the
+/// widget [`RenderOutput`] the field was drawn from; see the module docs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WidgetTextClickGeometry {
+    /// Screen column where the field's row was painted (its byte 0).
+    pub origin_col: u16,
+    /// The rendered row's text (label + `[` + visible value + `]`).
+    pub row_text: String,
+    /// `valueInnerStart` from the field's `focus` hit payload.
+    pub inner_start: usize,
+    /// `valueDropped` — bytes hidden off the left when head-truncated.
+    pub dropped: usize,
+    /// `ellipsisBytes` — width of the leading `…`, or 0 when not truncated.
+    pub ellipsis: usize,
+    /// `valueLen` — the value's byte length.
+    pub value_len: usize,
+}
+
+impl WidgetTextClickGeometry {
+    /// Build the geometry from a rendered field's [`RenderOutput`] and the
+    /// screen column its row was painted at. Returns `None` when the output
+    /// has no single-line text field (`focus` hit of kind `"text"`), e.g.
+    /// a non-text control or an unfocusable field with an empty key.
+    pub fn from_render_output(out: &RenderOutput, origin_col: u16) -> Option<Self> {
+        let hit = out
+            .hits
+            .iter()
+            .find(|h| h.widget_kind == "text" && h.event_type == "focus")?;
+        let entry = out.entries.get(hit.buffer_row as usize)?;
+        let row_text = entry.text.trim_end_matches('\n').to_string();
+        let field = |k: &str| hit.payload.get(k).and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        // The `focus` hit spans the whole row (`byte_start == 0`), so the
+        // payload offsets are already row-relative; `byte_start` is folded
+        // in here for uniformity with the mounted hit path.
+        Some(Self {
+            origin_col,
+            row_text,
+            inner_start: field("valueInnerStart").saturating_sub(hit.byte_start),
+            dropped: field("valueDropped"),
+            ellipsis: field("ellipsisBytes"),
+            value_len: field("valueLen"),
+        })
+    }
+
+    /// Map an absolute screen column to a byte offset in the field's value
+    /// (grapheme-boundary aligned, clamped to the value). A click left of
+    /// the value yields 0; a click past its end yields `value_len`.
+    pub fn value_byte_at(&self, screen_col: u16) -> usize {
+        let col_in_row = screen_col.saturating_sub(self.origin_col) as usize;
+        let row_byte = grapheme_byte_at_visual_column(&self.row_text, col_in_row);
+        row_byte_to_value_byte(
+            row_byte,
+            0,
+            self.inner_start,
+            self.dropped,
+            self.ellipsis,
+            self.value_len,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_byte_to_value_byte_untruncated() {
+        // value "abcdef" begins 10 bytes into the row (label + `[`).
+        assert_eq!(row_byte_to_value_byte(10, 0, 10, 0, 0, 6), 0); // at value start
+        assert_eq!(row_byte_to_value_byte(13, 0, 10, 0, 0, 6), 3); // mid value
+        assert_eq!(row_byte_to_value_byte(3, 0, 10, 0, 0, 6), 0); // in the label → clamp 0
+        assert_eq!(row_byte_to_value_byte(99, 0, 10, 0, 0, 6), 6); // past end → value_len
+    }
+
+    #[test]
+    fn row_byte_to_value_byte_truncated() {
+        // Head-truncated `…tail`: inner_start=10, ellipsis=3 ("…"),
+        // dropped=4 bytes hidden off the left, value_len=20.
+        // Click on the ellipsis → first visible byte (== dropped).
+        assert_eq!(row_byte_to_value_byte(10, 0, 10, 4, 3, 20), 4);
+        assert_eq!(row_byte_to_value_byte(12, 0, 10, 4, 3, 20), 4); // still on `…`
+                                                                    // First real char after `…` (row byte 13 = inner_start+ellipsis).
+        assert_eq!(row_byte_to_value_byte(13, 0, 10, 4, 3, 20), 4);
+        assert_eq!(row_byte_to_value_byte(15, 0, 10, 4, 3, 20), 6); // 2 past the tail start
+    }
+
+    #[test]
+    fn value_byte_at_maps_screen_column() {
+        // Row "Name: [abcdef]" painted at screen col 4. Value "abcdef"
+        // begins at row byte 7 ("Name: [" == 7 chars, all ASCII).
+        let g = WidgetTextClickGeometry {
+            origin_col: 4,
+            row_text: "Name: [abcdef]".to_string(),
+            inner_start: 7,
+            dropped: 0,
+            ellipsis: 0,
+            value_len: 6,
+        };
+        // Screen col 4 → row col 0 (the 'N') → left of value → 0.
+        assert_eq!(g.value_byte_at(4), 0);
+        // Screen col 11 → row col 7 → value byte 0 ('a').
+        assert_eq!(g.value_byte_at(11), 0);
+        // Screen col 14 → row col 10 → value byte 3 ('d').
+        assert_eq!(g.value_byte_at(14), 3);
+        // Far right → clamps to value_len.
+        assert_eq!(g.value_byte_at(200), 6);
+    }
+
+    #[test]
+    fn value_byte_at_wide_and_grapheme() {
+        // Value "中b" (中 is 3 bytes / 2 cols) begins at row byte 1
+        // (after "["), painted at origin 0. Row "[中b]".
+        let g = WidgetTextClickGeometry {
+            origin_col: 0,
+            row_text: "[中b]".to_string(),
+            inner_start: 1,
+            dropped: 0,
+            ellipsis: 0,
+            value_len: 4, // 中(3) + b(1)
+        };
+        assert_eq!(g.value_byte_at(1), 0); // left half of 中 → its start
+        assert_eq!(g.value_byte_at(2), 0); // right half of 中 → its start
+        assert_eq!(g.value_byte_at(3), 3); // the 'b' (row col 3)
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -211,6 +211,7 @@ pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
 pub mod settings_save_error_popup;
 pub mod settings_scrolled_list_click;
+pub mod settings_text_click_position;
 pub mod settings_text_field_esc_cancels;
 pub mod settings_text_input_focus;
 pub mod settings_tree_view;

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -2397,3 +2397,90 @@ fn test_search_replace_nav_highlights_selection() {
         after
     );
 }
+
+/// Clicking inside a Search & Replace text field moves the caret to
+/// the clicked column, exactly like every GUI text input — the next
+/// typed character lands where you clicked, not at the end of the
+/// value (#2573: "the cursor doesn't attach to the nearest text
+/// position in the search and replace panel").
+///
+/// Driven on the Replace field because typing into Search kicks off
+/// the debounced async search worker; the Replace field exercises the
+/// identical widget kind + click path with no async tail, so the test
+/// is deterministic. The `test_search_replace_click_positions_cursor_in_search_field`
+/// case below covers the literally-reported Search field.
+#[test]
+fn test_widget_text_click_positions_cursor() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+    let (mut harness, _) = open_panel_with_focus_on_replace(&project_root);
+
+    // Type a value whose characters are all distinct so the click
+    // target is unambiguous. Cursor is now at the end (after "Z").
+    harness.type_text("abcXYZ").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Replace: [abcXYZ"))
+        .unwrap();
+
+    // Locate the value on screen and click on the "X" cell (index 3),
+    // so the caret should land *before* the "X".
+    let (vcol, vrow) = harness
+        .find_text_on_screen("abcXYZ")
+        .expect("the typed value should be visible in the field");
+    harness.mouse_click(vcol + 3, vrow).unwrap();
+
+    // Type a sentinel; with the caret repositioned it splits the value.
+    harness.type_text("!").unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            // Fixed: caret moved to the click → "abc!XYZ".
+            // Bug: caret stayed at end → "abcXYZ!".
+            s.contains("Replace: [abc!XYZ") && !s.contains("Replace: [abcXYZ!")
+        })
+        .unwrap();
+}
+
+/// The literally-reported case (#2573): clicking in the **Search**
+/// field repositions the caret there. Same mechanism as the Replace
+/// test above; kept separate so the reported field is covered directly.
+#[test]
+fn test_search_replace_click_positions_cursor_in_search_field() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    // A pattern that matches nothing in the fixtures, so the value
+    // appears only in the Search field (not in any results row).
+    harness.type_text("abcXYZ").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search: [abcXYZ"))
+        .unwrap();
+
+    let (vcol, vrow) = harness
+        .find_text_on_screen("abcXYZ")
+        .expect("the typed pattern should be visible in the Search field");
+    // Click on the "X" cell (index 3) → caret before "X".
+    harness.mouse_click(vcol + 3, vrow).unwrap();
+
+    harness.type_text("!").unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("Search: [abc!XYZ") && !s.contains("Search: [abcXYZ!")
+        })
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/settings_text_click_position.rs
+++ b/crates/fresh-editor/tests/e2e/settings_text_click_position.rs
@@ -1,0 +1,179 @@
+//! E2E: clicking inside a Settings text field moves the caret to the
+//! clicked position (#2573), like any GUI text input — instead of leaving
+//! it at the end (or wiping the value via the "replace on first keystroke"
+//! affordance that arms when a field enters edit mode).
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Navigate to Terminal -> Command (a single-line text field) and leave it
+/// focused. Mirrors the helper in `settings_text_input_focus`.
+fn open_terminal_command(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("/terminal/shell/command").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Command");
+
+    for _ in 0..30 {
+        if find_command_row(harness).is_some() {
+            return;
+        }
+        harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    for _ in 0..30 {
+        if find_command_row(harness).is_some() {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    panic!(
+        "Could not focus the Terminal -> Command row.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Row index of the focused `Command` text-input label (walks by char to
+/// step over multibyte box-drawing glyphs).
+fn find_command_row(harness: &EditorTestHarness) -> Option<u16> {
+    let height = harness.buffer().area.height;
+    for y in 0..height {
+        let line = harness.get_row_text(y);
+        let chars: Vec<char> = line.chars().collect();
+        let needle: Vec<char> = "Command".chars().collect();
+        let Some(cmd_col) = (0..chars.len().saturating_sub(needle.len().saturating_sub(1)))
+            .find(|&i| chars[i..i + needle.len()] == needle[..])
+        else {
+            continue;
+        };
+        if !chars[cmd_col..].contains(&'[') {
+            continue;
+        }
+        if let Some(arrow_col) = chars[..cmd_col].iter().rposition(|&c| c == '>') {
+            if cmd_col - arrow_col <= 6 {
+                return Some(y);
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn test_settings_text_field_click_positions_cursor() {
+    let mut harness = EditorTestHarness::new(140, 40).unwrap();
+    harness.render().unwrap();
+    open_terminal_command(&mut harness);
+
+    // Enter edit mode, type a value with all-distinct characters, and
+    // commit it (Enter) so the field holds a saved value — the way a real
+    // setting would when you later click into it.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("abcXYZ").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("[abcXYZ");
+
+    // Click on the "X" cell (value index 3): the caret should land before
+    // the X. Clicking also re-enters edit mode and re-arms replace-on-type;
+    // positioning the caret from the click must cancel that arm.
+    let (vcol, vrow) = harness
+        .find_text_on_screen("abcXYZ")
+        .expect("the committed value should be visible in the field");
+    harness.mouse_click(vcol + 3, vrow).unwrap();
+    harness.render().unwrap();
+
+    // Type a sentinel. Fixed: caret at the click, arm cancelled → "abc!XYZ".
+    // Regressions this guards:
+    //   * caret left at end           → "abcXYZ!"
+    //   * replace-on-type still armed  → "!"
+    harness.type_text("!").unwrap();
+    harness.render().unwrap();
+
+    let s = harness.screen_to_string();
+    assert!(
+        s.contains("[abc!XYZ") && !s.contains("[abcXYZ!"),
+        "expected the caret to split the value at the click (abc!XYZ).\nScreen:\n{}",
+        s
+    );
+}
+
+/// Screen (col, row) of the first `[+] Add new` affordance, scanning by
+/// character to step over multibyte box-drawing glyphs.
+fn find_add_new(harness: &EditorTestHarness) -> Option<(u16, u16)> {
+    let height = harness.buffer().area.height;
+    for y in 0..height {
+        let chars: Vec<char> = harness.get_row_text(y).chars().collect();
+        let needle: Vec<char> = "[+] Add new".chars().collect();
+        if let Some(c) = (0..chars.len().saturating_sub(needle.len().saturating_sub(1)))
+            .find(|&i| chars[i..i + needle.len()] == needle[..])
+        {
+            return Some((c as u16 + 1, y)); // +1 → on the '+' cell
+        }
+    }
+    None
+}
+
+/// The same fix on the entry (add/edit) sub-dialog: clicking a text field
+/// inside the "Add Value" dialog positions the caret at the click.
+#[test]
+fn test_settings_entry_dialog_text_click_positions_cursor() {
+    let mut harness = EditorTestHarness::new(150, 45).unwrap();
+    harness.render().unwrap();
+    harness.open_settings().unwrap();
+
+    // Jump to the Keybindings settings, whose "Keybinding Maps" list has an
+    // "[+] Add new" that opens an "Add Value" dialog with an editable "Key"
+    // text field.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("keybinding maps").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let (ac, ar) = find_add_new(&harness).unwrap_or_else(|| {
+        panic!(
+            "no '[+] Add new' on the Keybindings page.\nScreen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    harness.mouse_click(ac, ar).unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Key");
+
+    // The dialog's Key field is focused; type a distinct value into it.
+    harness.type_text("abcXYZ").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("[abcXYZ");
+
+    // Click on the "X" cell (value index 3) and type a sentinel.
+    let (vcol, vrow) = harness
+        .find_text_on_screen("abcXYZ")
+        .expect("the typed value should be visible in the dialog's Key field");
+    harness.mouse_click(vcol + 3, vrow).unwrap();
+    harness.render().unwrap();
+    harness.type_text("!").unwrap();
+    harness.render().unwrap();
+
+    let s = harness.screen_to_string();
+    assert!(
+        s.contains("[abc!XYZ") && !s.contains("[abcXYZ!"),
+        "expected the caret to split the dialog value at the click (abc!XYZ).\nScreen:\n{}",
+        s
+    );
+}


### PR DESCRIPTION
Fixes #2573.

## Problem

Clicking inside a text field left the caret at the end of the value instead of moving it to the clicked column, and you couldn't edit from where you clicked — unlike every GUI text input. As the reporter put it, "the cursor doesn't attach to the nearest text position … and I can't left/right it."

This affected every host text input: the **Search & Replace** panel and, as it turned out, the **Settings** panel's text controls and its **add/edit dialogs** too.

## Fix

All these fields render through the same widget-spec path, which already emits a `focus` hit carrying the value's layout breadcrumbs (`valueInnerStart` / `valueDropped` / `ellipsisBytes` / `valueLen`). The fix turns a screen-column click into a value byte offset and moves the field's `TextEdit` caret there.

The mapping is captured once as `widgets::WidgetTextClickGeometry` and reused everywhere:

- **Search & Replace panel** — the mounted widget hit path (`reposition_widget_text_cursor_from_click`).
- **Main Settings panel** — the geometry is *stamped* into `ControlLayoutInfo::Text` at render time (from the `RenderOutput` already in hand) and read back on a `ControlText` click in the TUI mouse caller, where the screen column is available (the web-shared `dispatch_settings_hit` carries none).
- **Settings add/edit dialog** — the modal recomputes item positions on click, so it reconstructs the same geometry by replaying the field's widget render.

Both settings paths feed the shared `screen col → value byte` mapping and then `TextInputState::set_cursor_from_flat`, which — like the arrow keys — also cancels the "replace the value on the first keystroke" affordance a field arms on focus, so clicking to place the caret no longer wipes the value on the next key.

## Refactors (less duplication, better layering)

- The grapheme-aware **column→byte** mapping now lives in the shared `primitives::display_width` (`grapheme_byte_at_visual_column`), replacing a private per-codepoint duplicate in `app::mouse_input`; the widget-panel path uses it too.
- The **row-byte→value-byte** truncation math and the geometry type live in the widget layer (`widgets::text_click`), used by both the mounted-panel hit handler and the Settings UI, so `view` no longer reaches into `app::mouse_input` internals.
- `TextEdit::set_cursor_from_flat` snaps to a **grapheme boundary**, so a click never lands the caret inside a multi-codepoint cluster (Thai combining marks, emoji ZWJ sequences, flags); the mapping also measures width per cluster, so wide (CJK) glyphs map correctly.

When the Settings controls are eventually mounted as real widget panels (a direction the code already notes), the stamping/replay becomes redundant with the registry hit path and can be deleted — the fix already lives on that shared path.

### Not included: web frontend

The web Settings UI is a bespoke DOM view that sends only a semantic hit (no click column) and renders the caret as `▌` appended at the end. Web click-to-position would need a protocol addition (send the click offset) plus a model/render change to draw a mid-value caret; it's left as a follow-up and is unaffected by this PR.

## Testing

- **Unit**: the width mapping, the geometry (`value_byte_at`, including label offset, `…`-truncation, wide/grapheme cases), and grapheme snapping.
- **E2E** (real clicks, asserting on rendered output — a sentinel typed after the click splits the value at the clicked position): the Search field, the Replace field, the main Settings panel, and the Settings add/edit dialog. Each fails without the fix (caret at end → `abcXYZ!`, or value wiped → `!`).
- Full **settings** e2e suite (148) and **search_replace** e2e (41) pass; `cargo clippy` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoGk5depVdqxx9auDwmWwk