### PR TITLE
fix(orchestrator): merge plugin global state on write instead of snapshotting

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -636,6 +636,8 @@ impl Editor {
             suppress_chrome_cells: false,
             suspend_requested: false,
             plugin_global_state: parts.plugin_global_state,
+            // Boot-loaded state came *from* disk — nothing is dirty yet.
+            plugin_global_dirty: HashMap::new(),
             warning_log: None,
             status_log_path: None,
             #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -935,6 +935,13 @@ pub struct Editor {
     /// Plugin-managed global state, isolated per plugin name.
     /// Outer key is plugin name, inner key is the state key set by the plugin.
     plugin_global_state: HashMap<String, HashMap<String, serde_json::Value>>,
+    /// Keys of `plugin_global_state` this instance changed (set or deleted)
+    /// and has not yet flushed. The on-disk `orchestrator/state/<plugin>.json`
+    /// is shared with any concurrently running editor process, so persistence
+    /// merges exactly these keys over the file's current content instead of
+    /// snapshotting the whole in-memory map — a stale instance must not
+    /// revert keys another instance wrote after this one booted.
+    plugin_global_dirty: HashMap<String, std::collections::HashSet<String>>,
     /// Warning log receiver and path (for tracking warnings)
     warning_log: Option<(std::sync::mpsc::Receiver<()>, PathBuf)>,
 

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -762,40 +762,57 @@ impl Editor {
     /// Persist `sessions` + `plugin_global_state` to disk. Best-
     /// effort: filesystem errors are logged at WARN and swallowed
     /// so a transient permission glitch doesn't block quit.
-    pub fn save_orchestrator_state(&self) {
-        let data_dir = self.dir_context.data_dir.clone();
-        let orch_dir = orchestrator_dir(&data_dir);
-        if let Err(e) = self.authority().filesystem.create_dir_all(&orch_dir) {
-            tracing::warn!("orchestrator persistence: failed to create {orch_dir:?}: {e}");
-            return;
-        }
-
+    pub fn save_orchestrator_state(&mut self) {
         // Sessions are no longer written to a central windows.json:
         // each window's identity (label, per-session plugin_state) is
         // persisted in its own per-dir workspace file by
         // `save_all_windows_workspaces` (called just before this on
         // quit), and the session list is rediscovered from those files
         // at boot. Only editor-global plugin state is written here.
-        for plugin in self.plugin_global_state.keys() {
-            self.persist_plugin_global_state(plugin);
+        //
+        // Every change is already flushed eagerly by `handle_set_global_state`,
+        // so this quit-time pass is a backstop for keys whose eager flush
+        // failed (they stay dirty). Plugins with no locally-changed keys are
+        // deliberately NOT written: their in-memory map is a boot-time
+        // snapshot, and rewriting it would revert anything a concurrently
+        // running editor process saved since this one started.
+        let plugins: Vec<String> = self.plugin_global_dirty.keys().cloned().collect();
+        for plugin in plugins {
+            self.persist_plugin_global_state(&plugin);
         }
     }
 
-    /// Write one plugin's global-state file (atomic tmp+rename). Called
-    /// eagerly from `handle_set_global_state` on every mutation — not just
-    /// at clean quit — so a killed or crashed editor doesn't forget
-    /// editor-global plugin state (e.g. the Orchestrator dock's folders and
-    /// session→folder assignments; issue #2703). Mirrors the eager
-    /// per-session workspace checkpointing (`checkpoint_window_workspace`).
-    /// Best-effort: errors are logged at WARN and swallowed.
+    /// Flush one plugin's locally-changed global-state keys (atomic
+    /// tmp+rename). Called eagerly from `handle_set_global_state` on every
+    /// mutation — not just at clean quit — so a killed or crashed editor
+    /// doesn't forget editor-global plugin state (e.g. the Orchestrator
+    /// dock's folders and session→folder assignments; issue #2703). Mirrors
+    /// the eager per-session workspace checkpointing
+    /// (`checkpoint_window_workspace`). Best-effort: errors are logged at
+    /// WARN and swallowed (failed keys stay dirty for the next attempt).
     ///
-    /// An empty (or absent) map is still written as `{}` so deleting a
-    /// plugin's last key survives a later crash too.
-    pub(crate) fn persist_plugin_global_state(&self, plugin: &str) {
+    /// The state file is shared with any concurrently running editor
+    /// process, and each process only loads it once at boot — so this MERGES
+    /// rather than snapshots: it re-reads the file and overlays exactly the
+    /// keys this instance changed (`plugin_global_dirty`), leaving keys other
+    /// instances wrote in the meantime intact. Writing the whole in-memory
+    /// map here used to let a stale instance's fold-toggle (or quit) silently
+    /// revert another instance's entire dock organisation.
+    ///
+    /// Same-key writes remain last-writer-wins, and a deletion still writes
+    /// the file even when the result is empty (`{}`) so clearing a plugin's
+    /// last key survives a crash too.
+    pub(crate) fn persist_plugin_global_state(&mut self, plugin: &str) {
         if !plugin_name_is_safe(plugin) {
             tracing::warn!(
                 "orchestrator persistence: skipping plugin with unsafe name: {plugin:?}"
             );
+            return;
+        }
+        let Some(dirty) = self.plugin_global_dirty.get(plugin) else {
+            return;
+        };
+        if dirty.is_empty() {
             return;
         }
         let data_dir = self.dir_context.data_dir.clone();
@@ -807,11 +824,35 @@ impl Editor {
             tracing::warn!("orchestrator persistence: failed to create {state_dir:?}: {e}");
             return;
         }
-        let empty = HashMap::new();
-        let map = self.plugin_global_state.get(plugin).unwrap_or(&empty);
-        match serde_json::to_vec_pretty(map) {
+        // Merge base: the file's current content. Absent → empty; unparseable
+        // → warn and start empty (the boot loader skips such files too).
+        let path = global_plugin_state_path(&data_dir, plugin);
+        let mut merged: HashMap<String, serde_json::Value> =
+            match self.authority().filesystem.read_file(&path) {
+                Ok(bytes) => match serde_json::from_slice(&bytes) {
+                    Ok(map) => map,
+                    Err(e) => {
+                        tracing::warn!(
+                            "orchestrator persistence: failed to parse {path:?}, rewriting: {e}"
+                        );
+                        HashMap::new()
+                    }
+                },
+                Err(_) => HashMap::new(),
+            };
+        let mem = self.plugin_global_state.get(plugin);
+        for key in dirty {
+            match mem.and_then(|m| m.get(key)) {
+                Some(v) => {
+                    merged.insert(key.clone(), v.clone());
+                }
+                None => {
+                    merged.remove(key);
+                }
+            }
+        }
+        match serde_json::to_vec_pretty(&merged) {
             Ok(bytes) => {
-                let path = global_plugin_state_path(&data_dir, plugin);
                 let tmp = path.with_extension("json.tmp");
                 if let Err(e) = self.authority().filesystem.write_file(&tmp, &bytes) {
                     tracing::warn!("orchestrator persistence: failed to write {tmp:?}: {e}");
@@ -821,7 +862,12 @@ impl Editor {
                     tracing::warn!(
                         "orchestrator persistence: failed to rename {tmp:?} → {path:?}: {e}"
                     );
+                    return;
                 }
+                // Flushed: these keys are on disk now. Clearing them keeps a
+                // later flush from re-imposing old values over a concurrent
+                // instance's newer write of the same key.
+                self.plugin_global_dirty.remove(plugin);
             }
             Err(e) => {
                 tracing::warn!(

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1795,7 +1795,7 @@ impl Editor {
                 self.plugin_global_state
                     .entry(plugin_name.clone())
                     .or_default()
-                    .insert(key, v);
+                    .insert(key.clone(), v);
             }
             None => {
                 if let Some(map) = self.plugin_global_state.get_mut(&plugin_name) {
@@ -1806,6 +1806,13 @@ impl Editor {
                 }
             }
         }
+        // Dirty-mark the key (deletions too) so persistence knows which keys
+        // THIS instance changed — the state file is shared with concurrent
+        // editor processes and only locally-changed keys may be rewritten.
+        self.plugin_global_dirty
+            .entry(plugin_name.clone())
+            .or_default()
+            .insert(key);
         // Editor-global plugin state is durable state (the Orchestrator
         // files its dock folders / session→folder assignments here), so
         // checkpoint it to disk now: without this it was flushed only by a

--- a/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
+++ b/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
@@ -162,6 +162,116 @@ fn setting_global_state_persists_it_without_a_quit() {
     );
 }
 
+/// Two editor processes sharing the data dir must not clobber each other's
+/// global plugin state. Each instance loads `orchestrator/state/*.json` once
+/// at boot, and the per-change flush used to rewrite the whole file from that
+/// instance's in-memory map — so an instance that booted *before* another
+/// instance organised the dock would, on its next unrelated write (a fold
+/// toggle, a history push) or on quit, silently revert every folder and
+/// session→folder assignment the other instance had saved. Reproduced
+/// interactively: organise folders in instance B, collapse a folder in
+/// instance A → B's folders vanish from disk.
+///
+/// The fix merges on write: an instance only rewrites the keys *it* changed,
+/// on top of whatever is on disk, instead of snapshotting its whole map.
+#[cfg(feature = "plugins")]
+#[test]
+fn concurrent_instances_do_not_clobber_each_others_global_state() {
+    use fresh_core::api::PluginCommand;
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let proj_a = sandbox.path().join("a");
+    let proj_b = sandbox.path().join("b");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&proj_a).unwrap();
+    std::fs::create_dir_all(&proj_b).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    let proj_a = proj_a.canonicalize().unwrap();
+    let proj_b = proj_b.canonicalize().unwrap();
+
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    // Instance A boots first — its in-memory copy of the global state is
+    // whatever was on disk now (nothing).
+    let mut a = editor_in(&proj_a, &dir_context);
+    // Instance B boots and the user organises the dock there: a folder and a
+    // session filed under it.
+    let mut b = editor_in(&proj_b, &dir_context);
+    let folders = serde_json::json!([{ "id": "df1", "name": "Keep", "parent": null }]);
+    let assignments = serde_json::json!({ proj_b.to_string_lossy(): "df1" });
+    b.handle_plugin_command(PluginCommand::SetGlobalState {
+        plugin_name: "orchestrator".into(),
+        key: "orchestrator.dock.folders".into(),
+        value: Some(folders.clone()),
+    })
+    .unwrap();
+    b.handle_plugin_command(PluginCommand::SetGlobalState {
+        plugin_name: "orchestrator".into(),
+        key: "orchestrator.dock.assignments".into(),
+        value: Some(assignments.clone()),
+    })
+    .unwrap();
+
+    // Instance A — which knows nothing of B's folders — makes an unrelated
+    // change (what a fold toggle in A's dock does). This must not wipe B's
+    // folders from disk.
+    let expanded = serde_json::json!(["folder:df1"]);
+    a.handle_plugin_command(PluginCommand::SetGlobalState {
+        plugin_name: "orchestrator".into(),
+        key: "orchestrator.dock.expanded".into(),
+        value: Some(expanded.clone()),
+    })
+    .unwrap();
+
+    let state_path = dir_context
+        .data_dir
+        .join("orchestrator")
+        .join("state")
+        .join("orchestrator.json");
+    let read_state = || -> serde_json::Value {
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap()
+    };
+    let map = read_state();
+    assert_eq!(
+        map["orchestrator.dock.folders"], folders,
+        "A's unrelated write must not clobber the folders B saved; got: {map}"
+    );
+    assert_eq!(
+        map["orchestrator.dock.assignments"], assignments,
+        "A's unrelated write must not clobber the assignments B saved; got: {map}"
+    );
+    assert_eq!(
+        map["orchestrator.dock.expanded"], expanded,
+        "A's own change must land alongside B's keys; got: {map}"
+    );
+
+    // A's clean quit must not resurrect its stale snapshot either — the
+    // quit-time save flushes only what A actually changed.
+    a.save_orchestrator_state();
+    let map = read_state();
+    assert_eq!(
+        map["orchestrator.dock.folders"], folders,
+        "A's quit-time save must not clobber the folders B saved; got: {map}"
+    );
+
+    // And a deletion in A merges too: it removes exactly that key from disk,
+    // not everything A never knew about.
+    a.handle_plugin_command(PluginCommand::SetGlobalState {
+        plugin_name: "orchestrator".into(),
+        key: "orchestrator.dock.expanded".into(),
+        value: None,
+    })
+    .unwrap();
+    let map = read_state();
+    assert!(
+        map.get("orchestrator.dock.expanded").is_none(),
+        "A's deletion must be flushed; got: {map}"
+    );
+    assert_eq!(
+        map["orchestrator.dock.folders"], folders,
+        "A's deletion must leave B's keys intact; got: {map}"
+    );
+}
+
 /// Setting per-session plugin state (what the Orchestrator does right after
 /// creating a session, to tag its `project_path`) checkpoints the window, so a
 /// freshly created session is in the registry the moment it is tagged — before

--- a/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
+++ b/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
@@ -39,7 +39,7 @@ fn save_orchestrator_state_does_not_create_dotfresh_in_working_dir() {
         ..Config::default()
     };
 
-    let editor = fresh::app::Editor::for_test(
+    let mut editor = fresh::app::Editor::for_test(
         config,
         80,
         24,


### PR DESCRIPTION
## Problem

Dock folder organization ("organize workspaces into folders, quit, restart — the workspaces are no longer under their folders") gets silently lost whenever **two fresh processes share the data dir** — trivially common under tmux (a forgotten instance in another window is enough).

Each editor process loads `<data>/orchestrator/state/<plugin>.json` once at boot, but every write — the eager per-change flush (#2703 part 4) and the quit-time `save_orchestrator_state` — rewrote the **whole file from that process's in-memory map**. So an instance that booted *before* another instance organized the dock reverts the entire organization on its next unrelated write: a fold toggle, a history push on session create, or simply quitting last.

Reproduced interactively in tmux (debug build of master):

1. Instance A: `fresh` in projA, leave it running.
2. Instance B: `fresh` in projB. Organize the dock — folder "Keep", projB filed under it. Disk state is correct.
3. In A, merely **collapse a folder**: disk instantly becomes A's stale view — "Keep" and the assignment are gone. (Quitting A last does the same via the quit-time save.)
4. Restart → dock is flat.

Single-instance flows were verified fine on master (create-with-organize, move-to-folder, nested subfolders, detached rows, clean quit, `kill -9`) — the loss requires the second instance.

## Fix

Persistence now **merges instead of snapshots**:

- `Editor` tracks `plugin_global_dirty` — exactly the keys *this* instance set or deleted (`handle_set_global_state` marks them).
- `persist_plugin_global_state` re-reads the file and overlays only those dirty keys, leaving keys other instances wrote in the meantime intact. Dirty keys clear on a successful flush; a failed write keeps them dirty for retry.
- The quit-time `save_orchestrator_state` flushes only still-dirty plugins (a backstop for failed eager writes) instead of re-imposing its boot-time snapshot.
- Deletions still write `{}` for an emptied plugin, preserving the #2703 eager-flush semantics.

Known limitation (called out in code + commit): the merge unit is a state *key*, and the dock stores all folders under one key — two live instances both *editing folders* concurrently remain last-writer-wins for that key. What's eliminated is a stale instance destroying state it never touched, which is the whole-organization loss users actually hit.

## Testing

- New reproducer `concurrent_instances_do_not_clobber_each_others_global_state` (`orchestrator_eager_persistence.rs`): two editors share a data dir; B saves folders, A writes an unrelated key, then quit-saves, then deletes its key — B's keys must survive each step. **Fails on master** at the first clobber assertion; passes with the fix.
- Existing eager-persistence, persistence-paths, dock integration, and e2e dock-folder suites all pass.
- Manual interactive validation in tmux with the fixed debug build: B organizes "Work"; stale A fold-toggles, navigates, quits; B quits; restart → dock still shows projB filed under `Work (1)`, and the state file kept `folders: ['Work']`, `assign: {projB: df1}` through every step.
- `cargo check --all-targets`, `--no-default-features --features runtime`, `cargo fmt`, clippy: clean (remaining warnings pre-existing, unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWyUoVoJanWWhx9uMSFWdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWyUoVoJanWWhx9uMSFWdm)_