### PR TITLE
fix(lsp): re-pull diagnostics from every server, not just the first (#2615)

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -248,11 +248,18 @@ impl Editor {
                 AsyncMessage::LspPulledDiagnostics {
                     request_id: _,
                     uri,
+                    server_name,
                     result_id,
                     diagnostics,
                     unchanged,
                 } => {
-                    self.handle_lsp_pulled_diagnostics(uri, result_id, diagnostics, unchanged);
+                    self.handle_lsp_pulled_diagnostics(
+                        uri,
+                        server_name,
+                        result_id,
+                        diagnostics,
+                        unchanged,
+                    );
                 }
                 AsyncMessage::LspInlayHints {
                     request_id,

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -221,42 +221,61 @@ impl Editor {
     pub(super) fn handle_lsp_pulled_diagnostics(
         &mut self,
         uri: String,
+        server_name: String,
         result_id: Option<String>,
         diagnostics: Vec<Diagnostic>,
         unchanged: bool,
     ) {
+        // Drop reports from servers that have since been shut down, matching
+        // the push path — queued messages can outlive the server.
+        if let Some(lsp) = self.lsp() {
+            if !lsp.has_server_named(&server_name) {
+                tracing::debug!(
+                    "Dropping pulled diagnostics from stopped server '{}' for {}",
+                    server_name,
+                    uri
+                );
+                return;
+            }
+        }
+
+        // Store result_id (per-server) even on an unchanged report so the
+        // next pull for this server keeps sending the correct cursor.
+        if let Some(result_id) = result_id {
+            self.active_window_mut()
+                .diagnostic_result_ids
+                .entry(uri.clone())
+                .or_default()
+                .insert(server_name.clone(), result_id);
+        }
+
         if unchanged {
-            tracing::debug!(
-                "Diagnostics unchanged for {} (result_id: {:?})",
-                uri,
-                result_id
-            );
+            tracing::debug!("Diagnostics unchanged for {} from '{}'", uri, server_name);
             return;
         }
 
         tracing::debug!(
-            "Processing {} pulled diagnostics for {} (result_id: {:?})",
+            "Processing {} pulled diagnostics for {} from '{}'",
             diagnostics.len(),
             uri,
-            result_id
+            server_name
         );
 
-        // Store result_id for incremental updates
-        if let Some(result_id) = result_id {
-            self.active_window_mut()
-                .diagnostic_result_ids
-                .insert(uri.clone(), result_id);
-        }
-
         let anchored = self.anchor_diagnostics(&uri, diagnostics);
+        let server_map = self
+            .active_window_mut()
+            .stored_pull_diagnostics
+            .entry(uri.clone())
+            .or_default();
         if anchored.is_empty() {
-            self.active_window_mut()
-                .stored_pull_diagnostics
-                .remove(&uri);
+            server_map.remove(&server_name);
+            if server_map.is_empty() {
+                self.active_window_mut()
+                    .stored_pull_diagnostics
+                    .remove(&uri);
+            }
         } else {
-            self.active_window_mut()
-                .stored_pull_diagnostics
-                .insert(uri.clone(), anchored);
+            server_map.insert(server_name, anchored);
         }
 
         self.merge_and_apply_diagnostics(&uri);
@@ -264,23 +283,29 @@ impl Editor {
 
     /// Clear all diagnostics originating from a specific server.
     ///
-    /// Removes the server's entries from `stored_push_diagnostics`, then
+    /// Removes the server's entries from both `stored_push_diagnostics`
+    /// and `stored_pull_diagnostics` (plus its per-server result_id), then
     /// re-merges and re-applies diagnostics for every affected URI so that
     /// overlays on screen are updated immediately.
     pub(crate) fn clear_diagnostics_for_server(&mut self, server_name: &str) {
-        // Collect URIs that have diagnostics from this server.
-        let affected_uris: Vec<String> = self
-            .active_window()
-            .stored_push_diagnostics
-            .iter()
-            .filter_map(|(uri, server_map)| {
-                if server_map.contains_key(server_name) {
-                    Some(uri.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // Collect URIs that have push or pull diagnostics from this server.
+        let mut affected_uris: Vec<String> = {
+            let win = self.active_window();
+            let mut uris: std::collections::HashSet<String> = win
+                .stored_push_diagnostics
+                .iter()
+                .filter(|(_, sm)| sm.contains_key(server_name))
+                .map(|(uri, _)| uri.clone())
+                .collect();
+            uris.extend(
+                win.stored_pull_diagnostics
+                    .iter()
+                    .filter(|(_, sm)| sm.contains_key(server_name))
+                    .map(|(uri, _)| uri.clone()),
+            );
+            uris.into_iter().collect()
+        };
+        affected_uris.sort();
 
         if affected_uris.is_empty() {
             return;
@@ -293,6 +318,22 @@ impl Editor {
         );
 
         for uri in &affected_uris {
+            if let Some(server_map) = self
+                .active_window_mut()
+                .stored_pull_diagnostics
+                .get_mut(uri)
+            {
+                server_map.remove(server_name);
+                if server_map.is_empty() {
+                    self.active_window_mut().stored_pull_diagnostics.remove(uri);
+                }
+            }
+            if let Some(id_map) = self.active_window_mut().diagnostic_result_ids.get_mut(uri) {
+                id_map.remove(server_name);
+                if id_map.is_empty() {
+                    self.active_window_mut().diagnostic_result_ids.remove(uri);
+                }
+            }
             if let Some(server_map) = self
                 .active_window_mut()
                 .stored_push_diagnostics
@@ -981,30 +1022,11 @@ impl Editor {
         let Some(__win) = self.windows.get_mut(&__active_id) else {
             return;
         };
-        let diagnostic_result_ids = &__win.diagnostic_result_ids;
-        let lsp = &mut __win.lsp;
-        let Some(sh) = lsp.handle_for_feature_mut(language, crate::types::LspFeature::Diagnostics)
-        else {
-            return;
-        };
-        let client = &mut sh.handle;
-        let __next_id = &mut __win.next_lsp_request_id;
 
+        // Fan each URI out to every diagnostic-capable server (merged
+        // feature), not just the first-listed one.
         for uri in uris {
-            let request_id = *__next_id;
-            *__next_id += 1;
-            let previous_result_id = diagnostic_result_ids.get(uri.as_str()).cloned();
-            if let Err(e) =
-                client.document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
-            {
-                tracing::debug!("Failed to re-pull diagnostics for {}: {}", uri.as_str(), e);
-            } else {
-                tracing::info!(
-                    "Re-pulling diagnostics for {} (request_id={})",
-                    uri.as_str(),
-                    request_id
-                );
-            }
+            __win.pull_diagnostics_for_uri(language, &uri);
         }
     }
 

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -1401,7 +1401,14 @@ impl crate::app::window::Window {
         };
 
         let enable_inlay_hints = self.resources.config.editor.enable_inlay_hints;
-        let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
+        // Per-server last result_ids for this URI, snapshotted before the
+        // `&mut self.lsp` borrow below. Diagnostics is a merged feature, so
+        // each diagnostic-capable server is pulled with its own cursor.
+        let previous_result_ids = self
+            .diagnostic_result_ids
+            .get(uri.as_str())
+            .cloned()
+            .unwrap_or_default();
 
         // Get buffer line count and version for inlay hints
         let (last_line, last_char, buffer_version) = self
@@ -1454,14 +1461,15 @@ impl crate::app::window::Window {
                 // check returns `None` (capabilities aren't known until the
                 // `initialize` response arrives); the `LspInitialized`
                 // handler replays these requests once capabilities land.
-                if let Some(sh) =
-                    lsp.handle_for_feature_mut(&language, crate::types::LspFeature::Diagnostics)
+                for sh in
+                    lsp.handles_for_feature_mut(&language, crate::types::LspFeature::Diagnostics)
                 {
                     let request_id = {
                         let id = *__next_id;
                         *__next_id += 1;
                         id
                     };
+                    let previous_result_id = previous_result_ids.get(&sh.name).cloned();
                     if let Err(e) = sh.handle.document_diagnostic(
                         request_id,
                         uri.as_uri().clone(),
@@ -1470,8 +1478,9 @@ impl crate::app::window::Window {
                         tracing::debug!("Failed to request pull diagnostics: {}", e);
                     } else {
                         tracing::info!(
-                            "Requested pull diagnostics for {} (request_id={})",
+                            "Requested pull diagnostics for {} from '{}' (request_id={})",
                             uri.as_str(),
+                            sh.name,
                             request_id
                         );
                     }

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -1174,7 +1174,6 @@ impl Editor {
         let Some(__win) = self.windows.get_mut(&__active_id) else {
             return;
         };
-        let diagnostic_result_ids = &__win.diagnostic_result_ids;
         let __next_id = &mut __win.next_lsp_request_id;
         let buffer_metadata = &mut __win.buffer_metadata;
         let lsp = &mut __win.lsp;
@@ -1198,16 +1197,15 @@ impl Editor {
             metadata.lsp_opened_with.insert(handle_id);
         }
 
-        // Request diagnostics
+        // Request diagnostics. We just re-sent didOpen, so ask for a full
+        // report (no previous result_id) — any prior per-server result_ids
+        // for this URI were cleared when LSP was disabled for the buffer.
         let request_id = {
             let id = *__next_id;
             *__next_id += 1;
             id
         };
-        let previous_result_id = diagnostic_result_ids.get(uri.as_str()).cloned();
-        if let Err(e) =
-            handle.document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
-        {
+        if let Err(e) = handle.document_diagnostic(request_id, uri.as_uri().clone(), None) {
             tracing::warn!("LSP document_diagnostic request failed: {}", e);
         }
 

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -509,28 +509,37 @@ impl Editor {
                 if any_opened {
                     tracing::info!("Successfully sent didOpen to LSP after confirmation");
 
-                    // Request pull diagnostics from primary handle
-                    if let Some(handle) = lsp.get_handle_mut(language) {
-                        let previous_result_id = diagnostic_result_ids.get(uri.as_str()).cloned();
+                    // Request pull diagnostics from EVERY diagnostic-capable
+                    // server (merged feature), each with its own result_id —
+                    // not just the first-listed handle.
+                    for sh in
+                        lsp.handles_for_feature_mut(language, crate::types::LspFeature::Diagnostics)
+                    {
                         let request_id = {
                             let id = *__next_id;
                             *__next_id += 1;
                             id
                         };
-
-                        if let Err(e) = handle.document_diagnostic(
+                        let previous_result_id = diagnostic_result_ids
+                            .get(uri.as_str())
+                            .and_then(|m| m.get(&sh.name))
+                            .cloned();
+                        if let Err(e) = sh.handle.document_diagnostic(
                             request_id,
                             uri.as_uri().clone(),
                             previous_result_id,
                         ) {
                             tracing::debug!(
-                                "Failed to request pull diagnostics (server may not support): {}",
+                                "Failed to request pull diagnostics from '{}' (server may not support): {}",
+                                sh.name,
                                 e
                             );
                         }
+                    }
 
-                        // Request inlay hints if enabled
-                        if enable_inlay_hints {
+                    // Request inlay hints if enabled (uses the primary handle).
+                    if enable_inlay_hints {
+                        if let Some(handle) = lsp.get_handle_mut(language) {
                             let request_id = {
                                 let id = *__next_id;
                                 *__next_id += 1;

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -627,10 +627,14 @@ pub struct Window {
     /// overlays, and buffers are per-window, so the namespace follows.
     pub lsp_diagnostic_namespace: crate::view::overlay::OverlayNamespace,
 
-    /// Last `result_id` seen from the LSP server per URI for incremental
-    /// pull diagnostics. Per-window because each window has its own
-    /// LSP manager and therefore its own result-id stream.
-    pub diagnostic_result_ids: HashMap<String, String>,
+    /// Last `result_id` seen per URI *and per server* for incremental
+    /// pull diagnostics. Keyed URI → server name → result_id. Per-server
+    /// because `Diagnostics` is a merged feature: several servers (e.g.
+    /// `ruff` + `ty`) can each pull-serve the same URI with their own
+    /// independent result-id streams, so a single shared id would send
+    /// one server's cursor to another. Per-window because each window has
+    /// its own LSP manager.
+    pub diagnostic_result_ids: HashMap<String, HashMap<String, String>>,
 
     /// `$/progress` token → progress info for this window's LSP servers.
     /// Drives the spinner in the status bar's LSP pill. Per-window
@@ -674,11 +678,15 @@ pub struct Window {
     /// position tracks edits between re-publishes via `CoordMap` (#2602).
     pub stored_push_diagnostics: HashMap<String, HashMap<String, Vec<AnchoredDiagnostic>>>,
 
-    /// Pull-model diagnostics (rust-analyzer-style native pull)
-    /// keyed by URI. Independent of `stored_push_diagnostics`; the
-    /// two are merged into `stored_diagnostics` for plugin / overlay
-    /// consumption.
-    pub stored_pull_diagnostics: HashMap<String, Vec<AnchoredDiagnostic>>,
+    /// Pull-model diagnostics (rust-analyzer-style native pull) keyed by
+    /// URI, then by server name — mirroring `stored_push_diagnostics`.
+    /// `Diagnostics` is a merged feature, so multiple servers (e.g.
+    /// `ruff` + `ty` for Python) can each pull-serve the same URI; keying
+    /// by server keeps their results from clobbering one another (#2615).
+    /// Independent of `stored_push_diagnostics`; both are merged into
+    /// `stored_diagnostics`. Each entry carries a byte anchor so its
+    /// position tracks edits between re-pulls via `CoordMap` (#2602).
+    pub stored_pull_diagnostics: HashMap<String, HashMap<String, Vec<AnchoredDiagnostic>>>,
 
     /// Merged view of push + pull diagnostics with every position mapped
     /// forward to the buffer's current version, exposed to plugins and read
@@ -2814,33 +2822,79 @@ impl Window {
             return false;
         };
 
-        let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
-        let request_id = self.next_lsp_request_id;
-        self.next_lsp_request_id += 1;
-
-        let lsp = &mut self.lsp;
-        let Some(sh) = lsp.handle_for_feature_mut(&language, crate::types::LspFeature::Diagnostics)
-        else {
-            return false;
-        };
-        if let Err(e) =
-            sh.handle
-                .document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
-        {
-            tracing::debug!(
-                "Failed to pull diagnostics after edit for {}: {}",
-                uri.as_str(),
-                e
-            );
-        } else {
-            tracing::debug!(
-                "Pulling diagnostics after edit for {} (request_id={})",
-                uri.as_str(),
-                request_id
-            );
-        }
+        self.pull_diagnostics_for_uri(&language, &uri);
 
         false
+    }
+
+    /// Send a `textDocument/diagnostic` pull request for `uri` to **every**
+    /// diagnostic-capable server for `language`, each with its own last
+    /// `result_id`.
+    ///
+    /// `Diagnostics` is a merged feature, so when several servers pull-serve
+    /// the same language (e.g. `ruff` + `ty` for Python) each one must be
+    /// re-pulled — pulling only the first-listed server leaves the others'
+    /// diagnostics (type errors, in the reported case) stale until restart
+    /// (sinelaw/fresh#2615). Servers that never advertised `diagnosticProvider`
+    /// drop the request on the async side, so fanning out to every eligible
+    /// handle is safe.
+    pub(crate) fn pull_diagnostics_for_uri(
+        &mut self,
+        language: &str,
+        uri: &crate::app::types::LspUri,
+    ) {
+        // Snapshot the eligible server names first so we can read
+        // `diagnostic_result_ids` and bump request ids without holding the
+        // `&mut self.lsp` borrow that `handles_for_feature_mut` needs.
+        let server_names: Vec<String> = self
+            .lsp
+            .handles_for_feature(language, crate::types::LspFeature::Diagnostics)
+            .into_iter()
+            .map(|sh| sh.name.clone())
+            .collect();
+        if server_names.is_empty() {
+            return;
+        }
+
+        let mut plan: Vec<(String, u64, Option<String>)> = Vec::with_capacity(server_names.len());
+        for name in server_names {
+            let previous_result_id = self
+                .diagnostic_result_ids
+                .get(uri.as_str())
+                .and_then(|m| m.get(&name))
+                .cloned();
+            let request_id = self.next_lsp_request_id;
+            self.next_lsp_request_id += 1;
+            plan.push((name, request_id, previous_result_id));
+        }
+
+        let lsp = &mut self.lsp;
+        for sh in lsp.handles_for_feature_mut(language, crate::types::LspFeature::Diagnostics) {
+            let Some((_, request_id, previous_result_id)) =
+                plan.iter().find(|(n, _, _)| n.as_str() == sh.name.as_str())
+            else {
+                continue;
+            };
+            if let Err(e) = sh.handle.document_diagnostic(
+                *request_id,
+                uri.as_uri().clone(),
+                previous_result_id.clone(),
+            ) {
+                tracing::debug!(
+                    "Failed to pull diagnostics for {} from '{}': {}",
+                    uri.as_str(),
+                    sh.name,
+                    e
+                );
+            } else {
+                tracing::debug!(
+                    "Pulling diagnostics for {} from '{}' (request_id={})",
+                    uri.as_str(),
+                    sh.name,
+                    request_id
+                );
+            }
+        }
     }
 
     /// Open a local file in this window (always uses local filesystem,
@@ -3445,8 +3499,10 @@ impl Window {
                 merged.extend(entries.iter().map(|e| e.at_current_version(state)));
             }
         }
-        if let Some(pull) = self.stored_pull_diagnostics.get(uri) {
-            merged.extend(pull.iter().map(|e| e.at_current_version(state)));
+        if let Some(server_map) = self.stored_pull_diagnostics.get(uri) {
+            for entries in server_map.values() {
+                merged.extend(entries.iter().map(|e| e.at_current_version(state)));
+            }
         }
 
         let store = Arc::make_mut(&mut self.stored_diagnostics);

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -214,6 +214,11 @@ pub enum AsyncMessage {
     LspPulledDiagnostics {
         request_id: u64,
         uri: String,
+        /// Name of the server that produced this pull report. Pull
+        /// diagnostics are tracked per-server (several servers can
+        /// pull-serve the same URI), so the response must say who it
+        /// came from.
+        server_name: String,
         /// New result_id for incremental updates (None if server doesn't support)
         result_id: Option<String>,
         /// Diagnostics (empty if unchanged)

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -2384,6 +2384,7 @@ impl LspState {
                     let _ = self.async_tx.send(AsyncMessage::LspPulledDiagnostics {
                         request_id,
                         uri: uri_string,
+                        server_name: (*self.server_name).clone(),
                         result_id,
                         diagnostics,
                         unchanged: false,
@@ -2405,6 +2406,7 @@ impl LspState {
                     let _ = self.async_tx.send(AsyncMessage::LspPulledDiagnostics {
                         request_id,
                         uri: uri_string,
+                        server_name: (*self.server_name).clone(),
                         result_id: Some(result_id),
                         diagnostics: Vec::new(),
                         unchanged: true,
@@ -2418,6 +2420,7 @@ impl LspState {
                     let _ = self.async_tx.send(AsyncMessage::LspPulledDiagnostics {
                         request_id,
                         uri: uri_string,
+                        server_name: (*self.server_name).clone(),
                         result_id: None,
                         diagnostics: Vec::new(),
                         unchanged: false,
@@ -2432,6 +2435,7 @@ impl LspState {
                 let _ = self.async_tx.send(AsyncMessage::LspPulledDiagnostics {
                     request_id,
                     uri: uri.as_str().to_string(),
+                    server_name: (*self.server_name).clone(),
                     result_id: None,
                     diagnostics: Vec::new(),
                     unchanged: false,
@@ -3522,6 +3526,7 @@ impl LspTask {
                         let _ = state.async_tx.send(AsyncMessage::LspPulledDiagnostics {
                             request_id,
                             uri: uri.as_str().to_string(),
+                            server_name: (*state.server_name).clone(),
                             result_id: None,
                             diagnostics: Vec::new(),
                             unchanged: false,

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -3468,6 +3468,7 @@ fn test_pull_diagnostics_message_handling() -> anyhow::Result<()> {
         let _ = bridge.sender().send(AsyncMessage::LspPulledDiagnostics {
             request_id: 1,
             uri: uri.as_str().to_string(),
+            server_name: "test-server".to_string(),
             result_id: Some("test-result-id-123".to_string()),
             diagnostics: vec![diagnostic],
             unchanged: false,
@@ -3511,6 +3512,7 @@ fn test_pull_diagnostics_unchanged_response() -> anyhow::Result<()> {
         let _ = bridge.sender().send(AsyncMessage::LspPulledDiagnostics {
             request_id: 2,
             uri: uri.as_str().to_string(),
+            server_name: "test-server".to_string(),
             result_id: Some("test-result-id-456".to_string()),
             diagnostics: Vec::new(), // Empty when unchanged
             unchanged: true,

--- a/crates/fresh-editor/tests/e2e/lsp_multi_server_diagnostic_pull.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_multi_server_diagnostic_pull.rs
@@ -1,0 +1,226 @@
+//! Reproduction for sinelaw/fresh#2615 — "incremental type checking not
+//! working".
+//!
+//! User setup: two Python LSP servers configured for the same language,
+//! `ruff` (linter) and `ty` (type checker), both of which serve diagnostics
+//! via the pull model (`textDocument/diagnostic`). Symptom: `ty`'s type
+//! errors never refresh after an edit — they only update on restart.
+//!
+//! Root cause: every pull-diagnostic request site resolved a *single*
+//! handle via `handle_for_feature_mut(Diagnostics)` — the first-listed
+//! diagnostic-capable server. But `Diagnostics` is a *merged* feature:
+//! results are supposed to be combined from all eligible servers. So only
+//! the first server (`ruff`) was ever re-pulled after an edit; the second
+//! (`ty`) went stale until a restart re-opened the document.
+//!
+//! This test spawns two fake pull-diagnostic servers for the same language,
+//! each logging the URIs it is asked to pull. After an edit, BOTH servers
+//! must be re-pulled.
+
+use crate::common::harness::EditorTestHarness;
+
+/// Fake pull-diagnostic server: advertises `diagnosticProvider`, logs every
+/// `textDocument/diagnostic` URI to the file given as `$1`, and always
+/// responds with a full report carrying one diagnostic.
+fn create_pull_diag_server_script(dir: &std::path::Path, file_name: &str) -> std::path::PathBuf {
+    let script = r##"#!/bin/bash
+LOG_FILE="${1:-/tmp/fake_pull_log.txt}"
+> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then
+        break
+    fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"positionEncoding":"utf-16","textDocumentSync":{"openClose":true,"change":2,"save":{}},"diagnosticProvider":{"interFileDependencies":false,"workspaceDiagnostics":false}}}}'
+            ;;
+        "initialized") ;;
+        "textDocument/didOpen")
+            URI=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            echo "DIDOPEN: $URI" >> "$LOG_FILE"
+            ;;
+        "textDocument/diagnostic")
+            URI=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            echo "PULL: $URI" >> "$LOG_FILE"
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"kind":"full","resultId":"fake","items":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},"severity":1,"message":"diag from fake server"}]}}'
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+        *)
+            if [ -n "$method" ] && [ -n "$msg_id" ]; then
+                send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            fi
+            ;;
+    esac
+done
+echo "SERVER: exiting" >> "$LOG_FILE"
+"##;
+
+    let script_path = dir.join(file_name);
+    std::fs::write(&script_path, script).expect("Failed to write fake pull-diag server");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    script_path
+}
+
+fn pull_count(log_path: &std::path::Path, uri_fragment: &str) -> usize {
+    std::fs::read_to_string(log_path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| l.starts_with("PULL:") && l.contains(uri_fragment))
+        .count()
+}
+
+/// Drive the editor event loop (processing async LSP messages and advancing
+/// the debounce clock) until `cond` holds or `max_iters` elapse. Unlike
+/// `harness.wait_until`, this is bounded: a regression makes the test *fail*
+/// rather than hang forever on an unsatisfiable condition.
+fn pump_until<F>(harness: &mut EditorTestHarness, max_iters: usize, cond: F) -> anyhow::Result<bool>
+where
+    F: Fn() -> bool,
+{
+    for _ in 0..max_iters {
+        harness.tick_and_render()?;
+        if cond() {
+            return Ok(true);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        harness.advance_time(std::time::Duration::from_millis(50));
+    }
+    Ok(cond())
+}
+
+/// With two pull-diagnostic servers configured for one language, an edit
+/// must re-pull diagnostics from BOTH servers. Before the fix, only the
+/// first-listed server was ever pulled, so the second server's diagnostics
+/// (e.g. `ty`'s type errors) never refreshed until restart.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_all_pull_diagnostic_servers_repulled_after_edit() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("fresh=debug")
+        .try_init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let script_a = create_pull_diag_server_script(temp_dir.path(), "fake_server_a.sh");
+    let script_b = create_pull_diag_server_script(temp_dir.path(), "fake_server_b.sh");
+    let log_a = temp_dir.path().join("server_a_log.txt");
+    let log_b = temp_dir.path().join("server_b_log.txt");
+
+    let rust_file = temp_dir.path().join("api.rs");
+    std::fs::write(&rust_file, "fn main() {}\n")?;
+
+    let make_server = |script: &std::path::Path, log: &std::path::Path, name: &str| {
+        fresh::services::lsp::LspServerConfig {
+            command: script.to_string_lossy().to_string(),
+            args: Some(vec![log.to_string_lossy().to_string()]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some(name.to_string()),
+            only_features: None,
+            except_features: None,
+        }
+    };
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![
+            make_server(&script_a, &log_a, "linter"),
+            make_server(&script_b, &log_b, "typechecker"),
+        ]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&rust_file)?;
+    harness.render()?;
+
+    // Both servers should receive the initial open pull. This alone already
+    // failed before the fix for the second (non-first-listed) server.
+    let both_opened = pump_until(&mut harness, 200, || {
+        pull_count(&log_a, "api.rs") >= 1 && pull_count(&log_b, "api.rs") >= 1
+    })?;
+    assert!(
+        both_opened,
+        "BUG #2615: both servers should receive the initial open pull \
+         (linter={}, typechecker={})",
+        pull_count(&log_a, "api.rs"),
+        pull_count(&log_b, "api.rs"),
+    );
+
+    // Edit the buffer: schedules a per-edit diagnostic re-pull (debounced).
+    use crossterm::event::{KeyCode, KeyModifiers};
+    harness.send_key(KeyCode::Char('x'), KeyModifiers::NONE)?;
+
+    // After the edit, BOTH servers must be pulled again — not just the
+    // first-listed one. This is the core of #2615.
+    let both_repulled = pump_until(&mut harness, 300, || {
+        pull_count(&log_a, "api.rs") >= 2 && pull_count(&log_b, "api.rs") >= 2
+    })?;
+
+    let a = pull_count(&log_a, "api.rs");
+    let b = pull_count(&log_b, "api.rs");
+    eprintln!("[TEST] linter pulls={a}, typechecker pulls={b}");
+
+    assert!(
+        a >= 2,
+        "Sanity: first-listed server should be re-pulled after an edit (pulls={a})"
+    );
+    assert!(
+        both_repulled && b >= 2,
+        "BUG #2615: the second diagnostic server was not re-pulled after an edit \
+         (pulls={b}). Diagnostics is a merged feature — every pull-capable server \
+         must be re-pulled, otherwise its diagnostics (e.g. `ty` type errors) go \
+         stale until restart."
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -127,6 +127,7 @@ pub mod lsp_inlay_hints_capability;
 pub mod lsp_lifecycle_visibility;
 pub mod lsp_missing_binary_and_dismiss;
 pub mod lsp_multi_semantic_tokens;
+pub mod lsp_multi_server_diagnostic_pull;
 pub mod lsp_no_config;
 pub mod lsp_order;
 pub mod lsp_popup_focus_keybinding;


### PR DESCRIPTION
Fixes #2615.

## Problem

The reporter runs two Python LSP servers — `ruff` and `ty` (type checker) — both configured with `args: ["server"]`, and both serve diagnostics via the **pull model** (`textDocument/diagnostic`). Symptom: `ty`'s type errors never refresh after an edit; they only update on a restart.

## Root cause

`Diagnostics` is a **merged** feature — results are meant to be combined from *all* eligible servers. But every pull-diagnostic request site resolved a *single* handle via `handle_for_feature_mut(Diagnostics)`, i.e. the first-listed diagnostic-capable server. So only `ruff` (first in the config) was ever re-pulled after an edit; `ty` was never re-pulled and its diagnostics went stale until a restart re-opened the document.

A secondary latent bug: pull diagnostics and their `result_id`s were keyed by URI only, so two pull servers on the same file would have clobbered each other's results and cross-sent incremental cursors.

## Fix

- Every pull site now fans the `textDocument/diagnostic` request out to **all** diagnostic-capable handles:
  - the per-edit debounce (`check_diagnostic_pull_timer`)
  - the didOpen initial pull (`file_operations`)
  - `workspace/diagnostic/refresh` and post-quiescent re-pull (`pull_diagnostics_for_language`)
  - dynamic capability registration
  - the settings confirm-open path (`popup_overlay_actions`)
- Introduced `Window::pull_diagnostics_for_uri`, the single fan-out helper the pull sites share.
- Pull diagnostics are now stored **per-server** (`URI → server → diagnostics`), mirroring `stored_push_diagnostics`, and `result_id`s are tracked per-server (`URI → server → result_id`) so servers keep independent incremental cursors.
- `LspPulledDiagnostics` carries the originating `server_name`; the handler stores per-server and drops reports from servers that have shut down (parity with the push path).
- `clear_diagnostics_for_server` now also clears the server's pull diagnostics and result_ids.

Servers that never advertised `diagnosticProvider` drop the request on the async side, so fanning out to every eligible handle is safe.

## Tests

- New e2e regression test `lsp_multi_server_diagnostic_pull.rs`: spawns two fake pull-diagnostic servers for one language and asserts **both** are re-pulled after an edit. Verified it fails against the pre-fix behavior (second server never reaches its post-edit pull) and passes with the fix.
- Full `lsp` e2e suite green (235 passed), diagnostics subset green (41 passed).

## Manual validation

Ran the regression test in a tmux session; captured output shows both servers re-pulled after edits:

```
[TEST] linter pulls=3, typechecker pulls=2
test ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExQjfkPm1voC4XXP6BN1HG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExQjfkPm1voC4XXP6BN1HG)_