### PR TITLE
fix(settings): honor Home/End & forward-Delete in body text fields, and unify the text-key dispatch

### DIFF
--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -54,6 +54,29 @@ fn find_scrollable_widget_key(spec: &fresh_core::api::WidgetSpec) -> Option<Stri
     spec.children().find_map(find_scrollable_widget_key)
 }
 
+/// Re-hydrate the plugin runtime's flattened key *name* (e.g. `"Home"`)
+/// back into a `KeyEvent`, so widget text editing can go through the shared
+/// [`apply_text_key`](crate::primitives::text_key::apply_text_key) table
+/// rather than its own dispatch. Only the bare named keys the widget key
+/// router forwards to text fields are recognized; `"Enter"` is handled by
+/// the caller, and modifier chords aren't currently surfaced to widget
+/// text fields.
+fn widget_key_name_to_event(name: &str) -> Option<crossterm::event::KeyEvent> {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    let code = match name {
+        "Backspace" => KeyCode::Backspace,
+        "Delete" => KeyCode::Delete,
+        "Left" => KeyCode::Left,
+        "Right" => KeyCode::Right,
+        "Up" => KeyCode::Up,
+        "Down" => KeyCode::Down,
+        "Home" => KeyCode::Home,
+        "End" => KeyCode::End,
+        _ => return None,
+    };
+    Some(KeyEvent::new(code, KeyModifiers::NONE))
+}
+
 /// A `DualList` interaction, resolved from a keystroke or click by
 /// [`Editor::handle_widget_dual`].
 pub(super) enum DualOp {
@@ -2801,23 +2824,34 @@ impl Editor {
         self.with_focused_text_editor(panel_key, |editor| editor.set_cursor_from_flat(value_byte));
     }
 
-    /// Apply a non-printable editing key to the focused text widget
-    /// by dispatching to the corresponding `TextEdit` method. The
-    /// single/multi-line discriminator is carried by `TextEdit`'s
-    /// `multiline` field, so the same set of methods serves both
-    /// kinds — single-line just no-ops on Up/Down/Enter.
+    /// Apply a non-printable editing key to the focused text widget. See
+    /// [`widget_key_name_to_event`] for the name → `KeyEvent` re-hydration.
+    ///
+    /// Every caret-motion / mutation key is routed through the shared
+    /// [`apply_text_key`](crate::primitives::text_key::apply_text_key)
+    /// table — the single source of truth the Settings input handler also
+    /// uses, so the two surfaces can't drift. `Enter` = newline is the one
+    /// widget-multiline affordance the shared table deliberately leaves as
+    /// chrome (it means "commit" on other surfaces), so it's handled here.
+    ///
+    /// The single/multi-line discriminator is carried by `TextEdit`'s own
+    /// `multiline` field, so passing `multiline: true` lets the router
+    /// forward Up/Down while a single-line editor simply no-ops on them —
+    /// matching the prior dispatch.
     fn handle_widget_text_key(&mut self, panel_key: &crate::widgets::PanelKey, key: &str) {
-        self.with_focused_text_editor(panel_key, |editor| match key {
-            "Backspace" => editor.backspace(),
-            "Delete" => editor.delete(),
-            "Left" => editor.move_left(),
-            "Right" => editor.move_right(),
-            "Up" => editor.move_up(),
-            "Down" => editor.move_down(),
-            "Home" => editor.move_home(),
-            "End" => editor.move_end(),
-            "Enter" => editor.insert_char('\n'),
-            _ => { /* unknown key — no-op */ }
+        if key == "Enter" {
+            self.with_focused_text_editor(panel_key, |editor| editor.insert_char('\n'));
+            return;
+        }
+        let Some(event) = widget_key_name_to_event(key) else {
+            return;
+        };
+        self.with_focused_text_editor(panel_key, |editor| {
+            crate::primitives::text_key::apply_text_key(
+                editor,
+                &event,
+                crate::primitives::text_key::TextKeyContext::multiline(true),
+            );
         });
     }
 

--- a/crates/fresh-editor/src/primitives/mod.rs
+++ b/crates/fresh-editor/src/primitives/mod.rs
@@ -31,6 +31,12 @@ pub mod word_navigation;
 // and the plugin widget framework.
 pub mod text_edit;
 
+// The single `key → text-editing operation` table shared by the Settings
+// input handler and the plugin widget runtime. Runtime-gated because it
+// speaks crossterm's `KeyEvent`; both callers are `runtime`-only.
+#[cfg(feature = "runtime")]
+pub mod text_key;
+
 // Modules using ratatui types (Color, Style, etc.) - available for both runtime and WASM
 // since ratatui core is WASM-compatible (only the crossterm backend is native-only)
 #[cfg(any(feature = "runtime", feature = "wasm"))]

--- a/crates/fresh-editor/src/primitives/text_key.rs
+++ b/crates/fresh-editor/src/primitives/text_key.rs
@@ -1,0 +1,555 @@
+//! The single source of truth for "which key performs which text-editing
+//! operation" across every text surface in the editor.
+//!
+//! Historically two independent handlers each had their own `key → op`
+//! table: the Settings UI's `handle_text_editing_input` and the plugin
+//! widget runtime's `handle_widget_text_key`. They drifted — the Settings
+//! table was missing `Home`/`End` and routed `Delete` to list-item removal,
+//! so a scalar field like *Terminal ▸ Command* silently ignored those keys
+//! while the widget path handled them fine.
+//!
+//! [`apply_text_key`] is that table, extracted once. Both handlers now feed
+//! it a `KeyEvent` and a [`TextSurface`] (their focused editor), so the
+//! motion / mutation / selection semantics can no longer diverge — a new
+//! surface gets the whole behavior for free, and a missing arm is a
+//! compile-time `match` gap, not a per-site omission.
+//!
+//! Only the *universal* text keys live here — caret motion, text mutation,
+//! and shift-selection. Keys that legitimately mean different things per
+//! surface (Enter = commit-a-field vs insert-a-newline, Tab = focus-advance,
+//! Esc = revert, and the clipboard chords, which ride each surface's own
+//! clipboard plumbing) stay in the outer handlers: [`apply_text_key`]
+//! returns [`TextKeyResult::Ignored`] for them so the caller can fall
+//! through to its own chrome.
+//!
+//! This module is `runtime`-gated because it speaks crossterm's `KeyEvent`;
+//! both callers (`view::settings::input`, `app::widget_runtime`) are
+//! `runtime`-only, so the wasm build never needs it.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// A text-editing surface the shared key router can drive. Implemented by
+/// the raw [`TextEdit`](crate::primitives::text_edit::TextEdit) engine (the
+/// plugin widget runtime's editors) and by
+/// [`TextInputState`](crate::view::controls::TextInputState) (the Settings
+/// UI's single-line control), so one `key → op` table serves both.
+///
+/// Each method is a *primitive* editing operation; the routing from a key
+/// chord to the right primitive lives in [`apply_text_key`] alone.
+pub trait TextSurface {
+    /// Insert printable text at the caret (a single grapheme, or an
+    /// IME/paste chunk). Newlines are flattened by single-line surfaces.
+    fn insert_text(&mut self, text: &str);
+    /// Delete the grapheme before the caret (Backspace).
+    fn backspace(&mut self);
+    /// Delete the grapheme at the caret (Delete).
+    fn delete_forward(&mut self);
+    /// Delete the word before the caret (Ctrl+Backspace).
+    fn delete_word_backward(&mut self);
+    /// Delete the word at/after the caret (Ctrl+Delete).
+    fn delete_word_forward(&mut self);
+
+    /// Move the caret one grapheme left / right.
+    fn move_left(&mut self);
+    fn move_right(&mut self);
+    /// Move the caret one visual line up / down (multi-line only).
+    fn move_up(&mut self);
+    fn move_down(&mut self);
+    /// Move the caret to the start / end of the line.
+    fn move_home(&mut self);
+    fn move_end(&mut self);
+    /// Move the caret one word left / right.
+    fn move_word_left(&mut self);
+    fn move_word_right(&mut self);
+
+    /// Extend the selection by the matching motion (the Shift+… chords).
+    fn extend_left(&mut self);
+    fn extend_right(&mut self);
+    fn extend_up(&mut self);
+    fn extend_down(&mut self);
+    fn extend_home(&mut self);
+    fn extend_end(&mut self);
+    fn extend_word_left(&mut self);
+    fn extend_word_right(&mut self);
+}
+
+/// Per-call routing context — currently just whether the surface is
+/// multi-line. Single-line surfaces return [`TextKeyResult::Ignored`] for
+/// Up/Down so the caller can repurpose them (field-focus navigation in
+/// Settings, picker navigation in widget panels).
+#[derive(Debug, Clone, Copy)]
+pub struct TextKeyContext {
+    /// True when the surface has more than one row.
+    pub multiline: bool,
+}
+
+impl TextKeyContext {
+    /// A single-line text surface.
+    pub fn single_line() -> Self {
+        Self { multiline: false }
+    }
+
+    /// A multi-line text surface (Up/Down move the caret between rows).
+    pub fn multiline(multiline: bool) -> Self {
+        Self { multiline }
+    }
+}
+
+/// Outcome of routing one key through [`apply_text_key`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextKeyResult {
+    /// The key was a text-editing key and was applied to the surface.
+    Handled,
+    /// Not a universal text-editing key — the caller should handle it
+    /// (Enter/Tab/Esc/clipboard chords, or Up/Down on a single-line
+    /// surface).
+    Ignored,
+}
+
+/// Route one key event to the matching text-editing operation on `surface`.
+///
+/// This is the *only* place the `key → op` mapping is defined; both the
+/// Settings input handler and the plugin widget runtime call it. Returns
+/// [`TextKeyResult::Handled`] when the key was a universal text-editing key
+/// (and was applied), or [`TextKeyResult::Ignored`] when the caller should
+/// handle it as chrome.
+///
+/// Ctrl/Alt-modified printable chars (Ctrl+A/C/V/X, Alt-chords) are
+/// deliberately *not* inserted — they fall through to `Ignored` so each
+/// surface can apply its own select-all / clipboard behavior.
+pub fn apply_text_key<S: TextSurface + ?Sized>(
+    surface: &mut S,
+    key: &KeyEvent,
+    ctx: TextKeyContext,
+) -> TextKeyResult {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    match key.code {
+        // Printable insertion — plain or Shift-modified (uppercase). Ctrl/
+        // Alt chords are left for the caller's clipboard/select handling.
+        KeyCode::Char(c) if !ctrl && !alt => {
+            let mut buf = [0u8; 4];
+            surface.insert_text(c.encode_utf8(&mut buf));
+            TextKeyResult::Handled
+        }
+
+        KeyCode::Backspace if ctrl => {
+            surface.delete_word_backward();
+            TextKeyResult::Handled
+        }
+        KeyCode::Backspace => {
+            surface.backspace();
+            TextKeyResult::Handled
+        }
+        KeyCode::Delete if ctrl => {
+            surface.delete_word_forward();
+            TextKeyResult::Handled
+        }
+        KeyCode::Delete => {
+            surface.delete_forward();
+            TextKeyResult::Handled
+        }
+
+        KeyCode::Left if ctrl && shift => {
+            surface.extend_word_left();
+            TextKeyResult::Handled
+        }
+        KeyCode::Left if ctrl => {
+            surface.move_word_left();
+            TextKeyResult::Handled
+        }
+        KeyCode::Left if shift => {
+            surface.extend_left();
+            TextKeyResult::Handled
+        }
+        KeyCode::Left => {
+            surface.move_left();
+            TextKeyResult::Handled
+        }
+
+        KeyCode::Right if ctrl && shift => {
+            surface.extend_word_right();
+            TextKeyResult::Handled
+        }
+        KeyCode::Right if ctrl => {
+            surface.move_word_right();
+            TextKeyResult::Handled
+        }
+        KeyCode::Right if shift => {
+            surface.extend_right();
+            TextKeyResult::Handled
+        }
+        KeyCode::Right => {
+            surface.move_right();
+            TextKeyResult::Handled
+        }
+
+        KeyCode::Home if shift => {
+            surface.extend_home();
+            TextKeyResult::Handled
+        }
+        KeyCode::Home => {
+            surface.move_home();
+            TextKeyResult::Handled
+        }
+        KeyCode::End if shift => {
+            surface.extend_end();
+            TextKeyResult::Handled
+        }
+        KeyCode::End => {
+            surface.move_end();
+            TextKeyResult::Handled
+        }
+
+        // Up/Down only edit text on a multi-line surface; single-line
+        // surfaces leave them for the caller (field / picker navigation).
+        KeyCode::Up if ctx.multiline && shift => {
+            surface.extend_up();
+            TextKeyResult::Handled
+        }
+        KeyCode::Up if ctx.multiline => {
+            surface.move_up();
+            TextKeyResult::Handled
+        }
+        KeyCode::Down if ctx.multiline && shift => {
+            surface.extend_down();
+            TextKeyResult::Handled
+        }
+        KeyCode::Down if ctx.multiline => {
+            surface.move_down();
+            TextKeyResult::Handled
+        }
+
+        _ => TextKeyResult::Ignored,
+    }
+}
+
+impl TextSurface for crate::primitives::text_edit::TextEdit {
+    fn insert_text(&mut self, text: &str) {
+        self.insert_str(text);
+    }
+    fn backspace(&mut self) {
+        self.backspace();
+    }
+    fn delete_forward(&mut self) {
+        self.delete();
+    }
+    fn delete_word_backward(&mut self) {
+        self.delete_word_backward();
+    }
+    fn delete_word_forward(&mut self) {
+        self.delete_word_forward();
+    }
+    fn move_left(&mut self) {
+        self.move_left();
+    }
+    fn move_right(&mut self) {
+        self.move_right();
+    }
+    fn move_up(&mut self) {
+        self.move_up();
+    }
+    fn move_down(&mut self) {
+        self.move_down();
+    }
+    fn move_home(&mut self) {
+        self.move_home();
+    }
+    fn move_end(&mut self) {
+        self.move_end();
+    }
+    fn move_word_left(&mut self) {
+        self.move_word_left();
+    }
+    fn move_word_right(&mut self) {
+        self.move_word_right();
+    }
+    fn extend_left(&mut self) {
+        self.move_left_selecting();
+    }
+    fn extend_right(&mut self) {
+        self.move_right_selecting();
+    }
+    fn extend_up(&mut self) {
+        self.move_up_selecting();
+    }
+    fn extend_down(&mut self) {
+        self.move_down_selecting();
+    }
+    fn extend_home(&mut self) {
+        self.move_home_selecting();
+    }
+    fn extend_end(&mut self) {
+        self.move_end_selecting();
+    }
+    fn extend_word_left(&mut self) {
+        self.move_word_left_selecting();
+    }
+    fn extend_word_right(&mut self) {
+        self.move_word_right_selecting();
+    }
+}
+
+impl TextSurface for crate::view::controls::TextInputState {
+    fn insert_text(&mut self, text: &str) {
+        self.insert_str(text);
+    }
+    fn backspace(&mut self) {
+        self.backspace();
+    }
+    fn delete_forward(&mut self) {
+        self.delete();
+    }
+    fn delete_word_backward(&mut self) {
+        self.delete_word_backward();
+    }
+    fn delete_word_forward(&mut self) {
+        self.delete_word_forward();
+    }
+    fn move_left(&mut self) {
+        self.move_left();
+    }
+    fn move_right(&mut self) {
+        self.move_right();
+    }
+    fn move_up(&mut self) {
+        self.move_up();
+    }
+    fn move_down(&mut self) {
+        self.move_down();
+    }
+    fn move_home(&mut self) {
+        self.move_home();
+    }
+    fn move_end(&mut self) {
+        self.move_end();
+    }
+    fn move_word_left(&mut self) {
+        self.move_word_left();
+    }
+    fn move_word_right(&mut self) {
+        self.move_word_right();
+    }
+    fn extend_left(&mut self) {
+        self.move_left_selecting();
+    }
+    fn extend_right(&mut self) {
+        self.move_right_selecting();
+    }
+    fn extend_up(&mut self) {
+        self.move_up_selecting();
+    }
+    fn extend_down(&mut self) {
+        self.move_down_selecting();
+    }
+    fn extend_home(&mut self) {
+        self.move_home_selecting();
+    }
+    fn extend_end(&mut self) {
+        self.move_end_selecting();
+    }
+    fn extend_word_left(&mut self) {
+        self.move_word_left_selecting();
+    }
+    fn extend_word_right(&mut self) {
+        self.move_word_right_selecting();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::text_edit::TextEdit;
+
+    fn ev(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    fn plain(code: KeyCode) -> KeyEvent {
+        ev(code, KeyModifiers::NONE)
+    }
+
+    /// Drive a single-line `TextEdit` through the router and read back its
+    /// value + flat cursor, the two things a user actually sees.
+    fn single_line(text: &str) -> TextEdit {
+        let mut e = TextEdit::single_line_with_text(text);
+        e.move_end();
+        e
+    }
+
+    #[test]
+    fn home_moves_caret_to_start() {
+        let mut e = single_line("bash");
+        assert_eq!(
+            apply_text_key(&mut e, &plain(KeyCode::Home), TextKeyContext::single_line()),
+            TextKeyResult::Handled
+        );
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Char('X')),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "Xbash");
+    }
+
+    #[test]
+    fn end_moves_caret_to_end() {
+        let mut e = single_line("bash");
+        apply_text_key(&mut e, &plain(KeyCode::Home), TextKeyContext::single_line());
+        apply_text_key(&mut e, &plain(KeyCode::End), TextKeyContext::single_line());
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Char('Z')),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "bashZ");
+    }
+
+    #[test]
+    fn delete_forward_removes_char_at_caret() {
+        let mut e = single_line("abcde");
+        apply_text_key(&mut e, &plain(KeyCode::Home), TextKeyContext::single_line());
+        assert_eq!(
+            apply_text_key(
+                &mut e,
+                &plain(KeyCode::Delete),
+                TextKeyContext::single_line()
+            ),
+            TextKeyResult::Handled
+        );
+        assert_eq!(e.value(), "bcde");
+    }
+
+    #[test]
+    fn backspace_removes_char_before_caret() {
+        let mut e = single_line("abc");
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Backspace),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "ab");
+    }
+
+    #[test]
+    fn shift_arrows_and_home_end_select_then_replace() {
+        // Select "de" with Shift+Left twice, then typing replaces it.
+        let mut e = single_line("abcde");
+        apply_text_key(
+            &mut e,
+            &ev(KeyCode::Left, KeyModifiers::SHIFT),
+            TextKeyContext::single_line(),
+        );
+        apply_text_key(
+            &mut e,
+            &ev(KeyCode::Left, KeyModifiers::SHIFT),
+            TextKeyContext::single_line(),
+        );
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Char('Q')),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "abcQ");
+
+        // Shift+Home selects to start; Backspace deletes the selection.
+        let mut e = single_line("hello");
+        apply_text_key(
+            &mut e,
+            &ev(KeyCode::Home, KeyModifiers::SHIFT),
+            TextKeyContext::single_line(),
+        );
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Backspace),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "");
+    }
+
+    #[test]
+    fn ctrl_arrows_move_by_word() {
+        let mut e = single_line("foo bar baz");
+        apply_text_key(
+            &mut e,
+            &ev(KeyCode::Left, KeyModifiers::CONTROL),
+            TextKeyContext::single_line(),
+        );
+        apply_text_key(
+            &mut e,
+            &plain(KeyCode::Char('|')),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "foo bar |baz");
+    }
+
+    #[test]
+    fn ctrl_backspace_deletes_word() {
+        let mut e = single_line("foo bar");
+        apply_text_key(
+            &mut e,
+            &ev(KeyCode::Backspace, KeyModifiers::CONTROL),
+            TextKeyContext::single_line(),
+        );
+        assert_eq!(e.value(), "foo ");
+    }
+
+    #[test]
+    fn up_down_ignored_on_single_line_but_handled_on_multiline() {
+        let mut e = single_line("abc");
+        assert_eq!(
+            apply_text_key(&mut e, &plain(KeyCode::Up), TextKeyContext::single_line()),
+            TextKeyResult::Ignored
+        );
+
+        let mut m = TextEdit::with_text("line1\nline2");
+        m.move_end(); // end of line2
+        assert_eq!(
+            apply_text_key(&mut m, &plain(KeyCode::Up), TextKeyContext::multiline(true)),
+            TextKeyResult::Handled
+        );
+        apply_text_key(
+            &mut m,
+            &plain(KeyCode::Char('X')),
+            TextKeyContext::multiline(true),
+        );
+        assert_eq!(m.value(), "line1X\nline2");
+    }
+
+    #[test]
+    fn ctrl_and_alt_chars_are_ignored_for_clipboard_and_chords() {
+        let mut e = single_line("hi");
+        assert_eq!(
+            apply_text_key(
+                &mut e,
+                &ev(KeyCode::Char('a'), KeyModifiers::CONTROL),
+                TextKeyContext::single_line()
+            ),
+            TextKeyResult::Ignored
+        );
+        assert_eq!(
+            apply_text_key(
+                &mut e,
+                &ev(KeyCode::Char('v'), KeyModifiers::ALT),
+                TextKeyContext::single_line()
+            ),
+            TextKeyResult::Ignored
+        );
+        // Value untouched — neither chord typed a letter.
+        assert_eq!(e.value(), "hi");
+    }
+
+    #[test]
+    fn enter_tab_esc_are_ignored_as_chrome() {
+        let mut e = single_line("hi");
+        for code in [KeyCode::Enter, KeyCode::Tab, KeyCode::Esc] {
+            assert_eq!(
+                apply_text_key(&mut e, &plain(code), TextKeyContext::single_line()),
+                TextKeyResult::Ignored
+            );
+        }
+        assert_eq!(e.value(), "hi");
+    }
+}

--- a/crates/fresh-editor/src/view/controls/text_input/mod.rs
+++ b/crates/fresh-editor/src/view/controls/text_input/mod.rs
@@ -218,6 +218,89 @@ impl TextInputState {
         self.editor.move_right_selecting();
     }
 
+    /// Move cursor up a visual line (multi-line surfaces; a no-op on the
+    /// single-line control, but part of the shared [`TextSurface`] contract).
+    pub fn move_up(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_up();
+    }
+
+    /// Move cursor down a visual line (see [`Self::move_up`]).
+    pub fn move_down(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_down();
+    }
+
+    /// Move the cursor one word left (Ctrl+Left).
+    pub fn move_word_left(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_word_left();
+    }
+
+    /// Move the cursor one word right (Ctrl+Right).
+    pub fn move_word_right(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_word_right();
+    }
+
+    /// Extend the selection to the line start (Shift+Home).
+    pub fn move_home_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_home_selecting();
+    }
+
+    /// Extend the selection to the line end (Shift+End).
+    pub fn move_end_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_end_selecting();
+    }
+
+    /// Extend the selection up a line (Shift+Up; multi-line surfaces).
+    pub fn move_up_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_up_selecting();
+    }
+
+    /// Extend the selection down a line (Shift+Down; multi-line surfaces).
+    pub fn move_down_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_down_selecting();
+    }
+
+    /// Extend the selection one word left (Ctrl+Shift+Left).
+    pub fn move_word_left_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_word_left_selecting();
+    }
+
+    /// Extend the selection one word right (Ctrl+Shift+Right).
+    pub fn move_word_right_selecting(&mut self) {
+        self.pending_replace_on_type = false;
+        self.editor.move_word_right_selecting();
+    }
+
+    /// Delete the word before the cursor (Ctrl+Backspace).
+    pub fn delete_word_backward(&mut self) {
+        if !self.is_enabled() {
+            return;
+        }
+        if self.consume_pending_replace() {
+            return;
+        }
+        self.editor.delete_word_backward();
+    }
+
+    /// Delete the word at/after the cursor (Ctrl+Delete).
+    pub fn delete_word_forward(&mut self) {
+        if !self.is_enabled() {
+            return;
+        }
+        if self.consume_pending_replace() {
+            return;
+        }
+        self.editor.delete_word_forward();
+    }
+
     /// Select the whole value (Ctrl+A). The selection is live editor
     /// state — the next insert replaces it — so the replace-on-type
     /// affordance is superseded and cleared.

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -1161,7 +1161,13 @@ impl SettingsState {
                 InputResult::Consumed
             }
             KeyCode::Delete => {
-                self.text_remove_focused();
+                // A plain Text field forward-deletes the character at the
+                // cursor. TextList/Map keep Delete = remove the focused row.
+                if self.is_editing_plain_text() {
+                    self.text_delete();
+                } else {
+                    self.text_remove_focused();
+                }
                 InputResult::Consumed
             }
             KeyCode::Left => {
@@ -1178,6 +1184,14 @@ impl SettingsState {
                 } else {
                     self.text_move_right();
                 }
+                InputResult::Consumed
+            }
+            KeyCode::Home => {
+                self.text_move_home();
+                InputResult::Consumed
+            }
+            KeyCode::End => {
+                self.text_move_end();
                 InputResult::Consumed
             }
             KeyCode::Up => {
@@ -1581,6 +1595,32 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::NONE)
     }
 
+    /// The value shown in the currently-focused plain `Text` control.
+    fn text_value(state: &SettingsState) -> String {
+        match state.current_item().map(|i| &i.control) {
+            Some(SettingControl::Text(s)) => s.value(),
+            _ => panic!("current item is not a Text control"),
+        }
+    }
+
+    /// Focus the first editable plain `Text` control in the body. The
+    /// Terminal shell `command` field is one such scalar; any Text control
+    /// exercises the same shared body text handler.
+    fn select_first_text_control(state: &mut SettingsState) -> bool {
+        for pi in 0..state.pages.len() {
+            for ii in 0..state.pages[pi].items.len() {
+                if let SettingControl::Text(s) = &state.pages[pi].items[ii].control {
+                    if s.is_enabled() {
+                        state.selected_category = pi;
+                        state.selected_item = ii;
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     #[test]
     fn test_settings_is_modal() {
         // SettingsState should be modal - consume all unhandled input
@@ -1914,6 +1954,63 @@ mod tests {
         assert!(
             !state.is_number_editing(),
             "Tab while editing a Number control must exit editing mode"
+        );
+    }
+
+    /// A plain `Text` field in the main settings body (e.g. Terminal ▸
+    /// Command) must honor Home, End, and forward-Delete. The body text
+    /// handler previously had no `Home`/`End` arms — the caret never moved —
+    /// and routed `Delete` to list-item removal, a no-op on a scalar field.
+    /// Regression guard for both.
+    #[test]
+    fn test_body_text_field_home_end_and_forward_delete() {
+        let schema = include_str!("../../../plugins/config-schema.json");
+        let config = crate::config::Config::default();
+        let mut state = SettingsState::new(schema, &config).unwrap();
+        state.visible = true;
+        state.focus.set(FocusPanel::Settings);
+
+        assert!(
+            select_first_text_control(&mut state),
+            "expected at least one editable Text control in the schema"
+        );
+
+        let mut ctx = InputContext::new();
+
+        // Enter edit mode and type a known value. The first keystroke clears
+        // any armed replace-on-type, so the field ends up holding "abcdef".
+        state.start_editing();
+        for c in "abcdef".chars() {
+            state.handle_key_event(&key(KeyCode::Char(c)), &mut ctx);
+        }
+        assert_eq!(text_value(&state), "abcdef");
+
+        // Home moves the caret to the start: the next char lands there.
+        state.handle_key_event(&key(KeyCode::Home), &mut ctx);
+        state.handle_key_event(&key(KeyCode::Char('X')), &mut ctx);
+        assert_eq!(
+            text_value(&state),
+            "Xabcdef",
+            "Home must move the caret to the start of the field"
+        );
+
+        // End moves the caret to the end: the next char appends.
+        state.handle_key_event(&key(KeyCode::End), &mut ctx);
+        state.handle_key_event(&key(KeyCode::Char('Z')), &mut ctx);
+        assert_eq!(
+            text_value(&state),
+            "XabcdefZ",
+            "End must move the caret to the end of the field"
+        );
+
+        // Delete forward-deletes: Left puts the caret before 'Z', Delete
+        // removes the 'Z' at the caret (rather than no-op'ing).
+        state.handle_key_event(&key(KeyCode::Left), &mut ctx);
+        state.handle_key_event(&key(KeyCode::Delete), &mut ctx);
+        assert_eq!(
+            text_value(&state),
+            "Xabcdef",
+            "Delete must forward-delete the character at the caret"
         );
     }
 }

--- a/crates/fresh-editor/src/view/settings/input.rs
+++ b/crates/fresh-editor/src/view/settings/input.rs
@@ -1094,6 +1094,19 @@ impl SettingsState {
             return self.handle_dual_list_editing_input(event);
         }
 
+        // A plain single-line Text field routes every caret-motion and
+        // text-mutation key through the one shared text-key engine
+        // (`primitives::text_key::apply_text_key`) — the same table the
+        // plugin widget runtime uses, so Home/End, forward-Delete, word
+        // motion, and shift-selection can never drift between the two
+        // surfaces again. Chrome keys (Enter/Tab/Esc, Up/Down field-nav,
+        // Ctrl+A/C/V) come back unhandled and fall through to the match
+        // below; composite controls (TextList/Map) keep their own per-row
+        // handling there.
+        if self.is_editing_plain_text() && self.apply_plain_text_key(event) {
+            return InputResult::Consumed;
+        }
+
         match event.code {
             KeyCode::Esc => {
                 // A plain Text field: Esc cancels the in-progress edit and
@@ -1160,30 +1173,20 @@ impl SettingsState {
                 self.text_backspace();
                 InputResult::Consumed
             }
+            // The arms below only run for composite controls (TextList/Map):
+            // a plain Text field consumed its motion/mutation keys through
+            // `apply_plain_text_key` above.
             KeyCode::Delete => {
-                // A plain Text field forward-deletes the character at the
-                // cursor. TextList/Map keep Delete = remove the focused row.
-                if self.is_editing_plain_text() {
-                    self.text_delete();
-                } else {
-                    self.text_remove_focused();
-                }
+                // TextList/Map: Delete removes the focused row.
+                self.text_remove_focused();
                 InputResult::Consumed
             }
             KeyCode::Left => {
-                if event.modifiers.contains(KeyModifiers::SHIFT) && self.is_editing_plain_text() {
-                    self.text_move_left_selecting();
-                } else {
-                    self.text_move_left();
-                }
+                self.text_move_left();
                 InputResult::Consumed
             }
             KeyCode::Right => {
-                if event.modifiers.contains(KeyModifiers::SHIFT) && self.is_editing_plain_text() {
-                    self.text_move_right_selecting();
-                } else {
-                    self.text_move_right();
-                }
+                self.text_move_right();
                 InputResult::Consumed
             }
             KeyCode::Home => {

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -2612,6 +2612,40 @@ impl SettingsState {
         }
     }
 
+    /// Move cursor to the start of the current editable control (Home).
+    pub fn text_move_home(&mut self) {
+        if let Some(item) = self.current_item_mut() {
+            match &mut item.control {
+                SettingControl::TextList(state) => state.move_home(),
+                SettingControl::Text(state) => state.move_home(),
+                SettingControl::Map(state) => state.cursor = 0,
+                SettingControl::Json(state) => state.move_home(),
+                _ => {}
+            }
+        }
+    }
+
+    /// Move cursor to the end of the current editable control (End).
+    pub fn text_move_end(&mut self) {
+        if let Some(item) = self.current_item_mut() {
+            match &mut item.control {
+                SettingControl::TextList(state) => state.move_end(),
+                SettingControl::Text(state) => state.move_end(),
+                SettingControl::Map(state) => state.cursor = state.new_key_text.len(),
+                SettingControl::Json(state) => state.move_end(),
+                _ => {}
+            }
+        }
+    }
+
+    /// Forward-delete the character at the cursor (Delete key) in the focused
+    /// plain `Text` control. TextList/Map use Delete to remove the focused row
+    /// instead (see [`Self::text_remove_focused`]), so this is gated to plain
+    /// Text and no-ops for the others.
+    pub fn text_delete(&mut self) {
+        self.with_editing_text(|state| state.delete());
+    }
+
     /// Move focus to previous item in TextList/Map (wraps within control)
     pub fn text_focus_prev(&mut self) {
         if let Some(item) = self.current_item_mut() {

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -2549,16 +2549,23 @@ impl SettingsState {
         }
     }
 
-    /// Extend the selection left in the focused plain Text control
-    /// (Shift+Left).
-    pub fn text_move_left_selecting(&mut self) {
-        self.with_editing_text(|state| state.move_left_selecting());
-    }
-
-    /// Extend the selection right in the focused plain Text control
-    /// (Shift+Right).
-    pub fn text_move_right_selecting(&mut self) {
-        self.with_editing_text(|state| state.move_right_selecting());
+    /// Route a key through the shared text-key engine
+    /// ([`crate::primitives::text_key::apply_text_key`]) when a plain,
+    /// single-line `Text` field is being edited. Returns `true` when the key
+    /// was a universal text-editing key (caret motion, mutation, or
+    /// selection) and was applied, so the caller can stop; `false` leaves
+    /// chrome keys (Enter/Tab/Esc, Up/Down field-nav, Ctrl+A/C/V) for the
+    /// caller's own handling. This is the seam that makes the Settings body
+    /// and the plugin widget runtime share one `key → op` table.
+    pub fn apply_plain_text_key(&mut self, event: &crossterm::event::KeyEvent) -> bool {
+        use crate::primitives::text_key::{apply_text_key, TextKeyContext, TextKeyResult};
+        self.with_editing_text(|state| {
+            matches!(
+                apply_text_key(state, event, TextKeyContext::single_line()),
+                TextKeyResult::Handled
+            )
+        })
+        .unwrap_or(false)
     }
 
     /// Select the focused plain Text control's whole value (Ctrl+A).
@@ -2636,14 +2643,6 @@ impl SettingsState {
                 _ => {}
             }
         }
-    }
-
-    /// Forward-delete the character at the cursor (Delete key) in the focused
-    /// plain `Text` control. TextList/Map use Delete to remove the focused row
-    /// instead (see [`Self::text_remove_focused`]), so this is gated to plain
-    /// Text and no-ops for the others.
-    pub fn text_delete(&mut self) {
-        self.with_editing_text(|state| state.delete());
     }
 
     /// Move focus to previous item in TextList/Map (wraps within control)


### PR DESCRIPTION
## Summary

Interactive testing of the Settings UI (via tmux + send-keys, driving the real `fresh` binary) found that a plain **`Text` field in the main settings body** — e.g. **Terminal ▸ Command** — silently ignored several line-editing keys, while the *same* keys worked in the plugin widget runtime and the entry-dialog/search handlers. Root cause: the Settings body had its **own** `key → text-operation` table that had drifted from the others.

This PR fixes the bug and then removes the duplication that caused it, so the class of bug can't recur.

### Commit 1 — `fix(settings): honor Home/End and forward-Delete in body text fields`
The immediate parity fix on the Settings body handler `handle_text_editing_input`:
- **Home / End** did nothing (no arms → fell through the catch-all); added them.
- **Delete** called `text_remove_focused`, a no-op on a scalar `Text` control; branched it to forward-delete for plain text while keeping row-removal for `TextList`/`Map`.

Backed by a handler-level regression test that drives real `KeyEvent`s and **fails without the fix / passes with it**.

### Commit 2 — `refactor(text): route Settings & widget text fields through one key engine`
Removes the second table entirely. New module **`primitives::text_key`** provides one `apply_text_key(surface, key, ctx)` router over a `TextSurface` trait — the single place the `key → op` mapping lives. Both `TextEdit` (the plugin widget editors) and `TextInputState` (the Settings control) implement `TextSurface`, so caret motion, mutation, and shift-selection have exactly one definition.

- Only the **universal** text keys live in the router. Chrome that legitimately differs per surface — Enter (commit-a-field vs insert-a-newline), Tab, Esc, and the clipboard chords (which ride each surface's own plumbing) — comes back `Ignored` and stays in each outer handler.
- **Settings**: the plain-`Text` arms collapse into a single `apply_plain_text_key` call; the composite (`TextList`/`Map`) arms stay.
- **Widget runtime**: `handle_widget_text_key` re-hydrates its flattened key name and calls the same router.
- The module is `runtime`-gated (it speaks crossterm's `KeyEvent`); both callers are `runtime`-only, so the wasm build is untouched.

**Bonus:** because the shared engine already supported them, the Settings text fields now also get **word motion** (Ctrl+Left/Right), **word delete** (Ctrl+Backspace/Delete), and **Shift+Home/End** selection.

## Testing

- New unit tests on the router (`primitives::text_key`) covering Home/End, forward-Delete, word motion, word delete, shift-selection, the single-line vs multi-line Up/Down gate, and that Ctrl/Alt chords + Enter/Tab/Esc are left as chrome.
- The handler-level regression test from commit 1.
- Full `cargo test -p fresh-editor --lib`: **3000 passed, 0 failed** (includes the Settings input/state and widget-runtime suites).
- `cargo fmt --check` and `cargo clippy -p fresh-editor --lib` clean (no new warnings).
- End-to-end in the real binary via tmux: Home/End/forward-Delete now work in Terminal ▸ Command, and Ctrl+Left word-motion works through the unified path.

## Notes / out of scope

Widget text fields don't yet receive modifier chords (their key names are flattened to bare `"Left"`/`"Home"` before reaching the runtime), so they keep today's capability set; surfacing modifiers to them is a separate follow-up now that both sit on one engine. The clipboard chords remain per-surface by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)