### PR TITLE
fix(orchestrator): remember killed sessions, show all projects' worktrees, Cancel not Quit on activation

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4145,6 +4145,16 @@ function toggleShowWorktrees(): void {
   const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
   openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
   refreshOpenDialog();
+  // Turning "Show all worktrees" ON re-scans *now* so the rows reflect every
+  // project's on-disk worktrees at this moment — not just whatever the single
+  // scan at dialog-open time happened to catch. Discovery walks every known
+  // project (each open/persisted session's repo, plus the cwd repo), so a
+  // fresh scan here is what makes the toggle show worktrees across all
+  // projects rather than a stale subset. Async; `refreshDiscoveredWorktrees`
+  // re-renders the dialog when the scan lands.
+  if (openDialog.showWorktrees) {
+    void refreshDiscoveredWorktrees();
+  }
 }
 
 registerHandler("orchestrator_toggle_worktrees", toggleShowWorktrees);

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1770,6 +1770,15 @@ impl Editor {
                 }
             }
         }
+
+        // Per-session plugin state carries a session's *identity* (the
+        // Orchestrator writes `project_path` / `shared_worktree` here right
+        // after creating a window). That identity is part of the persisted
+        // workspace file, so checkpoint the window now: a session created via
+        // the dock is written to the on-disk registry the moment it's tagged,
+        // rather than only at clean quit. Without this, a hard kill right after
+        // creating a session forgot it entirely. Guarded + best-effort.
+        self.checkpoint_window_workspace(id);
     }
 
     /// Handle SetLineNumbers command

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -1189,7 +1189,16 @@ impl Editor {
     /// `.sln`/`.csproj`, …). No-op once a decision is recorded or when there's
     /// nothing to gate. Called from every editor-startup path (in-process run
     /// and the session server) so the prompt fires regardless of launch mode.
-    pub fn maybe_prompt_workspace_trust(&mut self) {
+    ///
+    /// `cancellable` picks the modal's secondary button. The mandatory
+    /// open-time gate (`false`) offers **Quit** — there is nothing else to fall
+    /// back to before a decision is made. Prompts raised by *activating another
+    /// workspace* in an already-running editor (opening/switching an
+    /// Orchestrator session, changing the project) pass `true` so the secondary
+    /// is **Cancel**: dismissing it simply leaves the just-activated workspace
+    /// Restricted rather than tearing down the whole editor — the other open
+    /// sessions must survive.
+    pub fn maybe_prompt_workspace_trust(&mut self, cancellable: bool) {
         // Phase 1 of the trust+env+devcontainer UX plan (see
         // `docs/internal/trust-env-devcontainer-ux-plan.md`): when the
         // workspace is undecided AND has executable content, the core trust
@@ -1254,10 +1263,10 @@ impl Editor {
             .workspace_trust
             .set_level_transient(crate::services::workspace_trust::TrustLevel::Restricted);
 
-        // Non-cancellable on open: the choice has to be made, but any
-        // concrete option resolves it. (`Esc` is inert on the forced-choice
-        // variant; the user must pick a row.)
-        self.show_workspace_trust_popup(false);
+        // Secondary button follows the caller: Quit for the mandatory
+        // open-time gate, Cancel for a workspace-activation prompt (where any
+        // concrete option resolves it and Esc just leaves it Restricted).
+        self.show_workspace_trust_popup(cancellable);
     }
 
     /// Show the workspace-trust prompt: a centered list asking how this

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -577,8 +577,11 @@ impl Editor {
         self.set_active_window(new_id);
         self.close_window(old_id);
 
-        // Re-evaluate workspace trust for the freshly-rooted project.
-        self.maybe_prompt_workspace_trust();
+        // Re-evaluate workspace trust for the freshly-rooted project. This is
+        // a project switch on a running editor, so the prompt's secondary is
+        // Cancel (not Quit): cancelling leaves the new project Restricted
+        // instead of quitting and losing the other open windows.
+        self.maybe_prompt_workspace_trust(true);
     }
 
     /// Load directory contents for the file open dialog

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -300,7 +300,11 @@ impl crate::app::Editor {
             .remote_connection_info()
             .is_none()
         {
-            self.maybe_prompt_workspace_trust();
+            // Activating a new Orchestrator session on a running editor:
+            // secondary is Cancel, not Quit — dismissing the prompt must leave
+            // the new session Restricted, never tear down the editor and the
+            // other open sessions.
+            self.maybe_prompt_workspace_trust(true);
         }
 
         // The argv to re-run if this session is restored. `None` (plain
@@ -494,6 +498,14 @@ impl crate::app::Editor {
         }
 
         let previous_id = self.active_window;
+
+        // Checkpoint the outgoing window's workspace before we leave it, so a
+        // later kill can't lose its layout. Switching away is the natural
+        // save point — the window is fully materialized and its state is now
+        // final until the user returns to it. (No-op for an unmaterialized
+        // seed or a window with no splits — see `checkpoint_window_workspace`.)
+        self.checkpoint_window_workspace(previous_id);
+
         // Capture the outgoing backend label so we can tell, after the
         // switch, whether the active *authority* actually changed (most
         // window switches are between same-authority local sessions, where

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -607,6 +607,37 @@ impl Editor {
         }
     }
 
+    /// Persist a single window's workspace *now*, as a crash-safety checkpoint
+    /// outside the quit path.
+    ///
+    /// Sessions used to be written only when the editor exited cleanly
+    /// (`save_all_windows_workspaces` on quit). A killed or crashed editor
+    /// therefore forgot every Orchestrator session created since the last clean
+    /// exit — the directory-keyed registry (`workspaces/*.json`) is *the* record
+    /// of which sessions exist, and it never got the new file. Calling this at
+    /// natural checkpoints — finalizing a new session's identity, and switching
+    /// away from a window — keeps that on-disk registry current, so the dock
+    /// remembers every open workspace even after a hard kill.
+    ///
+    /// Mirrors `save_all_windows_workspaces`'s guard exactly: never write a
+    /// window still pending lazy materialization (it holds only an empty seed
+    /// while its on-disk file is authoritative) or one without a split layout
+    /// yet. Best-effort — a failed write is logged and swallowed so a checkpoint
+    /// never disrupts the interactive action that triggered it.
+    pub(crate) fn checkpoint_window_workspace(&mut self, id: fresh_core::WindowId) {
+        let savable = self
+            .windows
+            .get(&id)
+            .is_some_and(|w| w.buffers.splits().is_some())
+            && !self.materialize_pending.contains(&id);
+        if !savable {
+            return;
+        }
+        if let Err(e) = self.save_workspace_for(id) {
+            tracing::warn!("checkpoint_window_workspace: failed to save window {id}: {e}");
+        }
+    }
+
     /// Restore window `id`'s persisted workspace from disk the first
     /// time it's dived into or previewed — the lazy counterpart to the
     /// active window's eager `try_restore_workspace`. Idempotent: the

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4023,8 +4023,10 @@ fn real_main() -> AnyhowResult<()> {
 
         // Surface the Workspace Trust prompt for an undecided project with
         // executable content. The in-process run path needs this explicitly —
-        // the session-server path calls it from `initialize_editor`.
-        editor.maybe_prompt_workspace_trust();
+        // the session-server path calls it from `initialize_editor`. This is
+        // the mandatory open-time gate, so the secondary button is Quit
+        // (`cancellable = false`).
+        editor.maybe_prompt_workspace_trust(false);
 
         let iteration = run_editor_iteration(
             &mut editor,

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -661,7 +661,8 @@ impl EditorServer {
         self.terminal = Some(terminal);
         self.editor = Some(editor);
 
-        self.maybe_prompt_workspace_trust();
+        // Initial open-time gate: secondary is Quit (nothing to fall back to).
+        self.maybe_prompt_workspace_trust(false);
 
         tracing::info!(
             "Editor initialized with size {}x{}",
@@ -674,10 +675,13 @@ impl EditorServer {
 
     /// Surface the workspace-trust prompt after the editor is built. Delegates
     /// to `Editor::maybe_prompt_workspace_trust` (single source of truth shared
-    /// with the in-process run path).
-    fn maybe_prompt_workspace_trust(&mut self) {
+    /// with the in-process run path). `cancellable` selects the secondary
+    /// button: `false` (Quit) for the initial open-time gate, `true` (Cancel)
+    /// for a re-evaluation after a working-directory change on a running
+    /// editor.
+    fn maybe_prompt_workspace_trust(&mut self, cancellable: bool) {
         if let Some(editor) = self.editor.as_mut() {
-            editor.maybe_prompt_workspace_trust();
+            editor.maybe_prompt_workspace_trust(cancellable);
         }
     }
 
@@ -788,8 +792,10 @@ impl EditorServer {
 
         // A working-dir change lands us in a possibly-undecided project;
         // re-evaluate the trust prompt. (A rebuild triggered by a trust
-        // decision just recorded one, so this is a no-op there.)
-        self.maybe_prompt_workspace_trust();
+        // decision just recorded one, so this is a no-op there.) This is an
+        // activation on an already-running editor, so the secondary is Cancel
+        // (`cancellable = true`) — dismissing must not quit the server.
+        self.maybe_prompt_workspace_trust(true);
 
         // Force every attached client to repaint from scratch — the
         // previous frame described the old editor's screen.

--- a/crates/fresh-editor/src/view/workspace_trust_dialog.rs
+++ b/crates/fresh-editor/src/view/workspace_trust_dialog.rs
@@ -3,9 +3,11 @@
 //! A bespoke security modal (radio group + descriptions + an OK button and a
 //! secondary button), rendered on a dimmed backdrop in the modal z-band. As
 //! the mandatory open-time gate the secondary button is "Quit" (exit the
-//! editor) and there is no undecided outcome; when opened voluntarily from the
-//! command palette the secondary button is "Cancel" (close without changing
-//! the current level).
+//! editor) and there is no undecided outcome. Every other trigger — opening it
+//! voluntarily from the command palette, or activating another workspace on an
+//! already-running editor (an Orchestrator session, a project switch) — uses
+//! "Cancel" (dismiss without changing the current level), because there are
+//! other open sessions that must survive the dismissal.
 
 use crate::primitives::display_width::{str_width, DisplayWidth};
 use crate::view::theme::Theme;

--- a/crates/fresh-editor/tests/e2e/blog_showcases.rs
+++ b/crates/fresh-editor/tests/e2e/blog_showcases.rs
@@ -4575,7 +4575,7 @@ fn blog_showcase_fresh_0_4_0_workspace_trust() {
         .authority()
         .workspace_trust
         .set_store(Some(store));
-    h.editor_mut().maybe_prompt_workspace_trust();
+    h.editor_mut().maybe_prompt_workspace_trust(false);
     h.render().unwrap();
 
     // The folder opens Restricted, and the security prompt names the markers.

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -252,6 +252,7 @@ pub mod theme;
 pub mod theme_screenshots;
 pub mod toggle_bars;
 pub mod toggle_comment;
+pub mod trust_activation_cancellable;
 pub mod undo_bulk_edit_after_save;
 pub mod undo_redo_marker_roundtrip;
 pub mod unicode_cursor;

--- a/crates/fresh-editor/tests/e2e/plugins/env_manager.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/env_manager.rs
@@ -140,7 +140,7 @@ fn boot_with_dir_context(
         .authority()
         .workspace_trust
         .set_store(Some(store));
-    harness.editor_mut().maybe_prompt_workspace_trust();
+    harness.editor_mut().maybe_prompt_workspace_trust(false);
     // Republish the plugin state snapshot so JS reads the trust level
     // we just installed. Without this, `editor.workspaceTrustLevel()`
     // from the plugin returns whatever was current when the editor was

--- a/crates/fresh-editor/tests/e2e/trust_activation_cancellable.rs
+++ b/crates/fresh-editor/tests/e2e/trust_activation_cancellable.rs
@@ -1,0 +1,87 @@
+//! Regression: the workspace-trust prompt's secondary button follows *why* it
+//! was raised.
+//!
+//! The mandatory open-time gate (nothing else to fall back to yet) offers
+//! **Quit**. But when the prompt is raised by *activating another workspace* on
+//! an already-running editor — opening/switching an Orchestrator session, or
+//! changing the project — the secondary must be **Cancel**: dismissing it has
+//! to leave the just-activated workspace Restricted, never tear the whole
+//! editor (and every other open session) down.
+//!
+//! Before the fix both paths went through `show_workspace_trust_popup(false)`,
+//! so activating a session that tripped the trust prompt showed "Quit" and
+//! pressing it exited the editor.
+
+use crate::common::harness::EditorTestHarness;
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 40;
+
+/// Wire a real per-project trust store for the harness's current working dir
+/// and drop a manifest so the folder has executable-content markers (which is
+/// what makes an undecided folder raise the prompt).
+fn arm_undecided_project_with_markers(harness: &mut EditorTestHarness) {
+    let dir = harness.editor().working_dir().to_path_buf();
+    std::fs::write(dir.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let store_path = harness
+        .editor()
+        .dir_context()
+        .project_state_dir(&dir);
+    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
+    harness
+        .editor()
+        .authority()
+        .workspace_trust
+        .set_store(Some(store));
+}
+
+#[test]
+fn activation_trust_prompt_offers_cancel_not_quit() {
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    arm_undecided_project_with_markers(&mut harness);
+
+    // Raise the prompt the way an in-editor workspace activation does.
+    harness.editor_mut().maybe_prompt_workspace_trust(true);
+    harness.render().unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("SECURITY WARNING"))
+        .expect("an undecided project with a manifest must raise the trust prompt");
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Cancel"),
+        "an activation-raised trust prompt must offer Cancel.\nScreen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("Quit"),
+        "an activation-raised trust prompt must NOT offer Quit (that would kill \
+         the editor and every other open session).\nScreen:\n{screen}"
+    );
+}
+
+#[test]
+fn open_time_gate_trust_prompt_offers_quit() {
+    // The counterpart: the mandatory open-time gate (`cancellable = false`)
+    // still offers Quit — there is nothing to fall back to before the first
+    // trust decision is made.
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    arm_undecided_project_with_markers(&mut harness);
+
+    harness.editor_mut().maybe_prompt_workspace_trust(false);
+    harness.render().unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("SECURITY WARNING"))
+        .expect("an undecided project with a manifest must raise the trust prompt");
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Quit"),
+        "the open-time gate must offer Quit.\nScreen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("Cancel"),
+        "the open-time gate must NOT offer Cancel.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/trust_activation_cancellable.rs
+++ b/crates/fresh-editor/tests/e2e/trust_activation_cancellable.rs
@@ -23,10 +23,7 @@ const HEIGHT: u16 = 40;
 fn arm_undecided_project_with_markers(harness: &mut EditorTestHarness) {
     let dir = harness.editor().working_dir().to_path_buf();
     std::fs::write(dir.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
-    let store_path = harness
-        .editor()
-        .dir_context()
-        .project_state_dir(&dir);
+    let store_path = harness.editor().dir_context().project_state_dir(&dir);
     let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
     harness
         .editor()

--- a/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
+++ b/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
@@ -1,0 +1,159 @@
+//! Regression tests for eager Orchestrator-session persistence.
+//!
+//! Sessions used to be written to the directory-keyed workspace registry
+//! (`workspaces/*.json`) only when the editor exited *cleanly* (the quit-time
+//! `save_all_windows_workspaces`). A killed or crashed editor therefore forgot
+//! every session opened since the last clean quit — the dock came back missing
+//! the workspaces the user actually had open.
+//!
+//! The fix checkpoints a window's workspace at natural points that don't depend
+//! on a clean shutdown: switching away from a window, and finalizing a new
+//! session's identity (`setWindowState`, which the Orchestrator calls right
+//! after creating a window). These tests pin that behavior by asserting the
+//! on-disk workspace exists *without any quit having happened*.
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::model::filesystem::StdFileSystem;
+use fresh::workspace::Workspace;
+use std::path::Path;
+use std::sync::Arc;
+
+fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Editor {
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project.to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap()
+}
+
+/// Switching away from a window writes its workspace immediately — a later
+/// hard kill (no clean quit) still finds it in the registry.
+#[test]
+fn switching_away_persists_the_outgoing_window_without_a_quit() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let proj_a = sandbox.path().join("a");
+    let proj_b = sandbox.path().join("b");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&proj_a).unwrap();
+    std::fs::create_dir_all(&proj_b).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    // Unique tmp roots, so the global workspace registry has no stale entry for
+    // either — the precondition assertion below is meaningful.
+    let proj_a = proj_a.canonicalize().unwrap();
+    let proj_b = proj_b.canonicalize().unwrap();
+    let file_a = proj_a.join("hello.txt");
+    std::fs::write(&file_a, "hi").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    let mut e = editor_in(&proj_a, &dir_context);
+    e.open_file(&file_a).unwrap();
+
+    // No clean quit has happened and we never switched away, so A's session is
+    // not yet in the on-disk registry.
+    assert!(
+        Workspace::load(&proj_a).unwrap().is_none(),
+        "precondition: window A's workspace must not be on disk before any checkpoint"
+    );
+
+    // Open a second window and switch to it. The switch is the checkpoint: it
+    // must persist the *outgoing* window (A) before leaving it.
+    let win_b = e.create_window_at(proj_b.clone(), "b".into());
+    e.set_active_window(win_b);
+
+    let saved = Workspace::load(&proj_a)
+        .unwrap()
+        .expect("switching away must persist the outgoing window without a quit");
+    assert_eq!(
+        saved.working_dir, proj_a,
+        "the persisted workspace is window A's, keyed on its own root"
+    );
+    assert!(
+        saved_contains_file(&saved, &file_a),
+        "the checkpoint captured A's open file (hello.txt)"
+    );
+}
+
+/// The file A had open must be recorded somewhere in the saved workspace. It
+/// lives under the project root, so it is captured in the split layout rather
+/// than `external_files`; a JSON scan for its name is stable regardless of the
+/// exact serialized split-node shape.
+fn saved_contains_file(ws: &Workspace, file: &Path) -> bool {
+    let json = serde_json::to_string(ws).unwrap_or_default();
+    let name = file.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    !name.is_empty() && json.contains(name)
+}
+
+/// Setting per-session plugin state (what the Orchestrator does right after
+/// creating a session, to tag its `project_path`) checkpoints the window, so a
+/// freshly created session is in the registry the moment it is tagged — before
+/// any switch or quit.
+#[test]
+fn tagging_a_new_session_persists_it_without_a_quit() {
+    use fresh_core::api::PluginCommand;
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let proj_a = sandbox.path().join("a");
+    let proj_b = sandbox.path().join("b");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&proj_a).unwrap();
+    std::fs::create_dir_all(&proj_b).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    let proj_a = proj_a.canonicalize().unwrap();
+    let proj_b = proj_b.canonicalize().unwrap();
+    let file_a = proj_a.join("seed.txt");
+    std::fs::write(&file_a, "x").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    let mut e = editor_in(&proj_a, &dir_context);
+
+    // Create a second session for project B and make it active — this mirrors
+    // what `createWindowWithTerminal` does (it dives into the new window). Give
+    // it real content so it is savable.
+    let win_b = e.create_window_at(proj_b.clone(), "b".into());
+    e.set_active_window(win_b);
+    let file_b = proj_b.join("seed.txt");
+    std::fs::write(&file_b, "y").unwrap();
+    e.open_file(&file_b).unwrap();
+
+    // Not yet tagged, and if the harness didn't checkpoint on switch we can't
+    // rely on B being on disk — so drive the exact tagging call the plugin
+    // makes and require *that* to persist B.
+    let before = Workspace::load(&proj_b).unwrap();
+
+    e.handle_plugin_command(PluginCommand::SetWindowState {
+        plugin_name: "orchestrator".into(),
+        key: "project_path".into(),
+        value: Some(serde_json::Value::String(proj_b.to_string_lossy().into_owned())),
+    })
+    .unwrap();
+
+    let after = Workspace::load(&proj_b)
+        .unwrap()
+        .expect("tagging a session's identity must persist it without a quit");
+    assert_eq!(after.working_dir, proj_b);
+    assert_eq!(
+        after.session_plugin_state["orchestrator"]["project_path"],
+        serde_json::Value::String(proj_b.to_string_lossy().into_owned()),
+        "the persisted session carries the project_path the plugin just set"
+    );
+    // Whether or not `before` existed (a switch-away checkpoint may have
+    // written it already), the tagging call must leave a complete, identity-
+    // carrying record behind.
+    let _ = before;
+}

--- a/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
+++ b/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
@@ -103,6 +103,11 @@ fn saved_contains_file(ws: &Workspace, file: &Path) -> bool {
 /// creating a session, to tag its `project_path`) checkpoints the window, so a
 /// freshly created session is in the registry the moment it is tagged — before
 /// any switch or quit.
+///
+/// `SetWindowState` is a plugin command (`handle_plugin_command` only exists
+/// with the `plugins` feature), so this test is gated to that build — the
+/// min-size / no-plugins configuration has no session-tagging path to exercise.
+#[cfg(feature = "plugins")]
 #[test]
 fn tagging_a_new_session_persists_it_without_a_quit() {
     use fresh_core::api::PluginCommand;
@@ -139,7 +144,9 @@ fn tagging_a_new_session_persists_it_without_a_quit() {
     e.handle_plugin_command(PluginCommand::SetWindowState {
         plugin_name: "orchestrator".into(),
         key: "project_path".into(),
-        value: Some(serde_json::Value::String(proj_b.to_string_lossy().into_owned())),
+        value: Some(serde_json::Value::String(
+            proj_b.to_string_lossy().into_owned(),
+        )),
     })
     .unwrap();
 


### PR DESCRIPTION
Three orchestrator-dock issues, reproduced interactively and fixed:

1. "Show all worktrees" missed other projects' worktrees. The discovered-
   worktree scan covers every project that has an open/persisted session, but
   sessions were only persisted on clean quit (issue 2), so a killed editor
   forgot most projects and their worktrees vanished from the list. With
   sessions now persisted eagerly, their repos are scanned again. The Alt+T
   toggle also re-runs discovery now, so turning "Show all worktrees" on does a
   fresh, comprehensive scan of every known project rather than reusing a
   possibly-stale scan from dialog-open time.

2. A killed (not cleanly quit) editor forgot every workspace opened since the
   last quit. The directory-keyed registry (workspaces/*.json) was written only
   by the quit-time save. Now a window's workspace is checkpointed at natural
   points that don't depend on a clean shutdown: switching away from a window,
   and finalizing a new session's identity (the setWindowState the Orchestrator
   issues right after creating a session). A new checkpoint_window_workspace
   helper mirrors the quit-time guard (skips unmaterialized seeds / split-less
   windows). Best-effort; a failed write is logged and swallowed.

3. Activating a workspace that tripped the trust prompt showed "Quit" as the
   secondary button — pressing it exited the whole editor and lost every other
   open session. maybe_prompt_workspace_trust now takes a `cancellable` flag:
   the mandatory open-time gate keeps Quit, but in-editor activation paths (new
   Orchestrator session, project switch, server working-dir change) pass
   cancellable so the secondary is "Cancel" — dismissing just leaves the new
   workspace Restricted.

Adds regression tests: eager persistence via switch-away and session tagging
(orchestrator_eager_persistence), and the trust prompt's Cancel-vs-Quit
secondary button (e2e/trust_activation_cancellable).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011b9FUJbmjYdiJxTJvmqAY4