### PR TITLE
feat(terminal): auto-resume the live grid when a drag-select gesture ends

### DIFF
--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -276,6 +276,24 @@ impl Editor {
             return self.handle_composite_click(col, row, split_id, buffer_id, content_rect);
         }
 
+        // A bare press on a terminal parked in implicit (drag-initiated)
+        // scrollback abandons the selection gesture: resume the live grid and
+        // fall through to the live-grid branch below, which re-records the
+        // press as a potential selection origin — so the pane keeps behaving
+        // like the live grid it appears to be (click focuses, click-then-drag
+        // starts a fresh selection). Shift/Ctrl-clicks extend the selection
+        // instead (the gesture continues), and explicit scrollback visits are
+        // never resumed by a click.
+        if self.active_window().is_terminal_buffer(buffer_id)
+            && self
+                .active_window()
+                .split_terminal_drag_scrollback(split_id, buffer_id)
+            && !modifiers.contains(KeyModifiers::SHIFT)
+            && !modifiers.contains(KeyModifiers::CONTROL)
+        {
+            self.enter_terminal_mode();
+        }
+
         // Live terminal grid: the grid overlay covers a stale buffer view, so
         // positioning a cursor at the click would land in invisible text — and
         // a bare click must keep the terminal live (click-to-focus-and-type).

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1205,7 +1205,33 @@ impl Editor {
                         return Ok(());
                     }
                 }
-                self.copy_selection()
+                // Copying the selection completes a drag-to-select gesture on
+                // a live terminal grid: the split was only parked in implicit
+                // (drag-initiated) scrollback so the selection could exist,
+                // and the copy is the gesture's natural end — resume the live
+                // grid. Explicit scrollback visits (Ctrl+Space, Shift+PageUp,
+                // wheel) are never resumed by a copy: the user chose a stable
+                // reading view and yanking it to the bottom would lose their
+                // place.
+                let resume_terminal = {
+                    let win = self.active_window();
+                    let split = win.effective_active_split();
+                    win.split_terminal_drag_scrollback(split, buffer_id)
+                        && win
+                            .buffers
+                            .splits()
+                            .and_then(|(_, vs)| vs.get(&split))
+                            .is_some_and(|vs| {
+                                vs.cursors.iter().any(|(_, c)| {
+                                    c.selection_range().is_some() || c.has_block_selection()
+                                })
+                            })
+                };
+                self.copy_selection();
+                if resume_terminal {
+                    self.enter_terminal_mode();
+                    self.set_status_message("Copied - terminal resumed".to_string());
+                }
             }
             Action::CopyWithTheme(theme) => self.copy_selection_with_theme(&theme),
             Action::CopyFilePath => self.copy_active_buffer_path(false),

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -519,6 +519,16 @@ impl Editor {
                 // Scrolling up drops the focused split into read-only scrollback
                 // (recorded per-split, so re-focusing keeps it there).
                 self.enter_terminal_scrollback();
+            } else if let Some((split_id, buffer_id)) =
+                self.active_window().split_at_position(col, row)
+            {
+                // Scrolling a terminal split that a drag parked in implicit
+                // scrollback means the user is now *reading* the scrollback:
+                // convert the visit to an explicit one, so copy / click-away
+                // no longer auto-resume the live grid (no-op for everything
+                // else).
+                self.active_window_mut()
+                    .set_split_terminal_drag_scrollback(split_id, buffer_id, false);
             }
             self.dismiss_transient_popups();
             self.active_window_mut()
@@ -1361,14 +1371,21 @@ impl Editor {
         {
             if in_rect(col, row, *content_rect) {
                 // Double-clicked on an editor split. A LIVE terminal grid has
-                // no selection model — keep the terminal key context and do
-                // nothing. A terminal in read-only scrollback is an ordinary
-                // buffer view: fall through so double-click selects the word.
+                // no selection model of its own — select the word through the
+                // same implicit-scrollback detour a drag uses (the first
+                // press of the pair already focused the split; with
+                // `mouse_drag_selects` off the grid stays inert). A terminal
+                // in read-only scrollback is an ordinary buffer view: fall
+                // through so double-click selects the word.
                 if self.active_window().is_terminal_buffer(*buffer_id)
                     && !self
                         .active_window()
                         .split_terminal_scrollback(*split_id, *buffer_id)
                 {
+                    if self.config.terminal.mouse_drag_selects {
+                        return self
+                            .begin_terminal_grid_word_selection(*split_id, *buffer_id, col, row);
+                    }
                     self.active_window_mut().key_context =
                         crate::input::keybindings::KeyContext::Terminal;
                     return Ok(());
@@ -1532,13 +1549,18 @@ impl Editor {
             &split_areas
         {
             if in_rect(col, row, *content_rect) {
-                // Live grid: no selection model (see double-click above);
-                // scrollback view: ordinary buffer, select the line.
+                // Live grid: select the line via the implicit-scrollback
+                // detour (see double-click above); scrollback view: ordinary
+                // buffer, select the line.
                 if self.active_window().is_terminal_buffer(*buffer_id)
                     && !self
                         .active_window()
                         .split_terminal_scrollback(*split_id, *buffer_id)
                 {
+                    if self.config.terminal.mouse_drag_selects {
+                        return self
+                            .begin_terminal_grid_line_selection(*split_id, *buffer_id, col, row);
+                    }
                     return Ok(());
                 }
 
@@ -2267,6 +2289,11 @@ impl Editor {
             )?;
 
         self.focus_split(split_id, buffer_id);
+        // Grabbing the scrollbar of a drag-parked terminal scrollback view is
+        // scrollback *reading* — convert the implicit visit to an explicit one
+        // (no-op otherwise).
+        self.active_window_mut()
+            .set_split_terminal_drag_scrollback(split_id, buffer_id, false);
         if is_on_thumb {
             self.active_window_mut().mouse_state.dragging_scrollbar = Some(split_id);
             self.active_window_mut().mouse_state.drag_start_row = Some(row);
@@ -3104,22 +3131,42 @@ impl Editor {
         let drag_by_words = self.active_window_mut().mouse_state.drag_selection_by_words;
         let drag_word_end = self.active_window_mut().mouse_state.drag_selection_word_end;
 
+        // Terminal scrollback views are unwrapped and gutter-free, so a
+        // screen cell maps to a byte exactly (viewport top line + row).
+        // Resolve directly instead of through the render-cached view-line
+        // mappings: drag events processed after the live-grid→scrollback
+        // flip but before the next render would otherwise resolve against
+        // mappings cached from a *previous* buffer view of this split and
+        // land the selection head far from the pointer.
+        let terminal_grid_target = if self.active_window().is_terminal_buffer(buffer_id)
+            && self
+                .active_window()
+                .split_terminal_scrollback(leaf_id, buffer_id)
+        {
+            self.terminal_grid_byte_at(leaf_id, buffer_id, content_rect, col, row)
+        } else {
+            None
+        };
+
         let Some((target_position, new_position, anchor_position, new_sticky_column)) = self
             .active_window()
             .buffers
             .get(&buffer_id)
             .and_then(|state| {
                 let gutter_width = state.margins.left_total_width() as u16;
-                let target_position = super::click_geometry::screen_to_buffer_position(
-                    col,
-                    row,
-                    content_rect,
-                    gutter_width,
-                    &cached_mappings,
-                    fallback,
-                    true, // Allow gutter clicks for drag selection
-                    compose_width,
-                )?;
+                let target_position = match terminal_grid_target {
+                    Some(pos) => pos,
+                    None => super::click_geometry::screen_to_buffer_position(
+                        col,
+                        row,
+                        content_rect,
+                        gutter_width,
+                        &cached_mappings,
+                        fallback,
+                        true, // Allow gutter clicks for drag selection
+                        compose_width,
+                    )?,
+                };
                 let (new_position, anchor_pos) = if drag_by_words {
                     if target_position >= anchor_position {
                         (

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1395,6 +1395,12 @@ impl Editor {
             let __active_split = self.split_manager().active_split();
             if let Some(view_state) = self.split_view_states_mut().get_mut(&__active_split) {
                 view_state.viewport.line_wrap_enabled = false;
+                // A selection made in the scrollback view must not outlive
+                // the visit: the anchor would otherwise re-materialize as a
+                // phantom selection on the next scrollback entry (the sync
+                // pins only the cursor *position*) and re-suppress the
+                // output-driven auto-resume in `handle_terminal_output`.
+                view_state.cursors.map(|c| c.clear_selection());
             }
 
             // Truncate backing file to remove visible screen tail and scroll to bottom

--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -336,53 +336,21 @@ impl super::Editor {
     ) -> AnyhowResult<()> {
         self.active_window_mut().mouse_state.terminal_drag_pending = None;
 
-        // The terminal may have changed under us (mode flip, split closed).
-        if !self.active_window().is_terminal_buffer(buffer_id)
-            || self
-                .active_window()
-                .split_terminal_scrollback(split_id, buffer_id)
-        {
-            return Ok(());
-        }
-        let Some(content_rect) = self
-            .active_layout()
-            .split_areas
-            .iter()
-            .find(|(sid, bid, _, _, _, _)| *sid == split_id && *bid == buffer_id)
-            .map(|(_, _, rect, _, _, _)| *rect)
+        let Some(content_rect) =
+            self.drop_terminal_grid_into_selection_scrollback(split_id, buffer_id)
         else {
             return Ok(());
         };
-
-        // Drop into read-only scrollback. The press already focused the
-        // split, so the sync pins THIS split's viewport to the grid's row 0.
-        self.active_window_mut()
-            .set_split_terminal_scrollback(split_id, buffer_id, true);
-        self.active_window_mut().sync_terminal_mode_flags();
-        self.set_status_message(
-            "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
-        );
 
         // Resolve both grid positions to byte positions. Columns are taken
         // as byte offsets into the line (terminal rows are overwhelmingly
         // single-width; `snap_to_char_boundary` keeps multi-byte glyphs
         // safe), and subsequent drag motion refines through the standard
         // width-aware `handle_text_selection_drag` path anyway.
-        let Some((anchor, head)) = self.windows.get(&self.active_window).and_then(|win| {
-            let (_, view_states) = win.buffers.splits()?;
-            let vs = view_states.get(&split_id)?;
-            let state = win.buffers.get(&buffer_id)?;
-            let (top_line, _) = state.buffer.position_to_line_col(vs.viewport.top_byte);
-            let to_byte = |c: u16, r: u16| {
-                let grid_row = r.saturating_sub(content_rect.y) as usize;
-                let grid_col = c.saturating_sub(content_rect.x) as usize;
-                let pos = state
-                    .buffer
-                    .line_col_to_position(top_line + grid_row, grid_col);
-                state.buffer.snap_to_char_boundary(pos)
-            };
-            Some((to_byte(origin_col, origin_row), to_byte(col, row)))
-        }) else {
+        let anchor =
+            self.terminal_grid_byte_at(split_id, buffer_id, content_rect, origin_col, origin_row);
+        let head = self.terminal_grid_byte_at(split_id, buffer_id, content_rect, col, row);
+        let (Some(anchor), Some(head)) = (anchor, head) else {
             return Ok(());
         };
 
@@ -403,5 +371,165 @@ impl super::Editor {
         ms.drag_selection_split = Some(split_id);
         ms.drag_selection_anchor = Some(anchor);
         Ok(())
+    }
+
+    /// Double-click on the live terminal grid: select the word under the
+    /// pointer. Same trick as [`Editor::begin_terminal_grid_selection`] — the
+    /// live grid has no selection model, so the split first drops into
+    /// implicit scrollback (pixel-identical view), then the standard
+    /// word-selection and word-wise drag machinery take over.
+    pub(super) fn begin_terminal_grid_word_selection(
+        &mut self,
+        split_id: crate::model::event::LeafId,
+        buffer_id: BufferId,
+        col: u16,
+        row: u16,
+    ) -> AnyhowResult<()> {
+        self.active_window_mut().mouse_state.terminal_drag_pending = None;
+
+        let Some(content_rect) =
+            self.drop_terminal_grid_into_selection_scrollback(split_id, buffer_id)
+        else {
+            return Ok(());
+        };
+        let Some(pos) = self.terminal_grid_byte_at(split_id, buffer_id, content_rect, col, row)
+        else {
+            return Ok(());
+        };
+
+        if let Some(view_state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.buffers.splits_mut())
+            .and_then(|(_, vs)| vs.get_mut(&split_id))
+        {
+            let cursor = view_state.cursors.primary_mut();
+            cursor.position = pos;
+            cursor.anchor = None;
+        }
+        self.handle_action(crate::input::keybindings::Action::SelectWord)?;
+
+        // Mirror `handle_editor_double_click`: arm word-wise drag extension.
+        if let Some((sel_start, sel_end)) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .and_then(|(_, vs)| vs.get(&split_id))
+            .map(|vs| {
+                let c = vs.cursors.primary();
+                (c.selection_start(), c.selection_end())
+            })
+        {
+            let ms = &mut self.active_window_mut().mouse_state;
+            ms.dragging_text_selection = true;
+            ms.drag_selection_split = Some(split_id);
+            ms.drag_selection_anchor = Some(sel_start);
+            ms.drag_selection_by_words = true;
+            ms.drag_selection_word_end = Some(sel_end);
+        }
+        Ok(())
+    }
+
+    /// Triple-click on the live terminal grid: select the whole line under
+    /// the pointer, via the same implicit-scrollback detour.
+    pub(super) fn begin_terminal_grid_line_selection(
+        &mut self,
+        split_id: crate::model::event::LeafId,
+        buffer_id: BufferId,
+        col: u16,
+        row: u16,
+    ) -> AnyhowResult<()> {
+        self.active_window_mut().mouse_state.terminal_drag_pending = None;
+
+        let Some(content_rect) =
+            self.drop_terminal_grid_into_selection_scrollback(split_id, buffer_id)
+        else {
+            return Ok(());
+        };
+        let Some(pos) = self.terminal_grid_byte_at(split_id, buffer_id, content_rect, col, row)
+        else {
+            return Ok(());
+        };
+
+        if let Some(view_state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.buffers.splits_mut())
+            .and_then(|(_, vs)| vs.get_mut(&split_id))
+        {
+            let cursor = view_state.cursors.primary_mut();
+            cursor.position = pos;
+            cursor.anchor = None;
+        }
+        self.handle_action(crate::input::keybindings::Action::SelectLine)?;
+        Ok(())
+    }
+
+    /// Drop a *live* terminal grid split into read-only scrollback for a
+    /// selection gesture, pinned pixel-identical to the grid (see
+    /// [`Editor::begin_terminal_grid_selection`]), and mark the visit
+    /// implicit (drag-initiated) so completing the gesture — copying, or a
+    /// bare click abandoning the selection — resumes the live grid
+    /// automatically. Returns the split's content rect, or `None` when the
+    /// situation changed under the gesture (buffer no longer a terminal,
+    /// split already in scrollback, layout gone) and nothing was done.
+    fn drop_terminal_grid_into_selection_scrollback(
+        &mut self,
+        split_id: crate::model::event::LeafId,
+        buffer_id: BufferId,
+    ) -> Option<Rect> {
+        if !self.active_window().is_terminal_buffer(buffer_id)
+            || self
+                .active_window()
+                .split_terminal_scrollback(split_id, buffer_id)
+        {
+            return None;
+        }
+        let content_rect = self
+            .active_layout()
+            .split_areas
+            .iter()
+            .find(|(sid, bid, _, _, _, _)| *sid == split_id && *bid == buffer_id)
+            .map(|(_, _, rect, _, _, _)| *rect)?;
+
+        // Drop into read-only scrollback. The press already focused the
+        // split, so the sync pins THIS split's viewport to the grid's row 0.
+        self.active_window_mut()
+            .set_split_terminal_scrollback(split_id, buffer_id, true);
+        self.active_window_mut()
+            .set_split_terminal_drag_scrollback(split_id, buffer_id, true);
+        self.active_window_mut().sync_terminal_mode_flags();
+        self.set_status_message(
+            "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
+        );
+        Some(content_rect)
+    }
+
+    /// Resolve a screen position over a terminal scrollback view to a byte
+    /// offset: grid row `r` is buffer line `top_line + r` and grid columns
+    /// map 1:1 (wrap off, no gutter). Exact for any scroll position, with no
+    /// dependency on render-cached view-line mappings.
+    pub(super) fn terminal_grid_byte_at(
+        &self,
+        split_id: crate::model::event::LeafId,
+        buffer_id: BufferId,
+        content_rect: Rect,
+        col: u16,
+        row: u16,
+    ) -> Option<usize> {
+        let win = self.windows.get(&self.active_window)?;
+        let (_, view_states) = win.buffers.splits()?;
+        let vs = view_states.get(&split_id)?;
+        let state = win.buffers.get(&buffer_id)?;
+        let (top_line, _) = state.buffer.position_to_line_col(vs.viewport.top_byte);
+        let grid_row = row.saturating_sub(content_rect.y) as usize;
+        // Account for horizontal scroll (a pinned view starts at 0, but an
+        // explicit scrollback view may have been scrolled right).
+        let grid_col =
+            col.saturating_sub(content_rect.x) as usize + vs.viewport.left_column as usize;
+        let pos = state
+            .buffer
+            .line_col_to_position(top_line + grid_row, grid_col);
+        Some(state.buffer.snap_to_char_boundary(pos))
     }
 }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -102,6 +102,22 @@ pub struct TerminalBuffer {
     /// through [`Window::set_split_terminal_scrollback`] and pruned on split
     /// close via [`Window::forget_split_terminal_modes`].
     scrollback_splits: std::collections::HashSet<LeafId>,
+
+    /// The subset of `scrollback_splits` that entered scrollback *implicitly*
+    /// — dropped there by a selection gesture on the live grid
+    /// (`begin_terminal_grid_selection`) rather than by an explicit request
+    /// (Ctrl+Space, Shift+PageUp, wheel-up, process exit).
+    ///
+    /// Implicit scrollback is an implementation detail of drag-to-select, so
+    /// it also *ends* automatically: completing the gesture (copying the
+    /// selection) or abandoning it (a bare click) resumes the live grid.
+    /// Engaging with the scrollback as a view — scrolling it — clears the
+    /// marker, converting the visit to an explicit one that only ends by the
+    /// explicit rules. Invariant: `drag_scrollback_splits ⊆
+    /// scrollback_splits`, maintained by `set_scrollback_in` (any transition
+    /// through the sole mutator clears the marker; the drag path re-marks
+    /// afterwards).
+    drag_scrollback_splits: std::collections::HashSet<LeafId>,
 }
 
 impl TerminalBuffer {
@@ -111,6 +127,7 @@ impl TerminalBuffer {
         Self {
             terminal_id,
             scrollback_splits: std::collections::HashSet::new(),
+            drag_scrollback_splits: std::collections::HashSet::new(),
         }
     }
 
@@ -119,14 +136,34 @@ impl TerminalBuffer {
         self.scrollback_splits.contains(&split)
     }
 
+    /// Whether `split`'s scrollback visit is implicit (drag-initiated).
+    pub fn is_drag_scrollback_in(&self, split: LeafId) -> bool {
+        self.drag_scrollback_splits.contains(&split)
+    }
+
     /// Record `split`'s live↔scrollback edge for this terminal: `true` adds it
     /// to the scrollback set, `false` removes it (back to live). Sole mutator,
-    /// reached via [`Window::set_split_terminal_scrollback`].
+    /// reached via [`Window::set_split_terminal_scrollback`]. Every transition
+    /// clears the implicit (drag-initiated) marker: leaving scrollback ends
+    /// the visit, and an explicit (re-)entry downgrades an implicit one —
+    /// only `begin_terminal_grid_selection` re-marks, after calling this.
     fn set_scrollback_in(&mut self, split: LeafId, scrollback: bool) {
         if scrollback {
             self.scrollback_splits.insert(split);
         } else {
             self.scrollback_splits.remove(&split);
+        }
+        self.drag_scrollback_splits.remove(&split);
+    }
+
+    /// Mark or unmark `split`'s scrollback visit as implicit (drag-initiated).
+    /// Marking a split that isn't in scrollback is a no-op, preserving the
+    /// subset invariant.
+    fn set_drag_scrollback_in(&mut self, split: LeafId, drag: bool) {
+        if drag && self.scrollback_splits.contains(&split) {
+            self.drag_scrollback_splits.insert(split);
+        } else if !drag {
+            self.drag_scrollback_splits.remove(&split);
         }
     }
 
@@ -134,6 +171,7 @@ impl TerminalBuffer {
     /// longer shows this terminal), reverting it to the live default.
     fn forget_split(&mut self, split: LeafId) {
         self.scrollback_splits.remove(&split);
+        self.drag_scrollback_splits.remove(&split);
     }
 }
 
@@ -2384,6 +2422,29 @@ impl Window {
     ) {
         if let Some(tb) = self.terminal_buffer_mut(buffer_id) {
             tb.set_scrollback_in(split, scrollback);
+        }
+    }
+
+    /// Whether `split`'s scrollback visit for terminal `buffer_id` is
+    /// implicit — entered by a selection gesture on the live grid rather than
+    /// an explicit request. `false` for live splits, explicit scrollback, and
+    /// non-terminal buffers.
+    pub fn split_terminal_drag_scrollback(&self, split: LeafId, buffer_id: BufferId) -> bool {
+        self.terminal_buffer(buffer_id)
+            .is_some_and(|tb| tb.is_drag_scrollback_in(split))
+    }
+
+    /// Mark (or unmark) `split`'s scrollback visit for terminal `buffer_id`
+    /// as implicit (drag-initiated). No-op for non-terminal buffers and, when
+    /// marking, for splits not currently in scrollback.
+    pub fn set_split_terminal_drag_scrollback(
+        &mut self,
+        split: LeafId,
+        buffer_id: BufferId,
+        drag: bool,
+    ) {
+        if let Some(tb) = self.terminal_buffer_mut(buffer_id) {
+            tb.set_drag_scrollback_in(split, drag);
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4258,3 +4258,297 @@ fn test_terminal_buffers_never_line_wrap() {
         "terminal buffers must never resolve to line-wrap even when global line wrap is on"
     );
 }
+
+// --- Drag-to-select exit conditions (implicit scrollback) -----------------
+//
+// A drag on the live grid parks the split in *implicit* scrollback so the
+// selection can exist (the grid has no selection model). Implicit scrollback
+// ends automatically: copying the selection or a bare click resumes the live
+// grid, while engaging with the scrollback as a view (scrolling) converts
+// the visit to an explicit one that only ends by the explicit rules.
+
+/// Locate the top-left screen cell of the row that contains `needle`.
+fn screen_pos_of(harness: &EditorTestHarness, needle: &str) -> Option<(u16, u16)> {
+    harness
+        .screen_to_string()
+        .lines()
+        .enumerate()
+        .find_map(|(row, line)| {
+            line.find(needle)
+                .map(|byte| (line[..byte].chars().count() as u16, row as u16))
+        })
+}
+
+/// Whether the focused split's primary cursor carries an active selection.
+fn primary_selection_active(harness: &EditorTestHarness) -> bool {
+    let win = harness.editor().active_window();
+    let Some((mgr, view_states)) = win.buffers.splits() else {
+        return false;
+    };
+    view_states
+        .get(&mgr.active_split())
+        .map(|vs| {
+            let c = vs.cursors.primary();
+            c.anchor.is_some_and(|a| a != c.position)
+        })
+        .unwrap_or(false)
+}
+
+/// Drag-select from `(from_col, row)` to `(to_col, row)` with a render after
+/// every event, like the interactive event loop (each event redraws). The
+/// harness's `mouse_drag` sends the whole gesture without intermediate
+/// renders, so drag steps after the live-grid→scrollback flip would resolve
+/// against the pre-flip cached view-line mappings.
+fn drag_select_row(
+    harness: &mut EditorTestHarness,
+    from_col: u16,
+    to_col: u16,
+    row: u16,
+) -> anyhow::Result<()> {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    let ev = |kind, column| MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: KeyModifiers::empty(),
+    };
+    harness.send_mouse(ev(MouseEventKind::Down(MouseButton::Left), from_col))?;
+    harness.render()?;
+    harness.send_mouse(ev(MouseEventKind::Drag(MouseButton::Left), to_col))?;
+    harness.render()?;
+    harness.send_mouse(ev(MouseEventKind::Up(MouseButton::Left), to_col))?;
+    harness.render()?;
+    Ok(())
+}
+
+/// Open a terminal, print `output` on its own row (the shell quoting keeps
+/// the echoed *command* from containing the marker), and return the marker
+/// row's screen position.
+fn terminal_with_marker(harness: &mut EditorTestHarness, output: &str) -> (u16, u16) {
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    assert!(harness.editor().is_terminal_mode());
+
+    // Type `echo 'X'MARKER` so the typed command line on screen never
+    // contains the bare marker; only the output row does.
+    let (head, tail) = output.split_at(1);
+    let cmd = format!("echo '{}'{}\n", head, tail);
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(cmd.as_bytes());
+    harness
+        .wait_until(|h| screen_pos_of(h, output).is_some())
+        .unwrap();
+    screen_pos_of(harness, output).unwrap()
+}
+
+/// Copying a drag selection completes the gesture: the split must resume the
+/// live grid on Ctrl+C, without waiting for new output or a manual
+/// Ctrl+Space (the "stuck in scrollback after copy" complaint).
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_drag_select_copy_resumes_live() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let (col, row) = terminal_with_marker(&mut harness, "XSELECT_COPY_ME");
+
+    drag_select_row(&mut harness, col, col + 10, row).unwrap();
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "drag on the live grid should park the split in read-only scrollback"
+    );
+    assert!(
+        primary_selection_active(&harness),
+        "drag should build a real selection over the terminal text"
+    );
+
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    let clip = harness.editor_mut().clipboard_content_for_test();
+    assert!(
+        clip.contains("XSELECT_CO"),
+        "Ctrl+C should copy the dragged terminal text, got {clip:?}"
+    );
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "copying the selection should resume the live terminal"
+    );
+}
+
+/// A bare click on a drag-parked scrollback pane abandons the selection and
+/// resumes the live grid immediately — no new output required.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_drag_select_click_away_resumes_live() {
+    let mut harness = harness_or_return!(120, 30);
+    let (col, row) = terminal_with_marker(&mut harness, "XSELECT_CLICK_AWAY");
+
+    drag_select_row(&mut harness, col, col + 8, row).unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+
+    harness.mouse_click(col + 20, row).unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "a bare click should abandon the drag selection and resume the live terminal"
+    );
+}
+
+/// Scrolling the drag-parked scrollback converts the visit to an explicit
+/// one: the user is reading history now, so neither copy nor click may yank
+/// the view back to the live grid.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_drag_select_scroll_converts_to_explicit() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let (col, row) = terminal_with_marker(&mut harness, "XSELECT_THEN_SCROLL");
+
+    drag_select_row(&mut harness, col, col + 8, row).unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+
+    harness.mouse_scroll_up(col + 2, row).unwrap();
+
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(
+        harness
+            .editor_mut()
+            .clipboard_content_for_test()
+            .contains("XSELECT_"),
+        "copy should still work after scrolling"
+    );
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "after scrolling, the visit is explicit: copy must not yank back to the live grid"
+    );
+
+    harness.mouse_click(col + 20, row).unwrap();
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "after scrolling, a click places the cursor without resuming the live grid"
+    );
+}
+
+/// An explicit scrollback visit (Ctrl+Space) keeps the manual model: a
+/// selection copied there must NOT resume the live grid.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_explicit_scrollback_copy_does_not_resume() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let (col, row) = terminal_with_marker(&mut harness, "XSELECT_EXPLICIT");
+
+    // Let trailing shell output (prompt redraw) drain first: with no
+    // selection pinning the view, `jump_to_end_on_output` would legitimately
+    // resume the split right back out of the manual scrollback below.
+    harness.wait_for_async_quiescence(3).unwrap();
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+
+    // The pinned scrollback view is pixel-identical to the grid: the marker
+    // is still at the same screen position. Select part of it.
+    drag_select_row(&mut harness, col, col + 8, row).unwrap();
+    assert!(primary_selection_active(&harness));
+
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(
+        harness
+            .editor_mut()
+            .clipboard_content_for_test()
+            .contains("XSELECT_"),
+        "copy should work in explicit scrollback"
+    );
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "explicit scrollback must not be resumed by a copy"
+    );
+}
+
+/// Regression: the drag's selection anchor must not outlive the visit. It
+/// used to survive the resume, re-materialize as a phantom selection on the
+/// next scrollback entry, and permanently suppress the output-driven
+/// auto-resume in `handle_terminal_output`.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_no_phantom_selection_after_drag_copy_resume() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let (col, row) = terminal_with_marker(&mut harness, "XSELECT_PHANTOM");
+
+    // Drag + copy (resumes live), then re-enter scrollback manually.
+    drag_select_row(&mut harness, col, col + 8, row).unwrap();
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(harness.editor().is_terminal_mode());
+    // Drain trailing shell output before the manual scrollback entry: an
+    // output byte landing right after Ctrl+Space would auto-resume the split
+    // (with no selection, that is now the intended behavior).
+    harness.wait_for_async_quiescence(3).unwrap();
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+
+    assert!(
+        !primary_selection_active(&harness),
+        "no phantom selection may survive into a fresh scrollback entry"
+    );
+
+    // With no selection pinning the view, new output must auto-resume the
+    // terminal (jump_to_end_on_output defaults to true).
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"echo 'B'ACK_ALIVE\n");
+    harness
+        .wait_until(|h| h.editor().is_terminal_mode())
+        .unwrap();
+}
+
+/// Double-click on the live grid selects the word under the pointer (via the
+/// same implicit-scrollback detour as a drag); copying it resumes the grid.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_double_click_selects_word_and_copy_resumes() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let (col, row) = terminal_with_marker(&mut harness, "XWORDSEL_TARGET");
+
+    // Two clicks at the same cell within the double-click window.
+    harness.mouse_click(col + 3, row).unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "the first (bare) click must keep the terminal live"
+    );
+    harness.mouse_click(col + 3, row).unwrap();
+
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "double-click should park the split in scrollback with the word selected"
+    );
+    assert!(
+        primary_selection_active(&harness),
+        "double-click should select the word under the pointer"
+    );
+
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    assert_eq!(
+        harness.editor_mut().clipboard_content_for_test(),
+        "XWORDSEL_TARGET",
+        "double-click + copy should yield exactly the word under the pointer"
+    );
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "copying the double-click selection should resume the live terminal"
+    );
+}

--- a/docs/internal/terminal-drag-select-exit-analysis.md
+++ b/docs/internal/terminal-drag-select-exit-analysis.md
@@ -1,0 +1,285 @@
+# Terminal drag-select: why the split stays stuck in scrollback, and how it should exit
+
+Status: analysis only — no behavior change implemented yet.
+Scope: the live↔scrollback state machine around mouse drag-to-select on the
+live terminal grid (added in PR #2701), the `jump_to_end_on_output`
+selection-suppression, and the recommended automatic exit condition.
+All code paths are in the shared core (`crates/fresh-editor/src/app/`), so
+everything below applies identically to the TUI and the web UI; the web
+bridge only forwards mouse/key events.
+
+## 1. The current state machine
+
+Per (split, terminal buffer) there are exactly two states. The source of
+truth is `TerminalBuffer::scrollback_splits` (`app/window/mod.rs:104`) — a
+split is **live** iff absent from the set, **scrollback** iff present. The
+only writer is `Window::set_split_terminal_scrollback`
+(`app/window/mod.rs:2379`). The `KeyContext::Terminal`/`Normal` edge is a
+projection derived from that set for the focused split by
+`sync_terminal_mode_flags` (`app/active_focus.rs:189`), and
+`focused_terminal_live()` (`app/window/mod.rs:2410`) just reads the
+projection.
+
+### Live → scrollback (all call `set_split_terminal_scrollback(.., true)`)
+
+| trigger | site |
+|---|---|
+| `Ctrl+Space` / `Ctrl+]` / `` Ctrl+` `` in terminal mode | `app/terminal.rs:1342` → `enter_terminal_scrollback` |
+| `Escape` (`Action::TerminalEscape`) | `app/input.rs:2348` |
+| `Shift+PageUp` | `app/input_dispatch.rs:552` |
+| wheel scroll-up over the live grid | `app/mouse_input.rs:518` |
+| **left-drag on the live grid** (new) | `app/terminal_mouse.rs:328` `begin_terminal_grid_selection` |
+| terminal process exit (all splits) | `app/async_dispatch.rs:1043` |
+
+### Scrollback → live (all call `enter_terminal_mode`, `app/terminal.rs:1369`)
+
+| trigger | site |
+|---|---|
+| `Ctrl+Space` / `Ctrl+]` / `` Ctrl+` `` | `app/input_dispatch.rs:84` via `should_enter_terminal_mode` (`app/terminal_input.rs:96`) |
+| any plain char / Enter / Tab / Backspace (key is then forwarded to the PTY) | same path |
+| `Action::FocusTerminal` | `app/input.rs:2336` |
+| **new PTY output**, iff `terminal.jump_to_end_on_output` (default `true`) **and no selection is active** | `app/async_dispatch.rs:767` `handle_terminal_output` |
+
+`enter_terminal_mode` clears the split's scrollback edge, restores
+`KeyContext::Terminal`, truncates the backing file back to the history end
+(removing the appended visible-screen tail) and scrolls the grid to the
+bottom. Note what it does **not** do: it never touches the split view
+state's cursor — the selection anchor survives (this matters, §3).
+
+### The drag-select flow through those states
+
+1. **mouse-down** on a live grid: `handle_mouse_click` focuses the split
+   and, when `terminal.mouse_drag_selects` is on, records
+   `MouseState::terminal_drag_pending = (split, buffer, col, row)`
+   (`app/click_handlers.rs:287-299`). State is still live — a bare click
+   never leaves live mode.
+2. **first drag event**: `handle_mouse_drag` sees the pending origin
+   (`app/mouse_input.rs:3021-3030`) and calls
+   `begin_terminal_grid_selection` (`app/terminal_mouse.rs:328`), which
+   drops the split into scrollback (`set_split_terminal_scrollback(true)` +
+   `sync_terminal_mode_flags` → `sync_terminal_to_buffer` pins the viewport
+   so the view is pixel-identical to the grid), anchors a normal text
+   selection at the press origin, and hands off to the standard
+   `dragging_text_selection` machinery.
+3. **mouse-up**: `clear_active_window_drag_state`
+   (`app/mouse_input.rs:300`, `:4405`) clears every drag bookkeeping field
+   (including `terminal_drag_pending` and `dragging_text_selection`) but
+   deliberately **keeps the selection** (anchor stays set).
+4. **`Ctrl+C`**: key context is `Normal` in scrollback, and Ctrl-modified
+   keys don't match `should_enter_terminal_mode`, so the key resolves to
+   `Action::Copy` (`app/input.rs:1168`) → `copy_selection`
+   (`app/clipboard.rs:129`). `copy_selection` copies the text and — like
+   every editor copy — **does not collapse the selection**.
+5. Nothing else happens. There is no transition armed to fire.
+
+## 2. Where "stuck in scrollback" comes from
+
+The only *automatic* scrollback→live transition is the output-driven one in
+`handle_terminal_output`, and it is guarded (`app/async_dispatch.rs:753-769`)
+by `selection_active`:
+
+```
+dragging_text_selection || terminal_drag_pending.is_some()
+    || primary cursor anchor exists and != position   (focused split)
+```
+
+That guard is correct and deliberate *before* the copy: without it, a chatty
+program's next output line would call `enter_terminal_mode`, truncate the
+backing buffer, and destroy the selection before the user could copy it —
+the exact case drag-to-select exists for.
+
+The trap is that the guard's third clause **outlives the copy**. After
+`Ctrl+C` the selection persists, so getting back to live requires *both*
+of:
+
+- the selection must be collapsed (a bare click in the pane, or Ctrl+Space /
+  typing which bypass the guard entirely), **and**
+- new output must arrive afterwards.
+
+In the most common workflow — run a command, drag-select part of its
+output while the shell sits at an idle prompt, copy — *neither* happens on
+its own. The shell prints nothing further, so even a user who clicks to
+collapse the selection stays in scrollback indefinitely. Verified end-to-end
+against the web bridge (Playwright driving `webui_server`, statusbar scene
+region as the mode oracle):
+
+```
+[after drag]                       … Terminal mode disabled - read only (Ctrl+Space to resume) …
+[after Ctrl+C copy]                … Copied …                     ← hint gone, still scrollback
+[output arrives, selection active] … Copied …                     ← suppressed, still scrollback
+[after click collapses selection]  … still scrollback (no output yet)
+[next output after collapse]       … Terminal mode enabled        ← only NOW resumes
+```
+
+Two aggravating details:
+
+- **Discoverability regression**: the "read only (Ctrl+Space to resume)"
+  text is a transient status *message*; the `Copied` message from the copy
+  immediately overwrites it. At exactly the moment the user is stranded, the
+  UI stops telling them how to get out.
+- `Ctrl+Space` "toggle" asymmetry: the same chord that resumes also drops a
+  live terminal back into scrollback, so a user mashing it lands wherever
+  the parity of presses leaves them.
+
+## 3. Confirmed latent bug: the phantom selection
+
+`sync_terminal_to_buffer` (`app/terminal.rs:1678`) reloads the buffer and
+pins the *primary cursor position* to the anchor byte
+(`app/terminal.rs:1763`), but never clears the cursor's selection
+`anchor`. `enter_terminal_mode` doesn't either. So the anchor set by a drag
+survives a `Ctrl+Space` resume, and the *next* entry into scrollback — for
+any reason — resurrects it against freshly re-synced buffer contents:
+
+```
+drag-select → Ctrl+C → Ctrl+Space (resume, anchor NOT cleared)
+→ Ctrl+Space (or wheel-up) back into scrollback
+→ a phantom selection the user never made is rendered
+   (observed: an entire prompt line highlighted)
+→ selection_active is true → output-driven auto-resume is suppressed
+→ this split now NEVER auto-resumes again (until a click/typing)
+```
+
+Reproduced end-to-end: after the resume/re-enter cycle, output arrived and
+the split stayed `read only` with a visible bogus highlight. This is worse
+than the reported complaint — it detaches the suppression from any real
+selection — and any fix for the exit condition should also clear the anchor
+on the scrollback↔live transitions.
+
+## 4. Evaluating the candidate exit conditions
+
+The design constraint everything must respect: the selection must survive —
+against arbitrary PTY output — from mouse-up until the user has copied it,
+and the protections the current design gets right must not regress
+(bare click keeps the terminal live; `Ctrl+Space` keeps working; a user
+deliberately reading scrollback must not be yanked to the bottom).
+
+**(a) Resume on mouse-up ending the drag.** Non-starter. The selection's
+byte ranges refer to the synced scrollback buffer; `enter_terminal_mode`
+truncates that buffer's backing file and the live grid has no selection
+model to migrate into, so resuming at mouse-up destroys the selection
+before it can be copied. Copy-on-mouse-up (X11 primary-selection style)
+would sidestep that but silently clobbers the clipboard on every drag —
+not this editor's clipboard model, and it would still leave "drag to
+scroll-and-read" impossible.
+
+**(b) Resume when the copy completes.** Matches the gesture: drag → copy →
+done is one arc, and copy is its natural end. Works in the idle-shell case
+(no output needed). Two problems if applied *unconditionally* to every
+terminal-scrollback copy: a user who entered scrollback explicitly
+(`Ctrl+Space`, wheel) and copied something from deep history gets yanked to
+the bottom, losing their reading position — a regression of the manual
+scrollback model; and copy-without-selection (line copy) resuming would be
+bizarre.
+
+**(c) Resume when the selection is cleared (click collapses it).** Fixes
+the "clicked away but still stuck" leg (today that click only removes the
+suppression; it still needs output to fire). Doesn't touch the primary
+complaint on its own — after copy the selection is still there, so the user
+must additionally click. Same caveat as (b): unconditional, it breaks
+click-to-place-cursor for deliberate scrollback readers.
+
+**(d) Re-enable `jump_to_end_on_output` once the copy is done** (collapse
+the selection on copy, keep waiting for output). Least surprising visually
+(no immediate viewport jump), preserves all current protections — but it
+does **not** fix the reported case: an idle shell emits nothing, so the
+user who copied at a quiet prompt stays stuck exactly as today. It's a
+component of a fix, not a fix.
+
+**(e) Never auto-resume; improve discoverability.** This is the status quo
+users are complaining about, and the status-message overwrite (§2) means
+the one breadcrumb disappears on copy. Rejected as the primary answer,
+though the discoverability half (a persistent scrollback statusbar segment
+rather than a transient message) is worth doing regardless.
+
+### The missing distinction
+
+Every option is wrong *unconditionally* and right *conditionally*, and the
+condition is the same one each time: **who initiated scrollback**. A drag
+on the live grid enters scrollback as an implementation detail — the user
+never asked to leave the live terminal, so the detour should end as
+automatically as it began. `Ctrl+Space` / `Shift+PageUp` / wheel-up is an
+explicit request for a stable reading view — the current "resume manually,
+or on output once no selection pins the view" model is right for it and
+must not change.
+
+## 5. Recommendation
+
+Track drag-initiated ("implicit") scrollback separately, and end it when
+the selection gesture ends:
+
+1. **Copy resumes.** `Ctrl+C` (or Edit▸Copy — same `Action::Copy`) with an
+   active selection while the focused split is in *implicit* scrollback:
+   copy, collapse the selection, `enter_terminal_mode`. Immediate, output
+   not required — fixes the idle-shell case, which is the complaint.
+2. **Click-away resumes.** A bare mouse-down in an implicit-scrollback pane
+   collapses the selection and resumes live. The split then behaves exactly
+   like the live grid it appears to be: click = focus, click-then-drag =
+   new selection (the mouse-down re-records `terminal_drag_pending` via the
+   existing live-grid path). Selection abandoned = back to a normal
+   terminal, matching plain-terminal muscle memory.
+3. **Engaging with scrollback converts it to explicit.** Wheel/keyboard
+   scrolling (or `Shift+PageUp`, or paging keys) while in implicit
+   scrollback clears the implicit marker: the user is now *reading*, and
+   from then on the existing explicit-scrollback rules apply — copy does
+   NOT yank them, output resumes only once no selection is active. This is
+   the line that protects the "select, then scroll up to check something,
+   then copy" flow from surprise jumps.
+4. **Clear the anchor on transition** (both `enter_terminal_mode` and the
+   cursor-pinning in `sync_terminal_to_buffer`): fixes the phantom-selection
+   bug (§3) for every path, independent of the rest.
+5. **Leave `handle_terminal_output` untouched.** The suppression is still
+   exactly right for the window between mouse-up and copy (in both modes),
+   and for explicit-scrollback selections after it.
+
+What this preserves: bare click on the live grid still only focuses
+(nothing changes before a drag starts); a selection still survives chatty
+output until copied; `Ctrl+Space` still toggles both ways;
+`terminal.mouse_drag_selects = false` still disables the whole feature
+(no pending origin is ever recorded); explicit scrollback UX is unchanged.
+
+Known accepted edge: after a copy-resume, a *second* `Ctrl+C` goes to the
+PTY as SIGINT (the selection is gone, the split is live). This mirrors
+VS Code's "Ctrl+C copies iff a terminal selection exists" behavior and is
+the standard resolution of that ambiguity, but it's worth a line in the
+docs. No new config knob initially; if field feedback wants one,
+`terminal.resume_after_copy: bool` (default `true`) slots cleanly next to
+`mouse_drag_selects`.
+
+### Functions that change
+
+| change | site |
+|---|---|
+| add per-split "implicit (drag-initiated)" marker alongside `scrollback_splits`, e.g. `drag_scrollback: HashSet<LeafId>`; cleared whenever the split leaves scrollback or the marker is downgraded | `TerminalBuffer`, `app/window/mod.rs:86` (+ accessors near `:2369`, pruned in `forget_split_terminal_modes`) |
+| set the marker when the drag drops the split into scrollback | `begin_terminal_grid_selection`, `app/terminal_mouse.rs:328` |
+| explicit entries never set (and clear any stale) marker | `enter_terminal_scrollback` `app/terminal.rs:1442`, `DeferredAction::EnterScrollbackMode` `app/input_dispatch.rs:552`, wheel-up entry `app/mouse_input.rs:518` |
+| after `copy_selection` with a selection, if focused split is implicit-scrollback: collapse selection + `enter_terminal_mode` | `Action::Copy` arm, `app/input.rs:1168` (keeps `copy_selection` itself terminal-agnostic) |
+| bare mouse-down on an implicit-scrollback terminal pane: resume live first, then fall into the existing live-grid click branch (focus + record pending origin) | `handle_mouse_click` terminal branch, `app/click_handlers.rs:287` |
+| scrolling an implicit-scrollback split downgrades the marker to explicit | scroll path for scrollback panes, `app/mouse_input.rs` around `:518` / `handle_mouse_scroll` |
+| clear primary-cursor `anchor` when resuming live / when pinning the cursor on sync | `enter_terminal_mode` `app/terminal.rs:1369`, `sync_terminal_to_buffer` `app/terminal.rs:1760-1768` |
+
+### Tests that need to move
+
+- `web-ui/test/drive.mjs` terminal-selection block (lines ~708-755)
+  currently asserts the *old* contract: it presses `Ctrl+Space` after the
+  copy and expects that to resume. Under the recommendation the copy itself
+  resumes; the block should assert auto-resume on copy, then verify
+  `Ctrl+Space` still round-trips, and keep the bare-click-stays-live check.
+- New core e2e tests (`tests/e2e/terminal.rs`): copy-resumes-implicit,
+  click-away-resumes-implicit, scroll-converts-implicit-to-explicit (copy
+  then does NOT resume), explicit-scrollback copy does NOT resume, and a
+  regression test for the phantom selection (drag → copy → resume →
+  re-enter scrollback → new output must resume; no selection rendered).
+
+## 6. Repro notes (web bridge)
+
+Build and run `cargo build --features web -p fresh-editor --example
+webui_server`, start it on a port, then drive with Playwright (Chromium at
+`/opt/pw-browsers/chromium`). Mode oracle: the statusbar scene region
+(`window.fresh.scene.regions.statusbar`) — "read only (Ctrl+Space to
+resume)" vs "Terminal mode enabled". To make output arrive without typing
+(typing would itself resume), schedule it before dragging:
+`echo MARKER; (sleep 6; echo LATER-1; sleep 6; echo LATER-2) &`, then
+drag over the MARKER row, `Ctrl+C`, and observe: LATER-1 does not resume
+(selection alive), a bare click doesn't either (no output), LATER-2 after
+the click does. The phantom-selection repro is: drag → `Ctrl+Space` →
+`Ctrl+Space` → observe the bogus highlight and that LATER-3 never resumes.

--- a/docs/internal/terminal-drag-select-exit-analysis.md
+++ b/docs/internal/terminal-drag-select-exit-analysis.md
@@ -1,6 +1,8 @@
 # Terminal drag-select: why the split stays stuck in scrollback, and how it should exit
 
-Status: analysis only — no behavior change implemented yet.
+Status: **implemented** — §5's recommendation landed (see §6 for what shipped
+and the deltas discovered during implementation). §§1–4 document the state
+machine and defect as they stood before the change.
 Scope: the live↔scrollback state machine around mouse drag-to-select on the
 live terminal grid (added in PR #2701), the `jump_to_end_on_output`
 selection-suppression, and the recommended automatic exit condition.
@@ -270,7 +272,61 @@ docs. No new config knob initially; if field feedback wants one,
   regression test for the phantom selection (drag → copy → resume →
   re-enter scrollback → new output must resume; no selection rendered).
 
-## 6. Repro notes (web bridge)
+## 6. What shipped (implementation notes)
+
+The recommendation in §5 was implemented as specified, with three deltas
+discovered during implementation:
+
+- **Double/triple-click select on the live grid.** With click-away-resume in
+  place, a double-click's first press resumes an implicit-scrollback pane, so
+  its second press lands on the live grid — which used to be inert. Rather
+  than regress word-select, the live grid now supports it: double-click
+  selects the word (word-wise drag extension included) and triple-click the
+  line, through the same implicit-scrollback detour as a drag
+  (`begin_terminal_grid_word_selection` / `begin_terminal_grid_line_selection`,
+  gated on `terminal.mouse_drag_selects`). Copying those selections resumes
+  the grid like any drag selection.
+- **Render-independent drag resolution on terminal scrollback.** Drag events
+  processed after the live→scrollback flip but before the next render used to
+  resolve against view-line mappings cached from a *previous* buffer view of
+  the split, throwing the selection head far from the pointer (reproducible
+  in the web bridge, whose event bursts outrun renders, and in the test
+  harness). Terminal scrollback is unwrapped and gutter-free, so
+  `handle_text_selection_drag` now resolves those positions directly
+  (`terminal_grid_byte_at`: viewport top line + row, columns 1:1 plus
+  horizontal scroll) with no cache dependency.
+- **Scrollbar interaction also downgrades.** Grabbing the scrollback view's
+  scrollbar is scrollback *reading*, so it clears the implicit marker exactly
+  like wheel scrolling.
+
+The phantom-selection fix is the `enter_terminal_mode` clear only. An earlier
+draft also cleared selections in `sync_terminal_to_buffer`, but that path
+runs on every focus change of a scrollback split and would have destroyed
+legitimate selections on refocus; every resume goes through
+`enter_terminal_mode`, which is sufficient.
+
+The `Copy` status message reads "Copied - terminal resumed" when the copy
+resumes the grid, keeping the mode change visible.
+
+Verified by: 6 new core e2e tests (`cargo test -p fresh-editor --test
+e2e_tests terminal_drag_select` + explicit/phantom/double-click tests), the
+updated `web-ui/test/drive.mjs` terminal block (copy auto-resumes, Ctrl+Space
+round-trips, bare click stays live — 140/140 checks green), and a manual
+Playwright sweep of all five exit rules against the web bridge.
+
+**Known residual (pre-existing, out of scope):** under many repeated
+enter/exit cycles in the *web bridge*, the scrollback backing file
+accumulates stale copies of the visible screen (an un-truncated re-append per
+cycle somewhere in the web-only flow), which can momentarily corrupt a drag's
+selection extent mid-gesture and leave stale highlight cells in the pane.
+The same interleaving is clean in the core harness
+(single-cycle and 4-cycle drag/copy/click/wheel sequences show no
+accumulation: backing file stays minimal, selections exact). This reproduces
+identically on the pre-change code — the change strictly improves it (the
+output-suppression no longer wedges) — and should be chased as a separate
+web-bridge/backing-file issue.
+
+## 7. Repro notes (web bridge)
 
 Build and run `cargo build --features web -p fresh-editor --example
 webui_server`, start it on a port, then drive with Playwright (Chromium at

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -709,8 +709,10 @@ console.log('\n[terminal text selection: drag → scrollback selection → edito
 // Open a real PTY terminal, echo a marker, and drag across the echoed row.
 // A drag on the LIVE grid must drop the split into read-only scrollback
 // (pixel-identical view) and build a real editor selection there; Ctrl+C
-// then copies through the editor clipboard (scene.clipboard sync). A bare
-// click must NOT leave live mode (click-to-focus-and-type).
+// then copies through the editor clipboard (scene.clipboard sync) AND
+// resumes the live terminal — the copy completes the gesture, so the split
+// must not stay stuck in scrollback. A bare click must NOT leave live mode
+// (click-to-focus-and-type).
 await page.request.post(URL + '/action', { data: { action: 'open_terminal' } });
 await page.waitForFunction(() => window.fresh.scene.regions.statusbar.segments.some(s => /Terminal \d+ opened/.test(s.text || s.label || '')), null, { timeout: 15000 }).catch(() => {});
 await page.waitForTimeout(800);
@@ -743,10 +745,16 @@ await page.waitForFunction(() => window.fresh.scene.clipboard && /web-sel-MARKER
 sd = await scene(page);
 check('Ctrl+C copies the terminal selection through the editor clipboard',
   !!sd.clipboard && (sd.clipboard.text || '').startsWith('web-sel-MARKER-42'), JSON.stringify(sd.clipboard));
-await page.keyboard.press('Control+ ');   // resume the live terminal
-await page.waitForTimeout(400);
+check('copying the selection auto-resumes the live terminal', /terminal resumed/.test(tStatus(sd)), tStatus(sd));
+// Ctrl+Space still round-trips: into scrollback and back to live.
+await page.keyboard.press('Control+ ');
+await page.waitForTimeout(300);
 sd = await scene(page);
-check('Ctrl+Space resumes the live terminal after a selection', /Terminal mode enabled/.test(tStatus(sd)), tStatus(sd));
+check('Ctrl+Space still drops the live terminal into scrollback', /read only/.test(tStatus(sd)), tStatus(sd));
+await page.keyboard.press('Control+ ');
+await page.waitForTimeout(300);
+sd = await scene(page);
+check('Ctrl+Space resumes the live terminal from scrollback', /Terminal mode enabled/.test(tStatus(sd)), tStatus(sd));
 if (tp) {  // a bare click must keep the terminal live
   await page.mouse.click((tp.content.x + 4) * tmet.cw, (tp.content.y + 1) * tmet.ch);
   await page.waitForTimeout(300);


### PR DESCRIPTION
## Problem

Drag-to-select on the live terminal grid (#2701) parks the split in read-only scrollback so the selection can exist — but nothing ever brings it back. The copied selection keeps suppressing the output-driven auto-resume (`jump_to_end_on_output`), and an idle shell never emits the output the resume path waits for, so after select + copy the user is stranded in scrollback until a manual `Ctrl+Space`.

## Approach

`TerminalBuffer` now distinguishes **implicit** scrollback (entered by a selection gesture on the live grid) from **explicit** scrollback (`Ctrl+Space`, `Shift+PageUp`, wheel-up). The implicit detour ends as automatically as it began; the explicit model is untouched. Full analysis, alternatives considered, and edge cases: `docs/internal/terminal-drag-select-exit-analysis.md`.

- **Copy resumes.** `Ctrl+C` with a selection in implicit scrollback copies, then immediately resumes the live grid (status: `Copied - terminal resumed`). No new output required — fixes the idle-shell case.
- **Click-away resumes.** A bare click abandons the selection and resumes; the same press re-records a selection origin, so click-then-drag starts a fresh selection. The pane keeps behaving like the live grid it appears to be.
- **Reading converts to explicit.** Wheel-scrolling or grabbing the scrollbar clears the implicit marker: the user is reading history now, so copy/click no longer yank them to the bottom.
- **Explicit scrollback unchanged.** Copy never resumes it; `Ctrl+Space` still round-trips; the `handle_terminal_output` suppression still protects an un-copied selection from chatty programs.

## Also fixed along the way

- **Phantom selection:** the drag's anchor survived a resume, re-rendered as a bogus selection on the next scrollback entry, and permanently suppressed auto-resume. `enter_terminal_mode` now clears the split's selections.
- **Stale-mapping drags:** drag events processed between the scrollback flip and the next render resolved against view-line mappings cached from a previous view, landing the selection far from the pointer. Terminal-scrollback drags now resolve directly (viewport top line + row — exact, since these views never wrap and have no gutter).
- **Inert double/triple-click on the live grid:** now select the word/line via the same implicit-scrollback detour (gated on `terminal.mouse_drag_selects`), so click-away-resume doesn't regress word selection.

## Known edge (documented)

After a copy-resume, a second `Ctrl+C` goes to the PTY as SIGINT — same resolution VS Code uses for the copy/SIGINT ambiguity.

## Testing

- 6 new core e2e tests: copy-resumes, click-away-resumes, scroll-converts-to-explicit, explicit-scrollback-copy-stays, phantom-selection regression, double-click-word-select.
- Full suites green: 119/119 terminal e2e, 3002/3002 lib tests.
- `web-ui/test/drive.mjs` terminal block updated to the new contract (copy auto-resumes, `Ctrl+Space` round-trips, bare click stays live) — 140/140 checks pass against the web bridge.
- Manual Playwright sweep of all five exit rules end-to-end in the web UI; TUI parity is structural (all logic lives in the shared core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXGoGYEeDAXTLLP3LwuJKU