### PR TITLE
Plugin filesystem: route through window authorities, with explicit typed paths (local / authority / per-window)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "trash",
  "ts-rs",
 ]
 

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -5206,6 +5206,51 @@ pub struct SessionWithTerminalResult {
 #[ts(export, type = "Array<Record<string, unknown>>")]
 pub struct TextPropertiesAtCursor(pub Vec<HashMap<String, JsonValue>>);
 
+/// A filesystem path passed from a plugin, tagged with which filesystem it
+/// resolves against.
+///
+/// Windows each own their own authority (local, or a remote/SSH/container
+/// backend), so a path must say which one it means — like a VS Code `Uri`
+/// naming its authority. The tagging mirrors how the rest of the plugin API is
+/// window-scoped by identity (a `bufferId` locates its window); a path's tag is
+/// the filesystem counterpart.
+///
+/// - A bare JS string is [`PluginPath::Authority`] with no window → the
+///   **active** window's backend. This is the backward-compatible default:
+///   existing plugins that pass strings keep working unchanged.
+/// - `{ kind: "local", value }`, built via `editor.localPath(...)`, is
+///   [`PluginPath::Local`] — always the local editor host, whatever the active
+///   authority is.
+/// - `{ kind: "authority", window, value }`, built via
+///   `editor.windowPath(windowId, ...)`, is [`PluginPath::Authority`] bound to
+///   a **specific** window's backend, regardless of focus.
+///
+/// The TypeScript surface renders this as `string | LocalPath | WindowPath`
+/// (see the hand-written declarations in `ts_export.rs`).
+#[derive(Debug, Clone)]
+pub enum PluginPath {
+    /// A path on a window's authority filesystem. `window` selects which
+    /// window; `None` means the active window.
+    Authority {
+        /// The owning window's id, or `None` for the active window.
+        window: Option<u64>,
+        /// The path string.
+        path: String,
+    },
+    /// A path on the local editor-host filesystem.
+    Local(String),
+}
+
+impl PluginPath {
+    /// The underlying path string, regardless of variant.
+    pub fn as_str(&self) -> &str {
+        match self {
+            PluginPath::Authority { path, .. } => path,
+            PluginPath::Local(path) => path,
+        }
+    }
+}
+
 // Implement FromJs for option types using rquickjs_serde
 #[cfg(feature = "plugins")]
 mod fromjs_impls {
@@ -5256,6 +5301,42 @@ mod fromjs_impls {
         fn into_js(self, ctx: &Ctx<'js>) -> rquickjs::Result<Value<'js>> {
             rquickjs_serde::to_value(ctx.clone(), &self.0)
                 .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
+        }
+    }
+
+    impl<'js> FromJs<'js> for PluginPath {
+        fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> rquickjs::Result<Self> {
+            // A bare string is an active-window authority path (backward compatible).
+            if let Some(s) = value.as_string() {
+                let s = s.to_string()?;
+                return Ok(PluginPath::Authority {
+                    window: None,
+                    path: s,
+                });
+            }
+            // A `{ kind, value, window? }` object selects the filesystem explicitly.
+            if let Some(obj) = value.as_object() {
+                let kind: String = obj.get::<_, String>("kind").unwrap_or_default();
+                let path: String = obj.get::<_, String>("value")?;
+                return match kind.as_str() {
+                    "local" => Ok(PluginPath::Local(path)),
+                    "authority" | "" => Ok(PluginPath::Authority {
+                        // Absent/undefined `window` ⇒ active window.
+                        window: obj.get::<_, u64>("window").ok(),
+                        path,
+                    }),
+                    other => Err(rquickjs::Error::new_from_js_message(
+                        "object",
+                        "PluginPath",
+                        format!("unknown path kind: {other}"),
+                    )),
+                };
+            }
+            Err(rquickjs::Error::new_from_js_message(
+                "value",
+                "PluginPath",
+                "expected a string path or a { kind, value } path object".to_string(),
+            ))
         }
     }
 

--- a/crates/fresh-core/src/services.rs
+++ b/crates/fresh-core/src/services.rs
@@ -91,11 +91,20 @@ pub trait PluginServiceBridge: Send + Sync + 'static {
     /// Support downcasting for tests
     fn as_any(&self) -> &dyn std::any::Any;
 
-    /// The filesystem plugins must use for all file I/O. Implementations MUST
-    /// route through the active window's authority so plugin file access follows
-    /// remote/SSH backends exactly like the editor core does — never a bare
-    /// `std::fs` fallback.
-    fn filesystem(&self) -> Arc<dyn PluginFilesystem>;
+    /// The filesystem plugins use for authority-scoped file I/O — a window's
+    /// backend (local for a local window, remote for an SSH/container window).
+    /// `window` selects which window; `None` means the active window (where a
+    /// bare string path resolves). A `None` return of an operation on a window
+    /// that no longer exists is treated as a failed op, never a silent fallback.
+    fn authority_filesystem(&self, window: Option<u64>) -> Arc<dyn PluginFilesystem>;
+
+    /// The filesystem plugins use for explicitly local file I/O — always the
+    /// editor host, regardless of the active authority. This is where a
+    /// `LocalPath` (built via `editor.localPath(...)`) resolves; the package
+    /// manager and other plugins that persist editor-owned state under the
+    /// config/data dirs use it so their files stay on the host during remote
+    /// sessions.
+    fn local_filesystem(&self) -> Arc<dyn PluginFilesystem>;
 
     /// Translate a string for a plugin
     fn translate(&self, plugin_name: &str, key: &str, args: &HashMap<String, String>) -> String;
@@ -198,7 +207,10 @@ impl PluginServiceBridge for NoopServiceBridge {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-    fn filesystem(&self) -> Arc<dyn PluginFilesystem> {
+    fn authority_filesystem(&self, _window: Option<u64>) -> Arc<dyn PluginFilesystem> {
+        Arc::new(NoopPluginFilesystem)
+    }
+    fn local_filesystem(&self) -> Arc<dyn PluginFilesystem> {
         Arc::new(NoopPluginFilesystem)
     }
     fn translate(&self, _plugin_name: &str, key: &str, _args: &HashMap<String, String>) -> String {

--- a/crates/fresh-core/src/services.rs
+++ b/crates/fresh-core/src/services.rs
@@ -1,10 +1,101 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Filesystem operations exposed to plugins.
+///
+/// Plugins must perform *all* file I/O through this handle rather than touching
+/// `std::fs` directly, so their reads and writes follow the active window's
+/// authority — the local host for a local session, the remote host for an
+/// SSH/container session. There is no local fallback: an implementation routes
+/// every call to exactly one filesystem backend and nothing else.
+pub trait PluginFilesystem: Send + Sync {
+    /// Read a file's raw bytes. `None` if it can't be read.
+    fn read_file(&self, path: &Path) -> Option<Vec<u8>>;
+    /// Write bytes to a file, creating parent directories as needed. Returns
+    /// whether the write succeeded.
+    fn write_file(&self, path: &Path, contents: &[u8]) -> bool;
+    /// Whether a path exists.
+    fn exists(&self, path: &Path) -> bool;
+    /// List a directory's entries (empty on error).
+    fn read_dir(&self, path: &Path) -> Vec<crate::api::DirEntry>;
+    /// Create a directory and all parents. Returns whether it exists afterwards.
+    fn create_dir_all(&self, path: &Path) -> bool;
+    /// Remove a file or directory (recursively for directories).
+    fn remove_path(&self, path: &Path) -> bool;
+    /// Rename/move a path. Returns whether it succeeded.
+    fn rename(&self, from: &Path, to: &Path) -> bool;
+    /// Copy a file or directory (recursively for directories).
+    fn copy(&self, from: &Path, to: &Path) -> bool;
+    /// Stat a path.
+    fn stat(&self, path: &Path) -> Option<PluginFileStat>;
+    /// Canonicalize a path (resolve symlinks / `..`). `None` if it can't be
+    /// resolved (e.g. the path does not exist on the backend).
+    fn canonicalize(&self, path: &Path) -> Option<PathBuf>;
+}
+
+/// Metadata about a path, as surfaced to plugins via `fileStat`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PluginFileStat {
+    /// Whether the path is a regular file.
+    pub is_file: bool,
+    /// Whether the path is a directory.
+    pub is_dir: bool,
+    /// Size in bytes.
+    pub size: u64,
+    /// Whether the path is read-only.
+    pub readonly: bool,
+}
+
+/// A [`PluginFilesystem`] that does nothing — every read fails and every
+/// mutation is a no-op. Used by the no-op service bridge in headless/test
+/// contexts. It never touches any real filesystem.
+pub struct NoopPluginFilesystem;
+
+impl PluginFilesystem for NoopPluginFilesystem {
+    fn read_file(&self, _path: &Path) -> Option<Vec<u8>> {
+        None
+    }
+    fn write_file(&self, _path: &Path, _contents: &[u8]) -> bool {
+        false
+    }
+    fn exists(&self, _path: &Path) -> bool {
+        false
+    }
+    fn read_dir(&self, _path: &Path) -> Vec<crate::api::DirEntry> {
+        Vec::new()
+    }
+    fn create_dir_all(&self, _path: &Path) -> bool {
+        false
+    }
+    fn remove_path(&self, _path: &Path) -> bool {
+        false
+    }
+    fn rename(&self, _from: &Path, _to: &Path) -> bool {
+        false
+    }
+    fn copy(&self, _from: &Path, _to: &Path) -> bool {
+        false
+    }
+    fn stat(&self, _path: &Path) -> Option<PluginFileStat> {
+        None
+    }
+    fn canonicalize(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+}
 
 /// Trait for the editor to provide services to the plugin runtime
 /// without the runtime depending directly on UI or complex system logic.
 pub trait PluginServiceBridge: Send + Sync + 'static {
     /// Support downcasting for tests
     fn as_any(&self) -> &dyn std::any::Any;
+
+    /// The filesystem plugins must use for all file I/O. Implementations MUST
+    /// route through the active window's authority so plugin file access follows
+    /// remote/SSH backends exactly like the editor core does — never a bare
+    /// `std::fs` fallback.
+    fn filesystem(&self) -> Arc<dyn PluginFilesystem>;
 
     /// Translate a string for a plugin
     fn translate(&self, plugin_name: &str, key: &str, args: &HashMap<String, String>) -> String;
@@ -106,6 +197,9 @@ pub struct NoopServiceBridge;
 impl PluginServiceBridge for NoopServiceBridge {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+    fn filesystem(&self) -> Arc<dyn PluginFilesystem> {
+        Arc::new(NoopPluginFilesystem)
     }
     fn translate(&self, _plugin_name: &str, key: &str, _args: &HashMap<String, String>) -> String {
         key.to_string()

--- a/crates/fresh-editor/plugins/asm-lsp.ts
+++ b/crates/fresh-editor/plugins/asm-lsp.ts
@@ -161,7 +161,7 @@ function globalConfigExists(): boolean {
       editor.pathJoin(home, "Library", "Application Support", "asm-lsp", ".asm-lsp.toml")
     );
   }
-  return candidates.some((path) => editor.fileExists(path));
+  return candidates.some((path) => editor.fileExists(editor.authorityPath(path)));
 }
 
 /// Guess the assembler dialect from the language key and buffer contents.
@@ -219,7 +219,7 @@ function handleConfigOfferResult(actionId: string) {
     const assembler = actionId.slice("create:".length);
     const arch = offer ? offer.arch : "x86/x86-64";
     const path = projectConfigPath();
-    if (!editor.writeFile(path, configToml(assembler, arch))) {
+    if (!editor.writeFile(editor.authorityPath(path), configToml(assembler, arch))) {
       editor.setStatus(`Failed to write ${path}`);
       return;
     }
@@ -262,7 +262,7 @@ async function maybeOfferConfig(bufferId: number, path: string) {
   if (!language) {
     return;
   }
-  if (editor.fileExists(projectConfigPath()) || globalConfigExists()) {
+  if (editor.fileExists(editor.authorityPath(projectConfigPath())) || globalConfigExists()) {
     return;
   }
   if (editor.getGlobalState(`config-offer-never:${editor.getCwd()}`) === true) {

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -498,7 +498,7 @@ function persistReview(): void {
     if (!path) return;
     const dir = reviewStorageDirFor(state.repo.root);
     if (dir) {
-        try { editor.createDir(dir); } catch {}
+        try { editor.createDir(editor.localPath(dir)); } catch {}
     }
     const payload: PersistedReview = {
         version: REVIEW_STORAGE_VERSION,
@@ -509,7 +509,7 @@ function persistReview(): void {
         updated_at: new Date().toISOString(),
     };
     try {
-        editor.writeFile(path, JSON.stringify(payload, null, 2));
+        editor.writeFile(editor.localPath(path), JSON.stringify(payload, null, 2));
     } catch {}
 }
 
@@ -518,9 +518,9 @@ function loadPersistedReview(repoRoot: string, reviewKey: string): PersistedRevi
     if (!repoRoot) return null;
     const path = reviewStoragePathFor(repoRoot, reviewKey);
     if (!path) return null;
-    if (!editor.fileExists(path)) return null;
+    if (!editor.fileExists(editor.localPath(path))) return null;
     try {
-        const raw = editor.readFile(path);
+        const raw = editor.readFile(editor.localPath(path));
         if (!raw) return null;
         const parsed = JSON.parse(raw) as PersistedReview;
         if (!parsed || typeof parsed !== 'object') return null;
@@ -2989,7 +2989,7 @@ function buildHunkPatch(filePath: string, hunk: Hunk, lineRange?: { start: numbe
 async function applyHunkPatch(patch: string, flags: string[]): Promise<boolean> {
     const tmpDir = editor.getTempDir();
     const patchPath = editor.pathJoin(tmpDir, `fresh-review-${Date.now()}.patch`);
-    editor.writeFile(patchPath, patch);
+    editor.writeFile(editor.localPath(patchPath), patch);
     const cwd = gitCwd();
     // Validate first
     const check = await editor.spawnProcess("git", ["apply", "--check", ...flags, patchPath], cwd);
@@ -3810,7 +3810,7 @@ async function fetchFileVersions(file: FileEntry): Promise<{ oldContent: string;
         if (show.exit_code === 0) oldContent = show.stdout;
     }
     if (file.status !== 'D') {
-        const read = await editor.readFile(absPath);
+        const read = await editor.readFile(editor.authorityPath(absPath));
         if (read !== null) newContent = read;
     }
     return { oldContent, newContent, absPath };
@@ -4022,7 +4022,7 @@ async function review_drill_down() {
     if (selectedFile.status === 'D') {
         newContent = "";
     } else {
-        const readResult = await editor.readFile(absoluteFilePath);
+        const readResult = await editor.readFile(editor.authorityPath(absoluteFilePath));
         if (readResult === null) {
             editor.setStatus(editor.t("status.failed_new_version"));
             return;
@@ -5251,7 +5251,7 @@ async function review_export_session() {
     }
 
     const filePath = editor.pathJoin(reviewDir, "session.md");
-    await editor.writeFile(filePath, md);
+    await editor.writeFile(editor.authorityPath(filePath), md);
     editor.setStatus(editor.t("status.exported", { path: filePath }));
 }
 registerHandler("review_export_session", review_export_session);
@@ -5275,7 +5275,7 @@ async function review_export_json() {
     };
 
     const filePath = editor.pathJoin(reviewDir, "session.json");
-    await editor.writeFile(filePath, JSON.stringify(session, null, 2));
+    await editor.writeFile(editor.authorityPath(filePath), JSON.stringify(session, null, 2));
     editor.setStatus(editor.t("status.exported", { path: filePath }));
 }
 registerHandler("review_export_json", review_export_json);
@@ -5915,7 +5915,7 @@ async function side_by_side_diff_current_file() {
     }
 
     // Read new file content (use absolute path for readFile)
-    const newContent = await editor.readFile(absolutePath);
+    const newContent = await editor.readFile(editor.authorityPath(absolutePath));
     if (newContent === null) {
         editor.setStatus(editor.t("status.failed_new_version"));
         return;

--- a/crates/fresh-editor/plugins/clangd_support.ts
+++ b/crates/fresh-editor/plugins/clangd_support.ts
@@ -147,7 +147,7 @@ function analyzeProject(root: string | null) {
   for (const base of dirCandidates) {
     for (const relative of compileCandidates) {
       const candidate = editor.pathJoin(base, relative);
-      if (editor.fileExists(candidate)) {
+      if (editor.fileExists(editor.authorityPath(candidate))) {
         compilePath = candidate;
         break;
       }
@@ -162,7 +162,7 @@ function analyzeProject(root: string | null) {
   for (const base of dirCandidates) {
     for (const relative of clangdFileCandidates) {
       const candidate = editor.pathJoin(base, relative);
-      if (editor.fileExists(candidate)) {
+      if (editor.fileExists(editor.authorityPath(candidate))) {
         clangdPath = candidate;
         break;
       }
@@ -196,17 +196,17 @@ function analyzeProject(root: string | null) {
 
   const buildHints: string[] = [];
   if (root) {
-    if (editor.fileExists(editor.pathJoin(root, "CMakeLists.txt"))) {
+    if (editor.fileExists(editor.authorityPath(editor.pathJoin(root, "CMakeLists.txt")))) {
       buildHints.push("CMake project detected (configure with `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`).");
     }
     if (
-      editor.fileExists(editor.pathJoin(root, "WORKSPACE")) ||
-      editor.fileExists(editor.pathJoin(root, "WORKSPACE.bazel")) ||
-      editor.fileExists(editor.pathJoin(root, "BUILD.bazel"))
+      editor.fileExists(editor.authorityPath(editor.pathJoin(root, "WORKSPACE"))) ||
+      editor.fileExists(editor.authorityPath(editor.pathJoin(root, "WORKSPACE.bazel"))) ||
+      editor.fileExists(editor.authorityPath(editor.pathJoin(root, "BUILD.bazel")))
     ) {
       buildHints.push("Bazel project detected (use `bazel build //...` and attach the generated compile_commands.json).");
     }
-    if (editor.fileExists(editor.pathJoin(root, "Makefile"))) {
+    if (editor.fileExists(editor.authorityPath(editor.pathJoin(root, "Makefile")))) {
       buildHints.push("Makefile detected (run `bear -- make` or `intercept-build make` to emit compile_commands.json).");
     }
   }
@@ -264,7 +264,7 @@ function clangdOpenProjectConfig() : void {
   let opened = false;
   for (const dir of Array.from(targets)) {
     const configPath = editor.pathJoin(dir, ".clangd");
-    if (editor.fileExists(configPath)) {
+    if (editor.fileExists(editor.authorityPath(configPath))) {
       editor.openFile(configPath, 0, 0);
       setClangdStatus(editor.t("status.opened_config"));
       opened = true;

--- a/crates/fresh-editor/plugins/code-tour.ts
+++ b/crates/fresh-editor/plugins/code-tour.ts
@@ -179,7 +179,7 @@ async function navigateToStep(stepIndex: number): Promise<void> {
   if (!step) return;
 
   // Check if file exists (fileExists is sync, not async)
-  const fileExists = editor.fileExists(step.file_path);
+  const fileExists = editor.fileExists(editor.authorityPath(step.file_path));
 
   if (!fileExists) {
     // Show error in popup but allow navigation to continue
@@ -228,7 +228,7 @@ async function navigateToStep(stepIndex: number): Promise<void> {
 async function loadTour(manifestPath: string): Promise<void> {
   try {
     // Read and parse manifest
-    const content = editor.readFile(manifestPath);
+    const content = editor.readFile(editor.authorityPath(manifestPath));
     if (!content) {
       editor.error("Failed to read tour file: " + manifestPath);
       return;

--- a/crates/fresh-editor/plugins/csharp_support.ts
+++ b/crates/fresh-editor/plugins/csharp_support.ts
@@ -107,7 +107,7 @@ function findProjectRoot(startPath: string): string | null {
   while (depth < maxDepth) {
     // Check if this directory contains a .csproj or .sln file
     try {
-      const entries = editor.readDir(currentDir);
+      const entries = editor.readDir(editor.authorityPath(currentDir));
       for (const entry of entries) {
         if (entry.is_file) {
           if (entry.name.endsWith(".csproj") || entry.name.endsWith(".sln")) {

--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -191,26 +191,26 @@ function findConfig(): boolean {
 
   // Priority 1: .devcontainer/devcontainer.json
   const primary = editor.pathJoin(cwd, ".devcontainer", "devcontainer.json");
-  const primaryContent = editor.readFile(primary);
+  const primaryContent = editor.readFile(editor.authorityPath(primary));
   if (primaryContent !== null) {
     if (tryParse(primary, primaryContent)) return true;
   }
 
   // Priority 2: .devcontainer.json
   const secondary = editor.pathJoin(cwd, ".devcontainer.json");
-  const secondaryContent = editor.readFile(secondary);
+  const secondaryContent = editor.readFile(editor.authorityPath(secondary));
   if (secondaryContent !== null) {
     if (tryParse(secondary, secondaryContent)) return true;
   }
 
   // Priority 3: .devcontainer/<subfolder>/devcontainer.json
   const dcDir = editor.pathJoin(cwd, ".devcontainer");
-  if (editor.fileExists(dcDir)) {
-    const entries = editor.readDir(dcDir);
+  if (editor.fileExists(editor.authorityPath(dcDir))) {
+    const entries = editor.readDir(editor.authorityPath(dcDir));
     for (const entry of entries) {
       if (entry.is_dir) {
         const subConfig = editor.pathJoin(dcDir, entry.name, "devcontainer.json");
-        const subContent = editor.readFile(subConfig);
+        const subContent = editor.readFile(editor.authorityPath(subConfig));
         if (subContent !== null) {
           if (tryParse(subConfig, subContent)) return true;
         }
@@ -1843,7 +1843,7 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
     // On failure the log file holds the stderr trace — surface its
     // last non-empty line as a human-readable status blurb. This
     // is purely cosmetic; exit_code drove the branch.
-    const logText = editor.readFile(logPath) ?? "";
+    const logText = editor.readFile(editor.authorityPath(logPath)) ?? "";
     const errText = extractLastNonEmptyLine(logText)
       ?? `exit ${result.exit_code}`;
     enterFailedAttach(errText);
@@ -1912,10 +1912,10 @@ async function prepareBuildLogFile(cwd: string): Promise<string | null> {
     return null;
   }
   const cacheIgnore = `${cacheDir}/.gitignore`;
-  if (editor.readFile(cacheIgnore) === null) {
+  if (editor.readFile(editor.authorityPath(cacheIgnore)) === null) {
     // writeFile failure is non-fatal — worst case the user sees
     // `.fresh-cache/` in `git status` once.
-    editor.writeFile(cacheIgnore, "*\n");
+    editor.writeFile(editor.authorityPath(cacheIgnore), "*\n");
   }
   // `toISOString()` → "2026-04-21T12:34:56.789Z"; strip the ms+Z
   // and swap separators that are awkward in filenames on some
@@ -2211,7 +2211,7 @@ async function devcontainer_show_build_logs(): Promise<void> {
     editor.setStatus(editor.t("status.no_build_log"));
     return;
   }
-  if (editor.readFile(path) === null) {
+  if (editor.readFile(editor.authorityPath(path)) === null) {
     editor.setStatus(editor.t("status.build_log_missing"));
     return;
   }
@@ -2301,13 +2301,13 @@ function devcontainer_scaffold_config(): void {
   // Respect an existing config — always a safer default than
   // overwriting. The user can call `devcontainer_open_config` if they
   // just meant to edit it.
-  if (editor.fileExists(configFile)) {
+  if (editor.fileExists(editor.authorityPath(configFile))) {
     editor.setStatus(editor.t("status.scaffold_already_exists"));
     editor.openFile(configFile, null, null);
     return;
   }
 
-  if (!editor.createDir(dcDir)) {
+  if (!editor.createDir(editor.authorityPath(dcDir))) {
     editor.setStatus(editor.t("status.scaffold_failed"));
     return;
   }
@@ -2323,7 +2323,7 @@ function devcontainer_scaffold_config(): void {
       2,
     ) + "\n";
 
-  if (!editor.writeFile(configFile, template)) {
+  if (!editor.writeFile(editor.authorityPath(configFile), template)) {
     editor.setStatus(editor.t("status.scaffold_failed"));
     return;
   }

--- a/crates/fresh-editor/plugins/env-manager.ts
+++ b/crates/fresh-editor/plugins/env-manager.ts
@@ -84,7 +84,7 @@ interface Detected {
 
 function fileExists(p: string): boolean {
   try {
-    return editor.fileExists(p);
+    return editor.fileExists(editor.authorityPath(p));
   } catch (_e) {
     return false;
   }

--- a/crates/fresh-editor/plugins/find_references.ts
+++ b/crates/fresh-editor/plugins/find_references.ts
@@ -65,7 +65,7 @@ async function loadLineContent(
       lines = cached;
     } else {
       try {
-        const content = await editor.readFile(ref.file);
+        const content = await editor.readFile(editor.authorityPath(ref.file));
         lines = content ? content.split("\n") : [];
       } catch {
         lines = [];

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -271,7 +271,7 @@ async function fetchFileContent(repo: GitRepo, filePath: string, commit: string 
 
   // Get current file content using editor API (cross-platform)
   try {
-    return await editor.readFile(filePath) ?? "";
+    return await editor.readFile(editor.authorityPath(filePath)) ?? "";
   } catch {
     return "";
   }

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -350,8 +350,8 @@ function donePathForHash(hash: string): string {
  */
 function isCommitDiffComplete(hash: string): boolean {
   return (
-    editor.fileExists(cachePathForHash(hash)) &&
-    editor.fileExists(donePathForHash(hash))
+    editor.fileExists(editor.localPath(cachePathForHash(hash))) &&
+    editor.fileExists(editor.localPath(donePathForHash(hash)))
   );
 }
 
@@ -433,7 +433,7 @@ async function pollUntilSpawnDone(
   // Durable completion marker: an empty sidecar file whose existence
   // says "complete". Written after the bytes are on disk so a reader
   // that sees the marker also sees the full diff.
-  editor.writeFile(donePathForHash(hash), "");
+  editor.writeFile(editor.localPath(donePathForHash(hash)), "");
   // Apply diff coloring once the buffer is complete. Doing this
   // pre-completion would either churn (re-walk on every refresh) or
   // double-overlay newly-extended lines; on completion we walk once.

--- a/crates/fresh-editor/plugins/k8s-workspace.ts
+++ b/crates/fresh-editor/plugins/k8s-workspace.ts
@@ -102,8 +102,8 @@ function configPath(): string {
 
 function loadConfig(): K8sConfig | null {
   const path = configPath();
-  if (!editor.fileExists(path)) return null;
-  const text = editor.readFile(path);
+  if (!editor.fileExists(editor.authorityPath(path))) return null;
+  const text = editor.readFile(editor.authorityPath(path));
   if (text === null) return null;
   try {
     const parsed = editor.parseJsonc(text) as K8sConfig;
@@ -259,7 +259,7 @@ async function resolveProvider(
 
     case "manifest": {
       if (!(await confirmCreate(target, name))) return null;
-      const text = editor.readFile(expand(provider.template, vars));
+      const text = editor.readFile(editor.localPath(expand(provider.template, vars)));
       if (text === null) {
         editor.setStatus(`K8s: manifest not found: ${provider.template}`);
         return null;

--- a/crates/fresh-editor/plugins/lib/finder.ts
+++ b/crates/fresh-editor/plugins/lib/finder.ts
@@ -1079,7 +1079,7 @@ export class Finder<T> {
     if (!entry.location) return;
 
     try {
-      const content = await this.editor.readFile(entry.location.file);
+      const content = await this.editor.readFile(this.editor.authorityPath(entry.location.file));
       if (!content) return;
       const lines = content.split("\n");
 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1949,6 +1949,10 @@ type LanguagePackConfig = {
 	*/
 	formatter: FormatterPackConfig | null;
 };
+type LocalPath = {
+	kind: "local";
+	value: string;
+};
 type LspServerPackConfig = {
 	/**
 	* Command to start the LSP server
@@ -2064,6 +2068,11 @@ type VirtualBufferResult = {
 	* The split ID (if created in a new split)
 	*/
 	splitId: number | null;
+};
+type WindowPath = {
+	kind: "authority";
+	window: number;
+	value: string;
 };
 /**
 * Main editor API interface
@@ -2521,42 +2530,56 @@ interface EditorAPI {
 	*/
 	utf8ByteLength(text: string): number;
 	/**
-	* Check if file exists
+	* Check if a file exists on the path's filesystem (a window's authority,
+	* or the local host for a `LocalPath`).
 	*/
-	fileExists(path: string): boolean;
+	fileExists(path: string | LocalPath | WindowPath): boolean;
 	/**
-	* Read file contents
+	* Read file contents from the path's filesystem.
 	*/
-	readFile(path: string): string | null;
+	readFile(path: string | LocalPath | WindowPath): string | null;
 	/**
-	* Write file contents
+	* Write file contents to the path's filesystem. Parent directories are
+	* created as needed.
 	*/
-	writeFile(path: string, content: string): boolean;
+	writeFile(path: string | LocalPath | WindowPath, content: string): boolean;
 	/**
 	* Read directory contents (returns array of {name, is_file, is_dir})
 	*/
-	readDir(path: string): DirEntry[];
+	readDir(path: string | LocalPath | WindowPath): DirEntry[];
 	/**
-	* Create a directory (and all parent directories) recursively.
-	* Returns true if the directory was created or already exists.
+	* Create a directory (and all parent directories) recursively on the
+	* path's filesystem. Returns true if the directory was created or already
+	* exists.
 	*/
-	createDir(path: string): boolean;
+	createDir(path: string | LocalPath | WindowPath): boolean;
 	/**
-	* Remove a file or directory by moving it to the OS trash/recycle bin.
-	* For safety, the path must be under the OS temp directory or the Fresh
-	* config directory. Returns true on success.
+	* Permanently remove a file or directory on the path's filesystem
+	* (recursively for directories). For safety, the path must be under the OS
+	* temp directory or the Fresh config directory. Returns true on success.
 	*/
-	removePath(path: string): boolean;
+	removePath(path: string | LocalPath | WindowPath): boolean;
 	/**
-	* Rename/move a file or directory. Returns true on success.
-	* Falls back to copy then trash for cross-filesystem moves.
+	* Rename/move a file or directory. Both paths must target the same
+	* filesystem (a cross-backend move is rejected). Returns true on success.
 	*/
-	renamePath(from: string, to: string): boolean;
+	renamePath(from: string | LocalPath | WindowPath, to: string | LocalPath | WindowPath): boolean;
 	/**
-	* Copy a file or directory recursively to a new location.
-	* Returns true on success.
+	* Copy a file or directory recursively to a new location. Both paths must
+	* target the same filesystem. Returns true on success.
 	*/
-	copyPath(from: string, to: string): boolean;
+	copyPath(from: string | LocalPath | WindowPath, to: string | LocalPath | WindowPath): boolean;
+	/**
+	* Construct a `LocalPath` — a path that always resolves on the local
+	* editor host, regardless of the active window's authority. Use for
+	* editor-owned state under the config/data dirs.
+	*/
+	localPath(path: string): LocalPath;
+	/**
+	* Construct a `WindowPath` — a path that resolves on a specific window's
+	* authority filesystem, regardless of which window is focused.
+	*/
+	windowPath(windowId: number, path: string): WindowPath;
 	/**
 	* Get the OS temporary directory path.
 	*/
@@ -2771,7 +2794,7 @@ interface EditorAPI {
 	/**
 	* Get file stat information
 	*/
-	fileStat(path: string): unknown;
+	fileStat(path: string | LocalPath | WindowPath): unknown;
 	/**
 	* Check if a background process is still running
 	*/

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1672,6 +1672,10 @@ type ReplaceResult = {
 	*/
 	bufferId: number;
 };
+type AuthorityPath = {
+	kind: "authority";
+	value: string;
+};
 type AuthorityFilesystem = {
 	kind: "local";
 };
@@ -2533,42 +2537,42 @@ interface EditorAPI {
 	* Check if a file exists on the path's filesystem (a window's authority,
 	* or the local host for a `LocalPath`).
 	*/
-	fileExists(path: string | LocalPath | WindowPath): boolean;
+	fileExists(path: string | LocalPath | WindowPath | AuthorityPath): boolean;
 	/**
 	* Read file contents from the path's filesystem.
 	*/
-	readFile(path: string | LocalPath | WindowPath): string | null;
+	readFile(path: string | LocalPath | WindowPath | AuthorityPath): string | null;
 	/**
 	* Write file contents to the path's filesystem. Parent directories are
 	* created as needed.
 	*/
-	writeFile(path: string | LocalPath | WindowPath, content: string): boolean;
+	writeFile(path: string | LocalPath | WindowPath | AuthorityPath, content: string): boolean;
 	/**
 	* Read directory contents (returns array of {name, is_file, is_dir})
 	*/
-	readDir(path: string | LocalPath | WindowPath): DirEntry[];
+	readDir(path: string | LocalPath | WindowPath | AuthorityPath): DirEntry[];
 	/**
 	* Create a directory (and all parent directories) recursively on the
 	* path's filesystem. Returns true if the directory was created or already
 	* exists.
 	*/
-	createDir(path: string | LocalPath | WindowPath): boolean;
+	createDir(path: string | LocalPath | WindowPath | AuthorityPath): boolean;
 	/**
 	* Permanently remove a file or directory on the path's filesystem
 	* (recursively for directories). For safety, the path must be under the OS
 	* temp directory or the Fresh config directory. Returns true on success.
 	*/
-	removePath(path: string | LocalPath | WindowPath): boolean;
+	removePath(path: string | LocalPath | WindowPath | AuthorityPath): boolean;
 	/**
 	* Rename/move a file or directory. Both paths must target the same
 	* filesystem (a cross-backend move is rejected). Returns true on success.
 	*/
-	renamePath(from: string | LocalPath | WindowPath, to: string | LocalPath | WindowPath): boolean;
+	renamePath(from: string | LocalPath | WindowPath | AuthorityPath, to: string | LocalPath | WindowPath | AuthorityPath): boolean;
 	/**
 	* Copy a file or directory recursively to a new location. Both paths must
 	* target the same filesystem. Returns true on success.
 	*/
-	copyPath(from: string | LocalPath | WindowPath, to: string | LocalPath | WindowPath): boolean;
+	copyPath(from: string | LocalPath | WindowPath | AuthorityPath, to: string | LocalPath | WindowPath | AuthorityPath): boolean;
 	/**
 	* Construct a `LocalPath` — a path that always resolves on the local
 	* editor host, regardless of the active window's authority. Use for
@@ -2580,6 +2584,13 @@ interface EditorAPI {
 	* authority filesystem, regardless of which window is focused.
 	*/
 	windowPath(windowId: number, path: string): WindowPath;
+	/**
+	* Construct an `AuthorityPath` — the active window's authority filesystem,
+	* stated explicitly. Routes identically to passing a bare string, but is
+	* self-documenting: bundled plugins use it so bare strings are reserved as
+	* the backward-compatible default for external plugins.
+	*/
+	authorityPath(path: string): AuthorityPath;
 	/**
 	* Get the OS temporary directory path.
 	*/
@@ -2794,7 +2805,7 @@ interface EditorAPI {
 	/**
 	* Get file stat information
 	*/
-	fileStat(path: string | LocalPath | WindowPath): unknown;
+	fileStat(path: string | LocalPath | WindowPath | AuthorityPath): unknown;
 	/**
 	* Check if a background process is still running
 	*/

--- a/crates/fresh-editor/plugins/lib/git_repo.ts
+++ b/crates/fresh-editor/plugins/lib/git_repo.ts
@@ -143,7 +143,7 @@ export function discoverSubRepos(
 ): string[] {
   if (maxDepth <= 0) return [];
   const repos: string[] = [];
-  const entries = editor.readDir(dir);
+  const entries = editor.readDir(editor.authorityPath(dir));
   for (const entry of entries) {
     if (
       entry.name.startsWith(".") ||
@@ -153,7 +153,7 @@ export function discoverSubRepos(
       continue;
     }
     const subDir = editor.pathJoin(dir, entry.name);
-    if (editor.fileExists(editor.pathJoin(subDir, ".git"))) {
+    if (editor.fileExists(editor.authorityPath(editor.pathJoin(subDir, ".git")))) {
       repos.push(subDir);
     } else {
       repos.push(...discoverSubRepos(editor, subDir, maxDepth - 1));

--- a/crates/fresh-editor/plugins/lib/search-utils.ts
+++ b/crates/fresh-editor/plugins/lib/search-utils.ts
@@ -36,7 +36,8 @@ export interface DebouncedSearchOptions {
 
 // Editor interface (subset of what we need)
 interface EditorApi {
-  readFile(path: string): Promise<string>;
+  readFile(path: string | AuthorityPath | LocalPath | WindowPath): Promise<string>;
+  authorityPath(path: string): AuthorityPath;
   defineMode(name: string, bindings: [string, string][], readOnly: boolean): void;
   createVirtualBufferInSplit(options: {
     name: string;
@@ -91,7 +92,7 @@ export class SearchPreview {
    */
   async update(match: SearchMatch): Promise<void> {
     try {
-      const content = await this.editor.readFile(match.file);
+      const content = await this.editor.readFile(this.editor.authorityPath(match.file));
       const lines = content.split("\n");
 
       // Calculate context window (5 lines before and after)

--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -269,7 +269,7 @@ async function loadBranchRef(filePath: string, ref: string): Promise<string | nu
 }
 
 function loadDiskRef(filePath: string): string | null {
-  return editor.readFile(filePath);
+  return editor.readFile(editor.authorityPath(filePath));
 }
 
 async function resolveDefaultBranch(filePath: string): Promise<string> {

--- a/crates/fresh-editor/plugins/merge_conflict.ts
+++ b/crates/fresh-editor/plugins/merge_conflict.ts
@@ -1245,7 +1245,7 @@ async function start_merge_conflict() : Promise<void> {
   let content: string;
   if (catFileResult.exit_code !== 0) {
     editor.debug(`Merge: git show :0: failed, reading working tree file`);
-    const fileContent = await editor.readFile(info.path);
+    const fileContent = await editor.readFile(editor.authorityPath(info.path));
     if (!fileContent) {
       editor.setStatus(editor.t("status.failed_read"));
       return;
@@ -1253,7 +1253,7 @@ async function start_merge_conflict() : Promise<void> {
     content = fileContent;
   } else {
     // The staged version shouldn't have conflict markers, use working tree
-    const fileContent = await editor.readFile(info.path);
+    const fileContent = await editor.readFile(editor.authorityPath(info.path));
     if (!fileContent) {
       editor.setStatus(editor.t("status.failed_read"));
       return;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1274,14 +1274,14 @@ function scanSessionContent(): void {
   const dir = editor.pathJoin(editor.getDataDir(), "workspaces");
   let entries: DirEntry[];
   try {
-    entries = editor.readDir(dir);
+    entries = editor.readDir(editor.localPath(dir));
   } catch {
     return;
   }
   if (!entries) return;
   for (const e of entries) {
     if (!e.is_file || !e.name.endsWith(".json")) continue;
-    const raw = editor.readFile(editor.pathJoin(dir, e.name));
+    const raw = editor.readFile(editor.localPath(editor.pathJoin(dir, e.name)));
     if (!raw) continue;
     let ws: Record<string, unknown>;
     try {
@@ -4811,7 +4811,7 @@ function archiveManifestPath(repoRoot: string): string {
 
 function loadArchiveManifest(repoRoot: string): ArchiveManifest {
   const path = archiveManifestPath(repoRoot);
-  const raw = editor.readFile(path);
+  const raw = editor.readFile(editor.localPath(path));
   if (!raw) return { version: 1, sessions: [] };
   try {
     const parsed = JSON.parse(raw);
@@ -4831,8 +4831,8 @@ function loadArchiveManifest(repoRoot: string): ArchiveManifest {
 function saveArchiveManifest(repoRoot: string, m: ArchiveManifest): boolean {
   const path = archiveManifestPath(repoRoot);
   const dir = editor.pathDirname(path);
-  if (!editor.createDir(dir)) return false;
-  return editor.writeFile(path, JSON.stringify(m, null, 2));
+  if (!editor.createDir(editor.localPath(dir))) return false;
+  return editor.writeFile(editor.localPath(path), JSON.stringify(m, null, 2));
 }
 
 // Pick a session id to make active so that `excludeId` can be
@@ -4985,7 +4985,7 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
       s.label,
     );
     const parent = editor.pathDirname(archivedRoot);
-    if (!editor.createDir(parent)) {
+    if (!editor.createDir(editor.localPath(parent))) {
       return { ok: false, err: editor.t("err.could_not_create", { path: parent }), repoRoot };
     }
     const moveRes = await spawnCollect(
@@ -5118,7 +5118,7 @@ async function syncSessions(repoRoot: string): Promise<SyncResult> {
   // First-time setup creates the worktree as an orphan branch
   // with no parent commit (cleanest history; no leftover files
   // from the original tree).
-  if (!editor.createDir(editor.pathDirname(wt))) {
+  if (!editor.createDir(editor.localPath(editor.pathDirname(wt)))) {
     return { ok: false, err: "createDir failed for sync workspace parent" };
   }
   const branchExists = await spawnCollect(
@@ -5173,7 +5173,7 @@ async function syncSessions(repoRoot: string): Promise<SyncResult> {
   // lives at the root of the sync branch.
   const snapshot = await buildSyncSnapshot(repoRoot);
   const sessionsPath = editor.pathJoin(wt, "sessions.json");
-  if (!editor.writeFile(sessionsPath, JSON.stringify(snapshot, null, 2))) {
+  if (!editor.writeFile(editor.localPath(sessionsPath), JSON.stringify(snapshot, null, 2))) {
     return { ok: false, err: "writeFile sessions.json failed" };
   }
 
@@ -6007,14 +6007,14 @@ const FRESH_CLI_BLOCK_END = "<!-- fresh-cli:end -->";
 // rather than overwriting the user's content; otherwise create it fresh.
 function writeFreshCliPromptFile(path: string): void {
   const block = `${FRESH_CLI_BLOCK_START}\n${FRESH_CLI_SYSTEM_PROMPT}\n${FRESH_CLI_BLOCK_END}\n`;
-  if (editor.fileExists(path)) {
-    const existing = editor.readFile(path) ?? "";
+  if (editor.fileExists(editor.localPath(path))) {
+    const existing = editor.readFile(editor.localPath(path)) ?? "";
     // Idempotent on retry / restart-recovery: never stack duplicate blocks.
     if (existing.includes(FRESH_CLI_BLOCK_START)) return;
     const sep = existing.length === 0 || existing.endsWith("\n") ? "\n" : "\n\n";
-    editor.writeFile(path, existing + sep + block);
+    editor.writeFile(editor.localPath(path), existing + sep + block);
   } else {
-    editor.writeFile(path, block);
+    editor.writeFile(editor.localPath(path), block);
   }
 }
 
@@ -7441,7 +7441,7 @@ function computePathCompletions(typed: string): string[] {
     parent = typed.slice(0, slashIdx);
     basename = typed.slice(slashIdx + 1);
   }
-  const entries = editor.readDir(parent);
+  const entries = editor.readDir(editor.localPath(parent));
   const matches = entries
     .filter((e) => !basename || e.name.startsWith(basename))
     .filter((e) => !e.name.startsWith(".") || basename.startsWith("."));
@@ -8037,14 +8037,14 @@ async function runLocalCreate(id: number): Promise<void> {
 
   // Recovery idempotency: a worktree left on disk by an interrupted run is
   // reused rather than re-added (a re-add would fail and error the row).
-  const rootExists = createWorktree && editor.fileExists(root);
+  const rootExists = createWorktree && editor.fileExists(editor.localPath(root));
   // Whether *this* run put the worktree on disk (vs. reusing an existing one),
   // so a mid-flight dismissal can remove exactly what it created.
   let addedWorktree = false;
   if (createWorktree && !rootExists) {
     setPendingMessage(id, editor.t("dock.pending_adding_worktree"));
     const parent = editor.pathDirname(root);
-    if (!editor.createDir(parent)) {
+    if (!editor.createDir(editor.localPath(parent))) {
       failPending(id, editor.t("err.mkdir_failed", { path: parent }));
       return;
     }

--- a/crates/fresh-editor/plugins/path_complete.ts
+++ b/crates/fresh-editor/plugins/path_complete.ts
@@ -105,7 +105,7 @@ function missingFileSuggestion(
     absolutePath = editor.pathJoin(cwd, absolutePath);
   }
 
-  if (editor.fileExists(absolutePath)) {
+  if (editor.fileExists(editor.authorityPath(absolutePath))) {
     return null;
   }
 
@@ -121,7 +121,7 @@ function generateCompletions(input: string): PromptSuggestion[] {
   const { dir, pattern } = parsePath(input);
 
   // Read the directory
-  const entries = editor.readDir(dir);
+  const entries = editor.readDir(editor.authorityPath(dir));
   const newFileSuggestion = missingFileSuggestion(input, pattern);
 
   if (!entries) {

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -40,6 +40,25 @@ import { Finder } from "./lib/finder.ts";
 
 const editor = getEditor();
 
+// The package manager operates entirely on editor-owned state — installed
+// packages under the config dir and download scratch under the temp dir — which
+// live on the local editor host regardless of the active window's authority
+// (e.g. an SSH session). Route every filesystem call through `localPath(...)`
+// so installs/uninstalls always hit the host, never a remote backend.
+const fsLocal = {
+  readFile: (p: string) => editor.readFile(editor.localPath(p)),
+  writeFile: (p: string, content: string) =>
+    editor.writeFile(editor.localPath(p), content),
+  readDir: (p: string) => editor.readDir(editor.localPath(p)),
+  fileExists: (p: string) => editor.fileExists(editor.localPath(p)),
+  createDir: (p: string) => editor.createDir(editor.localPath(p)),
+  removePath: (p: string) => editor.removePath(editor.localPath(p)),
+  renamePath: (from: string, to: string) =>
+    editor.renamePath(editor.localPath(from), editor.localPath(to)),
+  copyPath: (from: string, to: string) =>
+    editor.copyPath(editor.localPath(from), editor.localPath(to)),
+};
+
 // =============================================================================
 // Configuration
 // =============================================================================
@@ -248,7 +267,7 @@ interface ParsedPackageUrl {
  * Ensure a directory exists (cross-platform)
  */
 function ensureDir(path: string): boolean {
-  return editor.createDir(path);
+  return fsLocal.createDir(path);
 }
 
 /**
@@ -400,7 +419,7 @@ function getRegistrySources(): string[] {
  */
 function readJsonFile<T>(path: string): T | null {
   try {
-    const content = editor.readFile(path);
+    const content = fsLocal.readFile(path);
     if (content) {
       return JSON.parse(content) as T;
     }
@@ -416,7 +435,7 @@ function readJsonFile<T>(path: string): T | null {
 async function writeJsonFile(path: string, data: unknown): Promise<boolean> {
   try {
     const content = JSON.stringify(data, null, 2);
-    return editor.writeFile(path, content);
+    return fsLocal.writeFile(path, content);
   } catch (e) {
     editor.debug(`[pkg] Failed to write JSON file ${path}: ${e}`);
     return false;
@@ -442,7 +461,7 @@ async function syncRegistry(): Promise<void> {
   for (const source of sources) {
     const indexPath = editor.pathJoin(INDEX_DIR, hashString(source));
 
-    if (editor.fileExists(indexPath)) {
+    if (fsLocal.fileExists(indexPath)) {
       // Update existing
       editor.setStatus(`Updating registry: ${source}...`);
       const result = await gitCommand(["-C", `${indexPath}`, "pull", "--ff-only"]);
@@ -556,12 +575,12 @@ function isRegistrySynced(): boolean {
   for (const source of sources) {
     // Check git index
     const indexPath = editor.pathJoin(INDEX_DIR, hashString(source));
-    if (editor.fileExists(indexPath)) {
+    if (fsLocal.fileExists(indexPath)) {
       return true;
     }
     // Check cache
     const cachePath = editor.pathJoin(CACHE_DIR, `${hashString(source)}_plugins.json`);
-    if (editor.fileExists(cachePath)) {
+    if (fsLocal.fileExists(cachePath)) {
       return true;
     }
   }
@@ -582,12 +601,12 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
                     : LANGUAGES_PACKAGES_DIR;
   const packages: InstalledPackage[] = [];
 
-  if (!editor.fileExists(packagesDir)) {
+  if (!fsLocal.fileExists(packagesDir)) {
     return packages;
   }
 
   try {
-    const entries = editor.readDir(packagesDir);
+    const entries = fsLocal.readDir(packagesDir);
     for (const entry of entries) {
       if (entry.is_dir && !entry.name.startsWith(".")) {
         const pkgPath = editor.pathJoin(packagesDir, entry.name);
@@ -598,8 +617,8 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
         const gitConfigPath = editor.pathJoin(pkgPath, ".git", "config");
         let source = "";
         let localSource: string | undefined;
-        if (editor.fileExists(gitConfigPath)) {
-          const gitConfig = editor.readFile(gitConfigPath);
+        if (fsLocal.fileExists(gitConfigPath)) {
+          const gitConfig = fsLocal.readFile(gitConfigPath);
           if (gitConfig) {
             const match = gitConfig.match(/url\s*=\s*(.+)/);
             if (match) {
@@ -658,7 +677,7 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
   const manifestPath = editor.pathJoin(packageDir, "package.json");
 
   // Check package.json exists
-  if (!editor.fileExists(manifestPath)) {
+  if (!fsLocal.fileExists(manifestPath)) {
     return {
       valid: false,
       error: `Missing package.json - expected at ${manifestPath}`
@@ -713,10 +732,10 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
     const entryFile = manifest.fresh?.entry || manifest.fresh?.main || `${manifest.name}.ts`;
     const entryPath = editor.pathJoin(packageDir, entryFile);
 
-    if (!editor.fileExists(entryPath)) {
+    if (!fsLocal.fileExists(entryPath)) {
       // Try .js as fallback
       const jsEntryPath = entryPath.replace(/\.ts$/, ".js");
-      if (editor.fileExists(jsEntryPath)) {
+      if (fsLocal.fileExists(jsEntryPath)) {
         return { valid: true, manifest, entryPath: jsEntryPath };
       }
 
@@ -741,7 +760,7 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
     // Validate grammar file exists if specified
     if (manifest.fresh?.grammar?.file) {
       const grammarPath = editor.pathJoin(packageDir, manifest.fresh.grammar.file);
-      if (!editor.fileExists(grammarPath)) {
+      if (!fsLocal.fileExists(grammarPath)) {
         return {
           valid: false,
           error: `Grammar file not found: ${manifest.fresh.grammar.file}`
@@ -777,7 +796,7 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
         // Validate grammar file exists if specified
         if (lang.grammar?.file) {
           const grammarPath = editor.pathJoin(packageDir, lang.grammar.file);
-          if (!editor.fileExists(grammarPath)) {
+          if (!fsLocal.fileExists(grammarPath)) {
             return {
               valid: false,
               error: `Grammar file not found for language '${lang.id}': ${lang.grammar.file}`
@@ -797,10 +816,10 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
           };
         }
         const entryPath = editor.pathJoin(packageDir, plugin.entry);
-        if (!editor.fileExists(entryPath)) {
+        if (!fsLocal.fileExists(entryPath)) {
           // Try .js as fallback
           const jsEntryPath = entryPath.replace(/\.ts$/, ".js");
-          if (!editor.fileExists(jsEntryPath)) {
+          if (!fsLocal.fileExists(jsEntryPath)) {
             return {
               valid: false,
               error: `Plugin entry file not found: ${plugin.entry}`
@@ -886,14 +905,14 @@ async function installFromDirectFile(
       ? `HTTP ${result.exit_code}`
       : result.stderr.split("\n")[0] || "Download failed";
     editor.setStatus(`Failed to download ${packageName}: ${errorMsg}`);
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
-  const content = editor.readFile(tempFile);
+  const content = fsLocal.readFile(tempFile);
   if (!content) {
     editor.setStatus(`Failed to read downloaded file`);
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
@@ -902,7 +921,7 @@ async function installFromDirectFile(
     parsed = JSON.parse(content) as Record<string, unknown>;
   } catch (e) {
     editor.setStatus(`Downloaded file is not valid JSON: ${e}`);
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
@@ -923,7 +942,7 @@ async function installFromDirectFile(
     editor.setStatus(
       `Unrecognized file format at ${url} - direct file install currently supports Fresh theme JSON only`
     );
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
@@ -934,24 +953,24 @@ async function installFromDirectFile(
   const safeName = packageName.replace(/[^a-zA-Z0-9_.-]/g, "-");
   const targetDir = editor.pathJoin(THEMES_PACKAGES_DIR, safeName);
 
-  if (editor.fileExists(targetDir)) {
+  if (fsLocal.fileExists(targetDir)) {
     editor.setStatus(`Package '${safeName}' is already installed`);
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
   ensureDir(THEMES_PACKAGES_DIR);
   if (!ensureDir(targetDir)) {
     editor.setStatus(`Failed to create package directory ${targetDir}`);
-    editor.removePath(tempFile);
+    fsLocal.removePath(tempFile);
     return false;
   }
 
   const themeFileName = "theme.json";
-  if (!editor.writeFile(editor.pathJoin(targetDir, themeFileName), content)) {
+  if (!fsLocal.writeFile(editor.pathJoin(targetDir, themeFileName), content)) {
     editor.setStatus(`Failed to write theme file`);
-    editor.removePath(tempFile);
-    editor.removePath(targetDir);
+    fsLocal.removePath(tempFile);
+    fsLocal.removePath(targetDir);
     return false;
   }
 
@@ -966,8 +985,8 @@ async function installFromDirectFile(
   };
   if (!await writeJsonFile(editor.pathJoin(targetDir, "package.json"), manifest)) {
     editor.setStatus(`Failed to write package manifest`);
-    editor.removePath(tempFile);
-    editor.removePath(targetDir);
+    fsLocal.removePath(tempFile);
+    fsLocal.removePath(targetDir);
     return false;
   }
 
@@ -976,7 +995,7 @@ async function installFromDirectFile(
     installed_at: new Date().toISOString(),
   });
 
-  editor.removePath(tempFile);
+  fsLocal.removePath(tempFile);
   editor.reloadThemes();
   editor.setStatus(`Installed theme ${themeName ?? safeName}`);
   return true;
@@ -1026,7 +1045,7 @@ async function installFromRepo(
     editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
     editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
     // Clean up
-    editor.removePath(tempDir);
+    fsLocal.removePath(tempDir);
     return false;
   }
 
@@ -1044,17 +1063,17 @@ async function installFromRepo(
   const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
   // Check if already installed in correct location
-  if (editor.fileExists(correctTargetDir)) {
+  if (fsLocal.fileExists(correctTargetDir)) {
     editor.setStatus(`Package '${packageName}' is already installed`);
-    editor.removePath(tempDir);
+    fsLocal.removePath(tempDir);
     return false;
   }
 
   // Ensure correct directory exists and move from temp
   ensureDir(correctPackagesDir);
-  if (!editor.renamePath(tempDir, correctTargetDir)) {
+  if (!fsLocal.renamePath(tempDir, correctTargetDir)) {
     editor.setStatus(`Failed to install ${packageName}: could not move package to target directory`);
-    editor.removePath(tempDir);
+    fsLocal.removePath(tempDir);
     return false;
   }
 
@@ -1107,14 +1126,14 @@ async function installFromLocalPath(
   }
 
   // Check if source exists
-  if (!editor.fileExists(sourcePath)) {
+  if (!fsLocal.fileExists(sourcePath)) {
     editor.setStatus(`Local path not found: ${sourcePath}`);
     return false;
   }
 
   // Check if it's a directory (by checking for package.json)
   const manifestPath = editor.pathJoin(sourcePath, "package.json");
-  if (!editor.fileExists(manifestPath)) {
+  if (!fsLocal.fileExists(manifestPath)) {
     editor.setStatus(`Not a valid package (no package.json): ${sourcePath}`);
     return false;
   }
@@ -1138,7 +1157,7 @@ async function installFromLocalPath(
   const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
   // Check if already installed in correct location
-  if (editor.fileExists(correctTargetDir)) {
+  if (fsLocal.fileExists(correctTargetDir)) {
     editor.setStatus(`Package '${packageName}' is already installed`);
     return false;
   }
@@ -1148,7 +1167,7 @@ async function installFromLocalPath(
 
   // Copy the directory to correct target
   editor.setStatus(`Copying from ${sourcePath}...`);
-  if (!editor.copyPath(sourcePath, correctTargetDir)) {
+  if (!fsLocal.copyPath(sourcePath, correctTargetDir)) {
     editor.setStatus(`Failed to copy package from ${sourcePath}`);
     return false;
   }
@@ -1159,7 +1178,7 @@ async function installFromLocalPath(
     editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
     editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
     // Clean up the invalid package
-    editor.removePath(correctTargetDir);
+    fsLocal.removePath(correctTargetDir);
     return false;
   }
 
@@ -1233,9 +1252,9 @@ async function installFromMonorepo(
 
     // Verify subpath exists
     const subpathDir = editor.pathJoin(tempDir, parsed.subpath!);
-    if (!editor.fileExists(subpathDir)) {
+    if (!fsLocal.fileExists(subpathDir)) {
       editor.setStatus(`Subpath '${parsed.subpath}' not found in repository`);
-      editor.removePath(tempDir);
+      fsLocal.removePath(tempDir);
       return false;
     }
 
@@ -1244,7 +1263,7 @@ async function installFromMonorepo(
     if (!validation.valid) {
       editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
       editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
-      editor.removePath(tempDir);
+      fsLocal.removePath(tempDir);
       return false;
     }
 
@@ -1262,9 +1281,9 @@ async function installFromMonorepo(
     const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
     // Check if already installed
-    if (editor.fileExists(correctTargetDir)) {
+    if (fsLocal.fileExists(correctTargetDir)) {
       editor.setStatus(`Package '${packageName}' is already installed`);
-      editor.removePath(tempDir);
+      fsLocal.removePath(tempDir);
       return false;
     }
 
@@ -1273,9 +1292,9 @@ async function installFromMonorepo(
 
     // Copy subdirectory to correct target
     editor.setStatus(`Installing ${packageName} from ${parsed.subpath}...`);
-    if (!editor.copyPath(subpathDir, correctTargetDir)) {
+    if (!fsLocal.copyPath(subpathDir, correctTargetDir)) {
       editor.setStatus(`Failed to copy package from ${parsed.subpath}`);
-      editor.removePath(tempDir);
+      fsLocal.removePath(tempDir);
       return false;
     }
 
@@ -1309,7 +1328,7 @@ async function installFromMonorepo(
     return true;
   } finally {
     // Cleanup temp directory
-    editor.removePath(tempDir);
+    fsLocal.removePath(tempDir);
   }
 }
 
@@ -1418,14 +1437,14 @@ async function loadBundle(packageDir: string, manifest: PackageManifest): Promis
       let entryPath = editor.pathJoin(packageDir, plugin.entry);
 
       // Try .js fallback if .ts doesn't exist
-      if (!editor.fileExists(entryPath) && entryPath.endsWith(".ts")) {
+      if (!fsLocal.fileExists(entryPath) && entryPath.endsWith(".ts")) {
         const jsPath = entryPath.replace(/\.ts$/, ".js");
-        if (editor.fileExists(jsPath)) {
+        if (fsLocal.fileExists(jsPath)) {
           entryPath = jsPath;
         }
       }
 
-      if (editor.fileExists(entryPath)) {
+      if (fsLocal.fileExists(entryPath)) {
         editor.debug(`[pkg] Loading bundle plugin: ${plugin.entry}`);
         await editor.loadPlugin(entryPath);
       } else {
@@ -1557,7 +1576,7 @@ async function reinstallPackage(pkg: InstalledPackage): Promise<boolean> {
 
   const sourcePath = pkg.localSource;
 
-  if (!editor.fileExists(sourcePath)) {
+  if (!fsLocal.fileExists(sourcePath)) {
     editor.setStatus(`Source path no longer exists: ${sourcePath}`);
     return false;
   }
@@ -1574,13 +1593,13 @@ async function reinstallPackage(pkg: InstalledPackage): Promise<boolean> {
   }
 
   // Remove old copy
-  if (!editor.removePath(pkg.path)) {
+  if (!fsLocal.removePath(pkg.path)) {
     editor.setStatus(`Failed to remove old copy of ${pkg.name}`);
     return false;
   }
 
   // Re-copy from source
-  if (!editor.copyPath(sourcePath, pkg.path)) {
+  if (!fsLocal.copyPath(sourcePath, pkg.path)) {
     editor.setStatus(`Failed to copy from source: ${sourcePath}`);
     return false;
   }
@@ -1639,7 +1658,7 @@ async function removePackage(pkg: InstalledPackage): Promise<boolean> {
   }
 
   // Remove package directory
-  if (editor.removePath(pkg.path)) {
+  if (fsLocal.removePath(pkg.path)) {
     // Reload themes if we removed a theme so Select Theme list is updated
     if (pkg.type === "theme") {
       editor.reloadThemes();
@@ -1755,9 +1774,9 @@ async function installFromLockfile(): Promise<void> {
     const pluginPath = editor.pathJoin(PACKAGES_DIR, name);
     const themePath = editor.pathJoin(THEMES_PACKAGES_DIR, name);
 
-    if (editor.fileExists(pluginPath) || editor.fileExists(themePath)) {
+    if (fsLocal.fileExists(pluginPath) || fsLocal.fileExists(themePath)) {
       // Already installed, just checkout the commit
-      const path = editor.fileExists(pluginPath) ? pluginPath : themePath;
+      const path = fsLocal.fileExists(pluginPath) ? pluginPath : themePath;
       await gitCommand(["-C", `${path}`, "fetch"]);
       const result = await gitCommand(["-C", `${path}`, "checkout", entry.commit]);
       if (result.exit_code === 0) {

--- a/crates/fresh-editor/plugins/slang-lsp.ts
+++ b/crates/fresh-editor/plugins/slang-lsp.ts
@@ -70,7 +70,7 @@ async function cachePathFor(module: string): Promise<string> {
   const root = version
     ? `${editor.getDataDir()}/slang-builtin/${version}`
     : `${editor.getTempDir()}/fresh-slang-builtin`;
-  editor.createDir(root); // stdoutTo won't create parent dirs
+  editor.createDir(editor.localPath(root)); // stdoutTo won't create parent dirs
   return `${root}/${module}.slang`;
 }
 
@@ -105,7 +105,7 @@ editor.on("lsp_open_external_uri", async (data: LspOpenExternalUriData) => {
 
   const path = await cachePathFor(module);
 
-  if (!editor.fileExists(path)) {
+  if (!editor.fileExists(editor.localPath(path))) {
     editor.setStatus(`slang-lsp: loading builtin module '${module}'…`);
     const res = await editor.spawnProcess(
       "slangd",
@@ -113,7 +113,7 @@ editor.on("lsp_open_external_uri", async (data: LspOpenExternalUriData) => {
       undefined,
       path // stdoutTo: write the dump straight to the cache file
     );
-    if (res.exit_code !== 0 || !editor.fileExists(path)) {
+    if (res.exit_code !== 0 || !editor.fileExists(editor.localPath(path))) {
       editor.setStatus(
         `slang-lsp: failed to load builtin module '${module}' (exit ${res.exit_code})`
       );

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -715,21 +715,6 @@ impl Editor {
         }
     }
 
-    /// Repoint the plugin filesystem at the active window's authority backend,
-    /// so plugin file I/O (`readFile`/`readDir`/`writeFile`/…) follows the
-    /// focused session — the local host for a local window, the remote host for
-    /// an SSH/container window. Called at startup and on every active-window
-    /// change. No-op when compiled without plugins.
-    pub(crate) fn publish_active_filesystem_to_plugins(&self) {
-        #[cfg(feature = "plugins")]
-        {
-            let fs = std::sync::Arc::clone(&self.active_window().authority.filesystem);
-            if let Some(cell) = self.plugin_manager.read().unwrap().active_filesystem() {
-                cell.set(fs);
-            }
-        }
-    }
-
     /// Read-only access to the active authority.
     pub fn authority(&self) -> &crate::services::authority::Authority {
         // The editor's active backend *is* the active window's authority —

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -715,6 +715,21 @@ impl Editor {
         }
     }
 
+    /// Repoint the plugin filesystem at the active window's authority backend,
+    /// so plugin file I/O (`readFile`/`readDir`/`writeFile`/…) follows the
+    /// focused session — the local host for a local window, the remote host for
+    /// an SSH/container window. Called at startup and on every active-window
+    /// change. No-op when compiled without plugins.
+    pub(crate) fn publish_active_filesystem_to_plugins(&self) {
+        #[cfg(feature = "plugins")]
+        {
+            let fs = std::sync::Arc::clone(&self.active_window().authority.filesystem);
+            if let Some(cell) = self.plugin_manager.read().unwrap().active_filesystem() {
+                cell.set(fs);
+            }
+        }
+    }
+
     /// Read-only access to the active authority.
     pub fn authority(&self) -> &crate::services::authority::Authority {
         // The editor's active backend *is* the active window's authority —

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -667,10 +667,9 @@ impl Editor {
             dock_resizing: false,
         };
 
-        // Seed plugin file I/O with the initial active window's authority, so
-        // it is correct even for sessions launched directly against a remote
-        // backend (before any window switch occurs).
-        editor.publish_active_filesystem_to_plugins();
+        // The plugin per-window filesystem registry is populated on the first
+        // `update_plugin_state_snapshot` (during startup, before any plugin
+        // runs), so nothing to seed here.
         editor
     }
 
@@ -1127,7 +1126,10 @@ impl Editor {
             Arc::clone(&command_registry),
             dir_context.clone(),
             Arc::clone(&theme_cache),
+            // Authority seed (repointed to the active window shortly after) and
+            // the fixed local-host filesystem for `LocalPath` values.
             Arc::clone(&filesystem),
+            Arc::clone(&orchestrator_filesystem),
         )));
         t.phase("PluginManager::new");
 

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -554,7 +554,7 @@ impl Editor {
     /// than capturing a new clock — so two editors built from the
     /// same parts agree on "now".
     pub(super) fn from_parts(parts: EditorParts) -> Self {
-        Editor {
+        let editor = Editor {
             // From parts (non-trivial):
             next_buffer_id: parts.next_buffer_id,
             buffer_id_alloc: parts.buffer_id_alloc,
@@ -665,7 +665,13 @@ impl Editor {
             dock: None,
             dock_width: None,
             dock_resizing: false,
-        }
+        };
+
+        // Seed plugin file I/O with the initial active window's authority, so
+        // it is correct even for sessions launched directly against a remote
+        // backend (before any window switch occurs).
+        editor.publish_active_filesystem_to_plugins();
+        editor
     }
 
     /// Create a new editor with the given configuration and terminal dimensions
@@ -1121,6 +1127,7 @@ impl Editor {
             Arc::clone(&command_registry),
             dir_context.clone(),
             Arc::clone(&theme_cache),
+            Arc::clone(&filesystem),
         )));
         t.phase("PluginManager::new");
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -194,6 +194,24 @@ impl Editor {
     }
 
     pub fn update_plugin_state_snapshot(&mut self) {
+        // Rebuild the per-window filesystem registry so plugin file I/O resolves
+        // against the correct window's authority (or the active one). This runs
+        // on the same cadence as the snapshot, so it captures window
+        // create/close and focus changes without hooking each site.
+        #[cfg(feature = "plugins")]
+        if let Some(registry) = self.plugin_manager.read().unwrap().window_fs_registry() {
+            let active = self.active_window;
+            let entries: Vec<(
+                fresh_core::WindowId,
+                std::sync::Arc<dyn crate::model::filesystem::FileSystem + Send + Sync>,
+            )> = self
+                .windows
+                .iter()
+                .map(|(id, w)| (*id, std::sync::Arc::clone(&w.authority.filesystem)))
+                .collect();
+            registry.rebuild(active, entries);
+        }
+
         let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle()
         else {
             return;

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -371,7 +371,6 @@ impl crate::app::Editor {
         // directly.
         let previous_id = self.active_window;
         self.active_window = id;
-        self.publish_active_filesystem_to_plugins();
 
         // Run the workspace-trust decision for the project this session opens,
         // exactly as the CLI / session-server startup paths do — the
@@ -467,7 +466,6 @@ impl crate::app::Editor {
                 // out of PTYs, ...).
                 self.windows.remove(&id);
                 self.active_window = previous_id;
-                self.publish_active_filesystem_to_plugins();
                 return Err(e);
             }
         };
@@ -664,8 +662,6 @@ impl crate::app::Editor {
         // derives from the active window's root, so moving the pointer
         // is all it takes (no separate working_dir to sync).
         self.active_window = id;
-        // Repoint plugin file I/O at the newly focused window's authority.
-        self.publish_active_filesystem_to_plugins();
 
         // For a never-activated incoming window, install the freshly
         // built layout into the window's `splits` field and attach

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -371,6 +371,7 @@ impl crate::app::Editor {
         // directly.
         let previous_id = self.active_window;
         self.active_window = id;
+        self.publish_active_filesystem_to_plugins();
 
         // Run the workspace-trust decision for the project this session opens,
         // exactly as the CLI / session-server startup paths do — the
@@ -466,6 +467,7 @@ impl crate::app::Editor {
                 // out of PTYs, ...).
                 self.windows.remove(&id);
                 self.active_window = previous_id;
+                self.publish_active_filesystem_to_plugins();
                 return Err(e);
             }
         };
@@ -662,6 +664,8 @@ impl crate::app::Editor {
         // derives from the active window's root, so moving the pointer
         // is all it takes (no separate working_dir to sync).
         self.active_window = id;
+        // Repoint plugin file I/O at the newly focused window's authority.
+        self.publish_active_filesystem_to_plugins();
 
         // For a never-activated incoming window, install the freshly
         // built layout into the window's `splits` field and attach

--- a/crates/fresh-editor/src/services/plugins/bridge.rs
+++ b/crates/fresh-editor/src/services/plugins/bridge.rs
@@ -11,41 +11,84 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-/// Shared, live handle to the active window's filesystem backend.
-///
-/// The editor updates this whenever the active window (and therefore its
-/// authority) changes, so plugin file I/O always follows the currently focused
-/// session — the local host for a local window, the remote host for an
-/// SSH/container window — with no snapshotting and no local fallback.
-pub struct ActiveFilesystem(RwLock<Arc<dyn FileSystem + Send + Sync>>);
+use fresh_core::WindowId;
 
-impl ActiveFilesystem {
-    pub fn new(fs: Arc<dyn FileSystem + Send + Sync>) -> Self {
-        Self(RwLock::new(fs))
+/// Per-window filesystem registry: maps each live window to its authority
+/// backend, plus which window is active. The editor rebuilds it from its
+/// windows whenever it refreshes the plugin state snapshot, so plugin file I/O
+/// can target a specific window (or the active one) regardless of focus — the
+/// filesystem counterpart of addressing a window by `bufferId`.
+pub struct WindowFsRegistry {
+    inner: RwLock<WindowFsRegistryInner>,
+}
+
+struct WindowFsRegistryInner {
+    active: WindowId,
+    map: HashMap<WindowId, Arc<dyn FileSystem + Send + Sync>>,
+}
+
+impl WindowFsRegistry {
+    /// Seed with a single backend under `WindowId(1)` (the boot window). The
+    /// editor replaces this with the real window set on the first snapshot
+    /// refresh, which runs during startup before any plugin executes.
+    pub fn new(seed: Arc<dyn FileSystem + Send + Sync>) -> Self {
+        let mut map = HashMap::new();
+        map.insert(WindowId(1), seed);
+        Self {
+            inner: RwLock::new(WindowFsRegistryInner {
+                active: WindowId(1),
+                map,
+            }),
+        }
     }
 
-    /// The filesystem backend currently in effect.
-    pub fn get(&self) -> Arc<dyn FileSystem + Send + Sync> {
-        self.0.read().unwrap().clone()
+    /// Replace the whole registry from the editor's current windows.
+    pub fn rebuild(
+        &self,
+        active: WindowId,
+        entries: Vec<(WindowId, Arc<dyn FileSystem + Send + Sync>)>,
+    ) {
+        let mut inner = self.inner.write().unwrap();
+        inner.active = active;
+        inner.map = entries.into_iter().collect();
     }
 
-    /// Point plugin file I/O at a new backend (called on active-window change).
-    pub fn set(&self, fs: Arc<dyn FileSystem + Send + Sync>) {
-        *self.0.write().unwrap() = fs;
+    /// The backend for `window`, or the active window's when `None`. Returns
+    /// `None` if the requested window no longer exists.
+    fn get(&self, window: Option<WindowId>) -> Option<Arc<dyn FileSystem + Send + Sync>> {
+        let inner = self.inner.read().unwrap();
+        let id = window.unwrap_or(inner.active);
+        inner.map.get(&id).cloned()
     }
 }
 
-/// [`PluginFilesystem`] that routes every operation to the active window's
-/// authority filesystem via [`ActiveFilesystem`]. This is the *only* filesystem
-/// plugins touch, so their file access follows remote/SSH backends exactly like
-/// the editor core does.
-pub struct AuthorityPluginFilesystem {
-    active: Arc<ActiveFilesystem>,
+/// Resolves the concrete backend a [`RoutedFilesystem`] should use for the
+/// current call. Returns `None` when the target is unavailable (e.g. a window
+/// that has closed), in which case every operation fails rather than silently
+/// retargeting.
+type FsResolver = Arc<dyn Fn() -> Option<Arc<dyn FileSystem + Send + Sync>> + Send + Sync>;
+
+/// [`PluginFilesystem`] that routes every operation to a backend chosen per
+/// call by its resolver — either a fixed local-host filesystem (`LocalPath`)
+/// or a window's authority looked up live in a [`WindowFsRegistry`].
+pub struct RoutedFilesystem {
+    resolve: FsResolver,
 }
 
-impl AuthorityPluginFilesystem {
-    pub fn new(active: Arc<ActiveFilesystem>) -> Self {
-        Self { active }
+impl RoutedFilesystem {
+    /// Always route to `fs` (used for the local editor host).
+    pub fn fixed(fs: Arc<dyn FileSystem + Send + Sync>) -> Self {
+        Self {
+            resolve: Arc::new(move || Some(Arc::clone(&fs))),
+        }
+    }
+
+    /// Route to `window`'s authority (or the active window's) looked up in
+    /// `registry` on each call.
+    pub fn window(registry: Arc<WindowFsRegistry>, window: Option<WindowId>) -> Self {
+        Self {
+            resolve: Arc::new(move || registry.get(window)),
+        }
     }
 
     /// Ensure `path`'s parent directory exists, creating it if necessary.
@@ -63,22 +106,27 @@ impl AuthorityPluginFilesystem {
     }
 }
 
-impl PluginFilesystem for AuthorityPluginFilesystem {
+impl PluginFilesystem for RoutedFilesystem {
     fn read_file(&self, path: &Path) -> Option<Vec<u8>> {
-        self.active.get().read_file(path).ok()
+        (self.resolve)()?.read_file(path).ok()
     }
 
     fn write_file(&self, path: &Path, contents: &[u8]) -> bool {
-        let fs = self.active.get();
+        let Some(fs) = (self.resolve)() else {
+            return false;
+        };
         Self::ensure_parent(fs.as_ref(), path) && fs.write_file(path, contents).is_ok()
     }
 
     fn exists(&self, path: &Path) -> bool {
-        self.active.get().exists(path)
+        (self.resolve)().map(|fs| fs.exists(path)).unwrap_or(false)
     }
 
     fn read_dir(&self, path: &Path) -> Vec<PluginDirEntry> {
-        match self.active.get().read_dir(path) {
+        let Some(fs) = (self.resolve)() else {
+            return Vec::new();
+        };
+        match fs.read_dir(path) {
             Ok(entries) => entries
                 .into_iter()
                 .map(|e| PluginDirEntry {
@@ -92,12 +140,16 @@ impl PluginFilesystem for AuthorityPluginFilesystem {
     }
 
     fn create_dir_all(&self, path: &Path) -> bool {
-        let fs = self.active.get();
+        let Some(fs) = (self.resolve)() else {
+            return false;
+        };
         fs.is_dir(path).unwrap_or(false) || fs.create_dir_all(path).is_ok()
     }
 
     fn remove_path(&self, path: &Path) -> bool {
-        let fs = self.active.get();
+        let Some(fs) = (self.resolve)() else {
+            return false;
+        };
         if fs.is_dir(path).unwrap_or(false) {
             fs.remove_dir_all(path).is_ok()
         } else {
@@ -106,7 +158,9 @@ impl PluginFilesystem for AuthorityPluginFilesystem {
     }
 
     fn rename(&self, from: &Path, to: &Path) -> bool {
-        let fs = self.active.get();
+        let Some(fs) = (self.resolve)() else {
+            return false;
+        };
         if fs.rename(from, to).is_ok() {
             return true;
         }
@@ -128,7 +182,9 @@ impl PluginFilesystem for AuthorityPluginFilesystem {
     }
 
     fn copy(&self, from: &Path, to: &Path) -> bool {
-        let fs = self.active.get();
+        let Some(fs) = (self.resolve)() else {
+            return false;
+        };
         if fs.is_dir(from).unwrap_or(false) {
             fs.copy_dir_all(from, to).is_ok()
         } else {
@@ -137,7 +193,7 @@ impl PluginFilesystem for AuthorityPluginFilesystem {
     }
 
     fn stat(&self, path: &Path) -> Option<PluginFileStat> {
-        let fs = self.active.get();
+        let fs = (self.resolve)()?;
         let md = fs.metadata(path).ok()?;
         Some(PluginFileStat {
             is_file: fs.is_file(path).unwrap_or(false),
@@ -148,7 +204,7 @@ impl PluginFilesystem for AuthorityPluginFilesystem {
     }
 
     fn canonicalize(&self, path: &Path) -> Option<PathBuf> {
-        self.active.get().canonicalize(path).ok()
+        (self.resolve)()?.canonicalize(path).ok()
     }
 }
 
@@ -156,8 +212,13 @@ pub struct EditorServiceBridge {
     pub command_registry: Arc<RwLock<CommandRegistry>>,
     pub dir_context: DirectoryContext,
     pub theme_cache: Arc<RwLock<std::collections::HashMap<String, serde_json::Value>>>,
-    /// The plugin filesystem, routing to the active window's authority.
-    pub plugin_fs: Arc<dyn PluginFilesystem>,
+    /// Local-host plugin filesystem — always the editor host, regardless of
+    /// authority. Backs `LocalPath` values.
+    pub local_plugin_fs: Arc<dyn PluginFilesystem>,
+    /// Per-window authority backends; the editor rebuilds it on each snapshot
+    /// refresh. Backs bare-string paths (active window) and `WindowPath` values
+    /// (a specific window).
+    pub window_registry: Arc<WindowFsRegistry>,
 }
 
 impl PluginServiceBridge for EditorServiceBridge {
@@ -165,8 +226,15 @@ impl PluginServiceBridge for EditorServiceBridge {
         self
     }
 
-    fn filesystem(&self) -> Arc<dyn PluginFilesystem> {
-        Arc::clone(&self.plugin_fs)
+    fn authority_filesystem(&self, window: Option<u64>) -> Arc<dyn PluginFilesystem> {
+        Arc::new(RoutedFilesystem::window(
+            Arc::clone(&self.window_registry),
+            window.map(WindowId),
+        ))
+    }
+
+    fn local_filesystem(&self) -> Arc<dyn PluginFilesystem> {
+        Arc::clone(&self.local_plugin_fs)
     }
 
     fn translate(&self, plugin_name: &str, key: &str, args: &HashMap<String, String>) -> String {

--- a/crates/fresh-editor/src/services/plugins/bridge.rs
+++ b/crates/fresh-editor/src/services/plugins/bridge.rs
@@ -1,23 +1,172 @@
 use crate::config_io::DirectoryContext;
 use crate::i18n;
 use crate::input::command_registry::CommandRegistry;
+use crate::model::filesystem::FileSystem;
 use crate::services::signal_handler;
 use crate::view::theme;
-use fresh_core::services::PluginServiceBridge;
+use fresh_core::api::DirEntry as PluginDirEntry;
+use fresh_core::services::{PluginFileStat, PluginFilesystem, PluginServiceBridge};
 use std::any::Any;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+
+/// Shared, live handle to the active window's filesystem backend.
+///
+/// The editor updates this whenever the active window (and therefore its
+/// authority) changes, so plugin file I/O always follows the currently focused
+/// session — the local host for a local window, the remote host for an
+/// SSH/container window — with no snapshotting and no local fallback.
+pub struct ActiveFilesystem(RwLock<Arc<dyn FileSystem + Send + Sync>>);
+
+impl ActiveFilesystem {
+    pub fn new(fs: Arc<dyn FileSystem + Send + Sync>) -> Self {
+        Self(RwLock::new(fs))
+    }
+
+    /// The filesystem backend currently in effect.
+    pub fn get(&self) -> Arc<dyn FileSystem + Send + Sync> {
+        self.0.read().unwrap().clone()
+    }
+
+    /// Point plugin file I/O at a new backend (called on active-window change).
+    pub fn set(&self, fs: Arc<dyn FileSystem + Send + Sync>) {
+        *self.0.write().unwrap() = fs;
+    }
+}
+
+/// [`PluginFilesystem`] that routes every operation to the active window's
+/// authority filesystem via [`ActiveFilesystem`]. This is the *only* filesystem
+/// plugins touch, so their file access follows remote/SSH backends exactly like
+/// the editor core does.
+pub struct AuthorityPluginFilesystem {
+    active: Arc<ActiveFilesystem>,
+}
+
+impl AuthorityPluginFilesystem {
+    pub fn new(active: Arc<ActiveFilesystem>) -> Self {
+        Self { active }
+    }
+
+    /// Ensure `path`'s parent directory exists, creating it if necessary.
+    /// Returns false only when creation was required and failed.
+    fn ensure_parent(fs: &dyn FileSystem, path: &Path) -> bool {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty()
+                && !fs.exists(parent)
+                && fs.create_dir_all(parent).is_err()
+            {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl PluginFilesystem for AuthorityPluginFilesystem {
+    fn read_file(&self, path: &Path) -> Option<Vec<u8>> {
+        self.active.get().read_file(path).ok()
+    }
+
+    fn write_file(&self, path: &Path, contents: &[u8]) -> bool {
+        let fs = self.active.get();
+        Self::ensure_parent(fs.as_ref(), path) && fs.write_file(path, contents).is_ok()
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.active.get().exists(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> Vec<PluginDirEntry> {
+        match self.active.get().read_dir(path) {
+            Ok(entries) => entries
+                .into_iter()
+                .map(|e| PluginDirEntry {
+                    name: e.name.clone(),
+                    is_file: e.is_file(),
+                    is_dir: e.is_dir(),
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn create_dir_all(&self, path: &Path) -> bool {
+        let fs = self.active.get();
+        fs.is_dir(path).unwrap_or(false) || fs.create_dir_all(path).is_ok()
+    }
+
+    fn remove_path(&self, path: &Path) -> bool {
+        let fs = self.active.get();
+        if fs.is_dir(path).unwrap_or(false) {
+            fs.remove_dir_all(path).is_ok()
+        } else {
+            fs.remove_file(path).is_ok()
+        }
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> bool {
+        let fs = self.active.get();
+        if fs.rename(from, to).is_ok() {
+            return true;
+        }
+        // Same-backend cross-device fallback: copy then remove the source.
+        let is_dir = fs.is_dir(from).unwrap_or(false);
+        let copied = if is_dir {
+            fs.copy_dir_all(from, to).is_ok()
+        } else {
+            fs.copy(from, to).is_ok()
+        };
+        if !copied {
+            return false;
+        }
+        if is_dir {
+            fs.remove_dir_all(from).is_ok()
+        } else {
+            fs.remove_file(from).is_ok()
+        }
+    }
+
+    fn copy(&self, from: &Path, to: &Path) -> bool {
+        let fs = self.active.get();
+        if fs.is_dir(from).unwrap_or(false) {
+            fs.copy_dir_all(from, to).is_ok()
+        } else {
+            Self::ensure_parent(fs.as_ref(), to) && fs.copy(from, to).is_ok()
+        }
+    }
+
+    fn stat(&self, path: &Path) -> Option<PluginFileStat> {
+        let fs = self.active.get();
+        let md = fs.metadata(path).ok()?;
+        Some(PluginFileStat {
+            is_file: fs.is_file(path).unwrap_or(false),
+            is_dir: fs.is_dir(path).unwrap_or(false),
+            size: md.size,
+            readonly: md.is_readonly,
+        })
+    }
+
+    fn canonicalize(&self, path: &Path) -> Option<PathBuf> {
+        self.active.get().canonicalize(path).ok()
+    }
+}
 
 pub struct EditorServiceBridge {
     pub command_registry: Arc<RwLock<CommandRegistry>>,
     pub dir_context: DirectoryContext,
     pub theme_cache: Arc<RwLock<std::collections::HashMap<String, serde_json::Value>>>,
+    /// The plugin filesystem, routing to the active window's authority.
+    pub plugin_fs: Arc<dyn PluginFilesystem>,
 }
 
 impl PluginServiceBridge for EditorServiceBridge {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn filesystem(&self) -> Arc<dyn PluginFilesystem> {
+        Arc::clone(&self.plugin_fs)
     }
 
     fn translate(&self, plugin_name: &str, key: &str, args: &HashMap<String, String>) -> String {

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -24,10 +24,10 @@ use fresh_plugin_runtime::PluginThreadHandle;
 pub struct PluginManager {
     #[cfg(feature = "plugins")]
     inner: Option<PluginThreadHandle>,
-    /// Live handle to the filesystem plugins use, kept so the editor can
-    /// repoint it at the active window's authority on focus changes.
+    /// Per-window filesystem registry, kept so the editor can rebuild it from
+    /// its windows whenever it refreshes the plugin state snapshot.
     #[cfg(feature = "plugins")]
-    active_fs: Option<Arc<super::bridge::ActiveFilesystem>>,
+    window_registry: Option<Arc<super::bridge::WindowFsRegistry>>,
     #[cfg(not(feature = "plugins"))]
     _phantom: std::marker::PhantomData<()>,
     /// Test-only side channel: commands pushed via
@@ -49,29 +49,34 @@ impl PluginManager {
         command_registry: Arc<RwLock<CommandRegistry>>,
         dir_context: DirectoryContext,
         theme_cache: Arc<RwLock<HashMap<String, serde_json::Value>>>,
+        authority_filesystem: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync>,
         local_filesystem: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync>,
     ) -> Self {
         #[cfg(feature = "plugins")]
         {
             if enable {
-                // Seed the plugin filesystem with the boot backend; the editor
-                // repoints it at the active window's authority once windows
-                // exist and on every focus change.
-                let active_fs = Arc::new(super::bridge::ActiveFilesystem::new(local_filesystem));
-                let plugin_fs: Arc<dyn fresh_core::services::PluginFilesystem> = Arc::new(
-                    super::bridge::AuthorityPluginFilesystem::new(Arc::clone(&active_fs)),
-                );
+                // Per-window authority registry: seeded with the boot backend
+                // and rebuilt from the editor's windows on each snapshot
+                // refresh. Backs bare-string paths (active window) and
+                // `WindowPath` values (a specific window).
+                let window_registry =
+                    Arc::new(super::bridge::WindowFsRegistry::new(authority_filesystem));
+                // Local-host filesystem: fixed, never retargeted, so `LocalPath`
+                // values always resolve on the editor host.
+                let local_plugin_fs: Arc<dyn fresh_core::services::PluginFilesystem> =
+                    Arc::new(super::bridge::RoutedFilesystem::fixed(local_filesystem));
                 let services = Arc::new(EditorServiceBridge {
                     command_registry: command_registry.clone(),
                     dir_context,
                     theme_cache,
-                    plugin_fs,
+                    local_plugin_fs,
+                    window_registry: Arc::clone(&window_registry),
                 });
                 match PluginThreadHandle::spawn(services) {
                     Ok(handle) => {
                         return Self {
                             inner: Some(handle),
-                            active_fs: Some(active_fs),
+                            window_registry: Some(window_registry),
                             pending_injected_commands: Vec::new(),
                         }
                     }
@@ -86,7 +91,7 @@ impl PluginManager {
             }
             Self {
                 inner: None,
-                active_fs: None,
+                window_registry: None,
                 pending_injected_commands: Vec::new(),
             }
         }
@@ -96,6 +101,7 @@ impl PluginManager {
             let _ = command_registry; // Suppress unused warning
             let _ = dir_context; // Suppress unused warning
             let _ = theme_cache; // Suppress unused warning
+            let _ = authority_filesystem; // Suppress unused warning
             let _ = local_filesystem; // Suppress unused warning
             if enable {
                 tracing::warn!("Plugins requested but compiled without plugin support");
@@ -107,14 +113,14 @@ impl PluginManager {
         }
     }
 
-    /// Live handle to the filesystem plugins use, if plugins are active.
+    /// The per-window filesystem registry, if plugins are active.
     ///
-    /// The editor calls [`ActiveFilesystem::set`](super::bridge::ActiveFilesystem::set)
-    /// on it whenever the active window changes so plugin file I/O follows the
-    /// focused session's authority (local or remote).
+    /// The editor calls [`WindowFsRegistry::rebuild`](super::bridge::WindowFsRegistry::rebuild)
+    /// on it whenever it refreshes the plugin state snapshot, so plugin file I/O
+    /// resolves against the correct window's authority (or the active one).
     #[cfg(feature = "plugins")]
-    pub fn active_filesystem(&self) -> Option<Arc<super::bridge::ActiveFilesystem>> {
-        self.active_fs.clone()
+    pub fn window_fs_registry(&self) -> Option<Arc<super::bridge::WindowFsRegistry>> {
+        self.window_registry.clone()
     }
 
     /// Inject a [`PluginCommand`](super::api::PluginCommand) into the

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -24,6 +24,10 @@ use fresh_plugin_runtime::PluginThreadHandle;
 pub struct PluginManager {
     #[cfg(feature = "plugins")]
     inner: Option<PluginThreadHandle>,
+    /// Live handle to the filesystem plugins use, kept so the editor can
+    /// repoint it at the active window's authority on focus changes.
+    #[cfg(feature = "plugins")]
+    active_fs: Option<Arc<super::bridge::ActiveFilesystem>>,
     #[cfg(not(feature = "plugins"))]
     _phantom: std::marker::PhantomData<()>,
     /// Test-only side channel: commands pushed via
@@ -45,19 +49,29 @@ impl PluginManager {
         command_registry: Arc<RwLock<CommandRegistry>>,
         dir_context: DirectoryContext,
         theme_cache: Arc<RwLock<HashMap<String, serde_json::Value>>>,
+        local_filesystem: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync>,
     ) -> Self {
         #[cfg(feature = "plugins")]
         {
             if enable {
+                // Seed the plugin filesystem with the boot backend; the editor
+                // repoints it at the active window's authority once windows
+                // exist and on every focus change.
+                let active_fs = Arc::new(super::bridge::ActiveFilesystem::new(local_filesystem));
+                let plugin_fs: Arc<dyn fresh_core::services::PluginFilesystem> = Arc::new(
+                    super::bridge::AuthorityPluginFilesystem::new(Arc::clone(&active_fs)),
+                );
                 let services = Arc::new(EditorServiceBridge {
                     command_registry: command_registry.clone(),
                     dir_context,
                     theme_cache,
+                    plugin_fs,
                 });
                 match PluginThreadHandle::spawn(services) {
                     Ok(handle) => {
                         return Self {
                             inner: Some(handle),
+                            active_fs: Some(active_fs),
                             pending_injected_commands: Vec::new(),
                         }
                     }
@@ -72,6 +86,7 @@ impl PluginManager {
             }
             Self {
                 inner: None,
+                active_fs: None,
                 pending_injected_commands: Vec::new(),
             }
         }
@@ -81,6 +96,7 @@ impl PluginManager {
             let _ = command_registry; // Suppress unused warning
             let _ = dir_context; // Suppress unused warning
             let _ = theme_cache; // Suppress unused warning
+            let _ = local_filesystem; // Suppress unused warning
             if enable {
                 tracing::warn!("Plugins requested but compiled without plugin support");
             }
@@ -89,6 +105,16 @@ impl PluginManager {
                 pending_injected_commands: Vec::new(),
             }
         }
+    }
+
+    /// Live handle to the filesystem plugins use, if plugins are active.
+    ///
+    /// The editor calls [`ActiveFilesystem::set`](super::bridge::ActiveFilesystem::set)
+    /// on it whenever the active window changes so plugin file I/O follows the
+    /// focused session's authority (local or remote).
+    #[cfg(feature = "plugins")]
+    pub fn active_filesystem(&self) -> Option<Arc<super::bridge::ActiveFilesystem>> {
+        self.active_fs.clone()
     }
 
     /// Inject a [`PluginCommand`](super::api::PluginCommand) into the

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -1252,6 +1252,7 @@ impl Editor {
             dir_context.clone(),
             Arc::clone(&theme_cache),
             Arc::clone(&filesystem),
+            Arc::clone(&filesystem),
         );
 
         // Update the plugin state snapshot with working_dir BEFORE loading plugins

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -1251,6 +1251,7 @@ impl Editor {
             Arc::clone(&command_registry),
             dir_context.clone(),
             Arc::clone(&theme_cache),
+            Arc::clone(&filesystem),
         );
 
         // Update the plugin state snapshot with working_dir BEFORE loading plugins

--- a/crates/fresh-plugin-runtime/Cargo.toml
+++ b/crates/fresh-plugin-runtime/Cargo.toml
@@ -27,7 +27,6 @@ oxc_parser.workspace = true
 oxc_codegen.workspace = true
 oxc_span.workspace = true
 oxc_diagnostics.workspace = true
-trash = "5.2.5"
 
 # rquickjs-sys has no pre-generated bindings for FreeBSD
 [target.'cfg(target_os = "freebsd")'.dependencies]

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -2345,7 +2345,7 @@ impl JsEditorApi {
     /// or the local host for a `LocalPath`).
     pub fn file_exists(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> bool {
         self.fs_for(&path).exists(Path::new(path.as_str()))
@@ -2354,7 +2354,7 @@ impl JsEditorApi {
     /// Read file contents from the path's filesystem.
     pub fn read_file(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> Option<String> {
         self.fs_for(&path)
@@ -2366,7 +2366,7 @@ impl JsEditorApi {
     /// created as needed.
     pub fn write_file(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
         content: String,
     ) -> bool {
@@ -2379,7 +2379,7 @@ impl JsEditorApi {
     pub fn read_dir<'js>(
         &self,
         ctx: rquickjs::Ctx<'js>,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> rquickjs::Result<Value<'js>> {
         let entries = self.fs_for(&path).read_dir(Path::new(path.as_str()));
@@ -2392,7 +2392,7 @@ impl JsEditorApi {
     /// exists.
     pub fn create_dir(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> bool {
         self.fs_for(&path).create_dir_all(Path::new(path.as_str()))
@@ -2403,7 +2403,7 @@ impl JsEditorApi {
     /// temp directory or the Fresh config directory. Returns true on success.
     pub fn remove_path(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> bool {
         let fs = self.fs_for(&path);
@@ -2449,9 +2449,10 @@ impl JsEditorApi {
     /// filesystem (a cross-backend move is rejected). Returns true on success.
     pub fn rename_path(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         from: fresh_core::api::PluginPath,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")] to: fresh_core::api::PluginPath,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
+        to: fresh_core::api::PluginPath,
     ) -> bool {
         if !Self::same_backend(&from, &to) {
             return false;
@@ -2464,9 +2465,10 @@ impl JsEditorApi {
     /// target the same filesystem. Returns true on success.
     pub fn copy_path(
         &self,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         from: fresh_core::api::PluginPath,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")] to: fresh_core::api::PluginPath,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
+        to: fresh_core::api::PluginPath,
     ) -> bool {
         if !Self::same_backend(&from, &to) {
             return false;
@@ -2519,6 +2521,31 @@ impl JsEditorApi {
             &WindowPathJs {
                 kind: "authority",
                 window: window_id,
+                value: &path,
+            },
+        )
+        .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
+    }
+
+    /// Construct an `AuthorityPath` — the active window's authority filesystem,
+    /// stated explicitly. Routes identically to passing a bare string, but is
+    /// self-documenting: bundled plugins use it so bare strings are reserved as
+    /// the backward-compatible default for external plugins.
+    #[plugin_api(ts_return = "AuthorityPath")]
+    pub fn authority_path<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        path: String,
+    ) -> rquickjs::Result<Value<'js>> {
+        #[derive(serde::Serialize)]
+        struct AuthorityPathJs<'a> {
+            kind: &'static str,
+            value: &'a str,
+        }
+        rquickjs_serde::to_value(
+            ctx,
+            &AuthorityPathJs {
+                kind: "authority",
                 value: &path,
             },
         )
@@ -3320,7 +3347,7 @@ impl JsEditorApi {
     pub fn file_stat<'js>(
         &self,
         ctx: rquickjs::Ctx<'js>,
-        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath | AuthorityPath")]
         path: fresh_core::api::PluginPath,
     ) -> rquickjs::Result<Value<'js>> {
         let stat = self.fs_for(&path).stat(Path::new(path.as_str())).map(|s| {

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -115,23 +115,6 @@ use std::sync::{mpsc, Arc, RwLock};
 type PluginApiExports =
     Rc<RefCell<HashMap<String, (String, rquickjs::Persistent<rquickjs::Object<'static>>)>>>;
 
-/// Recursively copy a directory and all its contents.
-fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        if file_type.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            std::fs::copy(&src_path, &dst_path)?;
-        }
-    }
-    Ok(())
-}
-
 /// Convert a QuickJS Value to serde_json::Value
 #[allow(clippy::only_used_in_recursion)]
 fn js_to_json(ctx: &rquickjs::Ctx<'_>, val: Value<'_>) -> serde_json::Value {
@@ -2331,25 +2314,25 @@ impl JsEditorApi {
 
     // === File System ===
 
-    /// Check if file exists
+    /// Check if file exists (via the active window's authority filesystem).
     pub fn file_exists(&self, path: String) -> bool {
-        Path::new(&path).exists()
+        self.services.filesystem().exists(Path::new(&path))
     }
 
-    /// Read file contents
+    /// Read file contents (via the active window's authority filesystem).
     pub fn read_file(&self, path: String) -> Option<String> {
-        std::fs::read_to_string(&path).ok()
+        self.services
+            .filesystem()
+            .read_file(Path::new(&path))
+            .and_then(|bytes| String::from_utf8(bytes).ok())
     }
 
-    /// Write file contents
+    /// Write file contents (via the active window's authority filesystem).
+    /// Parent directories are created as needed.
     pub fn write_file(&self, path: String, content: String) -> bool {
-        let p = Path::new(&path);
-        if let Some(parent) = p.parent() {
-            if !parent.exists() && std::fs::create_dir_all(parent).is_err() {
-                return false;
-            }
-        }
-        std::fs::write(p, content).is_ok()
+        self.services
+            .filesystem()
+            .write_file(Path::new(&path), content.as_bytes())
     }
 
     /// Read directory contents (returns array of {name, is_file, is_dir})
@@ -2359,78 +2342,37 @@ impl JsEditorApi {
         ctx: rquickjs::Ctx<'js>,
         path: String,
     ) -> rquickjs::Result<Value<'js>> {
-        use fresh_core::api::DirEntry;
-
-        let entries: Vec<DirEntry> = match std::fs::read_dir(&path) {
-            Ok(entries) => entries
-                .filter_map(|e| e.ok())
-                .map(|entry| {
-                    let file_type = entry.file_type().ok();
-                    let is_symlink = file_type
-                        .as_ref()
-                        .map(|ft| ft.is_symlink())
-                        .unwrap_or(false);
-                    let (is_file, is_dir) = if is_symlink {
-                        let meta = std::fs::metadata(entry.path());
-                        (
-                            meta.as_ref().map(|m| m.is_file()).unwrap_or(false),
-                            meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
-                        )
-                    } else {
-                        (
-                            file_type.as_ref().map(|ft| ft.is_file()).unwrap_or(false),
-                            file_type.as_ref().map(|ft| ft.is_dir()).unwrap_or(false),
-                        )
-                    };
-                    DirEntry {
-                        name: entry.file_name().to_string_lossy().to_string(),
-                        is_file,
-                        is_dir,
-                    }
-                })
-                .collect(),
-            Err(e) => {
-                tracing::warn!("readDir failed for '{}': {}", path, e);
-                Vec::new()
-            }
-        };
-
+        let entries = self.services.filesystem().read_dir(Path::new(&path));
         rquickjs_serde::to_value(ctx, &entries)
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
-    /// Create a directory (and all parent directories) recursively.
-    /// Returns true if the directory was created or already exists.
+    /// Create a directory (and all parent directories) recursively, via the
+    /// active window's authority filesystem. Returns true if the directory was
+    /// created or already exists.
     pub fn create_dir(&self, path: String) -> bool {
-        let p = Path::new(&path);
-        if p.is_dir() {
-            return true;
-        }
-        std::fs::create_dir_all(p).is_ok()
+        self.services.filesystem().create_dir_all(Path::new(&path))
     }
 
-    /// Remove a file or directory by moving it to the OS trash/recycle bin.
-    /// For safety, the path must be under the OS temp directory or the Fresh
-    /// config directory. Returns true on success.
+    /// Permanently remove a file or directory via the active window's authority
+    /// filesystem (recursively for directories). For safety, the path must be
+    /// under the OS temp directory or the Fresh config directory. Returns true
+    /// on success.
     pub fn remove_path(&self, path: String) -> bool {
-        let target = match Path::new(&path).canonicalize() {
-            Ok(p) => p,
-            Err(_) => return false, // path doesn't exist or can't be resolved
+        let fs = self.services.filesystem();
+        let target = match fs.canonicalize(Path::new(&path)) {
+            Some(p) => p,
+            None => return false, // path doesn't exist or can't be resolved
         };
 
-        // Canonicalize allowed roots too, so that path prefix comparisons are
-        // consistent.  On Windows, `Path::canonicalize` returns extended-length
-        // UNC paths (e.g. `\\?\C:\...`) while `std::env::temp_dir()` and the
-        // config dir may use regular paths.  Without canonicalizing the roots
-        // the `starts_with` check would always fail on Windows.
-        let temp_dir = std::env::temp_dir()
-            .canonicalize()
-            .unwrap_or_else(|_| std::env::temp_dir());
-        let config_dir = self
-            .services
-            .config_dir()
-            .canonicalize()
-            .unwrap_or_else(|_| self.services.config_dir());
+        // Canonicalize allowed roots through the same backend so path prefix
+        // comparisons are consistent (e.g. Windows extended-length paths).
+        let temp_dir = fs
+            .canonicalize(&std::env::temp_dir())
+            .unwrap_or_else(std::env::temp_dir);
+        let config_dir = fs
+            .canonicalize(&self.services.config_dir())
+            .unwrap_or_else(|| self.services.config_dir());
 
         // Verify the path is under an allowed root (temp or config dir)
         let allowed = target.starts_with(&temp_dir) || target.starts_with(&config_dir);
@@ -2453,51 +2395,23 @@ impl JsEditorApi {
             return false;
         }
 
-        match trash::delete(&target) {
-            Ok(()) => true,
-            Err(e) => {
-                tracing::warn!("removePath trash failed for {:?}: {}", target, e);
-                false
-            }
-        }
+        fs.remove_path(&target)
     }
 
-    /// Rename/move a file or directory. Returns true on success.
-    /// Falls back to copy then trash for cross-filesystem moves.
+    /// Rename/move a file or directory via the active window's authority
+    /// filesystem. Returns true on success.
     pub fn rename_path(&self, from: String, to: String) -> bool {
-        // Try direct rename first (works for same-filesystem moves)
-        if std::fs::rename(&from, &to).is_ok() {
-            return true;
-        }
-        // Cross-filesystem fallback: copy then trash the original
-        let from_path = Path::new(&from);
-        let copied = if from_path.is_dir() {
-            copy_dir_recursive(from_path, Path::new(&to)).is_ok()
-        } else {
-            std::fs::copy(&from, &to).is_ok()
-        };
-        if copied {
-            return trash::delete(from_path).is_ok();
-        }
-        false
+        self.services
+            .filesystem()
+            .rename(Path::new(&from), Path::new(&to))
     }
 
-    /// Copy a file or directory recursively to a new location.
-    /// Returns true on success.
+    /// Copy a file or directory recursively to a new location via the active
+    /// window's authority filesystem. Returns true on success.
     pub fn copy_path(&self, from: String, to: String) -> bool {
-        let from_path = Path::new(&from);
-        let to_path = Path::new(&to);
-        if from_path.is_dir() {
-            copy_dir_recursive(from_path, to_path).is_ok()
-        } else {
-            // Ensure parent directory exists
-            if let Some(parent) = to_path.parent() {
-                if !parent.exists() && std::fs::create_dir_all(parent).is_err() {
-                    return false;
-                }
-            }
-            std::fs::copy(from_path, to_path).is_ok()
-        }
+        self.services
+            .filesystem()
+            .copy(Path::new(&from), Path::new(&to))
     }
 
     /// Get the OS temporary directory path.
@@ -3297,13 +3211,12 @@ impl JsEditorApi {
         ctx: rquickjs::Ctx<'js>,
         path: String,
     ) -> rquickjs::Result<Value<'js>> {
-        let metadata = std::fs::metadata(&path).ok();
-        let stat = metadata.map(|m| {
+        let stat = self.services.filesystem().stat(Path::new(&path)).map(|s| {
             serde_json::json!({
-                "isFile": m.is_file(),
-                "isDir": m.is_dir(),
-                "size": m.len(),
-                "readonly": m.permissions().readonly(),
+                "isFile": s.is_file,
+                "isDir": s.is_dir,
+                "size": s.size,
+                "readonly": s.readonly,
             })
         });
         rquickjs_serde::to_value(ctx, &stat)
@@ -8392,19 +8305,103 @@ mod tests {
 
     struct TestServiceBridge {
         en_strings: std::sync::Mutex<HashMap<String, String>>,
+        fs: Arc<dyn fresh_core::services::PluginFilesystem>,
     }
 
     impl TestServiceBridge {
         fn new() -> Self {
             Self {
                 en_strings: std::sync::Mutex::new(HashMap::new()),
+                fs: Arc::new(StdTestFilesystem),
             }
+        }
+
+        /// Build a bridge whose plugin filesystem is `fs`, to assert that the
+        /// file-I/O plugin APIs route through the bridge rather than `std::fs`.
+        fn with_fs(fs: Arc<dyn fresh_core::services::PluginFilesystem>) -> Self {
+            Self {
+                en_strings: std::sync::Mutex::new(HashMap::new()),
+                fs,
+            }
+        }
+    }
+
+    /// A `std::fs`-backed [`PluginFilesystem`](fresh_core::services::PluginFilesystem)
+    /// used only by these unit tests. It stands in for the editor's authority
+    /// filesystem so the file-I/O plugin APIs can be exercised against real
+    /// temp paths without an `Editor`.
+    struct StdTestFilesystem;
+
+    impl fresh_core::services::PluginFilesystem for StdTestFilesystem {
+        fn read_file(&self, path: &Path) -> Option<Vec<u8>> {
+            std::fs::read(path).ok()
+        }
+        fn write_file(&self, path: &Path, contents: &[u8]) -> bool {
+            if let Some(parent) = path.parent() {
+                if !parent.as_os_str().is_empty()
+                    && !parent.exists()
+                    && std::fs::create_dir_all(parent).is_err()
+                {
+                    return false;
+                }
+            }
+            std::fs::write(path, contents).is_ok()
+        }
+        fn exists(&self, path: &Path) -> bool {
+            path.exists()
+        }
+        fn read_dir(&self, path: &Path) -> Vec<fresh_core::api::DirEntry> {
+            match std::fs::read_dir(path) {
+                Ok(entries) => entries
+                    .filter_map(|e| e.ok())
+                    .map(|entry| {
+                        let meta = entry.metadata().ok();
+                        fresh_core::api::DirEntry {
+                            name: entry.file_name().to_string_lossy().to_string(),
+                            is_file: meta.as_ref().map(|m| m.is_file()).unwrap_or(false),
+                            is_dir: meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
+                        }
+                    })
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
+        }
+        fn create_dir_all(&self, path: &Path) -> bool {
+            path.is_dir() || std::fs::create_dir_all(path).is_ok()
+        }
+        fn remove_path(&self, path: &Path) -> bool {
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).is_ok()
+            } else {
+                std::fs::remove_file(path).is_ok()
+            }
+        }
+        fn rename(&self, from: &Path, to: &Path) -> bool {
+            std::fs::rename(from, to).is_ok()
+        }
+        fn copy(&self, from: &Path, to: &Path) -> bool {
+            !from.is_dir() && std::fs::copy(from, to).is_ok()
+        }
+        fn stat(&self, path: &Path) -> Option<fresh_core::services::PluginFileStat> {
+            let m = std::fs::metadata(path).ok()?;
+            Some(fresh_core::services::PluginFileStat {
+                is_file: m.is_file(),
+                is_dir: m.is_dir(),
+                size: m.len(),
+                readonly: m.permissions().readonly(),
+            })
+        }
+        fn canonicalize(&self, path: &Path) -> Option<PathBuf> {
+            std::fs::canonicalize(path).ok()
         }
     }
 
     impl fresh_core::services::PluginServiceBridge for TestServiceBridge {
         fn as_any(&self) -> &dyn std::any::Any {
             self
+        }
+        fn filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+            Arc::clone(&self.fs)
         }
         fn translate(
             &self,
@@ -10235,6 +10232,9 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
+        fn filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+            self.inner.filesystem()
+        }
         fn translate(
             &self,
             plugin_name: &str,
@@ -10901,6 +10901,83 @@ mod tests {
     }
 
     // ==================== Read Dir Test ====================
+
+    /// The file-I/O plugin APIs must route through the service bridge's
+    /// filesystem (the active window's authority), never `std::fs` directly.
+    /// A sentinel filesystem returns data for paths that do not exist on disk;
+    /// if the backend still touched `std::fs` these reads would come back empty.
+    #[test]
+    fn fs_apis_route_through_bridge_filesystem() {
+        struct SentinelFs;
+        impl fresh_core::services::PluginFilesystem for SentinelFs {
+            fn read_file(&self, _path: &Path) -> Option<Vec<u8>> {
+                Some(b"SENTINEL".to_vec())
+            }
+            fn write_file(&self, _path: &Path, _contents: &[u8]) -> bool {
+                true
+            }
+            fn exists(&self, _path: &Path) -> bool {
+                true
+            }
+            fn read_dir(&self, _path: &Path) -> Vec<fresh_core::api::DirEntry> {
+                vec![fresh_core::api::DirEntry {
+                    name: "only.txt".to_string(),
+                    is_file: true,
+                    is_dir: false,
+                }]
+            }
+            fn create_dir_all(&self, _path: &Path) -> bool {
+                true
+            }
+            fn remove_path(&self, _path: &Path) -> bool {
+                true
+            }
+            fn rename(&self, _from: &Path, _to: &Path) -> bool {
+                true
+            }
+            fn copy(&self, _from: &Path, _to: &Path) -> bool {
+                true
+            }
+            fn stat(&self, _path: &Path) -> Option<fresh_core::services::PluginFileStat> {
+                None
+            }
+            fn canonicalize(&self, _path: &Path) -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let (tx, _rx) = mpsc::channel();
+        let state_snapshot = Arc::new(RwLock::new(EditorStateSnapshot::new()));
+        let services = Arc::new(TestServiceBridge::with_fs(Arc::new(SentinelFs)));
+        let mut backend = QuickJsBackend::with_state(state_snapshot, tx, services).unwrap();
+
+        backend
+            .execute_js(
+                r#"
+            const editor = getEditor();
+            // A path that does not exist on the real disk — the sentinel
+            // filesystem still returns content, proving the read is routed.
+            globalThis._read = editor.readFile("/definitely/not/on/disk/xyz");
+            globalThis._exists = editor.fileExists("/definitely/not/on/disk/xyz");
+            globalThis._entries = editor.readDir("/whatever").map(e => e.name).join(",");
+        "#,
+                "test.js",
+            )
+            .unwrap();
+
+        backend
+            .plugin_contexts
+            .borrow()
+            .get("test")
+            .unwrap()
+            .clone()
+            .with(|ctx| {
+                let global = ctx.globals();
+                assert_eq!(global.get::<_, String>("_read").unwrap(), "SENTINEL");
+                assert!(global.get::<_, bool>("_exists").unwrap());
+                assert_eq!(global.get::<_, String>("_entries").unwrap(), "only.txt");
+            });
+    }
 
     #[test]
     fn test_api_read_dir() {

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -994,6 +994,33 @@ fn check_range<'js>(
 // Internal helpers used by the macro-processed `impl JsEditorApi` below.
 // Kept in a plain impl block so they don't get exported as JS methods.
 impl JsEditorApi {
+    /// The filesystem a plugin path resolves against: the local editor host for
+    /// a `LocalPath`, or a window's authority (a specific window, or the active
+    /// one for a bare string) otherwise.
+    fn fs_for(
+        &self,
+        path: &fresh_core::api::PluginPath,
+    ) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+        match path {
+            fresh_core::api::PluginPath::Local(_) => self.services.local_filesystem(),
+            fresh_core::api::PluginPath::Authority { window, .. } => {
+                self.services.authority_filesystem(*window)
+            }
+        }
+    }
+
+    /// Whether two plugin paths resolve to the same filesystem backend (so a
+    /// two-path op like rename/copy is well-defined). Cross-backend moves are
+    /// rejected rather than silently operating on one side.
+    fn same_backend(a: &fresh_core::api::PluginPath, b: &fresh_core::api::PluginPath) -> bool {
+        use fresh_core::api::PluginPath::{Authority, Local};
+        match (a, b) {
+            (Local(_), Local(_)) => true,
+            (Authority { window: wa, .. }, Authority { window: wb, .. }) => wa == wb,
+            _ => false,
+        }
+    }
+
     /// Send an AddPluginConfigField command to the host.
     fn send_field_registration(&self, field_name: &str, field_schema: serde_json::Value) {
         let _ = self
@@ -2314,25 +2341,37 @@ impl JsEditorApi {
 
     // === File System ===
 
-    /// Check if file exists (via the active window's authority filesystem).
-    pub fn file_exists(&self, path: String) -> bool {
-        self.services.filesystem().exists(Path::new(&path))
+    /// Check if a file exists on the path's filesystem (a window's authority,
+    /// or the local host for a `LocalPath`).
+    pub fn file_exists(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
+    ) -> bool {
+        self.fs_for(&path).exists(Path::new(path.as_str()))
     }
 
-    /// Read file contents (via the active window's authority filesystem).
-    pub fn read_file(&self, path: String) -> Option<String> {
-        self.services
-            .filesystem()
-            .read_file(Path::new(&path))
+    /// Read file contents from the path's filesystem.
+    pub fn read_file(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
+    ) -> Option<String> {
+        self.fs_for(&path)
+            .read_file(Path::new(path.as_str()))
             .and_then(|bytes| String::from_utf8(bytes).ok())
     }
 
-    /// Write file contents (via the active window's authority filesystem).
-    /// Parent directories are created as needed.
-    pub fn write_file(&self, path: String, content: String) -> bool {
-        self.services
-            .filesystem()
-            .write_file(Path::new(&path), content.as_bytes())
+    /// Write file contents to the path's filesystem. Parent directories are
+    /// created as needed.
+    pub fn write_file(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
+        content: String,
+    ) -> bool {
+        self.fs_for(&path)
+            .write_file(Path::new(path.as_str()), content.as_bytes())
     }
 
     /// Read directory contents (returns array of {name, is_file, is_dir})
@@ -2340,27 +2379,35 @@ impl JsEditorApi {
     pub fn read_dir<'js>(
         &self,
         ctx: rquickjs::Ctx<'js>,
-        path: String,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
     ) -> rquickjs::Result<Value<'js>> {
-        let entries = self.services.filesystem().read_dir(Path::new(&path));
+        let entries = self.fs_for(&path).read_dir(Path::new(path.as_str()));
         rquickjs_serde::to_value(ctx, &entries)
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
-    /// Create a directory (and all parent directories) recursively, via the
-    /// active window's authority filesystem. Returns true if the directory was
-    /// created or already exists.
-    pub fn create_dir(&self, path: String) -> bool {
-        self.services.filesystem().create_dir_all(Path::new(&path))
+    /// Create a directory (and all parent directories) recursively on the
+    /// path's filesystem. Returns true if the directory was created or already
+    /// exists.
+    pub fn create_dir(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
+    ) -> bool {
+        self.fs_for(&path).create_dir_all(Path::new(path.as_str()))
     }
 
-    /// Permanently remove a file or directory via the active window's authority
-    /// filesystem (recursively for directories). For safety, the path must be
-    /// under the OS temp directory or the Fresh config directory. Returns true
-    /// on success.
-    pub fn remove_path(&self, path: String) -> bool {
-        let fs = self.services.filesystem();
-        let target = match fs.canonicalize(Path::new(&path)) {
+    /// Permanently remove a file or directory on the path's filesystem
+    /// (recursively for directories). For safety, the path must be under the OS
+    /// temp directory or the Fresh config directory. Returns true on success.
+    pub fn remove_path(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
+    ) -> bool {
+        let fs = self.fs_for(&path);
+        let target = match fs.canonicalize(Path::new(path.as_str())) {
             Some(p) => p,
             None => return false, // path doesn't exist or can't be resolved
         };
@@ -2398,20 +2445,84 @@ impl JsEditorApi {
         fs.remove_path(&target)
     }
 
-    /// Rename/move a file or directory via the active window's authority
-    /// filesystem. Returns true on success.
-    pub fn rename_path(&self, from: String, to: String) -> bool {
-        self.services
-            .filesystem()
-            .rename(Path::new(&from), Path::new(&to))
+    /// Rename/move a file or directory. Both paths must target the same
+    /// filesystem (a cross-backend move is rejected). Returns true on success.
+    pub fn rename_path(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        from: fresh_core::api::PluginPath,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")] to: fresh_core::api::PluginPath,
+    ) -> bool {
+        if !Self::same_backend(&from, &to) {
+            return false;
+        }
+        self.fs_for(&from)
+            .rename(Path::new(from.as_str()), Path::new(to.as_str()))
     }
 
-    /// Copy a file or directory recursively to a new location via the active
-    /// window's authority filesystem. Returns true on success.
-    pub fn copy_path(&self, from: String, to: String) -> bool {
-        self.services
-            .filesystem()
-            .copy(Path::new(&from), Path::new(&to))
+    /// Copy a file or directory recursively to a new location. Both paths must
+    /// target the same filesystem. Returns true on success.
+    pub fn copy_path(
+        &self,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        from: fresh_core::api::PluginPath,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")] to: fresh_core::api::PluginPath,
+    ) -> bool {
+        if !Self::same_backend(&from, &to) {
+            return false;
+        }
+        self.fs_for(&from)
+            .copy(Path::new(from.as_str()), Path::new(to.as_str()))
+    }
+
+    /// Construct a `LocalPath` — a path that always resolves on the local
+    /// editor host, regardless of the active window's authority. Use for
+    /// editor-owned state under the config/data dirs.
+    #[plugin_api(ts_return = "LocalPath")]
+    pub fn local_path<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        path: String,
+    ) -> rquickjs::Result<Value<'js>> {
+        #[derive(serde::Serialize)]
+        struct LocalPathJs<'a> {
+            kind: &'static str,
+            value: &'a str,
+        }
+        rquickjs_serde::to_value(
+            ctx,
+            &LocalPathJs {
+                kind: "local",
+                value: &path,
+            },
+        )
+        .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
+    }
+
+    /// Construct a `WindowPath` — a path that resolves on a specific window's
+    /// authority filesystem, regardless of which window is focused.
+    #[plugin_api(ts_return = "WindowPath")]
+    pub fn window_path<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        window_id: u64,
+        path: String,
+    ) -> rquickjs::Result<Value<'js>> {
+        #[derive(serde::Serialize)]
+        struct WindowPathJs<'a> {
+            kind: &'static str,
+            window: u64,
+            value: &'a str,
+        }
+        rquickjs_serde::to_value(
+            ctx,
+            &WindowPathJs {
+                kind: "authority",
+                window: window_id,
+                value: &path,
+            },
+        )
+        .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
     /// Get the OS temporary directory path.
@@ -3209,9 +3320,10 @@ impl JsEditorApi {
     pub fn file_stat<'js>(
         &self,
         ctx: rquickjs::Ctx<'js>,
-        path: String,
+        #[plugin_api(ts_type = "string | LocalPath | WindowPath")]
+        path: fresh_core::api::PluginPath,
     ) -> rquickjs::Result<Value<'js>> {
-        let stat = self.services.filesystem().stat(Path::new(&path)).map(|s| {
+        let stat = self.fs_for(&path).stat(Path::new(path.as_str())).map(|s| {
             serde_json::json!({
                 "isFile": s.is_file,
                 "isDir": s.is_dir,
@@ -8400,8 +8512,14 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
-        fn filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+        fn authority_filesystem(
+            &self,
+            _window: Option<u64>,
+        ) -> Arc<dyn fresh_core::services::PluginFilesystem> {
             Arc::clone(&self.fs)
+        }
+        fn local_filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+            Arc::new(StdTestFilesystem)
         }
         fn translate(
             &self,
@@ -10232,8 +10350,14 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
-        fn filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
-            self.inner.filesystem()
+        fn authority_filesystem(
+            &self,
+            window: Option<u64>,
+        ) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+            self.inner.authority_filesystem(window)
+        }
+        fn local_filesystem(&self) -> Arc<dyn fresh_core::services::PluginFilesystem> {
+            self.inner.local_filesystem()
         }
         fn translate(
             &self,
@@ -10948,22 +11072,34 @@ mod tests {
 
         let (tx, _rx) = mpsc::channel();
         let state_snapshot = Arc::new(RwLock::new(EditorStateSnapshot::new()));
+        // Authority = sentinel (returns data for any path); local = real disk.
         let services = Arc::new(TestServiceBridge::with_fs(Arc::new(SentinelFs)));
         let mut backend = QuickJsBackend::with_state(state_snapshot, tx, services).unwrap();
 
-        backend
-            .execute_js(
-                r#"
+        // A real file on the local host, for the LocalPath route to read back.
+        let local_file =
+            std::env::temp_dir().join(format!("fresh_ptp_route_{}.txt", std::process::id()));
+        std::fs::write(&local_file, b"LOCALDATA").unwrap();
+        let local_file_js = local_file.to_string_lossy().replace('\\', "\\\\");
+
+        let js = format!(
+            r#"
             const editor = getEditor();
-            // A path that does not exist on the real disk — the sentinel
-            // filesystem still returns content, proving the read is routed.
-            globalThis._read = editor.readFile("/definitely/not/on/disk/xyz");
-            globalThis._exists = editor.fileExists("/definitely/not/on/disk/xyz");
+            // Bare string → active-window authority (the sentinel), even for a
+            // path that doesn't exist on disk — proving reads route through the
+            // bridge, never std::fs.
+            globalThis._authRead = editor.readFile("/definitely/not/on/disk/xyz");
+            globalThis._authExists = editor.fileExists("/definitely/not/on/disk/xyz");
             globalThis._entries = editor.readDir("/whatever").map(e => e.name).join(",");
+            // windowPath(id, ...) → that window's authority (still the sentinel).
+            globalThis._winRead = editor.readFile(editor.windowPath(7, "/definitely/not/on/disk/xyz"));
+            // localPath(...) → the local host, reading the real temp file.
+            globalThis._localRead = editor.readFile(editor.localPath("{local}"));
         "#,
-                "test.js",
-            )
-            .unwrap();
+            local = local_file_js,
+        );
+
+        backend.execute_js(&js, "test.js").unwrap();
 
         backend
             .plugin_contexts
@@ -10973,10 +11109,16 @@ mod tests {
             .clone()
             .with(|ctx| {
                 let global = ctx.globals();
-                assert_eq!(global.get::<_, String>("_read").unwrap(), "SENTINEL");
-                assert!(global.get::<_, bool>("_exists").unwrap());
+                // String and WindowPath both hit the authority (sentinel).
+                assert_eq!(global.get::<_, String>("_authRead").unwrap(), "SENTINEL");
+                assert!(global.get::<_, bool>("_authExists").unwrap());
                 assert_eq!(global.get::<_, String>("_entries").unwrap(), "only.txt");
+                assert_eq!(global.get::<_, String>("_winRead").unwrap(), "SENTINEL");
+                // LocalPath hits the local host and reads the real file.
+                assert_eq!(global.get::<_, String>("_localRead").unwrap(), "LOCALDATA");
             });
+
+        std::fs::remove_file(&local_file).ok();
     }
 
     #[test]

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -192,6 +192,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         // `editor.localPath` / `editor.windowPath`.
         "LocalPath" => Some(LOCAL_PATH_DECL.to_string()),
         "WindowPath" => Some(WINDOW_PATH_DECL.to_string()),
+        "AuthorityPath" => Some(AUTHORITY_PATH_DECL.to_string()),
 
         _ => None,
     }
@@ -205,6 +206,10 @@ const LOCAL_PATH_DECL: &str = r#"type LocalPath = { kind: "local"; value: string
 /// `editor.windowPath(windowId, ...)`.
 const WINDOW_PATH_DECL: &str =
     r#"type WindowPath = { kind: "authority"; window: number; value: string };"#;
+
+/// A path that resolves on the active window's authority filesystem, stated
+/// explicitly. Built via `editor.authorityPath(...)`.
+const AUTHORITY_PATH_DECL: &str = r#"type AuthorityPath = { kind: "authority"; value: string };"#;
 
 /// Hand-written declaration for `AuthorityPayload` and its helpers.
 /// See the doc comment on the match arm for why this isn't ts-rs.

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -184,9 +184,27 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         // and this crate must not depend on it. Keep in sync.
         "RemoteIndicatorStatePayload" => Some(REMOTE_INDICATOR_STATE_DECL.to_string()),
 
+        // Typed plugin paths. A bare `string` (an authority path on the active
+        // window) stays valid everywhere for backward compatibility; these two
+        // tag a path for a specific filesystem. Hand-written because the
+        // authoritative `PluginPath` enum is decoded in the backend, not
+        // ts-rs-derived. Keep in sync with `fresh_core::api::PluginPath` and
+        // `editor.localPath` / `editor.windowPath`.
+        "LocalPath" => Some(LOCAL_PATH_DECL.to_string()),
+        "WindowPath" => Some(WINDOW_PATH_DECL.to_string()),
+
         _ => None,
     }
 }
+
+/// A path that always resolves on the local editor host. Built via
+/// `editor.localPath(...)`.
+const LOCAL_PATH_DECL: &str = r#"type LocalPath = { kind: "local"; value: string };"#;
+
+/// A path that resolves on a specific window's authority filesystem. Built via
+/// `editor.windowPath(windowId, ...)`.
+const WINDOW_PATH_DECL: &str =
+    r#"type WindowPath = { kind: "authority"; window: number; value: string };"#;
 
 /// Hand-written declaration for `AuthorityPayload` and its helpers.
 /// See the doc comment on the match arm for why this isn't ts-rs.


### PR DESCRIPTION
## Problem

Plugin file I/O — `readFile`/`readDir`/`writeFile`/`fileExists`/`createDir`/`removePath`/`renamePath`/`copyPath`/`fileStat` — used direct `std::fs` in the QuickJS backend, which always targets the **editor host's local disk**. So:

1. On an SSH/container session, every file-touching plugin operated on the wrong machine instead of the remote workspace. ~20 bundled plugins use these APIs.
2. Each window owns its own authority (one can be local while another is remote), but a plugin path couldn't name a window — file I/O always hit "whatever's focused", so multi-session plugins (e.g. `orchestrator`) couldn't act on a specific window's filesystem.
3. Editor-owned state (the package manager's installs under the config dir, session caches, etc.) rode the active authority, so it hit the remote host during a remote session.

## Solution (three commits)

**1. Route plugin file I/O through the editor's `FileSystem` abstraction** (the same one core uses) instead of `std::fs`, so it follows a window's authority backend.

**2. Give plugin paths an explicit typed identity** — mirroring how the rest of the API is window-scoped by identity (a `bufferId` locates its window; a path's tag is the filesystem counterpart), à la VS Code's `Uri`. File APIs accept `string | LocalPath | WindowPath | AuthorityPath`:

| Argument | Resolves to |
|---|---|
| bare `string` | the **active window's** authority — *unchanged; the backward-compatible default for external plugins* |
| `editor.authorityPath(p)` | the active window's authority, **stated explicitly** |
| `editor.windowPath(id, p)` | a **specific window's** authority, focus-independent |
| `editor.localPath(p)` | the **local editor host**, always |

**3. Migrate every bundled plugin to explicit typed paths**, classified by where each path lives — so our plugins never rely on the bare-string default (that's reserved for external plugins), and editor-owned state stays on the host during remote sessions:
- **local** — `orchestrator` (its sessions/worktrees are host-managed; the remote authority is only for editor navigation/editing), `slang-lsp` (builtin-module cache), `git_log` (per-SHA diff cache), `audit_mode` (review store + temp patch), `k8s-workspace` (host-side provider template).
- **authority** — `merge_conflict`, `path_complete`, `find_references`, `live_diff`, `git_blame`, `csharp_support`, `clangd_support`, `asm-lsp`, `code-tour`, `env-manager`, `devcontainer`, `audit_mode` (reviewed files + in-project exports), and the `lib/*` helpers.

## Design

- **fresh-core**: `PluginFilesystem` trait (+ `PluginFileStat`) and a `PluginPath` type that decodes a JS argument as string / `LocalPath` / `WindowPath` / `AuthorityPath`. `PluginServiceBridge` exposes `filesystem()`, `local_filesystem()`, and per-window authority access — no `std::fs` default; a path routes to exactly one backend or fails, never a silent fallback.
- **fresh-editor**: a `WindowFsRegistry` maps each live window → its backend, rebuilt from the editor's windows on every plugin state-snapshot refresh (one choke point covering window create/close/focus). A path resolves against the correct window, or fails if it's gone. The local host filesystem is a fixed, separate handle.

## Testing

- Runtime test `fs_apis_route_through_bridge_filesystem`: a sentinel filesystem proves a bare string and a `windowPath` route to the authority while a `localPath` reads the real local file — the backend no longer touches `std::fs`.
- Backend `test_api_*` suite green (114); `fresh.d.ts` regenerated (`LocalPath`/`WindowPath`/`AuthorityPath` + `localPath`/`windowPath`/`authorityPath`); dts-validation tests pass; plugin `tsc` type-check clean.
- `cargo fmt`/`clippy` clean; `fresh-editor --all-targets` and the plugins-disabled build both compile.

## Behavior note

`removePath` is now a permanent delete via the target filesystem (previously OS-trash). The temp/config sandbox still bounds it; OS-trash has no meaning on a remote backend, so uniform permanent-delete stays predictable across local/remote.

Out of scope: `getCwd()`/`getTempDir()` still return the local host's paths (path getters, not FS ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XapqzEgRUvCaNAj21KdQLM