### PR TITLE
Fix flaky e2e test timeouts by replacing racy waits with semantic waits

### DIFF
--- a/crates/fresh-editor/tests/e2e/issue_2605_format_selection_range.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2605_format_selection_range.rs
@@ -179,8 +179,27 @@ fn setup(
     harness.open_file(&test_file)?;
     harness.render()?;
 
-    // Wait for the LSP to be reported ready (capabilities received).
+    // Wait for the LSP pill to appear. NOTE: "LSP (on)" also renders while the
+    // server is merely Starting/Initializing (see app/lsp_status.rs — those
+    // states deliberately count as "on"), so it does NOT prove the initialize
+    // handshake finished or that the client has stored the server's
+    // capabilities.
     harness.wait_for_screen_contains("LSP (on)")?;
+
+    // Gate on the server having logged didOpen before returning. The client
+    // sends didOpen only after it has processed the initialize *response*
+    // (which is when it records documentRangeFormattingProvider), so a logged
+    // didOpen means the range-formatting capability is known client-side.
+    // Without this, a fast Format Buffer can race the still-initializing client:
+    // the selection then falls back to whole-file formatting, the range request
+    // is never sent, and the test's rangeFormatting wait hangs to the external
+    // timeout (CONTRIBUTING.md §3 semantic waiting; LSP lifecycle: didOpen must
+    // precede other requests). Mirrors hot_exit_recovery_lsp_sync.rs.
+    harness.wait_until(|_| {
+        std::fs::read_to_string(log_file)
+            .unwrap_or_default()
+            .contains("METHOD:textDocument/didOpen")
+    })?;
 
     Ok((harness, test_file))
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -139,6 +139,13 @@ fn test_review_visual_stage_single_added_line() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // Read the row→line mapping only from a converged frame — the async,
+    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
+    // cursor lands off "+extra line" and the wait below hangs until the
+    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
+    // state behind an unbounded wait).
+    harness.wait_for_screen_contains("+extra line").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "+extra line");
     move_cursor_to_line(&mut harness, target);
 
@@ -184,6 +191,11 @@ fn test_review_visual_stage_modified_line_pair() {
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
     // Land on the removed "-beta" row, then visual-extend down over "+BETA".
+    // Read the row→line mapping only from a converged frame — the async,
+    // multi-phase hunk-jump repaint can otherwise mis-map the target and hang
+    // the wait below until the external timeout (CONTRIBUTING.md §3/§16).
+    harness.wait_for_screen_contains("-beta").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "-beta");
     move_cursor_to_line(&mut harness, target);
     harness
@@ -218,6 +230,13 @@ fn test_review_visual_discard_single_added_line() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // Read the row→line mapping only from a converged frame — the async,
+    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
+    // cursor lands off "+extra line" and the wait below hangs until the
+    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
+    // state behind an unbounded wait).
+    harness.wait_for_screen_contains("+extra line").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "+extra line");
     move_cursor_to_line(&mut harness, target);
     harness
@@ -254,6 +273,13 @@ fn test_review_visual_discard_status_is_localized() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // Read the row→line mapping only from a converged frame — the async,
+    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
+    // cursor lands off "+extra line" and the wait below hangs until the
+    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
+    // state behind an unbounded wait).
+    harness.wait_for_screen_contains("+extra line").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "+extra line");
     move_cursor_to_line(&mut harness, target);
     harness
@@ -339,6 +365,17 @@ fn test_review_visual_stage_only_selected_line_of_hunk() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // The hunk-jump repaint is async + multi-phase (focus mode paints the
+    // focused file's body, then the panel can still reflow). `diff_line_of`
+    // maps a *screen* row to a diff-buffer line against a fixed panel offset,
+    // so sampling a mid-reflow frame yields a wrong target: the cursor lands
+    // off `+ADD1`, `s` stages nothing, and the wait below hangs until the
+    // external timeout. Wait for the body to appear *and* for the async plugin
+    // pipeline to go quiet, so the row→line mapping is read from a converged
+    // frame (CONTRIBUTING.md §3 semantic waiting, §16 no wrong state behind an
+    // unbounded wait).
+    harness.wait_for_screen_contains("+ADD1").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "+ADD1");
     move_cursor_to_line(&mut harness, target);
     harness
@@ -470,6 +507,13 @@ fn test_review_visual_unstage_single_added_line() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // Read the row→line mapping only from a converged frame — the async,
+    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
+    // cursor lands off "+extra line" and the wait below hangs until the
+    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
+    // state behind an unbounded wait).
+    harness.wait_for_screen_contains("+extra line").unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
     let target = diff_line_of(&mut harness, "+extra line");
     move_cursor_to_line(&mut harness, target);
     harness

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1523,6 +1523,14 @@ fn test_vi_bug_2441_semicolon_repeats_find() {
     enable_vi_mode(&mut harness);
 
     send_key(&mut harness, 'f');
+    // `f` enters vi-find-char and consumes the *next* key as the target.
+    // Wait for that mode before sending 'o'; otherwise a fast/slow-CI race
+    // delivers 'o' while still in vi-normal, where it means "open line below"
+    // (→ insert mode), the find never happens, and the cursor wait below hangs
+    // to the external timeout. Matches the f-find sibling tests above.
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-find-char".to_string()))
+        .unwrap();
     send_key(&mut harness, 'o');
     harness.wait_until(|h| h.cursor_position() == 4).unwrap();
 
@@ -1541,7 +1549,17 @@ fn test_vi_bug_2441_comma_repeats_find_reverse() {
     enable_vi_mode(&mut harness);
 
     send_key(&mut harness, 'f');
+    // `f` enters vi-find-char and consumes the *next* key as the target.
+    // Wait for that mode before sending 'o'; otherwise a fast/slow-CI race
+    // delivers 'o' while still in vi-normal, where it means "open line below"
+    // (→ insert mode), the find never happens, and the cursor waits below hang
+    // to the external timeout. Gate each subsequent step on the cursor landing
+    // so `;`/`,` repeat a completed find rather than racing an in-flight one.
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-find-char".to_string()))
+        .unwrap();
     send_key(&mut harness, 'o');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
     send_key(&mut harness, ';');
     harness.wait_until(|h| h.cursor_position() == 7).unwrap();
 


### PR DESCRIPTION
## Summary

Three e2e tests intermittently hit the external 180s nextest timeout. In each case the test drove an async, multi-phase editor flow but then read/acted on state sampled from a **transient, not-yet-converged frame**. On a fast/loaded runner the sampling lost the race, the intended action never happened, and an indefinite `wait_until` (correctly written per the "wait indefinitely, no in-test timers" guideline) hung until nextest killed it.

Each fix replaces the implicit assumption with an explicit **semantic wait** on the state the test actually depends on — the same patterns already used by sibling tests in the codebase. No production code changes; test-only.

## Fixes

### 1. `review_diff_line_staging.rs` — wait for a converged frame before mapping diff rows
- **Symptom:** `test_review_visual_stage_only_selected_line_of_hunk` (and five siblings) time out.
- **Cause:** after `n` (next hunk), the focus-mode repaint is async and multi-phase (focused file's body paints, then the panel can still reflow). `diff_line_of()` maps a *screen* row to a diff-buffer line via a fixed panel offset, so sampling a mid-reflow frame returns the wrong target line; the cursor lands off the intended row, `s`/`u`/`d` act on nothing, and the git-state wait hangs.
- **Fix:** before `diff_line_of()`, `wait_for_screen_contains(<needle>)` + `wait_for_async_quiescence(6)` so the row→line mapping is read from a converged frame. Mirrors the guard already in `test_review_visual_stage_line_in_second_file`. Applied to all six affected tests.

### 2. `vi_mode_bugs.rs` — wait for `vi-find-char` before sending the `f` target key
- **Symptom:** `test_vi_bug_2441_comma_repeats_find_reverse` (and the `;` sibling) time out.
- **Cause:** `f` enters `vi-find-char` and consumes the *next* key as the find target. The tests sent `f` then `o` back-to-back; if `o` arrives while still in `vi-normal` it means "open line below" (→ insert mode), the find never runs, and the cursor wait hangs.
- **Fix:** wait for `vi-find-char` mode between `f` and `o`, and gate each `;`/`,` repeat on the prior find landing. Mirrors the existing `test_vi_bug_find_char_special_chars/_dot/_slash` tests.

### 3. `issue_2605_format_selection_range.rs` — gate on LSP `didOpen`, not the premature `"LSP (on)"` pill
- **Symptom:** `test_selection_routes_to_lsp_range_formatting` times out.
- **Cause:** setup waited only for the `"LSP (on)"` status pill, but that pill renders while the server is merely `Starting`/`Initializing` (`app/lsp_status.rs` treats those as "on"). It does not prove the initialize handshake finished or that the client recorded `documentRangeFormattingProvider`. Format Buffer could then run mid-initialize, the selection fell back to whole-file formatting, `textDocument/rangeFormatting` was never sent, and the request-log wait hung.
- **Fix:** after the pill, `wait_until` the fake server logs `didOpen`. The client sends `didOpen` only after processing the initialize response (when it stores capabilities), so this deterministically gates the format request behind a capability-aware client. Mirrors the readiness gate in `hot_exit_recovery_lsp_sync.rs`.

## Guidelines applied
- **Testing — semantic waiting:** wait for the specific state change each flow depends on, not a proxy that's true too early (`"LSP (on)"`) or a transient frame (mid-reflow diff view, `vi-normal` before `vi-find-char`).
- **LSP lifecycle:** `didOpen` must precede other requests — fix #3 now guarantees it before formatting.
- **No in-test timeouts:** the indefinite `wait_until`s are kept; the fixes ensure their conditions can actually become true.

## Testing
Each fix mirrors an existing passing sibling/precedent. `cargo test -p fresh-editor --test e2e_tests --no-run` builds clean after every change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GkL9P6XVkxCgUGX7jkYes