### PR TITLE
fix(explorer): let a new item's name create its missing parent directories (#2640)

### DIFF
--- a/crates/fresh-editor/locales/bg.json
+++ b/crates/fresh-editor/locales/bg.json
@@ -1006,6 +1006,8 @@
   "explorer.moved_to_trash": "Преместено в кошчето: %{name}",
   "explorer.new_directory_prompt": "Име на новата папка: ",
   "explorer.new_file_prompt": "Име на новия файл: ",
+  "explorer.new_item_path_must_be_relative": "Пътят на новия елемент трябва да бъде относителен",
+  "explorer.new_item_path_outside_project": "Пътят на новия елемент трябва да остане в директорията на проекта",
   "explorer.opened": "Файловият браузър е отворен",
   "explorer.opened_file": "Отворен: %{name}",
   "explorer.paste_cancelled": "Поставянето е отменено",

--- a/crates/fresh-editor/locales/bg.json
+++ b/crates/fresh-editor/locales/bg.json
@@ -1006,6 +1006,7 @@
   "explorer.moved_to_trash": "Преместено в кошчето: %{name}",
   "explorer.new_directory_prompt": "Име на новата папка: ",
   "explorer.new_file_prompt": "Име на новия файл: ",
+  "explorer.new_item_path_exists": "'%{name}' вече съществува",
   "explorer.new_item_path_must_be_relative": "Пътят на новия елемент трябва да бъде относителен",
   "explorer.new_item_path_outside_project": "Пътят на новия елемент трябва да остане в директорията на проекта",
   "explorer.opened": "Файловият браузър е отворен",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Obnovuji %{name}...",
   "explorer.rename_cancelled": "Přejmenování zrušeno",
   "explorer.new_item_path_must_be_relative": "Cesta nové položky musí být relativní",
+  "explorer.new_item_path_outside_project": "Cesta nové položky musí zůstat v adresáři projektu",
   "explorer.rename_invalid_dot": "Název nemůže být '.' ani '..'",
   "explorer.rename_invalid_separator": "Název nemůže obsahovat oddělovač cesty",
   "explorer.rename_prompt": "Přejmenovat na: ",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Obnoveno",
   "explorer.refreshing": "Obnovuji %{name}...",
   "explorer.rename_cancelled": "Přejmenování zrušeno",
+  "explorer.new_item_path_exists": "'%{name}' již existuje",
   "explorer.new_item_path_must_be_relative": "Cesta nové položky musí být relativní",
   "explorer.new_item_path_outside_project": "Cesta nové položky musí zůstat v adresáři projektu",
   "explorer.rename_invalid_dot": "Název nemůže být '.' ani '..'",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Obnoveno",
   "explorer.refreshing": "Obnovuji %{name}...",
   "explorer.rename_cancelled": "Přejmenování zrušeno",
+  "explorer.new_item_path_must_be_relative": "Cesta nové položky musí být relativní",
   "explorer.rename_invalid_dot": "Název nemůže být '.' ani '..'",
   "explorer.rename_invalid_separator": "Název nemůže obsahovat oddělovač cesty",
   "explorer.rename_prompt": "Přejmenovat na: ",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Obnovuji %{name}...",
   "explorer.rename_cancelled": "Přejmenování zrušeno",
   "explorer.new_item_path_must_be_relative": "Cesta nové položky musí být relativní",
+  "explorer.new_item_path_outside_project": "Cesta nové položky musí zůstat v adresáři projektu",
   "explorer.rename_invalid_dot": "Název nemůže být '.' ani '..'",
   "explorer.rename_invalid_separator": "Název nemůže obsahovat oddělovač cesty",
   "explorer.rename_prompt": "Přejmenovat na: ",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Obnoveno",
   "explorer.refreshing": "Obnovuji %{name}...",
   "explorer.rename_cancelled": "Přejmenování zrušeno",
+  "explorer.new_item_path_must_be_relative": "Cesta nové položky musí být relativní",
   "explorer.rename_invalid_dot": "Název nemůže být '.' ani '..'",
   "explorer.rename_invalid_separator": "Název nemůže obsahovat oddělovač cesty",
   "explorer.rename_prompt": "Přejmenovat na: ",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Aktualisiert",
   "explorer.refreshing": "Aktualisiere %{name}...",
   "explorer.rename_cancelled": "Umbenennung abgebrochen",
+  "explorer.new_item_path_exists": "'%{name}' existiert bereits",
   "explorer.new_item_path_must_be_relative": "Der Pfad des neuen Elements muss relativ sein",
   "explorer.new_item_path_outside_project": "Der Pfad des neuen Elements muss im Projektverzeichnis bleiben",
   "explorer.rename_invalid_dot": "Name darf nicht '.' oder '..' sein",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Aktualisiert",
   "explorer.refreshing": "Aktualisiere %{name}...",
   "explorer.rename_cancelled": "Umbenennung abgebrochen",
+  "explorer.new_item_path_must_be_relative": "Der Pfad des neuen Elements muss relativ sein",
   "explorer.rename_invalid_dot": "Name darf nicht '.' oder '..' sein",
   "explorer.rename_invalid_separator": "Name darf keinen Pfadtrenner enthalten",
   "explorer.rename_prompt": "Umbenennen zu: ",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Aktualisiere %{name}...",
   "explorer.rename_cancelled": "Umbenennung abgebrochen",
   "explorer.new_item_path_must_be_relative": "Der Pfad des neuen Elements muss relativ sein",
+  "explorer.new_item_path_outside_project": "Der Pfad des neuen Elements muss im Projektverzeichnis bleiben",
   "explorer.rename_invalid_dot": "Name darf nicht '.' oder '..' sein",
   "explorer.rename_invalid_separator": "Name darf keinen Pfadtrenner enthalten",
   "explorer.rename_prompt": "Umbenennen zu: ",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Aktualisiert",
   "explorer.refreshing": "Aktualisiere %{name}...",
   "explorer.rename_cancelled": "Umbenennung abgebrochen",
+  "explorer.new_item_path_must_be_relative": "Der Pfad des neuen Elements muss relativ sein",
   "explorer.rename_invalid_dot": "Name darf nicht '.' oder '..' sein",
   "explorer.rename_invalid_separator": "Name darf keinen Pfadtrenner enthalten",
   "explorer.rename_prompt": "Umbenennen zu: ",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Aktualisiere %{name}...",
   "explorer.rename_cancelled": "Umbenennung abgebrochen",
   "explorer.new_item_path_must_be_relative": "Der Pfad des neuen Elements muss relativ sein",
+  "explorer.new_item_path_outside_project": "Der Pfad des neuen Elements muss im Projektverzeichnis bleiben",
   "explorer.rename_invalid_dot": "Name darf nicht '.' oder '..' sein",
   "explorer.rename_invalid_separator": "Name darf keinen Pfadtrenner enthalten",
   "explorer.rename_prompt": "Umbenennen zu: ",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1001,6 +1001,7 @@
   "explorer.pasted": "Pasted: %{name}",
   "explorer.pasted_moved": "Moved: %{name}",
   "explorer.rename_cancelled": "Rename cancelled",
+  "explorer.new_item_path_exists": "'%{name}' already exists",
   "explorer.new_item_path_must_be_relative": "New item path must be relative",
   "explorer.new_item_path_outside_project": "New item path must stay within the project directory",
   "explorer.rename_invalid_dot": "Name cannot be '.' or '..'",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1001,6 +1001,7 @@
   "explorer.pasted": "Pasted: %{name}",
   "explorer.pasted_moved": "Moved: %{name}",
   "explorer.rename_cancelled": "Rename cancelled",
+  "explorer.new_item_path_must_be_relative": "New item path must be relative",
   "explorer.rename_invalid_dot": "Name cannot be '.' or '..'",
   "explorer.rename_invalid_separator": "Name cannot contain '/'",
   "explorer.rename_prompt": "Rename to: ",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1002,6 +1002,7 @@
   "explorer.pasted_moved": "Moved: %{name}",
   "explorer.rename_cancelled": "Rename cancelled",
   "explorer.new_item_path_must_be_relative": "New item path must be relative",
+  "explorer.new_item_path_outside_project": "New item path must stay within the project directory",
   "explorer.rename_invalid_dot": "Name cannot be '.' or '..'",
   "explorer.rename_invalid_separator": "Name cannot contain '/'",
   "explorer.rename_prompt": "Rename to: ",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -985,6 +985,7 @@
   "explorer.pasted_moved": "Moved: %{name}",
   "explorer.rename_cancelled": "Rename cancelled",
   "explorer.new_item_path_must_be_relative": "New item path must be relative",
+  "explorer.new_item_path_outside_project": "New item path must stay within the project directory",
   "explorer.rename_invalid_dot": "Name cannot be '.' or '..'",
   "explorer.rename_invalid_separator": "Name cannot contain '/'",
   "explorer.rename_prompt": "Rename to: ",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -984,6 +984,7 @@
   "explorer.pasted": "Pasted: %{name}",
   "explorer.pasted_moved": "Moved: %{name}",
   "explorer.rename_cancelled": "Rename cancelled",
+  "explorer.new_item_path_must_be_relative": "New item path must be relative",
   "explorer.rename_invalid_dot": "Name cannot be '.' or '..'",
   "explorer.rename_invalid_separator": "Name cannot contain '/'",
   "explorer.rename_prompt": "Rename to: ",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Actualizado",
   "explorer.refreshing": "Actualizando %{name}...",
   "explorer.rename_cancelled": "Renombrado cancelado",
+  "explorer.new_item_path_must_be_relative": "La ruta del nuevo elemento debe ser relativa",
   "explorer.rename_invalid_dot": "El nombre no puede ser '.' ni '..'",
   "explorer.rename_invalid_separator": "El nombre no puede contener un separador de ruta",
   "explorer.rename_prompt": "Renombrar a: ",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Actualizando %{name}...",
   "explorer.rename_cancelled": "Renombrado cancelado",
   "explorer.new_item_path_must_be_relative": "La ruta del nuevo elemento debe ser relativa",
+  "explorer.new_item_path_outside_project": "La ruta del nuevo elemento debe permanecer dentro del directorio del proyecto",
   "explorer.rename_invalid_dot": "El nombre no puede ser '.' ni '..'",
   "explorer.rename_invalid_separator": "El nombre no puede contener un separador de ruta",
   "explorer.rename_prompt": "Renombrar a: ",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Actualizado",
   "explorer.refreshing": "Actualizando %{name}...",
   "explorer.rename_cancelled": "Renombrado cancelado",
+  "explorer.new_item_path_exists": "'%{name}' ya existe",
   "explorer.new_item_path_must_be_relative": "La ruta del nuevo elemento debe ser relativa",
   "explorer.new_item_path_outside_project": "La ruta del nuevo elemento debe permanecer dentro del directorio del proyecto",
   "explorer.rename_invalid_dot": "El nombre no puede ser '.' ni '..'",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Actualizado",
   "explorer.refreshing": "Actualizando %{name}...",
   "explorer.rename_cancelled": "Renombrado cancelado",
+  "explorer.new_item_path_must_be_relative": "La ruta del nuevo elemento debe ser relativa",
   "explorer.rename_invalid_dot": "El nombre no puede ser '.' ni '..'",
   "explorer.rename_invalid_separator": "El nombre no puede contener un separador de ruta",
   "explorer.rename_prompt": "Renombrar a: ",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Actualizando %{name}...",
   "explorer.rename_cancelled": "Renombrado cancelado",
   "explorer.new_item_path_must_be_relative": "La ruta del nuevo elemento debe ser relativa",
+  "explorer.new_item_path_outside_project": "La ruta del nuevo elemento debe permanecer dentro del directorio del proyecto",
   "explorer.rename_invalid_dot": "El nombre no puede ser '.' ni '..'",
   "explorer.rename_invalid_separator": "El nombre no puede contener un separador de ruta",
   "explorer.rename_prompt": "Renombrar a: ",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Actualisation de %{name}...",
   "explorer.rename_cancelled": "Renommage annulé",
   "explorer.new_item_path_must_be_relative": "Le chemin du nouvel élément doit être relatif",
+  "explorer.new_item_path_outside_project": "Le chemin du nouvel élément doit rester dans le répertoire du projet",
   "explorer.rename_invalid_dot": "Le nom ne peut pas être '.' ou '..'",
   "explorer.rename_invalid_separator": "Le nom ne peut pas contenir de séparateur de chemin",
   "explorer.rename_prompt": "Renommer en : ",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Actualisé",
   "explorer.refreshing": "Actualisation de %{name}...",
   "explorer.rename_cancelled": "Renommage annulé",
+  "explorer.new_item_path_exists": "'%{name}' existe déjà",
   "explorer.new_item_path_must_be_relative": "Le chemin du nouvel élément doit être relatif",
   "explorer.new_item_path_outside_project": "Le chemin du nouvel élément doit rester dans le répertoire du projet",
   "explorer.rename_invalid_dot": "Le nom ne peut pas être '.' ou '..'",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Actualisé",
   "explorer.refreshing": "Actualisation de %{name}...",
   "explorer.rename_cancelled": "Renommage annulé",
+  "explorer.new_item_path_must_be_relative": "Le chemin du nouvel élément doit être relatif",
   "explorer.rename_invalid_dot": "Le nom ne peut pas être '.' ou '..'",
   "explorer.rename_invalid_separator": "Le nom ne peut pas contenir de séparateur de chemin",
   "explorer.rename_prompt": "Renommer en : ",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Actualisé",
   "explorer.refreshing": "Actualisation de %{name}...",
   "explorer.rename_cancelled": "Renommage annulé",
+  "explorer.new_item_path_must_be_relative": "Le chemin du nouvel élément doit être relatif",
   "explorer.rename_invalid_dot": "Le nom ne peut pas être '.' ou '..'",
   "explorer.rename_invalid_separator": "Le nom ne peut pas contenir de séparateur de chemin",
   "explorer.rename_prompt": "Renommer en : ",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Actualisation de %{name}...",
   "explorer.rename_cancelled": "Renommage annulé",
   "explorer.new_item_path_must_be_relative": "Le chemin du nouvel élément doit être relatif",
+  "explorer.new_item_path_outside_project": "Le chemin du nouvel élément doit rester dans le répertoire du projet",
   "explorer.rename_invalid_dot": "Le nom ne peut pas être '.' ou '..'",
   "explorer.rename_invalid_separator": "Le nom ne peut pas contenir de séparateur de chemin",
   "explorer.rename_prompt": "Renommer en : ",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Aggiornamento %{name}...",
   "explorer.rename_cancelled": "Rinomina annullata",
   "explorer.new_item_path_must_be_relative": "Il percorso del nuovo elemento deve essere relativo",
+  "explorer.new_item_path_outside_project": "Il percorso del nuovo elemento deve rimanere nella directory del progetto",
   "explorer.rename_invalid_dot": "Il nome non può essere '.' o '..'",
   "explorer.rename_invalid_separator": "Il nome non può contenere un separatore di percorso",
   "explorer.rename_prompt": "Rinomina in: ",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Aggiornato",
   "explorer.refreshing": "Aggiornamento %{name}...",
   "explorer.rename_cancelled": "Rinomina annullata",
+  "explorer.new_item_path_must_be_relative": "Il percorso del nuovo elemento deve essere relativo",
   "explorer.rename_invalid_dot": "Il nome non può essere '.' o '..'",
   "explorer.rename_invalid_separator": "Il nome non può contenere un separatore di percorso",
   "explorer.rename_prompt": "Rinomina in: ",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Aggiornato",
   "explorer.refreshing": "Aggiornamento %{name}...",
   "explorer.rename_cancelled": "Rinomina annullata",
+  "explorer.new_item_path_exists": "'%{name}' esiste già",
   "explorer.new_item_path_must_be_relative": "Il percorso del nuovo elemento deve essere relativo",
   "explorer.new_item_path_outside_project": "Il percorso del nuovo elemento deve rimanere nella directory del progetto",
   "explorer.rename_invalid_dot": "Il nome non può essere '.' o '..'",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Aggiornamento %{name}...",
   "explorer.rename_cancelled": "Rinomina annullata",
   "explorer.new_item_path_must_be_relative": "Il percorso del nuovo elemento deve essere relativo",
+  "explorer.new_item_path_outside_project": "Il percorso del nuovo elemento deve rimanere nella directory del progetto",
   "explorer.rename_invalid_dot": "Il nome non può essere '.' o '..'",
   "explorer.rename_invalid_separator": "Il nome non può contenere un separatore di percorso",
   "explorer.rename_prompt": "Rinomina in: ",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Aggiornato",
   "explorer.refreshing": "Aggiornamento %{name}...",
   "explorer.rename_cancelled": "Rinomina annullata",
+  "explorer.new_item_path_must_be_relative": "Il percorso del nuovo elemento deve essere relativo",
   "explorer.rename_invalid_dot": "Il nome non può essere '.' o '..'",
   "explorer.rename_invalid_separator": "Il nome non può contenere un separatore di percorso",
   "explorer.rename_prompt": "Rinomina in: ",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "更新しました",
   "explorer.refreshing": "%{name} を更新中...",
   "explorer.rename_cancelled": "名前変更をキャンセル",
+  "explorer.new_item_path_must_be_relative": "新しい項目のパスは相対パスである必要があります",
   "explorer.rename_invalid_dot": "名前に '.' や '..' は使えません",
   "explorer.rename_invalid_separator": "名前にパス区切り文字は使えません",
   "explorer.rename_prompt": "名前を変更: ",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "更新しました",
   "explorer.refreshing": "%{name} を更新中...",
   "explorer.rename_cancelled": "名前変更をキャンセル",
+  "explorer.new_item_path_exists": "'%{name}' は既に存在します",
   "explorer.new_item_path_must_be_relative": "新しい項目のパスは相対パスである必要があります",
   "explorer.new_item_path_outside_project": "新しい項目のパスはプロジェクトディレクトリ内である必要があります",
   "explorer.rename_invalid_dot": "名前に '.' や '..' は使えません",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "%{name} を更新中...",
   "explorer.rename_cancelled": "名前変更をキャンセル",
   "explorer.new_item_path_must_be_relative": "新しい項目のパスは相対パスである必要があります",
+  "explorer.new_item_path_outside_project": "新しい項目のパスはプロジェクトディレクトリ内である必要があります",
   "explorer.rename_invalid_dot": "名前に '.' や '..' は使えません",
   "explorer.rename_invalid_separator": "名前にパス区切り文字は使えません",
   "explorer.rename_prompt": "名前を変更: ",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "更新しました",
   "explorer.refreshing": "%{name} を更新中...",
   "explorer.rename_cancelled": "名前変更をキャンセル",
+  "explorer.new_item_path_must_be_relative": "新しい項目のパスは相対パスである必要があります",
   "explorer.rename_invalid_dot": "名前に '.' や '..' は使えません",
   "explorer.rename_invalid_separator": "名前にパス区切り文字は使えません",
   "explorer.rename_prompt": "名前を変更: ",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "%{name} を更新中...",
   "explorer.rename_cancelled": "名前変更をキャンセル",
   "explorer.new_item_path_must_be_relative": "新しい項目のパスは相対パスである必要があります",
+  "explorer.new_item_path_outside_project": "新しい項目のパスはプロジェクトディレクトリ内である必要があります",
   "explorer.rename_invalid_dot": "名前に '.' や '..' は使えません",
   "explorer.rename_invalid_separator": "名前にパス区切り文字は使えません",
   "explorer.rename_prompt": "名前を変更: ",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "새로 고침됨",
   "explorer.refreshing": "%{name} 새로 고침 중...",
   "explorer.rename_cancelled": "이름 변경 취소됨",
+  "explorer.new_item_path_exists": "'%{name}'이(가) 이미 존재합니다",
   "explorer.new_item_path_must_be_relative": "새 항목 경로는 상대 경로여야 합니다",
   "explorer.new_item_path_outside_project": "새 항목 경로는 프로젝트 디렉터리 안에 있어야 합니다",
   "explorer.rename_invalid_dot": "이름은 '.' 또는 '..'일 수 없습니다",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "새로 고침됨",
   "explorer.refreshing": "%{name} 새로 고침 중...",
   "explorer.rename_cancelled": "이름 변경 취소됨",
+  "explorer.new_item_path_must_be_relative": "새 항목 경로는 상대 경로여야 합니다",
   "explorer.rename_invalid_dot": "이름은 '.' 또는 '..'일 수 없습니다",
   "explorer.rename_invalid_separator": "이름에 경로 구분 기호를 사용할 수 없습니다",
   "explorer.rename_prompt": "이름 변경: ",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "%{name} 새로 고침 중...",
   "explorer.rename_cancelled": "이름 변경 취소됨",
   "explorer.new_item_path_must_be_relative": "새 항목 경로는 상대 경로여야 합니다",
+  "explorer.new_item_path_outside_project": "새 항목 경로는 프로젝트 디렉터리 안에 있어야 합니다",
   "explorer.rename_invalid_dot": "이름은 '.' 또는 '..'일 수 없습니다",
   "explorer.rename_invalid_separator": "이름에 경로 구분 기호를 사용할 수 없습니다",
   "explorer.rename_prompt": "이름 변경: ",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "%{name} 새로 고침 중...",
   "explorer.rename_cancelled": "이름 변경 취소됨",
   "explorer.new_item_path_must_be_relative": "새 항목 경로는 상대 경로여야 합니다",
+  "explorer.new_item_path_outside_project": "새 항목 경로는 프로젝트 디렉터리 안에 있어야 합니다",
   "explorer.rename_invalid_dot": "이름은 '.' 또는 '..'일 수 없습니다",
   "explorer.rename_invalid_separator": "이름에 경로 구분 기호를 사용할 수 없습니다",
   "explorer.rename_prompt": "이름 변경: ",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "새로 고침됨",
   "explorer.refreshing": "%{name} 새로 고침 중...",
   "explorer.rename_cancelled": "이름 변경 취소됨",
+  "explorer.new_item_path_must_be_relative": "새 항목 경로는 상대 경로여야 합니다",
   "explorer.rename_invalid_dot": "이름은 '.' 또는 '..'일 수 없습니다",
   "explorer.rename_invalid_separator": "이름에 경로 구분 기호를 사용할 수 없습니다",
   "explorer.rename_prompt": "이름 변경: ",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Atualizando %{name}...",
   "explorer.rename_cancelled": "Renomeação cancelada",
   "explorer.new_item_path_must_be_relative": "O caminho do novo item deve ser relativo",
+  "explorer.new_item_path_outside_project": "O caminho do novo item deve permanecer dentro do diretório do projeto",
   "explorer.rename_invalid_dot": "O nome não pode ser '.' nem '..'",
   "explorer.rename_invalid_separator": "O nome não pode conter um separador de caminho",
   "explorer.rename_prompt": "Renomear para: ",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Atualizado",
   "explorer.refreshing": "Atualizando %{name}...",
   "explorer.rename_cancelled": "Renomeação cancelada",
+  "explorer.new_item_path_must_be_relative": "O caminho do novo item deve ser relativo",
   "explorer.rename_invalid_dot": "O nome não pode ser '.' nem '..'",
   "explorer.rename_invalid_separator": "O nome não pode conter um separador de caminho",
   "explorer.rename_prompt": "Renomear para: ",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Atualizado",
   "explorer.refreshing": "Atualizando %{name}...",
   "explorer.rename_cancelled": "Renomeação cancelada",
+  "explorer.new_item_path_exists": "'%{name}' já existe",
   "explorer.new_item_path_must_be_relative": "O caminho do novo item deve ser relativo",
   "explorer.new_item_path_outside_project": "O caminho do novo item deve permanecer dentro do diretório do projeto",
   "explorer.rename_invalid_dot": "O nome não pode ser '.' nem '..'",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Atualizando %{name}...",
   "explorer.rename_cancelled": "Renomeação cancelada",
   "explorer.new_item_path_must_be_relative": "O caminho do novo item deve ser relativo",
+  "explorer.new_item_path_outside_project": "O caminho do novo item deve permanecer dentro do diretório do projeto",
   "explorer.rename_invalid_dot": "O nome não pode ser '.' nem '..'",
   "explorer.rename_invalid_separator": "O nome não pode conter um separador de caminho",
   "explorer.rename_prompt": "Renomear para: ",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Atualizado",
   "explorer.refreshing": "Atualizando %{name}...",
   "explorer.rename_cancelled": "Renomeação cancelada",
+  "explorer.new_item_path_must_be_relative": "O caminho do novo item deve ser relativo",
   "explorer.rename_invalid_dot": "O nome não pode ser '.' nem '..'",
   "explorer.rename_invalid_separator": "O nome não pode conter um separador de caminho",
   "explorer.rename_prompt": "Renomear para: ",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Обновление %{name}...",
   "explorer.rename_cancelled": "Переименование отменено",
   "explorer.new_item_path_must_be_relative": "Путь нового элемента должен быть относительным",
+  "explorer.new_item_path_outside_project": "Путь нового элемента должен оставаться в каталоге проекта",
   "explorer.rename_invalid_dot": "Имя не может быть '.' или '..'",
   "explorer.rename_invalid_separator": "Имя не может содержать разделитель пути",
   "explorer.rename_prompt": "Переименовать в: ",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Обновлено",
   "explorer.refreshing": "Обновление %{name}...",
   "explorer.rename_cancelled": "Переименование отменено",
+  "explorer.new_item_path_must_be_relative": "Путь нового элемента должен быть относительным",
   "explorer.rename_invalid_dot": "Имя не может быть '.' или '..'",
   "explorer.rename_invalid_separator": "Имя не может содержать разделитель пути",
   "explorer.rename_prompt": "Переименовать в: ",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Обновлено",
   "explorer.refreshing": "Обновление %{name}...",
   "explorer.rename_cancelled": "Переименование отменено",
+  "explorer.new_item_path_exists": "'%{name}' уже существует",
   "explorer.new_item_path_must_be_relative": "Путь нового элемента должен быть относительным",
   "explorer.new_item_path_outside_project": "Путь нового элемента должен оставаться в каталоге проекта",
   "explorer.rename_invalid_dot": "Имя не может быть '.' или '..'",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Обновление %{name}...",
   "explorer.rename_cancelled": "Переименование отменено",
   "explorer.new_item_path_must_be_relative": "Путь нового элемента должен быть относительным",
+  "explorer.new_item_path_outside_project": "Путь нового элемента должен оставаться в каталоге проекта",
   "explorer.rename_invalid_dot": "Имя не может быть '.' или '..'",
   "explorer.rename_invalid_separator": "Имя не может содержать разделитель пути",
   "explorer.rename_prompt": "Переименовать в: ",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Обновлено",
   "explorer.refreshing": "Обновление %{name}...",
   "explorer.rename_cancelled": "Переименование отменено",
+  "explorer.new_item_path_must_be_relative": "Путь нового элемента должен быть относительным",
   "explorer.rename_invalid_dot": "Имя не может быть '.' или '..'",
   "explorer.rename_invalid_separator": "Имя не может содержать разделитель пути",
   "explorer.rename_prompt": "Переименовать в: ",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "รีเฟรชแล้ว",
   "explorer.refreshing": "กำลังรีเฟรช %{name}...",
   "explorer.rename_cancelled": "ยกเลิกการเปลี่ยนชื่อ",
+  "explorer.new_item_path_exists": "'%{name}' มีอยู่แล้ว",
   "explorer.new_item_path_must_be_relative": "เส้นทางของรายการใหม่ต้องเป็นพาธสัมพัทธ์",
   "explorer.new_item_path_outside_project": "เส้นทางของรายการใหม่ต้องอยู่ภายในไดเรกทอรีโครงการ",
   "explorer.rename_invalid_dot": "ชื่อไม่สามารถเป็น '.' หรือ '..'",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "กำลังรีเฟรช %{name}...",
   "explorer.rename_cancelled": "ยกเลิกการเปลี่ยนชื่อ",
   "explorer.new_item_path_must_be_relative": "เส้นทางของรายการใหม่ต้องเป็นพาธสัมพัทธ์",
+  "explorer.new_item_path_outside_project": "เส้นทางของรายการใหม่ต้องอยู่ภายในไดเรกทอรีโครงการ",
   "explorer.rename_invalid_dot": "ชื่อไม่สามารถเป็น '.' หรือ '..'",
   "explorer.rename_invalid_separator": "ชื่อไม่สามารถมีตัวคั่นเส้นทาง",
   "explorer.rename_prompt": "เปลี่ยนชื่อเป็น: ",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "รีเฟรชแล้ว",
   "explorer.refreshing": "กำลังรีเฟรช %{name}...",
   "explorer.rename_cancelled": "ยกเลิกการเปลี่ยนชื่อ",
+  "explorer.new_item_path_must_be_relative": "เส้นทางของรายการใหม่ต้องเป็นพาธสัมพัทธ์",
   "explorer.rename_invalid_dot": "ชื่อไม่สามารถเป็น '.' หรือ '..'",
   "explorer.rename_invalid_separator": "ชื่อไม่สามารถมีตัวคั่นเส้นทาง",
   "explorer.rename_prompt": "เปลี่ยนชื่อเป็น: ",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "กำลังรีเฟรช %{name}...",
   "explorer.rename_cancelled": "ยกเลิกการเปลี่ยนชื่อ",
   "explorer.new_item_path_must_be_relative": "เส้นทางของรายการใหม่ต้องเป็นพาธสัมพัทธ์",
+  "explorer.new_item_path_outside_project": "เส้นทางของรายการใหม่ต้องอยู่ภายในไดเรกทอรีโครงการ",
   "explorer.rename_invalid_dot": "ชื่อไม่สามารถเป็น '.' หรือ '..'",
   "explorer.rename_invalid_separator": "ชื่อไม่สามารถมีตัวคั่นเส้นทาง",
   "explorer.rename_prompt": "เปลี่ยนชื่อเป็น: ",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "รีเฟรชแล้ว",
   "explorer.refreshing": "กำลังรีเฟรช %{name}...",
   "explorer.rename_cancelled": "ยกเลิกการเปลี่ยนชื่อ",
+  "explorer.new_item_path_must_be_relative": "เส้นทางของรายการใหม่ต้องเป็นพาธสัมพัทธ์",
   "explorer.rename_invalid_dot": "ชื่อไม่สามารถเป็น '.' หรือ '..'",
   "explorer.rename_invalid_separator": "ชื่อไม่สามารถมีตัวคั่นเส้นทาง",
   "explorer.rename_prompt": "เปลี่ยนชื่อเป็น: ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Оновлено",
   "explorer.refreshing": "Оновлення %{name}...",
   "explorer.rename_cancelled": "Перейменування скасовано",
+  "explorer.new_item_path_exists": "'%{name}' вже існує",
   "explorer.new_item_path_must_be_relative": "Шлях нового елемента має бути відносним",
   "explorer.new_item_path_outside_project": "Шлях нового елемента має залишатися в каталозі проєкту",
   "explorer.rename_invalid_dot": "Ім'я не може бути '.' або '..'",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Оновлено",
   "explorer.refreshing": "Оновлення %{name}...",
   "explorer.rename_cancelled": "Перейменування скасовано",
+  "explorer.new_item_path_must_be_relative": "Шлях нового елемента має бути відносним",
   "explorer.rename_invalid_dot": "Ім'я не може бути '.' або '..'",
   "explorer.rename_invalid_separator": "Ім'я не може містити роздільник шляху",
   "explorer.rename_prompt": "Перейменувати на: ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Оновлення %{name}...",
   "explorer.rename_cancelled": "Перейменування скасовано",
   "explorer.new_item_path_must_be_relative": "Шлях нового елемента має бути відносним",
+  "explorer.new_item_path_outside_project": "Шлях нового елемента має залишатися в каталозі проєкту",
   "explorer.rename_invalid_dot": "Ім'я не може бути '.' або '..'",
   "explorer.rename_invalid_separator": "Ім'я не може містити роздільник шляху",
   "explorer.rename_prompt": "Перейменувати на: ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Оновлення %{name}...",
   "explorer.rename_cancelled": "Перейменування скасовано",
   "explorer.new_item_path_must_be_relative": "Шлях нового елемента має бути відносним",
+  "explorer.new_item_path_outside_project": "Шлях нового елемента має залишатися в каталозі проєкту",
   "explorer.rename_invalid_dot": "Ім'я не може бути '.' або '..'",
   "explorer.rename_invalid_separator": "Ім'я не може містити роздільник шляху",
   "explorer.rename_prompt": "Перейменувати на: ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Оновлено",
   "explorer.refreshing": "Оновлення %{name}...",
   "explorer.rename_cancelled": "Перейменування скасовано",
+  "explorer.new_item_path_must_be_relative": "Шлях нового елемента має бути відносним",
   "explorer.rename_invalid_dot": "Ім'я не може бути '.' або '..'",
   "explorer.rename_invalid_separator": "Ім'я не може містити роздільник шляху",
   "explorer.rename_prompt": "Перейменувати на: ",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Đã làm mới",
   "explorer.refreshing": "Đang làm mới %{name}...",
   "explorer.rename_cancelled": "Đã hủy đổi tên",
+  "explorer.new_item_path_must_be_relative": "Đường dẫn của mục mới phải là đường dẫn tương đối",
   "explorer.rename_invalid_dot": "Tên không thể là '.' hoặc '..'",
   "explorer.rename_invalid_separator": "Tên không được chứa dấu phân cách đường dẫn",
   "explorer.rename_prompt": "Đổi tên thành: ",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "Đang làm mới %{name}...",
   "explorer.rename_cancelled": "Đã hủy đổi tên",
   "explorer.new_item_path_must_be_relative": "Đường dẫn của mục mới phải là đường dẫn tương đối",
+  "explorer.new_item_path_outside_project": "Đường dẫn của mục mới phải nằm trong thư mục dự án",
   "explorer.rename_invalid_dot": "Tên không thể là '.' hoặc '..'",
   "explorer.rename_invalid_separator": "Tên không được chứa dấu phân cách đường dẫn",
   "explorer.rename_prompt": "Đổi tên thành: ",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "Đã làm mới",
   "explorer.refreshing": "Đang làm mới %{name}...",
   "explorer.rename_cancelled": "Đã hủy đổi tên",
+  "explorer.new_item_path_exists": "'%{name}' đã tồn tại",
   "explorer.new_item_path_must_be_relative": "Đường dẫn của mục mới phải là đường dẫn tương đối",
   "explorer.new_item_path_outside_project": "Đường dẫn của mục mới phải nằm trong thư mục dự án",
   "explorer.rename_invalid_dot": "Tên không thể là '.' hoặc '..'",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "Đã làm mới",
   "explorer.refreshing": "Đang làm mới %{name}...",
   "explorer.rename_cancelled": "Đã hủy đổi tên",
+  "explorer.new_item_path_must_be_relative": "Đường dẫn của mục mới phải là đường dẫn tương đối",
   "explorer.rename_invalid_dot": "Tên không thể là '.' hoặc '..'",
   "explorer.rename_invalid_separator": "Tên không được chứa dấu phân cách đường dẫn",
   "explorer.rename_prompt": "Đổi tên thành: ",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "Đang làm mới %{name}...",
   "explorer.rename_cancelled": "Đã hủy đổi tên",
   "explorer.new_item_path_must_be_relative": "Đường dẫn của mục mới phải là đường dẫn tương đối",
+  "explorer.new_item_path_outside_project": "Đường dẫn của mục mới phải nằm trong thư mục dự án",
   "explorer.rename_invalid_dot": "Tên không thể là '.' hoặc '..'",
   "explorer.rename_invalid_separator": "Tên không được chứa dấu phân cách đường dẫn",
   "explorer.rename_prompt": "Đổi tên thành: ",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "已刷新",
   "explorer.refreshing": "正在刷新 %{name}...",
   "explorer.rename_cancelled": "重命名已取消",
+  "explorer.new_item_path_exists": "'%{name}' 已存在",
   "explorer.new_item_path_must_be_relative": "新项目路径必须是相对路径",
   "explorer.new_item_path_outside_project": "新项目路径必须位于项目目录内",
   "explorer.rename_invalid_dot": "名称不能为 '.' 或 '..'",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -973,6 +973,7 @@
   "explorer.refreshing": "正在刷新 %{name}...",
   "explorer.rename_cancelled": "重命名已取消",
   "explorer.new_item_path_must_be_relative": "新项目路径必须是相对路径",
+  "explorer.new_item_path_outside_project": "新项目路径必须位于项目目录内",
   "explorer.rename_invalid_dot": "名称不能为 '.' 或 '..'",
   "explorer.rename_invalid_separator": "名称不能包含路径分隔符",
   "explorer.rename_prompt": "重命名为：",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -972,6 +972,7 @@
   "explorer.refreshed_default": "已刷新",
   "explorer.refreshing": "正在刷新 %{name}...",
   "explorer.rename_cancelled": "重命名已取消",
+  "explorer.new_item_path_must_be_relative": "新项目路径必须是相对路径",
   "explorer.rename_invalid_dot": "名称不能为 '.' 或 '..'",
   "explorer.rename_invalid_separator": "名称不能包含路径分隔符",
   "explorer.rename_prompt": "重命名为：",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -955,6 +955,7 @@
   "explorer.refreshed_default": "已刷新",
   "explorer.refreshing": "正在刷新 %{name}...",
   "explorer.rename_cancelled": "重命名已取消",
+  "explorer.new_item_path_must_be_relative": "新项目路径必须是相对路径",
   "explorer.rename_invalid_dot": "名称不能为 '.' 或 '..'",
   "explorer.rename_invalid_separator": "名称不能包含路径分隔符",
   "explorer.rename_prompt": "重命名为：",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -956,6 +956,7 @@
   "explorer.refreshing": "正在刷新 %{name}...",
   "explorer.rename_cancelled": "重命名已取消",
   "explorer.new_item_path_must_be_relative": "新项目路径必须是相对路径",
+  "explorer.new_item_path_outside_project": "新项目路径必须位于项目目录内",
   "explorer.rename_invalid_dot": "名称不能为 '.' 或 '..'",
   "explorer.rename_invalid_separator": "名称不能包含路径分隔符",
   "explorer.rename_prompt": "重命名为：",

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -850,10 +850,8 @@ impl Editor {
         if self.tokio_runtime.is_some() {
             let fs = std::sync::Arc::clone(&self.authority().filesystem);
             if is_new_file {
-                // Only a name with separators can leave the directory the
-                // temporary item was created in, and the walk canonicalizes
-                // every ancestor — a blocking round trip each on a remote
-                // filesystem. Flat names are already known to be inside.
+                // Only a name with separators can redirect the item out of
+                // the directory Ctrl+N already created it in unchecked.
                 if has_separator {
                     match creation_path_is_within_project(
                         fs.as_ref(),

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -818,12 +818,22 @@ impl Editor {
             return;
         }
 
-        // Reject any platform path separator — `/` on all OSes plus `\` on
-        // Windows. `is_separator` is const-folded per platform so this keeps
-        // the same behavior on Linux (reject `/`) while also rejecting `\`
-        // when running on Windows.
-        if new_name.chars().any(std::path::is_separator) {
+        let requested_path = Path::new(&new_name);
+
+        // Existing items are renamed in place, so their names must remain a
+        // single path component. Newly-created items may include separators:
+        // their missing parent directories are created below before the
+        // temporary item is moved into place.
+        if !is_new_file && new_name.chars().any(std::path::is_separator) {
             self.set_status_message(t!("explorer.rename_invalid_separator").to_string());
+            return;
+        }
+        // Joining an absolute/rooted path would discard the directory in
+        // which creation started. Prefix components cover Windows drive and
+        // UNC paths; RootDir covers `/foo` and `\foo`. Tilde and environment
+        // variable syntax remain ordinary, literal relative components.
+        if is_new_file && !is_relative_creation_path(requested_path) {
+            self.set_status_message(t!("explorer.new_item_path_must_be_relative").to_string());
             return;
         }
         if new_name == "." || new_name == ".." {
@@ -837,10 +847,18 @@ impl Editor {
             .unwrap_or_else(|| original_path.clone());
 
         if self.tokio_runtime.is_some() {
-            let result = self
-                .authority()
-                .filesystem
-                .rename(&original_path, &new_path);
+            let fs = &self.authority().filesystem;
+            let result = if is_new_file {
+                // `create_dir_all` is also safe when the parent already
+                // exists. Keep both operations on the active filesystem so
+                // local, virtual, and remote workspaces behave alike.
+                new_path
+                    .parent()
+                    .map_or(Ok(()), |parent| fs.create_dir_all(parent))
+                    .and_then(|()| fs.rename(&original_path, &new_path))
+            } else {
+                fs.rename(&original_path, &new_path)
+            };
 
             match result {
                 Ok(_) => {
@@ -2105,4 +2123,44 @@ fn split_stem_ext(name: &str) -> (&str, &str) {
         }
     }
     (name, "")
+}
+
+/// Whether a user-entered creation path stays relative to the selected
+/// directory. `Path::is_absolute` is insufficient on Windows because a drive
+/// prefix can replace the base path without being absolute (for example
+/// `C:foo`), so reject both root and prefix components explicitly.
+fn is_relative_creation_path(path: &Path) -> bool {
+    !matches!(
+        path.components().next(),
+        Some(std::path::Component::RootDir | std::path::Component::Prefix(_))
+    )
+}
+
+#[cfg(test)]
+mod creation_path_tests {
+    use super::is_relative_creation_path;
+    use std::path::Path;
+
+    #[test]
+    fn nested_and_parent_relative_creation_paths_are_allowed() {
+        assert!(is_relative_creation_path(Path::new(
+            "src/components/app.rs"
+        )));
+        assert!(is_relative_creation_path(Path::new("../shared/app.rs")));
+        assert!(is_relative_creation_path(Path::new("./app.rs")));
+        assert!(is_relative_creation_path(Path::new("~/app.rs")));
+        assert!(is_relative_creation_path(Path::new("$HOME/app.rs")));
+    }
+
+    #[test]
+    fn rooted_creation_paths_are_rejected() {
+        assert!(!is_relative_creation_path(Path::new("/tmp/app.rs")));
+
+        #[cfg(windows)]
+        {
+            assert!(!is_relative_creation_path(Path::new(r"C:\tmp\app.rs")));
+            assert!(!is_relative_creation_path(Path::new(r"C:app.rs")));
+            assert!(!is_relative_creation_path(Path::new(r"\tmp\app.rs")));
+        }
+    }
 }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -847,7 +847,24 @@ impl Editor {
             .unwrap_or_else(|| original_path.clone());
 
         if self.tokio_runtime.is_some() {
-            let fs = &self.authority().filesystem;
+            let fs = std::sync::Arc::clone(&self.authority().filesystem);
+            if is_new_file {
+                match creation_path_is_within_project(fs.as_ref(), self.working_dir(), &new_path) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        self.set_status_message(
+                            t!("explorer.new_item_path_outside_project").to_string(),
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        self.set_status_message(
+                            t!("explorer.error_renaming", error = e.to_string()).to_string(),
+                        );
+                        return;
+                    }
+                }
+            }
             let result = if is_new_file {
                 // `create_dir_all` is also safe when the parent already
                 // exists. Keep both operations on the active filesystem so
@@ -2136,9 +2153,66 @@ fn is_relative_creation_path(path: &Path) -> bool {
     )
 }
 
+/// Check a not-yet-created target against the project root without creating
+/// any of its missing parents first.
+///
+/// The lexical check catches `..` escaping through missing directories. The
+/// canonical check resolves the deepest existing ancestor, catching paths
+/// that leave the project through a symlink. Reattaching the missing tail is
+/// safe because none of those components exist yet and therefore none can be
+/// symlinks at the time of this check.
+fn creation_path_is_within_project(
+    fs: &dyn crate::model::filesystem::FileSystem,
+    project_root: &Path,
+    target: &Path,
+) -> std::io::Result<bool> {
+    let lexical_root = crate::app::normalize_path(project_root);
+    let lexical_target = crate::app::normalize_path(target);
+    if !lexical_target.starts_with(&lexical_root) {
+        return Ok(false);
+    }
+
+    let canonical_root = fs.canonicalize(project_root)?;
+    let canonical_target = canonicalize_deepest_existing(fs, target)?;
+    Ok(canonical_target.starts_with(canonical_root))
+}
+
+/// Canonicalize the deepest existing ancestor and append its missing path
+/// components. Unlike `Path::canonicalize`, this also works for a target file
+/// and parent directories that have not been created yet.
+fn canonicalize_deepest_existing(
+    fs: &dyn crate::model::filesystem::FileSystem,
+    path: &Path,
+) -> std::io::Result<PathBuf> {
+    let mut ancestor = path;
+    let mut missing_tail = Vec::new();
+
+    loop {
+        match fs.canonicalize(ancestor) {
+            Ok(mut canonical) => {
+                for component in missing_tail.iter().rev() {
+                    canonical.push(component);
+                }
+                return Ok(crate::app::normalize_path(&canonical));
+            }
+            Err(error) => {
+                let Some(parent) = ancestor.parent() else {
+                    return Err(error);
+                };
+                let Ok(component) = ancestor.strip_prefix(parent) else {
+                    return Err(error);
+                };
+                missing_tail.push(component.to_path_buf());
+                ancestor = parent;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod creation_path_tests {
-    use super::is_relative_creation_path;
+    use super::{creation_path_is_within_project, is_relative_creation_path};
+    use crate::model::filesystem::StdFileSystem;
     use std::path::Path;
 
     #[test]
@@ -2162,5 +2236,41 @@ mod creation_path_tests {
             assert!(!is_relative_creation_path(Path::new(r"C:app.rs")));
             assert!(!is_relative_creation_path(Path::new(r"\tmp\app.rs")));
         }
+    }
+
+    #[test]
+    fn creation_path_cannot_escape_project_with_parent_components() {
+        let project = tempfile::tempdir().unwrap();
+        let fs = StdFileSystem;
+
+        assert!(creation_path_is_within_project(
+            &fs,
+            project.path(),
+            &project.path().join("src/../app.rs")
+        )
+        .unwrap());
+        assert!(!creation_path_is_within_project(
+            &fs,
+            project.path(),
+            &project.path().join("../escaped.rs")
+        )
+        .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn creation_path_cannot_escape_project_through_symlink() {
+        let container = tempfile::tempdir().unwrap();
+        let project = container.path().join("project");
+        let outside = container.path().join("outside");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, project.join("link")).unwrap();
+        let fs = StdFileSystem;
+
+        assert!(
+            !creation_path_is_within_project(&fs, &project, &project.join("link/escaped.rs"))
+                .unwrap()
+        );
     }
 }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -819,12 +819,13 @@ impl Editor {
         }
 
         let requested_path = Path::new(&new_name);
+        let has_separator = new_name.chars().any(std::path::is_separator);
 
         // Existing items are renamed in place, so their names must remain a
         // single path component. Newly-created items may include separators:
         // their missing parent directories are created below before the
         // temporary item is moved into place.
-        if !is_new_file && new_name.chars().any(std::path::is_separator) {
+        if !is_new_file && has_separator {
             self.set_status_message(t!("explorer.rename_invalid_separator").to_string());
             return;
         }
@@ -849,19 +850,29 @@ impl Editor {
         if self.tokio_runtime.is_some() {
             let fs = std::sync::Arc::clone(&self.authority().filesystem);
             if is_new_file {
-                match creation_path_is_within_project(fs.as_ref(), self.working_dir(), &new_path) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        self.set_status_message(
-                            t!("explorer.new_item_path_outside_project").to_string(),
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        self.set_status_message(
-                            t!("explorer.error_renaming", error = e.to_string()).to_string(),
-                        );
-                        return;
+                // Only a name with separators can leave the directory the
+                // temporary item was created in, and the walk canonicalizes
+                // every ancestor — a blocking round trip each on a remote
+                // filesystem. Flat names are already known to be inside.
+                if has_separator {
+                    match creation_path_is_within_project(
+                        fs.as_ref(),
+                        self.working_dir(),
+                        &new_path,
+                    ) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            self.set_status_message(
+                                t!("explorer.new_item_path_outside_project").to_string(),
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            self.set_status_message(
+                                t!("explorer.error_renaming", error = e.to_string()).to_string(),
+                            );
+                            return;
+                        }
                     }
                 }
             }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -875,6 +875,18 @@ impl Editor {
                         }
                     }
                 }
+
+                // `rename` replaces an existing destination without warning,
+                // so a name that collides with a real file would destroy it.
+                // Refuse: the temporary item stays where it is and can be
+                // renamed again with F2.
+                if fs.exists(&new_path) {
+                    let name = truncate_name_for_prompt(&new_name, 40);
+                    self.set_status_message(
+                        t!("explorer.new_item_path_exists", name = &name).to_string(),
+                    );
+                    return;
+                }
             }
             let result = if is_new_file {
                 // `create_dir_all` is also safe when the parent already

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -2195,7 +2195,11 @@ fn canonicalize_deepest_existing(
                 }
                 return Ok(crate::app::normalize_path(&canonical));
             }
-            Err(error) => {
+            // Only a missing component means "not created yet". Treating
+            // every failure that way (EACCES, ELOOP, …) would silently
+            // downgrade the symlink escape check to a lexical one, so
+            // surface anything else to the caller.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let Some(parent) = ancestor.parent() else {
                     return Err(error);
                 };
@@ -2205,6 +2209,7 @@ fn canonicalize_deepest_existing(
                 missing_tail.push(component.to_path_buf());
                 ancestor = parent;
             }
+            Err(error) => return Err(error),
         }
     }
 }
@@ -2255,6 +2260,23 @@ mod creation_path_tests {
             &project.path().join("../escaped.rs")
         )
         .unwrap());
+    }
+
+    /// A canonicalize failure that does not mean "missing" must reach the
+    /// caller. Folding it into the not-yet-created case would leave only the
+    /// lexical check, which cannot see through symlinks.
+    #[cfg(unix)]
+    #[test]
+    fn creation_path_check_propagates_non_missing_errors() {
+        let project = tempfile::tempdir().unwrap();
+        // A symlink pointing at itself resolves to ELOOP, not ENOENT.
+        std::os::unix::fs::symlink("loop", project.path().join("loop")).unwrap();
+        let fs = StdFileSystem;
+
+        let error =
+            creation_path_is_within_project(&fs, project.path(), &project.path().join("loop/a.rs"))
+                .expect_err("a symlink loop must not be reported as a usable creation path");
+        assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[cfg(unix)]

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -847,7 +847,24 @@ impl Editor {
             .unwrap_or_else(|| original_path.clone());
 
         if self.tokio_runtime.is_some() {
-            let fs = &self.authority().filesystem;
+            let fs = std::sync::Arc::clone(&self.authority().filesystem);
+            if is_new_file {
+                match creation_path_is_within_project(fs.as_ref(), self.working_dir(), &new_path) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        self.set_status_message(
+                            t!("explorer.new_item_path_outside_project").to_string(),
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        self.set_status_message(
+                            t!("explorer.error_renaming", error = e.to_string()).to_string(),
+                        );
+                        return;
+                    }
+                }
+            }
             let result = if is_new_file {
                 // `create_dir_all` is also safe when the parent already
                 // exists. Keep both operations on the active filesystem so
@@ -2139,9 +2156,66 @@ fn is_relative_creation_path(path: &Path) -> bool {
     )
 }
 
+/// Check a not-yet-created target against the project root without creating
+/// any of its missing parents first.
+///
+/// The lexical check catches `..` escaping through missing directories. The
+/// canonical check resolves the deepest existing ancestor, catching paths
+/// that leave the project through a symlink. Reattaching the missing tail is
+/// safe because none of those components exist yet and therefore none can be
+/// symlinks at the time of this check.
+fn creation_path_is_within_project(
+    fs: &dyn crate::model::filesystem::FileSystem,
+    project_root: &Path,
+    target: &Path,
+) -> std::io::Result<bool> {
+    let lexical_root = crate::app::normalize_path(project_root);
+    let lexical_target = crate::app::normalize_path(target);
+    if !lexical_target.starts_with(&lexical_root) {
+        return Ok(false);
+    }
+
+    let canonical_root = fs.canonicalize(project_root)?;
+    let canonical_target = canonicalize_deepest_existing(fs, target)?;
+    Ok(canonical_target.starts_with(canonical_root))
+}
+
+/// Canonicalize the deepest existing ancestor and append its missing path
+/// components. Unlike `Path::canonicalize`, this also works for a target file
+/// and parent directories that have not been created yet.
+fn canonicalize_deepest_existing(
+    fs: &dyn crate::model::filesystem::FileSystem,
+    path: &Path,
+) -> std::io::Result<PathBuf> {
+    let mut ancestor = path;
+    let mut missing_tail = Vec::new();
+
+    loop {
+        match fs.canonicalize(ancestor) {
+            Ok(mut canonical) => {
+                for component in missing_tail.iter().rev() {
+                    canonical.push(component);
+                }
+                return Ok(crate::app::normalize_path(&canonical));
+            }
+            Err(error) => {
+                let Some(parent) = ancestor.parent() else {
+                    return Err(error);
+                };
+                let Ok(component) = ancestor.strip_prefix(parent) else {
+                    return Err(error);
+                };
+                missing_tail.push(component.to_path_buf());
+                ancestor = parent;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod creation_path_tests {
-    use super::is_relative_creation_path;
+    use super::{creation_path_is_within_project, is_relative_creation_path};
+    use crate::model::filesystem::StdFileSystem;
     use std::path::Path;
 
     #[test]
@@ -2165,5 +2239,41 @@ mod creation_path_tests {
             assert!(!is_relative_creation_path(Path::new(r"C:app.rs")));
             assert!(!is_relative_creation_path(Path::new(r"\tmp\app.rs")));
         }
+    }
+
+    #[test]
+    fn creation_path_cannot_escape_project_with_parent_components() {
+        let project = tempfile::tempdir().unwrap();
+        let fs = StdFileSystem;
+
+        assert!(creation_path_is_within_project(
+            &fs,
+            project.path(),
+            &project.path().join("src/../app.rs")
+        )
+        .unwrap());
+        assert!(!creation_path_is_within_project(
+            &fs,
+            project.path(),
+            &project.path().join("../escaped.rs")
+        )
+        .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn creation_path_cannot_escape_project_through_symlink() {
+        let container = tempfile::tempdir().unwrap();
+        let project = container.path().join("project");
+        let outside = container.path().join("outside");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, project.join("link")).unwrap();
+        let fs = StdFileSystem;
+
+        assert!(
+            !creation_path_is_within_project(&fs, &project, &project.join("link/escaped.rs"))
+                .unwrap()
+        );
     }
 }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -818,12 +818,22 @@ impl Editor {
             return;
         }
 
-        // Reject any platform path separator — `/` on all OSes plus `\` on
-        // Windows. `is_separator` is const-folded per platform so this keeps
-        // the same behavior on Linux (reject `/`) while also rejecting `\`
-        // when running on Windows.
-        if new_name.chars().any(std::path::is_separator) {
+        let requested_path = Path::new(&new_name);
+
+        // Existing items are renamed in place, so their names must remain a
+        // single path component. Newly-created items may include separators:
+        // their missing parent directories are created below before the
+        // temporary item is moved into place.
+        if !is_new_file && new_name.chars().any(std::path::is_separator) {
             self.set_status_message(t!("explorer.rename_invalid_separator").to_string());
+            return;
+        }
+        // Joining an absolute/rooted path would discard the directory in
+        // which creation started. Prefix components cover Windows drive and
+        // UNC paths; RootDir covers `/foo` and `\foo`. Tilde and environment
+        // variable syntax remain ordinary, literal relative components.
+        if is_new_file && !is_relative_creation_path(requested_path) {
+            self.set_status_message(t!("explorer.new_item_path_must_be_relative").to_string());
             return;
         }
         if new_name == "." || new_name == ".." {
@@ -837,10 +847,18 @@ impl Editor {
             .unwrap_or_else(|| original_path.clone());
 
         if self.tokio_runtime.is_some() {
-            let result = self
-                .authority()
-                .filesystem
-                .rename(&original_path, &new_path);
+            let fs = &self.authority().filesystem;
+            let result = if is_new_file {
+                // `create_dir_all` is also safe when the parent already
+                // exists. Keep both operations on the active filesystem so
+                // local, virtual, and remote workspaces behave alike.
+                new_path
+                    .parent()
+                    .map_or(Ok(()), |parent| fs.create_dir_all(parent))
+                    .and_then(|()| fs.rename(&original_path, &new_path))
+            } else {
+                fs.rename(&original_path, &new_path)
+            };
 
             match result {
                 Ok(_) => {
@@ -2108,4 +2126,44 @@ fn split_stem_ext(name: &str) -> (&str, &str) {
         }
     }
     (name, "")
+}
+
+/// Whether a user-entered creation path stays relative to the selected
+/// directory. `Path::is_absolute` is insufficient on Windows because a drive
+/// prefix can replace the base path without being absolute (for example
+/// `C:foo`), so reject both root and prefix components explicitly.
+fn is_relative_creation_path(path: &Path) -> bool {
+    !matches!(
+        path.components().next(),
+        Some(std::path::Component::RootDir | std::path::Component::Prefix(_))
+    )
+}
+
+#[cfg(test)]
+mod creation_path_tests {
+    use super::is_relative_creation_path;
+    use std::path::Path;
+
+    #[test]
+    fn nested_and_parent_relative_creation_paths_are_allowed() {
+        assert!(is_relative_creation_path(Path::new(
+            "src/components/app.rs"
+        )));
+        assert!(is_relative_creation_path(Path::new("../shared/app.rs")));
+        assert!(is_relative_creation_path(Path::new("./app.rs")));
+        assert!(is_relative_creation_path(Path::new("~/app.rs")));
+        assert!(is_relative_creation_path(Path::new("$HOME/app.rs")));
+    }
+
+    #[test]
+    fn rooted_creation_paths_are_rejected() {
+        assert!(!is_relative_creation_path(Path::new("/tmp/app.rs")));
+
+        #[cfg(windows)]
+        {
+            assert!(!is_relative_creation_path(Path::new(r"C:\tmp\app.rs")));
+            assert!(!is_relative_creation_path(Path::new(r"C:app.rs")));
+            assert!(!is_relative_creation_path(Path::new(r"\tmp\app.rs")));
+        }
+    }
 }

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2284,6 +2284,56 @@ fn test_file_explorer_new_file_opens_rename_prompt_and_buffer() {
     );
 }
 
+/// A slash in a newly-created file name is a relative path: Fresh creates
+/// any missing parent directories, moves the temporary file into place, and
+/// keeps the resulting file open in the editor.
+#[test]
+fn test_file_explorer_new_file_creates_missing_parent_directories() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    harness.type_text("src/components/app.rs").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.sleep(std::time::Duration::from_millis(100));
+    harness.render().unwrap();
+
+    let created_path = project_root.join("src/components/app.rs");
+    assert!(created_path.is_file(), "nested file should be created");
+    assert!(
+        project_root.join("src/components").is_dir(),
+        "missing parent directories should be created"
+    );
+    assert_eq!(
+        harness.editor().get_key_context(),
+        fresh::input::keybindings::KeyContext::Normal,
+        "focus should move to the newly-created file"
+    );
+    assert_eq!(
+        harness.editor().active_state().buffer.file_path(),
+        Some(created_path.as_path()),
+        "the buffer path should follow the file into the nested directory"
+    );
+
+    let untitled_files: Vec<_> = std::fs::read_dir(&project_root)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("untitled_"))
+        .collect();
+    assert!(
+        untitled_files.is_empty(),
+        "the temporary file should be moved, not copied"
+    );
+}
+
 /// Test that renaming an existing file from file explorer updates buffer metadata
 /// but keeps focus in file explorer (not switching to editor)
 #[test]

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2300,13 +2300,13 @@ fn test_file_explorer_new_file_creates_missing_parent_directories() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_prompt().unwrap();
 
     harness.type_text("src/components/app.rs").unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    harness.sleep(std::time::Duration::from_millis(100));
+    harness.wait_for_prompt_closed().unwrap();
     harness.render().unwrap();
 
     // Chained join: a single "src/components/app.rs" only compares equal on

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2290,7 +2290,10 @@ fn test_file_explorer_new_file_opens_rename_prompt_and_buffer() {
 #[test]
 fn test_file_explorer_new_file_creates_missing_parent_directories() {
     let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
-    let project_root = harness.project_dir().unwrap();
+    // Canonicalize: the editor stores the resolved path, so on platforms that
+    // reach the temp dir through a symlink (macOS) or spell it differently
+    // (Windows verbatim prefixes) the raw handout compares unequal.
+    let project_root = harness.project_dir().unwrap().canonicalize().unwrap();
 
     harness.editor_mut().focus_file_explorer();
     harness.wait_for_file_explorer().unwrap();

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2367,6 +2367,54 @@ fn test_file_explorer_new_file_cannot_escape_project_directory() {
     );
 }
 
+/// The explorer lists a directory that symlinks out of the project, and
+/// Ctrl+N inside it creates the temporary item there. Naming that item with
+/// a plain name has to work too, otherwise the user is left holding an
+/// `untitled_*` file that the containment check will not let them rename.
+#[cfg(unix)]
+#[test]
+fn test_file_explorer_new_file_flat_name_in_symlinked_directory() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    let outside = project_root.parent().unwrap().join("outside");
+    fs::create_dir(&outside).unwrap();
+    std::os::unix::fs::symlink(&outside, project_root.join("linked_out")).unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_screen_contains("linked_out").unwrap();
+
+    // Directories sort first and the root has no other children, so one Down
+    // from the root lands on `linked_out/`.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("notes.md").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        outside.join("notes.md").is_file(),
+        "a plain name must be accepted in a directory the explorer itself lists"
+    );
+    let leftover: Vec<_> = fs::read_dir(&outside)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("untitled_"))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "the temporary item should have been renamed, not left behind: {:?}",
+        leftover
+    );
+}
+
 /// Now that a new item's name may contain separators, it can address a file
 /// that already exists. `rename` would replace it without asking, so the
 /// contents of an unrelated file would be gone with no way back. The

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2322,17 +2322,24 @@ fn test_file_explorer_new_file_creates_missing_parent_directories() {
     // Semantic sync: wait for the new name to surface on screen at all.
     harness.wait_for_screen_contains("app.rs").unwrap();
 
-    // Typing reaches that buffer only if focus left the explorer and landed
-    // in the newly-created file -- the visible form of both invariants this
-    // test used to read out of the editor's model.
+    // Type, then save. The text can only reach this path through the buffer
+    // the rename left open, and only if focus followed it out of the
+    // explorer -- the two invariants this test used to read out of the
+    // editor's model. Asserting on the screen alone would not do: had focus
+    // stayed behind, the same characters would render in the explorer's
+    // search box.
     harness.type_text("fn main() {}").unwrap();
-    harness.render().unwrap();
-    let screen = harness.screen_to_string();
-    assert!(
-        screen.contains("fn main() {}"),
-        "typing should reach the new file's buffer. Screen:\n{}",
-        screen
-    );
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    let saved_path = created_path.clone();
+    harness
+        .wait_until(move |_| {
+            std::fs::read_to_string(&saved_path)
+                .map(|contents| contents.contains("fn main() {}"))
+                .unwrap_or(false)
+        })
+        .unwrap();
 
     let untitled_files: Vec<_> = std::fs::read_dir(&project_root)
         .unwrap()

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2356,22 +2356,17 @@ fn test_file_explorer_new_file_cannot_escape_project_directory() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_prompt().unwrap();
     harness.type_text("../escaped.rs").unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
     harness.render().unwrap();
 
     assert!(
         !escaped_path.exists(),
         "a relative creation path must not escape the project"
-    );
-    assert!(
-        harness
-            .screen_to_string()
-            .contains("New item path must stay within the project directory"),
-        "the rejected path should produce a clear status message"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2334,6 +2334,36 @@ fn test_file_explorer_new_file_creates_missing_parent_directories() {
     );
 }
 
+#[test]
+fn test_file_explorer_new_file_cannot_escape_project_directory() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    let escaped_path = project_root.parent().unwrap().join("escaped.rs");
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("../escaped.rs").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        !escaped_path.exists(),
+        "a relative creation path must not escape the project"
+    );
+    assert!(
+        harness
+            .screen_to_string()
+            .contains("New item path must stay within the project directory"),
+        "the rejected path should produce a clear status message"
+    );
+}
+
 /// Test that renaming an existing file from file explorer updates buffer metadata
 /// but keeps focus in file explorer (not switching to editor)
 #[test]

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2309,21 +2309,29 @@ fn test_file_explorer_new_file_creates_missing_parent_directories() {
     harness.sleep(std::time::Duration::from_millis(100));
     harness.render().unwrap();
 
-    let created_path = project_root.join("src/components/app.rs");
+    // Chained join: a single "src/components/app.rs" only compares equal on
+    // Windows because PathBuf::push rewrites separators under a verbatim
+    // prefix, which is exactly the platform assumption to avoid baking in.
+    let created_path = project_root.join("src").join("components").join("app.rs");
     assert!(created_path.is_file(), "nested file should be created");
     assert!(
-        project_root.join("src/components").is_dir(),
+        project_root.join("src").join("components").is_dir(),
         "missing parent directories should be created"
     );
-    assert_eq!(
-        harness.editor().get_key_context(),
-        fresh::input::keybindings::KeyContext::Normal,
-        "focus should move to the newly-created file"
-    );
-    assert_eq!(
-        harness.editor().active_state().buffer.file_path(),
-        Some(created_path.as_path()),
-        "the buffer path should follow the file into the nested directory"
+
+    // Semantic sync: wait for the new name to surface on screen at all.
+    harness.wait_for_screen_contains("app.rs").unwrap();
+
+    // Typing reaches that buffer only if focus left the explorer and landed
+    // in the newly-created file -- the visible form of both invariants this
+    // test used to read out of the editor's model.
+    harness.type_text("fn main() {}").unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("fn main() {}"),
+        "typing should reach the new file's buffer. Screen:\n{}",
+        screen
     );
 
     let untitled_files: Vec<_> = std::fs::read_dir(&project_root)

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2364,6 +2364,58 @@ fn test_file_explorer_new_file_cannot_escape_project_directory() {
     );
 }
 
+/// Now that a new item's name may contain separators, it can address a file
+/// that already exists. `rename` would replace it without asking, so the
+/// contents of an unrelated file would be gone with no way back. The
+/// collision must be refused and the temporary item left alone.
+#[test]
+fn test_file_explorer_new_file_does_not_overwrite_existing_file() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let existing = project_root.join("src").join("main.rs");
+    fs::create_dir_all(existing.parent().unwrap()).unwrap();
+    fs::write(&existing, "fn main() { println!(\"keep me\"); }\n").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("src/main.rs").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&existing).unwrap(),
+        "fn main() { println!(\"keep me\"); }\n",
+        "an existing file must survive a colliding new-item name"
+    );
+
+    // The temporary item was not moved, so the user can rename it again.
+    let untitled_files: Vec<_> = fs::read_dir(&project_root)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("untitled_"))
+        .collect();
+    assert_eq!(
+        untitled_files.len(),
+        1,
+        "the temporary file should stay put after a refused rename"
+    );
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("untitled_"),
+        "the temporary file should still be open and visible. Screen:\n{}",
+        screen
+    );
+}
+
 /// Test that renaming an existing file from file explorer updates buffer metadata
 /// but keeps focus in file explorer (not switching to editor)
 #[test]

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2176,6 +2176,56 @@ fn test_file_explorer_new_file_opens_rename_prompt_and_buffer() {
     );
 }
 
+/// A slash in a newly-created file name is a relative path: Fresh creates
+/// any missing parent directories, moves the temporary file into place, and
+/// keeps the resulting file open in the editor.
+#[test]
+fn test_file_explorer_new_file_creates_missing_parent_directories() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    harness.type_text("src/components/app.rs").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.sleep(std::time::Duration::from_millis(100));
+    harness.render().unwrap();
+
+    let created_path = project_root.join("src/components/app.rs");
+    assert!(created_path.is_file(), "nested file should be created");
+    assert!(
+        project_root.join("src/components").is_dir(),
+        "missing parent directories should be created"
+    );
+    assert_eq!(
+        harness.editor().get_key_context(),
+        fresh::input::keybindings::KeyContext::Normal,
+        "focus should move to the newly-created file"
+    );
+    assert_eq!(
+        harness.editor().active_state().buffer.file_path(),
+        Some(created_path.as_path()),
+        "the buffer path should follow the file into the nested directory"
+    );
+
+    let untitled_files: Vec<_> = std::fs::read_dir(&project_root)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("untitled_"))
+        .collect();
+    assert!(
+        untitled_files.is_empty(),
+        "the temporary file should be moved, not copied"
+    );
+}
+
 /// Test that renaming an existing file from file explorer updates buffer metadata
 /// but keeps focus in file explorer (not switching to editor)
 #[test]

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2226,6 +2226,36 @@ fn test_file_explorer_new_file_creates_missing_parent_directories() {
     );
 }
 
+#[test]
+fn test_file_explorer_new_file_cannot_escape_project_directory() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    let escaped_path = project_root.parent().unwrap().join("escaped.rs");
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("../escaped.rs").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        !escaped_path.exists(),
+        "a relative creation path must not escape the project"
+    );
+    assert!(
+        harness
+            .screen_to_string()
+            .contains("New item path must stay within the project directory"),
+        "the rejected path should produce a clear status message"
+    );
+}
+
 /// Test that renaming an existing file from file explorer updates buffer metadata
 /// but keeps focus in file explorer (not switching to editor)
 #[test]


### PR DESCRIPTION
## Summary

**Motivation.** Creating a file somewhere other than the selected directory meant leaving the explorer: make the directory first, then create the file inside it, or drop to a shell. `Ctrl+N` accepted a bare filename only — a `/` in the name was refused outright — so the natural thing to type, `src/components/app.rs`, simply didn't work.

**Goal.** Let a new item's name carry a path, create whatever directories are missing along the way, and refuse the names that would put the file somewhere the user didn't mean.

**Before → after**

| You type at `Ctrl+N` | Before | After |
|---|---|---|
| `src/components/app.rs` | `Name cannot contain '/'` | file created, both missing directories created with it |
| `src/main.rs`, and that file exists | *(unreachable — `/` was refused)* | `'src/main.rs' already exists`; the existing file is untouched |
| `../notes.md`, staying inside the project | `Name cannot contain '/'` | created in the parent directory |
| `../../../outside.rs` | `Name cannot contain '/'` | `New item path must stay within the project directory`; nothing is written |
| `/etc/passwd`, `C:\…`, `\\server\share\…` | `Name cannot contain '/'` | rejected as not relative |
| `~/notes.md` | `Name cannot contain '/'` | `~` stays literal — no home expansion |

The existing-file check matters because this PR is what makes it reachable: once a name can address an existing path, `rename` would otherwise replace that file silently, with no prompt and no undo. Rejecting is deliberate — every other name that fails validation here reports why and leaves the temporary item in place, and an "overwrite" answer would also have to invalidate the clobbered file's open buffer.

Symlink escapes are checked by resolving the deepest existing ancestor, not lexically, so a directory that links out of the project can't be used as a way around the containment check. Only a genuinely missing path is treated as "not created yet" — permission and loop errors are reported rather than being read as absence.

**Verified by hand**, driving the real UI and comparing against the released 0.4.10 binary: nested creation, the collision refusal with the target file's bytes intact, and the escape refusal with nothing written outside the project.

---

fix #2640 

New files can use nested paths such as src/components/app.rs; missing directories are created automatically.
Relative . and .. components remain supported.
Absolute, drive-prefixed, and UNC paths are rejected.
~ and $HOME remain literal—no expansion.
Filesystem and permission errors are handled without panics.
Added localized validation messages and regression coverage.
