### PR TITLE
Block bracketed paste in read-only buffers (issue #2674)

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1255,6 +1255,20 @@ impl Editor {
             return;
         }
 
+        // Read-only buffers must reject a paste, exactly as they reject
+        // typing and `Ctrl+V`. The `Action::Paste` (Ctrl+V) path gates on
+        // `is_editing_disabled` before it ever reaches here, but a
+        // terminal-initiated bracketed paste (`Ev::Paste`: right-click /
+        // middle-click / Ctrl+Shift+V) lands straight in `paste_text`,
+        // bypassing that gate (issue #2674). Enforce the gate at this single
+        // buffer-destined fork — after the prompt and live-terminal routes
+        // above, which have their own targets and are unaffected by the
+        // buffer's read-only state.
+        if self.active_window().is_editing_disabled() {
+            self.set_status_message(t!("buffer.editing_disabled").to_string());
+            return;
+        }
+
         // Collect cursor info sorted in reverse order by position
         let vs_mode = self.active_state().buffer_settings.virtual_space;
         let mut cursor_data: Vec<_> = {

--- a/crates/fresh-editor/tests/e2e/auto_read_only.rs
+++ b/crates/fresh-editor/tests/e2e/auto_read_only.rs
@@ -305,3 +305,87 @@ fn test_auto_read_only_disabled_opens_library_file_editable() {
         screen
     );
 }
+
+/// A terminal-initiated bracketed paste (`Event::Paste` — right-click /
+/// middle-click / Ctrl+Shift+V) must be rejected in a read-only buffer, just
+/// like typing and `Ctrl+V` are (issue #2674). Before the fix this path
+/// bypassed the read-only gate and mutated the buffer.
+#[test]
+fn test_bracketed_paste_blocked_in_read_only_buffer() {
+    let temp_dir = TempDir::new().unwrap();
+    let lib_dir = temp_dir.path().join("node_modules").join("somelib");
+    std::fs::create_dir_all(&lib_dir).unwrap();
+    let file_path = lib_dir.join("index.js");
+    std::fs::write(&file_path, "library content\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        24,
+        Config::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("library content");
+    harness.assert_screen_contains(READ_ONLY_INDICATOR);
+
+    // Deliver a bracketed paste, exactly as the terminal does.
+    harness.send_paste("ZZPASTEDZZ").unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+
+    assert!(
+        !screen.contains("ZZPASTEDZZ"),
+        "Bracketed paste must not insert into a read-only buffer. Screen:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains(EDITING_DISABLED_MSG),
+        "Blocked bracketed paste should surface the editing-disabled message. Screen:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains(READ_ONLY_INDICATOR),
+        "Buffer should remain read-only after the blocked paste. Screen:\n{}",
+        screen
+    );
+}
+
+/// The read-only paste gate must not over-block: in an editable buffer a
+/// terminal bracketed paste still lands. Guards against the gate leaking into
+/// the normal-editing path.
+#[test]
+fn test_bracketed_paste_works_in_editable_buffer() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("editable.txt");
+    std::fs::write(&file_path, "editable content\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        24,
+        Config::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("editable content");
+
+    harness.send_paste("ZZPASTEDZZ").unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+
+    assert!(
+        screen.contains("ZZPASTEDZZ"),
+        "Bracketed paste should insert into an editable buffer. Screen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains(EDITING_DISABLED_MSG),
+        "No editing-disabled message expected for an editable buffer. Screen:\n{}",
+        screen
+    );
+}


### PR DESCRIPTION
## Summary
Fixes a bug where terminal-initiated bracketed paste events (right-click, middle-click, or Ctrl+Shift+V) could bypass the read-only buffer protection and mutate the buffer, while other input methods like typing and Ctrl+V were correctly blocked.

## Key Changes
- **clipboard.rs**: Added a read-only check in the `paste_text` method to gate terminal-initiated bracketed pastes, matching the behavior of the `Action::Paste` (Ctrl+V) path. The check is placed after prompt and live-terminal routes to avoid affecting those unrelated features.
- **auto_read_only.rs**: Added two comprehensive test cases:
  - `test_bracketed_paste_blocked_in_read_only_buffer`: Verifies that bracketed paste is rejected in read-only buffers and displays the editing-disabled message
  - `test_bracketed_paste_works_in_editable_buffer`: Ensures the fix doesn't over-block and that bracketed paste still works normally in editable buffers

## Implementation Details
The root cause was that `Action::Paste` (Ctrl+V) gates on `is_editing_disabled()` before reaching `paste_text()`, but terminal-initiated bracketed paste events (`Event::Paste`) bypass that gate and land directly in `paste_text()`. The fix enforces the read-only check at the single buffer-destined fork in `paste_text()`, after handling prompt and live-terminal routes which have their own targets and should not be affected by buffer read-only state.

https://claude.ai/code/session_01VG5BxEuPF9zyXiZesfeqMC