### PR TITLE
fix(rulers): span full editor height, not just written lines (#2631)

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -525,7 +525,12 @@ pub(crate) fn draw_buffer_in_split(
         None
     };
 
-    // Render config-based vertical rulers
+    // Render config-based vertical rulers. Span the full editor height rather
+    // than stopping at the last text line: the ruler is a column guide, so it
+    // must stay visible through the empty area below the buffer (matching VS
+    // Code / Zed). Bounding it to `content_lines_rendered` made a short buffer
+    // show the ruler only on written lines, leaving the rest of the pane blank
+    // and the guide looking truncated (#2631).
     if !rulers.is_empty() {
         let ruler_cols: Vec<u16> = rulers.iter().map(|&r| r as u16).collect();
         render_ruler_bg(
@@ -534,7 +539,7 @@ pub(crate) fn draw_buffer_in_split(
             theme.ruler_bg,
             render_area,
             gutter_width,
-            layout_output.render_output.content_lines_rendered,
+            render_area.height as usize,
             layout_output.left_column,
         );
     }

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -105,6 +105,35 @@ fn test_rulers_span_full_height() {
     }
 }
 
+/// Regression (#2631): the ruler must span the full editor height even when the
+/// buffer has fewer lines than the viewport. Previously it stopped at the last
+/// written line, leaving the empty area below without the guide — so a buffer
+/// with a single short line showed the ruler on just one row.
+#[test]
+fn test_rulers_span_full_height_short_buffer() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![10];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    // Only three lines of text in a 24-row terminal: most of the pane is empty.
+    let _fixture = harness
+        .load_buffer_from_text("line one\nline two\nline three")
+        .unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, content_last_row) = harness.content_area_rows();
+    let ruler_x = gutter_width(&harness) + 10;
+
+    // The ruler must appear on every content row, including the empty rows
+    // below the last line of text.
+    for row in content_first_row..=content_last_row {
+        assert!(
+            has_ruler_bg(&harness, ruler_x, row as u16),
+            "Ruler bg should appear on row {row} (short buffer, {content_first_row}..={content_last_row})"
+        );
+    }
+}
+
 /// Test that rulers scroll horizontally with content.
 #[test]
 fn test_rulers_horizontal_scroll() {


### PR DESCRIPTION
## Summary

Fixes #2631. Vertical column rulers only rendered on lines that had text and stopped at the last written line, leaving the empty area below without the guide. On a buffer with few lines (e.g. a single short line) the ruler looked truncated — like a stray character on the first row rather than a column marker — which is confusing.

Now the ruler spans the full editor content height, staying consistent through the empty rows below the buffer, matching VS Code and Zed.

## Root cause

`render_buffer.rs` passed `content_lines_rendered` (the count of actual text lines drawn) as the ruler's height, so `render_ruler_bg` tinted the ruler column only down to the last line of text. Below that, `fill_eof_rows` pads the pane with `~`/EOF shading, but the ruler was absent there.

## Fix

Pass the full `render_area.height` as the ruler height instead. This only ever *extends* the ruler downward: full-height buffers are unchanged because the height was already clamped to the render area inside `render_ruler_bg`. Scope is limited to the config-driven rulers (the cursor-column highlight and compose guides are untouched).

## Testing

- Added an e2e regression test `test_rulers_span_full_height_short_buffer` that loads a 3-line buffer into a 24-row terminal and asserts the ruler background appears on every content row, including the empty rows below the last line. It **fails without** this change (ruler stops at the last line) and passes with it.
- All existing `vertical_rulers` e2e tests pass (15 passed, 1 pre-existing ignored screenshot test).
- `cargo fmt --check` and `cargo clippy --all-targets` clean for the changed code.
- Manually validated in a tmux session: with `editor.rulers=[10]` and a short file, the ruler tint now runs from the first line through the empty `~` region down to the status bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z9LhjbfM4b45eP7rwwz2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013z9LhjbfM4b45eP7rwwz2Z)_