### PR TITLE
feat(config): per-language indentation_guide gate; plain text defaults off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 * **Slang shader support** - syntax highlighting and [slangd](https://github.com/shader-slang/slang) LSP integration, with **Go to Definition** into read-only builtin modules (#2536, #2539, requested by @batoripX in #2517).
 * **NetBSD builds** - Fresh now compiles on NetBSD (#2534, by @ci4ic4).
+* **Per-language indentation guides** - plain-text buffers (language `text`) no longer draw indentation guides even when guides are enabled globally; any language can opt out (or plain text back in) with the new `languages.<id>.indentation_guide` setting.
 
 ### Bug Fixes
 

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -1571,6 +1571,14 @@
             }
           ],
           "default": null
+        },
+        "indentation_guide": {
+          "description": "Whether to render indentation guides for this language.\nIf not specified (`null`), follows the global `editor.indentation_guide`\nsetting — except for plain text (`text`), where guides default off:\nthey are a source-code aid and plain-text indentation rarely nests\nmeaningfully. Set `false` to suppress guides for a language even when\nthey are enabled globally, or `true` under `[languages.text]` to bring\nthem back for plain text.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
         }
       },
       "x-display-field": "/grammar"

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1057,8 +1057,9 @@ type TreeNode = {
 	* Continuation lines rendered below the node's primary `text`
 	* line when the parent `Tree` has `item_height > 1`. Each entry
 	* is one screen row, indented to align under the primary line's
-	* body. The host renders at most `item_height - 1` of them and
-	* blank-pads a shorter node so every row is the same height.
+	* body (past the indent + disclosure/checkbox prefix). The host
+	* renders at most `item_height - 1` of them and blank-pads a
+	* shorter node so every row in the tree is the same fixed height.
 	* Ignored when `item_height == 1`.
 	*/
 	extraLines?: Array<TextPropertyEntry>;
@@ -1351,11 +1352,11 @@ type WidgetSpec = {
 	/**
 	* Fixed number of screen rows each node occupies. `1` (the
 	* default) is the classic single-line tree. A larger value
-	* renders every node as a card of that many rows — the node's
-	* primary `text` plus its `extra_lines`, blank-padded to this
-	* height. Windowing/scroll stay node-based (the node budget
-	* becomes `visible_rows / item_height`), so single-line trees
-	* are unaffected.
+	* renders every node as a card of that many rows — the
+	* node's primary `text` plus its `extra_lines`, blank-padded
+	* to this height. Windowing/scroll stay node-based (the node
+	* budget becomes `visible_rows / item_height`), so all
+	* existing single-line trees are unaffected.
 	*/
 	itemHeight: number;
 	/**
@@ -1365,7 +1366,9 @@ type WidgetSpec = {
 	* panel width), taking `item_height + 2` rows: top border,
 	* `item_height` content rows, bottom border. Non-card nodes
 	* (e.g. folder headers) render as plain single rows instead
-	* of being blank-padded to the card height. Scroll and
+	* of being blank-padded to the card height. Restores the
+	* bordered-pill look the Orchestrator dock's card density
+	* had before it moved to a tree (issue #2703). Scroll and
 	* selection stay node-based; rows per node just vary.
 	*/
 	cardBorders: boolean;

--- a/crates/fresh-editor/plugins/schemas/theme.schema.json
+++ b/crates/fresh-editor/plugins/schemas/theme.schema.json
@@ -82,6 +82,36 @@
           50
         ],
         "indentation_guide_fg": null,
+        "indent_rainbow_1": [
+          255,
+          215,
+          0
+        ],
+        "indent_rainbow_2": [
+          218,
+          112,
+          214
+        ],
+        "indent_rainbow_3": [
+          50,
+          205,
+          50
+        ],
+        "indent_rainbow_4": [
+          30,
+          144,
+          255
+        ],
+        "indent_rainbow_5": [
+          255,
+          127,
+          80
+        ],
+        "indent_rainbow_6": [
+          147,
+          112,
+          219
+        ],
         "whitespace_indicator_fg": [
           70,
           70,
@@ -680,6 +710,60 @@
             }
           ],
           "default": null
+        },
+        "indent_rainbow_1": {
+          "description": "Rainbow indentation-guide color (nesting level 1)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            255,
+            215,
+            0
+          ]
+        },
+        "indent_rainbow_2": {
+          "description": "Rainbow indentation-guide color (nesting level 2)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            218,
+            112,
+            214
+          ]
+        },
+        "indent_rainbow_3": {
+          "description": "Rainbow indentation-guide color (nesting level 3)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            50,
+            205,
+            50
+          ]
+        },
+        "indent_rainbow_4": {
+          "description": "Rainbow indentation-guide color (nesting level 4)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            30,
+            144,
+            255
+          ]
+        },
+        "indent_rainbow_5": {
+          "description": "Rainbow indentation-guide color (nesting level 5)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            255,
+            127,
+            80
+          ]
+        },
+        "indent_rainbow_6": {
+          "description": "Rainbow indentation-guide color (nesting level 6)",
+          "$ref": "#/$defs/ColorDef",
+          "default": [
+            147,
+            112,
+            219
+          ]
         },
         "whitespace_indicator_fg": {
           "description": "Whitespace indicator foreground color (for tab arrows and space dots)",

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1392,6 +1392,7 @@ impl Editor {
                 if detected.highlighter.has_highlighting() || !state.highlighter.has_highlighting()
                 {
                     state.apply_language(detected);
+                    state.apply_buffer_config(&self.config);
                 }
             }
         }

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -567,17 +567,12 @@ impl Editor {
             .buffer
             .set_default_line_ending(self.config.editor.default_line_ending.to_line_ending());
         state.reference_highlight_overlay.enabled = self.config.editor.highlight_occurrences;
-        // Whitespace indicator visibility: resolve from the user's editor config
-        // so a brand-new buffer shows the same indicators as an opened file.
-        // Without this the buffer kept `WhitespaceVisibility::default()` (tabs on
-        // / spaces off), so configured space indicators never showed in a new
-        // file (issue #2580).
-        let mut whitespace =
-            crate::config::WhitespaceVisibility::from_editor_config(&self.config.editor);
-        if let Some(lang_config) = self.config.languages.get(&state.language) {
-            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
-        }
-        state.buffer_settings.whitespace = whitespace;
+        // Buffer settings (whitespace visibility, tabs, guides, …): resolve
+        // from the user's config so a brand-new buffer behaves the same as an
+        // opened file. Without this the buffer kept `BufferSettings::default()`
+        // (e.g. tabs-on/spaces-off whitespace), so configured space indicators
+        // never showed in a new file (issue #2580).
+        state.apply_buffer_config(&self.config);
         self.windows
             .get_mut(&self.active_window)
             .map(|w| &mut w.buffers)

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -957,9 +957,7 @@ impl Editor {
         state
             .margins
             .configure_for_line_numbers(config.editor.line_numbers);
-        state.buffer_settings.tab_size = config.editor.tab_size;
-        state.buffer_settings.auto_close = config.editor.auto_close;
-        state.buffer_settings.virtual_space = config.editor.virtual_space;
+        state.apply_buffer_config(&config);
         // Note: line_wrap_enabled is now stored in SplitViewState.viewport
         tracing::info!("EditorState created for buffer {:?}", buffer_id);
         buffers.insert(buffer_id, state);

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -796,23 +796,10 @@ impl Editor {
         let mut state = EditorState::from_buffer_with_language(buffer, detected);
         state.editing_disabled = true;
 
-        // Whitespace / tab settings — same shape as `open_file_no_focus`
-        // so the rendered look is consistent. Container-fetched
-        // buffers should obey the user's editor config like any other
-        // read-only buffer.
-        let mut whitespace =
-            crate::config::WhitespaceVisibility::from_editor_config(&self.config.editor);
-        if let Some(lang_config) = self.config.languages.get(&state.language) {
-            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
-            state.buffer_settings.use_tabs =
-                lang_config.use_tabs.unwrap_or(self.config.editor.use_tabs);
-            state.buffer_settings.tab_size =
-                lang_config.tab_size.unwrap_or(self.config.editor.tab_size);
-        } else {
-            state.buffer_settings.tab_size = self.config.editor.tab_size;
-            state.buffer_settings.use_tabs = self.config.editor.use_tabs;
-        }
-        state.buffer_settings.whitespace = whitespace;
+        // Buffer settings — same resolution as `open_file_no_focus` so the
+        // rendered look is consistent. Container-fetched buffers should obey
+        // the user's editor config like any other read-only buffer.
+        state.apply_buffer_config(&self.config);
         state
             .margins
             .configure_for_line_numbers(self.config.editor.line_numbers);
@@ -1106,40 +1093,11 @@ impl crate::app::window::Window {
             state.editing_disabled = true;
         }
 
-        // Set whitespace visibility, use_tabs, and tab_size based on language config
-        // with fallback to global editor config for tab_size
-        // Use the buffer's stored language (already set by from_file_with_languages)
-        let mut whitespace =
-            crate::config::WhitespaceVisibility::from_editor_config(&self.resources.config.editor);
-        state.buffer_settings.auto_close = self.resources.config.editor.auto_close;
-        state.buffer_settings.auto_surround = self.resources.config.editor.auto_surround;
-        state.buffer_settings.virtual_space = self.resources.config.editor.virtual_space;
-        if let Some(lang_config) = self.resources.config.languages.get(&state.language) {
-            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
-            state.buffer_settings.use_tabs = lang_config
-                .use_tabs
-                .unwrap_or(self.resources.config.editor.use_tabs);
-            // Use language-specific tab_size if set, otherwise fall back to global
-            state.buffer_settings.tab_size = lang_config
-                .tab_size
-                .unwrap_or(self.resources.config.editor.tab_size);
-            // Auto close: language override (only if globally enabled)
-            if state.buffer_settings.auto_close {
-                if let Some(lang_auto_close) = lang_config.auto_close {
-                    state.buffer_settings.auto_close = lang_auto_close;
-                }
-            }
-            // Auto surround: language override (only if globally enabled)
-            if state.buffer_settings.auto_surround {
-                if let Some(lang_auto_surround) = lang_config.auto_surround {
-                    state.buffer_settings.auto_surround = lang_auto_surround;
-                }
-            }
-        } else {
-            state.buffer_settings.tab_size = self.resources.config.editor.tab_size;
-            state.buffer_settings.use_tabs = self.resources.config.editor.use_tabs;
-        }
-        state.buffer_settings.whitespace = whitespace;
+        // Apply the global + per-language buffer settings (whitespace
+        // visibility, tabs, auto-close/surround, guides, …).
+        // Uses the buffer's stored language (already set by
+        // from_file_with_languages).
+        state.apply_buffer_config(&self.resources.config);
 
         // Apply line_numbers default from config
         state

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -115,6 +115,7 @@ impl Editor {
                             &self.config.languages,
                         );
                     state.apply_language(detected);
+                    state.apply_buffer_config(&self.config);
                 }
             }
         }

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -1337,6 +1337,7 @@ impl Editor {
                             &self.config.languages,
                         );
                     state.apply_language(detected);
+                    state.apply_buffer_config(&self.config);
                 }
 
                 // Allow TypeScript language so LSP auto-spawns

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -802,6 +802,7 @@ impl Editor {
                             );
                         new_language = detected.name.clone();
                         state.apply_language(detected);
+                        state.apply_buffer_config(&self.config);
                         language_changed = new_language != "text";
                     }
                 }
@@ -1242,14 +1243,14 @@ impl Editor {
         }
     }
 
-    /// Re-resolve the active buffer's whitespace indicator visibility from the
+    /// Re-resolve the buffer's language-dependent settings (whitespace
+    /// visibility, tabs, auto-close/surround, indentation guides, …) from the
     /// current config after its language changed. This applies the new
-    /// language's `show_whitespace_tabs` override (and restores config defaults
-    /// when switching away from a language that hid tab indicators), matching
-    /// what the file-open path does so a manual **Set Language** stays
-    /// consistent with opening a file of that type (issue #2580).
-    fn refresh_whitespace_visibility(&mut self, buffer_id: fresh_core::BufferId) {
-        let whitespace = self.configured_whitespace_visibility(buffer_id);
+    /// language's overrides (and restores config defaults when switching away
+    /// from a language that overrode them), matching what the file-open path
+    /// does so a manual **Set Language** stays consistent with opening a file
+    /// of that type (issue #2580).
+    fn refresh_buffer_config(&mut self, buffer_id: fresh_core::BufferId) {
         if let Some(state) = self
             .windows
             .get_mut(&self.active_window)
@@ -1257,7 +1258,7 @@ impl Editor {
             .expect("active window present")
             .get_mut(&buffer_id)
         {
-            state.buffer_settings.whitespace = whitespace;
+            state.apply_buffer_config(&self.config);
         }
     }
 
@@ -1280,7 +1281,7 @@ impl Editor {
                 state.apply_language(DetectedLanguage::plain_text());
                 self.set_status_message("Language set to Plain Text".to_string());
             }
-            self.refresh_whitespace_visibility(buffer_id);
+            self.refresh_buffer_config(buffer_id);
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
             self.plugin_manager.read().unwrap().run_hook(
@@ -1311,7 +1312,7 @@ impl Editor {
                 state.apply_language(detected);
                 self.set_status_message(format!("Language set to {}", trimmed));
             }
-            self.refresh_whitespace_visibility(buffer_id);
+            self.refresh_buffer_config(buffer_id);
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
             self.plugin_manager.read().unwrap().run_hook(

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -540,7 +540,6 @@ impl Editor {
         // so the two coexist.
         let cfg = crate::view::ui::EditorRenderConfig::new(
             &self.config.editor,
-            &self.config.languages,
             self.background_fade,
             self.software_cursor_only,
         );
@@ -2637,7 +2636,6 @@ impl Editor {
             show_tilde: false,
             ..crate::view::ui::EditorRenderConfig::new(
                 &self.config.editor,
-                &self.config.languages,
                 self.background_fade,
                 self.software_cursor_only,
             )
@@ -3746,7 +3744,6 @@ impl Editor {
                     ansi_background: self.ansi_background.as_ref(),
                     cfg: crate::view::ui::EditorRenderConfig::new(
                         &self.config.editor,
-                        &self.config.languages,
                         self.background_fade,
                         self.software_cursor_only,
                     ),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -540,6 +540,7 @@ impl Editor {
         // so the two coexist.
         let cfg = crate::view::ui::EditorRenderConfig::new(
             &self.config.editor,
+            &self.config.languages,
             self.background_fade,
             self.software_cursor_only,
         );
@@ -2636,6 +2637,7 @@ impl Editor {
             show_tilde: false,
             ..crate::view::ui::EditorRenderConfig::new(
                 &self.config.editor,
+                &self.config.languages,
                 self.background_fade,
                 self.software_cursor_only,
             )
@@ -3744,6 +3746,7 @@ impl Editor {
                     ansi_background: self.ansi_background.as_ref(),
                     cfg: crate::view::ui::EditorRenderConfig::new(
                         &self.config.editor,
+                        &self.config.languages,
                         self.background_fade,
                         self.software_cursor_only,
                     ),

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -282,17 +282,7 @@ impl Editor {
         let config = self.config.clone();
         for window in self.windows.values_mut() {
             for state in window.buffers.as_map_mut().values_mut() {
-                let resolved = crate::config::BufferConfig::resolve(&config, Some(&state.language));
-                state.buffer_settings.tab_size = resolved.tab_size;
-                state.buffer_settings.use_tabs = resolved.use_tabs;
-                state.buffer_settings.auto_close = resolved.auto_close;
-                state.buffer_settings.auto_surround = resolved.auto_surround;
-                state.buffer_settings.virtual_space = state
-                    .buffer_settings
-                    .virtual_space_override
-                    .unwrap_or(resolved.virtual_space);
-                state.buffer_settings.whitespace = resolved.whitespace;
-                state.buffer_settings.word_characters = resolved.word_characters;
+                state.apply_buffer_config(&config);
             }
         }
     }

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -400,47 +400,11 @@ impl Editor {
         whitespace
     }
 
-    /// Reset buffer settings (tab_size, use_tabs, auto_close, whitespace visibility) to config defaults
+    /// Reset buffer settings (tab_size, use_tabs, auto_close, whitespace
+    /// visibility, indentation guides, …) to config defaults — the same
+    /// resolution a freshly opened file of this language would get.
     pub fn reset_buffer_settings(&mut self) {
-        use crate::config::WhitespaceVisibility;
         let buffer_id = self.active_buffer();
-
-        // Determine settings from config using buffer's stored language
-        let mut whitespace = WhitespaceVisibility::from_editor_config(&self.config.editor);
-        let mut auto_close = self.config.editor.auto_close;
-        let mut word_characters = String::new();
-        let (tab_size, use_tabs) = if let Some(state) = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
-            .get(&buffer_id)
-        {
-            let language = &state.language;
-            if let Some(lang_config) = self.config.languages.get(language) {
-                whitespace =
-                    whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
-                // Auto close: language override (only if globally enabled)
-                if auto_close {
-                    if let Some(lang_auto_close) = lang_config.auto_close {
-                        auto_close = lang_auto_close;
-                    }
-                }
-                if let Some(ref wc) = lang_config.word_characters {
-                    word_characters = wc.clone();
-                }
-                (
-                    lang_config.tab_size.unwrap_or(self.config.editor.tab_size),
-                    lang_config.use_tabs.unwrap_or(self.config.editor.use_tabs),
-                )
-            } else {
-                (self.config.editor.tab_size, self.config.editor.use_tabs)
-            }
-        } else {
-            (self.config.editor.tab_size, self.config.editor.use_tabs)
-        };
-
-        // Apply settings to buffer
         if let Some(state) = self
             .windows
             .get_mut(&self.active_window)
@@ -448,11 +412,7 @@ impl Editor {
             .expect("active window present")
             .get_mut(&buffer_id)
         {
-            state.buffer_settings.tab_size = tab_size;
-            state.buffer_settings.use_tabs = use_tabs;
-            state.buffer_settings.auto_close = auto_close;
-            state.buffer_settings.whitespace = whitespace;
-            state.buffer_settings.word_characters = word_characters;
+            state.apply_buffer_config(&self.config);
         }
 
         self.set_status_message(t!("toggle.buffer_settings_reset").to_string());

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -90,11 +90,9 @@ impl Editor {
         // Clear modified flag - content is "fresh" from stdin (vim behavior)
         state.buffer.clear_modified();
 
-        // Set tab size, auto_close, and auto_surround from config
-        state.buffer_settings.tab_size = self.config.editor.tab_size;
-        state.buffer_settings.auto_close = self.config.editor.auto_close;
-        state.buffer_settings.auto_surround = self.config.editor.auto_surround;
-        state.buffer_settings.virtual_space = self.config.editor.virtual_space;
+        // Apply the global + per-language buffer settings (tabs, auto-close,
+        // whitespace visibility, indentation guides, …)
+        state.apply_buffer_config(&self.config);
 
         // Apply line_numbers default from config
         state

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2679,26 +2679,6 @@ pub struct LanguageConfig {
     pub indentation_guide: Option<bool>,
 }
 
-/// Resolve whether indentation guides may render for a buffer of the given
-/// language. An explicit per-language `indentation_guide` setting wins;
-/// otherwise every language follows the global `editor.indentation_guide`
-/// mode except plain text (`text`), which defaults off — guides are a
-/// source-code aid, and undetected/plain-text files rarely have meaningful
-/// indentation nesting. Returns `false` to suppress guides regardless of the
-/// global mode, `true` to let the global mode apply.
-pub fn language_indentation_guides_enabled(
-    languages: &HashMap<String, LanguageConfig>,
-    language_id: &str,
-) -> bool {
-    if let Some(explicit) = languages
-        .get(language_id)
-        .and_then(|lc| lc.indentation_guide)
-    {
-        return explicit;
-    }
-    language_id != "text"
-}
-
 /// User-overridable auto-indentation rules for a language.
 ///
 /// When you press Enter, Fresh looks at the line being split (the "reference
@@ -2829,6 +2809,15 @@ pub struct BufferConfig {
     /// Extra word-constituent characters for this language (for completion).
     /// Empty string means standard alphanumeric + underscore only.
     pub word_characters: String,
+
+    /// Whether indentation guides may render for this buffer. `false`
+    /// suppresses them regardless of the global `editor.indentation_guide`
+    /// mode; `true` lets the global mode apply. An explicit per-language
+    /// `indentation_guide` setting wins; otherwise every language follows
+    /// the global mode except plain text (`text`), which defaults off —
+    /// guides are a source-code aid, and undetected/plain-text files rarely
+    /// have meaningful indentation nesting.
+    pub indentation_guide: bool,
 }
 
 impl BufferConfig {
@@ -2860,6 +2849,7 @@ impl BufferConfig {
             on_save: Vec::new(),
             textmate_grammar: None,
             word_characters: String::new(),
+            indentation_guide: language_id.is_none_or(|id| id != "text"),
         };
 
         // Apply language-specific overrides if available.
@@ -2878,6 +2868,11 @@ impl BufferConfig {
                 }
             });
         if let Some(lang_config) = lang_config_ref {
+            // Indentation guides: language override (only if explicitly set)
+            if let Some(indentation_guide) = lang_config.indentation_guide {
+                config.indentation_guide = indentation_guide;
+            }
+
             // Tab size: use language setting if specified, else global
             if let Some(ts) = lang_config.tab_size {
                 config.tab_size = ts;
@@ -8496,19 +8491,12 @@ mod tests {
     fn test_language_indentation_guides_enabled_defaults() {
         let config = Config::default();
         // Plain text defaults off; code languages follow the global mode.
-        assert!(!language_indentation_guides_enabled(
-            &config.languages,
-            "text"
-        ));
-        assert!(language_indentation_guides_enabled(
-            &config.languages,
-            "rust"
-        ));
-        // Unknown languages (no config entry) follow the global mode too.
-        assert!(language_indentation_guides_enabled(
-            &config.languages,
-            "some_unknown_lang"
-        ));
+        assert!(!BufferConfig::resolve(&config, Some("text")).indentation_guide);
+        assert!(BufferConfig::resolve(&config, Some("rust")).indentation_guide);
+        // Unknown languages (no config entry) follow the global mode too,
+        // as does a buffer with no language at all.
+        assert!(BufferConfig::resolve(&config, Some("some_unknown_lang")).indentation_guide);
+        assert!(BufferConfig::resolve(&config, None).indentation_guide);
     }
 
     #[test]
@@ -8521,20 +8509,10 @@ mod tests {
                 ..Default::default()
             },
         );
-        config
-            .languages
-            .get_mut("rust")
-            .unwrap()
-            .indentation_guide = Some(false);
+        config.languages.get_mut("rust").unwrap().indentation_guide = Some(false);
 
-        assert!(language_indentation_guides_enabled(
-            &config.languages,
-            "text"
-        ));
-        assert!(!language_indentation_guides_enabled(
-            &config.languages,
-            "rust"
-        ));
+        assert!(BufferConfig::resolve(&config, Some("text")).indentation_guide);
+        assert!(!BufferConfig::resolve(&config, Some("rust")).indentation_guide);
     }
 
     #[test]

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2667,6 +2667,36 @@ pub struct LanguageConfig {
     /// grammar. See `IndentRulesConfig`.
     #[serde(default)]
     pub indent: Option<IndentRulesConfig>,
+
+    /// Whether to render indentation guides for this language.
+    /// If not specified (`null`), follows the global `editor.indentation_guide`
+    /// setting — except for plain text (`text`), where guides default off:
+    /// they are a source-code aid and plain-text indentation rarely nests
+    /// meaningfully. Set `false` to suppress guides for a language even when
+    /// they are enabled globally, or `true` under `[languages.text]` to bring
+    /// them back for plain text.
+    #[serde(default)]
+    pub indentation_guide: Option<bool>,
+}
+
+/// Resolve whether indentation guides may render for a buffer of the given
+/// language. An explicit per-language `indentation_guide` setting wins;
+/// otherwise every language follows the global `editor.indentation_guide`
+/// mode except plain text (`text`), which defaults off — guides are a
+/// source-code aid, and undetected/plain-text files rarely have meaningful
+/// indentation nesting. Returns `false` to suppress guides regardless of the
+/// global mode, `true` to let the global mode apply.
+pub fn language_indentation_guides_enabled(
+    languages: &HashMap<String, LanguageConfig>,
+    language_id: &str,
+) -> bool {
+    if let Some(explicit) = languages
+        .get(language_id)
+        .and_then(|lc| lc.indentation_guide)
+    {
+        return explicit;
+    }
+    language_id != "text"
 }
 
 /// User-overridable auto-indentation rules for a language.
@@ -4044,6 +4074,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4075,6 +4106,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4106,6 +4138,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4141,6 +4174,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4167,6 +4201,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4198,6 +4233,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4236,6 +4272,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4262,6 +4299,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4303,6 +4341,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4329,6 +4368,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4359,6 +4399,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4385,6 +4426,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4416,6 +4458,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4472,6 +4515,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4498,6 +4542,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4529,6 +4574,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4555,6 +4601,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4587,6 +4634,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4613,6 +4661,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4639,6 +4688,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4665,6 +4715,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4691,6 +4742,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4731,6 +4783,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4762,6 +4815,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4788,6 +4842,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4814,6 +4869,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4840,6 +4896,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4866,6 +4923,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4901,6 +4959,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4927,6 +4986,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4953,6 +5013,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -4979,6 +5040,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5012,6 +5074,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5038,6 +5101,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5064,6 +5128,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5090,6 +5155,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5116,6 +5182,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5142,6 +5209,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5169,6 +5237,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5200,6 +5269,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5231,6 +5301,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5257,6 +5328,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5283,6 +5355,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5309,6 +5382,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5339,6 +5413,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5365,6 +5440,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5391,6 +5467,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5417,6 +5494,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5443,6 +5521,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5469,6 +5548,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5495,6 +5575,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5521,6 +5602,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5552,6 +5634,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5578,6 +5661,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5604,6 +5688,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5630,6 +5715,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5656,6 +5742,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5682,6 +5769,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5713,6 +5801,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5739,6 +5828,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5765,6 +5855,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5791,6 +5882,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5817,6 +5909,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5843,6 +5936,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5874,6 +5968,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5900,6 +5995,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5929,6 +6025,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5957,6 +6054,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -5987,6 +6085,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6013,6 +6112,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6039,6 +6139,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6065,6 +6166,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6091,6 +6193,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6117,6 +6220,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6143,6 +6247,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6169,6 +6274,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6195,6 +6301,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6221,6 +6328,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6247,6 +6355,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6273,6 +6382,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6299,6 +6409,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6327,6 +6438,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6353,6 +6465,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6379,6 +6492,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6405,6 +6519,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6431,6 +6546,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6461,6 +6577,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6487,6 +6604,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6513,6 +6631,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6539,6 +6658,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6565,6 +6685,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -6591,6 +6712,7 @@ impl Config {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -8371,6 +8493,62 @@ mod tests {
     }
 
     #[test]
+    fn test_language_indentation_guides_enabled_defaults() {
+        let config = Config::default();
+        // Plain text defaults off; code languages follow the global mode.
+        assert!(!language_indentation_guides_enabled(
+            &config.languages,
+            "text"
+        ));
+        assert!(language_indentation_guides_enabled(
+            &config.languages,
+            "rust"
+        ));
+        // Unknown languages (no config entry) follow the global mode too.
+        assert!(language_indentation_guides_enabled(
+            &config.languages,
+            "some_unknown_lang"
+        ));
+    }
+
+    #[test]
+    fn test_language_indentation_guides_explicit_overrides() {
+        let mut config = Config::default();
+        config.languages.insert(
+            "text".to_string(),
+            LanguageConfig {
+                indentation_guide: Some(true),
+                ..Default::default()
+            },
+        );
+        config
+            .languages
+            .get_mut("rust")
+            .unwrap()
+            .indentation_guide = Some(false);
+
+        assert!(language_indentation_guides_enabled(
+            &config.languages,
+            "text"
+        ));
+        assert!(!language_indentation_guides_enabled(
+            &config.languages,
+            "rust"
+        ));
+    }
+
+    #[test]
+    fn test_language_indentation_guide_deserializes() {
+        let cfg: Config = serde_json::from_str(
+            r#"{"languages":{"text":{"indentation_guide":true},"rust":{"indentation_guide":false}}}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.languages["text"].indentation_guide, Some(true));
+        assert_eq!(cfg.languages["rust"].indentation_guide, Some(false));
+        assert_eq!(Config::default().languages["rust"].indentation_guide, None);
+    }
+
+    #[test]
     fn test_config_with_custom_keybinding() {
         let json = r#"{
             "editor": {
@@ -8574,6 +8752,7 @@ mod tests {
                 format_on_save: true,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -556,6 +556,7 @@ pub struct PartialLanguageConfig {
     pub on_save: Option<Vec<OnSaveAction>>,
     pub word_characters: Option<Option<String>>,
     pub indent: Option<crate::config::IndentRulesConfig>,
+    pub indentation_guide: Option<bool>,
 }
 
 impl Merge for PartialLanguageConfig {
@@ -581,6 +582,7 @@ impl Merge for PartialLanguageConfig {
         self.on_save.merge_from(&other.on_save);
         self.word_characters.merge_from(&other.word_characters);
         self.indent.merge_from(&other.indent);
+        self.indentation_guide.merge_from(&other.indentation_guide);
     }
 }
 
@@ -1078,6 +1080,7 @@ impl From<&LanguageConfig> for PartialLanguageConfig {
             on_save: Some(cfg.on_save.clone()),
             word_characters: Some(cfg.word_characters.clone()),
             indent: cfg.indent.clone(),
+            indentation_guide: cfg.indentation_guide,
         }
     }
 }
@@ -1115,6 +1118,7 @@ impl PartialLanguageConfig {
                 .word_characters
                 .unwrap_or_else(|| defaults.word_characters.clone()),
             indent: self.indent.or_else(|| defaults.indent.clone()),
+            indentation_guide: self.indentation_guide.or(defaults.indentation_guide),
         }
     }
 }
@@ -1397,6 +1401,7 @@ impl Default for LanguageConfig {
             on_save: Vec::new(),
             word_characters: None,
             indent: None,
+            indentation_guide: None,
         }
     }
 }

--- a/crates/fresh-editor/src/primitives/grammar/loader.rs
+++ b/crates/fresh-editor/src/primitives/grammar/loader.rs
@@ -912,6 +912,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -1900,6 +1900,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -1945,6 +1946,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -1993,6 +1995,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2020,6 +2023,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2393,6 +2397,7 @@ mod tests {
             format_on_save: false,
             on_save: vec![],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         }
     }

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -2341,6 +2341,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2366,6 +2367,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2391,6 +2393,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2457,6 +2460,7 @@ mod tests {
                 format_on_save: false,
                 on_save: vec![],
                 word_characters: None,
+                indentation_guide: None,
                 indent: None,
             },
         );
@@ -2573,6 +2577,7 @@ mod tests {
             format_on_save: false,
             on_save: vec![],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         };
         languages.insert(

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -124,6 +124,13 @@ pub struct BufferSettings {
     /// Extra characters (beyond alphanumeric + `_`) considered part of
     /// identifiers for this language. Used by completion providers.
     pub word_characters: String,
+
+    /// Whether indentation guides may render for this buffer. `false`
+    /// suppresses them regardless of the global `editor.indentation_guide`
+    /// mode (plain-text buffers default off; any language can opt out via
+    /// `languages.<id>.indentation_guide`). Set based on global + language
+    /// config.
+    pub indentation_guide: bool,
 }
 
 impl Default for BufferSettings {
@@ -137,7 +144,33 @@ impl Default for BufferSettings {
             virtual_space: crate::config::VirtualSpaceMode::default(),
             virtual_space_override: None,
             word_characters: String::new(),
+            indentation_guide: true,
         }
+    }
+}
+
+impl BufferSettings {
+    /// Stamp a resolved global + per-language configuration onto this
+    /// buffer's settings. Together with [`EditorState::apply_buffer_config`]
+    /// this is THE single place language-dependent settings land on a buffer
+    /// — when a new language-overridable flag is added, extend
+    /// [`crate::config::BufferConfig::resolve`] and this function, and every
+    /// call site (file open, new buffer, Set Language, save-time detection,
+    /// config reload) picks it up automatically.
+    ///
+    /// Explicit per-buffer user overrides are preserved: `virtual_space`
+    /// keeps following `virtual_space_override` when one is set.
+    pub fn apply_config(&mut self, resolved: &crate::config::BufferConfig) {
+        self.tab_size = resolved.tab_size;
+        self.use_tabs = resolved.use_tabs;
+        self.auto_close = resolved.auto_close;
+        self.auto_surround = resolved.auto_surround;
+        self.virtual_space = self
+            .virtual_space_override
+            .unwrap_or(resolved.virtual_space);
+        self.whitespace = resolved.whitespace;
+        self.word_characters = resolved.word_characters.clone();
+        self.indentation_guide = resolved.indentation_guide;
     }
 }
 
@@ -327,6 +360,20 @@ impl EditorState {
         if let Some(lang) = &detected.ts_language {
             self.reference_highlighter.set_language(lang);
         }
+    }
+
+    /// Resolve the global + per-language configuration for this buffer's
+    /// current language and stamp it onto `buffer_settings`. THE single
+    /// entry point for applying language-dependent settings to a buffer —
+    /// call it whenever the buffer's language or the config changes: file
+    /// open, new-buffer creation, **Set Language**, save-time language
+    /// detection, and config reload/save all go through here, so a new
+    /// language-overridable setting only needs to be added to
+    /// [`crate::config::BufferConfig::resolve`] and
+    /// [`BufferSettings::apply_config`].
+    pub fn apply_buffer_config(&mut self, config: &crate::config::Config) {
+        let resolved = crate::config::BufferConfig::resolve(config, Some(&self.language));
+        self.buffer_settings.apply_config(&resolved);
     }
 
     /// Create a new state with a buffer and default (plain text) language.

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -69,22 +69,15 @@ pub struct EditorRenderConfig<'a> {
     pub hide_current_line_on_selection: bool,
     pub background_fade: f32,
     pub software_cursor_only: bool,
-    /// Per-language config map, used to resolve the per-buffer
-    /// `indentation_guide` override (a buffer's language can suppress
-    /// guides even when they are enabled globally — plain text does so
-    /// by default). Looked up at render time so the resolution stays
-    /// correct across file open, Set Language, and config reload.
-    pub languages: &'a HashMap<String, crate::config::LanguageConfig>,
 }
 
 impl<'a> EditorRenderConfig<'a> {
     /// Build from the static editor config plus the two stable `Editor`
     /// flags that don't live under `config.editor`. Borrows only
-    /// `config.editor` and `config.languages`, so it composes with a
-    /// disjoint `&mut windows` borrow at the call site.
+    /// `config.editor`, so it composes with a disjoint `&mut windows`
+    /// borrow at the call site.
     pub fn new(
         editor: &'a crate::config::EditorConfig,
-        languages: &'a HashMap<String, crate::config::LanguageConfig>,
         background_fade: f32,
         software_cursor_only: bool,
     ) -> Self {
@@ -106,7 +99,6 @@ impl<'a> EditorRenderConfig<'a> {
             hide_current_line_on_selection: editor.hide_current_line_on_selection,
             background_fade,
             software_cursor_only,
-            languages,
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -69,15 +69,22 @@ pub struct EditorRenderConfig<'a> {
     pub hide_current_line_on_selection: bool,
     pub background_fade: f32,
     pub software_cursor_only: bool,
+    /// Per-language config map, used to resolve the per-buffer
+    /// `indentation_guide` override (a buffer's language can suppress
+    /// guides even when they are enabled globally — plain text does so
+    /// by default). Looked up at render time so the resolution stays
+    /// correct across file open, Set Language, and config reload.
+    pub languages: &'a HashMap<String, crate::config::LanguageConfig>,
 }
 
 impl<'a> EditorRenderConfig<'a> {
     /// Build from the static editor config plus the two stable `Editor`
     /// flags that don't live under `config.editor`. Borrows only
-    /// `config.editor`, so it composes with a disjoint `&mut windows`
-    /// borrow at the call site.
+    /// `config.editor` and `config.languages`, so it composes with a
+    /// disjoint `&mut windows` borrow at the call site.
     pub fn new(
         editor: &'a crate::config::EditorConfig,
+        languages: &'a HashMap<String, crate::config::LanguageConfig>,
         background_fade: f32,
         software_cursor_only: bool,
     ) -> Self {
@@ -99,6 +106,7 @@ impl<'a> EditorRenderConfig<'a> {
             hide_current_line_on_selection: editor.hide_current_line_on_selection,
             background_fade,
             software_cursor_only,
+            languages,
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -452,8 +452,9 @@ pub(crate) fn render_content(
             // plugin override (`setIndentationGuide`) wins; otherwise virtual
             // buffers (grep results, *Diagnostics*, the Git Log commit list, …)
             // default off because they aren't code, while ordinary file buffers
-            // follow the buffer language's `indentation_guide` gate (plain text
-            // defaults off; every other language follows the global setting).
+            // follow the buffer's resolved `indentation_guide` gate (plain text
+            // defaults off; any language can opt out — see
+            // `BufferSettings::apply_config`) and then the global setting.
             // A file-backed tool view the virtual default can't catch — the Git
             // Log commit-detail diff — opts out via the override. This is
             // independent of the line-number gutter, so an ordinary buffer
@@ -463,13 +464,7 @@ pub(crate) fn render_content(
                 Some(true) => style.cfg.indentation_guide,
                 Some(false) => IndentationGuideMode::None,
                 None if is_virtual_buffer => IndentationGuideMode::None,
-                None if !crate::config::language_indentation_guides_enabled(
-                    style.cfg.languages,
-                    &state.language,
-                ) =>
-                {
-                    IndentationGuideMode::None
-                }
+                None if !state.buffer_settings.indentation_guide => IndentationGuideMode::None,
                 None => style.cfg.indentation_guide,
             };
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -452,15 +452,24 @@ pub(crate) fn render_content(
             // plugin override (`setIndentationGuide`) wins; otherwise virtual
             // buffers (grep results, *Diagnostics*, the Git Log commit list, …)
             // default off because they aren't code, while ordinary file buffers
-            // follow the global setting. A file-backed tool view the virtual
-            // default can't catch — the Git Log commit-detail diff — opts out via
-            // the override. This is independent of the line-number gutter, so an
-            // ordinary buffer keeps its guides with line numbers turned off.
+            // follow the buffer language's `indentation_guide` gate (plain text
+            // defaults off; every other language follows the global setting).
+            // A file-backed tool view the virtual default can't catch — the Git
+            // Log commit-detail diff — opts out via the override. This is
+            // independent of the line-number gutter, so an ordinary buffer
+            // keeps its guides with line numbers turned off.
             let mut style = style;
             style.cfg.indentation_guide = match state.indentation_guide_override {
                 Some(true) => style.cfg.indentation_guide,
                 Some(false) => IndentationGuideMode::None,
                 None if is_virtual_buffer => IndentationGuideMode::None,
+                None if !crate::config::language_indentation_guides_enabled(
+                    style.cfg.languages,
+                    &state.language,
+                ) =>
+                {
+                    IndentationGuideMode::None
+                }
                 None => style.cfg.indentation_guide,
             };
 

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -430,3 +430,106 @@ fn indentation_guide_active_mode_continues_through_wrapped_line() {
         "active indent guide should continue through the wrapped continuation row\ncont row: {cont_row:?}\n{screen}"
     );
 }
+
+#[test]
+fn plain_text_files_suppress_indentation_guides_by_default() {
+    // Guides are a source-code aid: a plain-text buffer (language "text")
+    // must not render them even when `editor.indentation_guide = "all"` is
+    // enabled globally.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("notes.txt");
+    std::fs::write(
+        &file_path,
+        "shopping list\n    milk\n        whole, not skim\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("    milk"),
+        "indented plain-text line should render with plain spaces\n{screen}"
+    );
+    assert!(
+        !screen.contains("┊"),
+        "plain-text buffers should not render indentation guides by default\n{screen}"
+    );
+}
+
+#[test]
+fn languages_text_indentation_guide_true_reenables_guides_for_plain_text() {
+    // `[languages.text] indentation_guide = true` opts plain text back in,
+    // restoring the global mode.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("notes.txt");
+    std::fs::write(
+        &file_path,
+        "shopping list\n    milk\n        whole, not skim\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+    config.languages.insert(
+        "text".to_string(),
+        fresh::config::LanguageConfig {
+            indentation_guide: Some(true),
+            ..Default::default()
+        },
+    );
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("┊   milk"),
+        "explicit [languages.text] indentation_guide = true should re-enable guides\n{screen}"
+    );
+}
+
+#[test]
+fn per_language_indentation_guide_false_suppresses_guides() {
+    // Any language can opt out of guides even when they are enabled
+    // globally, e.g. `[languages.rust] indentation_guide = false`.
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides.rs");
+    std::fs::write(
+        &file_path,
+        "fn main() {\n    let child = 1;\n        let grand = child + 1;\n}\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+    if let Some(rust) = config.languages.get_mut("rust") {
+        rust.indentation_guide = Some(false);
+    }
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("    let child = 1;"),
+        "indented code should still render\n{screen}"
+    );
+    assert!(
+        !screen.contains("┊"),
+        "a language with indentation_guide = false should suppress guides\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_2345_language_settings.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2345_language_settings.rs
@@ -186,7 +186,9 @@ fn issue_2345_inherited_auto_surround_shows_neutral_chip() {
 /// that one field to inherited, without touching its siblings.
 #[test]
 fn issue_2345_per_field_inherit_button_reverts_single_field() {
-    let mut harness = EditorTestHarness::with_config(120, 30, html_only_config()).unwrap();
+    // 32 rows: the dialog lists fields alphabetically and the assertion below
+    // needs the "Line Wrap" row on screen ("Indentation Guide" sits above it).
+    let mut harness = EditorTestHarness::with_config(120, 32, html_only_config()).unwrap();
     harness.render().unwrap();
 
     open_html_language_dialog(&mut harness);

--- a/crates/fresh-editor/tests/e2e/on_save_actions.rs
+++ b/crates/fresh-editor/tests/e2e/on_save_actions.rs
@@ -56,6 +56,7 @@ fn test_format_on_save() {
             format_on_save: true,
             on_save: vec![],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -126,6 +127,7 @@ fn test_on_save_linter_style() {
             format_on_save: false,
             on_save: vec![action],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -196,6 +198,7 @@ fn test_on_save_action_failure() {
             format_on_save: false,
             on_save: vec![action],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -275,6 +278,7 @@ fn test_on_save_file_placeholder() {
             format_on_save: false,
             on_save: vec![action],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -348,6 +352,7 @@ fn test_formatter_stdin_mode() {
             format_on_save: true,
             on_save: vec![],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -428,6 +433,7 @@ fn test_on_save_stops_on_failure() {
             format_on_save: false,
             on_save: vec![action1, action2],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );
@@ -529,6 +535,7 @@ fn test_formatter_not_found_shows_message() {
             format_on_save: true,
             on_save: vec![],
             word_characters: None,
+            indentation_guide: None,
             indent: None,
         },
     );

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -26,6 +26,17 @@ Guides are visual-only: they replace rendered leading whitespace cells without c
 
 Turn on `editor.rainbow_indentation` to color guide levels independently. Themes configure the six-color cycle with `indent_rainbow_1` through `indent_rainbow_6`; these colors are separate from bracket-rainbow and accent colors.
 
+Guides are a source-code aid, so plain-text buffers (language `text` — undetected files, `.txt`, and buffers manually set to Plain Text) never draw them, even when guides are enabled globally. Any language can opt out (or plain text back in) with the per-language `indentation_guide` setting:
+
+```jsonc
+{
+  "languages": {
+    "text": { "indentation_guide": true },  // bring guides back for plain text
+    "yaml": { "indentation_guide": false }  // suppress guides for a language
+  }
+}
+```
+
 ## Current-Line Highlight
 
 The row the cursor is on is highlighted for quick visual tracking. Enabled by default; toggle via the command palette ("Toggle Current Line Highlight") or in the Settings UI. A matching **Toggle Current Column Highlight** highlights the cursor's column too — useful for visually aligning code with rulers. The Settings UI also has an option to drop the line highlight while text is selected.


### PR DESCRIPTION
## Summary

Indentation guides are a source-code aid, so plain-text buffers (language `text` — undetected files, `.txt`, or **Set Language → Plain Text**) no longer render them, even when `editor.indentation_guide` is enabled globally.

Any language can now opt out — or plain text back in — via a new nullable per-language setting:

```jsonc
{
  "languages": {
    "text": { "indentation_guide": true },  // bring guides back for plain text
    "yaml": { "indentation_guide": false }  // suppress guides for a language
  }
}
```

## Implementation

- New `LanguageConfig.indentation_guide: Option<bool>` (config + partial-config merge/resolve layers, regenerated `config-schema.json`, so it also appears in the Settings UI language dialog).
- The gate is resolved by `BufferConfig::resolve` into a new `BufferSettings.indentation_guide` flag, following the same pattern as every other per-language setting; the renderer reads the pre-resolved per-buffer flag.
- Precedence unchanged for existing mechanisms: the plugin override (`setIndentationGuide`) wins, then the virtual-buffer default, then the new per-language gate, then the global mode.

## Refactor: one entry point for per-language buffer settings

Language-dependent buffer settings (tabs, auto-close/surround, whitespace visibility, word characters, virtual space, and now guides) used to be stamped onto buffers by six hand-rolled copies of the same global+language merge, each drifting from the others (e.g. `word_characters` was only applied on settings save; whitespace was missing on the startup and stdin buffers). All of them now call **`EditorState::apply_buffer_config`**, which resolves `BufferConfig::resolve` for the buffer's language and stamps it via `BufferSettings::apply_config` (preserving the per-buffer `virtual_space_override`).

Language-change sites that never refreshed settings at all — save-time detection, Save As on a plain-text buffer, grammar-rebuild redetection, the plugin-dev TypeScript buffer — now do, so switching a buffer's language behaves like opening a file of that type everywhere. Adding the next language-overridable flag only requires extending `BufferConfig::resolve` and `BufferSettings::apply_config`. Net −88 lines.

Also regenerates stale generated files that had drifted on master (`theme.schema.json` missing the `indent_rainbow_*` keys, `fresh.d.ts` doc comments).

## Testing

- New e2e tests: `.txt` renders no guides under global `"all"`; `[languages.text] indentation_guide = true` re-enables them; `[languages.rust] indentation_guide = false` suppresses them for code.
- New unit tests for the resolution and config deserialization.
- Validated interactively (tmux): plain text shows no guides while Rust shows them; the opt-in config restores them; **Set Language** flips guides live in both directions; **Save As `*.rs`** from an unnamed buffer turns guides on at save-time detection.
- Suites green at time of validation: full lib (3,012), guides/whitespace/settings/language e2e groups.
- `issue_2345_per_field_inherit_button_reverts_single_field` needed a 2-row-taller harness: the new field row pushed "Line Wrap" off-screen in its dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUfyzFEjQsXyRFD5o5FspA