### PR TITLE
fix(rust-lsp): keep proc-macro expansion on in Reduced Memory mode (#2598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 ### Bug Fixes
 
 * **LSP diagnostic fixes**: the gutter marker, `F8` target, hover, and panel now shift with inserted/deleted lines instead of freezing at the pre-edit position until the next save (#2602); and dismissing a hover popup no longer drops an unrelated error from the status bar, gutter, and `F8` navigation (#2601).
+* **Rust LSP Reduced Memory mode**: hover and Go to Definition no longer silently fail on macro names and inside macro arguments (e.g. a call inside `println!(...)`/`format!(...)`); the mode was disabling proc-macro expansion, which rust-analyzer also uses to resolve identifiers inside macro invocations. Proc-macro expansion now stays on in Reduced mode (#2598).
 * **LSP Rename keeps focus** - a cross-file F2 rename no longer jumps you to the definition's file at a stale cursor position (#2599).
 * **LSP now pulls diagnostics from every server** configured for a language, not just the first - e.g. both `ruff` and `ty` for Python now stay live (#2615, reported by @ak24watch).
 * **Format Buffer respects the selection** - with an active selection and a server that supports range formatting, only the selected range is formatted instead of silently reformatting the whole file (#2605).

--- a/crates/fresh-editor/config.example.json
+++ b/crates/fresh-editor/config.example.json
@@ -578,7 +578,7 @@
           "enable": false
         },
         "procMacro": {
-          "enable": false
+          "enable": true
         },
         "cargo": {
           "buildScripts": {

--- a/crates/fresh-editor/plugins/rust-lsp.ts
+++ b/crates/fresh-editor/plugins/rust-lsp.ts
@@ -182,13 +182,23 @@ editor.on("action_popup_result", (data) => {
 // Reduced-memory init options for rust-analyzer:
 // - checkOnSave: false - disables cargo check on every save (#1 cause of slowdowns)
 // - cachePriming.enable: false - no background indexing of entire crate graph
-// - procMacro.enable: false - no proc-macro expansion (saves CPU/RAM)
 // - cargo.buildScripts.enable: false - no build.rs
 // - cargo.autoreload: false - manual reload only
+//
+// procMacro stays ENABLED on purpose. rust-analyzer resolves identifiers
+// *inside* a macro invocation's arguments (and the macro name itself)
+// through macro expansion, so turning procMacro off silently kills hover
+// and Go to Definition for the macro name and everything inside its args —
+// including built-in macros like println!/format!/assert!, which are among
+// the most common cursor positions in real Rust code. Losing navigation
+// there makes the editor look randomly broken, which is not the intent of a
+// memory mode. Proc-macro expansion is comparatively cheap next to
+// checkOnSave/cachePriming, and the process limits below still cap RAM/CPU.
+// See issue #2598.
 const REDUCED_MEMORY_INIT_OPTIONS = {
   checkOnSave: false,
   cachePriming: { enable: false },
-  procMacro: { enable: false },
+  procMacro: { enable: true },
   cargo: {
     buildScripts: { enable: false },
     autoreload: false,
@@ -258,7 +268,7 @@ editor.on("action_popup_result", (data) => {
         processLimits: REDUCED_MEMORY_PROCESS_LIMITS,
       });
       editor.restartLspForLanguage("rust");
-      editor.setStatus("Rust LSP: Reduced Memory mode — checkOnSave, procMacro, cachePriming disabled");
+      editor.setStatus("Rust LSP: Reduced Memory mode — checkOnSave, cachePriming, buildScripts disabled (macro navigation kept)");
       break;
 
     case "dismiss":

--- a/docs/features/lsp.md
+++ b/docs/features/lsp.md
@@ -209,7 +209,9 @@ Some LSP servers expect a different `languageId` than Fresh's internal language 
 
 ### Rust LSP Mode Switching
 
-Use "Switch Rust Analyzer Mode" from the command palette to toggle between Full and Reduced Memory modes for rust-analyzer.
+Use **Rust LSP: Configure Mode** from the command palette to toggle between Full and Reduced Memory modes for rust-analyzer.
+
+**Reduced Memory** mode restarts rust-analyzer with `checkOnSave`, `cachePriming`, and `cargo.buildScripts` disabled, plus 50% RAM / 90% CPU process limits. Proc-macro expansion stays enabled so hover and Go to Definition keep working on macro names and on symbols inside macro arguments (e.g. a call inside `println!(...)`); disabling it silently breaks that navigation. **Full** mode restores rust-analyzer's defaults with no process limits.
 
 ## Configuring Language Detection via Settings UI
 


### PR DESCRIPTION
Fixes #2598.

## Problem

Switching rust-analyzer to **Reduced Memory** mode ("Rust LSP: Configure Mode" → Reduced Memory) silently killed hover (`Alt+K`) and Go to Definition (`F12`) for:

- the macro name itself (`println!`), and
- **any symbol inside a macro invocation's arguments** — e.g. a plain function called inside `println!(...)`, or a method call inside `format!(...)`.

`F12` worked on a bare call but returned `No definition found` on the identical call one line up that happened to sit inside a `println!`, so the feature looked randomly broken. Positions inside `println!`/`format!`/`assert!` args are among the most common cursor positions in real Rust code.

## Root cause

Reduced Memory mode restarted rust-analyzer with `procMacro.enable: false`. rust-analyzer resolves identifiers *inside* a macro invocation's arguments (and the macro name itself) through macro expansion, so disabling proc-macro expansion takes navigation there down with it — including the built-in `println!`/`format!`/`assert!` macros, whose name doesn't obviously imply a proc-macro dependency. The mode's own status even claimed it only disabled `checkOnSave, procMacro, cachePriming`, none of which explains losing built-in-macro navigation to a user.

I isolated this by driving rust-analyzer directly over LSP against a minimal crate and toggling one option at a time. `procMacro.enable: false` is the sole cause; everything else in the reduced-mode options is fine.

## Fix

Keep `procMacro` **enabled** in Reduced Memory mode. Its expansion cost is small next to `checkOnSave`/`cachePriming`, and the 50% RAM / 90% CPU process limits still apply, so the mode keeps its memory character while navigation stays intact.

Changes:
- `crates/fresh-editor/plugins/rust-lsp.ts`: `procMacro.enable: true` in `REDUCED_MEMORY_INIT_OPTIONS`; comment explains why it must stay on; status message updated (no longer claims procMacro is disabled).
- `crates/fresh-editor/config.example.json`: mirror the same change in the sample reduced-memory config.
- `docs/features/lsp.md`: fix the palette command name (the doc said "Switch Rust Analyzer Mode"; the real command is **Rust LSP: Configure Mode** — a discrepancy also noted in the issue) and describe what Reduced Memory mode disables.
- `CHANGELOG.md`: bug-fix entry.

## Validation

Drove rust-analyzer 1.95.0 over LSP against a minimal crate:

```rust
fn main() {
    println!("{}", describe());   // in-macro arg
    let s = describe();           // bare call
}
fn describe() -> String { "x".to_string() }
```

| Reduced-mode config | def inside `println!` arg | def on `println` name | def on bare call |
|---|---|---|---|
| **shipped (procMacro on)** | ✅ resolves | ✅ resolves | ✅ resolves |
| pre-fix (procMacro off) | ❌ empty | ❌ empty | ✅ resolves |

The pre-fix column reproduces exactly the bug from the report; the shipped column shows it fixed. Plugin type-check (`check-types.sh`) passes.

## Notes / out of scope

The issue's secondary observation — a ~30–60 s window after a Reduced-mode restart where *all* requests return empty while the status reads `ready` — stems from `cachePriming.enable: false` (no background priming) and is an inherent, documented trade-off of the mode, not part of this navigation bug. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bSc9dVgYMs4C1cbm1p3bx

---
_Generated by [Claude Code](https://claude.ai/code/session_014bSc9dVgYMs4C1cbm1p3bx)_