### PR TITLE
perf(compose): evaluate cursor reveal at render time, not via marker rebuild

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2450,6 +2450,31 @@ pub enum WidgetMutation {
     SetFocusKey { widget_key: String },
 }
 
+/// Cursor-dependent activation rule for a conceal range or soft break.
+///
+/// Lets a plugin emit *both* renderings of a cursor-revealable decoration
+/// once (e.g. markdown_compose's concealed markup plus its cursor-row
+/// variant) and have the renderer pick per frame based on where the
+/// cursors are — instead of deleting and recreating markers on every
+/// cursor move, which invalidates the whole line-wrap cache and
+/// visual-row index (the compose-mode arrow-key lag).
+///
+/// The scope is a half-open byte range `[scope_start, scope_end)`
+/// evaluated against the rendering split's cursor positions. Absolute at
+/// emission time; the editor stores it relative to the decoration's own
+/// marker so it shifts with edits elsewhere in the buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct MarkerActivation {
+    /// `true`: active only while a cursor IS inside the scope
+    /// (`if-cursor-in`). `false`: active only while NO cursor is inside
+    /// the scope (`unless-cursor-in`).
+    pub if_cursor_in: bool,
+    /// Scope start byte (absolute, at emission time).
+    pub scope_start: usize,
+    /// Scope end byte, exclusive (absolute, at emission time).
+    pub scope_end: usize,
+}
+
 /// Plugin command - allows plugins to send commands to the editor
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
@@ -2973,6 +2998,9 @@ pub enum PluginCommand {
         /// verbatim.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         epoch: Option<u64>,
+        /// Optional cursor-dependent activation rule. `None` = always active.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<MarkerActivation>,
     },
 
     /// Clear all conceal ranges in a namespace
@@ -3056,6 +3084,9 @@ pub enum PluginCommand {
         /// from a lagged hook lands at the row's current bytes. `None` = verbatim.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         epoch: Option<u64>,
+        /// Optional cursor-dependent activation rule. `None` = always active.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        activation: Option<MarkerActivation>,
     },
 
     /// Clear all soft breaks in a namespace

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -922,17 +922,18 @@ type OverlayOptions = {
 	*/
 	extendToLineEnd: boolean;
 	/**
+	* Whether to render with reverse video (fg/bg swapped). Used for
+	* block-style text carets in form controls, where a hardware
+	* cursor isn't available (modal overlays).
+	*/
+	reversed: boolean;
+	/**
 	* When `true`, `fg` is applied only on cells whose existing fg
 	* matches this overlay's resolved bg — i.e. a same-colour fg/bg
 	* collision. Lets a row-wide overlay stay legible on tokens that
 	* share the bg's colour without repainting unrelated tokens.
 	*/
 	fgOnCollisionOnly: boolean;
-	/**
-	* Whether to render reverse-video (swap fg/bg). Modal surfaces use
-	* this for the block caret and selection cells.
-	*/
-	reversed: boolean;
 	/**
 	* Optional URL for OSC 8 terminal hyperlinks.
 	* When set, the overlay text becomes a clickable hyperlink in terminals
@@ -1080,20 +1081,25 @@ type WidgetSpec = {
 	label: string;
 	focused: boolean;
 	/**
-	* Neither checked nor unchecked: renders a neutral `[-]` chip
-	* for an unset value that inherits from a lower config layer.
+	* Neither checked nor unchecked: renders a neutral `[-]` chip.
+	* Used for values that are unset and inherit from a lower
+	* config layer (issue #2345) — a definite `[ ]` would read as
+	* "the user turned this off". Defaults to `false`.
 	*/
-	indeterminate?: boolean;
+	indeterminate: boolean;
 	/**
-	* Form layout `label: [v]` (chip after the label; only the
-	* chip is clickable). Default chip-first `[v] label`.
+	* Form-style layout: render `label: [v]` (label first, chip
+	* after) instead of the default `[v] label`. In this layout
+	* the toggle's hit area covers only the chip, so clicks on
+	* the label don't flip the value. Defaults to `false`.
 	*/
-	labelFirst?: boolean;
+	labelFirst: boolean;
 	/**
-	* Pad the label to this display width in `labelFirst` layout
-	* so a column of controls aligns. `0` = no padding.
+	* Pad the label to this display width in `label_first`
+	* layout so a column of controls aligns their chips. `0` =
+	* no padding. Defaults to `0`.
 	*/
-	labelWidth?: number;
+	labelWidth: number;
 	key?: string | null;
 } | {
 	"kind": "number";
@@ -1141,17 +1147,24 @@ type WidgetSpec = {
 	* Pad the label to this display width so a column of
 	* controls aligns their value cells. `0` = no padding.
 	*/
-	labelWidth?: number;
+	labelWidth: number;
 	/**
-	* In-place edit buffer: when set, the cell renders this text
-	* (with caret / selection) instead of the formatted value.
+	* In-place edit buffer. `Some` = the value is being edited:
+	* the cell renders this text (with caret / selection) instead
+	* of the formatted value. `None` = display mode.
 	*/
 	editText?: string | null;
-	/** Byte offset of the edit caret in `editText` (`-1` none). */
-	editCursor?: number;
-	/** Selection byte range in `editText` (`-1` = none). */
-	editSelStart?: number;
-	editSelEnd?: number;
+	/**
+	* Byte offset of the edit caret within `edit_text`. `-1` =
+	* no caret (ignored unless `edit_text` is `Some`).
+	*/
+	editCursor: number;
+	/**
+	* Selection byte range within `edit_text` (`start`, `end`).
+	* `-1` for either end = no selection.
+	*/
+	editSelStart: number;
+	editSelEnd: number;
 	key?: string | null;
 } | {
 	"kind": "dropdown";
@@ -1179,17 +1192,18 @@ type WidgetSpec = {
 	* Pad the label to this display width so a column of
 	* controls aligns their value buttons. `0` = no padding.
 	*/
-	labelWidth?: number;
+	labelWidth: number;
 	/**
 	* Whether the option list is expanded inline below the value
-	* button (`▲` arrow + one row per visible option).
+	* button (`▲` arrow + one row per visible option). Closed
+	* (`▼`) by default.
 	*/
-	open?: boolean;
+	open: boolean;
 	/**
 	* First visible option row when `open` and the list is
-	* taller than its window.
+	* taller than its window. Defaults to `0`.
 	*/
-	scrollOffset?: number;
+	scrollOffset: number;
 	key?: string | null;
 } | {
 	"kind": "dualList";
@@ -1418,27 +1432,34 @@ type WidgetSpec = {
 	*/
 	completionsVisibleRows: number;
 	/**
-	* Paint the caret as a REVERSED block cell inside the row (in
-	* addition to the hardware-cursor position) — used by modal
-	* form surfaces where a hardware cursor isn't visible.
+	* Paint the caret as a REVERSED block cell inside the row
+	* (in addition to publishing the hardware-cursor position).
+	* Modal form surfaces (e.g. Settings) use this — a hardware
+	* cursor isn't shown over a modal, so the block cell is the
+	* only visible caret. Defaults to `false`.
 	*/
-	blockCaret?: boolean;
+	blockCaret: boolean;
 	/**
 	* Selection byte range within `value` (`start`, `end`), shown
-	* with the selection background while focused. `-1` for either
-	* end = no selection. Seed-only, like `cursorByte`.
+	* with the selection background while the widget is focused.
+	* `-1` for either end = no selection. Seed-only, like
+	* `cursor_byte`: once host-owned instance state exists, the
+	* editor's own selection wins. Mirrors `Number`'s
+	* `edit_sel_start`/`edit_sel_end`.
 	*/
-	selStart?: number;
-	selEnd?: number;
+	selStart: number;
+	selEnd: number;
 	/**
 	* Form label-column width. When `> 0` (and `label` is set) the
-	* single-line field pads the label to this column and separates it
-	* from the value with `: `, so a column of `text`, `toggle`,
-	* `number`, and `dropdown` controls aligns their value cells. `0`
-	* (default) keeps the compact `label [value]` form. Clamped to keep
-	* the cell on-screen on narrow surfaces.
+	* single-line field pads the label to this column and separates
+	* it from the value with `: `, so a column of `Text`, `Toggle`,
+	* `Number`, and `Dropdown` controls aligns their value cells
+	* (the Settings entry dialog sets it to the page's max label
+	* width). `0` (default) keeps the compact `label [value]` form
+	* plugins get by default. Clamped to keep the cell on-screen on
+	* narrow surfaces.
 	*/
-	labelWidth?: number;
+	labelWidth: number;
 	key?: string | null;
 } | {
 	"kind": "labeledSection";
@@ -2790,9 +2811,17 @@ interface EditorAPI {
 	*/
 	removeOverlay(bufferId: number, handle: string): boolean;
 	/**
-	* Add a conceal range that hides or replaces a byte range during rendering
+	* Add a conceal range that hides or replaces a byte range during rendering.
+	* 
+	* `activation` optionally makes the conceal cursor-dependent:
+	* `"unless-cursor-in"` (active only while no cursor is inside
+	* `[scopeStart, scopeEnd)`) or `"if-cursor-in"` (active only while a
+	* cursor IS inside it). Emitting both renderings of a
+	* cursor-revealable decoration once — instead of rebuilding markers
+	* on every cursor move — is what keeps cursor movement free of
+	* marker churn (and of the cache invalidation it causes).
 	*/
-	addConceal(bufferId: number, namespace: string, start: number, end: number, replacement: string | null): boolean;
+	addConceal(bufferId: number, namespace: string, start: number, end: number, replacement: string | null, activation?: string, scopeStart?: number, scopeEnd?: number): boolean;
 	/**
 	* Clear all conceal ranges in a namespace
 	*/
@@ -2848,9 +2877,12 @@ interface EditorAPI {
 	*/
 	setFoldingRanges(bufferId: number, rangesArr: Record<string, unknown>[]): boolean;
 	/**
-	* Add a soft break point for marker-based line wrapping
+	* Add a soft break point for marker-based line wrapping.
+	* 
+	* `activation` optionally makes the break cursor-dependent — same
+	* semantics as `addConceal`'s activation parameters.
 	*/
-	addSoftBreak(bufferId: number, namespace: string, position: number, indent: number): boolean;
+	addSoftBreak(bufferId: number, namespace: string, position: number, indent: number, activation?: string, scopeStart?: number, scopeEnd?: number): boolean;
 	/**
 	* Clear all soft breaks in a namespace
 	*/

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -598,7 +598,6 @@ function enableMarkdownCompose(bufferId: number): void {
 // Disable compose mode for a buffer
 function disableMarkdownCompose(bufferId: number): void {
   if (isComposing(bufferId)) {
-    editor.setViewState(bufferId, "last-cursor-line", null);
     // Clear all table border virtual lines (one shared namespace) so the frame
     // can't linger as orphaned virtual lines after compose is toggled off, and
     // drop the per-table width memos.
@@ -1069,33 +1068,42 @@ function wrapText(text: string, width: number): string[] {
 
 /**
  * Process a single line: add overlays (emphasis, link styling) and conceals
- * (hide markdown syntax markers). Cursor-aware: when cursor is inside a span,
- * markers are revealed instead of concealed.
+ * (hide markdown syntax markers).
+ *
+ * Cursor-dependent rendering (revealing the markup under the cursor,
+ * un-truncating the table row the cursor is on) is expressed as *activation
+ * scopes* on the markers themselves — for each cursor-revealable decoration
+ * this pass emits the concealed variant tagged `unless-cursor-in` and, where
+ * the cursor-row rendering differs, a counterpart tagged `if-cursor-in`.
+ * The renderer picks per frame from the live cursor positions, so this pass
+ * runs only when *content* changes — never on cursor movement. That is what
+ * keeps arrow-key navigation free of marker churn (and of the whole-buffer
+ * cache invalidation it used to cause).
  */
 function processLineConceals(
   bufferId: number,
   lineContent: string,
   byteStart: number,
   byteEnd: number,
-  cursors: number[],
   lineNumber?: number,
 ): void {
   // Clear existing conceals and overlays for this line first.
   // This ensures clear+add commands are sent together from the plugin thread
   // and processed atomically in the same process_commands() batch, avoiding
   // the one-frame glitch where conceals are cleared but not yet rebuilt.
-  editor.debug(`[mc] processLine clear+rebuild bytes=${byteStart}..${byteEnd} content="${lineContent.slice(0,40)}"`);
   editor.clearConcealsInRange(bufferId, byteStart, byteEnd);
   // Only clear our own emphasis overlays — clearing ALL overlays in the range
   // would also wipe editor-owned overlays like LSP diagnostics (issue #2146).
   editor.clearOverlaysInRangeForNamespace(bufferId, "md-emphasis", byteStart, byteEnd);
 
-  const cursorOnLine = cursors.some(c => c >= byteStart && c <= byteEnd);
-  // Strict version: excludes the boundary at byteEnd so that the cursor
-  // sitting at the start of the *next* line doesn't count as being on
-  // *this* line.  Used for table row auto-expose to avoid exposing the
-  // previous row's emphasis markers.
-  const cursorStrictlyOnLine = cursors.some(c => c >= byteStart && c < byteEnd);
+  // Activation scopes:
+  //   - lineScopeInclEnd: "cursor anywhere on the line", including the
+  //     boundary position at byteEnd — a cursor sitting at the start of the
+  //     next line still reveals this line (matches the old `c <= byteEnd`).
+  //   - lineScopeStrictEnd: excludes byteEnd; used for table rows so a
+  //     cursor at the start of the next row doesn't expose this one.
+  const lineScopeInclEnd = byteEnd + 1;
+  const lineScopeStrictEnd = byteEnd;
 
   // Skip lines inside code fences (we'd need multi-line context for this;
   // for now, detect fence lines and code content lines)
@@ -1103,10 +1111,10 @@ function processLineConceals(
   if (trimmed.startsWith('```')) return; // fence line itself
 
   // --- Table row handling ---
-  // Always apply table conceals even when cursor is on the line.
-  // Tables are structural: pipes → box-drawing, cells padded for alignment.
-  // Toggling conceals on/off per cursor line causes visual width shifts that
-  // break cursor navigation (stuck cursor, ghost cursors) and lose alignment.
+  // Table conceals apply even when the cursor is on the line (pipes stay
+  // box-drawing). Tables are structural: pipes → box-drawing, cells padded
+  // for alignment. Only *cell padding* and *truncation/wrapping* differ on
+  // the cursor row, and those are emitted as unless/if-cursor-in pairs.
   const truncatedByteRanges: Array<{start: number; end: number}> = [];
   let isTableRow = false;
   if (trimmed.startsWith('|') || trimmed.endsWith('|')) {
@@ -1123,15 +1131,21 @@ function processLineConceals(
     if (inner.endsWith('|')) inner = inner.slice(0, -1);
     const cells = inner.split('|');
 
-    // Check if any data cell needs multi-line wrapping
+    // Pipe char positions, shared by truncation and both padding variants.
+    const pipePositions: number[] = [];
+    for (let i = 0; i < lineContent.length; i++) {
+      if (lineContent[i] === '|') pipePositions.push(i);
+    }
+
+    // Check if any data cell needs multi-line wrapping (concealed widths —
+    // the wrapped rendering is the cursor-OFF variant).
     let handledByWrapping = false;
-    if (colWidths && !isSeparator && !cursorStrictlyOnLine) {
+    if (colWidths && !isSeparator) {
       const numCols = Math.min(cells.length, colWidths.length);
       const cellWrapped: string[][] = [];
       let maxVisualLines = 1;
       for (let ci = 0; ci < numCols; ci++) {
-        // When cursor is on the row, use raw text (emphasis markers revealed).
-        const cellText = cursorStrictlyOnLine ? cells[ci].trim() : concealedText(cells[ci]).trim();
+        const cellText = concealedText(cells[ci]).trim();
         const wrapW = Math.max(1, colWidths[ci] - 2); // 1 leading + 1 trailing space margin
         const wrapped = wrapText(cellText, wrapW);
         cellWrapped.push(wrapped);
@@ -1187,30 +1201,46 @@ function processLineConceals(
         for (let vl = 0; vl < actualVisualLines; vl++) {
           const sByteS = charToByte(lineContent, segStarts[vl], byteStart);
           const sByteE = charToByte(lineContent, segEnds[vl], byteStart);
-          editor.addConceal(bufferId, "md-syntax", sByteS, sByteE, visualLines[vl] || '');
+          editor.addConceal(
+            bufferId, "md-syntax", sByteS, sByteE, visualLines[vl] || '',
+            "unless-cursor-in", byteStart, lineScopeStrictEnd,
+          );
         }
         handledByWrapping = true;
+
+        // Cursor-ON variant: the row the cursor is on renders as a plain
+        // single-line row — raw text, raw-width padding, no wrapping — so
+        // its full content stays editable.
+        let pipeIdx = 0;
+        for (let i = 0; i < lineContent.length; i++) {
+          if (lineContent[i] !== '|') continue;
+          const pipeByte = charToByte(lineContent, i, byteStart);
+          const pipeByteEnd = charToByte(lineContent, i + 1, byteStart);
+          let padOn = "";
+          const cellIdx = pipeIdx - 1;
+          if (pipeIdx > 0 && cellIdx < cells.length && cellIdx < colWidths.length) {
+            const rawW = displayWidth(cells[cellIdx]);
+            if (rawW <= colWidths[cellIdx]) {
+              padOn = " ".repeat(colWidths[cellIdx] - rawW);
+            }
+          }
+          editor.addConceal(
+            bufferId, "md-syntax", pipeByte, pipeByteEnd, padOn + "│",
+            "if-cursor-in", byteStart, lineScopeStrictEnd,
+          );
+          pipeIdx++;
+        }
       }
     }
 
     if (!handledByWrapping) {
-      // Find pipe positions for byte-range computation of truncated cells
-      const pipePositions: number[] = [];
-      for (let i = 0; i < lineContent.length; i++) {
-        if (lineContent[i] === '|') pipePositions.push(i);
-      }
-
-      // Precompute which cells will be truncated. Per-character conceals
-      // that land inside a truncated cell must be suppressed — the cell-
-      // wide truncate conceal already renders the replacement. When both
-      // fire, the per-char conceal at the cell's first byte emits its
-      // replacement, and the cell-wide conceal emits its replacement one
-      // byte later, producing a cell one character wider than allocated.
+      // Precompute which cells the cursor-off state truncates (concealed
+      // width exceeds the allocation), so the '-' substitution pass —
+      // which visits a cell's chars BEFORE its closing pipe — can tell.
       const truncatedCellCharRanges: Array<{start: number; end: number}> = [];
-      if (!cursorStrictlyOnLine && colWidths) {
+      if (colWidths) {
         for (let ci = 0; ci < Math.min(cells.length, colWidths.length); ci++) {
-          const cellText = concealedText(cells[ci]);
-          if (displayWidth(cellText) > colWidths[ci]) {
+          if (displayWidth(concealedText(cells[ci])) > colWidths[ci]) {
             const prevPipe = pipePositions[ci];
             const nextPipe = pipePositions[ci + 1];
             if (prevPipe !== undefined && nextPipe !== undefined) {
@@ -1227,8 +1257,8 @@ function processLineConceals(
           const pipeByte = charToByte(lineContent, i, byteStart);
           const pipeByteEnd = charToByte(lineContent, i + 1, byteStart);
 
-          // Compute padding (and, off the cursor row, truncation) for the cell
-          // that just ended.
+          // Compute padding for the cell that just ended, in both cursor
+          // states.
           //
           // Columns are sized to the widest *raw* cell, so a row only aligns
           // when its rendered cell is padded out to that width. The row the
@@ -1239,57 +1269,87 @@ function processLineConceals(
           // glitch). Trailing padding never hides content, so it is safe on the
           // cursor row; we still skip *truncation* there so a too-wide cell
           // stays fully visible for editing.
-          let padding = "";
+          let padOff = ""; // cursor elsewhere: concealed text width
+          let padOn = ""; // cursor on this row: raw text width
           const cellIdx = pipeIdx - 1;
           if (colWidths && pipeIdx > 0 && cellIdx < cells.length && cellIdx < colWidths.length) {
-            // The cursor row shows raw text (markers revealed), so measure its
-            // raw width; every other row shows concealed text.
-            const cellText = cursorStrictlyOnLine ? cells[cellIdx] : concealedText(cells[cellIdx]);
-            const cellWidth = displayWidth(cellText);
+            const offText = concealedText(cells[cellIdx]);
+            const offWidth = displayWidth(offText);
+            const rawWidth = displayWidth(cells[cellIdx]);
             const allocatedWidth = colWidths[cellIdx];
 
-            if (cellWidth > allocatedWidth) {
-              if (!cursorStrictlyOnLine) {
-                // Truncate: conceal entire cell content and replace with truncated text.
-                // Separator rows use box-drawing ─ to match the non-truncated path
-                // (per-char conceals replace source `-` with ─ and pad via pipe replacement).
-                const prevPipeCharPos = pipePositions[pipeIdx - 1];
-                const cellByteStart = charToByte(lineContent, prevPipeCharPos + 1, byteStart);
-                const cellByteEnd = pipeByte;
-                const truncated = isSeparator
-                  ? '─'.repeat(allocatedWidth)
-                  : cellText.slice(0, allocatedWidth - 1) + '-';
-                editor.addConceal(bufferId, "md-syntax", cellByteStart, cellByteEnd, truncated);
-                truncatedByteRanges.push({start: cellByteStart, end: cellByteEnd});
-              }
-              // On the cursor row a too-wide cell is left raw (no padding, no
-              // truncation) so its full content stays editable.
+            if (offWidth > allocatedWidth) {
+              // Truncate (cursor-off only): conceal entire cell content and
+              // replace with truncated text. Separator rows use box-drawing ─
+              // to match the non-truncated path (per-char conceals replace
+              // source `-` with ─ and pad via pipe replacement).
+              const prevPipeCharPos = pipePositions[pipeIdx - 1];
+              const cellByteStart = charToByte(lineContent, prevPipeCharPos + 1, byteStart);
+              const cellByteEnd = pipeByte;
+              const truncated = isSeparator
+                ? '─'.repeat(allocatedWidth)
+                : offText.slice(0, allocatedWidth - 1) + '-';
+              editor.addConceal(
+                bufferId, "md-syntax", cellByteStart, cellByteEnd, truncated,
+                "unless-cursor-in", byteStart, lineScopeStrictEnd,
+              );
+              truncatedByteRanges.push({start: cellByteStart, end: cellByteEnd});
+              // padOff stays "" — the truncate conceal fills the cell.
             } else {
-              const padCount = allocatedWidth - cellWidth;
+              const padCount = allocatedWidth - offWidth;
               if (padCount > 0) {
-                padding = isSeparator ? "─".repeat(padCount) : " ".repeat(padCount);
+                padOff = isSeparator ? "─".repeat(padCount) : " ".repeat(padCount);
               }
             }
+            if (rawWidth <= allocatedWidth) {
+              const padCount = allocatedWidth - rawWidth;
+              if (padCount > 0) {
+                padOn = isSeparator ? "─".repeat(padCount) : " ".repeat(padCount);
+              }
+            }
+            // rawWidth > allocatedWidth: the cursor row keeps the too-wide
+            // cell raw (no padding, no truncation) so it stays editable.
           }
 
+          let glyph = "│";
           if (isSeparator) {
             const pipeIndex = lineContent.substring(0, i + 1).split('|').length - 1;
             const totalPipes = lineContent.split('|').length - 1;
-            let replacement = '┼';
-            if (pipeIndex === 1) replacement = '├';
-            else if (pipeIndex === totalPipes) replacement = '┤';
-            editor.addConceal(bufferId, "md-syntax", pipeByte, pipeByteEnd, padding + replacement);
+            glyph = '┼';
+            if (pipeIndex === 1) glyph = '├';
+            else if (pipeIndex === totalPipes) glyph = '┤';
+          }
+          if (padOff === padOn) {
+            // Same rendering in both cursor states — one always-active conceal.
+            editor.addConceal(bufferId, "md-syntax", pipeByte, pipeByteEnd, padOff + glyph);
           } else {
-            editor.addConceal(bufferId, "md-syntax", pipeByte, pipeByteEnd, padding + "│");
+            editor.addConceal(
+              bufferId, "md-syntax", pipeByte, pipeByteEnd, padOff + glyph,
+              "unless-cursor-in", byteStart, lineScopeStrictEnd,
+            );
+            editor.addConceal(
+              bufferId, "md-syntax", pipeByte, pipeByteEnd, padOn + glyph,
+              "if-cursor-in", byteStart, lineScopeStrictEnd,
+            );
           }
           pipeIdx++;
         } else if (isSeparator && lineContent[i] === '-') {
-          // Skip per-character conceals that land inside a truncated cell;
-          // the cell-wide truncate conceal already handles the rendering.
+          // Per-character conceals inside a truncated cell are suppressed in
+          // the cursor-off state — the cell-wide truncate conceal already
+          // renders the replacement; if both fired, the cell would come out
+          // one character wider than allocated. On the cursor row the cell is
+          // raw (no truncate conceal), so the ─ substitution applies there.
           const inTruncated = truncatedCellCharRanges.some(r => i >= r.start && i < r.end);
-          if (inTruncated) continue;
           const db = charToByte(lineContent, i, byteStart);
-          editor.addConceal(bufferId, "md-syntax", db, charToByte(lineContent, i + 1, byteStart), "─");
+          const de = charToByte(lineContent, i + 1, byteStart);
+          if (inTruncated) {
+            editor.addConceal(
+              bufferId, "md-syntax", db, de, "─",
+              "if-cursor-in", byteStart, lineScopeStrictEnd,
+            );
+          } else {
+            editor.addConceal(bufferId, "md-syntax", db, de, "─");
+          }
         }
       }
     }
@@ -1299,12 +1359,17 @@ function processLineConceals(
   }
 
   // --- Image links: ![alt](url) → "Image: alt — url" ---
+  // The concealed banner deactivates while the cursor is on the line, which
+  // leaves the raw `![alt](url)` markup visible for editing.
   const imageRe = /^!\[([^\]]*)\]\(([^)]+)\)$/;
   const imageMatch = trimmed.match(imageRe);
-  if (imageMatch && !cursorOnLine) {
+  if (imageMatch) {
     const alt = imageMatch[1];
     const url = imageMatch[2];
-    editor.addConceal(bufferId, "md-syntax", byteStart, byteEnd, `Image: ${alt} — ${url}`);
+    editor.addConceal(
+      bufferId, "md-syntax", byteStart, byteEnd, `Image: ${alt} — ${url}`,
+      "unless-cursor-in", byteStart, lineScopeInclEnd,
+    );
     return;
   }
 
@@ -1348,24 +1413,24 @@ function processLineConceals(
       // entities: no overlay
     }
 
-    // Conceals (cursor-aware).
-    // For table rows: skip ALL emphasis conceals when cursor is on the line,
-    // not just the span the cursor is in. This "auto-expose entire row"
-    // approach keeps the row layout consistent with the raw-text-based
-    // column widths, preventing overflow/wrapping.
-    const cursorInSpan = cursors.some(c => c >= byteMS && c <= byteME);
-    const skipConceal = (isTableRow && cursorStrictlyOnLine) || cursorInSpan;
-    if (!skipConceal) {
-      for (const range of span.concealRanges) {
-        const rStart = charToByte(lineContent, range.start, byteStart);
-        const rEnd = charToByte(lineContent, range.end, byteStart);
-        editor.addConceal(bufferId, "md-syntax", rStart, rEnd, range.replacement);
-      }
+    // Conceals deactivate while a cursor is inside their reveal scope.
+    // For table rows the scope is the whole line ("auto-expose entire row"):
+    // this keeps the row layout consistent with the raw-text-based column
+    // widths, preventing overflow/wrapping. For other lines the scope is the
+    // span itself, so only the markup under the cursor is revealed.
+    const scopeStart = isTableRow ? byteStart : byteMS;
+    const scopeEnd = isTableRow ? lineScopeStrictEnd : byteME + 1;
+    for (const range of span.concealRanges) {
+      const rStart = charToByte(lineContent, range.start, byteStart);
+      const rEnd = charToByte(lineContent, range.end, byteStart);
+      editor.addConceal(
+        bufferId, "md-syntax", rStart, rEnd, range.replacement,
+        "unless-cursor-in", scopeStart, scopeEnd,
+      );
     }
   }
 }
 
-// Last cursor line is tracked per-buffer-per-split via setViewState/getViewState
 
 // Track viewport width per buffer for resize detection
 let lastViewportWidth = 0;
@@ -1384,7 +1449,6 @@ function processLineSoftBreaks(
   lineContent: string,
   byteStart: number,
   byteEnd: number,
-  cursors: number[],
   lineNumber?: number,
 ): void {
   // Clear existing soft breaks for this line range
@@ -1406,15 +1470,20 @@ function processLineSoftBreaks(
                  block.type === 'heading' || block.type === 'image' ||
                  block.type === 'empty';
 
-  // Image blocks: add a trailing blank line for visual separation when concealed
+  // Image blocks: add a trailing blank line for visual separation when
+  // concealed. Deactivates while the cursor is on the line (same scope as
+  // the image conceal), where the raw markup shows instead.
   if (block.type === 'image') {
-    const cursorOnLine = cursors.some(c => c >= byteStart && c <= byteEnd);
-    if (!cursorOnLine) {
-      editor.addSoftBreak(bufferId, "md-wrap", byteEnd - 1, 0);
-    }
+    editor.addSoftBreak(
+      bufferId, "md-wrap", byteEnd - 1, 0,
+      "unless-cursor-in", byteStart, byteEnd + 1,
+    );
   }
 
-  // Table row wrapping: add soft breaks for multi-line cells
+  // Table row wrapping: add soft breaks for multi-line cells. Computed from
+  // concealed cell widths — the cursor-OFF rendering. The breaks deactivate
+  // while the cursor is on the row (strict scope, matching the segment
+  // conceals), where the row renders as a plain single line.
   if (block.type === 'table-row') {
     const trimmedLine = lineContent.trim();
     const isSep = /^\|[-:\s|]+\|$/.test(trimmedLine);
@@ -1427,9 +1496,8 @@ function processLineSoftBreaks(
         const tableCells = innerLine.split('|');
         let maxVisualLines = 1;
         const numCols = Math.min(tableCells.length, colWidths.length);
-        const cursorOnTableLine = cursors.some(c => c >= byteStart && c < byteEnd);
         for (let ci = 0; ci < numCols; ci++) {
-          const cellText = cursorOnTableLine ? tableCells[ci].trim() : concealedText(tableCells[ci]).trim();
+          const cellText = concealedText(tableCells[ci]).trim();
           const wrapW = Math.max(1, colWidths[ci] - 2);
           const wrapped = wrapText(cellText, wrapW);
           maxVisualLines = Math.max(maxVisualLines, wrapped.length);
@@ -1450,7 +1518,10 @@ function processLineSoftBreaks(
           const breakChars = spacePositions.slice(0, maxVisualLines - 1);
           for (const charPos of breakChars) {
             const breakBytePos = byteStart + editor.utf8ByteLength(lineContent.slice(0, charPos));
-            editor.addSoftBreak(bufferId, "md-wrap", breakBytePos, 0);
+            editor.addSoftBreak(
+              bufferId, "md-wrap", breakBytePos, 0,
+              "unless-cursor-in", byteStart, byteEnd,
+            );
           }
         }
       }
@@ -1637,9 +1708,6 @@ function computeRowWidths(bufferId: number, lines: LineInfoLike[]): boolean {
 // after_delete: no-op for conceals/overlays (same reasoning as after_insert).
 
 
-// cursor_moved: update cursor-aware reveal/conceal for old and new cursor lines
-
-
 // view_transform_request is no longer needed — soft wrapping is handled by
 // marker-based soft breaks (computed in lines_changed), and layout hints
 // are set directly via setLayoutHints. This eliminates the one-frame flicker
@@ -1659,14 +1727,11 @@ function computeRowWidths(bufferId: number, lines: LineInfoLike[]): boolean {
 // Register hooks
 editor.on("lines_changed", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
-  const lineNums = data.lines.map(l => `${l.line_number}(${l.byte_start}..${l.byte_end})`).join(', ');
-  editor.debug(`[mc] lines_changed: ${data.lines.length} lines: [${lineNums}]`);
-  // Only use cursor positions for reveal/conceal decisions when the active
-  // split is in compose mode.  When a source-mode split is active, the cursor
-  // lives in that source view — it should NOT trigger "reveal" (skip-conceal)
-  // in the compose-mode split, because conceals are buffer-level decorations
-  // shared across splits.
-  const cursors = isComposing(data.buffer_id) ? [editor.getCursorPosition()] : [];
+  // Cursor reveal/conceal decisions are NOT made here: every emitted
+  // decoration carries an activation scope and the renderer evaluates it
+  // per frame against each split's own cursors. This handler runs only
+  // when content changes — cursor movement re-renders with the existing
+  // markers, so navigating never rebuilds anything.
 
   // Column widths for every table row in this batch (uniform per table, via the
   // grow-only memo). If a wider row scrolled into view and grew a table's
@@ -1691,8 +1756,8 @@ editor.on("lines_changed", (data) => {
     // off by the async lag).
     clearRowBorders(data.buffer_id, line.byte_start, line.byte_end);
 
-    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, cursors, line.line_number);
-    processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, cursors, line.line_number);
+    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, line.line_number);
+    processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, line.line_number);
 
     if (isTableRowContent(line.content)) {
       const widths = currentRowWidths.get(line.byte_start) ?? [];
@@ -1743,24 +1808,12 @@ editor.on("after_delete", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
   resetEditedTableWidths(data.buffer_id, data.affected_start, data.affected_start);
 });
-editor.on("cursor_moved", (data) => {
-  if (!isComposingInAnySplit(data.buffer_id)) return;
-
-  const prevLine = editor.getViewState(data.buffer_id, "last-cursor-line") as number | undefined;
-  editor.setViewState(data.buffer_id, "last-cursor-line", data.line);
-
-  editor.debug(`[mc] cursor_moved: old_pos=${data.old_position} new_pos=${data.new_position} line=${data.line} prevLine=${prevLine}`);
-
-  // Refresh all visible lines so span-level auto-expose (revealing the markup
-  // the cursor sits on) and table-row un/re-wrap stay consistent across the
-  // whole viewport, including intra-line moves.
-  //
-  // This re-fires `lines_changed` for the viewport. Tables are emitted per line
-  // (clear+rebuild each row's conceals and border frame from the live event),
-  // so repeated refreshes are idempotent and the frame stays correct no matter
-  // how often the cursor moves.
-  editor.refreshLines(data.buffer_id);
-});
+// cursor_moved: no handler. Cursor-dependent reveal/conceal and table-row
+// un/re-wrap are baked into the markers as activation scopes (emitted in the
+// lines_changed pass above) and evaluated by the renderer per frame — cursor
+// movement changes what's *active* without touching any marker, so it never
+// re-fires lines_changed, never bumps the conceal/soft-break versions, and
+// never invalidates the line-wrap cache or visual-row index.
 // view_transform_request hook no longer needed — wrapping is handled by soft breaks
 editor.on("buffer_closed", (data) => {
   // View state is cleaned up automatically when the buffer is removed from keyed_states

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -599,7 +599,6 @@ impl Editor {
         let buffer_id = self.active_buffer();
 
         // Convert event to hook args and fire the appropriate hook
-        let mut cursor_changed_lines = false;
         let hook_args = match event {
             Event::Insert { position, text, .. } => {
                 let insert_position = *position;
@@ -732,9 +731,7 @@ impl Editor {
                 ..
             } => {
                 // Get line numbers for old and new positions (1-indexed for plugins)
-                let old_line = self.active_state().buffer.get_line_number(*old_position) + 1;
                 let line = self.active_state().buffer.get_line_number(*new_position) + 1;
-                cursor_changed_lines = old_line != line;
                 let text_props = self
                     .active_state()
                     .text_properties
@@ -771,35 +768,34 @@ impl Editor {
                 .run_hook(hook_name, args.clone());
         }
 
-        // After inter-line cursor_moved, proactively refresh lines so
-        // cursor-dependent conceals (e.g. emphasis auto-expose in compose
-        // mode tables) update in the same frame. Without this, there's a
-        // one-frame lag: the cursor_moved hook fires async to the plugin
-        // which calls refreshLines() back, but that round-trip means the
-        // first render after the cursor move still shows stale conceals.
+        // Cursor movement needs NO refresh here: cursor-dependent conceals
+        // and soft breaks carry activation scopes evaluated at render time
+        // (see view/activation.rs), so the very next frame picks up the
+        // reveal without any marker churn or plugin round-trip. Refreshing
+        // the viewport on every inter-line move used to clear
+        // `seen_byte_ranges`, re-fire `lines_changed` for all visible
+        // lines, and rebuild every conceal/soft-break marker — bumping the
+        // manager versions and invalidating the whole `LineWrapCache` and
+        // `VisualRowIndex` per keypress (the compose-mode arrow-key lag).
         //
-        // Only refresh on inter-line movement: intra-line moves (e.g.
-        // Left/Right within a row) don't change which row is auto-exposed,
-        // and the plugin's async refreshLines() handles span-level changes.
-        //
-        // A structure-changing edit (a newline inserted or deleted) needs the
-        // same full refresh, for a subtler reason: it renumbers every row below
-        // it, but the per-edit `seen_byte_ranges` invalidation only drops the
-        // single line containing the edit point — every other row merely shifts
-        // and stays "seen", so it never re-fires `lines_changed`. A per-line
-        // decoration plugin (markdown_compose's table borders / conceals) then
-        // leaves the prior frame's decorations in place, scattered across the
-        // buffer versions they were last emitted at. During an Insert/Delete
-        // storm (which emits no MoveCursor events at all) nothing ever forces a
-        // complete re-fire, so the stale decorations pile up and persist until
-        // the user happens to make an explicit cursor move. Clearing seen here
-        // gives every such edit one consistent, whole-viewport re-fire — the
-        // same convergence an inter-line cursor move already gets. Intra-line
-        // edits (no line-count change) stay on the cheap path: the edited
-        // line's own invalidation re-fires it, which is sufficient.
+        // A structure-changing edit (a newline inserted or deleted) still
+        // needs a full refresh, for a subtler reason: it renumbers every row
+        // below it, but the per-edit `seen_byte_ranges` invalidation only
+        // drops the single line containing the edit point — every other row
+        // merely shifts and stays "seen", so it never re-fires
+        // `lines_changed`. A per-line decoration plugin (markdown_compose's
+        // table borders / conceals) then leaves the prior frame's decorations
+        // in place, scattered across the buffer versions they were last
+        // emitted at. During an Insert/Delete storm (which emits no
+        // MoveCursor events at all) nothing ever forces a complete re-fire,
+        // so the stale decorations pile up and persist. Clearing seen here
+        // gives every such edit one consistent, whole-viewport re-fire.
+        // Intra-line edits (no line-count change) stay on the cheap path:
+        // the edited line's own invalidation re-fires it, which is
+        // sufficient.
         let edit_changed_line_count = matches!(event, Event::Insert { .. } | Event::Delete { .. })
             && line_info.line_delta != 0;
-        if cursor_changed_lines || edit_changed_line_count {
+        if edit_changed_line_count {
             self.handle_refresh_lines(buffer_id);
         }
     }

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -449,8 +449,8 @@ impl Editor {
         {
             // Repair a stale anchor: the plugin computed `position` against the
             // `lines_changed` epoch, but later edits may have shifted it. Map it
-            // forward; if the epoch is too old to map, skip — convergence
-            // (cursor_moved → refreshLines) re-fires with fresh coordinates.
+            // forward; if the epoch is too old to map, skip — the next
+            // `lines_changed` for the line re-fires with fresh coordinates.
             let position = match state.map_plugin_coord(position, epoch) {
                 Some(p) => p,
                 None => return,
@@ -534,6 +534,7 @@ impl Editor {
     // ==================== Conceal Commands ====================
 
     /// Handle AddConceal command - add a conceal range that hides or replaces bytes
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn handle_add_conceal(
         &mut self,
         buffer_id: BufferId,
@@ -542,6 +543,7 @@ impl Editor {
         end: usize,
         replacement: Option<String>,
         epoch: Option<u64>,
+        activation: Option<fresh_core::api::MarkerActivation>,
     ) {
         if let Some(state) = self
             .windows
@@ -556,9 +558,24 @@ impl Editor {
                 Some(r) => r,
                 None => return,
             };
-            state
-                .conceals
-                .add(&mut state.marker_list, namespace, start..end, replacement);
+            // The activation scope was computed against the same epoch —
+            // remap it the same way before it's re-anchored to the marker.
+            let activation = activation.and_then(|a| {
+                let (scope_start, scope_end) =
+                    state.map_plugin_range(a.scope_start, a.scope_end, epoch)?;
+                Some(fresh_core::api::MarkerActivation {
+                    if_cursor_in: a.if_cursor_in,
+                    scope_start,
+                    scope_end,
+                })
+            });
+            state.conceals.add_with_activation(
+                &mut state.marker_list,
+                namespace,
+                start..end,
+                replacement,
+                activation,
+            );
             #[cfg(feature = "plugins")]
             {
                 self.plugin_render_requested = true;
@@ -699,6 +716,7 @@ impl Editor {
         position: usize,
         indent: u16,
         epoch: Option<u64>,
+        activation: Option<fresh_core::api::MarkerActivation>,
     ) {
         if let Some(state) = self
             .windows
@@ -711,9 +729,24 @@ impl Editor {
                 Some(p) => p,
                 None => return,
             };
-            state
-                .soft_breaks
-                .add(&mut state.marker_list, namespace, position, indent);
+            // The activation scope was computed against the same epoch —
+            // remap it the same way before it's re-anchored to the marker.
+            let activation = activation.and_then(|a| {
+                let (scope_start, scope_end) =
+                    state.map_plugin_range(a.scope_start, a.scope_end, epoch)?;
+                Some(fresh_core::api::MarkerActivation {
+                    if_cursor_in: a.if_cursor_in,
+                    scope_start,
+                    scope_end,
+                })
+            });
+            state.soft_breaks.add_with_activation(
+                &mut state.marker_list,
+                namespace,
+                position,
+                indent,
+                activation,
+            );
             #[cfg(feature = "plugins")]
             {
                 self.plugin_render_requested = true;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -519,8 +519,17 @@ impl Editor {
                 end,
                 replacement,
                 epoch,
+                activation,
             } => {
-                self.handle_add_conceal(buffer_id, namespace, start, end, replacement, epoch);
+                self.handle_add_conceal(
+                    buffer_id,
+                    namespace,
+                    start,
+                    end,
+                    replacement,
+                    epoch,
+                    activation,
+                );
             }
             PluginCommand::ClearConcealNamespace {
                 buffer_id,
@@ -570,8 +579,11 @@ impl Editor {
                 position,
                 indent,
                 epoch,
+                activation,
             } => {
-                self.handle_add_soft_break(buffer_id, namespace, position, indent, epoch);
+                self.handle_add_soft_break(
+                    buffer_id, namespace, position, indent, epoch, activation,
+                );
             }
             PluginCommand::ClearSoftBreakNamespace {
                 buffer_id,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -366,14 +366,14 @@ impl Editor {
             // Process any plugin commands (like AddOverlay) that resulted from the hooks.
             //
             // This is non-blocking: we collect whatever the plugin has sent so far.
-            // The plugin thread runs in parallel, and because we proactively call
-            // handle_refresh_lines after cursor_moved (in fire_cursor_hooks), the
-            // lines_changed hook fires early in the render cycle. By the time we
-            // reach this point, the plugin has typically already processed all hooks
-            // and sent back conceal/overlay commands. On rare occasions (high CPU
-            // load), the response arrives one frame late, which is imperceptible
-            // at 60fps. The plugin's own refreshLines() call from cursor_moved
-            // ensures a follow-up render cycle picks up any missed commands.
+            // The plugin thread runs in parallel; by the time we reach this point
+            // it has typically already processed the hooks and sent back
+            // conceal/overlay commands. On rare occasions (high CPU load), the
+            // response arrives one frame late, which is imperceptible at 60fps —
+            // each arriving decoration command sets `plugin_render_requested`, so
+            // a follow-up render cycle picks up anything missed here. (Cursor
+            // movement no longer participates: cursor-dependent decorations carry
+            // activation scopes evaluated at render time, see view/activation.rs.)
             #[cfg(not(feature = "plugins"))]
             let dispatched_any = false;
             #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -497,8 +497,8 @@ impl EditorState {
     /// `epoch` carried by the `lines_changed` hook). `None` means the caller
     /// has no epoch to remap against, so the coordinate is taken as-is.
     /// `Some(_)` returning `None` means the epoch is too old to map (evicted or
-    /// barriered) — the caller should skip the operation and let convergence
-    /// (`cursor_moved → refreshLines`) redo it with fresh coordinates.
+    /// barriered) — the caller should skip the operation; the next
+    /// `lines_changed` for the affected line redoes it with fresh coordinates.
     pub fn map_plugin_coord(&self, coord: usize, epoch: Option<u64>) -> Option<usize> {
         match epoch {
             None => Some(coord),
@@ -1500,8 +1500,10 @@ impl EditorState {
             return Vec::new();
         }
         // query_viewport already returns pairs sorted by ascending position.
+        // Cursor-blind: scroll math consumers see the canonical "no cursor
+        // anywhere" break set, consistent with `VisualRowIndex`.
         self.soft_breaks
-            .query_viewport(0, self.buffer.len() + 1, &self.marker_list)
+            .query_viewport(0, self.buffer.len() + 1, &self.marker_list, &[])
     }
 
     // ========== DocumentModel Helper Methods ==========

--- a/crates/fresh-editor/src/view/activation.rs
+++ b/crates/fresh-editor/src/view/activation.rs
@@ -1,0 +1,96 @@
+//! Cursor-dependent activation for conceals and soft breaks.
+//!
+//! A decoration tagged with a [`ScopedActivation`] is filtered at *query*
+//! time against the rendering split's cursor positions, instead of being
+//! deleted and recreated by the plugin on every cursor move. This is what
+//! lets cursor movement leave the marker set — and therefore the
+//! `LineWrapCache` / `VisualRowIndex` versions — completely untouched.
+//!
+//! The scope is stored **relative to the decoration's own marker
+//! position** (`before` bytes ahead of it, `len` bytes long). Both the
+//! decoration and its scope live on the same line, so an edit anywhere
+//! before that line shifts the marker and the scope stays aligned without
+//! any bookkeeping; an edit *inside* the line re-fires `lines_changed`
+//! for it and the plugin rebuilds the decoration anyway.
+
+use fresh_core::api::MarkerActivation;
+
+/// Cursor-scope rule stored on a conceal range or soft break.
+/// `None` on the owning entry means "always active".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopedActivation {
+    /// `true`: active only while a cursor IS in scope (`if-cursor-in`).
+    /// `false`: active only while NO cursor is in scope (`unless-cursor-in`).
+    pub if_cursor_in: bool,
+    /// Scope starts `before` bytes ahead of the decoration's anchor
+    /// position (the conceal's start marker / the soft break's marker).
+    pub before: u32,
+    /// Scope byte length (half-open range).
+    pub len: u32,
+}
+
+impl ScopedActivation {
+    /// Convert a wire-format rule (absolute scope bytes) into the
+    /// marker-relative form, anchored at `anchor` (the decoration's
+    /// position at emission time). A scope starting after the anchor is
+    /// clamped to it — plugins scope a decoration to its own span or
+    /// line, both of which start at or before the decoration.
+    pub fn from_absolute(rule: &MarkerActivation, anchor: usize) -> Self {
+        let scope_start = rule.scope_start.min(anchor);
+        Self {
+            if_cursor_in: rule.if_cursor_in,
+            before: (anchor - scope_start) as u32,
+            len: rule.scope_end.saturating_sub(scope_start) as u32,
+        }
+    }
+
+    /// Whether the decoration is active given its current anchor
+    /// position and the rendering split's cursor byte positions.
+    #[inline]
+    pub fn is_active(&self, anchor: usize, cursors: &[usize]) -> bool {
+        let scope_start = anchor.saturating_sub(self.before as usize);
+        let scope_end = scope_start + self.len as usize;
+        let cursor_in = cursors.iter().any(|&p| p >= scope_start && p < scope_end);
+        cursor_in == self.if_cursor_in
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(if_cursor_in: bool, start: usize, end: usize) -> MarkerActivation {
+        MarkerActivation {
+            if_cursor_in,
+            scope_start: start,
+            scope_end: end,
+        }
+    }
+
+    #[test]
+    fn unless_cursor_in_active_without_cursor() {
+        let a = ScopedActivation::from_absolute(&rule(false, 10, 20), 12);
+        assert!(a.is_active(12, &[]));
+        assert!(a.is_active(12, &[5, 25]));
+        assert!(!a.is_active(12, &[10]));
+        assert!(!a.is_active(12, &[19]));
+        assert!(a.is_active(12, &[20])); // end is exclusive
+    }
+
+    #[test]
+    fn if_cursor_in_active_only_with_cursor() {
+        let a = ScopedActivation::from_absolute(&rule(true, 10, 20), 12);
+        assert!(!a.is_active(12, &[]));
+        assert!(a.is_active(12, &[15]));
+        assert!(!a.is_active(12, &[20]));
+    }
+
+    #[test]
+    fn scope_shifts_with_anchor() {
+        // Emitted with anchor 12, scope [10, 20). After an edit shifts the
+        // line by +5 the anchor resolves to 17 and the scope follows.
+        let a = ScopedActivation::from_absolute(&rule(false, 10, 20), 12);
+        assert!(!a.is_active(17, &[15])); // shifted scope [15, 25)
+        assert!(a.is_active(17, &[10])); // now outside
+    }
+}

--- a/crates/fresh-editor/src/view/conceal.rs
+++ b/crates/fresh-editor/src/view/conceal.rs
@@ -20,6 +20,8 @@
 //! - Wrapping operates on the concealed (shorter) lines
 
 use crate::model::marker::{MarkerId, MarkerList};
+use crate::view::activation::ScopedActivation;
+use fresh_core::api::MarkerActivation;
 use fresh_core::overlay::OverlayNamespace;
 use std::collections::HashMap;
 use std::ops::Range;
@@ -39,6 +41,11 @@ pub struct ConcealRange {
     /// Optional replacement text to show instead of the concealed content.
     /// If None, the range is simply hidden (zero-width).
     pub replacement: Option<String>,
+
+    /// Optional cursor-dependent activation rule, scope stored relative to
+    /// the start marker. `None` = always active. Filtered at query time so
+    /// cursor movement never mutates the marker set (see view/activation.rs).
+    pub activation: Option<ScopedActivation>,
 }
 
 impl ConcealRange {
@@ -93,6 +100,20 @@ impl ConcealManager {
         range: Range<usize>,
         replacement: Option<String>,
     ) {
+        self.add_with_activation(marker_list, namespace, range, replacement, None);
+    }
+
+    /// Add a conceal range with an optional cursor-dependent activation
+    /// rule (wire format, absolute scope bytes — converted to the
+    /// marker-relative form here).
+    pub fn add_with_activation(
+        &mut self,
+        marker_list: &mut MarkerList,
+        namespace: OverlayNamespace,
+        range: Range<usize>,
+        replacement: Option<String>,
+        activation: Option<MarkerActivation>,
+    ) {
         let start_marker = marker_list.create(range.start, true); // left affinity
         let end_marker = marker_list.create(range.end, false); // right affinity
 
@@ -104,6 +125,7 @@ impl ConcealManager {
             start_marker,
             end_marker,
             replacement,
+            activation: activation.map(|rule| ScopedActivation::from_absolute(&rule, range.start)),
         });
         self.version = self.version.wrapping_add(1);
     }
@@ -247,13 +269,19 @@ impl ConcealManager {
 
     /// Query conceal ranges that overlap a viewport range.
     /// Returns ranges sorted by start position for efficient token filtering.
+    ///
+    /// `cursors` are the rendering split's cursor byte positions, used to
+    /// evaluate cursor-dependent activation rules. Pass `&[]` for
+    /// cursor-blind consumers (scroll math, `VisualRowIndex`) — they see
+    /// the canonical "no cursor anywhere" rendering.
     pub fn query_viewport(
         &self,
         start: usize,
         end: usize,
         marker_list: &MarkerList,
+        cursors: &[usize],
     ) -> Vec<(Range<usize>, Option<&str>)> {
-        self.query_viewport_excluding(start, end, marker_list, None)
+        self.query_viewport_excluding(start, end, marker_list, None, cursors)
     }
 
     /// Like [`query_viewport`](Self::query_viewport), but skips ranges whose
@@ -271,6 +299,7 @@ impl ConcealManager {
         end: usize,
         marker_list: &MarkerList,
         exclude_ns: Option<&OverlayNamespace>,
+        cursors: &[usize],
     ) -> Vec<(Range<usize>, Option<&str>)> {
         let mut results: Vec<(Range<usize>, Option<&str>)> = self
             .ranges
@@ -278,6 +307,11 @@ impl ConcealManager {
             .filter(|r| exclude_ns != Some(&r.namespace))
             .filter_map(|r| {
                 let range = r.range(marker_list);
+                if let Some(a) = &r.activation {
+                    if !a.is_active(range.start, cursors) {
+                        return None;
+                    }
+                }
                 if range.start < end && start < range.end {
                     Some((range, r.replacement.as_deref()))
                 } else {
@@ -382,7 +416,7 @@ mod tests {
         manager.remove_in_range(&(15..35), &mut marker_list);
 
         let kept: Vec<_> = manager
-            .query_viewport(0, 1000, &marker_list)
+            .query_viewport(0, 1000, &marker_list, &[])
             .into_iter()
             .map(|(r, _)| r)
             .collect();
@@ -454,7 +488,7 @@ mod tests {
         // Only "md"'s in-range range is gone; "other" and the out-of-range
         // "md" entry remain.
         let kept: Vec<_> = manager
-            .query_viewport(0, 1000, &marker_list)
+            .query_viewport(0, 1000, &marker_list, &[])
             .into_iter()
             .map(|(r, _)| r)
             .collect();
@@ -538,7 +572,7 @@ mod tests {
         );
         // Steady state preserved.
         let still_present = manager
-            .query_viewport(0, LINES * LINE_BYTES, &marker_list)
+            .query_viewport(0, LINES * LINE_BYTES, &marker_list, &[])
             .len();
         assert_eq!(still_present, initial);
     }
@@ -605,7 +639,7 @@ mod tests {
                         }
                         Op::RemoveInRange { start, end } => {
                             manager.remove_in_range(&(start..end), &mut marker_list);
-                            for (rng, _) in manager.query_viewport(0, BUFFER_SIZE, &marker_list) {
+                            for (rng, _) in manager.query_viewport(0, BUFFER_SIZE, &marker_list, &[]) {
                                 let overlaps = rng.start < end && start < rng.end;
                                 prop_assert!(
                                     !overlaps,

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -81,6 +81,35 @@ pub struct LineWrapKey {
     pub wrap_column: Option<u32>,
     pub hanging_indent: bool,
     pub line_wrap_enabled: bool,
+    /// Signature of the cursor positions inside this line (see
+    /// [`cursor_sig_for_line`]). Cursor-dependent conceal/soft-break
+    /// activation makes the cursor line's layout a function of where the
+    /// cursors sit within it; folding that into the key means a cursor
+    /// move invalidates at most the two lines whose signature changed
+    /// while every other entry stays valid. Cursor-blind consumers
+    /// (`VisualRowIndex`, scroll math) always use `0` — the canonical
+    /// "no cursor anywhere" layout.
+    pub cursor_sig: u64,
+}
+
+/// Fold the cursor positions that can affect a line's activation rules
+/// into a compact signature for [`LineWrapKey::cursor_sig`].
+///
+/// A cursor at byte `p` matters to line `[line_start, line_end)` when
+/// `line_start <= p <= line_end` — the inclusive upper bound covers
+/// plugin scopes that extend one past the line end (a cursor sitting at
+/// the start of the next line can still reveal this line's markup).
+/// Returns 0 when no cursor is in range, matching the cursor-blind
+/// convention.
+pub fn cursor_sig_for_line(cursors: &[usize], line_start: usize, line_end: usize) -> u64 {
+    let mut sig: u64 = 0;
+    for &p in cursors {
+        if p >= line_start && p <= line_end {
+            let rel = (p - line_start + 1) as u64;
+            sig = sig.wrapping_mul(0x100_0000_01b3).wrapping_add(rel);
+        }
+    }
+    sig
 }
 
 /// Derive the combined pipeline-inputs version from the three source
@@ -327,6 +356,7 @@ pub fn layout_for_line(
     line_start: usize,
     line_end: usize,
     geom: &WrapGeometry,
+    cursors: &[usize],
 ) -> Arc<Vec<ViewLine>> {
     let version = pipeline_inputs_version(
         state.buffer.version(),
@@ -334,11 +364,15 @@ pub fn layout_for_line(
         state.conceals.version(),
         state.virtual_texts.version(),
     );
-    let key = geom.key(line_start, version);
+    let key = geom.key(
+        line_start,
+        version,
+        cursor_sig_for_line(cursors, line_start, line_end),
+    );
     if let Some(cached) = state.line_wrap_cache.get(&key) {
         return cached;
     }
-    let layout = compute_line_layout(state, line_start, line_end, geom);
+    let layout = compute_line_layout(state, line_start, line_end, geom, cursors);
     let arc = Arc::new(layout);
     state.line_wrap_cache.put(key, arc.clone());
     arc
@@ -419,8 +453,15 @@ pub struct WrapGeometry {
 
 impl WrapGeometry {
     /// Build a cache key for a logical line at `line_start` under these
-    /// geometry and pipeline-input versions.
-    pub fn key(&self, line_start: usize, pipeline_inputs_version: u64) -> LineWrapKey {
+    /// geometry and pipeline-input versions. `cursor_sig` is the line's
+    /// cursor signature ([`cursor_sig_for_line`]); pass 0 for
+    /// cursor-blind consumers.
+    pub fn key(
+        &self,
+        line_start: usize,
+        pipeline_inputs_version: u64,
+        cursor_sig: u64,
+    ) -> LineWrapKey {
         LineWrapKey {
             pipeline_inputs_version,
             view_mode: self.view_mode,
@@ -430,6 +471,7 @@ impl WrapGeometry {
             wrap_column: self.wrap_column,
             hanging_indent: self.hanging_indent,
             line_wrap_enabled: self.line_wrap_enabled,
+            cursor_sig,
         }
     }
 }
@@ -461,6 +503,7 @@ pub fn compute_line_layout(
     line_start: usize,
     line_end: usize,
     geom: &WrapGeometry,
+    cursors: &[usize],
 ) -> Vec<ViewLine> {
     let is_binary = state.buffer.is_binary();
     let line_ending = state.buffer.line_ending();
@@ -482,9 +525,10 @@ pub fn compute_line_layout(
 
     // Step 2: soft breaks (Compose mode only; same gating as the renderer).
     if is_compose && !state.soft_breaks.is_empty() {
-        let sb = state
-            .soft_breaks
-            .query_viewport(line_start, line_end, &state.marker_list);
+        let sb =
+            state
+                .soft_breaks
+                .query_viewport(line_start, line_end, &state.marker_list, cursors);
         if !sb.is_empty() {
             tokens = apply_soft_breaks(tokens, &sb);
         }
@@ -494,7 +538,7 @@ pub fn compute_line_layout(
     if is_compose && !state.conceals.is_empty() {
         let cr = state
             .conceals
-            .query_viewport(line_start, line_end, &state.marker_list);
+            .query_viewport(line_start, line_end, &state.marker_list, cursors);
         if !cr.is_empty() {
             tokens = apply_conceal_ranges(tokens, &cr);
         }
@@ -572,7 +616,10 @@ pub fn count_visual_rows_via_pipeline(
     line_end: usize,
     geom: &WrapGeometry,
 ) -> u32 {
-    compute_line_layout(state, line_start, line_end, geom).len() as u32
+    // Cursor-blind by convention: scroll math sees the canonical
+    // "no cursor anywhere" layout (activation rules evaluated with no
+    // cursors), consistent with `VisualRowIndex`.
+    compute_line_layout(state, line_start, line_end, geom, &[]).len() as u32
 }
 
 /// Combined version of all pipeline inputs on the given state.  Fold into
@@ -798,6 +845,7 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            cursor_sig: 0,
         }
     }
 
@@ -1299,6 +1347,7 @@ mod tests {
                 wrap_column: None,
                 hanging_indent: false,
                 line_wrap_enabled: true,
+                cursor_sig: 0,
             };
             let real_val = real.get_or_insert_with(key, || dummy_lines(shadow_rows));
             assert_eq!(
@@ -1331,6 +1380,7 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            cursor_sig: 0,
         };
         cache.get_or_insert_with(key_v0, || dummy_lines(5));
         assert_eq!(cache.get(&key_v0).map(|v| v.len()), Some(5));
@@ -1373,6 +1423,7 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            cursor_sig: 0,
         };
 
         // Vary each field in turn; each variation must be a distinct key.
@@ -1407,6 +1458,7 @@ mod tests {
             },
             LineWrapKey {
                 line_wrap_enabled: false,
+                cursor_sig: 0,
                 ..base
             },
         ];

--- a/crates/fresh-editor/src/view/mod.rs
+++ b/crates/fresh-editor/src/view/mod.rs
@@ -13,6 +13,8 @@ pub mod theme;
 
 // WASM-compatible modules (pure rendering, no runtime deps)
 #[cfg(any(feature = "runtime", feature = "wasm"))]
+pub mod activation;
+#[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod animation;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod color_support;

--- a/crates/fresh-editor/src/view/soft_break.rs
+++ b/crates/fresh-editor/src/view/soft_break.rs
@@ -19,6 +19,8 @@
 //! - The wrapping transform sees pre-broken content
 
 use crate::model::marker::{MarkerId, MarkerList};
+use crate::view::activation::ScopedActivation;
+use fresh_core::api::MarkerActivation;
 use fresh_core::overlay::OverlayNamespace;
 use std::collections::HashMap;
 
@@ -33,6 +35,11 @@ pub struct SoftBreakPoint {
 
     /// Number of hanging indent spaces to insert after the break
     pub indent: u16,
+
+    /// Optional cursor-dependent activation rule, scope stored relative to
+    /// the break marker. `None` = always active. Filtered at query time so
+    /// cursor movement never mutates the marker set (see view/activation.rs).
+    pub activation: Option<ScopedActivation>,
 }
 
 impl SoftBreakPoint {
@@ -85,6 +92,20 @@ impl SoftBreakManager {
         position: usize,
         indent: u16,
     ) {
+        self.add_with_activation(marker_list, namespace, position, indent, None);
+    }
+
+    /// Add a soft break point with an optional cursor-dependent activation
+    /// rule (wire format, absolute scope bytes — converted to the
+    /// marker-relative form here).
+    pub fn add_with_activation(
+        &mut self,
+        marker_list: &mut MarkerList,
+        namespace: OverlayNamespace,
+        position: usize,
+        indent: u16,
+        activation: Option<MarkerActivation>,
+    ) {
         let marker_id = marker_list.create(position, false); // right affinity
 
         let idx = self.breaks.len();
@@ -93,6 +114,7 @@ impl SoftBreakManager {
             namespace,
             marker_id,
             indent,
+            activation: activation.map(|rule| ScopedActivation::from_absolute(&rule, position)),
         });
         self.version = self.version.wrapping_add(1);
     }
@@ -176,17 +198,28 @@ impl SoftBreakManager {
 
     /// Query soft breaks that fall within a viewport range.
     /// Returns sorted `(position, indent)` pairs for efficient token processing.
+    ///
+    /// `cursors` are the rendering split's cursor byte positions, used to
+    /// evaluate cursor-dependent activation rules. Pass `&[]` for
+    /// cursor-blind consumers (scroll math, `VisualRowIndex`) — they see
+    /// the canonical "no cursor anywhere" rendering.
     pub fn query_viewport(
         &self,
         start: usize,
         end: usize,
         marker_list: &MarkerList,
+        cursors: &[usize],
     ) -> Vec<(usize, u16)> {
         let mut results: Vec<(usize, u16)> = self
             .breaks
             .iter()
             .filter_map(|b| {
                 let pos = b.position(marker_list);
+                if let Some(a) = &b.activation {
+                    if !a.is_active(pos, cursors) {
+                        return None;
+                    }
+                }
                 if pos >= start && pos < end {
                     Some((pos, b.indent))
                 } else {
@@ -258,7 +291,7 @@ mod tests {
         manager.remove_in_range(20, 50, &mut marker_list);
 
         let kept: Vec<_> = manager
-            .query_viewport(0, 1000, &marker_list)
+            .query_viewport(0, 1000, &marker_list, &[])
             .into_iter()
             .map(|(p, _)| p)
             .collect();
@@ -277,7 +310,7 @@ mod tests {
 
         manager.remove_in_range(10, 20, &mut marker_list);
         let kept: Vec<_> = manager
-            .query_viewport(0, 1000, &marker_list)
+            .query_viewport(0, 1000, &marker_list, &[])
             .into_iter()
             .map(|(p, _)| p)
             .collect();
@@ -351,7 +384,7 @@ mod tests {
             elapsed / LINES as u32,
         );
         let still_present = manager
-            .query_viewport(0, LINES * LINE_BYTES, &marker_list)
+            .query_viewport(0, LINES * LINE_BYTES, &marker_list, &[])
             .len();
         assert_eq!(still_present, initial);
     }
@@ -404,7 +437,7 @@ mod tests {
                         Op::RemoveInRange { start, end } => {
                             manager.remove_in_range(start, end, &mut marker_list);
                             // No surviving entry inside the removed range.
-                            for (p, _) in manager.query_viewport(0, BUFFER_SIZE, &marker_list) {
+                            for (p, _) in manager.query_viewport(0, BUFFER_SIZE, &marker_list, &[]) {
                                 prop_assert!(
                                     !(p >= start && p < end),
                                     "entry at {p} survived remove_in_range({start}..{end})",

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -480,6 +480,7 @@ mod tests {
             &ViewMode::Source, // Tests use source mode
             &empty_folds,
             &theme,
+            &[],
         );
         let view_anchor = calculate_view_anchor(&view_data.lines, 0);
 
@@ -584,6 +585,7 @@ mod tests {
             &ViewMode::Source,
             &empty_folds,
             &theme,
+            &[],
         );
         let view_anchor = calculate_view_anchor(&view_data.lines, viewport.top_byte);
 
@@ -1256,6 +1258,7 @@ mod tests {
             &ViewMode::Source,
             &folds,
             &theme,
+            &[],
         );
 
         let lines: Vec<String> = view_data.lines.iter().map(|l| l.text.clone()).collect();
@@ -1294,6 +1297,7 @@ mod tests {
             &ViewMode::Source,
             &folds,
             &theme,
+            &[],
         );
 
         let indicators = fold_indicators_for_viewport(&state, &folds, &view_data.lines);
@@ -3133,6 +3137,7 @@ mod tests {
             &ViewMode::Source,
             &empty_folds,
             &theme,
+            &[],
         );
         let view_anchor = calculate_view_anchor(&view_data.lines, 0);
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -183,6 +183,11 @@ pub(crate) fn compute_buffer_layout(
     // Clone view_transform so we can reuse it if scrolling triggers a rebuild
     let view_transform_for_rebuild = view_transform.clone();
 
+    // This split's cursor byte positions, for cursor-dependent conceal /
+    // soft-break activation (evaluated per render, per split — cursor
+    // movement changes what's active without any marker churn).
+    let cursor_positions = cursors.positions();
+
     let view_data = {
         let _span = tracing::trace_span!("build_view_data").entered();
         build_view_data(
@@ -197,6 +202,7 @@ pub(crate) fn compute_buffer_layout(
             &view_mode,
             folds,
             theme,
+            &cursor_positions,
         )
     };
 
@@ -225,6 +231,7 @@ pub(crate) fn compute_buffer_layout(
             &view_mode,
             folds,
             theme,
+            &cursor_positions,
         );
         viewport.scroll_to_end_of_view(&rebuilt.lines);
         (rebuilt, None)
@@ -267,6 +274,7 @@ pub(crate) fn compute_buffer_layout(
                 &view_mode,
                 folds,
                 theme,
+                &cursor_positions,
             );
             let _ = viewport.ensure_visible_in_layout(&rebuilt.lines, &primary, gutter_width);
             rebuilt

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -277,6 +277,7 @@ fn build_pane_render_data(
             &ViewMode::Source, // Composite view uses source mode
             &empty_folds,
             theme,
+            &[], // composite panes render cursor-blind
         );
 
         let mut line_to_view_line: HashMap<usize, usize> = HashMap::new();

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -37,6 +37,12 @@ pub(super) struct ViewData {
 /// Run the entire view pipeline for the current viewport:
 /// base tokens → (optional plugin transform) → soft breaks → conceal →
 /// wrapping → [`ViewLine`] conversion → virtual lines → folding.
+///
+/// `cursor_positions` are the rendering split's cursor byte positions,
+/// used to evaluate cursor-dependent conceal / soft-break activation
+/// rules (e.g. markdown_compose revealing the markup under the cursor).
+/// Pass `&[]` for cursor-less consumers (previews) — they render the
+/// canonical "no cursor anywhere" form.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_view_data(
     state: &mut EditorState,
@@ -50,6 +56,7 @@ pub(super) fn build_view_data(
     view_mode: &ViewMode,
     folds: &FoldManager,
     theme: &Theme,
+    cursor_positions: &[usize],
 ) -> ViewData {
     let adjusted_visible_count = fold_adjusted_visible_count(
         &state.buffer,
@@ -94,10 +101,12 @@ pub(super) fn build_view_data(
             .next_back()
             .unwrap_or(viewport.top_byte)
             + 1;
-        let soft_breaks =
-            state
-                .soft_breaks
-                .query_viewport(viewport.top_byte, viewport_end, &state.marker_list);
+        let soft_breaks = state.soft_breaks.query_viewport(
+            viewport.top_byte,
+            viewport_end,
+            &state.marker_list,
+            cursor_positions,
+        );
         if !soft_breaks.is_empty() {
             tokens = apply_soft_breaks(tokens, &soft_breaks);
         }
@@ -125,6 +134,7 @@ pub(super) fn build_view_data(
             viewport_end,
             &state.marker_list,
             exclude_ns.as_ref(),
+            cursor_positions,
         );
         if !conceal_ranges.is_empty() {
             tokens = apply_conceal_ranges(tokens, &conceal_ranges);
@@ -243,7 +253,9 @@ pub(super) fn build_view_data(
         && fold_skip.is_empty()
         && state.virtual_texts.is_empty()
     {
-        use crate::view::line_wrap_cache::{pipeline_inputs_version, CacheViewMode, LineWrapKey};
+        use crate::view::line_wrap_cache::{
+            cursor_sig_for_line, pipeline_inputs_version, CacheViewMode, LineWrapKey,
+        };
         use crate::view::ui::view_pipeline::LineStart;
         use std::sync::Arc;
 
@@ -258,7 +270,7 @@ pub(super) fn build_view_data(
             state.conceals.version(),
             state.virtual_texts.version(),
         );
-        let make_key = |line_start: usize, mode: CacheViewMode| LineWrapKey {
+        let make_key = |line_start: usize, mode: CacheViewMode, cursor_sig: u64| LineWrapKey {
             pipeline_inputs_version: pipeline_inputs_ver,
             view_mode: mode,
             line_start,
@@ -267,6 +279,7 @@ pub(super) fn build_view_data(
             wrap_column: viewport.wrap_column.map(|c| c as u32),
             hanging_indent,
             line_wrap_enabled: true,
+            cursor_sig,
         };
 
         // Walk `source_lines` grouping consecutive rows that belong to
@@ -316,18 +329,36 @@ pub(super) fn build_view_data(
             if !has_injected {
                 // Slice `source_lines[i..j]` corresponds to one logical
                 // line with no plugin-injected reshaping.  Store it.
+                //
+                // The key's cursor signature spans through the byte after
+                // the line's last rendered source byte (the start of the
+                // next line when the row ends in a newline), matching the
+                // inclusive bound cursor-activation scopes use.
                 let slice: Vec<ViewLine> = source_lines[i..j].to_vec();
+                let sig_end = slice
+                    .iter()
+                    .flat_map(|l| l.char_source_bytes.iter().copied().flatten())
+                    .max()
+                    .map(|b| b + 1)
+                    .unwrap_or(line_start_byte);
+                let cursor_sig = cursor_sig_for_line(cursor_positions, line_start_byte, sig_end);
                 let arc = Arc::new(slice);
-                state
-                    .line_wrap_cache
-                    .put(make_key(line_start_byte, cache_view_mode), arc.clone());
+                state.line_wrap_cache.put(
+                    make_key(line_start_byte, cache_view_mode, cursor_sig),
+                    arc.clone(),
+                );
                 // Also write under `Source` so scroll math (which
                 // queries with its `Source` convention) hits the
                 // same entry.  Same value, same Arc — no deep copy.
+                // Scroll math queries with `cursor_sig: 0`, so the
+                // cursor line's entry (non-zero sig) deliberately
+                // doesn't serve it — cursor-blind consumers recompute
+                // that one line in its cursor-free form.
                 if !matches!(cache_view_mode, CacheViewMode::Source) {
-                    state
-                        .line_wrap_cache
-                        .put(make_key(line_start_byte, CacheViewMode::Source), arc);
+                    state.line_wrap_cache.put(
+                        make_key(line_start_byte, CacheViewMode::Source, cursor_sig),
+                        arc,
+                    );
                 }
             }
             i = j;

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -355,6 +355,9 @@ impl Viewport {
                     wrap_column: None,
                     hanging_indent: wrap_config.hanging_indent,
                     line_wrap_enabled: true,
+                    // Scroll math is cursor-blind by convention (matches
+                    // `VisualRowIndex` and its own cursor-free inputs).
+                    cursor_sig: 0,
                 };
                 return cache.get_or_insert_with(key, compute).len() + extra_virtual_rows;
             }

--- a/crates/fresh-editor/src/view/visual_row_index.rs
+++ b/crates/fresh-editor/src/view/visual_row_index.rs
@@ -59,6 +59,11 @@ pub struct VisualRowIndexKey {
 
 impl VisualRowIndexKey {
     /// Build the matching per-line `LineWrapKey` for a given line start.
+    /// The index is cursor-blind (`cursor_sig: 0`): it models the
+    /// canonical "no cursor anywhere" layout, so cursor movement never
+    /// invalidates it. The renderer writes the cursor line's real layout
+    /// under a non-zero signature; that entry simply doesn't serve this
+    /// index, which recounts that one line in its cursor-free form.
     fn line_key(&self, line_start: usize) -> LineWrapKey {
         LineWrapKey {
             pipeline_inputs_version: self.pipeline_inputs_version,
@@ -69,6 +74,7 @@ impl VisualRowIndexKey {
             wrap_column: self.wrap_column,
             hanging_indent: self.hanging_indent,
             line_wrap_enabled: self.line_wrap_enabled,
+            cursor_sig: 0,
         }
     }
 }
@@ -223,9 +229,11 @@ pub fn ensure_built(state: &mut EditorState, key: &VisualRowIndexKey) {
     let soft_break_pairs: Vec<(usize, u16)> = if state.soft_breaks.is_empty() {
         Vec::new()
     } else {
+        // Cursor-blind: activation rules evaluated with no cursors, so the
+        // index never has to rebuild on cursor movement.
         state
             .soft_breaks
-            .query_viewport(0, buffer_len + 1, &state.marker_list)
+            .query_viewport(0, buffer_len + 1, &state.marker_list, &[])
     };
     let virtual_line_positions: Vec<usize> = if state.virtual_texts.is_empty() {
         Vec::new()

--- a/crates/fresh-editor/tests/e2e/line_wrap_cache_consistency.rs
+++ b/crates/fresh-editor/tests/e2e/line_wrap_cache_consistency.rs
@@ -104,6 +104,7 @@ fn current_keys(harness: &EditorTestHarness, line_start: usize) -> (LineWrapKey,
         wrap_column,
         hanging_indent,
         line_wrap_enabled: true,
+        cursor_sig: 0,
     };
     let source = LineWrapKey {
         view_mode: CacheViewMode::Source,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1046,6 +1046,31 @@ impl JsEditorApi {
                 .cloned()
         })
     }
+
+    /// Build the wire-format cursor-activation rule from `addConceal` /
+    /// `addSoftBreak`'s optional trailing parameters. Unknown activation
+    /// strings and missing scope bounds fall back to `None` (always
+    /// active) rather than erroring — a plugin bug should degrade to
+    /// today's behavior, not break rendering.
+    fn parse_activation(
+        activation: Option<String>,
+        scope_start: Option<u32>,
+        scope_end: Option<u32>,
+    ) -> Option<fresh_core::api::MarkerActivation> {
+        let if_cursor_in = match activation.as_deref() {
+            Some("if-cursor-in") => true,
+            Some("unless-cursor-in") => false,
+            _ => return None,
+        };
+        let (Some(start), Some(end)) = (scope_start, scope_end) else {
+            return None;
+        };
+        Some(fresh_core::api::MarkerActivation {
+            if_cursor_in,
+            scope_start: start as usize,
+            scope_end: end as usize,
+        })
+    }
 }
 
 #[plugin_api_impl]
@@ -3580,7 +3605,15 @@ impl JsEditorApi {
 
     // === Conceal Ranges ===
 
-    /// Add a conceal range that hides or replaces a byte range during rendering
+    /// Add a conceal range that hides or replaces a byte range during rendering.
+    ///
+    /// `activation` optionally makes the conceal cursor-dependent:
+    /// `"unless-cursor-in"` (active only while no cursor is inside
+    /// `[scopeStart, scopeEnd)`) or `"if-cursor-in"` (active only while a
+    /// cursor IS inside it). Emitting both renderings of a
+    /// cursor-revealable decoration once — instead of rebuilding markers
+    /// on every cursor move — is what keeps cursor movement free of
+    /// marker churn (and of the cache invalidation it causes).
     pub fn add_conceal(
         &self,
         buffer_id: u32,
@@ -3588,6 +3621,9 @@ impl JsEditorApi {
         start: u32,
         end: u32,
         replacement: Option<String>,
+        activation: rquickjs::function::Opt<String>,
+        scope_start: rquickjs::function::Opt<u32>,
+        scope_end: rquickjs::function::Opt<u32>,
     ) -> bool {
         // Track namespace for cleanup on unload
         self.plugin_tracked_state
@@ -3605,6 +3641,7 @@ impl JsEditorApi {
                 end: end as usize,
                 replacement,
                 epoch: self.hook_epoch_for(buffer_id),
+                activation: Self::parse_activation(activation.0, scope_start.0, scope_end.0),
             })
             .is_ok()
     }
@@ -3755,13 +3792,19 @@ impl JsEditorApi {
 
     // === Soft Breaks ===
 
-    /// Add a soft break point for marker-based line wrapping
+    /// Add a soft break point for marker-based line wrapping.
+    ///
+    /// `activation` optionally makes the break cursor-dependent — same
+    /// semantics as `addConceal`'s activation parameters.
     pub fn add_soft_break(
         &self,
         buffer_id: u32,
         namespace: String,
         position: u32,
         indent: u32,
+        activation: rquickjs::function::Opt<String>,
+        scope_start: rquickjs::function::Opt<u32>,
+        scope_end: rquickjs::function::Opt<u32>,
     ) -> bool {
         // Track namespace for cleanup on unload
         self.plugin_tracked_state
@@ -3778,6 +3821,7 @@ impl JsEditorApi {
                 position: position as usize,
                 indent: indent as u16,
                 epoch: self.hook_epoch_for(buffer_id),
+                activation: Self::parse_activation(activation.0, scope_start.0, scope_end.0),
             })
             .is_ok()
     }


### PR DESCRIPTION
## Problem

Arrow-key navigation in compose mode was laggy — ~120ms per keypress in a debug build (~25ms release) on a 3k-line file, with the input queue backing up during key repeat.

Profiling (frame-pointer release build, 80-keypress arrow burst on CHANGELOG.md) showed each inter-line cursor move triggered O(entire-file) work:

1. Both the editor (`event_apply.rs`) and the plugin's `cursor_moved → refreshLines()` cleared `seen_byte_ranges` → `lines_changed` re-fired with **all 41 visible lines** per keypress.
2. markdown_compose unconditionally clear+rebuilt every conceal, soft break, and table border for every visible line (~27% of the plugin thread in QuickJS regex backtracking; ~34% of total CPU).
3. Every marker mutation bumped the `ConcealManager`/`SoftBreakManager` versions, which key both the `LineWrapCache` and the whole-buffer `VisualRowIndex` — so byte-identical rebuilds still invalidated everything.
4. The scrollbar's `ensure_built` then re-ran word-wrap width counting over all 3,092 lines per frame: **41.8% of main-thread cycles**.

All of this to change the appearance of exactly two lines (re-conceal the line you left, reveal the one you entered).

## Fix

Invert the responsibility: markers are cursor-independent, and the renderer decides per frame which ones apply.

- **Core**: conceals and soft breaks gain an optional activation rule — `"unless-cursor-in"` / `"if-cursor-in"` a byte scope. The scope is stored **relative to the decoration's own marker** (`view/activation.rs`), so it shifts with edits elsewhere in the buffer; an edit inside the line re-fires `lines_changed` and rebuilds it anyway. Scopes are epoch-remapped like the ranges themselves.
- **Renderer**: queries take the rendering split's cursor positions and filter by activation. `LineWrapKey` gains a per-line `cursor_sig` — a cursor move changes at most the two affected lines' keys while every other cache entry stays valid. Cursor-blind consumers (`VisualRowIndex`, scroll math) pass no cursors and see the canonical no-cursor layout, so cursor movement **never** invalidates them.
- **Plugin**: markdown_compose emits both renderings once per *content* change — the concealed variant tagged `unless-cursor-in` plus a cursor-row variant (`if-cursor-in`) where the rendering differs (span reveal, table cell padding at raw vs concealed width, truncation, multi-line cell wrapping). Its `cursor_moved` handler is deleted, as is the editor's proactive whole-viewport refresh on inter-line movement and the per-line `[mc]` hot-path debug logging.
- **Bonus correctness**: reveal is now evaluated per split, so two splits on the same buffer each reveal their own cursor line — previously one cursor's state was baked into the shared buffer-level markers (the old `ts:1664` comment wrestled with exactly this).

## Measured results (release build, same 80-keypress arrow burst)

| Metric | Before | After |
|---|---|---|
| Render per keypress (compose) | ~25ms | **8–10ms** (= source-mode baseline) |
| CPU samples during burst | 7,431 | 2,028 |
| Plugin-thread samples | 2,554 | 122 |
| `lines_changed` batches during navigation | 113 × 41 lines | **0** |
| `ensure_built` (whole-buffer rewrap) | 41.8% of main thread | not in profile |

Debug builds see the same shape (~120ms → ~10-15ms). Navigation cost no longer scales with file size.

Verified interactively in tmux: span-level markup reveal on cursor entry (link/bold/code), table row raw-reveal with stable box-drawing frame and padding, table truncation/un-truncation, compose toggle on/off.

## Known trade-offs

- Scroll math / `VisualRowIndex` model the canonical no-cursor layout; the cursor line's revealed layout can differ by a row or two. `ensure_visible` uses the real rendered lines so cursor visibility is exact; scrollbar total can be off by ±the delta while the cursor sits on a reveal-widened line (was previously "exact" only because everything was rebuilt per keypress).
- On image lines and wrapped/truncated table cells, the cursor row now shows fully raw markup without `md-emphasis` styling (previously styled). This is the state you edit in; the concealed rendering is unchanged.
- Typing still invalidates the whole `VisualRowIndex` (buffer version bump) — unchanged from before; the per-line activation machinery is groundwork for making that incremental too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)