### PR TITLE
fix(indent-guides): close staircase gap when block openers scroll off-screen

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -372,26 +372,27 @@ fn prime_guide_stack_from_buffer(
 }
 
 /// Fill `out` with the guide columns for a line of indent `width` whose open
-/// ancestors (strictly increasing, all `< width`) are `ancestors`. With no
-/// visible ancestor the guides fall back to tab stops so a scrolled view still
-/// shows guides for its topmost rows.
+/// ancestors (strictly increasing, all `< width`) are `ancestors`. Any indent
+/// level shallower than the shallowest known ancestor has scrolled off-screen,
+/// so its guides fall back to tab stops — the same fallback used when no
+/// ancestor is visible at all — keeping a scrolled view's staircase continuous.
 fn fill_guide_columns(ancestors: &[usize], width: usize, tab_size: usize, out: &mut Vec<usize>) {
     out.clear();
-    if ancestors.is_empty() {
-        let tab_size = normalized_tab_size(tab_size);
-        let mut col = 0;
-        while col < width {
-            out.push(col);
-            col += tab_size;
-        }
-    } else {
-        out.extend_from_slice(ancestors);
-        // A guide at column 0 is implied whenever the shallowest visible
-        // ancestor is itself indented (its own parent scrolled off-screen).
-        if ancestors[0] != 0 {
-            out.push(0);
-        }
+    // Everything below the shallowest visible ancestor (or the whole indent, if
+    // none is visible) is drawn at tab stops: those enclosing openers have
+    // scrolled above the viewport, so their exact columns are unknown and we
+    // assume regular tab-width indents. Filling this gap with the same tab-stop
+    // rule the empty-stack case uses stops deeper rows from dropping the
+    // intermediate guides that shallower rows still draw (which showed up as a
+    // staircase gap when a block's opener sat beyond the upward scan window).
+    let boundary = ancestors.first().copied().unwrap_or(width);
+    let step = normalized_tab_size(tab_size);
+    let mut col = 0;
+    while col < boundary {
+        out.push(col);
+        col += step;
     }
+    out.extend_from_slice(ancestors);
 }
 
 /// Append guide glyphs for `guide_columns` lying *beyond* the row's own rendered

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -251,6 +251,53 @@ fn indentation_guide_all_mode_continues_through_wrapped_line() {
 }
 
 #[test]
+fn indentation_guide_all_mode_no_staircase_gap_when_openers_scrolled_off() {
+    // Regression: when the enclosing block openers have scrolled far above the
+    // viewport (beyond the bounded upward scan that primes the guide stack), a
+    // deeply-indented row must still draw a guide at *every* level. The stack is
+    // seeded with only the shallowest ancestor visible in the scan window, and
+    // the off-screen levels below it fall back to tab stops. Previously that
+    // fallback added a single guide at column 0 instead of one per tab stop, so
+    // a row one level deeper than its block opener dropped an intermediate guide
+    // — the guide jumped from column 4 to column 8, leaving a staircase gap.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_scrolled.rs");
+
+    // Two enclosing openers (columns 0 and 4), then enough same-level filler to
+    // push those openers past the upward-scan window before the target block.
+    let mut src = String::from("root {\n    mid {\n");
+    for i in 0..300 {
+        src.push_str(&format!("        stmt_{i} = {i};\n"));
+    }
+    // Target block (indent 8) with a body one level deeper (indent 12).
+    src.push_str("        block {\n            deep = 1;\n        }\n    }\n}\n");
+    std::fs::write(&file_path, src).unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+
+    // Jump to the end of the document so the target block sits deep inside the
+    // buffer, its `root`/`mid` openers well above the scan window.
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    // The indent-12 body row must carry a guide at all three levels (columns 0,
+    // 4 and 8) — a continuous staircase, not a jump from column 4 to column 8.
+    assert!(
+        screen.contains("▏   ▏   ▏   deep = 1;"),
+        "deeply nested row should draw a guide at every level even with the block \
+         openers scrolled off-screen\n{screen}"
+    );
+}
+
+#[test]
 fn indentation_guide_active_mode_continues_through_wrapped_line() {
     let temp_dir = TempDir::new().unwrap();
     let file_path = temp_dir.path().join("guides_wrap_active.rs");


### PR DESCRIPTION
Fixes #2679

## Problem

With `editor.indentation_guide` set to `all`, a deeply-indented row could drop an intermediate guide once its enclosing block openers had scrolled far above the viewport, leaving a visible gap in the guide staircase:

```
▏   ▏   .hero-claim-sub {
▏       ▏   display: inline-block;   <- guide jumps from col 4 to col 8, col-4 guide missing
...
▏   ▏   }
```

## Root cause

In `all` mode the guide-column staircase is primed by a bounded upward scan (`INDENT_FOLD_MAX_UPWARD_SCAN` = 200 lines), so a viewport sitting deep inside a block seeds the stack with only the shallowest ancestor still inside that window. For `homepage/index.html`, viewing the CSS around line ~270 puts the `<head>`/`<style>` openers more than 200 lines up, so the stack is primed with just `[8]`.

`fill_guide_columns` then had **two inconsistent fallbacks** for the indent levels below the shallowest known ancestor:

- empty stack → draw a guide at **every tab stop** (`0, 4, 8, …`)
- non-empty stack → add a **single** implied guide at column 0

So a row one level deeper than its off-screen-opener block (`fill_guide_columns([8], 12, …)`) produced `{0, 8}` and skipped the column-4 tab stop, while the block's own header/closing lines (empty stack) drew `{0, 4}`. The two disagreed → staircase gap.

## Fix

Unify both paths in `fill_guide_columns`: fill tab stops for the entire region below the shallowest known ancestor, matching the empty-stack fallback. The staircase now stays continuous regardless of scroll position.

## Testing

- New regression test `indentation_guide_all_mode_no_staircase_gap_when_openers_scrolled_off` builds a buffer with 300 filler lines between the openers and the target block, jumps to the document end (Ctrl+End) so the openers fall outside the scan window, and asserts the indent-12 body row renders a guide at every level (`▏   ▏   ▏   deep = 1;`). It fails without the fix (renders `▏       ▏   deep = 1;`) and passes with it.
- All 10 `indentation_guide` e2e tests pass; `cargo fmt`, `cargo clippy`, and `cargo check --all-targets` are clean.
- Manually verified in tmux against `homepage/index.html` before and after: the gap is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWhohbf6sV4pMVmyHKw3aJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWhohbf6sV4pMVmyHKw3aJ)_