### PR TITLE
Web UI: navy/teal chrome redesign + surface web-invisible prompts

### DIFF
--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Skupina přeskočena: %{group}",
   "calibration.skipped_key": "Přeskočeno (použita výchozí hodnota)",
   "calibration.started": "Průvodce kalibrací spuštěn",
+  "calibration.tui_only": "Kalibrace klávesnice funguje pouze v terminálovém rozhraní",
   "calibration.step": "Krok",
   "calibration.title_capture": "Kalibrace vstupu - Záznam",
   "calibration.title_verify": "Kalibrace vstupu - Ověření",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Gruppe übersprungen: %{group}",
   "calibration.skipped_key": "Übersprungen (Standardwert wird verwendet)",
   "calibration.started": "Kalibrierungsassistent gestartet",
+  "calibration.tui_only": "Die Tastaturkalibrierung funktioniert nur in der Terminal-Oberfläche",
   "calibration.step": "Schritt",
   "calibration.title_capture": "Eingabekalibrierung - Erfassung",
   "calibration.title_verify": "Eingabekalibrierung - Überprüfung",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -461,6 +461,7 @@
   "calibration.skip": "Skip",
   "calibration.skip_group": "Skip group",
   "calibration.started": "Calibration wizard started",
+  "calibration.tui_only": "Keyboard calibration only works in the terminal UI",
   "calibration.step": "Step",
   "calibration.title_capture": "Input Calibration - Capture",
   "calibration.title_verify": "Input Calibration - Verify",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Grupo omitido: %{group}",
   "calibration.skipped_key": "Omitida (usando valor predeterminado)",
   "calibration.started": "Asistente de calibración iniciado",
+  "calibration.tui_only": "La calibración del teclado solo funciona en la interfaz de terminal",
   "calibration.step": "Paso",
   "calibration.title_capture": "Calibración de entrada - Captura",
   "calibration.title_verify": "Calibración de entrada - Verificar",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Groupe ignoré : %{group}",
   "calibration.skipped_key": "Ignorée (valeur par défaut utilisée)",
   "calibration.started": "Assistant de calibration démarré",
+  "calibration.tui_only": "La calibration du clavier ne fonctionne que dans l'interface terminal",
   "calibration.step": "Étape",
   "calibration.title_capture": "Calibration d'entrée - Capture",
   "calibration.title_verify": "Calibration d'entrée - Vérification",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Gruppo saltato: %{group}",
   "calibration.skipped_key": "Saltato (uso predefinito)",
   "calibration.started": "Calibrazione guidata avviata",
+  "calibration.tui_only": "La calibrazione della tastiera funziona solo nell'interfaccia terminale",
   "calibration.step": "Passaggio",
   "calibration.title_capture": "Calibrazione Input - Cattura",
   "calibration.title_verify": "Calibrazione Input - Verifica",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "グループをスキップしました: %{group}",
   "calibration.skipped_key": "スキップしました（デフォルト値を使用）",
   "calibration.started": "キャリブレーションウィザードを開始しました",
+  "calibration.tui_only": "キーボードのキャリブレーションはターミナルUIでのみ動作します",
   "calibration.step": "ステップ",
   "calibration.title_capture": "入力キャリブレーション - キャプチャ",
   "calibration.title_verify": "入力キャリブレーション - 確認",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "그룹 건너뜀: %{group}",
   "calibration.skipped_key": "건너뜀 (기본값 사용)",
   "calibration.started": "보정 마법사가 시작되었습니다",
+  "calibration.tui_only": "키보드 보정은 터미널 UI에서만 작동합니다",
   "calibration.step": "단계",
   "calibration.title_capture": "입력 보정 - 캡처",
   "calibration.title_verify": "입력 보정 - 확인",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Grupo pulado: %{group}",
   "calibration.skipped_key": "Pulada (usando padrão)",
   "calibration.started": "Assistente de calibração iniciado",
+  "calibration.tui_only": "A calibração do teclado só funciona na interface de terminal",
   "calibration.step": "Etapa",
   "calibration.title_capture": "Calibração de Entrada - Captura",
   "calibration.title_verify": "Calibração de Entrada - Verificar",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Группа пропущена: %{group}",
   "calibration.skipped_key": "Пропущено (используется значение по умолчанию)",
   "calibration.started": "Мастер калибровки запущен",
+  "calibration.tui_only": "Калибровка клавиатуры работает только в терминальном интерфейсе",
   "calibration.step": "Шаг",
   "calibration.title_capture": "Калибровка ввода - Захват",
   "calibration.title_verify": "Калибровка ввода - Проверка",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "ข้ามกลุ่ม: %{group}",
   "calibration.skipped_key": "ข้าม (ใช้ค่าเริ่มต้น)",
   "calibration.started": "เริ่มตัวช่วยการปรับเทียบแล้ว",
+  "calibration.tui_only": "การปรับเทียบแป้นพิมพ์ใช้ได้เฉพาะในหน้าจอเทอร์มินัลเท่านั้น",
   "calibration.step": "ขั้นตอน",
   "calibration.title_capture": "การปรับเทียบการป้อนข้อมูล - จับภาพ",
   "calibration.title_verify": "การปรับเทียบการป้อนข้อมูล - ตรวจสอบ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Групу пропущено: %{group}",
   "calibration.skipped_key": "Пропущено (використовується значення за замовчуванням)",
   "calibration.started": "Майстер калібрування запущено",
+  "calibration.tui_only": "Калібрування клавіатури працює лише в терміналі",
   "calibration.step": "Крок",
   "calibration.title_capture": "Калібрування введення - Захоплення",
   "calibration.title_verify": "Калібрування введення - Перевірка",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "Đã bỏ qua nhóm: %{group}",
   "calibration.skipped_key": "Đã bỏ qua (sử dụng mặc định)",
   "calibration.started": "Đã bắt đầu trình hướng dẫn hiệu chỉnh",
+  "calibration.tui_only": "Hiệu chỉnh bàn phím chỉ hoạt động trong giao diện terminal",
   "calibration.step": "Bước",
   "calibration.title_capture": "Hiệu chỉnh đầu vào - Bắt",
   "calibration.title_verify": "Hiệu chỉnh đầu vào - Xác minh",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -448,6 +448,7 @@
   "calibration.skipped_group": "已跳过组: %{group}",
   "calibration.skipped_key": "已跳过（使用默认值）",
   "calibration.started": "校准向导已启动",
+  "calibration.tui_only": "键盘校准仅在终端界面中可用",
   "calibration.step": "步骤",
   "calibration.title_capture": "输入校准 - 捕获",
   "calibration.title_verify": "输入校准 - 验证",

--- a/crates/fresh-editor/src/app/calibration_actions.rs
+++ b/crates/fresh-editor/src/app/calibration_actions.rs
@@ -11,6 +11,14 @@ use rust_i18n::t;
 impl Editor {
     /// Open the calibration wizard
     pub fn open_calibration_wizard(&mut self) {
+        // The wizard calibrates the *terminal's* key encoding and renders
+        // TUI-only cells (`!suppress_chrome_cells`, no web projection). On the
+        // web bridge it would be an invisible modal that owns the keyboard —
+        // a lockout, not a tool — so refuse with a visible status message.
+        if self.suppress_chrome_cells {
+            self.set_status_message(t!("calibration.tui_only").to_string());
+            return;
+        }
         self.calibration_wizard = Some(CalibrationWizard::new());
         self.set_status_message(t!("calibration.started").to_string());
     }

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1023,6 +1023,14 @@ impl Editor {
 
     // --- semantic accessors for the web/GUI chrome (read-only projections) ---
 
+    /// Read access to the shared keybinding resolver, for view projections
+    /// that surface shortcut hints (e.g. the search-options toggles).
+    pub(crate) fn keybinding_resolver(
+        &self,
+    ) -> std::sync::RwLockReadGuard<'_, crate::input::keybindings::KeybindingResolver> {
+        self.keybindings.read().unwrap()
+    }
+
     /// The menu-bar state (which menu is open, highlighted item, condition
     /// context for `when`/checkbox evaluation).
     pub(crate) fn menu_state(&self) -> &crate::view::ui::MenuState {

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -311,6 +311,29 @@ pub struct SuggestionView {
     pub disabled: bool,
 }
 
+/// One search-option toggle (Case / Whole Word / Regex / Confirm-each) as the
+/// TUI lays it out on the options row: state + the cell span of its checkbox,
+/// so a non-cell frontend can render a native toggle and route clicks back to
+/// the exact cells `SearchOptionsLayout::checkbox_at` hit-tests.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchOptionView {
+    pub name: &'static str,
+    pub label: String,
+    pub shortcut: Option<String>,
+    pub active: bool,
+    pub x: u16,
+    pub w: u16,
+}
+
+/// The search-options row shown with search/replace prompts.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchOptionsView {
+    pub row: u16,
+    pub options: Vec<SearchOptionView>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaletteView {
@@ -340,6 +363,10 @@ pub struct PaletteView {
     pub toolbar: Option<fresh_core::api::WidgetSpec>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub toolbar_focus: Option<String>,
+    /// Search-option toggles for search/replace prompts (the TUI's checkbox
+    /// row above the prompt line). `None` for every other prompt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_options: Option<SearchOptionsView>,
 }
 
 /// Stable tag for a prompt type so the frontend can label the palette/picker.
@@ -434,28 +461,86 @@ impl Editor {
         let sugg_area = chrome.suggestions_area;
         let prompt_results = chrome.prompt_results_area;
         let p = self.active_window().prompt.as_ref()?;
-        // A picker list (non-empty suggestions) or a floating overlay always
-        // projects. But a plain non-overlay prompt whose body is drawn into the
-        // pane cells rather than into `suggestions` — the file browser
-        // (`OpenFile`/`SaveFileAs`, whose `file_browser_layout` lives in the
-        // window and is rendered to cells) — still needs its INPUT LINE surfaced
-        // to non-cell frontends: the TUI draws that line on the bottom prompt row
-        // in place of the status bar, so without it the web has no path box to
-        // type into. Such prompts have no native suggestion list; the frontend
-        // renders just the input bar (null `list_rect`/`outer_rect` below).
-        use crate::view::prompt::PromptType;
-        let has_cell_browser = matches!(
-            p.prompt_type,
-            PromptType::OpenFile | PromptType::OpenFileWithEncoding { .. } | PromptType::SaveFileAs
-        );
-        if p.suggestions.is_empty() && !p.overlay && !has_cell_browser {
-            return None;
-        }
+        // EVERY active prompt projects. A picker list (non-empty suggestions)
+        // or a floating overlay projects its full geometry; everything else —
+        // plain input prompts (Add Ruler's column, goto-line, …) and prompts
+        // whose body is drawn into the pane cells rather than `suggestions`
+        // (the `OpenFile`/`SaveFileAs` file browser) — still needs its INPUT
+        // LINE surfaced to non-cell frontends: the TUI draws that line on the
+        // bottom prompt row in place of the status bar, so without projecting
+        // it the web shows no prompt at all while the editor waits for input.
+        // Such prompts have no native suggestion list; the frontend renders
+        // just the input bar (null `list_rect`/`outer_rect` below).
         let (scroll_start, visible, total) = sugg_area.map(|(_, s, v, t)| (s, v, t)).unwrap_or((
             p.scroll_offset,
             p.suggestions.len(),
             p.suggestions.len(),
         ));
+        // Search-option toggles: mirror the TUI's options row from the layout
+        // the renderer recorded (`search_options_layout`) — same cell spans the
+        // TUI hit-tests — plus the live state and the same label/shortcut
+        // derivation `StatusBarRenderer::render_search_options` uses.
+        let search_options = chrome.search_options_layout.as_ref().map(|lo| {
+            use crate::input::keybindings::{Action, KeyContext};
+            use rust_i18n::t;
+            let win = self.active_window();
+            let kb = self.keybinding_resolver();
+            let shortcut = |a: &Action| {
+                kb.get_keybinding_for_action(a, KeyContext::SearchPrompt)
+                    .or_else(|| kb.get_keybinding_for_action(a, KeyContext::Prompt))
+                    .or_else(|| kb.get_keybinding_for_action(a, KeyContext::Global))
+            };
+            let opt = |span: Option<(u16, u16)>,
+                       name: &'static str,
+                       label: String,
+                       active: bool,
+                       shortcut: Option<String>| {
+                span.map(|(x0, x1)| SearchOptionView {
+                    name,
+                    label,
+                    shortcut,
+                    active,
+                    x: x0,
+                    w: x1.saturating_sub(x0).max(1),
+                })
+            };
+            SearchOptionsView {
+                row: lo.row,
+                options: [
+                    opt(
+                        lo.case_sensitive,
+                        "case",
+                        t!("search.case_sensitive").to_string(),
+                        win.search_case_sensitive,
+                        shortcut(&Action::ToggleSearchCaseSensitive),
+                    ),
+                    opt(
+                        lo.whole_word,
+                        "word",
+                        t!("search.whole_word").to_string(),
+                        win.search_whole_word,
+                        shortcut(&Action::ToggleSearchWholeWord),
+                    ),
+                    opt(
+                        lo.regex,
+                        "regex",
+                        t!("search.regex").to_string(),
+                        win.search_use_regex,
+                        shortcut(&Action::ToggleSearchRegex),
+                    ),
+                    opt(
+                        lo.confirm_each,
+                        "confirm",
+                        t!("search.confirm_each").to_string(),
+                        win.search_confirm_each,
+                        shortcut(&Action::ToggleSearchConfirmEach),
+                    ),
+                ]
+                .into_iter()
+                .flatten()
+                .collect(),
+            }
+        });
         Some(PaletteView {
             query: p.input.clone(),
             message: p.message.clone(),
@@ -497,6 +582,7 @@ impl Editor {
                 .collect(),
             toolbar: p.toolbar_widget.clone(),
             toolbar_focus: p.toolbar_focus.clone(),
+            search_options,
         })
     }
 }

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -38,13 +38,22 @@
     --font-size-base:13px;
     --font-size:var(--font-size-base);
     --line-height:1.4}
-  :root{--bg:#1e1e1e;--bg2:#252526;--bg3:#333;--fg:#d4d4d4;--muted:#9aa0a6;
-    --accent:#0a84ff;--border:#3a3a3a;--menuhi:#0a64c8;
-    --status-bg:#0a84ff;--status-fg:#fff;
+  :root{--bg:#10161f;--bg2:#151d29;--bg3:#0c121b;--fg:#d7e0ea;--muted:#8494a8;
+    --accent:#2fd6c3;--border:#233043;--menuhi:#11675c;
+    --status-bg:#0c121b;--status-fg:#8fa0b3;
     /* Readable text/fill for anything painted ON the accent colour. Recomputed
        per theme in applyTheme() so e.g. high-contrast's white accent gets dark
        text instead of the white-on-white it used to render. */
-    --on-accent:#fff;--on-sel:#fff}
+    --on-accent:#04201c;--on-sel:var(--fg);
+    /* Chrome identity tokens (independent of the buffer theme): the teal the
+       shell is branded with, its readable on-colour, and the "healthy" green
+       of the status-bar connection dot. Fixed by design — the buffer theme
+       keeps owning every cell, but the frame always speaks this accent. */
+    --ui-accent:#2fd6c3;--on-ui-accent:#04201c;--ok:#3ecf8e;
+    /* Frame-chrome surface (sidebar/menu/tabs/status): the buffer bg pulled
+       toward deep navy so the frame reads darker than the editor, as in the
+       target design. applyTheme() re-derives it from the live theme bg. */
+    --shell:color-mix(in srgb, var(--bg) 55%, #060b13)}
   /* Theme-derived design tokens: elevated surfaces and soft hairlines mixed from
      the live --bg/--fg, so chrome reads as depth on ANY theme instead of piping
      the terminal palette's hard borders (e.g. high-contrast's cyan) into the UI.
@@ -727,6 +736,118 @@
   .popup .popup-desc,
   .popup .popup-row .pdetail,
   .m-file{min-width:0;overflow:hidden;text-overflow:clip;max-width:none}
+
+  /* ======================================================================
+     Design refresh — navy/teal "orchestrator" skin (target mock, 2026-07).
+     The frame chrome (sidebar / menubar / tabs / status bar) sits on the
+     darker --shell surface so the editor reads as the bright center pane;
+     floating chrome becomes frosted glass over the code; every selection is
+     a translucent teal pill with a hairline teal ring; keybindings render as
+     key chips. Buffer cells stay 100% theme-driven and NO geometry changes —
+     this layer only re-skins surfaces, fills and rules.
+     ====================================================================== */
+  :root{--r-lg:14px;
+    --sel:linear-gradient(90deg,
+      color-mix(in srgb, var(--ui-accent) 26%, transparent),
+      color-mix(in srgb, var(--ui-accent) 10%, transparent));
+    --sel-ring:inset 0 0 0 1px color-mix(in srgb, var(--ui-accent) 45%, transparent)}
+
+  /* Frame chrome on the shell surface. */
+  .menubar,.tabbar,.fileexplorer,.widget-surface.w-dock{background:var(--shell)}
+  .fileexplorer .fx-title{font-weight:700;letter-spacing:.08em}
+
+  /* Status bar: a quiet dark strip (no solid accent fill), muted text, and a
+     live-connection dot on the far left like the design's "connection" pill —
+     the reconnect pill takes over whenever the socket actually drops. */
+  .statusbar{background:var(--shell);color:var(--muted);border-top:1px solid var(--hairline)}
+  .statusbar .txt{color:var(--fg)}
+  .statusbar .seg:hover{background:var(--hover);color:var(--fg)}
+  .statusbar::before{content:"";align-self:center;width:7px;height:7px;flex:0 0 auto;
+    margin-right:4px;border-radius:50%;background:var(--ok);
+    box-shadow:0 0 6px color-mix(in srgb, var(--ok) 70%, transparent)}
+
+  /* Tabs on the shell; the active tab merges with the editor surface below
+     it and carries a thin teal rule on its top edge. */
+  .tab{color:var(--muted)}
+  .tab.active{background:var(--bg);color:var(--fg)}
+  .tab.active::after{top:0;bottom:auto;background:var(--ui-accent);border-radius:0 0 2px 2px}
+
+  /* Floating chrome: frosted glass over the code (the backdrop blur is what
+     makes the mock's palette read as a pane of smoked glass). */
+  .dropdown,.popup,.ctxmenu,.palette,.m-sheet{
+    background:color-mix(in srgb, var(--bg2) 74%, transparent);
+    -webkit-backdrop-filter:blur(22px) saturate(1.15);
+    backdrop-filter:blur(22px) saturate(1.15)}
+  @supports not ((backdrop-filter:blur(1px)) or (-webkit-backdrop-filter:blur(1px))){
+    .dropdown,.popup,.ctxmenu,.palette,.m-sheet{background:var(--bg2)}}
+
+  /* Palette card: bold title band, transparent input row, roomier rows, and
+     key chips on the right of each row. */
+  .palette .ptitle{font-weight:700;color:var(--fg);border-bottom:none;padding:10px 16px 2px}
+  .palette .pinput{background:transparent;padding:8px 16px}
+  .palette .prow{padding:5px 14px}
+  .palette .prow .pkey{padding:1px 8px;border-radius:6px;line-height:1.25;
+    background:color-mix(in srgb, var(--fg) 6%, transparent)}
+
+  /* Search-option toggle chips (Case / Whole Word / Regex / Confirm-each). */
+  .psearchopts{display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:7px 10px 5px}
+  .psopt{display:inline-flex;align-items:center;gap:7px;padding:2px 10px;
+    border:1px solid var(--hairline-strong);border-radius:999px;color:var(--muted);cursor:default}
+  .psopt:hover{background:var(--hover)}
+  .psopt .psbox{width:13px;height:13px;flex:0 0 auto;border:1px solid var(--hairline-strong);
+    border-radius:4px;display:inline-flex;align-items:center;justify-content:center;
+    font-size:.72em;line-height:1;color:transparent}
+  .psopt.on{color:var(--fg);border-color:color-mix(in srgb, var(--ui-accent) 50%, transparent);
+    background:color-mix(in srgb, var(--ui-accent) 10%, transparent)}
+  .psopt.on .psbox{background:var(--ui-accent);border-color:var(--ui-accent);color:var(--on-ui-accent)}
+  .psopt .pskey{color:var(--muted);border:1px solid var(--hairline);border-radius:5px;
+    padding:0 5px;line-height:1.25;background:color-mix(in srgb, var(--fg) 5%, transparent)}
+
+  /* Selections: one language — translucent teal pill + hairline teal ring.
+     Text on them is the plain theme foreground (--on-sel), never white-on-X. */
+  .fileexplorer .fx-row.sel,.palette .prow.sel,.popup .popup-row.sel,
+  .ctxmenu .ctxitem.sel,.settings-modal .set-cat.sel,.settings-modal .set-item.sel,
+  .kbedit .kb-row.sel,.settings-modal .set-dual-row.sel,.w-list-row.sel,
+  .auxmodal .am-line.sel,.mitem.hi,.trustdialog .td-opt.sel,
+  .settings-modal .set-sresult.sel,.kbedit .kb-field.focus{
+    background:var(--sel);box-shadow:var(--sel-ring)}
+  .menu.open{background:var(--sel);color:var(--fg)}
+  .settings-modal .set-dd-row.sel,.kbedit .kb-ac-row.sel{
+    background:var(--sel);box-shadow:var(--sel-ring);color:var(--fg)}
+
+  /* The dock's selected card is the signature moment: a soft teal glow
+     radiating from its left edge (the mock's highlighted project card). */
+  .w-list-card.sel{
+    border-color:color-mix(in srgb, var(--ui-accent) 55%, transparent);
+    background:
+      radial-gradient(120% 140% at 0% 50%,
+        color-mix(in srgb, var(--ui-accent) 22%, transparent), transparent 70%),
+      color-mix(in srgb, var(--ui-accent) 7%, transparent);
+    box-shadow:0 0 18px color-mix(in srgb, var(--ui-accent) 18%, transparent)}
+
+  /* Solid fills and accent marks speak the chrome teal (the theme's --accent
+     is the CURSOR colour — white in the stock dark theme — so it can't brand
+     the chrome). --on-ui-accent keeps their labels readable. */
+  .settings-modal .set-switch.on,.w-button.primary,.settings-modal .btn.primary,
+  .trustdialog .td-btn.primary,.m-icon.on,.m-sym.m-save,.m-mod.on{
+    background:var(--ui-accent);border-color:var(--ui-accent);color:var(--on-ui-accent)}
+  .settings-modal .set-switch.on::after{background:var(--on-ui-accent)}
+  .kbedit .kb-btn.focus{background:var(--ui-accent);border-color:var(--ui-accent);color:var(--on-ui-accent)}
+  .m-mod.on{box-shadow:0 0 0 2px color-mix(in srgb, var(--ui-accent) 45%, transparent)}
+  .w-toggle.on,.w-hint b,.m-logo .m-spark,.m-nav-item.active,
+  .settings-modal .set-section,.settings-modal .set-list-badge,
+  .settings-modal .set-list-add,.settings-modal .set-search,
+  .kbedit .kb-search b,.kbedit .kb-row.kb-section,
+  .fileexplorer .fx-icon.dir{color:var(--ui-accent)}
+  .separator:hover,.resize-grip:hover{background:var(--ui-accent)}
+  .settings-modal .set-dual-col.active{border-color:color-mix(in srgb, var(--ui-accent) 55%, transparent)}
+  #reconnect .rc-dot,#reconnect .rc-dot::after{background:var(--ui-accent)}
+
+  /* Focus rings in the same teal. */
+  .w-toggle.focus,.w-button.focus,.kbedit .kb-search.focus,.w-text.focus{
+    box-shadow:0 0 0 2px color-mix(in srgb, var(--ui-accent) 55%, transparent)}
+  .settings-modal .set-cats.focus,.settings-modal .set-items.focus{
+    box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--ui-accent) 55%, transparent)}
 </style>
 </head>
 <body>
@@ -942,11 +1063,22 @@ function applyTheme(t){
     const L=.2126*lin((n>>16)&255)+.7152*lin((n>>8)&255)+.0722*lin(n&255);
     return L>.45?"#10131a":"#ffffff"; };
   set("--on-accent", onColor(t.accent));
-  // Readable text colour for anything painted on the menu-highlight / --sel
-  // pill (selected rows, open menu, highlighted menu item). menuHi is light in
-  // a light theme, so white-on-highlight would be unreadable — pick by
-  // luminance exactly like --on-accent.
-  set("--on-sel", onColor(t.menuHi));
+  // Selected rows are a translucent --ui-accent tint over the panel surface
+  // (not a solid menuHi fill), so the readable text colour on them is simply
+  // the theme foreground.
+  set("--on-sel", t.fg);
+  // Frame-chrome surface: pull the buffer bg toward deep navy. Dark themes get
+  // the design's near-black navy shell; light themes only a gently shaded
+  // frame (same hue pull, ratio picked by bg luminance). Null bg (terminal
+  // reset) falls back to the :root color-mix default.
+  const mix=(a,b,k)=>{ const pa=/^#?([0-9a-fA-F]{6})$/.exec((a||"").trim()),
+      pb=/^#?([0-9a-fA-F]{6})$/.exec((b||"").trim());
+    if(!pa||!pb) return null;
+    const na=parseInt(pa[1],16), nb=parseInt(pb[1],16);
+    const ch=s=>Math.round(((na>>s)&255)*(1-k)+((nb>>s)&255)*k);
+    return "#"+[16,8,0].map(s=>ch(s).toString(16).padStart(2,"0")).join(""); };
+  const darkBg = onColor(t.bg)==="#ffffff";
+  set("--shell", mix(t.bg, "#060b13", darkBg?0.45:0.08));
 }
 
 // Selectors for natively-scrolled chrome whose scrollTop must survive a
@@ -1267,6 +1399,28 @@ function paletteListEl(p, list){
   return listBox;
 }
 
+// Native search-option toggles (Case / Whole Word / Regex / Confirm-each) for
+// search/replace prompts — the TUI's checkbox row above the prompt line.
+// Each chip forwards its click to the TUI's own checkbox cells
+// (SearchOptionsLayout::checkbox_at), so the editor flips the flag and the
+// refreshed state comes back through the scene — single source of truth.
+function searchOptionsEl(p){
+  const so=p.searchOptions;
+  if(!so || !so.options || !so.options.length) return null;
+  const bar=div("psearchopts");
+  for(const o of so.options){
+    const chip=div("psopt"+(o.active?" on":""));
+    const box=document.createElement("span"); box.className="psbox";
+    box.textContent=o.active?"✓":""; chip.appendChild(box);
+    const lb=document.createElement("span"); lb.textContent=o.label; chip.appendChild(lb);
+    if(o.shortcut){ const k=document.createElement("span"); k.className="pskey"; k.textContent=o.shortcut; chip.appendChild(k); }
+    const col=o.x+Math.floor(o.w/2), row=so.row;
+    chip.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); sendMouse({kind:"down",button:"left",col,row}); };
+    bar.appendChild(chip);
+  }
+  return bar;
+}
+
 // Input-only prompt (OpenFile / SaveFileAs): just the bottom prompt-row input
 // bar. The file browser body itself lives in the pane cells, so we draw NO
 // list — only the path box, full width, hugging the bottom of the cell grid
@@ -1290,6 +1444,7 @@ function paletteInputOnlyEl(p){
   q.innerHTML=esc(p.query||"")+'<span class="caret2">&nbsp;</span>';
   bar.appendChild(q); scrollToCaret(q);
   if(p.status){ const st=document.createElement("span"); st.className="status"; st.textContent=p.status; bar.appendChild(st); }
+  const so=searchOptionsEl(p); if(so) el.appendChild(so);   // TUI order: options above the prompt line
   el.appendChild(bar);
   return el;
 }
@@ -1330,8 +1485,10 @@ function paletteEl(p){
     // box is, with the input bar UNDER it on the prompt row, hugging the
     // bottom of the cell grid exactly like the terminal. Row clicks still
     // route through the editor's list cell rect; only the pixels are ours.
-    el.style.left=px(outer.x,CW)+"px";
-    el.style.width=px(outer.w,CW)+"px";
+    // The sheet spans the FULL grid width (from column 0, not outer.x), so it
+    // also covers the file-explorer band the TUI overlays at these rows.
+    el.style.left="0px";
+    el.style.width=px((scene&&scene.w)||(outer.x+outer.w),CW)+"px";
     el.style.top="auto";
     const gridBottom=px((scene&&scene.h)||(outer.y+outer.h+1),CH);
     el.style.bottom=Math.max(0, window.innerHeight-gridBottom)+"px";
@@ -1363,8 +1520,10 @@ function paletteEl(p){
     body.appendChild(listBox); body.appendChild(pv);
     el.appendChild(body);
   } else {
-    // Bottom sheet: list above, input UNDER it — the terminal's prompt order.
+    // Bottom sheet: list above, input UNDER it — the terminal's prompt order,
+    // with the search-options row (when present) between them like the TUI.
     el.appendChild(listBox);
+    const so=searchOptionsEl(p); if(so) el.appendChild(so);
     bar.style.borderBottom="none";
     bar.style.borderTop="1px solid var(--hairline)";
     el.appendChild(bar);


### PR DESCRIPTION
## Design refresh (web-ui/index.html)

Adapts the web chrome to the new navy/teal design mock:

- **Shell surface**: sidebar, menubar, tab bar and status bar sit on a darker navy-pulled `--shell` surface, re-derived per theme in `applyTheme()` by bg luminance (dark themes get the deep navy frame, light themes a gently shaded one).
- **Selections**: one language everywhere — translucent teal pill + hairline teal ring, with plain theme-foreground text. The orchestrator dock's selected card gets the mock's soft teal glow.
- **Frosted glass**: dropdowns, popups, context menus and the palette are translucent with `backdrop-filter` blur.
- **Status bar**: quiet dark strip with a green live-connection dot (the reconnect pill still takes over on socket drop) instead of the solid accent fill.
- **Chrome identity accent**: fixed `--ui-accent` teal for primary fills, toggles, focus rings, folder icons and the active-tab rule — the theme `accent` is the *cursor* colour (white in the stock dark theme), so it can't brand chrome.
- The plain palette stays the TUI-parity bottom sheet but now spans the full grid width, covering the file-explorer band exactly like the TUI overlay does.

Buffer cells and all geometry remain 100% pipeline/theme-driven.

## Web-invisible input states (found while testing)

Running **Add Ruler** from the web palette left the editor waiting on an invisible prompt. Root cause: `palette_view()` refused to project suggestion-less non-overlay prompts. Audit of `suppress_chrome_cells` sites found two more of the same class:

- `palette_view()` now projects **every** active prompt, so plain input prompts (Add Ruler, goto-line, macros, tab size, …) surface their input line via the existing input-only palette path.
- The **search options row** (Case / Whole Word / Regex / Confirm-each) had no projection at all: it's now `PaletteView.search_options` (state + the TUI's own checkbox cell spans + localized labels/shortcut hints) and renders as native toggle chips whose clicks route back through `handle_mouse` at the recorded cells.
- The **keyboard calibration wizard** renders TUI-only cells but owns the keyboard — on the web it was an invisible lockout requiring `a`,`d` to escape. It's now refused with a status message (`calibration.tui_only`, added to all 14 locales) when chrome cells are suppressed.

## Verification

- Drove the real bridge (`webui_server`) over HTTP and screenshotted headlessly: base view, palette + explorer overlap, menu dropdown, light theme, Add Ruler prompt, search-option chips (click on a chip cell flips the editor flag), calibration refusal message.
- `cargo test -p fresh-editor --features web --test scene_parity` passes; page JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)