### PR TITLE
fix(lsp): hover the buffer under the mouse, not the active one (#2572)

### DIFF
--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -630,7 +630,7 @@ impl Editor {
         self.active_window()
             .mouse_state
             .lsp_hover_state
-            .map(|(pos, _, x, y)| (pos, x, y))
+            .map(|(pos, _, x, y, _)| (pos, x, y))
     }
 
     /// Check if a transient popup (hover/signature help) is currently visible
@@ -644,14 +644,14 @@ impl Editor {
     /// Force check the mouse hover timer (for testing)
     /// This bypasses the normal 500ms delay
     pub fn force_check_mouse_hover(&mut self) -> bool {
-        if let Some((byte_pos, _, screen_x, screen_y)) =
+        if let Some((byte_pos, _, screen_x, screen_y, buffer_id)) =
             self.active_window_mut().mouse_state.lsp_hover_state
         {
             if !self.active_window_mut().mouse_state.lsp_hover_request_sent {
                 self.active_window_mut()
                     .hover
                     .set_screen_position((screen_x, screen_y));
-                match self.request_hover_at_position(byte_pos) {
+                match self.request_hover_at_position(byte_pos, buffer_id) {
                     Ok(true) => {
                         self.active_window_mut().mouse_state.lsp_hover_request_sent = true;
                         return true;

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1357,19 +1357,19 @@ impl Editor {
 
         // Get hover state without borrowing self
         let hover_info = match self.active_window_mut().mouse_state.lsp_hover_state {
-            Some((byte_pos, start_time, screen_x, screen_y)) => {
+            Some((byte_pos, start_time, screen_x, screen_y, buffer_id)) => {
                 if self.active_window_mut().mouse_state.lsp_hover_request_sent {
                     return false; // Already sent request for this position
                 }
                 if start_time.elapsed() < hover_delay {
                     return false; // Timer hasn't expired yet
                 }
-                Some((byte_pos, screen_x, screen_y))
+                Some((byte_pos, screen_x, screen_y, buffer_id))
             }
             None => return false,
         };
 
-        let Some((byte_pos, screen_x, screen_y)) = hover_info else {
+        let Some((byte_pos, screen_x, screen_y, buffer_id)) = hover_info else {
             return false;
         };
 
@@ -1379,7 +1379,7 @@ impl Editor {
             .set_screen_position((screen_x, screen_y));
 
         // Request hover at the byte position — only mark as sent if dispatched
-        match self.request_hover_at_position(byte_pos) {
+        match self.request_hover_at_position(byte_pos, buffer_id) {
             Ok(true) => {
                 self.active_window_mut().mouse_state.lsp_hover_request_sent = true;
                 true

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -937,9 +937,20 @@ impl Editor {
     /// Used for mouse-triggered hover
     /// Returns `Ok(true)` if the request was dispatched, `Ok(false)` if no
     /// eligible server was available (e.g. not yet initialized).
-    pub(crate) fn request_hover_at_position(&mut self, byte_pos: usize) -> AnyhowResult<bool> {
-        // Get the current buffer
-        let state = self.active_state();
+    pub(crate) fn request_hover_at_position(
+        &mut self,
+        byte_pos: usize,
+        buffer_id: BufferId,
+    ) -> AnyhowResult<bool> {
+        // Resolve against the buffer the pointer is over — not necessarily the
+        // active one. Hovering a non-active split (or a virtual UI buffer with
+        // no language server, like the Search/Replace panel) must query that
+        // buffer, so the hover card never leaks in from the active buffer
+        // (#2572). A virtual buffer has no `file_uri`, so `with_lsp_for_buffer`
+        // below returns `None` and nothing pops up.
+        let Some(state) = self.buffers().get(&buffer_id) else {
+            return Ok(false);
+        };
 
         // Convert byte position to LSP position (line, UTF-16 code units)
         let (line, character) = state.buffer.position_to_lsp_position(byte_pos);
@@ -955,7 +966,6 @@ impl Editor {
             );
         }
 
-        let buffer_id = self.active_buffer();
         let request_id = self.active_window_mut().next_lsp_request_id;
 
         // Use helper to ensure didOpen is sent before the request
@@ -1085,10 +1095,16 @@ impl Editor {
         } else {
             // No range provided by LSP - compute word boundaries at hover position
             // This prevents the popup from following the mouse within the same word
-            let computed_range = if let Some((hover_byte_pos, _, _, _)) =
+            let computed_range = if let Some((hover_byte_pos, _, _, _, hover_buf)) =
                 self.active_window_mut().mouse_state.lsp_hover_state
             {
-                let state = self.active_state();
+                // Compute word boundaries in the buffer the pointer is over —
+                // the same buffer the hover request targeted — not the active
+                // one (#2572).
+                let state = self
+                    .buffers()
+                    .get(&hover_buf)
+                    .unwrap_or(self.active_state());
                 let start_byte = find_word_start(&state.buffer, hover_byte_pos);
                 let end_byte = find_word_end(&state.buffer, hover_byte_pos);
                 if start_byte < end_byte {

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -937,9 +937,11 @@ impl Editor {
             }
         }
 
-        // Check if we're still hovering the same position
-        if let Some((old_pos, _, _, _)) = self.active_window_mut().mouse_state.lsp_hover_state {
-            if old_pos == byte_pos {
+        // Check if we're still hovering the same position in the same buffer
+        if let Some((old_pos, _, _, _, old_buf)) =
+            self.active_window_mut().mouse_state.lsp_hover_state
+        {
+            if old_pos == byte_pos && old_buf == buffer_id {
                 // Same position - keep existing state
                 return;
             }
@@ -950,9 +952,11 @@ impl Editor {
             // mouse passed through whitespace between two words (issue #692).
         }
 
-        // Start tracking new hover position
+        // Start tracking new hover position (remembering which buffer the
+        // pointer is over, so the request targets that buffer — not the
+        // active one — see `lsp_hover_state`).
         self.active_window_mut().mouse_state.lsp_hover_state =
-            Some((byte_pos, std::time::Instant::now(), col, row));
+            Some((byte_pos, std::time::Instant::now(), col, row, buffer_id));
         self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
     }
 

--- a/crates/fresh-editor/src/app/types/mouse.rs
+++ b/crates/fresh-editor/src/app/types/mouse.rs
@@ -16,9 +16,17 @@ pub struct MouseState {
     pub drag_start_left_column: Option<usize>,
     /// Last mouse position
     pub last_position: Option<(u16, u16)>,
-    /// Mouse hover for LSP: byte position being hovered, timer start, and screen position
-    /// Format: (byte_position, hover_start_instant, screen_x, screen_y)
-    pub lsp_hover_state: Option<(usize, std::time::Instant, u16, u16)>,
+    /// Mouse hover for LSP: byte position being hovered, timer start, screen
+    /// position, and the buffer the mouse is over.
+    /// Format: (byte_position, hover_start_instant, screen_x, screen_y, buffer_id)
+    ///
+    /// `buffer_id` records which split's buffer the pointer is over so the
+    /// hover request targets *that* buffer rather than the active one. Without
+    /// it, hovering a non-active split (or a UI panel such as the
+    /// Search/Replace dock) fired a hover for the active code buffer at a byte
+    /// offset taken from the hovered split's geometry — the popup "leaked
+    /// through" the panel (#2572).
+    pub lsp_hover_state: Option<(usize, std::time::Instant, u16, u16, BufferId)>,
     /// Whether we've already sent a hover request for the current position
     pub lsp_hover_request_sent: bool,
     /// Initial mouse row when starting to drag the scrollbar thumb

--- a/crates/fresh-editor/tests/e2e/issue_2572_hover_through_panel.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2572_hover_through_panel.rs
@@ -1,0 +1,156 @@
+//! Reproduction for issue #2572: "mouse will hover through 'search and
+//! replace in project'".
+//!
+//! With the Search/Replace panel open in the bottom Utility Dock, moving the
+//! mouse over the *panel* rows used to trigger an LSP **hover** request. The
+//! request was aimed at the editor's *active* buffer (the code file that was
+//! open before the panel), using a byte position computed from the *panel's*
+//! geometry — so a hover card for the code appeared "through" the panel.
+//!
+//! The fix: hover only fires for the buffer the mouse is actually over. Over
+//! the Search/Replace panel (a virtual UI buffer with no language server),
+//! nothing should pop up.
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::time::Duration;
+
+fn setup_project() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "search_replace");
+
+    // A short Rust file with a symbol to hover.
+    fs::write(project_root.join("main.rs"), "fn foo() {}\n").unwrap();
+
+    let status = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let status = std::process::Command::new("git")
+        .args(["add", "main.rs"])
+        .current_dir(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    (temp_dir, project_root)
+}
+
+fn open_search_replace_panel(harness: &mut EditorTestHarness) -> anyhow::Result<()> {
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_prompt()?;
+    harness.type_text("Search and Replace")?;
+    harness.wait_until(|h| h.screen_to_string().contains("Search and Replace"))?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    // The "Search:" control line only renders once the dock panel is up.
+    harness.wait_until(|h| h.screen_to_string().contains("Search:"))?;
+    Ok(())
+}
+
+fn row_of(harness: &EditorTestHarness, needle: &str) -> u16 {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("expected screen to contain '{needle}'\nScreen:\n{screen}"))
+        as u16
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_hover_does_not_leak_through_search_replace_panel() -> anyhow::Result<()> {
+    let (_temp_dir, project_root) = setup_project();
+
+    let _fake_server = FakeLspServer::spawn(&project_root)?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(&project_root)
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, config, project_root.clone())?;
+    harness.open_file(&project_root.join("main.rs"))?;
+    harness.render()?;
+
+    // Open the Search/Replace panel in the bottom dock (it takes focus), then
+    // click back into the code split so the *code* buffer is active again while
+    // the panel stays open below — the real-world state after opening the panel
+    // and returning to the file (e.g. clicking a search result).
+    open_search_replace_panel(&mut harness)?;
+    harness.mouse_click(10, 2)?;
+    harness.render()?;
+
+    // Precondition, established from rendered output only: hovering the code
+    // symbol "foo" pops the fake server's hover card. This proves in one step
+    // that (a) the LSP round-trip works and (b) the code buffer is active — a
+    // hover only fires for the buffer under the pointer, so the card appearing
+    // here means the pointer's split *is* the live code buffer. Column 10 lands
+    // on "foo" once the line-number gutter is accounted for (matching the
+    // working hover fixture in `e2e/lsp.rs`).
+    harness.mouse_move(10, 2)?;
+    harness.render()?;
+    harness.editor_mut().force_check_mouse_hover();
+    harness.wait_until(|h| h.screen_to_string().contains("Test hover content"))?;
+
+    // Move the pointer off the text to dismiss the card before the real check.
+    harness.mouse_move(0, 0)?;
+    harness.render()?;
+    harness.editor_mut().force_check_mouse_hover();
+    harness.wait_until(|h| !h.screen_to_string().contains("Test hover content"))?;
+
+    // Now move the mouse over a panel row (the "Search:" control line). On the
+    // unfixed editor this fired a hover request for the still-active code buffer
+    // — using a byte offset taken from the panel's geometry — and the card
+    // leaked in over the panel. With the fix, the pointer is over the panel's
+    // virtual buffer (no language server) so nothing is requested.
+    let panel_row = row_of(&harness, "Search:");
+    harness.mouse_move(6, panel_row)?;
+    harness.render()?;
+
+    // Negative check: there is no event to wait for, so pump the hover
+    // machinery a bounded number of times — enough that the erroneous request
+    // would have fired and rendered — then assert the card never appeared.
+    for _ in 0..40 {
+        harness.editor_mut().force_check_mouse_hover();
+        harness.process_async_and_render()?;
+        harness.sleep(Duration::from_millis(20));
+    }
+
+    assert!(
+        !harness.screen_to_string().contains("Test hover content"),
+        "LSP hover leaked through the Search/Replace panel.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -82,6 +82,7 @@ pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_2566_env_detector_labels;
+pub mod issue_2572_hover_through_panel;
 pub mod issue_2605_format_selection_range;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
## What & why

Fixes #2572 — "mouse will hover through 'search and replace in project'".

Moving the mouse over the **Search/Replace** panel (which lives in the bottom Utility Dock) popped an LSP hover card that appeared **through** the panel, showing info for the code file behind it.

### Root cause

The mouse handler and the hover request disagreed about *which buffer* was being hovered:

- `update_lsp_hover_state` computes the hovered byte offset from **the split under the pointer** (here, the panel).
- `request_hover_at_position` then sent the request for the editor's **active** buffer.

So with the code buffer active and the mouse over the panel, Fresh fired a hover for the *code* file using a byte offset taken from the *panel's* geometry — the card "leaked through" the panel. The same mismatch produced wrong-buffer hovers on any non-active split.

### Fix

Record the buffer the pointer is over in `MouseState::lsp_hover_state` and target **that** buffer for the hover request (and for the no-range word-boundary fallback). The Search/Replace panel is a virtual buffer with no `file_uri`, so `with_lsp_for_buffer` returns `None` and nothing pops up; genuine non-active code splits now hover their own buffer correctly.

## Changes

- `types/mouse.rs` — `lsp_hover_state` carries the hovered `BufferId`.
- `mouse_input.rs` — store the hovered buffer; keep the "same position" guard buffer-aware.
- `lsp_requests.rs` — `request_hover_at_position(byte_pos, buffer_id)` resolves against that buffer; word-boundary fallback does too.
- `buffer_management.rs`, `editor_accessors.rs` — thread the buffer id through the two hover callers.

## Testing

- New e2e reproduction `issue_2572_hover_through_panel.rs` (fake LSP): hovering the code pops the card, but hovering the Search/Replace panel does not. **Fails without the fix** (card leaks over the panel), **passes with it**.
- Regression suites green: hover (44), mouse (106), dock (54).
- Manually launched the real `fresh` binary in tmux, opened the panel, clicked into the code, and moved the mouse over the panel — no stray card, no crash. (A live `rust-analyzer` couldn't be exercised in the sandbox — it exits on start — so the deterministic fake-LSP e2e test is the authoritative check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YCJQxtRrKp4kh8m8SdukY

---
_Generated by [Claude Code](https://claude.ai/code/session_014YCJQxtRrKp4kh8m8SdukY)_