### PR TITLE
fix(web-ui): settings modal sizing and search-jump scrolling

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1972,8 +1972,13 @@ impl Editor {
         }
         if let Some(ref mut settings_state) = self.settings_state {
             if !draw_settings {
-                // keyboard-driven native render; skip cells (and the focus-state
-                // update tied to the cell layout pass).
+                // keyboard-driven native render; skip the cell layout pass but
+                // still sync per-control focus states — they're pure state the
+                // scene projection reads (map/list entry highlight), not
+                // something tied to cell geometry.
+                if settings_state.visible {
+                    settings_state.update_focus_states();
+                }
             } else if settings_state.visible {
                 settings_state.update_focus_states();
                 let settings_layout = crate::view::settings::render_settings(

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -396,6 +396,16 @@ impl Editor {
                         h.event_type == event_type
                             && h.widget_key == widget_key
                             && (!strict || h.payload == *payload)
+                            // Never loose-match across rows: tree hits all
+                            // share the tree's spec key, so when both payloads
+                            // carry an `index` they must agree — otherwise a
+                            // click on an off-window row would deliver some
+                            // other row's recorded hit.
+                            && (strict
+                                || match (h.payload.get("index"), payload.get("index")) {
+                                    (Some(a), Some(b)) => a == b,
+                                    _ => true,
+                                })
                     })
                     .cloned()
             };
@@ -415,6 +425,7 @@ impl Editor {
                 })
                 .or_else(|| hit_index.and_then(|i| panel.hits.get(i).cloned()))
                 .or_else(|| Self::synthesize_list_hit(panel, event_type, payload))
+                .or_else(|| Self::synthesize_tree_hit(panel, widget_key, event_type, payload))
         };
         if let Some(hit) = hit {
             self.deliver_widget_hit(&panel_key, &hit, None);
@@ -468,6 +479,60 @@ impl Editor {
                 "list_key": list_key,
             }),
             event_type: "select",
+        })
+    }
+
+    /// Rebuild the `HitArea` `render_widget_tree` would have emitted for a
+    /// tree row outside the TUI's scroll window (so no hit was recorded),
+    /// from the panel's own spec: `widget_key` must name a `Tree`, the
+    /// payload's `index` must be in bounds, and the row's item key comes
+    /// from the spec's `item_keys`. Covers the row-body `select` and the
+    /// disclosure `expand` events (the natively-scrolled web frontend can
+    /// click any row, not just the TUI's visible window).
+    fn synthesize_tree_hit(
+        panel: &crate::widgets::WidgetPanelState,
+        widget_key: &str,
+        event_type: &str,
+        payload: &serde_json::Value,
+    ) -> Option<crate::widgets::HitArea> {
+        if (event_type != "select" && event_type != "expand") || widget_key.is_empty() {
+            return None;
+        }
+        let index = payload.get("index")?.as_i64()?;
+        let spec = crate::widgets::find_widget_by_key(&panel.spec, widget_key)?;
+        let fresh_core::api::WidgetSpec::Tree {
+            nodes, item_keys, ..
+        } = spec
+        else {
+            return None;
+        };
+        if index < 0 || index as usize >= nodes.len() {
+            return None;
+        }
+        let item_key = item_keys.get(index as usize).cloned().unwrap_or_default();
+        let (event_type, payload) = if event_type == "expand" {
+            (
+                "expand",
+                serde_json::json!({
+                    "index": index,
+                    "key": item_key,
+                    "expanded": payload.get("expanded").and_then(|v| v.as_bool()).unwrap_or(true),
+                }),
+            )
+        } else {
+            (
+                "select",
+                serde_json::json!({ "index": index, "key": item_key }),
+            )
+        };
+        Some(crate::widgets::HitArea {
+            widget_key: widget_key.to_string(),
+            widget_kind: "tree",
+            buffer_row: 0,
+            byte_start: 0,
+            byte_end: 0,
+            payload,
+            event_type,
         })
     }
 

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -1360,9 +1360,19 @@ pub enum SettingControlView {
         /// Auto-managed maps (e.g. Languages, LSP) take no user-added
         /// entries; the TUI hides the add row for them.
         no_add: bool,
+        /// Entry row carrying keyboard focus (only while the control itself
+        /// is focused), same condition the TUI's list highlight uses.
+        focused: Option<usize>,
+        /// The add-new row is the focused row (`focused_entry == None` on a
+        /// focused control), mirroring the TUI's add-row highlight.
+        add_focused: bool,
     },
+    #[serde(rename_all = "camelCase")]
     ObjectArray {
         entries: Vec<String>,
+        /// Focused entry row / add-row focus, as in `Map` above.
+        focused: Option<usize>,
+        add_focused: bool,
     },
     Json {
         value: String,
@@ -1504,6 +1514,11 @@ fn setting_control_view(c: &crate::view::settings::items::SettingControl) -> Set
                 .as_deref()
                 .map(crate::view::settings::widget_map::column_title),
             no_add: s.no_add,
+            focused: (s.focus == crate::view::controls::FocusState::Focused)
+                .then_some(s.focused_entry)
+                .flatten(),
+            add_focused: s.focus == crate::view::controls::FocusState::Focused
+                && s.focused_entry.is_none(),
         },
         // Same combo → action row text the TUI renders (keybinding-shaped
         // entries), collapsing to the bare display value when there is no
@@ -1531,6 +1546,11 @@ fn setting_control_view(c: &crate::view::settings::items::SettingControl) -> Set
                     }
                 })
                 .collect(),
+            focused: (s.focus == crate::view::controls::FocusState::Focused)
+                .then_some(s.focused_index)
+                .flatten(),
+            add_focused: s.focus == crate::view::controls::FocusState::Focused
+                && s.focused_index.is_none(),
         },
         C::Json(s) => SettingControlView::Json { value: s.value() },
         C::Complex { type_name } => SettingControlView::Complex {

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -1350,8 +1350,16 @@ pub enum SettingControlView {
         available_cursor: usize,
         active_column: &'static str, // "included" | "available"
     },
+    // Variant-level camelCase (see DualList above).
+    #[serde(rename_all = "camelCase")]
     Map {
         entries: Vec<MapEntryView>,
+        /// Title for the value column (`Name │ <column>` header in the TUI),
+        /// derived from the control's `display_field`. `None` = no header.
+        column: Option<String>,
+        /// Auto-managed maps (e.g. Languages, LSP) take no user-added
+        /// entries; the TUI hides the add row for them.
+        no_add: bool,
     },
     ObjectArray {
         entries: Vec<String>,
@@ -1478,30 +1486,49 @@ fn setting_control_view(c: &crate::view::settings::items::SettingControl) -> Set
                 crate::view::controls::DualListColumn::Available => "available",
             },
         },
+        // Rows must read exactly as the TUI's: the same domain helper
+        // (`get_display_value`, e.g. `/grammar` → "Assembly") formats the
+        // value preview, and the value-column title mirrors the TUI's
+        // `Name │ <Col>` header — never the raw JSON blob.
         C::Map(s) => SettingControlView::Map {
             entries: s
                 .entries
                 .iter()
                 .map(|(k, v)| MapEntryView {
                     key: k.clone(),
-                    display: v
-                        .as_str()
-                        .map(|x| x.to_string())
-                        .unwrap_or_else(|| v.to_string()),
+                    display: s.get_display_value(v),
                 })
                 .collect(),
+            column: s
+                .display_field
+                .as_deref()
+                .map(crate::view::settings::widget_map::column_title),
+            no_add: s.no_add,
         },
+        // Same combo → action row text the TUI renders (keybinding-shaped
+        // entries), collapsing to the bare display value when there is no
+        // key combo (LSP server lists and other non-keybinding arrays).
         C::ObjectArray(s) => SettingControlView::ObjectArray {
             entries: s
                 .bindings
                 .iter()
-                .map(|v| {
-                    s.display_field
-                        .as_ref()
-                        .and_then(|f| v.pointer(f))
-                        .and_then(|x| x.as_str())
-                        .map(|x| x.to_string())
-                        .unwrap_or_else(|| v.to_string())
+                .map(|b| {
+                    let field = s
+                        .display_field
+                        .as_deref()
+                        .and_then(|p| p.strip_prefix('/'))
+                        .or(s.display_field.as_deref())
+                        .unwrap_or("action");
+                    let combo = crate::view::controls::keybinding_list::format_key_combo(b);
+                    let action = b
+                        .get(field)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("(no action)");
+                    if combo.trim().is_empty() {
+                        action.to_string()
+                    } else {
+                        format!("{combo} → {action}")
+                    }
                 })
                 .collect(),
         },

--- a/crates/fresh-editor/src/view/settings/widget_map.rs
+++ b/crates/fresh-editor/src/view/settings/widget_map.rs
@@ -745,7 +745,7 @@ fn list_selection(focus: FocusState, focused: Option<usize>) -> i32 {
 
 /// Human column title from a `display_field` pointer (`/grammar` →
 /// `Grammar`).
-fn column_title(display_field: &str) -> String {
+pub(crate) fn column_title(display_field: &str) -> String {
     let last = display_field.rsplit('/').next().unwrap_or(display_field);
     let mut chars = last.chars();
     match chars.next() {

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -114,7 +114,7 @@ frames without page input, region diffs on typing, idle silence, and the
 single-client 409 — plus per-region DOM patching (a typing frame rebuilds
 only its pane), measured metrics + app zoom (Ctrl+= / Ctrl+0, hit-testing
 while zoomed), and touch pan/tap in a `hasTouch` mobile context.
-**113 assertions** across the chrome surfaces, plus screenshots.
+**117 assertions** across the chrome surfaces, plus screenshots.
 
 One command runs the whole thing — build the bridge, install the Playwright
 deps (`test/package.json`) on first use, start the server, run the suite,

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -114,7 +114,7 @@ frames without page input, region diffs on typing, idle silence, and the
 single-client 409 — plus per-region DOM patching (a typing frame rebuilds
 only its pane), measured metrics + app zoom (Ctrl+= / Ctrl+0, hit-testing
 while zoomed), and touch pan/tap in a `hasTouch` mobile context.
-**72 assertions** across the chrome surfaces, plus screenshots.
+**111 assertions** across the chrome surfaces, plus screenshots.
 
 One command runs the whole thing — build the bridge, install the Playwright
 deps (`test/package.json`) on first use, start the server, run the suite,

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -114,7 +114,7 @@ frames without page input, region diffs on typing, idle silence, and the
 single-client 409 — plus per-region DOM patching (a typing frame rebuilds
 only its pane), measured metrics + app zoom (Ctrl+= / Ctrl+0, hit-testing
 while zoomed), and touch pan/tap in a `hasTouch` mobile context.
-**111 assertions** across the chrome surfaces, plus screenshots.
+**113 assertions** across the chrome surfaces, plus screenshots.
 
 One command runs the whole thing — build the bridge, install the Playwright
 deps (`test/package.json`) on first use, start the server, run the suite,

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -297,7 +297,12 @@
   .settings-modal .set-list-row{display:flex;align-items:center;gap:8px;padding:2px 10px;border-bottom:1px solid rgba(255,255,255,.05)}
   .settings-modal .set-list-row:last-child{border-bottom:none}
   .settings-modal .set-list-badge{color:var(--accent)}
-  .settings-modal .set-list-sub{color:var(--muted);margin-left:auto;max-width:50%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  /* Two-column list rows mirroring the TUI's map layout: a fixed-ish key
+     column ("Name") that must never collapse, then the flexible value
+     preview. The header row reuses the same spans so columns line up. */
+  .settings-modal .set-list-label{flex:0 0 auto;min-width:16ch;max-width:24ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .settings-modal .set-list-sub{color:var(--muted);flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .settings-modal .set-list-head,.settings-modal .set-list-head .set-list-sub{color:var(--muted)}
   .settings-modal .set-list-empty{padding:3px 10px;color:var(--muted);font-style:italic}
   .settings-modal .set-list-add{padding:2px 10px;color:var(--accent);cursor:default;border-top:1px solid rgba(255,255,255,.06)}
   .settings-modal .set-dual{display:flex;align-items:stretch;gap:6px;margin:4px 0 2px 8px}
@@ -534,10 +539,7 @@
   .settings-modal .set-cat{padding:3px 12px}
   .settings-modal .set-item{padding:6px 16px}
 
-  /* Keep long composite-list values (e.g. the Languages JSON) on one tidy line
-     instead of overflowing the row. */
   .settings-modal .set-list-row{min-width:0;gap:10px}
-  .settings-modal .set-list-label{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 
   /* Slim, rounded, low-contrast scrollbars that match the hairline language. */
   *::-webkit-scrollbar{width:10px;height:10px}
@@ -782,8 +784,6 @@
   .trustdialog .td-path,
   .w-list-row,
   .settings-modal .set-field,
-  .settings-modal .set-list-sub,
-  .settings-modal .set-list-label,
   .settings-modal .set-dual-row,
   .kbedit .kb-cfg,
   .kbedit .kb-col,
@@ -1851,8 +1851,13 @@ function settingListEl(c, idx, live){
   // rowHit: (rowIndex) -> SettingsHit for clicking that row; addHit for "＋ Add".
   let rowHit=null, addHit=null;
   if(k==="textList"){ rows=c.items.map(t=>({label:t})); rowHit=i=>["controlTextListRow",idx,i]; addHit=["controlTextListRow",idx,c.items.length]; }
-  else if(k==="map"){ rows=c.entries.map(e=>({label:e.key, sub:e.display})); rowHit=i=>["controlMapRow",idx,i]; addHit=["controlMapAddNew",idx]; }
+  else if(k==="map"){ rows=c.entries.map(e=>({label:e.key, sub:e.display})); rowHit=i=>["controlMapRow",idx,i]; if(!c.noAdd) addHit=["controlMapAddNew",idx]; }
   else if(k==="objectArray"){ rows=c.entries.map(t=>({label:t})); rowHit=i=>["controlMapRow",idx,i]; }   // select item; Enter edits
+  // Column header (`Name │ <column>`), mirroring the TUI's dimmed header row.
+  if(k==="map"&&c.column&&rows.length){ const h=div("set-list-row set-list-head");
+    const l=document.createElement("span"); l.className="set-list-label"; l.textContent="Name"; h.appendChild(l);
+    const s=document.createElement("span"); s.className="set-list-sub"; s.textContent=c.column; h.appendChild(s);
+    el.appendChild(h); }
   if(!rows.length){ const e=div("set-list-empty"); e.textContent="No entries"; el.appendChild(e); }
   rows.forEach((r,i)=>{ const row=div("set-list-row");
     if(r.badge){ const b=document.createElement("span"); b.className="set-list-badge"; b.textContent=r.badge; row.appendChild(b); }
@@ -1860,7 +1865,8 @@ function settingListEl(c, idx, live){
     if(r.sub){ const s=document.createElement("span"); s.className="set-list-sub"; s.textContent=r.sub; row.appendChild(s); }
     if(live&&rowHit){ const h=rowHit(i); row.onmousedown=setHit(h[0],h[1],h[2]); }
     el.appendChild(row); });
-  const add=div("set-list-add"); add.textContent="＋ Add…"; if(live&&addHit) add.onmousedown=setHit(addHit[0],addHit[1],addHit[2]); el.appendChild(add);
+  // Auto-managed maps (noAdd, e.g. Languages/LSP) hide the add row like the TUI.
+  if(!(k==="map"&&c.noAdd)){ const add=div("set-list-add"); add.textContent="＋ Add…"; if(live&&addHit) add.onmousedown=setHit(addHit[0],addHit[1],addHit[2]); el.appendChild(add); }
   return el;
 }
 // Two-column dual list (Available ⇄ Included) with native add/remove/move

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -261,7 +261,9 @@
   .w-list-card.sel{border-color:var(--accent);background:var(--menuhi)}
   .w-list-card .w-section{border:none;padding:0}
   /* native Settings (full modal) */
-  .settings-modal{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:96;width:min(960px,90vw);height:min(640px,86vh);
+  /* Use ~80% of the viewport on large screens; keep the old 960×640-capped
+     size as a floor so small windows behave exactly as before. */
+  .settings-modal{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:96;width:max(min(960px,90vw),80vw);height:max(min(640px,86vh),80vh);
     background:#2b2b2b;border:1px solid #5a5a5a;border-radius:8px;box-shadow:0 18px 60px rgba(0,0,0,.6);display:flex;flex-direction:column;overflow:hidden}
   .settings-modal .set-title{padding:5px 12px;font-weight:600;background:var(--bg3);border-bottom:1px solid var(--border)}
   .settings-modal .set-body{flex:1;display:flex;overflow:hidden}
@@ -1281,6 +1283,25 @@ function renderRegion(name){
   if(name!=="caret") c.textContent="";     // the caret patches its own child in place
   REGION_FILL[name](c, scene.regions);
   c.querySelectorAll(SCROLL_KEEP).forEach((e,i)=>{ if(saved[i]) e.scrollTop=saved[i]; });
+  if(name==="settings") settingsEnsureSelectionVisible(c);
+}
+
+// The TUI windows the settings rows with the core's scroll offset, so its
+// selection is always on screen; the web renders the FULL list in native
+// overflow:auto panels, and the snapshot/restore above deliberately pins the
+// previous scrollTop. When a rebuild moves the selection (arrow keys past the
+// fold, and especially a search jump: "/" + query + Enter lands anywhere in
+// the tree while the restored scrollTop is from the results view), nudge each
+// scrolled panel just enough to bring its selected row back into view. Runs
+// after the scroll restore, and only when the row is actually outside the
+// panel, so a user's own wheel position is otherwise left alone.
+function settingsEnsureSelectionVisible(c){
+  for(const sel of c.querySelectorAll(".set-cat.sel,.set-item.sel,.set-sresult.sel")){
+    const list=sel.closest(".set-cats,.set-items,.set-overlay");
+    if(!list) continue;
+    const lr=list.getBoundingClientRect(), sr=sel.getBoundingClientRect();
+    if(sr.top<lr.top||sr.bottom>lr.bottom) sel.scrollIntoView({block:"nearest"});
+  }
 }
 
 // Full rebuild of every region container: hello (connect/reconnect), the HTTP

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -303,6 +303,12 @@
   .settings-modal .set-list-label{flex:0 0 auto;min-width:16ch;max-width:24ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .settings-modal .set-list-sub{color:var(--muted);flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .settings-modal .set-list-head,.settings-modal .set-list-head .set-list-sub{color:var(--muted)}
+  /* Keyboard focus inside a list control: highlight the focused entry / add
+     row and show the TUI's dim `[Enter to edit]` hint. */
+  .settings-modal .set-list-row.sel,.settings-modal .set-list-add.sel{background:var(--menuhi);color:#fff}
+  .settings-modal .set-list-row.sel .set-list-sub{color:#dfe8ff}
+  .settings-modal .set-list-hint{flex:0 0 auto;margin-left:8px;color:var(--muted);font-style:italic}
+  .settings-modal .set-list-row.sel .set-list-hint{color:#cfd8ea}
   .settings-modal .set-list-empty{padding:3px 10px;color:var(--muted);font-style:italic}
   .settings-modal .set-list-add{padding:2px 10px;color:var(--accent);cursor:default;border-top:1px solid rgba(255,255,255,.06)}
   .settings-modal .set-dual{display:flex;align-items:stretch;gap:6px;margin:4px 0 2px 8px}
@@ -1296,7 +1302,7 @@ function renderRegion(name){
 // after the scroll restore, and only when the row is actually outside the
 // panel, so a user's own wheel position is otherwise left alone.
 function settingsEnsureSelectionVisible(c){
-  for(const sel of c.querySelectorAll(".set-cat.sel,.set-item.sel,.set-sresult.sel")){
+  for(const sel of c.querySelectorAll(".set-cat.sel,.set-item.sel,.set-sresult.sel,.set-list-row.sel,.set-list-add.sel")){
     const list=sel.closest(".set-cats,.set-items,.set-overlay");
     if(!list) continue;
     const lr=list.getBoundingClientRect(), sr=sel.getBoundingClientRect();
@@ -1850,23 +1856,24 @@ function settingListEl(c, idx, live){
   const el=div("set-list"); let rows=[];
   // rowHit: (rowIndex) -> SettingsHit for clicking that row; addHit for "＋ Add".
   let rowHit=null, addHit=null;
-  if(k==="textList"){ rows=c.items.map(t=>({label:t})); rowHit=i=>["controlTextListRow",idx,i]; addHit=["controlTextListRow",idx,c.items.length]; }
-  else if(k==="map"){ rows=c.entries.map(e=>({label:e.key, sub:e.display})); rowHit=i=>["controlMapRow",idx,i]; if(!c.noAdd) addHit=["controlMapAddNew",idx]; }
-  else if(k==="objectArray"){ rows=c.entries.map(t=>({label:t})); rowHit=i=>["controlMapRow",idx,i]; }   // select item; Enter edits
+  if(k==="textList"){ rows=c.items.map((t,i)=>({label:t, focused:i===c.focused})); rowHit=i=>["controlTextListRow",idx,i]; addHit=["controlTextListRow",idx,c.items.length]; }
+  else if(k==="map"){ rows=c.entries.map((e,i)=>({label:e.key, sub:e.display, focused:i===c.focused})); rowHit=i=>["controlMapRow",idx,i]; if(!c.noAdd) addHit=["controlMapAddNew",idx]; }
+  else if(k==="objectArray"){ rows=c.entries.map((t,i)=>({label:t, focused:i===c.focused})); rowHit=i=>["controlMapRow",idx,i]; }   // select item; Enter edits
   // Column header (`Name │ <column>`), mirroring the TUI's dimmed header row.
   if(k==="map"&&c.column&&rows.length){ const h=div("set-list-row set-list-head");
     const l=document.createElement("span"); l.className="set-list-label"; l.textContent="Name"; h.appendChild(l);
     const s=document.createElement("span"); s.className="set-list-sub"; s.textContent=c.column; h.appendChild(s);
     el.appendChild(h); }
   if(!rows.length){ const e=div("set-list-empty"); e.textContent="No entries"; el.appendChild(e); }
-  rows.forEach((r,i)=>{ const row=div("set-list-row");
+  rows.forEach((r,i)=>{ const row=div("set-list-row"+(r.focused?" sel":""));
     if(r.badge){ const b=document.createElement("span"); b.className="set-list-badge"; b.textContent=r.badge; row.appendChild(b); }
     const l=document.createElement("span"); l.className="set-list-label"; l.textContent=r.label; row.appendChild(l);
     if(r.sub){ const s=document.createElement("span"); s.className="set-list-sub"; s.textContent=r.sub; row.appendChild(s); }
+    if(r.focused&&(k==="map"||k==="objectArray")){ const h=document.createElement("span"); h.className="set-list-hint"; h.textContent="[Enter to edit]"; row.appendChild(h); }
     if(live&&rowHit){ const h=rowHit(i); row.onmousedown=setHit(h[0],h[1],h[2]); }
     el.appendChild(row); });
   // Auto-managed maps (noAdd, e.g. Languages/LSP) hide the add row like the TUI.
-  if(!(k==="map"&&c.noAdd)){ const add=div("set-list-add"); add.textContent="＋ Add…"; if(live&&addHit) add.onmousedown=setHit(addHit[0],addHit[1],addHit[2]); el.appendChild(add); }
+  if(!(k==="map"&&c.noAdd)){ const add=div("set-list-add"+(c.addFocused?" sel":"")); add.textContent="＋ Add…"; if(live&&addHit) add.onmousedown=setHit(addHit[0],addHit[1],addHit[2]); el.appendChild(add); }
   return el;
 }
 // Two-column dual list (Available ⇄ Included) with native add/remove/move
@@ -2571,7 +2578,10 @@ function sendWidget(o){ wsSend({type:"widget",...o}); }
 function sendSettings(o){ wsSend({type:"settings",...o}); }
 function sendKbedit(o){ wsSend({type:"kbedit",...o}); }
 // click handler that forwards a SettingsHit (kind + indices) to the editor
-function setHit(kind,a,b){ return e=>{ e.preventDefault(); e.stopPropagation(); sendSettings({kind,a,b}); }; }
+// `double` carries the browser's click count so entry rows (map/list) can
+// open their edit dialog on double-click, exactly like the TUI's
+// double-click path (single click only focuses the row).
+function setHit(kind,a,b){ return e=>{ e.preventDefault(); e.stopPropagation(); sendSettings({kind,a,b,double:e.detail>=2}); }; }
 // Forward a hover as a `moved` event at a chrome element's *editor cell* (not the
 // pixel under the pointer — native chrome is laid out by CSS, so pixels don't map
 // to the editor's cell columns). Called from `onmousemove` (which, unlike

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -256,6 +256,12 @@
   .w-list-row{padding:1px 6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:default;border-radius:3px}
   .w-list-row.sel{background:var(--menuhi);color:#fff}
   .w-list-empty{color:var(--muted);font-style:italic;padding:2px 6px}
+  .w-tree{display:flex;flex-direction:column;overflow:auto}
+  .w-tree-row{padding:1px 6px;white-space:pre;overflow:hidden;text-overflow:ellipsis;cursor:default;border-radius:3px}
+  .w-tree-row.sel{background:var(--menuhi);color:#fff}
+  .w-tree-disc,.w-tree-check{color:var(--muted)} .w-tree-row.sel .w-tree-disc,.w-tree-row.sel .w-tree-check{color:#dfe8ff}
+  .w-overlay{align-self:flex-start;background:var(--bg2);border:1px solid var(--border);border-radius:6px;
+    box-shadow:0 10px 34px rgba(0,0,0,.5);padding:4px;margin:2px 0;z-index:4;position:relative}
   .w-list-cards{gap:4px;padding:2px}
   .w-list-card{border:1px solid var(--border);border-radius:6px;padding:3px 6px;cursor:default;background:rgba(255,255,255,.02)}
   .w-list-card.sel{border-color:var(--accent);background:var(--menuhi)}
@@ -389,10 +395,10 @@
   .widget-surface{background:var(--bg2);overflow:auto;z-index:40;padding:4px 6px;
     display:flex;flex-direction:column}
   .widget-surface>.w-col,.widget-surface>.w-row{flex:1 1 auto;min-height:0}
-  .widget-surface .w-list{flex:1 1 auto;min-height:0;overflow-y:auto}
+  .widget-surface .w-list,.widget-surface .w-tree{flex:1 1 auto;min-height:0;overflow-y:auto}
   /* rows/cards keep their natural height — the LIST scrolls, its items never
      squash to fit the flex-constrained track */
-  .widget-surface .w-list>*{flex:0 0 auto}
+  .widget-surface .w-list>*,.widget-surface .w-tree>*{flex:0 0 auto}
   .widget-surface.w-dock{border-right:1px solid var(--border)}
   .widget-surface.w-floatingModal{border:1px solid #5a5a5a;border-radius:8px;box-shadow:0 16px 60px rgba(0,0,0,.55);z-index:96}
   .widget-surface .w-col{gap:3px}
@@ -1823,8 +1829,67 @@ function widgetEl(spec, ctx){
     }
     return el;
   }
+  if(kind==="tree"){
+    // Same semantics as the TUI's render_widget_tree: the host-owned
+    // instance state (selection, expanded set) is authoritative, a node is
+    // visible iff every ancestor is expanded, and rows fire the identical
+    // select / expand hits. Rendered natively (all visible rows, no TUI
+    // scroll window) — off-window clicks are synthesized bridge-side.
+    const el=div("w-tree"+(focused?" focus":""));
+    const inst=(ctx.instances&&spec.key)?ctx.instances[spec.key]:null;
+    const sel=inst&&inst.selectedIndex!=null?inst.selectedIndex:(spec.selectedIndex!=null?spec.selectedIndex:-1);
+    const expanded=new Set(inst&&inst.expandedKeys?inst.expandedKeys:(spec.expandedKeys||[]));
+    const keys=spec.itemKeys||[];
+    const open=[];
+    (spec.nodes||[]).forEach((n,i)=>{
+      const d=n.depth||0; open.length=d;
+      const vis=open.every(Boolean);
+      const key=keys[i]||"";
+      const isOpen=n.hasChildren?(!!key&&expanded.has(key)):true;
+      open.push(isOpen);
+      if(!vis) return;
+      const row=div("w-tree-row"+(i===sel?" sel":""));
+      row.style.paddingLeft=(d*2)+"ch";
+      if(n.hasChildren){
+        const g=document.createElement("span"); g.className="w-tree-disc"; g.textContent=isOpen?"▼ ":"▶ ";
+        g.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"expand",{index:i,key,expanded:!isOpen}); };
+        row.appendChild(g);
+      }
+      if(spec.checkable&&n.checked!=null){
+        const cb=document.createElement("span"); cb.className="w-tree-check"; cb.textContent=n.checked?"☑ ":"☐ ";
+        cb.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"toggle",{index:i,key,checked:!n.checked}); };
+        row.appendChild(cb);
+      }
+      const t=document.createElement("span"); t.className="w-tree-text"; t.textContent=entryText(n.text||{});
+      row.appendChild(t);
+      row.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"select",{index:i,key}); };
+      el.appendChild(row);
+    });
+    return el;
+  }
+  if(kind==="overlay"){
+    // The TUI floats the child over the following rows; here it renders as
+    // a raised dropdown card in flow, right under the row that opened it.
+    const el=div("w-overlay");
+    if(spec.child) el.appendChild(widgetEl(spec.child, ctx));
+    return el;
+  }
   if(kind==="raw"&&spec.entries){ const el=div("w-raw"); el.textContent=spec.entries.map(entryText).join("\n"); return el; }
   const fb=div("w-unsupported"); fb.textContent="["+kind+"]"; return fb;
+}
+
+// Route a tree row interaction by identity (tree spec key + event + row
+// payload). When the TUI recorded a hit for this row, reuse its exact
+// payload + index so the bridge's strict identity tier matches; rows below
+// the TUI's scroll window carry just the synthesized payload and resolve
+// through the bridge's tree synthesis.
+function routeTree(ctx, node, eventType, payload){
+  const base={surface:"panel",plugin:ctx.plugin,panelId:ctx.panelId};
+  const hit=(ctx.hits||[]).find(h=>h.widgetKind==="tree"&&h.eventType===eventType
+    &&h.widgetKey===(node.key||"")&&h.payload&&h.payload.index===payload.index);
+  const msg={...base,widgetKey:node.key||"",eventType,payload:hit?hit.payload:payload};
+  if(hit) msg.hitIndex=hit.index;
+  sendWidget(msg);
 }
 
 // Native Settings — a control's value rendered semantically (read from the

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -249,7 +249,36 @@ await page.keyboard.press('Enter');
 await page.waitForFunction(() => { const s = window.fresh.scene.regions.settings; return s && s.entryDialog; }, { timeout: 5000 }).catch(() => {});
 check('Settings entry (add/edit) dialog renders natively', (await page.locator('.settings-modal .set-entry .set-item').count()) >= 3);
 await page.screenshot({ path: `${SHOTS}/30-native-settings.png` });
+// Size: the modal should claim ~80% of the viewport (with the old capped size
+// only as a small-window floor), not a fixed 960×640 box.
+const setSize = await page.evaluate(() => {
+  const r = document.querySelector('.settings-modal').getBoundingClientRect();
+  return { pw: +(100 * r.width / window.innerWidth).toFixed(1), ph: +(100 * r.height / window.innerHeight).toFixed(1) };
+});
+check('settings modal uses ~80% of the viewport', setSize.pw >= 79 && setSize.ph >= 79, JSON.stringify(setSize));
 await page.keyboard.press('Escape'); await page.waitForTimeout(120); await page.keyboard.press('Escape'); await page.waitForTimeout(150);
+
+console.log('\n[Settings search jump scrolls the selection into view]');
+await page.request.post(URL + '/action', { data: { action: 'open_settings' } });
+await page.waitForFunction(() => !!window.fresh.scene.regions.settings, { timeout: 8000 }).catch(() => {});
+await page.waitForTimeout(250);
+await page.keyboard.press('/'); await page.waitForTimeout(150);
+await page.keyboard.type('scroll', { delay: 30 }); await page.waitForTimeout(250);
+check('"/" enters search mode with results', await page.evaluate(() => {
+  const s = window.fresh.scene.regions.settings; return s.searchActive && s.searchResults.length >= 2; }));
+await page.keyboard.press('ArrowDown'); await page.keyboard.press('ArrowDown'); await page.waitForTimeout(150);
+await page.keyboard.press('Enter'); await page.waitForTimeout(400);
+const setScroll = await page.evaluate(() => {
+  const list = document.querySelector('.settings-modal .set-items');
+  const sel = document.querySelector('.settings-modal .set-item.sel');
+  if (!list || !sel) return { ok: false, why: 'missing ' + (!list ? '.set-items' : '.set-item.sel') };
+  const lr = list.getBoundingClientRect(), sr = sel.getBoundingClientRect();
+  return { ok: sr.top >= lr.top - 1 && sr.bottom <= lr.bottom + 1,
+           selTop: Math.round(sr.top), listTop: Math.round(lr.top), listBottom: Math.round(lr.bottom), scrollTop: list.scrollTop };
+});
+check('Enter on a search result scrolls the selected item into view', setScroll.ok, JSON.stringify(setScroll));
+await page.screenshot({ path: `${SHOTS}/31-settings-search-jump.png` });
+await page.keyboard.press('Escape'); await page.waitForTimeout(150);
 
 console.log('\n[WebSocket push transport (no polling)]');
 check('WebSocket transport is open (window.fresh.wsOpen)', await page.evaluate(() => window.fresh.wsOpen));

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -304,6 +304,47 @@ check('Enter on a search result scrolls the selected item into view', setScroll.
 await page.screenshot({ path: `${SHOTS}/31-settings-search-jump.png` });
 await page.keyboard.press('Escape'); await page.waitForTimeout(150);
 
+console.log('\n[Settings map entry rows: mouse + keyboard, TUI-parity interactions]');
+// Single click focuses a row (highlight + [Enter to edit] hint, no dialog);
+// Enter / double-click open the entry edit dialog; arrow keys walk the
+// entries with the focused row kept highlighted and scrolled into view.
+await page.request.post(URL + '/action', { data: { action: 'open_settings' } });
+await page.waitForFunction(() => !!window.fresh.scene.regions.settings, { timeout: 8000 }).catch(() => {});
+await page.waitForTimeout(250);
+const langIdx = await page.evaluate(() => [...document.querySelectorAll('.set-items > .set-item')]
+  .findIndex(r => (r.querySelector('.set-name') || {}).textContent === 'Languages'));
+const langRowsLoc = page.locator('.set-items > .set-item').nth(langIdx).locator('.set-list-row:not(.set-list-head)');
+await langRowsLoc.nth(2).click(); await page.waitForTimeout(250);
+const rowFocus = await page.evaluate(() => {
+  const it = window.fresh.scene.regions.settings.items.find(i => i.name === 'Languages');
+  const sel = document.querySelector('.set-items .set-list-row.sel');
+  return { focused: it.control.focused, dialog: !!window.fresh.scene.regions.settings.entryDialog,
+           sel: sel && sel.textContent.slice(0, 20), hint: !!(sel && sel.querySelector('.set-list-hint')) };
+});
+check('clicking a map entry row focuses + highlights it (no dialog)',
+  rowFocus.focused === 2 && !rowFocus.dialog && !!rowFocus.sel && rowFocus.hint, JSON.stringify(rowFocus));
+await page.keyboard.press('Enter'); await page.waitForTimeout(350);
+check('Enter opens the focused entry edit dialog',
+  await page.evaluate(() => !!window.fresh.scene.regions.settings.entryDialog));
+await page.keyboard.press('Escape'); await page.waitForTimeout(250);
+await langRowsLoc.nth(3).dblclick(); await page.waitForTimeout(350);
+check('double-click opens the entry edit dialog',
+  await page.evaluate(() => !!window.fresh.scene.regions.settings.entryDialog));
+await page.keyboard.press('Escape'); await page.waitForTimeout(250);
+await langRowsLoc.nth(2).click(); await page.waitForTimeout(200);
+for (let i = 0; i < 40; i++) { await page.keyboard.press('ArrowDown'); await page.waitForTimeout(30); }
+await page.waitForTimeout(250);
+const entryWalk = await page.evaluate(() => {
+  const list = document.querySelector('.settings-modal .set-items');
+  const sel = document.querySelector('.set-items .set-list-row.sel');
+  if (!sel) return { sel: false };
+  const lr = list.getBoundingClientRect(), sr = sel.getBoundingClientRect();
+  return { visible: sr.top >= lr.top - 1 && sr.bottom <= lr.bottom + 1, scrollTop: list.scrollTop };
+});
+check('keyboard walk through entries keeps the focused row visible', !!entryWalk.visible && entryWalk.scrollTop > 0, JSON.stringify(entryWalk));
+await page.screenshot({ path: `${SHOTS}/32-settings-entry-rows.png` });
+await page.keyboard.press('Escape'); await page.waitForTimeout(150);
+
 console.log('\n[WebSocket push transport (no polling)]');
 check('WebSocket transport is open (window.fresh.wsOpen)', await page.evaluate(() => window.fresh.wsOpen));
 // Genuine server PUSH: mutate the editor over the HTTP route (curl-equivalent,

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -256,6 +256,30 @@ const setSize = await page.evaluate(() => {
   return { pw: +(100 * r.width / window.innerWidth).toFixed(1), ph: +(100 * r.height / window.innerHeight).toFixed(1) };
 });
 check('settings modal uses ~80% of the viewport', setSize.pw >= 79 && setSize.ph >= 79, JSON.stringify(setSize));
+// Map/list parity with the TUI: entries render as a visible key column plus
+// the domain display value (e.g. Languages: "asm │ Assembly") under a dimmed
+// Name│<column> header — never the raw JSON blob — and auto-managed (noAdd)
+// maps hide the add row exactly like the TUI.
+const langRows = await page.evaluate(() => {
+  const item = [...document.querySelectorAll('.settings-modal .set-items > .set-item')]
+    .find(r => r.textContent.startsWith('Languages'));
+  if (!item) return null;
+  const head = item.querySelector('.set-list-head');
+  const row = item.querySelector('.set-list-row:not(.set-list-head)');
+  const label = row && row.querySelector('.set-list-label');
+  const sub = row && row.querySelector('.set-list-sub');
+  const model = window.fresh.scene.regions.settings.items.find(i => i.name === 'Languages');
+  return { header: head && head.textContent, key: label && label.textContent,
+           keyWidth: label ? label.getBoundingClientRect().width : 0,
+           display: sub && sub.textContent, noAdd: model.control.noAdd,
+           addRows: item.querySelectorAll('.set-list-add').length };
+});
+check('map entries render key + TUI display value (visible key, no raw JSON)',
+  !!langRows && langRows.keyWidth > 10 && !!langRows.display && !langRows.display.startsWith('{'),
+  JSON.stringify(langRows));
+check('map shows the Name│<column> header; add row follows the noAdd projection',
+  !!langRows && /Name/.test(langRows.header || '') && langRows.addRows === (langRows.noAdd ? 0 : 1),
+  JSON.stringify(langRows));
 await page.keyboard.press('Escape'); await page.waitForTimeout(120); await page.keyboard.press('Escape'); await page.waitForTimeout(150);
 
 console.log('\n[Settings search jump scrolls the selection into view]');

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -160,6 +160,11 @@ if (!((await scene(page)).regions.widgets || []).length) {
 await page.waitForFunction(() => { const w = window.fresh.scene.regions.widgets; return w && w.length > 0; }, { timeout: 8000 }).catch(() => {});
 await page.waitForTimeout(300);
 check('editor reports a widget surface', !!((await scene(page)).regions.widgets || []).length);
+// The redesigned dock (hierarchical folder tree) collapses the filter
+// toggles behind a "Filters" disclosure — expand it so the full toolbar
+// (view / project / worktree / hide-trivial / Manage) is rendered.
+await page.locator('.widget-surface.w-dock .w-button', { hasText: 'Filters' }).first().click();
+await page.waitForTimeout(400);
 check('dock rendered as a native widget panel', (await page.locator('.widget-surface .w-button').count()) >= 3);
 check('NO svg/cells inside the widget panel', (await page.locator('.widget-surface svg').count()) === 0);
 await page.screenshot({ path: `${SHOTS}/28-native-dock.png` });
@@ -207,8 +212,8 @@ await page.waitForFunction(v2 => { const d = (window.fresh.scene.regions.widgets
   return d && !!(f(d.spec) || {}).checked !== v2; }, t2v, { timeout: 5000 }).catch(() => {});
 const t3v = !!(findByKey((await dockSurf()).spec, 'hide-trivial') || {}).checked;
 check('stale hitIndex + correct identity still delivers (drift regression)', t3v !== t2v, `checked ${t2v}->${t3v}`);
-// A workspace-row (card) click selects it through the same identity path.
-await page.locator('.widget-surface.w-dock .w-list-card').first().click();
+// A session tree-row click selects it through the same identity path.
+await page.locator('.widget-surface.w-dock .w-tree-row').first().click();
 await page.waitForTimeout(500);
 const dSel = await dockSurf();
 check('clicking a dock workspace row selects it in the scene',
@@ -605,14 +610,19 @@ if (!((await scene(page)).regions.widgets || []).some(w => w.kind === 'dock')) {
 }
 await page.waitForTimeout(200);
 check('dock alone (no modal) has zero modal-scrims', (await page.locator('.modal-scrim').count()) === 0);
-await page.locator('.widget-surface.w-dock .w-button', { hasText: 'New' }).first().click();
+// "New Task… ▾" opens a create dropdown first (dock redesign); pick the
+// "New Task…" option (rendered as "  New Task…" / "● New Task…") to open
+// the form.
+await page.locator('.widget-surface.w-dock .w-button', { hasText: 'New Task' }).first().click();
+await page.waitForTimeout(300);
+await page.locator('.widget-surface.w-dock .w-button', { hasText: /New Task…$/ }).first().click();
 await page.waitForFunction(() => (window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
 await page.waitForTimeout(200);
 check('New Workspace dialog is a floatingModal', ((await scene(page)).regions.widgets || []).some(w => w.kind === 'floatingModal'));
 check('exactly one modal-scrim behind the floatingModal', (await page.locator('.modal-scrim').count()) === 1);
 const dockSel = async () => { const d = ((await scene(page)).regions.widgets || []).find(w => w.kind === 'dock'); return d && d.instances && d.instances.sessions ? d.instances.sessions.selectedIndex : null; };
 const sel0 = await dockSel();
-const cardBox = await page.locator('.widget-surface.w-dock .w-list-card').first().boundingBox();
+const cardBox = await page.locator('.widget-surface.w-dock .w-tree-row').first().boundingBox();
 if (cardBox) await page.mouse.click(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);
 await page.waitForTimeout(300);
 const sel1 = await dockSel();


### PR DESCRIPTION
Two web-mode Settings dialog issues, reproduced in headless Chromium
before fixing:

- The modal was hard-capped at 960x640, using only 50%x59% of a
  1920x1080 viewport (37.5%x44% at 2560x1440). It now takes 80% of the
  viewport on large screens, keeping the old capped size purely as a
  small-window floor.

- Pressing Enter on a filtered search result selected the item deep in
  the settings tree but left the item list at scrollTop 0 (the TUI
  windows rows with the core's scroll offset; the web renders the full
  list in overflow:auto panels and only snapshot/restores scrollTop
  across rebuilds). After each settings region rebuild the selected
  row is now nudged into view when it falls outside its panel, which
  also covers arrow-key navigation past the fold, the category column,
  search-result navigation, and the entry-dialog overlay.

Adds three drive.mjs regression assertions (modal >= ~80% of viewport,
search mode activation, search jump lands with the selected item
visible) and refreshes the stale suite assertion count in the README.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U4CRcpZCqhJk9Tt2x9fX6r