### PR TITLE
fix(lsp): anchor diagnostics to the editor's CoordMap so they track every edit kind (#2602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **LSP diagnostics** now track buffer edits: inserting or deleting lines above an error shifts its gutter marker, `F8`/Diagnostics-panel target, and inline text down/up with the text, instead of leaving them frozen at the pre-edit line until the next save re-publishes. Stored diagnostic positions are remapped by the same incremental changes sent to the server, matching VS Code (#2602).
 * **LSP Rename**: a cross-file rename (F2) invoked from a use site no longer steals the active tab, jumping you to the definition's file at its stale cursor position; focus stays on the buffer you were editing, matching VS Code / Sublime / IntelliJ (#2599).
 * **Vi mode**: the indent operators `>>` / `<<` (with counts and motions like `>j`) and visual, visual-line, and visual-block `>` / `<` now shift lines by one level instead of doing nothing; `.` repeats them (#2438, #2606).
 * **Vi mode**: quote text objects `i"`/`a"` (and `'`/`` ` ``) now search forward on the line, so `ci"`/`di"` work from before the quotes — e.g. from the start of the line — instead of only when the cursor is already inside them (#2439).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
-* **LSP diagnostics** now track buffer edits: inserting or deleting lines above an error shifts its gutter marker, `F8`/Diagnostics-panel target, and inline text down/up with the text, instead of leaving them frozen at the pre-edit line until the next save re-publishes. Stored diagnostic positions are remapped by the same incremental changes sent to the server, matching VS Code (#2602).
+* **LSP diagnostics** now track buffer edits: inserting or deleting lines above an error shifts its gutter marker, `F8` target, inline underline, hover, and the diagnostics panel down/up with the text, instead of leaving them frozen at the pre-edit line until the next save re-publishes. Each diagnostic is anchored to the buffer and carried forward by the same edit-tracking the editor uses for its own markers, so it stays put through ordinary typing, multi-cursor edits, code actions, and undo/redo alike, matching VS Code (#2602).
 * **LSP Rename**: a cross-file rename (F2) invoked from a use site no longer steals the active tab, jumping you to the definition's file at its stale cursor position; focus stays on the buffer you were editing, matching VS Code / Sublime / IntelliJ (#2599).
 * **Vi mode**: the indent operators `>>` / `<<` (with counts and motions like `>j`) and visual, visual-line, and visual-block `>` / `<` now shift lines by one level instead of doing nothing; `.` repeats them (#2438, #2606).
 * **Vi mode**: quote text objects `i"`/`a"` (and `'`/`` ` ``) now search forward on the line, so `ci"`/`di"` work from before the quotes — e.g. from the start of the line — instead of only when the cursor is already inside them (#2439).

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -12,6 +12,7 @@ use crate::model::event::BufferId;
 use crate::services::async_bridge::{
     LspMessageType, LspProgressValue, LspSemanticTokensResponse, LspServerStatus,
 };
+use crate::services::lsp::diagnostics::AnchoredDiagnostic;
 use crate::state::{SemanticTokenSpan, SemanticTokenStore};
 use crate::view::file_tree::{FileTreeView, NodeId};
 use lsp_types::{
@@ -114,26 +115,29 @@ impl Editor {
 // =============================================================================
 
 impl Editor {
-    /// Merge push + pull diagnostics for a URI and apply the combined set
-    fn merge_and_apply_diagnostics(&mut self, uri: &str) {
-        // Merge diagnostics from all servers (push model) and pull model
-        let mut merged = Vec::new();
-        if let Some(server_map) = self.active_window_mut().stored_push_diagnostics.get(uri) {
-            for diagnostics in server_map.values() {
-                merged.extend(diagnostics.iter().cloned());
-            }
-        }
-        if let Some(pull) = self.active_window_mut().stored_pull_diagnostics.get(uri) {
-            merged.extend(pull.iter().cloned());
-        }
+    /// Anchor freshly received diagnostics to the open buffer for `uri` (if
+    /// any), stamping each with the buffer's current version so `CoordMap` can
+    /// carry it forward across later edits (#2602).
+    fn anchor_diagnostics(
+        &self,
+        uri: &str,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Vec<AnchoredDiagnostic> {
+        let state = self.find_buffer_by_uri(uri).and_then(|id| {
+            self.windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.get(&id))
+        });
+        diagnostics
+            .into_iter()
+            .map(|d| AnchoredDiagnostic::capture(d, state))
+            .collect()
+    }
 
-        // Update the merged view
-        if merged.is_empty() {
-            self.stored_diagnostics_mut().remove(uri);
-        } else {
-            self.stored_diagnostics_mut()
-                .insert(uri.to_string(), merged.clone());
-        }
+    /// Materialise the merged push + pull view (positions mapped to the buffer's
+    /// current version) and rebuild the overlays from it.
+    fn merge_and_apply_diagnostics(&mut self, uri: &str) {
+        let merged = self.active_window_mut().recompute_merged_diagnostics(uri);
 
         if let Some((buffer_id, updated)) = self.apply_diagnostics_to_buffer(uri, &merged) {
             if updated {
@@ -192,12 +196,13 @@ impl Editor {
             uri
         );
 
+        let anchored = self.anchor_diagnostics(&uri, diagnostics);
         let server_map = self
             .active_window_mut()
             .stored_push_diagnostics
             .entry(uri.clone())
             .or_default();
-        if diagnostics.is_empty() {
+        if anchored.is_empty() {
             server_map.remove(&server_name);
             // Clean up empty outer entry
             if server_map.is_empty() {
@@ -206,7 +211,7 @@ impl Editor {
                     .remove(&uri);
             }
         } else {
-            server_map.insert(server_name, diagnostics);
+            server_map.insert(server_name, anchored);
         }
 
         self.merge_and_apply_diagnostics(&uri);
@@ -243,14 +248,15 @@ impl Editor {
                 .insert(uri.clone(), result_id);
         }
 
-        if diagnostics.is_empty() {
+        let anchored = self.anchor_diagnostics(&uri, diagnostics);
+        if anchored.is_empty() {
             self.active_window_mut()
                 .stored_pull_diagnostics
                 .remove(&uri);
         } else {
             self.active_window_mut()
                 .stored_pull_diagnostics
-                .insert(uri.clone(), diagnostics);
+                .insert(uri.clone(), anchored);
         }
 
         self.merge_and_apply_diagnostics(&uri);

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -3341,6 +3341,15 @@ impl Window {
                 any_sent = true;
             }
         }
+
+        // Keep stored diagnostics aligned with the buffer between server
+        // re-publishes. A server (e.g. rust-analyzer's cargo checkOnSave) only
+        // re-publishes on save, so after inserting/deleting lines above an
+        // error its stored positions go stale; the next `merge_and_apply`
+        // would rebuild overlays there, snapping the gutter marker, F8 target,
+        // inline text, and diagnostics panel back to the pre-edit line (#2602).
+        self.shift_stored_diagnostics_for_changes(uri.as_str(), &changes);
+
         if any_sent {
             tracing::trace!("Successfully sent batched didChange to LSP");
 
@@ -3363,6 +3372,41 @@ impl Window {
                     std::time::Instant::now()
                         + std::time::Duration::from_millis(INLAY_HINTS_DEBOUNCE_MS),
                 ));
+            }
+        }
+    }
+
+    /// Shift stored diagnostics (push, pull, and the merged view) for `uri`
+    /// so their positions track incremental buffer edits between server
+    /// re-publishes (#2602).
+    ///
+    /// The three maps hold independent `Diagnostic` copies, so each is shifted
+    /// directly — keeping them consistent without a full re-merge. On the next
+    /// publish/pull the authoritative positions replace these. Full-document
+    /// replacements carry no positional delta and are ignored.
+    pub(crate) fn shift_stored_diagnostics_for_changes(
+        &mut self,
+        uri: &str,
+        changes: &[lsp_types::TextDocumentContentChangeEvent],
+    ) {
+        use crate::services::lsp::diagnostics::shift_diagnostics_for_changes;
+
+        if changes.iter().all(|c| c.range.is_none()) {
+            return;
+        }
+
+        if let Some(server_map) = self.stored_push_diagnostics.get_mut(uri) {
+            for diags in server_map.values_mut() {
+                shift_diagnostics_for_changes(diags, changes);
+            }
+        }
+        if let Some(diags) = self.stored_pull_diagnostics.get_mut(uri) {
+            shift_diagnostics_for_changes(diags, changes);
+        }
+        if self.stored_diagnostics.contains_key(uri) {
+            if let Some(diags) = std::sync::Arc::make_mut(&mut self.stored_diagnostics).get_mut(uri)
+            {
+                shift_diagnostics_for_changes(diags, changes);
             }
         }
     }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -48,6 +48,7 @@ pub use process_group::{LocalSignaller, ProcessGroupEntry, ProcessGroups, Signal
 use crate::app::types::{ChromeLayout, WindowLayoutCache};
 use crate::app::window_resources::WindowResources;
 use crate::model::event::{Event, LeafId};
+use crate::services::lsp::diagnostics::AnchoredDiagnostic;
 use crate::services::lsp::manager::LspManager;
 use crate::types::LspFeature;
 use crate::view::file_tree::FileTreeView;
@@ -673,17 +674,21 @@ pub struct Window {
     /// Push-model diagnostics keyed by URI, then by server name. Each
     /// `publishDiagnostics` from a server replaces that server's slice
     /// for the URI; the merged view is materialised in
-    /// `stored_diagnostics`.
-    pub stored_push_diagnostics: HashMap<String, HashMap<String, Vec<lsp_types::Diagnostic>>>,
+    /// `stored_diagnostics`. Each entry carries a byte anchor so its
+    /// position tracks edits between re-publishes via `CoordMap` (#2602).
+    pub stored_push_diagnostics: HashMap<String, HashMap<String, Vec<AnchoredDiagnostic>>>,
 
     /// Pull-model diagnostics (rust-analyzer-style native pull)
     /// keyed by URI. Independent of `stored_push_diagnostics`; the
     /// two are merged into `stored_diagnostics` for plugin / overlay
     /// consumption.
-    pub stored_pull_diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
+    pub stored_pull_diagnostics: HashMap<String, Vec<AnchoredDiagnostic>>,
 
-    /// Merged view of push + pull diagnostics, exposed to plugins.
-    /// `Arc` wrapper so plugin snapshots can hold a refcount-bumped
+    /// Merged view of push + pull diagnostics with every position mapped
+    /// forward to the buffer's current version, exposed to plugins and read
+    /// by hover / the diagnostics panel. Derived — never a source of truth;
+    /// `recompute_merged_diagnostics` rebuilds it from the anchored push/pull
+    /// stores. `Arc` wrapper so plugin snapshots can hold a refcount-bumped
     /// reference; mutation goes through `Arc::make_mut` (CoW).
     pub stored_diagnostics: Arc<HashMap<String, Vec<lsp_types::Diagnostic>>>,
 
@@ -3342,13 +3347,15 @@ impl Window {
             }
         }
 
-        // Keep stored diagnostics aligned with the buffer between server
-        // re-publishes. A server (e.g. rust-analyzer's cargo checkOnSave) only
-        // re-publishes on save, so after inserting/deleting lines above an
-        // error its stored positions go stale; the next `merge_and_apply`
-        // would rebuild overlays there, snapping the gutter marker, F8 target,
-        // inline text, and diagnostics panel back to the pre-edit line (#2602).
-        self.shift_stored_diagnostics_for_changes(uri.as_str(), &changes);
+        // Re-derive the merged diagnostics at the buffer's current version so
+        // hover, the diagnostics panel, and plugin snapshots track the text
+        // between server re-publishes. A server (e.g. rust-analyzer's cargo
+        // checkOnSave) only re-publishes on save; the diagnostic overlays ride
+        // their markers in the meantime, and this keeps the raw readers aligned
+        // with them by mapping the anchors forward through `CoordMap` — no
+        // dependency on the LSP change payload, so it covers every edit kind
+        // including bulk edits and undo/redo (#2602).
+        self.recompute_merged_diagnostics(uri.as_str());
 
         if any_sent {
             tracing::trace!("Successfully sent batched didChange to LSP");
@@ -3376,39 +3383,46 @@ impl Window {
         }
     }
 
-    /// Shift stored diagnostics (push, pull, and the merged view) for `uri`
-    /// so their positions track incremental buffer edits between server
-    /// re-publishes (#2602).
+    /// The open buffer showing `uri`, if any. Diagnostics are keyed by URI but
+    /// only an open buffer has a `CoordMap`/marker tree to map positions with.
+    fn buffer_id_for_uri(&self, uri: &str) -> Option<BufferId> {
+        self.buffer_metadata
+            .iter()
+            .find_map(|(id, meta)| meta.file_uri().filter(|u| u.as_str() == uri).map(|_| *id))
+    }
+
+    /// Rebuild `stored_diagnostics[uri]` from the anchored push/pull stores,
+    /// mapping every diagnostic forward to the buffer's current version via
+    /// `CoordMap` (the same shift the overlays' markers apply). This is the
+    /// single materialisation point for the merged view: it runs on every
+    /// publish/pull and on every edit, so the raw readers (hover, panel, plugin
+    /// snapshots) never observe a stale position. Overlays are left to ride
+    /// their markers and are only rebuilt on a real publish (#2602).
     ///
-    /// The three maps hold independent `Diagnostic` copies, so each is shifted
-    /// directly — keeping them consistent without a full re-merge. On the next
-    /// publish/pull the authoritative positions replace these. Full-document
-    /// replacements carry no positional delta and are ignored.
-    pub(crate) fn shift_stored_diagnostics_for_changes(
-        &mut self,
-        uri: &str,
-        changes: &[lsp_types::TextDocumentContentChangeEvent],
-    ) {
-        use crate::services::lsp::diagnostics::shift_diagnostics_for_changes;
+    /// Returns the merged diagnostics (current positions) for the caller to
+    /// apply as overlays; empty when the URI has none.
+    pub(crate) fn recompute_merged_diagnostics(&mut self, uri: &str) -> Vec<lsp_types::Diagnostic> {
+        let state = self
+            .buffer_id_for_uri(uri)
+            .and_then(|id| self.buffers.get(&id));
 
-        if changes.iter().all(|c| c.range.is_none()) {
-            return;
-        }
-
-        if let Some(server_map) = self.stored_push_diagnostics.get_mut(uri) {
-            for diags in server_map.values_mut() {
-                shift_diagnostics_for_changes(diags, changes);
+        let mut merged = Vec::new();
+        if let Some(server_map) = self.stored_push_diagnostics.get(uri) {
+            for entries in server_map.values() {
+                merged.extend(entries.iter().map(|e| e.at_current_version(state)));
             }
         }
-        if let Some(diags) = self.stored_pull_diagnostics.get_mut(uri) {
-            shift_diagnostics_for_changes(diags, changes);
+        if let Some(pull) = self.stored_pull_diagnostics.get(uri) {
+            merged.extend(pull.iter().map(|e| e.at_current_version(state)));
         }
-        if self.stored_diagnostics.contains_key(uri) {
-            if let Some(diags) = std::sync::Arc::make_mut(&mut self.stored_diagnostics).get_mut(uri)
-            {
-                shift_diagnostics_for_changes(diags, changes);
-            }
+
+        let store = Arc::make_mut(&mut self.stored_diagnostics);
+        if merged.is_empty() {
+            store.remove(uri);
+        } else {
+            store.insert(uri.to_string(), merged.clone());
         }
+        merged
     }
 
     /// Invalidate cached layouts and view transforms for every split

--- a/crates/fresh-editor/src/services/lsp/diagnostics.rs
+++ b/crates/fresh-editor/src/services/lsp/diagnostics.rs
@@ -5,7 +5,7 @@
 use crate::model::buffer::Buffer;
 use crate::state::EditorState;
 use crate::view::overlay::{Overlay, OverlayFace, OverlayNamespace};
-use lsp_types::{Diagnostic, DiagnosticSeverity};
+use lsp_types::{Diagnostic, DiagnosticSeverity, Position, TextDocumentContentChangeEvent};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -252,6 +252,96 @@ pub fn apply_diagnostics_to_state(
     }
 }
 
+/// Compute the end position of an edit that inserts `text` starting at
+/// `start`. LSP character offsets are UTF-16 code units, so lengths are
+/// measured in UTF-16, and line breaks are counted by `\n`.
+fn edit_new_end(start: Position, text: &str) -> Position {
+    let newlines = text.matches('\n').count();
+    if newlines == 0 {
+        Position::new(
+            start.line,
+            start.character + text.encode_utf16().count() as u32,
+        )
+    } else {
+        // Characters on the last inserted line, after the final `\n`.
+        let last_line_len = text
+            .rsplit('\n')
+            .next()
+            .unwrap_or("")
+            .encode_utf16()
+            .count() as u32;
+        Position::new(start.line + newlines as u32, last_line_len)
+    }
+}
+
+/// Shift a single position to account for one text edit that replaced the
+/// range `[start, old_end)` with text spanning `[start, new_end)`.
+///
+/// Mirrors how an LSP client remaps positions between server publishes: a
+/// position before the edit is untouched, a position inside the replaced
+/// region collapses to the edit start (its text no longer exists), and a
+/// position after the edit shifts by the edit's line delta — plus the
+/// character delta when it sat on the edit's trailing line.
+fn shift_position(
+    pos: Position,
+    start: Position,
+    old_end: Position,
+    new_end: Position,
+) -> Position {
+    // At or before the edit start: unaffected.
+    if pos.line < start.line || (pos.line == start.line && pos.character <= start.character) {
+        return pos;
+    }
+    // Inside the replaced region: collapse to the edit start. There is no
+    // faithful mapping for deleted text; the next check-on-save republishes.
+    if pos.line < old_end.line || (pos.line == old_end.line && pos.character <= old_end.character) {
+        return start;
+    }
+    // After the edit: shift by the line delta, and by the character delta only
+    // when the position was on the edit's trailing (old_end) line.
+    let line_delta = new_end.line as i64 - old_end.line as i64;
+    let new_line = (pos.line as i64 + line_delta).max(0) as u32;
+    let new_character = if pos.line == old_end.line {
+        (pos.character as i64 + (new_end.character as i64 - old_end.character as i64)).max(0) as u32
+    } else {
+        pos.character
+    };
+    Position::new(new_line, new_character)
+}
+
+/// Shift the ranges of `diagnostics` in place to track a sequence of
+/// incremental buffer edits.
+///
+/// LSP servers publish diagnostics at fixed positions and only re-publish
+/// after a re-check (for rust-analyzer's cargo `checkOnSave`, that means on
+/// save). Between publishes the buffer can change — most commonly lines get
+/// inserted above an existing error. Without remapping, the next
+/// `merge_and_apply` rebuilds overlays from stale line/character positions,
+/// snapping the gutter marker, `F8` target, inline text, and diagnostics
+/// panel back to where the error was when it was last published (#2602).
+/// Applying the same content changes here keeps them aligned with the text,
+/// matching what the LSP client does in VS Code.
+///
+/// Full-document replacements (`range: None`) carry no positional delta and
+/// are skipped; the next publish overwrites those positions anyway.
+pub fn shift_diagnostics_for_changes(
+    diagnostics: &mut [Diagnostic],
+    changes: &[TextDocumentContentChangeEvent],
+) {
+    for change in changes {
+        let Some(change_range) = change.range else {
+            continue;
+        };
+        let start = change_range.start;
+        let old_end = change_range.end;
+        let new_end = edit_new_end(start, &change.text);
+        for diag in diagnostics.iter_mut() {
+            diag.range.start = shift_position(diag.range.start, start, old_end, new_end);
+            diag.range.end = shift_position(diag.range.end, start, old_end, new_end);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,5 +491,119 @@ mod tests {
         // end: line 1, char 2 = byte 8 ("ne")
         assert_eq!(range.start, 3);
         assert_eq!(range.end, 8);
+    }
+
+    // --- shift_diagnostics_for_changes -------------------------------------
+
+    fn diag_at(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position::new(start_line, start_char),
+                end: Position::new(end_line, end_char),
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: None,
+            message: "e".to_string(),
+            related_information: None,
+            tags: None,
+            data: None,
+        }
+    }
+
+    /// An insertion is a zero-width range at the insertion point, exactly as
+    /// `collect_lsp_changes` builds it for an `Insert` event.
+    fn insert_change(line: u32, character: u32, text: &str) -> TextDocumentContentChangeEvent {
+        let pos = Position::new(line, character);
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(pos, pos)),
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    fn delete_change(
+        start_line: u32,
+        start_char: u32,
+        end_line: u32,
+        end_char: u32,
+    ) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range: Some(Range::new(
+                Position::new(start_line, start_char),
+                Position::new(end_line, end_char),
+            )),
+            range_length: None,
+            text: String::new(),
+        }
+    }
+
+    #[test]
+    fn shift_inserting_lines_above_moves_diagnostic_down() {
+        // Issue #2602: error on line 8, insert a 6-line block above it.
+        // The diagnostic should ride down to line 14, not stay on line 8.
+        let mut diags = vec![diag_at(8, 4, 8, 12)];
+        let changes = vec![insert_change(1, 0, "aaa\nbbb\nccc\nddd\neee\nfff\n")];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        assert_eq!(diags[0].range.start, Position::new(14, 4));
+        assert_eq!(diags[0].range.end, Position::new(14, 12));
+    }
+
+    #[test]
+    fn shift_leaves_diagnostics_above_the_edit_untouched() {
+        let mut diags = vec![diag_at(2, 0, 2, 5)];
+        let changes = vec![insert_change(5, 0, "new line\n")];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        assert_eq!(diags[0].range.start, Position::new(2, 0));
+        assert_eq!(diags[0].range.end, Position::new(2, 5));
+    }
+
+    #[test]
+    fn shift_same_line_insert_before_moves_characters() {
+        // Insert text earlier on the same line as the diagnostic.
+        let mut diags = vec![diag_at(3, 10, 3, 15)];
+        let changes = vec![insert_change(3, 2, "abcd")];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        assert_eq!(diags[0].range.start, Position::new(3, 14));
+        assert_eq!(diags[0].range.end, Position::new(3, 19));
+    }
+
+    #[test]
+    fn shift_deleting_lines_above_moves_diagnostic_up() {
+        // Delete lines 2..5 (three full lines); a diagnostic on line 8 rises to 5.
+        let mut diags = vec![diag_at(8, 4, 8, 12)];
+        let changes = vec![delete_change(2, 0, 5, 0)];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        assert_eq!(diags[0].range.start, Position::new(5, 4));
+        assert_eq!(diags[0].range.end, Position::new(5, 12));
+    }
+
+    #[test]
+    fn shift_ignores_full_document_replacement() {
+        let mut diags = vec![diag_at(8, 4, 8, 12)];
+        let changes = vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: "whole new file".to_string(),
+        }];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        // Unchanged: no positional delta is available for a full replacement.
+        assert_eq!(diags[0].range.start, Position::new(8, 4));
+        assert_eq!(diags[0].range.end, Position::new(8, 12));
+    }
+
+    #[test]
+    fn shift_applies_a_batch_of_changes_in_order() {
+        // Two inserts above the error; deltas accumulate.
+        let mut diags = vec![diag_at(8, 0, 8, 3)];
+        let changes = vec![
+            insert_change(1, 0, "one\n"),
+            insert_change(2, 0, "two\nthree\n"),
+        ];
+        shift_diagnostics_for_changes(&mut diags, &changes);
+        // +1 line then +2 lines => line 11.
+        assert_eq!(diags[0].range.start, Position::new(11, 0));
+        assert_eq!(diags[0].range.end, Position::new(11, 3));
     }
 }

--- a/crates/fresh-editor/src/services/lsp/diagnostics.rs
+++ b/crates/fresh-editor/src/services/lsp/diagnostics.rs
@@ -5,7 +5,7 @@
 use crate::model::buffer::Buffer;
 use crate::state::EditorState;
 use crate::view::overlay::{Overlay, OverlayFace, OverlayNamespace};
-use lsp_types::{Diagnostic, DiagnosticSeverity, Position, TextDocumentContentChangeEvent};
+use lsp_types::{Diagnostic, DiagnosticSeverity, Position};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -252,93 +252,67 @@ pub fn apply_diagnostics_to_state(
     }
 }
 
-/// Compute the end position of an edit that inserts `text` starting at
-/// `start`. LSP character offsets are UTF-16 code units, so lengths are
-/// measured in UTF-16, and line breaks are counted by `\n`.
-fn edit_new_end(start: Position, text: &str) -> Position {
-    let newlines = text.matches('\n').count();
-    if newlines == 0 {
-        Position::new(
-            start.line,
-            start.character + text.encode_utf16().count() as u32,
-        )
-    } else {
-        // Characters on the last inserted line, after the final `\n`.
-        let last_line_len = text
-            .rsplit('\n')
-            .next()
-            .unwrap_or("")
-            .encode_utf16()
-            .count() as u32;
-        Position::new(start.line + newlines as u32, last_line_len)
-    }
-}
-
-/// Shift a single position to account for one text edit that replaced the
-/// range `[start, old_end)` with text spanning `[start, new_end)`.
-///
-/// Mirrors how an LSP client remaps positions between server publishes: a
-/// position before the edit is untouched, a position inside the replaced
-/// region collapses to the edit start (its text no longer exists), and a
-/// position after the edit shifts by the edit's line delta — plus the
-/// character delta when it sat on the edit's trailing line.
-fn shift_position(
-    pos: Position,
-    start: Position,
-    old_end: Position,
-    new_end: Position,
-) -> Position {
-    // At or before the edit start: unaffected.
-    if pos.line < start.line || (pos.line == start.line && pos.character <= start.character) {
-        return pos;
-    }
-    // Inside the replaced region: collapse to the edit start. There is no
-    // faithful mapping for deleted text; the next check-on-save republishes.
-    if pos.line < old_end.line || (pos.line == old_end.line && pos.character <= old_end.character) {
-        return start;
-    }
-    // After the edit: shift by the line delta, and by the character delta only
-    // when the position was on the edit's trailing (old_end) line.
-    let line_delta = new_end.line as i64 - old_end.line as i64;
-    let new_line = (pos.line as i64 + line_delta).max(0) as u32;
-    let new_character = if pos.line == old_end.line {
-        (pos.character as i64 + (new_end.character as i64 - old_end.character as i64)).max(0) as u32
-    } else {
-        pos.character
-    };
-    Position::new(new_line, new_character)
-}
-
-/// Shift the ranges of `diagnostics` in place to track a sequence of
-/// incremental buffer edits.
+/// A diagnostic paired with a byte-range anchor into the buffer it was
+/// published against.
 ///
 /// LSP servers publish diagnostics at fixed positions and only re-publish
 /// after a re-check (for rust-analyzer's cargo `checkOnSave`, that means on
-/// save). Between publishes the buffer can change — most commonly lines get
-/// inserted above an existing error. Without remapping, the next
-/// `merge_and_apply` rebuilds overlays from stale line/character positions,
-/// snapping the gutter marker, `F8` target, inline text, and diagnostics
-/// panel back to where the error was when it was last published (#2602).
-/// Applying the same content changes here keeps them aligned with the text,
-/// matching what the LSP client does in VS Code.
+/// save). Between publishes the buffer keeps changing, so the published
+/// positions go stale. Rather than hand-shift them, we anchor each diagnostic
+/// to a byte range and let the editor's [`CoordMap`](crate::model::coord_map)
+/// carry it forward — the exact shift the marker tree applies to the
+/// diagnostic overlays, fed at the same edit chokepoint, so it covers every
+/// edit kind (insert/delete/bulk/undo) and can never disagree with the
+/// overlays (#2602).
 ///
-/// Full-document replacements (`range: None`) carry no positional delta and
-/// are skipped; the next publish overwrites those positions anyway.
-pub fn shift_diagnostics_for_changes(
-    diagnostics: &mut [Diagnostic],
-    changes: &[TextDocumentContentChangeEvent],
-) {
-    for change in changes {
-        let Some(change_range) = change.range else {
-            continue;
-        };
-        let start = change_range.start;
-        let old_end = change_range.end;
-        let new_end = edit_new_end(start, &change.text);
-        for diag in diagnostics.iter_mut() {
-            diag.range.start = shift_position(diag.range.start, start, old_end, new_end);
-            diag.range.end = shift_position(diag.range.end, start, old_end, new_end);
+/// `anchor` is `Some((start_byte, end_byte, epoch))` when the file was open on
+/// receipt — `epoch` is the buffer version the bytes are valid at — and `None`
+/// for a diagnostic received while its file was closed. A closed file isn't
+/// being edited, so its published LSP range is used verbatim; it re-anchors on
+/// the next publish once open.
+#[derive(Clone, Debug)]
+pub struct AnchoredDiagnostic {
+    pub diagnostic: Diagnostic,
+    pub anchor: Option<(usize, usize, u64)>,
+}
+
+impl AnchoredDiagnostic {
+    /// Wrap a freshly received `diagnostic`, anchoring it to `state` (the open
+    /// buffer for its file, if any) at the buffer's current version. LSP
+    /// character offsets are UTF-16 code units, matching `lsp_position_to_byte`.
+    pub fn capture(diagnostic: Diagnostic, state: Option<&EditorState>) -> Self {
+        let anchor = state.map(|s| {
+            let start = s.buffer.lsp_position_to_byte(
+                diagnostic.range.start.line as usize,
+                diagnostic.range.start.character as usize,
+            );
+            let end = s.buffer.lsp_position_to_byte(
+                diagnostic.range.end.line as usize,
+                diagnostic.range.end.character as usize,
+            );
+            (start, end, s.buffer.version())
+        });
+        Self { diagnostic, anchor }
+    }
+
+    /// The diagnostic with its range mapped forward to `state`'s current
+    /// version via `CoordMap`. Falls back to the published range when there is
+    /// no anchor (closed file) or the anchor's epoch is too old to map (the
+    /// ring was evicted/barriered — a re-pull refreshes it).
+    pub fn at_current_version(&self, state: Option<&EditorState>) -> Diagnostic {
+        let mut diagnostic = self.diagnostic.clone();
+        if let (Some((start, end, epoch)), Some(state)) = (self.anchor, state) {
+            if let (Some(cur_start), Some(cur_end)) = (
+                state.coord_map.map(start, epoch),
+                state.coord_map.map(end, epoch),
+            ) {
+                let (sl, sc) = state.buffer.position_to_lsp_position(cur_start);
+                let (el, ec) = state.buffer.position_to_lsp_position(cur_end);
+                diagnostic.range.start = Position::new(sl as u32, sc as u32);
+                diagnostic.range.end = Position::new(el as u32, ec as u32);
+            }
         }
+        diagnostic
     }
 }
 
@@ -493,13 +467,38 @@ mod tests {
         assert_eq!(range.end, 8);
     }
 
-    // --- shift_diagnostics_for_changes -------------------------------------
+    // --- AnchoredDiagnostic (CoordMap-based position tracking, #2602) -------
 
-    fn diag_at(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Diagnostic {
+    use crate::config::LARGE_FILE_THRESHOLD_BYTES;
+    use crate::model::cursor::Cursors;
+    use crate::model::event::{CursorId, Event};
+    use crate::model::filesystem::StdFileSystem;
+
+    fn state_with(text: &str) -> (EditorState, Cursors, CursorId) {
+        let mut state = EditorState::new(
+            80,
+            24,
+            LARGE_FILE_THRESHOLD_BYTES as usize,
+            std::sync::Arc::new(StdFileSystem),
+        );
+        let mut cursors = Cursors::new();
+        let cursor_id = cursors.primary_id();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: text.to_string(),
+                cursor_id,
+            },
+        );
+        (state, cursors, cursor_id)
+    }
+
+    fn err_at(sl: u32, sc: u32, el: u32, ec: u32) -> Diagnostic {
         Diagnostic {
             range: Range {
-                start: Position::new(start_line, start_char),
-                end: Position::new(end_line, end_char),
+                start: Position::new(sl, sc),
+                end: Position::new(el, ec),
             },
             severity: Some(DiagnosticSeverity::ERROR),
             code: None,
@@ -512,98 +511,88 @@ mod tests {
         }
     }
 
-    /// An insertion is a zero-width range at the insertion point, exactly as
-    /// `collect_lsp_changes` builds it for an `Insert` event.
-    fn insert_change(line: u32, character: u32, text: &str) -> TextDocumentContentChangeEvent {
-        let pos = Position::new(line, character);
-        TextDocumentContentChangeEvent {
-            range: Some(Range::new(pos, pos)),
-            range_length: None,
-            text: text.to_string(),
-        }
-    }
+    #[test]
+    fn anchored_diagnostic_rides_an_insert_above() {
+        // Error on line 2 ("ccc"); insert a line at the top. The anchor is
+        // mapped forward through CoordMap so the diagnostic reports line 3.
+        let (mut state, mut cursors, cursor_id) = state_with("aaa\nbbb\nccc");
+        let anchored = AnchoredDiagnostic::capture(err_at(2, 0, 2, 3), Some(&state));
+        assert_eq!(anchored.anchor.map(|(s, e, _)| (s, e)), Some((8, 11)));
 
-    fn delete_change(
-        start_line: u32,
-        start_char: u32,
-        end_line: u32,
-        end_char: u32,
-    ) -> TextDocumentContentChangeEvent {
-        TextDocumentContentChangeEvent {
-            range: Some(Range::new(
-                Position::new(start_line, start_char),
-                Position::new(end_line, end_char),
-            )),
-            range_length: None,
-            text: String::new(),
-        }
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: "xxx\n".to_string(),
+                cursor_id,
+            },
+        );
+
+        let now = anchored.at_current_version(Some(&state));
+        assert_eq!(now.range.start, Position::new(3, 0));
+        assert_eq!(now.range.end, Position::new(3, 3));
     }
 
     #[test]
-    fn shift_inserting_lines_above_moves_diagnostic_down() {
-        // Issue #2602: error on line 8, insert a 6-line block above it.
-        // The diagnostic should ride down to line 14, not stay on line 8.
-        let mut diags = vec![diag_at(8, 4, 8, 12)];
-        let changes = vec![insert_change(1, 0, "aaa\nbbb\nccc\nddd\neee\nfff\n")];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        assert_eq!(diags[0].range.start, Position::new(14, 4));
-        assert_eq!(diags[0].range.end, Position::new(14, 12));
+    fn anchored_diagnostic_rides_a_delete_above() {
+        let (mut state, mut cursors, cursor_id) = state_with("aaa\nbbb\nccc");
+        let anchored = AnchoredDiagnostic::capture(err_at(2, 0, 2, 3), Some(&state));
+
+        // Delete the first line ("aaa\n", bytes 0..4).
+        state.apply(
+            &mut cursors,
+            &Event::Delete {
+                range: 0..4,
+                deleted_text: "aaa\n".to_string(),
+                cursor_id,
+            },
+        );
+
+        let now = anchored.at_current_version(Some(&state));
+        assert_eq!(now.range.start, Position::new(1, 0));
+        assert_eq!(now.range.end, Position::new(1, 3));
     }
 
     #[test]
-    fn shift_leaves_diagnostics_above_the_edit_untouched() {
-        let mut diags = vec![diag_at(2, 0, 2, 5)];
-        let changes = vec![insert_change(5, 0, "new line\n")];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        assert_eq!(diags[0].range.start, Position::new(2, 0));
-        assert_eq!(diags[0].range.end, Position::new(2, 5));
+    fn anchored_diagnostic_untouched_when_edit_is_below() {
+        let (mut state, mut cursors, cursor_id) = state_with("aaa\nbbb\nccc");
+        let anchored = AnchoredDiagnostic::capture(err_at(0, 0, 0, 3), Some(&state));
+
+        // Insert at the very end — below the diagnostic on line 0.
+        let end = state.buffer.len();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: end,
+                text: "\nddd".to_string(),
+                cursor_id,
+            },
+        );
+
+        let now = anchored.at_current_version(Some(&state));
+        assert_eq!(now.range.start, Position::new(0, 0));
+        assert_eq!(now.range.end, Position::new(0, 3));
     }
 
     #[test]
-    fn shift_same_line_insert_before_moves_characters() {
-        // Insert text earlier on the same line as the diagnostic.
-        let mut diags = vec![diag_at(3, 10, 3, 15)];
-        let changes = vec![insert_change(3, 2, "abcd")];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        assert_eq!(diags[0].range.start, Position::new(3, 14));
-        assert_eq!(diags[0].range.end, Position::new(3, 19));
-    }
+    fn unanchored_diagnostic_keeps_published_range() {
+        // Received while the file was closed (no state): the published range is
+        // used verbatim, and later mapping is a no-op.
+        let (mut state, mut cursors, cursor_id) = state_with("aaa\nbbb\nccc");
+        let anchored = AnchoredDiagnostic::capture(err_at(2, 0, 2, 3), None);
+        assert!(anchored.anchor.is_none());
 
-    #[test]
-    fn shift_deleting_lines_above_moves_diagnostic_up() {
-        // Delete lines 2..5 (three full lines); a diagnostic on line 8 rises to 5.
-        let mut diags = vec![diag_at(8, 4, 8, 12)];
-        let changes = vec![delete_change(2, 0, 5, 0)];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        assert_eq!(diags[0].range.start, Position::new(5, 4));
-        assert_eq!(diags[0].range.end, Position::new(5, 12));
-    }
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: "xxx\n".to_string(),
+                cursor_id,
+            },
+        );
 
-    #[test]
-    fn shift_ignores_full_document_replacement() {
-        let mut diags = vec![diag_at(8, 4, 8, 12)];
-        let changes = vec![TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text: "whole new file".to_string(),
-        }];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        // Unchanged: no positional delta is available for a full replacement.
-        assert_eq!(diags[0].range.start, Position::new(8, 4));
-        assert_eq!(diags[0].range.end, Position::new(8, 12));
-    }
-
-    #[test]
-    fn shift_applies_a_batch_of_changes_in_order() {
-        // Two inserts above the error; deltas accumulate.
-        let mut diags = vec![diag_at(8, 0, 8, 3)];
-        let changes = vec![
-            insert_change(1, 0, "one\n"),
-            insert_change(2, 0, "two\nthree\n"),
-        ];
-        shift_diagnostics_for_changes(&mut diags, &changes);
-        // +1 line then +2 lines => line 11.
-        assert_eq!(diags[0].range.start, Position::new(11, 0));
-        assert_eq!(diags[0].range.end, Position::new(11, 3));
+        let now = anchored.at_current_version(Some(&state));
+        assert_eq!(now.range.start, Position::new(2, 0));
+        assert_eq!(now.range.end, Position::new(2, 3));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2602. LSP diagnostics stayed frozen at their publish-time positions after editing above an error. Inserting or deleting lines above a diagnostic left the gutter `●`, `F8` navigation, inline underline, hover, and the Diagnostics panel pointing at the pre-edit line — the wrong code — until the next save re-published fresh positions.

## Root cause

LSP servers publish diagnostics at fixed positions and only re-publish after a re-check (for rust-analyzer's cargo `checkOnSave`, on save). Between publishes:

- The diagnostic **overlays** ride the buffer's marker tree, so they briefly track edits.
- But the stored diagnostics (`stored_push` / `stored_pull` / merged) keep their original LSP positions. The next `merge_and_apply` **rebuilds** overlays from those stale positions, snapping the gutter/`F8` target back; hover and the panel read the stale positions directly.

## Approach

Rather than hand-shift stored positions, **anchor each diagnostic to the buffer and let the editor's own coordinate mapper carry it forward** — the same `CoordMap` that already remaps virtual-line anchors and mirrors the marker tree.

- `AnchoredDiagnostic { diagnostic, anchor: Option<(start_byte, end_byte, epoch)> }` — each received diagnostic is stamped with a byte range and the buffer version it was seen at.
- `at_current_version` maps the anchor forward via `EditorState::coord_map` → current byte → current LSP position; falls back to the published range when there's no anchor (closed file) or the epoch was evicted/barriered.
- `Window::recompute_merged_diagnostics` is the **single materialisation point** for the merged view (still `Vec<Diagnostic>`, so no reader changed). It runs on every publish/pull **and** on every edit, mapping the anchored push/pull stores to the buffer's current version.

`CoordMap` is fed at the marker-adjustment chokepoint (`record_insert`/`delete`/`replace`, with barriers for opaque snapshot restores), so the raw readers use the exact same shift as the overlays and can never disagree with them.

## Why this replaces the first cut

The initial version derived the shift from the outgoing LSP `didChange` payload. That silently dropped whole classes of edits: a `BulkEdit` (undo, redo, replace-all, multi-cursor, code actions) is sent as a full-document replacement with `range: None`, so the shift skipped it and the diagnostic snapped back. It was also a fourth, independent copy of shift math already living in the marker tree. Anchoring to `CoordMap` covers every edit kind by construction and reuses the one canonical implementation.

Removed with no leftovers: `shift_diagnostics_for_changes`, `shift_position`, `edit_new_end`, and `Window::shift_stored_diagnostics_for_changes`. The push/pull stores now hold `AnchoredDiagnostic`; the merged `stored_diagnostics` stays `Vec<Diagnostic>`.

## Files

- `crates/fresh-editor/src/services/lsp/diagnostics.rs` — `AnchoredDiagnostic` (`capture` / `at_current_version`) + unit tests; removed the hand-rolled shift.
- `crates/fresh-editor/src/app/window/mod.rs` — anchored store types; `recompute_merged_diagnostics` + `buffer_id_for_uri`; edit-path call site.
- `crates/fresh-editor/src/app/async_messages.rs` — anchor diagnostics on receipt (push + pull); `merge_and_apply` delegates to `recompute_merged_diagnostics`.
- `CHANGELOG.md` — entry under 0.4.3 Bug Fixes.

## Testing

- New unit tests exercise the real `EditorState` + `coord_map` edit path: insert-above (rides down), delete-above (rides up), edit-below (untouched), and the closed-file no-op. All pass.
- Full `fresh-editor` lib suite: **2978 passed, 0 failed** (4 ignored).
- `cargo fmt` and `cargo clippy -p fresh-editor` clean (the only clippy warnings are pre-existing `type_complexity` in unrelated files).

## Known limitation

Like the overlays, anchoring happens when diagnostics are **received**, interpreting the server's positions against the buffer at that moment. If the server was behind when it published, that initial placement is as imprecise as it is today — corrected on the next publish. What's now robust is tracking every edit *after* a publish, across all edit kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)