### PR TITLE
Fix flaky rename-directory e2e test: wait for async rename to land

### DIFF
--- a/crates/fresh-editor/tests/e2e/explorer_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/explorer_bugs.rs
@@ -1461,11 +1461,14 @@ fn test_rename_directory_redirects_save_to_new_path() {
 
     let new_inner = project_root.join("renamed_dir").join("inner.txt");
     let old_inner = project_root.join("mydir").join("inner.txt");
-    assert!(new_inner.exists(), "rename must have landed on disk");
-    assert!(
-        !project_root.join("mydir").exists(),
-        "old directory must be gone after rename"
-    );
+    // The rename is async filesystem I/O: the prompt closing only means the
+    // dialog dismissed, not that the move has landed on disk. Wait
+    // semantically for the new path to appear (and the old one to vanish)
+    // instead of reading an immediate snapshot, which races on loaded CI.
+    let old_dir = project_root.join("mydir");
+    harness
+        .wait_until(|_| new_inner.exists() && !old_dir.exists())
+        .unwrap();
 
     // Switch focus back to the editor (Ctrl+E from explorer focuses the
     // editor), append a sentinel, Ctrl+S to save.


### PR DESCRIPTION
test_rename_directory_redirects_save_to_new_path asserted new_inner.exists()
immediately after wait_for_prompt_closed(). But that only waits for the rename
dialog to dismiss, while the directory rename itself is async filesystem I/O on
the tokio runtime. On loaded CI the disk check raced ahead of the I/O and
panicked with "rename must have landed on disk".

Replace the immediate exists() snapshot with a semantic wait_until for the new
path to appear and the old directory to vanish, matching CONTRIBUTING.md's
no-timeouts / semantic-waiting rule and the pattern the same test already uses
for the later save assertion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TgWRCg6zBG7Jde2vfGkTC5