### PR TITLE
web-ui: dock right-click context menu, complete widget-event parity, native form controls

### DIFF
--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -432,18 +432,35 @@ impl Editor {
         }
     }
 
+    /// Copy the right-click screen cell (`col`/`row`) from a frontend
+    /// `context` payload into the synthesized one, clamped to `u16` like a
+    /// real terminal cell. The plugin uses it to anchor its popup; absent
+    /// or malformed coordinates are simply omitted (the plugin falls back
+    /// to a default anchor).
+    fn copy_context_anchor_cell(from: &serde_json::Value, into: &mut serde_json::Value) {
+        if let Some(obj) = into.as_object_mut() {
+            for cell in ["col", "row"] {
+                if let Some(v) = from.get(cell).and_then(|v| v.as_u64()) {
+                    obj.insert(cell.to_string(), serde_json::json!(v.min(u16::MAX as u64)));
+                }
+            }
+        }
+    }
+
     /// Rebuild the `HitArea` that `collect_list` would have emitted for a
     /// list row that is outside the TUI's scroll window (so no hit was
     /// recorded), from the panel's own spec: the payload's `list_key` must
     /// name a `List` in the spec and `index` must be in bounds; the item key
     /// is read from the spec's `item_keys`. Returns `None` for anything
-    /// that isn't a valid in-bounds list `select`.
+    /// that isn't a valid in-bounds list `select` or right-click `context`
+    /// (which is never recorded as a hit — the TUI synthesizes it from a
+    /// right-click as well).
     fn synthesize_list_hit(
         panel: &crate::widgets::WidgetPanelState,
         event_type: &str,
         payload: &serde_json::Value,
     ) -> Option<crate::widgets::HitArea> {
-        if event_type != "select" {
+        if event_type != "select" && event_type != "context" {
             return None;
         }
         let list_key = payload.get("list_key")?.as_str()?;
@@ -467,18 +484,25 @@ impl Editor {
             return None;
         }
         let item_key = item_keys.get(index as usize).cloned().unwrap_or_default();
+        let mut row_payload = serde_json::json!({
+            "index": index,
+            "key": item_key,
+            "list_key": list_key,
+        });
+        let event_type = if event_type == "context" {
+            Self::copy_context_anchor_cell(payload, &mut row_payload);
+            "context"
+        } else {
+            "select"
+        };
         Some(crate::widgets::HitArea {
             widget_key: item_key.clone(),
             widget_kind: "list",
             buffer_row: 0,
             byte_start: 0,
             byte_end: 0,
-            payload: serde_json::json!({
-                "index": index,
-                "key": item_key,
-                "list_key": list_key,
-            }),
-            event_type: "select",
+            payload: row_payload,
+            event_type,
         })
     }
 
@@ -486,16 +510,18 @@ impl Editor {
     /// tree row outside the TUI's scroll window (so no hit was recorded),
     /// from the panel's own spec: `widget_key` must name a `Tree`, the
     /// payload's `index` must be in bounds, and the row's item key comes
-    /// from the spec's `item_keys`. Covers the row-body `select` and the
-    /// disclosure `expand` events (the natively-scrolled web frontend can
-    /// click any row, not just the TUI's visible window).
+    /// from the spec's `item_keys`. Covers the row-body `select`, the
+    /// disclosure `expand`, and the right-click `context` events (the
+    /// natively-scrolled web frontend can click any row, not just the
+    /// TUI's visible window; no `context` hit is ever recorded — the TUI
+    /// synthesizes those from a right-click too).
     fn synthesize_tree_hit(
         panel: &crate::widgets::WidgetPanelState,
         widget_key: &str,
         event_type: &str,
         payload: &serde_json::Value,
     ) -> Option<crate::widgets::HitArea> {
-        if (event_type != "select" && event_type != "expand") || widget_key.is_empty() {
+        if !matches!(event_type, "select" | "expand" | "context") || widget_key.is_empty() {
             return None;
         }
         let index = payload.get("index")?.as_i64()?;
@@ -510,20 +536,27 @@ impl Editor {
             return None;
         }
         let item_key = item_keys.get(index as usize).cloned().unwrap_or_default();
-        let (event_type, payload) = if event_type == "expand" {
-            (
+        let (event_type, payload) = match event_type {
+            "expand" => (
                 "expand",
                 serde_json::json!({
                     "index": index,
                     "key": item_key,
                     "expanded": payload.get("expanded").and_then(|v| v.as_bool()).unwrap_or(true),
                 }),
-            )
-        } else {
-            (
+            ),
+            // Right-click: same shape the TUI's context path fires —
+            // the row identity plus the click cell the plugin anchors
+            // its popup at (see `handle_floating_widget_context_click`).
+            "context" => {
+                let mut p = serde_json::json!({ "index": index, "key": item_key });
+                Self::copy_context_anchor_cell(payload, &mut p);
+                ("context", p)
+            }
+            _ => (
                 "select",
                 serde_json::json!({ "index": index, "key": item_key }),
-            )
+            ),
         };
         Some(crate::widgets::HitArea {
             widget_key: widget_key.to_string(),

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -426,6 +426,7 @@ impl Editor {
                 .or_else(|| hit_index.and_then(|i| panel.hits.get(i).cloned()))
                 .or_else(|| Self::synthesize_list_hit(panel, event_type, payload))
                 .or_else(|| Self::synthesize_tree_hit(panel, widget_key, event_type, payload))
+                .or_else(|| Self::synthesize_control_hit(panel, widget_key, event_type))
         };
         if let Some(hit) = hit {
             self.deliver_widget_hit(&panel_key, &hit, None);
@@ -511,17 +512,19 @@ impl Editor {
     /// from the panel's own spec: `widget_key` must name a `Tree`, the
     /// payload's `index` must be in bounds, and the row's item key comes
     /// from the spec's `item_keys`. Covers the row-body `select`, the
-    /// disclosure `expand`, and the right-click `context` events (the
-    /// natively-scrolled web frontend can click any row, not just the
-    /// TUI's visible window; no `context` hit is ever recorded — the TUI
-    /// synthesizes those from a right-click too).
+    /// disclosure `expand`, the checkbox `toggle`, and the right-click
+    /// `context` events (the natively-scrolled web frontend can click any
+    /// row, not just the TUI's visible window; no `context` hit is ever
+    /// recorded — the TUI synthesizes those from a right-click too).
     fn synthesize_tree_hit(
         panel: &crate::widgets::WidgetPanelState,
         widget_key: &str,
         event_type: &str,
         payload: &serde_json::Value,
     ) -> Option<crate::widgets::HitArea> {
-        if !matches!(event_type, "select" | "expand" | "context") || widget_key.is_empty() {
+        if !matches!(event_type, "select" | "expand" | "toggle" | "context")
+            || widget_key.is_empty()
+        {
             return None;
         }
         let index = payload.get("index")?.as_i64()?;
@@ -553,6 +556,22 @@ impl Editor {
                 Self::copy_context_anchor_cell(payload, &mut p);
                 ("context", p)
             }
+            // Checkbox click: same shape the renderer's checkbox hit
+            // carries — `checked` is the NEW value, derived from the
+            // spec (the plugin's pushed truth), never from the frontend.
+            // Only nodes that actually bear a checkbox (checked is
+            // Some) get one, mirroring the renderer.
+            "toggle" => {
+                let current = nodes.get(index as usize).and_then(|n| n.checked)?;
+                (
+                    "toggle",
+                    serde_json::json!({
+                        "index": index,
+                        "key": item_key,
+                        "checked": !current,
+                    }),
+                )
+            }
             _ => (
                 "select",
                 serde_json::json!({ "index": index, "key": item_key }),
@@ -566,6 +585,49 @@ impl Editor {
             byte_end: 0,
             payload,
             event_type,
+        })
+    }
+
+    /// Rebuild the `HitArea` the renderer would have emitted for a keyed
+    /// control widget (Button / Toggle / Text) that recorded no hit because
+    /// the TUI clipped it — a native frontend grows a floating panel to fit
+    /// its content, so it can render (and click) a control that fell below
+    /// the TUI's inner rect. State comes from the panel's own spec: a
+    /// disabled Button synthesizes nothing (the renderer records no hit for
+    /// it either), and a Toggle's `checked` is read from the spec, never
+    /// from the frontend.
+    fn synthesize_control_hit(
+        panel: &crate::widgets::WidgetPanelState,
+        widget_key: &str,
+        event_type: &str,
+    ) -> Option<crate::widgets::HitArea> {
+        if widget_key.is_empty() {
+            return None;
+        }
+        let spec = crate::widgets::find_widget_by_key(&panel.spec, widget_key)?;
+        use fresh_core::api::WidgetSpec as W;
+        let (widget_kind, payload) = match (spec, event_type) {
+            (W::Button { disabled, .. }, "activate") if !disabled => {
+                ("button", serde_json::json!({}))
+            }
+            (W::Toggle { checked, .. }, "toggle") => {
+                ("toggle", serde_json::json!({ "checked": !checked }))
+            }
+            (W::Text { .. }, "focus") => ("text", serde_json::json!({})),
+            _ => return None,
+        };
+        Some(crate::widgets::HitArea {
+            widget_key: widget_key.to_string(),
+            widget_kind,
+            buffer_row: 0,
+            byte_start: 0,
+            byte_end: 0,
+            payload,
+            event_type: match event_type {
+                "activate" => "activate",
+                "toggle" => "toggle",
+                _ => "focus",
+            },
         })
     }
 

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -426,7 +426,7 @@ impl Editor {
                 .or_else(|| hit_index.and_then(|i| panel.hits.get(i).cloned()))
                 .or_else(|| Self::synthesize_list_hit(panel, event_type, payload))
                 .or_else(|| Self::synthesize_tree_hit(panel, widget_key, event_type, payload))
-                .or_else(|| Self::synthesize_control_hit(panel, widget_key, event_type))
+                .or_else(|| Self::synthesize_control_hit(panel, widget_key, event_type, payload))
         };
         if let Some(hit) = hit {
             self.deliver_widget_hit(&panel_key, &hit, None);
@@ -589,31 +589,67 @@ impl Editor {
     }
 
     /// Rebuild the `HitArea` the renderer would have emitted for a keyed
-    /// control widget (Button / Toggle / Text) that recorded no hit because
-    /// the TUI clipped it — a native frontend grows a floating panel to fit
-    /// its content, so it can render (and click) a control that fell below
-    /// the TUI's inner rect. State comes from the panel's own spec: a
-    /// disabled Button synthesizes nothing (the renderer records no hit for
-    /// it either), and a Toggle's `checked` is read from the spec, never
-    /// from the frontend.
+    /// control widget that recorded no hit — because the TUI clipped it (a
+    /// native frontend grows a floating panel to fit its content) or
+    /// because the frontend renders states the TUI's hit window didn't
+    /// (e.g. a dropdown's option rows). State comes from the panel's own
+    /// spec: a disabled Button synthesizes nothing (the renderer records no
+    /// hit for it either), a Toggle's `checked` and a Dropdown's option
+    /// bounds are read from the spec, never trusted from the frontend.
     fn synthesize_control_hit(
         panel: &crate::widgets::WidgetPanelState,
         widget_key: &str,
         event_type: &str,
+        payload: &serde_json::Value,
     ) -> Option<crate::widgets::HitArea> {
         if widget_key.is_empty() {
             return None;
         }
         let spec = crate::widgets::find_widget_by_key(&panel.spec, widget_key)?;
         use fresh_core::api::WidgetSpec as W;
-        let (widget_kind, payload) = match (spec, event_type) {
+        let (widget_kind, event_type, payload): (_, &'static str, _) = match (spec, event_type) {
             (W::Button { disabled, .. }, "activate") if !disabled => {
-                ("button", serde_json::json!({}))
+                ("button", "activate", serde_json::json!({}))
             }
-            (W::Toggle { checked, .. }, "toggle") => {
-                ("toggle", serde_json::json!({ "checked": !checked }))
+            (W::Toggle { checked, .. }, "toggle") => (
+                "toggle",
+                "toggle",
+                serde_json::json!({ "checked": !checked }),
+            ),
+            (W::Text { .. }, "focus") => ("text", "focus", serde_json::json!({})),
+            (W::Number { .. }, "number_value") => ("number", "number_value", serde_json::json!({})),
+            (W::Dropdown { .. }, "dropdown_toggle") => {
+                ("dropdown", "dropdown_toggle", serde_json::json!({}))
             }
-            (W::Text { .. }, "focus") => ("text", serde_json::json!({})),
+            (W::Dropdown { options, .. }, "dropdown_select") => {
+                let index = payload.get("index")?.as_i64()?;
+                if index < 0 || index as usize >= options.len() {
+                    return None;
+                }
+                (
+                    "dropdown",
+                    "dropdown_select",
+                    serde_json::json!({ "index": index }),
+                )
+            }
+            (W::DualList { options, .. }, "dual_focus") => {
+                let column = payload.get("column")?.as_str()?;
+                if column != "available" && column != "included" {
+                    return None;
+                }
+                let index = payload.get("index")?.as_i64()?;
+                // Loose bound: either column's row count can never exceed
+                // the full option universe; the click handler clamps to the
+                // live column length itself.
+                if index < 0 || index as usize >= options.len().max(1) {
+                    return None;
+                }
+                (
+                    "dual_list",
+                    "dual_focus",
+                    serde_json::json!({ "column": column, "index": index }),
+                )
+            }
             _ => return None,
         };
         Some(crate::widgets::HitArea {
@@ -623,12 +659,34 @@ impl Editor {
             byte_start: 0,
             byte_end: 0,
             payload,
-            event_type: match event_type {
-                "activate" => "activate",
-                "toggle" => "toggle",
-                _ => "focus",
-            },
+            event_type,
         })
+    }
+
+    /// Native-frontend entry point: place a text widget's caret at a flat
+    /// byte offset into its value. A browser input positions its caret
+    /// natively on click (it owns the font metrics), then reports the
+    /// position here so the host `TextEdit` — the single source of truth —
+    /// follows. `set_cursor_from_flat` clamps, snaps to a grapheme
+    /// boundary, and clears any selection (matching a plain GUI click).
+    pub fn set_widget_text_cursor(
+        &mut self,
+        plugin: &str,
+        panel_id: u64,
+        widget_key: &str,
+        byte: usize,
+    ) {
+        let panel_key = crate::widgets::PanelKey::new(plugin, panel_id);
+        let Some(panel) = self.widget_registry.get_mut(&panel_key) else {
+            return;
+        };
+        let Some(crate::widgets::WidgetInstanceState::Text { editor: te, .. }) =
+            panel.instance_states.get_mut(widget_key)
+        else {
+            return;
+        };
+        te.set_cursor_from_flat(byte);
+        self.rerender_widget_panel(&panel_key);
     }
 
     /// Deliver a `widget_event` hook to the plugin owning `panel_key` —

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -930,10 +930,7 @@ impl Editor {
                 .collect();
             out.push(WidgetSurfaceView {
                 kind,
-                anchored: matches!(
-                    fwp.placement,
-                    crate::app::PanelPlacement::Anchored { .. }
-                ),
+                anchored: matches!(fwp.placement, crate::app::PanelPlacement::Anchored { .. }),
                 plugin: fwp.panel_key.plugin.clone(),
                 panel_id: fwp.panel_key.id,
                 rect: RectView::from(rect),

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -855,6 +855,11 @@ pub struct WidgetInstanceView {
 pub struct WidgetSurfaceView {
     /// "dock" (left dock) or "floatingModal" (centered).
     pub kind: &'static str,
+    /// True for a `floatingModal` in the anchored (context-menu popup)
+    /// placement: content-sized, pinned near its opening click, and — unlike
+    /// the centered modal — drawn without a background dim, dismissed by a
+    /// click outside its box.
+    pub anchored: bool,
     pub plugin: String,
     pub panel_id: u64,
     pub rect: RectView,
@@ -925,6 +930,10 @@ impl Editor {
                 .collect();
             out.push(WidgetSurfaceView {
                 kind,
+                anchored: matches!(
+                    fwp.placement,
+                    crate::app::PanelPlacement::Anchored { .. }
+                ),
                 plugin: fwp.panel_key.plugin.clone(),
                 panel_id: fwp.panel_key.id,
                 rect: RectView::from(rect),

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -839,15 +839,54 @@ pub struct WidgetHitView {
     pub payload: serde_json::Value,
 }
 
-/// Host-owned instance state a frontend needs to render a widget correctly
-/// (List/Tree selection + scroll). Keyed by widget `key`.
-#[derive(Debug, Clone, Serialize)]
+/// Host-owned instance state a frontend needs to render a widget correctly.
+/// Keyed by widget `key`. The host is authoritative for ALL of this — the
+/// spec's `value`/`checked`/`selected_index` are initial-only seeds once a
+/// widget has mounted (see `WidgetInstanceState`), so a frontend that renders
+/// from the spec alone shows stale values (e.g. a text field that only
+/// updates after the plugin's spec round-trip instead of on every keystroke).
+#[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WidgetInstanceView {
     pub selected_index: Option<i32>,
     pub scroll_offset: Option<u32>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub expanded_keys: Vec<String>,
+    /// Text widget: the host `TextEdit`'s live value — what the TUI echoes
+    /// per keystroke.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_value: Option<String>,
+    /// Text widget: cursor position as a flat byte offset into `text_value`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_byte: Option<u32>,
+    /// Text widget: active selection as a flat `[start, end)` byte range.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection: Option<(u32, u32)>,
+    /// Text widget: completion popup candidate labels (empty = closed).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub completions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_selected: Option<u32>,
+    /// Text widget: whether ↑/↓ has moved into the open completion popup
+    /// (drives the highlighted row, mirroring the TUI).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_navigated: Option<bool>,
+    /// Number widget: the host-owned current value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number_value: Option<f64>,
+    /// Dropdown widget: whether the option list is open (the selected
+    /// option index rides in `selected_index`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropdown_open: Option<bool>,
+    /// DualList widget: host-owned ordered included values + column focus.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub included: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_included: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_cursor: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub included_cursor: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -901,7 +940,7 @@ impl Editor {
                     } => WidgetInstanceView {
                         selected_index: Some(*selected_index),
                         scroll_offset: Some(*scroll_offset),
-                        expanded_keys: Vec::new(),
+                        ..Default::default()
                     },
                     W::Tree {
                         scroll_offset,
@@ -911,8 +950,53 @@ impl Editor {
                         selected_index: Some(*selected_index),
                         scroll_offset: Some(*scroll_offset),
                         expanded_keys: expanded_keys.iter().cloned().collect(),
+                        ..Default::default()
                     },
-                    _ => continue,
+                    // The host TextEdit is the live editing state — export
+                    // value + caret + selection so a frontend echoes every
+                    // keystroke (the spec's `value` is initial-only and lags
+                    // until the plugin round-trips it), plus the completion
+                    // popup the TUI paints as overlay rows.
+                    W::Text {
+                        editor: te,
+                        completions,
+                        completion_selected_index,
+                        completion_navigated,
+                        ..
+                    } => WidgetInstanceView {
+                        text_value: Some(te.value()),
+                        cursor_byte: Some(te.flat_cursor_byte() as u32),
+                        selection: te.selection_flat_range().map(|(s, e)| (s as u32, e as u32)),
+                        completions: completions.iter().map(|c| c.value.clone()).collect(),
+                        completion_selected: Some(*completion_selected_index as u32),
+                        completion_navigated: Some(*completion_navigated),
+                        ..Default::default()
+                    },
+                    W::Number { value } => WidgetInstanceView {
+                        number_value: Some(*value),
+                        ..Default::default()
+                    },
+                    W::Dropdown {
+                        selected_index,
+                        open,
+                    } => WidgetInstanceView {
+                        selected_index: Some(*selected_index),
+                        dropdown_open: Some(*open),
+                        ..Default::default()
+                    },
+                    W::DualList {
+                        included,
+                        active_included,
+                        available_cursor,
+                        included_cursor,
+                    } => WidgetInstanceView {
+                        included: included.clone(),
+                        active_included: Some(*active_included),
+                        available_cursor: Some(*available_cursor),
+                        included_cursor: Some(*included_cursor),
+                        ..Default::default()
+                    },
+                    W::None => continue,
                 };
                 instances.insert(key.clone(), view);
             }

--- a/crates/fresh-editor/src/webui/mod.rs
+++ b/crates/fresh-editor/src/webui/mod.rs
@@ -706,6 +706,16 @@ fn apply_widget(editor: &mut Editor, v: &Value) {
         Some("panel") => {
             let plugin = v.get("plugin").and_then(|p| p.as_str()).unwrap_or("");
             let panel_id = v.get("panelId").and_then(|p| p.as_u64()).unwrap_or(0);
+            // Caret placement from a native text input: the browser
+            // positioned its caret on click and reports the byte offset;
+            // the host TextEdit (source of truth) follows. Not a widget
+            // *event* — no plugin hook fires, exactly like a TUI click
+            // that only moves the caret.
+            if let Some(byte) = v.get("textCursor").and_then(|b| b.as_u64()) {
+                let widget_key = v.get("widgetKey").and_then(|k| k.as_str()).unwrap_or("");
+                editor.set_widget_text_cursor(plugin, panel_id, widget_key, byte as usize);
+                return;
+            }
             let hit_index = v
                 .get("hitIndex")
                 .and_then(|i| i.as_u64())

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -114,7 +114,7 @@ frames without page input, region diffs on typing, idle silence, and the
 single-client 409 — plus per-region DOM patching (a typing frame rebuilds
 only its pane), measured metrics + app zoom (Ctrl+= / Ctrl+0, hit-testing
 while zoomed), and touch pan/tap in a `hasTouch` mobile context.
-**117 assertions** across the chrome surfaces, plus screenshots.
+**123 assertions** across the chrome surfaces, plus screenshots.
 
 One command runs the whole thing — build the bridge, install the Playwright
 deps (`test/package.json`) on first use, start the server, run the suite,

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -114,7 +114,7 @@ frames without page input, region diffs on typing, idle silence, and the
 single-client 409 — plus per-region DOM patching (a typing frame rebuilds
 only its pane), measured metrics + app zoom (Ctrl+= / Ctrl+0, hit-testing
 while zoomed), and touch pan/tap in a `hasTouch` mobile context.
-**123 assertions** across the chrome surfaces, plus screenshots.
+**127 assertions** across the chrome surfaces, plus screenshots.
 
 One command runs the whole thing — build the bridge, install the Playwright
 deps (`test/package.json`) on first use, start the server, run the suite,

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -413,6 +413,13 @@
   .widget-surface .w-list>*,.widget-surface .w-tree>*{flex:0 0 auto}
   .widget-surface.w-dock{border-right:1px solid var(--border)}
   .widget-surface.w-floatingModal{border:1px solid #5a5a5a;border-radius:8px;box-shadow:0 16px 60px rgba(0,0,0,.55);z-index:96}
+  /* Anchored popup (right-click context menu): undimmed backdrop that still
+     catches outside-clicks (dismiss), and a snug menu card — content-sized
+     height, tighter padding, buttons as full-width menu rows. */
+  .modal-scrim.scrim-clear{background:transparent}
+  .widget-surface.w-floatingModal.anchored{padding:6px 8px;
+    box-shadow:0 10px 36px rgba(0,0,0,.45)}
+  .widget-surface.w-floatingModal.anchored .w-button{display:block;text-align:left}
   .widget-surface .w-col{gap:3px}
   /* --- Plugin dialog polish (New Folder, etc.) ---------------------------
      A floating modal whose root is a labeledSection is a small dialog. Give
@@ -1784,7 +1791,7 @@ function entryText(e){ return (e.segments&&e.segments.length)?e.segments.map(s=>
 // list, so a row below the TUI fold has no recorded hit at all. Identity
 // delivery survives both (the bridge resolves by equality, and synthesizes
 // off-window list selects from the panel's own spec).
-function routeWidget(ctx, node, listIndex){
+function routeWidget(ctx, node, listIndex, ev){
   if(ctx.kind==="toolbar"){ if(node.key) sendWidget({surface:"toolbar",key:node.key}); return; }
   const base={surface:"panel",plugin:ctx.plugin,panelId:ctx.panelId};
   if(listIndex!=null){
@@ -1794,6 +1801,15 @@ function routeWidget(ctx, node, listIndex){
     const hit=(ctx.hits||[]).find(h=>h.widgetKind==="list" && h.payload && h.payload.index===listIndex
       && (!node.key || h.payload.list_key===node.key));
     const itemKey=(node.itemKeys&&node.itemKeys[listIndex]!=null)?node.itemKeys[listIndex]:(hit?hit.payload.key:"");
+    // Right-click fires `context` (never recorded as a hit — the bridge
+    // synthesizes it, like the TUI's right-click path) with the click cell
+    // so the plugin can anchor its context-menu popup.
+    if(ev&&ev.button===2){
+      const c=cellAt(ev);
+      sendWidget({...base,widgetKey:itemKey||"",eventType:"context",
+        payload:{index:listIndex,key:itemKey||"",list_key:node.key||null,col:c.col,row:c.row}});
+      return;
+    }
     const msg={...base,widgetKey:itemKey||"",eventType:"select",
       payload:{index:listIndex,key:itemKey||"",list_key:node.key||null}};
     if(hit) msg.hitIndex=hit.index;
@@ -1862,14 +1878,14 @@ function widgetEl(spec, ctx){
       specs.forEach((s,i)=>{
         const card=div("w-list-card"+(i===sel?" sel":""));
         card.appendChild(widgetEl(s, ctx));
-        card.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeWidget(ctx,spec,i); };
+        card.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeWidget(ctx,spec,i,e); };
         el.appendChild(card);
       });
     } else {
       (spec.items||[]).forEach((it,i)=>{
         const row=div("w-list-row"+(i===sel?" sel":""));
         row.textContent=entryText(it);
-        row.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeWidget(ctx,spec,i); };
+        row.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeWidget(ctx,spec,i,e); };
         el.appendChild(row);
       });
       if(!(spec.items||[]).length){ const empty=div("w-list-empty"); empty.textContent="(empty)"; el.appendChild(empty); }
@@ -1897,19 +1913,23 @@ function widgetEl(spec, ctx){
       if(!vis) return;
       const row=div("w-tree-row"+(i===sel?" sel":""));
       row.style.paddingLeft=(d*2)+"ch";
+      // Right-click anywhere on the row (disclosure/checkbox included, like
+      // the TUI's cell hit-test) fires `context` instead of the cell's own
+      // event — the plugin raises a context menu anchored at the click cell.
+      const treeCtx=e=>{ const c=cellAt(e); routeTree(ctx,spec,"context",{index:i,key,col:c.col,row:c.row}); };
       if(n.hasChildren){
         const g=document.createElement("span"); g.className="w-tree-disc"; g.textContent=isOpen?"▼ ":"▶ ";
-        g.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"expand",{index:i,key,expanded:!isOpen}); };
+        g.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(e.button===2) treeCtx(e); else routeTree(ctx,spec,"expand",{index:i,key,expanded:!isOpen}); };
         row.appendChild(g);
       }
       if(spec.checkable&&n.checked!=null){
         const cb=document.createElement("span"); cb.className="w-tree-check"; cb.textContent=n.checked?"☑ ":"☐ ";
-        cb.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"toggle",{index:i,key,checked:!n.checked}); };
+        cb.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(e.button===2) treeCtx(e); else routeTree(ctx,spec,"toggle",{index:i,key,checked:!n.checked}); };
         row.appendChild(cb);
       }
       const t=document.createElement("span"); t.className="w-tree-text"; t.textContent=entryText(n.text||{});
       row.appendChild(t);
-      row.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"select",{index:i,key}); };
+      row.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(e.button===2) treeCtx(e); else routeTree(ctx,spec,"select",{index:i,key}); };
       el.appendChild(row);
       // Fixed-height card rows (Tree.itemHeight > 1): the node's
       // extraLines render as continuation rows below the primary line,
@@ -1920,7 +1940,7 @@ function widgetEl(spec, ctx){
         const xr=div("w-tree-xrow"+(i===sel?" sel":""));
         xr.style.paddingLeft=((d*2)+2)+"ch";
         xr.textContent=entryText(ex);
-        xr.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeTree(ctx,spec,"select",{index:i,key}); };
+        xr.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(e.button===2) treeCtx(e); else routeTree(ctx,spec,"select",{index:i,key}); };
         el.appendChild(xr);
       }
     });
@@ -2222,18 +2242,33 @@ function contextMenuEl(cm){
 function widgetSurfaceEls(s){
   const out=[];
   if(s.kind==="floatingModal"){
-    const scrim=div("modal-scrim"); scrim.onmousedown=e=>e.stopPropagation(); out.push(scrim);
+    // An ANCHORED panel (right-click context menu) keeps the scrim as a
+    // click-catcher but undimmed — the TUI draws no background dim for it —
+    // and a press outside the popup dismisses it (standard menu behaviour;
+    // the centered modal instead swallows outside-clicks, it has explicit
+    // Cancel / Esc).
+    const scrim=div("modal-scrim"+(s.anchored?" scrim-clear":""));
+    scrim.onmousedown=s.anchored
+      ? e=>{ e.preventDefault(); e.stopPropagation(); sendKey({key:"Escape"}); }
+      : e=>e.stopPropagation();
+    out.push(scrim);
   }
-  const el=div("region widget-surface w-"+s.kind); place(el,s.rect);
+  const el=div("region widget-surface w-"+s.kind+(s.anchored?" anchored":"")); place(el,s.rect);
   if(s.kind==="floatingModal"){
     // The host sizes the panel in whole terminal cells, but the DOM adds
     // per-row gaps + padding a cell grid can't express, so a snug dialog
     // (e.g. the New Folder dialog) would overflow its fixed height and clip
     // its buttons under `overflow:auto`. Treat the host height as a minimum
     // and let the modal grow to fit its content; nudge it up by half the
-    // overflow so it stays visually centered.
+    // overflow so it stays visually centered. An anchored popup instead
+    // stays pinned at its click cell — it grows downward, no recentering.
     const want=el.style.height; el.style.minHeight=want; el.style.height="auto";
-    requestAnimationFrame(()=>{
+    if(s.anchored){
+      // Content-sized in both axes (host cells can't express DOM padding);
+      // the host-clamped rect stays as the minimum so the popup never
+      // shrinks below its TUI footprint.
+      el.style.minWidth=el.style.width; el.style.width="auto"; el.style.maxWidth="60vw";
+    } else requestAnimationFrame(()=>{
       const grew=el.offsetHeight-parseFloat(want||"0");
       if(grew>0) el.style.top=(parseFloat(el.style.top)-grew/2)+"px";
     });

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -1818,7 +1818,14 @@ function routeWidget(ctx, node, listIndex, ev){
   }
   if(node.key){
     const hit=(ctx.hits||[]).find(h=>h.widgetKey===node.key);
-    if(hit) sendWidget({...base,widgetKey:node.key,eventType:hit.eventType,payload:hit.payload,hitIndex:hit.index});
+    if(hit){ sendWidget({...base,widgetKey:node.key,eventType:hit.eventType,payload:hit.payload,hitIndex:hit.index}); return; }
+    // No recorded hit: the TUI clipped this control below the panel's inner
+    // rect, but the DOM grew the panel to fit and rendered it anyway. Send
+    // the identity with the kind's own event — the bridge synthesizes the
+    // hit from the panel's spec (state like `checked`/`disabled` is read
+    // from the spec server-side, not trusted from here).
+    const ev=node.kind==="button"?"activate":node.kind==="toggle"?"toggle":node.kind==="text"?"focus":null;
+    if(ev) sendWidget({...base,widgetKey:node.key,eventType:ev,payload:{}});
   }
 }
 

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -453,6 +453,42 @@
   .w-floatingModal>.w-section .w-button{padding:5px 16px}
   /* Dimmed placeholder text so an empty field doesn't read as a real value. */
   .w-text-val.ph{color:var(--muted)}
+  /* Native input inside a .w-text field: the outer div keeps the themed box
+     (base .w-text rules above); the input is a transparent editing surface
+     whose value/caret the host drives. caret-color makes the real blinking
+     caret theme-aware; position:relative anchors the completion popup. */
+  .w-text{position:relative}
+  .w-text-input{flex:1;min-width:0;background:transparent;border:none;outline:none;
+    color:inherit;font:inherit;padding:0;caret-color:var(--accent)}
+  .w-text-input::placeholder{color:var(--muted);opacity:1}
+  textarea.w-text-input{resize:none}
+  /* Completion popup under a text field (host-owned candidates). */
+  .w-complete{position:absolute;left:0;right:0;top:100%;z-index:98;background:var(--bg2);
+    border:1px solid var(--hairline,var(--border));border-radius:4px;max-height:200px;overflow-y:auto;
+    box-shadow:0 8px 24px rgba(0,0,0,.4)}
+  .w-complete-row{padding:1px 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .w-complete-row.sel{background:var(--menuhi);color:var(--on-sel,#fff)}
+  /* number / dropdown / dual-list controls (host-state-driven) */
+  .w-number{display:flex;align-items:center;gap:4px}
+  .w-num-step{cursor:default;padding:0 6px;border:1px solid var(--hairline,var(--border));border-radius:4px}
+  .w-num-val{padding:0 6px;min-width:3ch;text-align:center}
+  .w-number.focus .w-num-val{outline:1px solid var(--accent)}
+  .w-dropdown{display:flex;align-items:center;gap:4px;position:relative}
+  .w-dd-pill{padding:0 8px;border:1px solid var(--hairline,var(--border));border-radius:4px}
+  .w-dropdown.focus .w-dd-pill{outline:1px solid var(--accent)}
+  .w-dd{position:absolute;left:0;top:100%;z-index:98;background:var(--bg2);
+    border:1px solid var(--hairline,var(--border));border-radius:4px;max-height:200px;overflow-y:auto;
+    box-shadow:0 8px 24px rgba(0,0,0,.4);min-width:100%}
+  .w-dd-row{padding:1px 10px;white-space:nowrap}
+  .w-dd-row.sel{background:var(--menuhi);color:var(--on-sel,#fff)}
+  .w-dual-cols{display:flex;gap:10px}
+  .w-dual-col{flex:1;border:1px solid var(--hairline,var(--border));border-radius:4px;padding:2px;min-height:3em}
+  .w-dual-col.active{border-color:var(--accent)}
+  .w-dual-title{color:var(--muted);padding:0 4px}
+  .w-dual-row{padding:0 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .w-dual-row.sel{background:var(--menuhi);color:var(--on-sel,#fff)}
+  .w-embed-ph{display:flex;align-items:center;justify-content:center;color:var(--muted);
+    border:1px dashed var(--hairline,var(--border));border-radius:4px;padding:8px}
 
   /* ---- popups (completion / hover / action / list / text) — native ---- */
   .popup{position:absolute;z-index:75;background:#252526;border:1px solid #454545;
@@ -1347,6 +1383,9 @@ function renderRegion(name){
   REGION_FILL[name](c, scene.regions);
   c.querySelectorAll(SCROLL_KEEP).forEach((e,i)=>{ if(saved[i]) e.scrollTop=saved[i]; });
   if(name==="settings") settingsEnsureSelectionVisible(c);
+  // A widgets rebuild replaces any focused text input — restore DOM focus
+  // and caret to the host-focused field (or the hidden sink if none).
+  if(name==="widgets") syncWidgetInputFocus();
 }
 
 // The TUI windows the settings rows with the core's scroll offset, so its
@@ -1829,6 +1868,62 @@ function routeWidget(ctx, node, listIndex, ev){
   }
 }
 
+// Route a control interaction by key + SPECIFIC eventType. routeWidget's
+// keyed path picks the first hit with a matching key, which is ambiguous
+// for widgets that record several hit kinds under one key (a dropdown
+// records `dropdown_toggle` plus one `dropdown_select` per option row).
+// Falls back to sending the bare identity; the bridge synthesizes the hit
+// from the panel's spec (same as the clipped-control path).
+function routeControl(ctx,key,eventType,payload){
+  const base={surface:"panel",plugin:ctx.plugin,panelId:ctx.panelId};
+  const hit=(ctx.hits||[]).find(h=>h.widgetKey===key&&h.eventType===eventType
+    &&(!(payload&&payload.index!=null)||(h.payload&&h.payload.index===payload.index)));
+  const msg={...base,widgetKey:key,eventType,payload:hit?hit.payload:(payload||{})};
+  if(hit) msg.hitIndex=hit.index;
+  sendWidget(msg);
+}
+
+// UTF-8 byte offset ⇄ UTF-16 code-unit index conversions for text widgets:
+// the host TextEdit speaks bytes, input.selectionStart speaks UTF-16.
+function byteToUtf16(s,byte){
+  let b=0;
+  for(let i=0;i<s.length;i++){
+    if(b>=byte) return i;
+    const c=s.codePointAt(i);
+    b+=c<0x80?1:c<0x800?2:c<0x10000?3:4;
+    if(c>0xffff) i++;
+  }
+  return s.length;
+}
+function utf16ToByte(s,idx){
+  let b=0;
+  for(let i=0;i<Math.min(idx,s.length);i++){
+    const c=s.codePointAt(i);
+    b+=c<0x80?1:c<0x800?2:c<0x10000?3:4;
+    if(c>0xffff) i++;
+  }
+  return b;
+}
+
+// After a widgets-region rebuild: hand real DOM focus to the host-focused
+// text widget's input (so the native caret blinks and IME composes there),
+// pin its caret to the host TextEdit's cursor, and fall back to the hidden
+// sink when no widget input holds focus anymore. Skipped mid-IME-composition
+// so a caret write can't cancel the preedit.
+function syncWidgetInputFocus(){
+  const t=document.querySelector(".w-text-input[data-wfocus='1']");
+  if(t){
+    if(document.activeElement!==t) t.focus({preventScroll:true});
+    if(!t.dataset.composing&&t.dataset.caret!==""&&t.dataset.caret!=null){
+      const i=+t.dataset.caret;
+      try{ t.setSelectionRange(i,i); }catch(_){}
+    }
+  } else if(document.activeElement&&document.activeElement.classList
+      &&document.activeElement.classList.contains("w-text-input")){
+    focusSink();
+  }
+}
+
 function widgetEl(spec, ctx){
   if(!spec) return document.createTextNode("");
   const kind=spec.kind, fk=ctx.focusKey;
@@ -1866,11 +1961,139 @@ function widgetEl(spec, ctx){
     if(spec.child) el.appendChild(widgetEl(spec.child, ctx)); return el;
   }
   if(kind==="text"){
+    // A REAL <input>/<textarea>, but the editor stays the single source of
+    // truth: the host TextEdit's live value + caret arrive via instance
+    // state (instances[key].textValue / cursorByte) and are written into
+    // the element on every frame. Keystrokes never edit the element
+    // locally — the global keydown handler preventDefaults and forwards
+    // them, and the pushed frame echoes the authoritative result back.
+    // The native element buys the real caret, focus ring, IME target and
+    // browser-computed click-to-caret positions for free.
+    const inst=(ctx.instances&&spec.key)?ctx.instances[spec.key]:null;
+    const val=(inst&&inst.textValue!=null)?inst.textValue:(spec.value||"");
     const el=div("w-text"+(focused?" focus":""));
     if(spec.label){ const l=document.createElement("span"); l.className="w-text-label"; l.textContent=spec.label+": "; el.appendChild(l); }
-    const v=document.createElement("span"); const showingPh=!spec.value&&!!spec.placeholder;
-    v.className="w-text-val"+(showingPh?" ph":""); v.textContent=spec.value||spec.placeholder||""; el.appendChild(v);
-    if(spec.key) el.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); routeWidget(ctx,spec); };
+    const multi=(spec.rows||1)>1;
+    const input=document.createElement(multi?"textarea":"input");
+    input.className="w-text-input";
+    if(multi) input.rows=spec.rows;
+    input.value=val;
+    input.placeholder=spec.placeholder||"";
+    input.setAttribute("autocapitalize","off"); input.setAttribute("autocomplete","off");
+    input.setAttribute("autocorrect","off"); input.setAttribute("spellcheck","false");
+    // Block every local edit outside the key-forwarding path (autofill,
+    // drag-drop text, context-menu paste): the paste event still bubbles to
+    // the document paste listener (the one real paste path), and IME
+    // composition — which beforeinput can't cancel — is forwarded on commit
+    // exactly like the hidden sink does, then discarded locally.
+    input.addEventListener("beforeinput",ev=>{ if(!ev.isComposing) ev.preventDefault(); });
+    input.addEventListener("compositionstart",()=>{ input.dataset.composing="1"; });
+    input.addEventListener("compositionend",ev=>{ delete input.dataset.composing; if(ev.data) sendPaste(ev.data); input.value=val; });
+    input.addEventListener("input",ev=>{ if(!ev.isComposing) input.value=val; });
+    // Mousedown focuses the widget host-side (the same `focus` event a TUI
+    // click fires). No preventDefault — the browser places its caret
+    // natively, and mouseup reports that position so the host TextEdit
+    // follows. (A drag-selection is left as a browser-local convenience
+    // for copy; the host tracks selection only via its own keybindings.)
+    input.addEventListener("mousedown",e=>{ e.stopPropagation(); if(spec.key) routeWidget(ctx,spec); });
+    input.addEventListener("mouseup",e=>{ e.stopPropagation();
+      if(spec.key && input.selectionStart===input.selectionEnd)
+        sendWidget({surface:"panel",plugin:ctx.plugin,panelId:ctx.panelId,widgetKey:spec.key,
+          textCursor:utf16ToByte(input.value,input.selectionStart)});
+    });
+    if(focused){
+      input.dataset.wfocus="1";
+      input.dataset.caret=(inst&&inst.cursorByte!=null)?String(byteToUtf16(val,inst.cursorByte)):"";
+    }
+    el.appendChild(input);
+    // Completion popup (e.g. path complete): candidates are host instance
+    // state; the highlighted row appears only once ↑/↓ entered the popup,
+    // mirroring the TUI.
+    if(focused&&inst&&inst.completions&&inst.completions.length){
+      const dd=div("w-complete");
+      inst.completions.forEach((cand,i)=>{
+        const r=div("w-complete-row"+((inst.completionNavigated&&i===(inst.completionSelected||0))?" sel":""));
+        r.textContent=cand; dd.appendChild(r);
+      });
+      el.appendChild(dd);
+    }
+    return el;
+  }
+  if(kind==="number"){
+    const inst=(ctx.instances&&spec.key)?ctx.instances[spec.key]:null;
+    const val=(inst&&inst.numberValue!=null)?inst.numberValue:(spec.value||0);
+    const el=div("w-number"+(focused?" focus":""));
+    if(spec.label){ const l=document.createElement("span"); l.className="w-text-label"; l.textContent=spec.label+": "; el.appendChild(l); }
+    const disp=spec.editText!=null?spec.editText
+      :spec.percent?Math.round(val*100)+"%"
+      :spec.integer?String(Math.trunc(val))
+      :String(+(+val).toFixed(3));
+    // −/+ steppers focus the widget then step it via the host's own
+    // Left/Right handling — the value math (min/max/step) stays host-side.
+    const mk=(t,key)=>{ const b=document.createElement("span"); b.className="w-num-step"; b.textContent=t;
+      b.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(!spec.key) return;
+        routeControl(ctx,spec.key,"number_value",{}); sendKey({key}); };
+      return b; };
+    el.appendChild(mk("−","ArrowLeft"));
+    const v=document.createElement("span"); v.className="w-num-val"; v.textContent=disp;
+    v.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"number_value",{}); };
+    el.appendChild(v);
+    el.appendChild(mk("+","ArrowRight"));
+    return el;
+  }
+  if(kind==="dropdown"){
+    const inst=(ctx.instances&&spec.key)?ctx.instances[spec.key]:null;
+    const selIdx=(inst&&inst.selectedIndex!=null)?inst.selectedIndex:(spec.selectedIndex||0);
+    const open=inst?!!inst.dropdownOpen:!!spec.open;
+    const el=div("w-dropdown"+(focused?" focus":""));
+    if(spec.label){ const l=document.createElement("span"); l.className="w-text-label"; l.textContent=spec.label+": "; el.appendChild(l); }
+    const pill=document.createElement("span"); pill.className="w-dd-pill";
+    pill.textContent=((spec.options||[])[selIdx]??"—")+(open?" ▲":" ▾");
+    pill.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_toggle",{}); };
+    el.appendChild(pill);
+    if(open){
+      const dd=div("w-dd");
+      (spec.options||[]).forEach((o,i)=>{
+        const r=div("w-dd-row"+(i===selIdx?" sel":"")); r.textContent=o;
+        r.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_select",{index:i}); };
+        dd.appendChild(r);
+      });
+      el.appendChild(dd);
+    }
+    return el;
+  }
+  if(kind==="dualList"){
+    // Two-column ordered-subset picker. Rows are derived exactly like the
+    // host: Available = options minus included minus excluded (in option
+    // order); Included = the host-owned ordered instance list. Clicks fire
+    // the same `dual_focus` hits a TUI cell click resolves; moves/reorders
+    // stay keyboard-driven through the host (Space / PageUp / PageDown).
+    const inst=(ctx.instances&&spec.key)?ctx.instances[spec.key]:null;
+    // `included` is skip-serialized when empty, so detect "host state
+    // exists" via activeIncluded (always present for a DualList instance).
+    const included=(inst&&inst.activeIncluded!=null)?(inst.included||[]):(spec.included||[]);
+    const activeIncluded=inst?!!inst.activeIncluded:false;
+    const cursors={available:inst&&inst.availableCursor||0, included:inst&&inst.includedCursor||0};
+    const optLabel=v=>{ const o=(spec.options||[]).find(o=>(o.value??o)===v); return o?(o.label??o.value??o):v; };
+    const excluded=new Set([...(spec.excluded||[]),...included]);
+    const avail=(spec.options||[]).map(o=>o.value??o).filter(v=>!excluded.has(v));
+    const el=div("w-dual"+(focused?" focus":""));
+    if(spec.label){ const l=div("w-section-label"); l.textContent=spec.label; el.appendChild(l); }
+    const cols=div("w-dual-cols");
+    const mkCol=(title,values,column,active)=>{
+      const c=div("w-dual-col"+(active?" active":""));
+      const t=div("w-dual-title"); t.textContent=title; c.appendChild(t);
+      values.forEach((v,i)=>{
+        const r=div("w-dual-row"+(active&&i===cursors[column]?" sel":"")); r.textContent=optLabel(v);
+        r.onmousedown=e=>{ e.preventDefault(); e.stopPropagation();
+          if(spec.key) routeControl(ctx,spec.key,"dual_focus",{column,index:i}); };
+        c.appendChild(r);
+      });
+      return c;
+    };
+    cols.appendChild(mkCol("Available",avail,"available",!activeIncluded));
+    cols.appendChild(mkCol("Included",included,"included",activeIncluded));
+    el.appendChild(cols);
     return el;
   }
   if(kind==="list"){
@@ -1961,6 +2184,15 @@ function widgetEl(spec, ctx){
     return el;
   }
   if(kind==="raw"&&spec.entries){ const el=div("w-raw"); el.textContent=spec.entries.map(entryText).join("\n"); return el; }
+  if(kind==="windowEmbed"){
+    // Embedding another editor window's live cells inside a native panel
+    // needs its own scene region (the webui cell buffer carries pane
+    // interiors only) — honest placeholder until that lands.
+    const el=div("w-embed-ph");
+    el.textContent="⧉ live preview is not available in the web UI yet";
+    if(spec.rows) el.style.minHeight=(spec.rows*CH)+"px";
+    return el;
+  }
   const fb=div("w-unsupported"); fb.textContent="["+kind+"]"; return fb;
 }
 

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -220,6 +220,33 @@ check('clicking a dock workspace row selects it in the scene',
   !!dSel && dSel.instances && dSel.instances.sessions && dSel.instances.sessions.selectedIndex === 0,
   JSON.stringify(dSel && dSel.instances));
 
+console.log('\n[dock right-click = plugin context menu (anchored popup, like the TUI)]');
+// Right-click on a session row fires a `context` widget event (never in the
+// recorded hits — the bridge synthesizes it, exactly like the TUI's
+// right-click path) and the orchestrator raises its anchored Visit / Move /
+// Archive / Delete popup, undimmed, dismissed by Esc or an outside click.
+const modalSurf = async () => ((await scene(page)).regions.widgets || []).find(w => w.kind === 'floatingModal');
+await page.locator('.widget-surface.w-dock .w-tree-row').first().click({ button: 'right' });
+await page.waitForFunction(() => (window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
+const ctxM = await modalSurf();
+check('right-click on a dock row opens the context-menu panel', !!ctxM);
+check('context menu is ANCHORED (popup placement, not centered)', !!ctxM && ctxM.anchored === true);
+const ctxText = ctxM ? await page.locator('.widget-surface.w-floatingModal').innerText() : '';
+check('context menu offers Visit / Move to folder / Archive / Delete',
+  /Visit/.test(ctxText) && /Move to Folder/i.test(ctxText) && /Archive/.test(ctxText) && /Delete/.test(ctxText), ctxText);
+check('anchored popup scrim is transparent (no modal dim)', (await page.locator('.modal-scrim.scrim-clear').count()) === 1);
+await page.screenshot({ path: `${SHOTS}/29-dock-context-menu.png` });
+// Esc dismisses the popup; the dock survives.
+await page.keyboard.press('Escape');
+await page.waitForFunction(() => !(window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
+check('Esc closes the context menu', !(await modalSurf()));
+// Reopen; a click outside the popup dismisses it (standard menu behaviour).
+await page.locator('.widget-surface.w-dock .w-tree-row').first().click({ button: 'right' });
+await page.waitForFunction(() => (window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
+await page.locator('.modal-scrim.scrim-clear').click({ position: { x: 900, y: 600 } });
+await page.waitForFunction(() => !(window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
+check('outside-click dismisses the context menu', !(await modalSurf()));
+
 console.log('\n[keybinding editor = full native modal incl. edit dialog]');
 // Start clean: dismiss any focused dock/floating panel so keys reach the editor.
 await page.keyboard.press('Escape'); await page.waitForTimeout(120);

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -648,6 +648,11 @@ await page.waitForTimeout(200);
 check('New Workspace dialog is a floatingModal', ((await scene(page)).regions.widgets || []).some(w => w.kind === 'floatingModal'));
 check('exactly one modal-scrim behind the floatingModal', (await page.locator('.modal-scrim').count()) === 1);
 const dockSel = async () => { const d = ((await scene(page)).regions.widgets || []).find(w => w.kind === 'dock'); return d && d.instances && d.instances.sessions ? d.instances.sessions.selectedIndex : null; };
+// A freshly (re)opened dock reports selectedIndex -1 until an async probe
+// repaint pins it to the highlighted session (refreshOpenDialog re-pins on
+// every repaint) — wait for the pin so the scrim check below isn't racing it.
+await page.waitForFunction(() => { const d = (window.fresh.scene.regions.widgets || []).find(w => w.kind === 'dock');
+  return d && d.instances && d.instances.sessions && d.instances.sessions.selectedIndex >= 0; }, { timeout: 8000 }).catch(() => {});
 const sel0 = await dockSel();
 const cardBox = await page.locator('.widget-surface.w-dock .w-tree-row').first().boundingBox();
 if (cardBox) await page.mouse.click(cardBox.x + cardBox.width / 2, cardBox.y + cardBox.height / 2);

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -247,6 +247,32 @@ await page.locator('.modal-scrim.scrim-clear').click({ position: { x: 900, y: 60
 await page.waitForFunction(() => !(window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'), { timeout: 8000 }).catch(() => {});
 check('outside-click dismisses the context menu', !(await modalSurf()));
 
+console.log('\n[widget text field = native <input>, host-authoritative echo + caret]');
+// The dock's "Search Tasks" field is a widget Text: it must render as a real
+// <input> whose value/caret mirror the host TextEdit per keystroke (the spec
+// value is initial-only and would lag until the plugin round-trip).
+const dockSearch = page.locator('.widget-surface.w-dock input.w-text-input').first();
+check('widget text field renders as a native <input>', (await dockSearch.count()) === 1);
+await dockSearch.click();
+await page.waitForTimeout(400);
+check('clicking the field takes real DOM focus (native caret)', await page.evaluate(() =>
+  document.activeElement && document.activeElement.classList.contains('w-text-input')));
+let echoOk = true;
+for (const ch of 'abc') {
+  await page.keyboard.type(ch);
+  const want = 'abc'.slice(0, 'abc'.indexOf(ch) + 1);
+  const ok = await page.waitForFunction(w => document.activeElement.value === w, want, { timeout: 2000 }).then(() => true).catch(() => false);
+  if (!ok) { echoOk = false; break; }
+}
+check('every keystroke echoes into the input (host TextEdit → instance state)', echoOk,
+  JSON.stringify(await page.evaluate(() => document.activeElement.value)));
+await page.keyboard.press('Home'); await page.waitForTimeout(300);
+check('caret follows the host cursor (Home → 0)', (await page.evaluate(() => document.activeElement.selectionStart)) === 0);
+// Clear the filter so later dock assertions see the full session list.
+await page.keyboard.press('End');
+for (let i = 0; i < 3; i++) await page.keyboard.press('Backspace');
+await page.keyboard.press('Escape'); await page.waitForTimeout(200);
+
 console.log('\n[keybinding editor = full native modal incl. edit dialog]');
 // Start clean: dismiss any focused dock/floating panel so keys reach the editor.
 await page.keyboard.press('Escape'); await page.waitForTimeout(120);


### PR DESCRIPTION
Makes plugin widget panels actually usable from the web UI. Started as "right-click in the orchestrator dock does nothing", grew into an audit of every event the TUI can fire vs. what the web frontend delivers, and ended at the root cause of the New Workspace dialog being barely usable (no typing echo, no caret, invisible focus).

## 1. Dock right-click context menu (`fa80d38`)

In the TUI, right-clicking a dock row fires a `context` widget event and the orchestrator raises its Visit / Move to Folder… / Archive / Delete popup. The web frontend routed every mouse button to `select`, so right-click just moved the selection.

- Frontend: right-button mousedown on tree rows (body, disclosure, checkbox, card continuation rows) and list rows/cards routes eventType `context` with the row identity + click cell for anchoring.
- Bridge: tree/list hit synthesis accepts `context` (never in the recorded hit list — the TUI synthesizes it from a right-click too); item keys still come from the spec, never frontend strings.
- `WidgetSurfaceView.anchored` lets the web render anchored popups like the TUI: no background dim, content-sized, pinned at the click, outside-click dismisses.

## 2. Complete widget-event parity audit (`9145905`)

Surfaces that forward raw mouse events (buffer, tabs, file explorer) had parity by construction; the semantically-routed widget-panel surface needed each event wired explicitly. The audit found and fixed the remaining same-class gaps:

- Tree checkbox `toggle` synthesized for rows beyond the TUI scroll window (`checked` derived from the spec, mirroring the renderer).
- `activate`/`toggle`/`focus` on Button/Toggle/Text synthesized when the TUI clipped the control but the DOM-grown panel still rendered it — previously those clicks died silently (disabled buttons stay dead).
- Hardened a pre-existing flaky suite assertion (modal-scrim check racing the dock's async selection re-pin).

## 3. Host-authoritative native form controls (`97b07b7`)

Root cause of the New Workspace dialog issues: the host owns the live editing state for Text (full `TextEdit`: value/cursor/selection/completions), Number, Dropdown and DualList — but `widgets_view` exported only List/Tree instance state, so the web rendered the *initial-only* spec values. Typing echoed only when the plugin's spec round-trip landed (~1s batches), fields drew no caret, and clicks could race constant re-renders.

The editor stays the single source of truth; the web now renders that truth with real form controls:

- Scene exports every host-owned instance state (text value + cursor byte + selection + completion popup, number value, dropdown selected/open, dual-list state).
- Text fields are native `<input>`/`<textarea>`: value and caret written from host state every frame → per-keystroke echo, real blinking theme-aware caret, real focus ring, IME composing in place. Local edits are blocked; keys flow through the editor as before, paste keeps the single bracketed-paste path.
- Click-to-caret: the browser places the caret natively; a new `textCursor` bridge message syncs the host `TextEdit` (grapheme-snapped host-side).
- Completion popups (path complete) render from host candidates.
- Number / Dropdown / DualList render natively instead of `[kind]` placeholders, routed by key + exact eventType with spec-derived hit synthesis; `windowEmbed` gets an honest "not available in the web UI yet" placeholder.

## Verification

- Reproduced each bug against the live bridge in headless Chromium before fixing (screenshots in session).
- New Workspace dialog end-to-end after: per-keystroke echo worst-case 88 ms in a **debug** build (was ~1 s batches), caret sync both directions, checkbox click, focus ring — 8/8.
- Web UI Playwright suite: **127 passed, 0 failed** (10 new regression assertions: 6 context menu, 4 native text field).
- TUI untouched in behavior: orchestrator dock e2e 46/46, context-menu e2e 38/38, `scene_parity` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvT9MdJTFVy9FWzkozNvfX