### PR TITLE
Common native infra for context menus and modal dialogs (+ terminal mouse-capture fix)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4430,6 +4430,18 @@ pub enum PluginCommand {
         /// false) so existing panels render unchanged.
         #[serde(default)]
         focus_marker: bool,
+        /// Native modal-frame title. When `Some`, a centered panel draws a
+        /// title bar into its top border (the declarative dialog's shell,
+        /// drawn by the host — not faked with a `labeledSection` inside the
+        /// spec). `None` (default) keeps the historical untitled frame.
+        #[serde(default)]
+        title: Option<String>,
+        /// Native modal-frame close button. When `true`, a centered panel
+        /// draws a `[×]` at the top-right of its border; clicking it
+        /// dismisses the panel exactly like Esc / Cancel. Default `false`
+        /// (no button) so existing panels render unchanged.
+        #[serde(default)]
+        closable: bool,
     },
 
     /// Replace the spec of the currently-mounted floating widget

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3508,7 +3508,7 @@ interface EditorAPI {
 	* Mount a declarative widget panel as a centered floating
 	* overlay (not bound to any virtual buffer).
 	*/
-	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number, asDock?: boolean, focusMarker?: boolean): boolean;
+	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number, asDock?: boolean, focusMarker?: boolean, title?: string, closable?: boolean): boolean;
 	/**
 	* Replace the spec of the currently-mounted floating widget panel.
 	*/

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -982,6 +982,16 @@ export class FloatingWidgetPanel {
        * control is legible from a plain terminal capture and the
        * layout stays constant as focus moves. Default false. */
       focusMarker?: boolean;
+      /** Native modal-frame title. When set, the host draws a title bar
+       * into the centered panel's top border (the dialog's *shell* —
+       * you no longer fake a title with a `labeledSection` border inside
+       * the spec). Ignored for `asDock`. Omitted → untitled frame. */
+      title?: string;
+      /** Native modal-frame close button. When true, the host draws a
+       * `[×]` at the centered panel's top-right; clicking it dismisses
+       * the panel exactly like Esc / Cancel (fires the panel's `cancel`
+       * `widget_event`). Ignored for `asDock`. Default false. */
+      closable?: boolean;
     } = {},
   ): boolean {
     // deno-lint-ignore no-explicit-any
@@ -996,6 +1006,8 @@ export class FloatingWidgetPanel {
       hp,
       options.asDock ?? false,
       options.focusMarker ?? false,
+      options.title ?? "",
+      options.closable ?? false,
     );
   }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4217,11 +4217,19 @@ function mountFolderDialog(): void {
     dockBlurred = true;
     editor.floatingPanelControl(openPanel.id(), "blur", 0);
   }
+  const renaming = createFolderDialog!.renameId !== null;
   createFolderPanel = new FloatingWidgetPanel();
   createFolderPanel.mount(buildCreateFolderSpec(), {
     widthPct: 50,
     heightPct: 42,
     focusMarker: true,
+    // The dialog's title + border are now native modal-frame chrome
+    // (drawn by the host around the WidgetSpec), and `closable` renders
+    // a native `[×]` that dismisses via the same cancel path as Esc.
+    title: renaming
+      ? editor.t("dock.rename_folder_dialog_title")
+      : editor.t("dock.new_folder_dialog_title"),
+    closable: true,
   });
   editor.floatingPanelControl(createFolderPanel.id(), "fullscreen", 1);
   editor.setEditorMode(CREATE_FOLDER_MODE);
@@ -4275,12 +4283,9 @@ function buildCreateFolderSpec(): WidgetSpec {
       ),
     ),
   );
-  return labeledSection({
-    label: renaming
-      ? editor.t("dock.rename_folder_dialog_title")
-      : editor.t("dock.new_folder_dialog_title"),
-    child: col(...children),
-  });
+  // The dialog's title + border come from the native modal-frame chrome
+  // (see `mountFolderDialog`), so the spec is just the content column.
+  return col(...children);
 }
 
 // Commit the dialog: create the folder and (when the checkbox is on)

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2829,15 +2829,12 @@ function buildOpenSpec(): WidgetSpec {
       }
     : null;
 
-  // Scope chrome. The title keeps the active project visible; the
-  // `Project:` control below is the clickable scope switch.
+  // Scope chrome. The `Project:` control below is the clickable scope
+  // switch; the current scope now reads off that button rather than a
+  // title suffix (the dialog title is native modal-frame chrome).
   const scope = openDialog.scope;
   const curKey = currentProjectKey();
-  const curName = projectLabel(curKey);
   const scopeKey = editor.getKeybindingLabel("orchestrator_toggle_scope", OPEN_MODE);
-  const titleSuffix = scope === "current"
-    ? editor.t("list.title_suffix_current", { project: curName })
-    : editor.t("list.title_suffix_all");
   const sectionLabel = editor.t("list.section_label");
   // `Project:` control — a visible, clickable scope switch with the
   // Alt+P hint baked into the button label. Shows the current
@@ -2899,21 +2896,9 @@ function buildOpenSpec(): WidgetSpec {
   );
 
   return col(
-    {
-      kind: "raw",
-      entries: [
-        styledRow([
-          {
-            text: editor.t("list.title"),
-            style: { fg: "ui.popup_border_fg", bold: true },
-          },
-          {
-            text: titleSuffix,
-            style: { fg: "ui.menu_disabled_fg" },
-          },
-        ]),
-      ],
-    },
+    // The "ORCHESTRATOR :: Workspaces" title is native modal-frame chrome
+    // now (set on the panel at mount — see `openControlRoom`), so the spec
+    // starts straight at the error banner / two-pane body.
     ...(errorBanner ? [errorBanner] : []),
     spacer(0),
     // Two-pane: sessions list | preview. Renderer's `row()`
@@ -3477,7 +3462,16 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     // 90% × 90% of the terminal — the open dialog wants room for
     // a real session list + preview pane, unlike the new-session
     // form which stays compact.
-    openPanel.mount(buildOpenSpec(), { widthPct: 90, heightPct: 90 });
+    openPanel.mount(buildOpenSpec(), {
+      widthPct: 90,
+      heightPct: 90,
+      // Native modal-frame chrome replaces the in-body "ORCHESTRATOR ::
+      // Workspaces" title row; `closable` renders a native `[×]` that
+      // dismisses via the same cancel path as Esc. Chrome is only drawn
+      // for Centered placement, so the dock mount above never gets it.
+      title: editor.t("list.title"),
+      closable: true,
+    });
     // The control room is a global orchestrator feature: render it over
     // the full screen (covering its own dimmed dock) rather than cramped
     // into the chrome area beside the dock. A no-op when no dock is up
@@ -6262,17 +6256,6 @@ async function nextAutoSessionName(
   return `${base}-${next}`;
 }
 
-// Three distinct styles for the header line: section keyword
-// ("ORCHESTRATOR"), structural separators ("::"), and step label. The
-// border-fg key picks up the same accent the floating panel border
-// uses, so the title visually anchors to the dialog chrome.
-const HEADER_KEYWORD_STYLE = {
-  fg: "ui.popup_border_fg",
-  bold: true,
-} as const;
-const HEADER_SEP_STYLE = { fg: "ui.menu_disabled_fg" } as const;
-const HEADER_LABEL_STYLE = { fg: "ui.menu_active_fg", bold: true } as const;
-
 // Subtitle splits the static prefix "Project:" from the project
 // path so each gets its own foreground — matching the three-tier
 // (label / label-value / input) palette the design calls for.
@@ -6672,21 +6655,9 @@ function buildConnectingView(): WidgetSpec {
 
   const remote = form.backend === "ssh" || form.backend === "kubernetes";
   return col(
-    row(
-      flexSpacer(),
-      {
-        kind: "raw",
-        entries: [
-          styledRow([
-            { text: editor.t("form.header_keyword"), style: HEADER_KEYWORD_STYLE },
-            { text: " :: ", style: HEADER_SEP_STYLE },
-            { text: editor.t("form.header_label"), style: HEADER_LABEL_STYLE },
-          ]),
-        ],
-      },
-      flexSpacer(),
-    ),
-    spacer(0),
+    // The "ORCHESTRATOR :: New Workspace" title is native modal-frame
+    // chrome now (set on the panel at mount time and kept across the
+    // connecting-state re-render), so no in-body banner is drawn here.
     ...rows,
     spacer(0),
     {
@@ -6719,22 +6690,9 @@ function buildFormSpec(): WidgetSpec {
   if (form.submitting) return buildConnectingView();
 
   const children: WidgetSpec[] = [
-    // === Header: centered title (no stale `Review Synthesized`). =
-    row(
-      flexSpacer(),
-      {
-        kind: "raw",
-        entries: [
-          styledRow([
-            { text: editor.t("form.header_keyword"), style: HEADER_KEYWORD_STYLE },
-            { text: " :: ", style: HEADER_SEP_STYLE },
-            { text: editor.t("form.header_label"), style: HEADER_LABEL_STYLE },
-          ]),
-        ],
-      },
-      flexSpacer(),
-    ),
-    spacer(0),
+    // The title ("ORCHESTRATOR :: New Workspace") + border are now
+    // native modal-frame chrome drawn by the host (see `openForm`), so
+    // the spec starts straight at the "Run in:" session-type tabs.
     // === "Run in:" session-type tabs. ============================
     backendTabsRow(),
     spacer(0),
@@ -6913,6 +6871,12 @@ function openForm(options?: { fromPicker?: boolean }): void {
     // a plain terminal capture (driveable by automation) and the
     // layout stays constant as Tab moves focus between controls.
     focusMarker: true,
+    // The dialog's title + border are now native modal-frame chrome
+    // (drawn by the host around the WidgetSpec) rather than the in-body
+    // "ORCHESTRATOR :: New Workspace" banner, and `closable` renders a
+    // native `[×]` that dismisses via the same cancel path as Esc.
+    title: `${editor.t("form.header_keyword")} :: ${editor.t("form.header_label")}`,
+    closable: true,
   });
   // The New-Session form is a global orchestrator feature too: center it
   // over the full screen (covering its own dimmed dock) rather than in the
@@ -9222,11 +9186,18 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "cancel") {
-      // Esc unmounted the picker panel — sync our own state. If the
-      // picker was floated over a live dock, hand control back to the
-      // dock (still mounted in its own slot) rather than dropping to the
-      // bare editor.
+      // Esc / native `[×]` unmounted the picker panel — sync our own
+      // state. This teardown is for the centered MODAL picker only: the
+      // dock (LeftDock placement) never fires `cancel` (its Esc blurs to
+      // the editor, host-side), and the modal always runs with
+      // `dockMode === false` — even when floated over a live dock, where
+      // the dock is parked in `dockPanel`. Guard on `dockMode` so a stray
+      // cancel can never tear the dock down.
+      if (dockMode) return;
       openPanel = null;
+      // If the picker was floated over a live dock, hand control back to
+      // the dock (still mounted in its own slot) rather than dropping to
+      // the bare editor.
       if (restoreDockBehindPicker()) return;
       openDialog = null;
       editor.setEditorMode(null);

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -357,9 +357,9 @@ impl Editor {
         }
         // The tab-bar popups (the "+" new-tab menu and the tab right-click
         // context menu) are modal chrome: while one is open it owns the
-        // keyboard via a custom dispatcher (`handle_new_tab_menu_key` /
-        // `handle_tab_context_menu_key`, run from `handle_key` ahead of
-        // `KeyContext` resolution), so they expose no `KeyContext` here.
+        // keyboard via a custom dispatcher (`handle_context_menu_key`, run
+        // from `handle_key` ahead of `KeyContext` resolution), so they expose
+        // no `KeyContext` here.
         // Like any covering overlay they block PTY routing — otherwise keys
         // would leak into an active terminal buffer underneath instead of
         // driving the menu. Ranked below `Popup` so the unfocused-popup
@@ -375,6 +375,19 @@ impl Editor {
         if self.active_window().tab_context_menu.is_some() {
             layers.push(Layer {
                 kind: LayerKind::TabContextMenu,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
+        // The file-explorer right-click context menu gets the same treatment
+        // as the tab-bar menus: a custom key dispatcher owns the keyboard
+        // while it's open (transparent to `KeyContext`), and it blocks PTY
+        // routing so keys drive the menu rather than leaking into a terminal
+        // buffer underneath.
+        if self.active_window().file_explorer_context_menu.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::FileExplorerContextMenu,
                 owns_keyboard: true,
                 key_context: None,
                 blocks_terminal_input: true,
@@ -571,24 +584,12 @@ impl Editor {
             self.active_window_mut().theme_info_popup = None;
         }
 
-        if self
-            .active_window_mut()
-            .file_explorer_context_menu
-            .is_some()
-        {
-            if let Some(result) = self.handle_file_explorer_context_menu_key(code, modifiers) {
-                return result;
-            }
-        }
-
-        // The tab-bar popups (the "+" new-tab menu and the tab right-click
-        // context menu) are modal: while one is open it owns the keyboard so
-        // navigation/selection work and every other key is filtered out
-        // instead of leaking into the active buffer underneath.
-        if let Some(result) = self.handle_new_tab_menu_key(code) {
-            return result;
-        }
-        if let Some(result) = self.handle_tab_context_menu_key(code) {
+        // The native context menus (file-explorer / tab / "+" new-tab) are
+        // modal: while one is open it owns the keyboard so navigation and
+        // selection work and every other key is filtered out instead of
+        // leaking into the active buffer or the explorer's type-ahead find
+        // underneath. One handler covers all three.
+        if let Some(result) = self.handle_context_menu_key(code, modifiers) {
             return result;
         }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1291,6 +1291,29 @@ pub(crate) struct FloatingWidgetState {
     /// (`MountFloatingWidget.focus_marker`); the Orchestrator New
     /// Session form uses it.
     pub focus_marker: bool,
+    /// Native modal-frame chrome: when `Some`, a `Centered` panel draws
+    /// a **title bar** into its top border (left-aligned title text,
+    /// styled like the frame). The content `WidgetSpec` is unchanged and
+    /// still renders in the interior below. This is the declarative
+    /// dialog's *shell* — plugins no longer fake a title with a
+    /// `labeledSection` border inside the spec. Ignored for the dock and
+    /// anchored placements. Opt-in at mount (`MountFloatingWidget.title`);
+    /// `None` keeps the historical untitled frame.
+    pub title: Option<String>,
+    /// Native modal-frame chrome: when `true`, a `Centered` panel draws a
+    /// `[×]` **close button** at the top-right of its border. Clicking it
+    /// dismisses the panel exactly like Esc / Cancel (fires the panel's
+    /// `cancel` `widget_event` via the same path as
+    /// `dismiss_floating_panel_with_cancel`). Opt-in at mount
+    /// (`MountFloatingWidget.closable`); `false` draws no button.
+    pub closable: bool,
+    /// Screen rect of the `[×]` close button, recomputed on every draw
+    /// (like `last_inner_rect`) so the mouse hit-test can map a press back
+    /// to the dismiss action, and the web projection can ship it for a
+    /// native close control. Populated even under `suppress_chrome_cells`
+    /// (web mode) since geometry is computed there without painting cells.
+    /// `None` when the panel isn't a closable `Centered` modal.
+    pub close_button_rect: Option<ratatui::layout::Rect>,
 }
 
 /// How long the dock's overlay scrollbar stays visible after a keyboard
@@ -1830,6 +1853,9 @@ mod tests {
             scrollbar_flash_until: None,
             fullscreen: false,
             focus_marker: false,
+            title: None,
+            closable: false,
+            close_button_rect: None,
         }
     }
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -85,6 +85,21 @@ impl Editor {
         let (col, row) = (mouse_event.column, mouse_event.row);
         match mouse_event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                // A press on the native modal-frame `[×]` close button
+                // dismisses the panel exactly like Esc / Cancel (same
+                // `dismiss_floating_panel_with_cancel` path that fires the
+                // panel's `cancel` widget_event). Checked BEFORE the general
+                // panel hit-test so the click never also focuses a widget in
+                // the interior beneath the button.
+                if let Some(cbr) = self
+                    .panel(super::PanelSlot::Floating)
+                    .and_then(|f| f.close_button_rect)
+                {
+                    if in_rect(col, row, cbr) {
+                        self.dismiss_floating_panel_with_cancel(super::PanelSlot::Floating);
+                        return Ok(true);
+                    }
+                }
                 // An anchored popup (right-click context menu) dismisses when
                 // the press lands outside its box — standard menu behaviour.
                 // The centered modal instead swallows outside-clicks (it has

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -181,7 +181,21 @@ impl Editor {
             let ms = &self.active_window().mouse_state;
             ms.dragging_separator.is_some() || ms.drag_start_explorer_width.is_some()
         };
-        if !chrome_drag_active {
+        // An open native context menu (tab / "+" new-tab / file-explorer)
+        // takes mouse precedence over terminal forwarding. These menus render
+        // on top of — and frequently overlap — an alternate-screen terminal
+        // that has captured the mouse (e.g. right-clicking a terminal's tab
+        // opens the tab menu directly over the terminal's content). Without
+        // this gate the terminal-forward path below would swallow clicks/moves
+        // aimed at the menu, so menu items couldn't be selected (they'd inject
+        // mouse escape codes into the PTY instead). Skipping forwarding lets
+        // the event fall through to the normal pipeline, where
+        // `handle_click_context_menus` (select / dismiss) and the hover
+        // hit-test (highlight-follows-pointer) already handle it. Centralizing
+        // the precedence at this single fork mirrors the modal-capture ladder
+        // in `dispatch_modal_mouse`.
+        let context_menu_open = self.active_window().context_menu_core().is_some();
+        if !chrome_drag_active && !context_menu_open {
             let forwarding = self.config.terminal.mouse_forwarding;
             if let Some(result) = self.active_window_mut().try_forward_mouse_to_terminal(
                 col,
@@ -700,30 +714,12 @@ impl Editor {
             }
         }
 
-        // Handle tab context menu hover - update highlighted item
-        if let Some(HoverTarget::TabContextMenuItem(item_idx)) = new_target.clone() {
-            if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
-                if menu.highlighted != item_idx {
-                    menu.highlighted = item_idx;
-                    return true;
-                }
-            }
-        }
-
-        if let Some(&HoverTarget::FileExplorerContextMenuItem(item_idx)) = new_target.as_ref() {
-            if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
-                if menu.highlighted != item_idx {
-                    menu.highlighted = item_idx;
-                    return true;
-                }
-            }
-        }
-
-        // Handle "+" new-tab popup menu hover - update highlighted item
-        if let Some(HoverTarget::NewTabMenuItem(item_idx)) = new_target.clone() {
-            if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
-                if menu.highlighted != item_idx {
-                    menu.highlighted = item_idx;
+        // Hovering an item in whichever native context menu is open moves its
+        // highlight. One handler covers all three menus via the shared core.
+        if let Some(HoverTarget::ContextMenuItem(item_idx)) = new_target {
+            if let Some(core) = self.active_window_mut().context_menu_core_mut() {
+                if core.highlighted != item_idx {
+                    core.highlighted = item_idx;
                     return true;
                 }
             }
@@ -766,12 +762,7 @@ impl Editor {
         // tab context menu, or the status-bar LSP status popup) to avoid hover
         // tooltips overlapping other popups.
         if self.active_window_mut().theme_info_popup.is_some()
-            || self.active_window_mut().tab_context_menu.is_some()
-            || self.active_window_mut().new_tab_menu.is_some()
-            || self
-                .active_window_mut()
-                .file_explorer_context_menu
-                .is_some()
+            || self.active_window().context_menu_core().is_some()
             || self.is_lsp_status_popup_open()
         {
             if self
@@ -1006,77 +997,19 @@ impl Editor {
     /// popup lists, and the file-browser dialog. These always render on
     /// top of the chrome and must be checked first.
     fn hover_target_in_floating_overlays(&self, col: u16, row: u16) -> Option<HoverTarget> {
-        if let Some(ref menu) = self.active_window().file_explorer_context_menu {
-            let (menu_x, menu_y) = menu.clamped_position(
+        // The native context menus (tab / "+" new-tab / file-explorer) all
+        // render on top and share one geometry core, so a single hit-test
+        // over the open menu covers all three. An interior (item) row yields
+        // a hover target; border rows and outside positions fall through to
+        // the chrome below.
+        if let Some(core) = self.active_window().context_menu_core() {
+            if let super::types::ContextMenuHit::Item(item_idx) = core.hit(
+                col,
+                row,
                 self.active_chrome().last_frame.width,
                 self.active_chrome().last_frame.height,
-            );
-            let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
-            let menu_height = menu.height();
-
-            if col >= menu_x
-                && col < menu_x + menu_width
-                && row > menu_y
-                && row < menu_y + menu_height - 1
-            {
-                let item_idx = (row - menu_y - 1) as usize;
-                if item_idx < menu.items().len() {
-                    return Some(HoverTarget::FileExplorerContextMenuItem(item_idx));
-                }
-            }
-        }
-
-        // Check the "+" new-tab popup menu (rendered on top)
-        if let Some(ref menu) = self.active_window().new_tab_menu {
-            // Clamp against the last rendered frame size (mirrored from
-            // `frame.area()` each draw), matching the popup's render clamp — so
-            // a menu near the right/bottom edge hovers exactly where it draws.
-            let (menu_x, menu_y) = menu.clamped_position(
-                self.active_chrome().last_frame.width,
-                self.active_chrome().last_frame.height,
-            );
-            let menu_width = super::types::NEW_TAB_MENU_WIDTH;
-            let items = super::types::NewTabMenuItem::all();
-            let menu_height = menu.height();
-
-            if col >= menu_x
-                && col < menu_x + menu_width
-                && row > menu_y
-                && row < menu_y + menu_height - 1
-            {
-                let item_idx = (row - menu_y - 1) as usize;
-                if item_idx < items.len() {
-                    return Some(HoverTarget::NewTabMenuItem(item_idx));
-                }
-            }
-        }
-
-        // Check tab context menu first (it's rendered on top)
-        if let Some(ref menu) = self.active_window().tab_context_menu {
-            // Clamp against the last rendered frame size, not `terminal_width/
-            // height`: the tab menu's render clamps to `frame.area()` (mirrored
-            // into `last_frame` each draw), while `terminal_width/height` only
-            // catches up when a crossterm `Resize` event is dequeued. During a
-            // resize those two disagree, so hit-testing against `last_frame`
-            // (as the file-explorer menu already does) keeps clicks landing on
-            // exactly what was drawn.
-            let (menu_x, menu_y) = menu.clamped_position(
-                self.active_chrome().last_frame.width,
-                self.active_chrome().last_frame.height,
-            );
-            let menu_width = super::types::TAB_CONTEXT_MENU_WIDTH;
-            let items = super::types::TabContextMenuItem::all();
-            let menu_height = items.len() as u16 + 2;
-
-            if col >= menu_x
-                && col < menu_x + menu_width
-                && row > menu_y
-                && row < menu_y + menu_height - 1
-            {
-                let item_idx = (row - menu_y - 1) as usize;
-                if item_idx < items.len() {
-                    return Some(HoverTarget::TabContextMenuItem(item_idx));
-                }
+            ) {
+                return Some(HoverTarget::ContextMenuItem(item_idx));
             }
         }
 
@@ -1888,27 +1821,41 @@ impl Editor {
     // ── handle_mouse_click helpers ──────────────────────────────────────────
     // Each returns Some(result) if the click was consumed, None to fall through.
 
+    /// Route a left-click to whichever native context menu is open (tab /
+    /// "+" new-tab / file-explorer). Returns `None` when no menu is open so
+    /// the caller continues the normal click pipeline.
+    ///
+    /// The shared geometry core does the hit-test; only the *activation* of a
+    /// selected item differs per menu, so that is the one part that branches
+    /// on [`ContextMenuKind`]. Click-outside dismisses; border rows are inert;
+    /// an item click closes the menu and runs its `execute_*` action.
     fn handle_click_context_menus(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        if self
-            .active_window_mut()
-            .file_explorer_context_menu
-            .is_some()
-        {
-            if let Some(result) = self.handle_file_explorer_context_menu_click(col, row) {
-                return Some(result);
+        use super::types::ContextMenuHit;
+
+        let (kind, core) = self.active_window().open_context_menu()?;
+        let hit = core.hit(
+            col,
+            row,
+            self.active_chrome().last_frame.width,
+            self.active_chrome().last_frame.height,
+        );
+        match hit {
+            // Click outside the box dismisses the menu.
+            ContextMenuHit::Outside => {
+                self.active_window_mut().close_context_menus();
+                Some(Ok(()))
+            }
+            // Border rows are inert — swallow without acting or closing.
+            ContextMenuHit::Border => Some(Ok(())),
+            // An item click moves the highlight to it and activates through
+            // the same path as a keyboard Enter.
+            ContextMenuHit::Item(idx) => {
+                if let Some(core) = self.active_window_mut().context_menu_core_mut() {
+                    core.highlighted = idx;
+                }
+                Some(self.activate_highlighted_context_menu(kind))
             }
         }
-        if self.active_window_mut().tab_context_menu.is_some() {
-            if let Some(result) = self.handle_tab_context_menu_click(col, row) {
-                return Some(result);
-            }
-        }
-        if self.active_window_mut().new_tab_menu.is_some() {
-            if let Some(result) = self.handle_new_tab_menu_click(col, row) {
-                return Some(result);
-            }
-        }
-        None
     }
 
     /// Hit-test (col, row) against the suggestions popup. Returns the index
@@ -3374,44 +3321,17 @@ impl Editor {
             }
         }
 
+        // A right-click landing inside an already-open native context menu
+        // (file-explorer or tab — the "+" popup was dismissed above) is
+        // swallowed so the menu stays put rather than being re-opened /
+        // re-targeted. One shared hit-test covers both.
         let frame_w = self.active_chrome().last_frame.width;
         let frame_h = self.active_chrome().last_frame.height;
-        if let Some(ref menu) = self.active_window().file_explorer_context_menu {
-            let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
-            let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
-            let menu_height = menu.height();
-            if col >= menu_x
-                && col < menu_x + menu_width
-                && row >= menu_y
-                && row < menu_y + menu_height
-            {
-                return Ok(());
-            }
-        }
-
-        // First check if a tab context menu is open and the click is on a menu item
-        if let Some(ref menu) = self.active_window().tab_context_menu {
-            // Clamp against the last rendered frame size, not `terminal_width/
-            // height`: the tab menu's render clamps to `frame.area()` (mirrored
-            // into `last_frame` each draw), while `terminal_width/height` only
-            // catches up when a crossterm `Resize` event is dequeued. During a
-            // resize those two disagree, so hit-testing against `last_frame`
-            // (as the file-explorer menu already does) keeps clicks landing on
-            // exactly what was drawn.
-            let (menu_x, menu_y) = menu.clamped_position(
-                self.active_chrome().last_frame.width,
-                self.active_chrome().last_frame.height,
-            );
-            let menu_width = super::types::TAB_CONTEXT_MENU_WIDTH;
-            let menu_height = menu.height();
-
-            // Check if click is inside the menu
-            if col >= menu_x
-                && col < menu_x + menu_width
-                && row >= menu_y
-                && row < menu_y + menu_height
-            {
-                // Click inside menu - let left-click handler deal with it
+        if let Some(core) = self.active_window().context_menu_core() {
+            if !matches!(
+                core.hit(col, row, frame_w, frame_h),
+                super::types::ContextMenuHit::Outside
+            ) {
                 return Ok(());
             }
         }
@@ -3483,92 +3403,6 @@ impl Editor {
         Ok(())
     }
 
-    /// Handle left-click on tab context menu
-    pub(super) fn handle_tab_context_menu_click(
-        &mut self,
-        col: u16,
-        row: u16,
-    ) -> Option<AnyhowResult<()>> {
-        let menu = self.active_window().tab_context_menu.as_ref()?;
-        let (menu_x, menu_y) = menu.clamped_position(self.terminal_width, self.terminal_height);
-        let menu_width = super::types::TAB_CONTEXT_MENU_WIDTH;
-        let items = super::types::TabContextMenuItem::all();
-        let menu_height = items.len() as u16 + 2; // items + borders
-
-        // Check if click is inside the menu area
-        if col < menu_x || col >= menu_x + menu_width || row < menu_y || row >= menu_y + menu_height
-        {
-            // Click outside menu - close it
-            self.active_window_mut().tab_context_menu = None;
-            return Some(Ok(()));
-        }
-
-        // Check if click is on the border (first or last row)
-        if row == menu_y || row == menu_y + menu_height - 1 {
-            return Some(Ok(()));
-        }
-
-        // Calculate which item was clicked (accounting for border)
-        let item_idx = (row - menu_y - 1) as usize;
-        if item_idx >= items.len() {
-            return Some(Ok(()));
-        }
-
-        // Get the menu state before closing it
-        let buffer_id = menu.buffer_id;
-        let split_id = menu.split_id;
-        let item = items[item_idx];
-
-        // Close the menu
-        self.active_window_mut().tab_context_menu = None;
-
-        // Execute the action
-        Some(self.execute_tab_context_menu_action(item, buffer_id, split_id))
-    }
-
-    /// Handle left-click on the "+" new-tab popup menu.
-    pub(super) fn handle_new_tab_menu_click(
-        &mut self,
-        col: u16,
-        row: u16,
-    ) -> Option<AnyhowResult<()>> {
-        // Clamp against the last rendered frame size, matching the popup's
-        // render and hover hit-test — during a resize `terminal_width/height`
-        // can lag `frame.area()`, drifting clicks off the drawn menu.
-        let frame_w = self.active_chrome().last_frame.width;
-        let frame_h = self.active_chrome().last_frame.height;
-        let menu = self.active_window().new_tab_menu.as_ref()?;
-        let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
-        let items = super::types::NewTabMenuItem::all();
-        let menu_width = super::types::NEW_TAB_MENU_WIDTH;
-        let menu_height = menu.height();
-
-        // Click outside the menu closes it.
-        if col < menu_x || col >= menu_x + menu_width || row < menu_y || row >= menu_y + menu_height
-        {
-            self.active_window_mut().new_tab_menu = None;
-            return Some(Ok(()));
-        }
-
-        // Border rows (first/last) are inert.
-        if row == menu_y || row == menu_y + menu_height - 1 {
-            return Some(Ok(()));
-        }
-
-        let item_idx = (row - menu_y - 1) as usize;
-        if item_idx >= items.len() {
-            return Some(Ok(()));
-        }
-
-        let split_id = menu.split_id;
-        let item = items[item_idx];
-
-        // Close the menu before running the action.
-        self.active_window_mut().new_tab_menu = None;
-
-        Some(self.execute_new_tab_menu_action(item, split_id))
-    }
-
     /// Execute a "+" new-tab popup menu action.
     fn execute_new_tab_menu_action(
         &mut self,
@@ -3636,200 +3470,102 @@ impl Editor {
         Ok(())
     }
 
-    /// Handle keyboard input for the "+" new-tab popup menu.
+    /// Handle a key event while a native context menu (tab / "+" new-tab /
+    /// file-explorer) is open — the one keyboard handler for all three.
     ///
-    /// While the popup is open it owns the keyboard: Up/Down move the
-    /// highlight, Enter activates the highlighted item, Esc dismisses it,
-    /// and *every other key is swallowed* so nothing leaks into the buffer
-    /// underneath. Returns `Some` when a popup is open (the key is always
-    /// consumed in that case), `None` when there is no popup.
-    pub(super) fn handle_new_tab_menu_key(
-        &mut self,
-        code: crossterm::event::KeyCode,
-    ) -> Option<AnyhowResult<()>> {
-        use crossterm::event::KeyCode;
-
-        self.active_window().new_tab_menu.as_ref()?;
-
-        match code {
-            KeyCode::Up => {
-                if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
-                    menu.prev_item();
-                }
-            }
-            KeyCode::Down => {
-                if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
-                    menu.next_item();
-                }
-            }
-            KeyCode::Enter => {
-                let selected = self.active_window().new_tab_menu.as_ref().map(|menu| {
-                    (
-                        super::types::NewTabMenuItem::all()[menu.highlighted],
-                        menu.split_id,
-                    )
-                });
-                self.active_window_mut().new_tab_menu = None;
-                if let Some((item, split_id)) = selected {
-                    return Some(self.execute_new_tab_menu_action(item, split_id));
-                }
-            }
-            KeyCode::Esc => {
-                self.active_window_mut().new_tab_menu = None;
-            }
-            // Filter out everything else while the popup is focused.
-            _ => {}
-        }
-        Some(Ok(()))
-    }
-
-    /// Handle keyboard input for the tab right-click context menu.
+    /// The open menu **grabs the keyboard**: Up/Down move the highlight,
+    /// Enter activates the highlighted item, Esc dismisses, and every other
+    /// key — printable characters, Backspace, modified chords — is swallowed
+    /// so it can't leak into the buffer or the explorer's type-ahead find
+    /// underneath and silently retarget the selection the menu acts on
+    /// (#2587). Navigation/activation act only on *unmodified* keys; a
+    /// modified chord is swallowed like any other non-menu key.
     ///
-    /// Modal like [`handle_new_tab_menu_key`]: Up/Down navigate, Enter
-    /// activates the highlighted item, Esc dismisses, and all other keys are
-    /// swallowed so they can't reach the buffer underneath.
-    pub(super) fn handle_tab_context_menu_key(
-        &mut self,
-        code: crossterm::event::KeyCode,
-    ) -> Option<AnyhowResult<()>> {
-        use crossterm::event::KeyCode;
-
-        self.active_window().tab_context_menu.as_ref()?;
-
-        match code {
-            KeyCode::Up => {
-                if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
-                    menu.prev_item();
-                }
-            }
-            KeyCode::Down => {
-                if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
-                    menu.next_item();
-                }
-            }
-            KeyCode::Enter => {
-                let selected = self
-                    .active_window()
-                    .tab_context_menu
-                    .as_ref()
-                    .map(|menu| (menu.highlighted_item(), menu.buffer_id, menu.split_id));
-                self.active_window_mut().tab_context_menu = None;
-                if let Some((item, buffer_id, split_id)) = selected {
-                    return Some(self.execute_tab_context_menu_action(item, buffer_id, split_id));
-                }
-            }
-            KeyCode::Esc => {
-                self.active_window_mut().tab_context_menu = None;
-            }
-            // Filter out everything else while the popup is focused.
-            _ => {}
-        }
-        Some(Ok(()))
-    }
-
-    /// Handle keyboard input for the file explorer right-click context menu.
-    ///
-    /// Modal like [`handle_tab_context_menu_key`]: while the menu is open it
-    /// **grabs the keyboard**. Up/Down navigate, Enter activates the
-    /// highlighted item, Esc dismisses, and every other key — printable
-    /// characters, Backspace, modified chords — is swallowed so it can't leak
-    /// into the tree's type-ahead find underneath and silently retarget the
-    /// selection the menu acts on (#2587). This mirrors the 0.4.2 keyboard
-    /// grab already applied to the tab context menu and the "+" new-tab popup.
-    ///
-    /// Returns `Some` whenever the menu is open, `None` only when there is no
-    /// menu so normal dispatch continues.
-    pub(super) fn handle_file_explorer_context_menu_key(
+    /// Returns `Some` whenever a menu is open (the key is always consumed),
+    /// `None` when no menu is open so normal dispatch continues.
+    pub(super) fn handle_context_menu_key(
         &mut self,
         code: crossterm::event::KeyCode,
         modifiers: crossterm::event::KeyModifiers,
     ) -> Option<AnyhowResult<()>> {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyModifiers;
+        use crossterm::event::{KeyCode, KeyModifiers};
 
-        // Only act while the menu is actually open; otherwise fall through to
-        // normal dispatch.
-        self.active_window().file_explorer_context_menu.as_ref()?;
+        let kind = self.active_window().open_context_menu().map(|(k, _)| k)?;
 
-        // Navigation/activation keys act only when unmodified.
         if modifiers == KeyModifiers::NONE {
             match code {
                 KeyCode::Up => {
-                    if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu
-                    {
-                        menu.prev_item();
+                    if let Some(core) = self.active_window_mut().context_menu_core_mut() {
+                        core.prev_item();
                     }
                     return Some(Ok(()));
                 }
                 KeyCode::Down => {
-                    if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu
-                    {
-                        menu.next_item();
+                    if let Some(core) = self.active_window_mut().context_menu_core_mut() {
+                        core.next_item();
                     }
                     return Some(Ok(()));
                 }
                 KeyCode::Enter => {
-                    let item = {
-                        let menu = self
-                            .active_window_mut()
-                            .file_explorer_context_menu
-                            .as_ref()?;
-                        menu.items()[menu.highlighted]
-                    };
-                    self.active_window_mut().file_explorer_context_menu = None;
-                    self.execute_file_explorer_context_menu_action(item);
-                    return Some(Ok(()));
+                    return Some(self.activate_highlighted_context_menu(kind));
                 }
                 KeyCode::Esc => {
-                    self.active_window_mut().file_explorer_context_menu = None;
+                    self.active_window_mut().close_context_menus();
                     return Some(Ok(()));
                 }
                 _ => {}
             }
         }
 
-        // Modal: swallow every other key while the menu is open so nothing
-        // leaks into the type-ahead find beneath it.
+        // Modal: swallow every other key while a menu is open.
         Some(Ok(()))
     }
 
-    /// Handle left-click on the file explorer context menu
-    pub(super) fn handle_file_explorer_context_menu_click(
+    /// Activate the highlighted item of the open context menu: resolve the
+    /// item + its payload from the concrete menu, dismiss the menu, then run
+    /// the matching `execute_*` action. Shared by both the keyboard (Enter)
+    /// and mouse (click) paths so activation lives in exactly one place.
+    fn activate_highlighted_context_menu(
         &mut self,
-        col: u16,
-        row: u16,
-    ) -> Option<AnyhowResult<()>> {
-        // Extract all needed values while the immutable borrow is live, then mutate.
-        let frame_w = self.active_chrome().last_frame.width;
-        let frame_h = self.active_chrome().last_frame.height;
-        let clicked_item: Option<super::types::FileExplorerContextMenuItem> = {
-            let menu = self.active_window().file_explorer_context_menu.as_ref()?;
-            let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
-            let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
-            let menu_height = menu.height();
-
-            if col < menu_x
-                || col >= menu_x + menu_width
-                || row < menu_y
-                || row >= menu_y + menu_height
-            {
-                self.active_window_mut().file_explorer_context_menu = None;
-                return Some(Ok(()));
+        kind: super::types::ContextMenuKind,
+    ) -> AnyhowResult<()> {
+        use super::types::ContextMenuKind;
+        match kind {
+            ContextMenuKind::Tab => {
+                let selected = self
+                    .active_window()
+                    .tab_context_menu
+                    .as_ref()
+                    .map(|m| (m.highlighted_item(), m.buffer_id, m.split_id));
+                self.active_window_mut().close_context_menus();
+                if let Some((item, buffer_id, split_id)) = selected {
+                    return self.execute_tab_context_menu_action(item, buffer_id, split_id);
+                }
             }
-
-            if row == menu_y || row == menu_y + menu_height - 1 {
-                return Some(Ok(()));
+            ContextMenuKind::NewTab => {
+                let selected = self
+                    .active_window()
+                    .new_tab_menu
+                    .as_ref()
+                    .map(|m| (m.highlighted_item(), m.split_id));
+                self.active_window_mut().close_context_menus();
+                if let Some((item, split_id)) = selected {
+                    return self.execute_new_tab_menu_action(item, split_id);
+                }
             }
-
-            let item_idx = (row - menu_y - 1) as usize;
-            menu.items().get(item_idx).copied()
-        };
-
-        self.active_window_mut().file_explorer_context_menu = None;
-        if let Some(item) = clicked_item {
-            self.execute_file_explorer_context_menu_action(item);
+            ContextMenuKind::FileExplorer => {
+                let selected = self
+                    .active_window()
+                    .file_explorer_context_menu
+                    .as_ref()
+                    .map(|m| m.highlighted_item());
+                self.active_window_mut().close_context_menus();
+                if let Some(item) = selected {
+                    self.execute_file_explorer_context_menu_action(item);
+                }
+            }
         }
-        Some(Ok(()))
+        Ok(())
     }
 
     fn execute_file_explorer_context_menu_action(

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -45,12 +45,18 @@ pub(crate) enum LayerKind {
     Popup,
     /// The tab bar's "+" new-tab popup (`active_window().new_tab_menu`). A
     /// modal chrome menu with a custom key dispatcher
-    /// (`handle_new_tab_menu_key`), so it's transparent to `KeyContext`
+    /// (`handle_context_menu_key`), so it's transparent to `KeyContext`
     /// resolution but still blocks PTY routing while open.
     NewTabMenu,
     /// The tab right-click context menu (`active_window().tab_context_menu`),
     /// same treatment as `NewTabMenu`.
     TabContextMenu,
+    /// The file-explorer right-click context menu
+    /// (`active_window().file_explorer_context_menu`), same treatment as
+    /// `NewTabMenu` / `TabContextMenu`: a modal chrome menu with a custom key
+    /// dispatcher, transparent to `KeyContext` resolution but blocking PTY
+    /// routing while open.
+    FileExplorerContextMenu,
     /// The centered widget modal (`floating_widget_panel`).
     FloatingModal,
     /// The editor-global left dock (`dock`).

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1662,6 +1662,8 @@ impl Editor {
                 height_pct,
                 as_dock,
                 focus_marker,
+                title,
+                closable,
             } => {
                 let key = crate::widgets::PanelKey::new(plugin, panel_id);
                 self.handle_mount_floating_widget(
@@ -1671,6 +1673,8 @@ impl Editor {
                     height_pct,
                     as_dock,
                     focus_marker,
+                    title,
+                    closable,
                 );
             }
 
@@ -4918,6 +4922,7 @@ impl Editor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_mount_floating_widget(
         &mut self,
         panel_key: crate::widgets::PanelKey,
@@ -4926,6 +4931,10 @@ impl Editor {
         height_pct: u8,
         as_dock: bool,
         focus_marker: bool,
+        // Native modal-frame chrome for a centered panel (ignored for the
+        // dock / anchored). See `FloatingWidgetState::{title,closable}`.
+        title: Option<String>,
+        closable: bool,
     ) {
         let width_pct = width_pct.clamp(1, 100);
         let height_pct = height_pct.clamp(1, 100);
@@ -4980,6 +4989,12 @@ impl Editor {
             scrollbar_flash_until: None,
             fullscreen: false,
             focus_marker,
+            // The native modal frame is a centered-modal affordance; the dock
+            // (left companion) and anchored (context-menu) placements never
+            // draw a title bar or close button, so drop the chrome there.
+            title: if as_dock { None } else { title },
+            closable: !as_dock && closable,
+            close_button_rect: None,
         });
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4377,6 +4377,8 @@ impl Editor {
             panel_focused,
             scrollbar_zone_hovered,
             scrollbar_flash_until,
+            title,
+            closable,
         ) = match self.panel(slot) {
             Some(fwp) => (
                 fwp.width_pct,
@@ -4390,6 +4392,8 @@ impl Editor {
                 fwp.focused,
                 fwp.scrollbar_zone_hovered,
                 fwp.scrollbar_flash_until,
+                fwp.title.clone(),
+                fwp.closable,
             ),
             None => return,
         };
@@ -4453,6 +4457,26 @@ impl Editor {
             }
         };
 
+        // Native modal-frame chrome (the declarative dialog's *shell*) is a
+        // centered-modal-only affordance: a title bar drawn into the top
+        // border and a `[×]` close button one cell in from the top-right
+        // corner. The dock draws only a right divider and the anchored popup
+        // hugs its content, so neither wears this chrome. The button rect is
+        // computed here — before the draw / no-draw split below — so the web
+        // projection and the mouse hit-test both see it even when we compute
+        // geometry without painting cells (`suppress_chrome_cells`).
+        let is_centered = matches!(placement, super::PanelPlacement::Centered);
+        let close_button_rect = if is_centered && closable && overlay_rect.width >= 5 {
+            Some(ratatui::layout::Rect {
+                x: overlay_rect.x + overlay_rect.width - 4,
+                y: overlay_rect.y,
+                width: 3,
+                height: 1,
+            })
+        } else {
+            None
+        };
+
         // Web renders this panel natively from `widgets_view`; compute geometry
         // (incl. `last_inner_rect` for click routing) but paint no cells. TUI
         // passes draw=true so its rendering is unchanged.
@@ -4480,7 +4504,7 @@ impl Editor {
         } else {
             theme.popup_border_fg
         };
-        let block = Block::default()
+        let mut block = Block::default()
             .borders(if is_dock {
                 Borders::RIGHT
             } else {
@@ -4488,14 +4512,43 @@ impl Editor {
             })
             .border_style(ratatui::style::Style::default().fg(dock_border_fg))
             .style(ratatui::style::Style::default().bg(theme.suggestion_bg));
+        // Native modal-frame title bar: a centered modal with a `title`
+        // renders it left-aligned into the top border (` My Dialog `),
+        // styled like the frame. Ratatui reserves the border cells the
+        // title overlaps, and a `closable` panel's `[×]` is painted after
+        // the block so it always sits on top at the top-right corner.
+        if is_centered {
+            if let Some(t) = title.as_deref() {
+                block = block.title(ratatui::text::Span::styled(
+                    format!(" {t} "),
+                    ratatui::style::Style::default()
+                        .fg(theme.popup_border_fg)
+                        .add_modifier(ratatui::style::Modifier::BOLD),
+                ));
+            }
+        }
         let inner = block.inner(overlay_rect);
         if draw {
             frame.render_widget(block, overlay_rect);
+            // Paint the `[×]` close button over the top border, after the
+            // block so it wins the corner cells. Its screen rect was
+            // recorded above for the mouse hit-test / web projection.
+            if let Some(cbr) = close_button_rect {
+                frame.buffer_mut().set_string(
+                    cbr.x,
+                    cbr.y,
+                    "[×]",
+                    ratatui::style::Style::default()
+                        .fg(theme.popup_border_fg)
+                        .bg(theme.suggestion_bg),
+                );
+            }
         }
 
         if inner.width == 0 || inner.height == 0 {
             if let Some(fwp) = self.panel_mut(slot) {
                 fwp.last_inner_rect = Some(inner);
+                fwp.close_button_rect = close_button_rect;
             }
             return;
         }
@@ -4505,6 +4558,7 @@ impl Editor {
         if !draw {
             if let Some(fwp) = self.panel_mut(slot) {
                 fwp.last_inner_rect = Some(inner);
+                fwp.close_button_rect = close_button_rect;
             }
             return;
         }
@@ -4754,6 +4808,7 @@ impl Editor {
 
         if let Some(fwp) = self.panel_mut(slot) {
             fwp.last_inner_rect = Some(inner);
+            fwp.close_button_rect = close_button_rect;
             fwp.scrollbar_tracks = scrollbar_tracks;
             fwp.scrollbar_hover_zones = scrollbar_hover_zones;
         }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2075,24 +2075,19 @@ impl Editor {
     /// Render the tab, file-explorer, and new-tab context menus. TUI-only
     /// cell drawing; the web projects these natively from `context_menu_view`.
     fn render_context_menus(&mut self, frame: &mut Frame) {
-        if !self.suppress_chrome_cells {
-            // Render tab context menu if open
-            let tab_ctx_menu = self.active_window().tab_context_menu.clone();
-            if let Some(menu) = tab_ctx_menu {
-                self.render_tab_context_menu(frame, &menu);
-            }
-
-            let fe_ctx_menu = self.active_window().file_explorer_context_menu.clone();
-            if let Some(menu) = fe_ctx_menu {
-                self.render_file_explorer_context_menu(frame, &menu);
-            }
-
-            // Render the "+" new-tab popup menu if open
-            let new_tab_menu = self.active_window().new_tab_menu.clone();
-            if let Some(menu) = new_tab_menu {
-                self.render_new_tab_menu(frame, &menu);
-            }
+        if self.suppress_chrome_cells {
+            return;
         }
+        // Only one native context menu is ever open at a time; the shared
+        // core + item labels drive a single generic renderer.
+        let Some((_, core)) = self.active_window().open_context_menu() else {
+            return;
+        };
+        let core = core.clone();
+        let Some(items) = self.active_window().context_menu_labels() else {
+            return;
+        };
+        self.render_context_menu(frame, &core, &items);
     }
 
     /// Drain plugin commands enqueued before this frame's layout pass.
@@ -3922,139 +3917,54 @@ impl Editor {
         }
     }
 
-    /// Render the tab context menu
-    fn render_tab_context_menu(&self, frame: &mut Frame, menu: &TabContextMenu) {
-        use ratatui::style::Style;
-        use ratatui::text::{Line, Span};
-        use ratatui::widgets::{Block, Borders, Clear, Paragraph};
-
-        let items = super::types::TabContextMenuItem::all();
-        let menu_width = super::types::TAB_CONTEXT_MENU_WIDTH;
-        let menu_height = items.len() as u16 + 2; // items + borders
-
-        // Adjust position to stay within screen bounds (same math the mouse
-        // hit-testing uses, so clicks always land on what was drawn)
-        let (menu_x, menu_y) = menu.clamped_position(frame.area().width, frame.area().height);
-
-        let area = ratatui::layout::Rect::new(menu_x, menu_y, menu_width, menu_height);
-
-        // Clear the area first
-        frame.render_widget(Clear, area);
-
-        // Build the menu lines
-        let mut lines = Vec::new();
-        for (idx, item) in items.iter().enumerate() {
-            let is_highlighted = idx == menu.highlighted;
-
-            let style = if is_highlighted {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_highlight_fg)
-                    .bg(self.theme.read().unwrap().menu_highlight_bg)
-            } else {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
-                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
-            };
-
-            // Pad the label to fill the menu width
-            let label = item.label();
-            let content_width = (menu_width as usize).saturating_sub(2); // -2 for borders
-            let padded_label = format!(" {:<width$}", label, width = content_width - 1);
-
-            lines.push(Line::from(vec![Span::styled(padded_label, style)]));
-        }
-
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
-            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
-
-        let paragraph = Paragraph::new(lines).block(block);
-        frame.render_widget(paragraph, area);
-    }
-
-    /// Render the "+" new-tab popup menu (New Terminal / New File).
-    fn render_new_tab_menu(&self, frame: &mut Frame, menu: &super::types::NewTabMenu) {
-        use ratatui::style::Style;
-        use ratatui::text::{Line, Span};
-        use ratatui::widgets::{Block, Borders, Clear, Paragraph};
-
-        let items = super::types::NewTabMenuItem::all();
-        let menu_width = super::types::NEW_TAB_MENU_WIDTH;
-        let menu_height = menu.height();
-
-        // Shared clamp — the same helper hover and click hit-testing use, so
-        // the popup accepts input exactly where it draws.
-        let (menu_x, menu_y) = menu.clamped_position(frame.area().width, frame.area().height);
-
-        let area = ratatui::layout::Rect::new(menu_x, menu_y, menu_width, menu_height);
-
-        frame.render_widget(Clear, area);
-
-        let mut lines = Vec::new();
-        for (idx, item) in items.iter().enumerate() {
-            let is_highlighted = idx == menu.highlighted;
-
-            let style = if is_highlighted {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_highlight_fg)
-                    .bg(self.theme.read().unwrap().menu_highlight_bg)
-            } else {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
-                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
-            };
-
-            let label = item.label();
-            let content_width = (menu_width as usize).saturating_sub(2);
-            let padded_label = format!(" {:<width$}", label, width = content_width - 1);
-
-            lines.push(Line::from(vec![Span::styled(padded_label, style)]));
-        }
-
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
-            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
-
-        let paragraph = Paragraph::new(lines).block(block);
-        frame.render_widget(paragraph, area);
-    }
-
-    /// Render the file explorer context menu
-    fn render_file_explorer_context_menu(
+    /// Render a native context menu (tab / "+" new-tab / file-explorer) from
+    /// its shared geometry core and pre-resolved item labels.
+    ///
+    /// All three menus draw an identical bordered list — a `Clear`ed box, one
+    /// padded row per item, the highlighted row in the highlight colours — so
+    /// this is the single renderer for every one of them. The `ContextMenu`
+    /// core supplies the fixed width and the edge-clamped position, keeping
+    /// the drawn box aligned with the hover/click hit-test that reads the same
+    /// core.
+    fn render_context_menu(
         &self,
         frame: &mut Frame,
-        menu: &super::types::FileExplorerContextMenu,
+        core: &super::types::ContextMenu,
+        items: &[String],
     ) {
         use ratatui::style::Style;
         use ratatui::text::{Line, Span};
         use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
-        let items = menu.items();
-        let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
-        let menu_height = menu.height();
-        let (menu_x, menu_y) = menu.clamped_position(frame.area().width, frame.area().height);
+        let menu_width = core.width;
+        let menu_height = core.height();
+        let (menu_x, menu_y) = core.clamped_position(frame.area().width, frame.area().height);
 
         let area = ratatui::layout::Rect::new(menu_x, menu_y, menu_width, menu_height);
 
+        // Clear the area first so the menu box paints over the content beneath.
         frame.render_widget(Clear, area);
 
-        let mut lines = Vec::new();
-        for (idx, item) in items.iter().enumerate() {
-            let is_highlighted = idx == menu.highlighted;
+        let (highlight_fg, highlight_bg, dropdown_fg, dropdown_bg, border_fg) = {
+            let theme = self.theme.read().unwrap();
+            (
+                theme.menu_highlight_fg,
+                theme.menu_highlight_bg,
+                theme.menu_dropdown_fg,
+                theme.menu_dropdown_bg,
+                theme.menu_border_fg,
+            )
+        };
 
-            let style = if is_highlighted {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_highlight_fg)
-                    .bg(self.theme.read().unwrap().menu_highlight_bg)
+        let mut lines = Vec::new();
+        for (idx, label) in items.iter().enumerate() {
+            let style = if idx == core.highlighted {
+                Style::default().fg(highlight_fg).bg(highlight_bg)
             } else {
-                Style::default()
-                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
-                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
+                Style::default().fg(dropdown_fg).bg(dropdown_bg)
             };
 
-            let label = item.label();
+            // Pad the label to fill the menu width (minus the two border cells).
             let content_width = (menu_width as usize).saturating_sub(2);
             let padded_label = format!(" {:<width$}", label, width = content_width - 1);
 
@@ -4063,8 +3973,8 @@ impl Editor {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
-            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
+            .border_style(Style::default().fg(border_fg))
+            .style(Style::default().bg(dropdown_bg));
 
         let paragraph = Paragraph::new(lines).block(block);
         frame.render_widget(paragraph, area);

--- a/crates/fresh-editor/src/app/types/context_menu.rs
+++ b/crates/fresh-editor/src/app/types/context_menu.rs
@@ -10,6 +10,138 @@ pub const NEW_TAB_MENU_WIDTH: u16 = 18;
 /// "Extract to New Workspace" + padding).
 pub const TAB_CONTEXT_MENU_WIDTH: u16 = 28;
 
+/// Shared geometry + navigation + hit-testing core for the native context
+/// menus.
+///
+/// `fresh` has three native right-click / popup menus — the tab context
+/// menu, the "+" new-tab popup, and the file-explorer context menu. They
+/// are visually and behaviourally identical bordered item lists; only their
+/// fixed width and their item source differ. This core owns everything that
+/// was previously hand-copied across all three (box height, edge-clamping,
+/// highlight navigation, and the "which item is at (col,row)?" hit-test), so
+/// each concrete menu is just this core plus its own payload (which
+/// buffer/split it acts on, which selection mode it was opened in).
+///
+/// The `item_count` is captured when the menu opens and is fixed for its
+/// lifetime — the item source never changes while a menu is on screen — so
+/// navigation and hit-testing need no access to the concrete item slice.
+#[derive(Debug, Clone)]
+pub struct ContextMenu {
+    /// Screen position where the menu's top-left corner is anchored (x, y),
+    /// before edge-clamping.
+    pub position: (u16, u16),
+    /// Currently highlighted item index (0-based).
+    pub highlighted: usize,
+    /// Menu box width in cells (fixed per menu kind).
+    pub width: u16,
+    /// Number of selectable items (fixed while the menu is open).
+    pub item_count: usize,
+}
+
+/// Result of hit-testing a screen position against a [`ContextMenu`] box.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextMenuHit {
+    /// The position is outside the (clamped) menu box entirely.
+    Outside,
+    /// The position is on the top or bottom border row — inert.
+    Border,
+    /// The position is on item row `idx` (0-based).
+    Item(usize),
+}
+
+impl ContextMenu {
+    /// Anchor a fresh menu of `item_count` items at the given screen
+    /// position, highlight cleared to the first item.
+    pub fn new(x: u16, y: u16, width: u16, item_count: usize) -> Self {
+        Self {
+            position: (x, y),
+            highlighted: 0,
+            width,
+            item_count,
+        }
+    }
+
+    /// Total box height: one row per item plus the top and bottom borders.
+    pub fn height(&self) -> u16 {
+        self.item_count as u16 + 2
+    }
+
+    /// The anchor position clamped so the whole box stays on screen.
+    pub fn clamped_position(&self, screen_width: u16, screen_height: u16) -> (u16, u16) {
+        let x = if self.position.0 + self.width > screen_width {
+            screen_width.saturating_sub(self.width)
+        } else {
+            self.position.0
+        };
+        let h = self.height();
+        let y = if self.position.1 + h > screen_height {
+            screen_height.saturating_sub(h)
+        } else {
+            self.position.1
+        };
+        (x, y)
+    }
+
+    /// Move the highlight down one item, wrapping at the end.
+    pub fn next_item(&mut self) {
+        if self.item_count == 0 {
+            return;
+        }
+        self.highlighted = (self.highlighted + 1) % self.item_count;
+    }
+
+    /// Move the highlight up one item, wrapping at the start.
+    pub fn prev_item(&mut self) {
+        if self.item_count == 0 {
+            return;
+        }
+        self.highlighted = if self.highlighted == 0 {
+            self.item_count - 1
+        } else {
+            self.highlighted - 1
+        };
+    }
+
+    /// Classify a screen position against the (edge-clamped) menu box: an
+    /// item row, a border row, or outside. This is the single hit-test both
+    /// mouse hover and click routing consult, so the drawn box and the
+    /// clickable box can never disagree.
+    pub fn hit(&self, col: u16, row: u16, screen_width: u16, screen_height: u16) -> ContextMenuHit {
+        let (menu_x, menu_y) = self.clamped_position(screen_width, screen_height);
+        let menu_height = self.height();
+        if col < menu_x || col >= menu_x + self.width || row < menu_y || row >= menu_y + menu_height
+        {
+            return ContextMenuHit::Outside;
+        }
+        // The first and last rows are the borders — inert.
+        if row == menu_y || row == menu_y + menu_height - 1 {
+            return ContextMenuHit::Border;
+        }
+        let idx = (row - menu_y - 1) as usize;
+        if idx < self.item_count {
+            ContextMenuHit::Item(idx)
+        } else {
+            // Unreachable given the bounds above (an interior row always maps
+            // to a valid item), but treat any gap as inert rather than
+            // fabricating an out-of-range index.
+            ContextMenuHit::Border
+        }
+    }
+}
+
+/// Discriminates which concrete native context menu is currently open, so a
+/// single generic handler can route activation to the right `execute_*`
+/// dispatch after the shared geometry/navigation has done its work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextMenuKind {
+    /// The tab right-click context menu.
+    Tab,
+    /// The "+" new-tab popup menu.
+    NewTab,
+    /// The file-explorer right-click context menu.
+    FileExplorer,
+}
+
 /// Tab context menu items
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabContextMenuItem {
@@ -71,10 +203,8 @@ pub struct TabContextMenu {
     pub buffer_id: BufferId,
     /// The split ID where the tab is located
     pub split_id: LeafId,
-    /// Screen position where the menu should appear (x, y)
-    pub position: (u16, u16),
-    /// Currently highlighted menu item index
-    pub highlighted: usize,
+    /// Shared geometry + navigation core (position, highlight, width, items).
+    pub menu: ContextMenu,
 }
 
 impl TabContextMenu {
@@ -83,53 +213,23 @@ impl TabContextMenu {
         Self {
             buffer_id,
             split_id,
-            position: (x, y),
-            highlighted: 0,
+            menu: ContextMenu::new(
+                x,
+                y,
+                TAB_CONTEXT_MENU_WIDTH,
+                TabContextMenuItem::all().len(),
+            ),
         }
+    }
+
+    /// The items this menu presents, in display order.
+    pub fn items(&self) -> &'static [TabContextMenuItem] {
+        TabContextMenuItem::all()
     }
 
     /// Get the currently highlighted item
     pub fn highlighted_item(&self) -> TabContextMenuItem {
-        TabContextMenuItem::all()[self.highlighted]
-    }
-
-    /// Menu height including the top/bottom borders.
-    pub fn height(&self) -> u16 {
-        TabContextMenuItem::all().len() as u16 + 2
-    }
-
-    /// Anchor position shifted so the menu fits on screen — the single
-    /// source of truth shared by rendering, hover, and click hit-testing
-    /// (diverging copies would let clicks land on a menu drawn elsewhere).
-    pub fn clamped_position(&self, screen_width: u16, screen_height: u16) -> (u16, u16) {
-        let x = if self.position.0 + TAB_CONTEXT_MENU_WIDTH > screen_width {
-            screen_width.saturating_sub(TAB_CONTEXT_MENU_WIDTH)
-        } else {
-            self.position.0
-        };
-        let h = self.height();
-        let y = if self.position.1 + h > screen_height {
-            screen_height.saturating_sub(h)
-        } else {
-            self.position.1
-        };
-        (x, y)
-    }
-
-    /// Move highlight down
-    pub fn next_item(&mut self) {
-        let items = TabContextMenuItem::all();
-        self.highlighted = (self.highlighted + 1) % items.len();
-    }
-
-    /// Move highlight up
-    pub fn prev_item(&mut self) {
-        let items = TabContextMenuItem::all();
-        self.highlighted = if self.highlighted == 0 {
-            items.len() - 1
-        } else {
-            self.highlighted - 1
-        };
+        TabContextMenuItem::all()[self.menu.highlighted]
     }
 }
 
@@ -164,10 +264,8 @@ impl NewTabMenuItem {
 pub struct NewTabMenu {
     /// The split whose tab bar's `+` button was clicked.
     pub split_id: LeafId,
-    /// Screen position where the menu should appear (x, y).
-    pub position: (u16, u16),
-    /// Currently highlighted menu item index.
-    pub highlighted: usize,
+    /// Shared geometry + navigation core (position, highlight, width, items).
+    pub menu: ContextMenu,
 }
 
 impl NewTabMenu {
@@ -175,50 +273,18 @@ impl NewTabMenu {
     pub fn new(split_id: LeafId, x: u16, y: u16) -> Self {
         Self {
             split_id,
-            position: (x, y),
-            highlighted: 0,
+            menu: ContextMenu::new(x, y, NEW_TAB_MENU_WIDTH, NewTabMenuItem::all().len()),
         }
     }
 
-    /// Menu height including the top/bottom borders.
-    pub fn height(&self) -> u16 {
-        NewTabMenuItem::all().len() as u16 + 2
+    /// The items this menu presents, in display order.
+    pub fn items(&self) -> &'static [NewTabMenuItem] {
+        NewTabMenuItem::all()
     }
 
-    /// Anchor position shifted so the menu fits on screen — the single source
-    /// of truth shared by rendering, hover, and click hit-testing, exactly as
-    /// [`TabContextMenu::clamped_position`]. Diverging copies would let the
-    /// popup draw shifted onto screen while its clickable region stayed
-    /// anchored offscreen.
-    pub fn clamped_position(&self, screen_width: u16, screen_height: u16) -> (u16, u16) {
-        let x = if self.position.0 + NEW_TAB_MENU_WIDTH > screen_width {
-            screen_width.saturating_sub(NEW_TAB_MENU_WIDTH)
-        } else {
-            self.position.0
-        };
-        let h = self.height();
-        let y = if self.position.1 + h > screen_height {
-            screen_height.saturating_sub(h)
-        } else {
-            self.position.1
-        };
-        (x, y)
-    }
-
-    /// Move highlight down.
-    pub fn next_item(&mut self) {
-        let items = NewTabMenuItem::all();
-        self.highlighted = (self.highlighted + 1) % items.len();
-    }
-
-    /// Move highlight up.
-    pub fn prev_item(&mut self) {
-        let items = NewTabMenuItem::all();
-        self.highlighted = if self.highlighted == 0 {
-            items.len() - 1
-        } else {
-            self.highlighted - 1
-        };
+    /// Get the currently highlighted item.
+    pub fn highlighted_item(&self) -> NewTabMenuItem {
+        NewTabMenuItem::all()[self.menu.highlighted]
     }
 }
 
@@ -298,66 +364,45 @@ impl FileExplorerContextMenuItem {
 /// State for file explorer context menu (right-click popup in the file explorer)
 #[derive(Debug, Clone)]
 pub struct FileExplorerContextMenu {
-    /// Screen position where the menu should appear (x, y)
-    pub position: (u16, u16),
-    /// Currently highlighted menu item index
-    pub highlighted: usize,
     /// Whether the menu was opened with multiple items selected
     pub is_multi_selection: bool,
     /// Whether the sole selected node is the project root
     pub is_root_selected: bool,
+    /// Shared geometry + navigation core (position, highlight, width, items).
+    pub menu: ContextMenu,
 }
 
 impl FileExplorerContextMenu {
     pub fn new(x: u16, y: u16, is_multi_selection: bool, is_root_selected: bool) -> Self {
+        let item_count = Self::items_for(is_multi_selection, is_root_selected).len();
         Self {
-            position: (x, y),
-            highlighted: 0,
             is_multi_selection,
             is_root_selected,
+            menu: ContextMenu::new(x, y, FILE_EXPLORER_CONTEXT_MENU_WIDTH, item_count),
         }
     }
 
-    pub fn items(&self) -> &'static [FileExplorerContextMenuItem] {
-        if self.is_multi_selection {
+    /// The item set for a given selection mode. The menu's item source is
+    /// fixed at open time (see [`ContextMenu`]), so this is pure.
+    fn items_for(
+        is_multi_selection: bool,
+        is_root_selected: bool,
+    ) -> &'static [FileExplorerContextMenuItem] {
+        if is_multi_selection {
             FileExplorerContextMenuItem::multi_selection()
-        } else if self.is_root_selected {
+        } else if is_root_selected {
             FileExplorerContextMenuItem::root_single_selection()
         } else {
             FileExplorerContextMenuItem::all()
         }
     }
 
-    pub fn height(&self) -> u16 {
-        self.items().len() as u16 + 2
+    pub fn items(&self) -> &'static [FileExplorerContextMenuItem] {
+        Self::items_for(self.is_multi_selection, self.is_root_selected)
     }
 
-    pub fn clamped_position(&self, screen_width: u16, screen_height: u16) -> (u16, u16) {
-        let x = if self.position.0 + FILE_EXPLORER_CONTEXT_MENU_WIDTH > screen_width {
-            screen_width.saturating_sub(FILE_EXPLORER_CONTEXT_MENU_WIDTH)
-        } else {
-            self.position.0
-        };
-        let h = self.height();
-        let y = if self.position.1 + h > screen_height {
-            screen_height.saturating_sub(h)
-        } else {
-            self.position.1
-        };
-        (x, y)
-    }
-
-    pub fn next_item(&mut self) {
-        let len = self.items().len();
-        self.highlighted = (self.highlighted + 1) % len;
-    }
-
-    pub fn prev_item(&mut self) {
-        let len = self.items().len();
-        self.highlighted = if self.highlighted == 0 {
-            len - 1
-        } else {
-            self.highlighted - 1
-        };
+    /// Get the currently highlighted item.
+    pub fn highlighted_item(&self) -> FileExplorerContextMenuItem {
+        self.items()[self.menu.highlighted]
     }
 }

--- a/crates/fresh-editor/src/app/types/hover.rs
+++ b/crates/fresh-editor/src/app/types/hover.rs
@@ -60,10 +60,10 @@ pub enum HoverTarget {
     SearchOptionRegex,
     /// Hovering over the search options "Confirm Each" checkbox
     SearchOptionConfirmEach,
-    /// Hovering over a tab context menu item (item_index)
-    TabContextMenuItem(usize),
-    /// Hovering over a file explorer context menu item (item_index)
-    FileExplorerContextMenuItem(usize),
-    /// Hovering over a "+" new-tab popup menu item (item_index)
-    NewTabMenuItem(usize),
+    /// Hovering over an item (by index) in whichever native context menu is
+    /// open — the tab context menu, the "+" new-tab popup, or the
+    /// file-explorer context menu. Only one is ever open at a time, so a
+    /// single variant suffices; the hover handler updates the open menu's
+    /// shared highlight via `Window::context_menu_core_mut`.
+    ContextMenuItem(usize),
 }

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -23,8 +23,8 @@ pub use context_menu::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
 pub use context_menu::NEW_TAB_MENU_WIDTH;
 pub use context_menu::TAB_CONTEXT_MENU_WIDTH;
 pub use context_menu::{
-    FileExplorerContextMenu, FileExplorerContextMenuItem, NewTabMenu, NewTabMenuItem,
-    TabContextMenu, TabContextMenuItem,
+    ContextMenu, ContextMenuHit, ContextMenuKind, FileExplorerContextMenu,
+    FileExplorerContextMenuItem, NewTabMenu, NewTabMenuItem, TabContextMenu, TabContextMenuItem,
 };
 
 // drag re-exports

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1064,6 +1064,94 @@ pub(crate) fn build_window_lsp(
 }
 
 impl Window {
+    /// The currently-open native context menu's shared geometry core, if
+    /// any, together with a discriminant identifying which concrete menu it
+    /// belongs to.
+    ///
+    /// Only one native context menu is ever on screen at a time (opening one
+    /// dismisses the others), so this is unambiguous. The precedence order
+    /// here — file-explorer, then new-tab, then tab — is the single source of
+    /// truth for the generic hover / click / key / render paths, replacing
+    /// the three hand-copied per-menu blocks that used to drift apart.
+    pub(crate) fn open_context_menu(
+        &self,
+    ) -> Option<(
+        crate::app::types::ContextMenuKind,
+        &crate::app::types::ContextMenu,
+    )> {
+        use crate::app::types::ContextMenuKind;
+        if let Some(m) = &self.file_explorer_context_menu {
+            return Some((ContextMenuKind::FileExplorer, &m.menu));
+        }
+        if let Some(m) = &self.new_tab_menu {
+            return Some((ContextMenuKind::NewTab, &m.menu));
+        }
+        if let Some(m) = &self.tab_context_menu {
+            return Some((ContextMenuKind::Tab, &m.menu));
+        }
+        None
+    }
+
+    /// The shared geometry core of the currently-open native context menu.
+    pub(crate) fn context_menu_core(&self) -> Option<&crate::app::types::ContextMenu> {
+        self.open_context_menu().map(|(_, core)| core)
+    }
+
+    /// Mutable access to the currently-open native context menu's shared
+    /// geometry core (for highlight navigation from hover / keyboard). Uses
+    /// the same precedence order as [`Window::open_context_menu`].
+    pub(crate) fn context_menu_core_mut(&mut self) -> Option<&mut crate::app::types::ContextMenu> {
+        if let Some(m) = self.file_explorer_context_menu.as_mut() {
+            return Some(&mut m.menu);
+        }
+        if let Some(m) = self.new_tab_menu.as_mut() {
+            return Some(&mut m.menu);
+        }
+        if let Some(m) = self.tab_context_menu.as_mut() {
+            return Some(&mut m.menu);
+        }
+        None
+    }
+
+    /// Item labels of the currently-open native context menu, in display
+    /// order — the single label source for both the TUI renderer and the
+    /// web `context_menu_view` projection.
+    pub(crate) fn context_menu_labels(&self) -> Option<Vec<String>> {
+        use crate::app::types::ContextMenuKind;
+        let (kind, _) = self.open_context_menu()?;
+        Some(match kind {
+            ContextMenuKind::FileExplorer => self
+                .file_explorer_context_menu
+                .as_ref()?
+                .items()
+                .iter()
+                .map(|i| i.label())
+                .collect(),
+            ContextMenuKind::NewTab => self
+                .new_tab_menu
+                .as_ref()?
+                .items()
+                .iter()
+                .map(|i| i.label())
+                .collect(),
+            ContextMenuKind::Tab => self
+                .tab_context_menu
+                .as_ref()?
+                .items()
+                .iter()
+                .map(|i| i.label())
+                .collect(),
+        })
+    }
+
+    /// Dismiss whichever native context menu is open (all three fields are
+    /// cleared unconditionally — only one is ever set).
+    pub(crate) fn close_context_menus(&mut self) {
+        self.tab_context_menu = None;
+        self.new_tab_menu = None;
+        self.file_explorer_context_menu = None;
+    }
+
     /// Apply LSP folding ranges to the named buffer's `folding_ranges`
     /// store. Pure window mutation — no editor-global state touched.
     /// Used by the LSP folding-ranges response dispatcher after the

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -907,6 +907,20 @@ pub struct WidgetSurfaceView {
     pub spec: fresh_core::api::WidgetSpec,
     pub instances: HashMap<String, WidgetInstanceView>,
     pub hits: Vec<WidgetHitView>,
+    /// Native modal-frame title (the declarative dialog's *shell*, drawn by
+    /// the frontend as a title bar — not part of the `spec`). `None` for the
+    /// dock, anchored popups, and untitled centered panels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// True when the centered modal draws a `[×]` close button; the frontend
+    /// renders it and forwards a click to `close_rect` (below).
+    pub closable: bool,
+    /// Screen rect of the `[×]` close button, in terminal cells. The frontend
+    /// forwards a click at this cell back through `handle_mouse`, which the
+    /// TUI hit-test resolves to the same dismiss path. `None` when the panel
+    /// isn't a closable centered modal.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub close_rect: Option<RectView>,
 }
 
 impl Editor {
@@ -1023,6 +1037,9 @@ impl Editor {
                 spec: panel.spec.clone(),
                 instances,
                 hits,
+                title: fwp.title.clone(),
+                closable: fwp.closable,
+                close_rect: fwp.close_button_rect.map(RectView::from),
             });
         }
         out

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -1048,43 +1048,26 @@ impl Editor {
     /// box); a click forwarded to `handle_mouse` at `(x + 1, y + 1 + i)` resolves
     /// to item `i` via the existing hover/hit-test (`item_idx = row - y - 1`).
     pub fn context_menu_view(&self) -> Option<ContextMenuView> {
+        use crate::app::types::ContextMenuKind;
         let w = self.active_window();
         let chrome = self.active_chrome();
-        if let Some(m) = &w.file_explorer_context_menu {
-            let (x, y) = m.clamped_position(chrome.last_frame.width, chrome.last_frame.height);
-            return Some(ContextMenuView {
-                kind: "fileExplorer",
-                x,
-                y,
-                highlighted: m.highlighted,
-                items: m.items().iter().map(|i| i.label()).collect(),
-            });
-        }
-        if let Some(m) = &w.new_tab_menu {
-            return Some(ContextMenuView {
-                kind: "newTab",
-                x: m.position.0,
-                y: m.position.1,
-                highlighted: m.highlighted,
-                items: crate::app::types::NewTabMenuItem::all()
-                    .iter()
-                    .map(|i| i.label())
-                    .collect(),
-            });
-        }
-        if let Some(m) = &w.tab_context_menu {
-            return Some(ContextMenuView {
-                kind: "tab",
-                x: m.position.0,
-                y: m.position.1,
-                highlighted: m.highlighted,
-                items: crate::app::types::TabContextMenuItem::all()
-                    .iter()
-                    .map(|i| i.label())
-                    .collect(),
-            });
-        }
-        None
+        // One shared geometry core drives all three menus; the only per-menu
+        // difference the web cares about is the `kind` tag. Position is
+        // edge-clamped so the native box matches the TUI renderer / hit-test.
+        let (kind, core) = w.open_context_menu()?;
+        let (x, y) = core.clamped_position(chrome.last_frame.width, chrome.last_frame.height);
+        let kind = match kind {
+            ContextMenuKind::FileExplorer => "fileExplorer",
+            ContextMenuKind::NewTab => "newTab",
+            ContextMenuKind::Tab => "tab",
+        };
+        Some(ContextMenuView {
+            kind,
+            x,
+            y,
+            highlighted: core.highlighted,
+            items: w.context_menu_labels()?,
+        })
     }
 }
 

--- a/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
+++ b/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
@@ -114,6 +114,8 @@ fn born_attached_session_does_not_wedge_source_window_typing() {
             height_pct: 90,
             as_dock: false,
             focus_marker: false,
+            title: None,
+            closable: false,
         })
         .unwrap();
     harness

--- a/crates/fresh-editor/tests/e2e/floating_modal_frame_chrome.rs
+++ b/crates/fresh-editor/tests/e2e/floating_modal_frame_chrome.rs
@@ -1,0 +1,112 @@
+//! Feature test for the **native modal-frame (dialog shell) chrome** wrapped
+//! around a declarative `WidgetSpec` floating panel.
+//!
+//! ## What the feature is
+//! The popup CONTENT stays a `WidgetSpec` tree (existing system), but the
+//! popup SHELL — its title bar and `[×]` close button — is native chrome the
+//! host draws AROUND the content (`MountFloatingWidget { title, closable }`),
+//! not something a plugin fakes with a `labeledSection` border inside the
+//! spec. See `FloatingWidgetState::{title, closable, close_button_rect}`.
+//!
+//! ## What this test asserts (on rendered output only — no model inspection)
+//!   1. A centered floating panel mounted with `title` + `closable` renders
+//!      its title bar text AND a `[×]` close button into the frame.
+//!   2. Clicking the `[×]` dismisses the panel (title + button vanish) — the
+//!      same dismiss path as Cancel.
+//!   3. Re-mounting and pressing Esc also dismisses it.
+//!
+//! Without the render change, no title bar / `[×]` is drawn, so step 1 fails —
+//! the assertion catches the feature's absence.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh_core::api::{PluginCommand, WidgetSpec};
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 40;
+
+/// A distinctive title so `assert_screen_contains` can't collide with other
+/// chrome text on screen.
+const FRAME_TITLE: &str = "ZZFrameTitleZZ";
+
+/// Minimal content spec — only the native shell (title + `[×]`) is under test,
+/// and that chrome is independent of the spec body.
+fn content_spec() -> WidgetSpec {
+    WidgetSpec::Spacer {
+        cols: 1,
+        flex: false,
+        key: None,
+    }
+}
+
+/// Mount a centered floating panel carrying the native modal-frame chrome.
+fn mount_titled_closable(harness: &mut EditorTestHarness) {
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::MountFloatingWidget {
+            plugin: "test-plugin".to_string(),
+            panel_id: 1,
+            spec: content_spec(),
+            width_pct: 60,
+            height_pct: 40,
+            as_dock: false,
+            focus_marker: false,
+            title: Some(FRAME_TITLE.to_string()),
+            closable: true,
+        })
+        .unwrap();
+}
+
+#[test]
+fn floating_modal_renders_native_title_bar_and_close_button() {
+    fresh::i18n::set_locale("en");
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    // Keep clipboard interaction internal so the test stays host-isolated.
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    harness.tick_and_render().unwrap();
+
+    // The title bar and `[×]` are host chrome, not part of the WidgetSpec.
+    mount_titled_closable(&mut harness);
+    harness.tick_and_render().unwrap();
+
+    // 1. The native title bar renders its title text, and the native close
+    //    button `[×]` renders in the frame. (The bracketed form is specific to
+    //    the modal-frame chrome, so it won't collide with the file explorer's
+    //    bare `×`.)
+    harness.assert_screen_contains(FRAME_TITLE);
+    harness.assert_screen_contains("[×]");
+
+    // 2. Clicking the `[×]` dismisses the panel via the same cancel/close path
+    //    as Esc. Locate the button on screen and click it — driving the real
+    //    mouse hit-test against the recorded `close_button_rect`.
+    let (bx, by) = harness
+        .find_text_on_screen("[×]")
+        .expect("close button `[×]` must be on screen");
+    harness.mouse_click(bx, by).unwrap();
+    harness.tick_and_render().unwrap();
+
+    // The whole panel is gone: neither its title nor its close button remain.
+    harness.assert_screen_not_contains(FRAME_TITLE);
+    harness.assert_screen_not_contains("[×]");
+}
+
+#[test]
+fn floating_modal_close_button_esc_also_dismisses() {
+    fresh::i18n::set_locale("en");
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    harness.tick_and_render().unwrap();
+
+    mount_titled_closable(&mut harness);
+    harness.tick_and_render().unwrap();
+    harness.assert_screen_contains(FRAME_TITLE);
+    harness.assert_screen_contains("[×]");
+
+    // 3. Esc dismisses the modal exactly like the `[×]` click.
+    harness
+        .send_key(KeyCode::Esc, KeyModifiers::empty())
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    harness.assert_screen_not_contains(FRAME_TITLE);
+    harness.assert_screen_not_contains("[×]");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -42,6 +42,7 @@ pub mod file_explorer_open_focus;
 pub mod file_explorer_session_persist;
 pub mod file_permissions;
 pub mod flash;
+#[cfg(feature = "plugins")]
 pub mod floating_modal_frame_chrome;
 pub mod folding;
 pub mod glob_language_detection;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -42,6 +42,7 @@ pub mod file_explorer_open_focus;
 pub mod file_explorer_session_persist;
 pub mod file_permissions;
 pub mod flash;
+pub mod floating_modal_frame_chrome;
 pub mod folding;
 pub mod glob_language_detection;
 #[cfg(feature = "gui")]

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -2973,3 +2973,155 @@ fn new_folder_dialog_wears_native_modal_frame() {
     h.assert_screen_not_contains("[×]");
     h.assert_screen_contains("Orchestrator");
 }
+
+/// Open the New-Session ("New Workspace") form via the command palette and
+/// wait for its body — the "Workspace Name" field label, which lives only
+/// inside the form — to render.
+fn open_new_session_form(h: &mut EditorTestHarness) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: New Workspace").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: New Workspace"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Workspace Name"))
+        .unwrap();
+}
+
+/// The New-Session ("New Workspace") form is a centered floating panel that
+/// now wears the native modal-frame chrome: its "ORCHESTRATOR :: New
+/// Workspace" title bar + border come from the host (`mount({ title,
+/// closable })`), replacing the in-body styled header banner the form used
+/// to draw itself. This asserts, on rendered cells, that (a) the title
+/// renders in the native title bar (the frame's top border) and (b) a
+/// clickable native `[×]` close button is drawn there, then confirms that
+/// clicking `[×]` — and, on a fresh open, pressing Esc — tears the form
+/// down through the plugin's existing cancel path.
+///
+/// Before the migration the form drew no `[×]` (its header was an in-body
+/// banner, dismissable only with Esc), so `find_text_on_screen("[×]")`
+/// would find nothing and this test would fail.
+#[test]
+fn new_session_form_wears_native_modal_frame() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    // Keep clipboard interaction internal so the test stays host-isolated.
+    h.editor_mut().set_clipboard_for_test(String::new());
+    h.render().unwrap();
+
+    open_new_session_form(&mut h);
+
+    // (a)+(b): the native `[×]` close button is drawn, and the form's title
+    // text sits on the SAME row — i.e. inside the frame's top border (the
+    // native title bar), not merely somewhere in the body.
+    let (cx, cy) = h
+        .find_text_on_screen("[×]")
+        .expect("the migrated New-Session form must draw a native `[×]` close button");
+    let title_row = h
+        .screen_to_string()
+        .lines()
+        .nth(cy as usize)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        title_row.contains("New Workspace"),
+        "the form title must render in the native title bar (top border, row {cy}), \
+         alongside the `[×]`. Row: {title_row:?}\nScreen:\n{}",
+        h.screen_to_string(),
+    );
+
+    // Clicking `[×]` dismisses the form via the same cancel path as Esc:
+    // the body ("Workspace Name") and the native chrome both vanish.
+    h.mouse_click(cx, cy).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Workspace Name"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+
+    // Re-open and confirm Esc dismisses it the same way (both routes fire
+    // the panel's cancel `widget_event`, which the orchestrator handles).
+    open_new_session_form(&mut h);
+    h.assert_screen_contains("[×]");
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Workspace Name"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+}
+
+/// Open the modal ("control room") session picker via the command palette
+/// and wait for its body — the "Project:" scope control, which lives only
+/// inside the picker — to render.
+fn open_modal_picker(h: &mut EditorTestHarness) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Open").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: Open"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Project:"))
+        .unwrap();
+}
+
+/// The centered modal session picker (`Orchestrator: Open`) now wears the
+/// native modal-frame chrome: its "ORCHESTRATOR :: Workspaces" title bar +
+/// border come from the host (`mount({ title, closable })`), replacing the
+/// in-body title row `buildOpenSpec` used to draw. This asserts, on
+/// rendered cells, that (a) the title renders in the native title bar and
+/// (b) a clickable native `[×]` is drawn there, then confirms that clicking
+/// `[×]` — and, on a fresh open, pressing Esc — dismisses the picker.
+///
+/// Note the DOCK is deliberately not involved: the frame is added only to
+/// the centered modal mount (chrome is dropped for dock placement), so this
+/// drives the pure-modal path (no dock open behind it).
+///
+/// Before the migration the picker drew no `[×]` (its title was an in-body
+/// row), so `find_text_on_screen("[×]")` would find nothing and this test
+/// would fail.
+#[test]
+fn modal_picker_wears_native_modal_frame() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    // Keep clipboard interaction internal so the test stays host-isolated.
+    h.editor_mut().set_clipboard_for_test(String::new());
+    h.render().unwrap();
+
+    open_modal_picker(&mut h);
+
+    // (a)+(b): the native `[×]` close button is drawn, and the picker's
+    // title text sits on the SAME row — inside the frame's top border.
+    let (cx, cy) = h
+        .find_text_on_screen("[×]")
+        .expect("the migrated modal picker must draw a native `[×]` close button");
+    let title_row = h
+        .screen_to_string()
+        .lines()
+        .nth(cy as usize)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        title_row.contains("Workspaces"),
+        "the picker title must render in the native title bar (top border, row {cy}), \
+         alongside the `[×]`. Row: {title_row:?}\nScreen:\n{}",
+        h.screen_to_string(),
+    );
+
+    // Clicking `[×]` dismisses the picker via the same cancel path as Esc:
+    // the body ("Project:") and the native chrome both vanish.
+    h.mouse_click(cx, cy).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Project:"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+
+    // Re-open and confirm Esc dismisses it the same way.
+    open_modal_picker(&mut h);
+    h.assert_screen_contains("[×]");
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Project:"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -2883,3 +2883,93 @@ fn dock_list_scrollbar_flashes_on_keyboard_nav_and_expires() {
          hover reveals"
     );
 }
+
+/// Drive the dock's "New Task… ▾" create dropdown to open the "New Folder"
+/// dialog. Clicks the dropdown, then clicks its "New Folder…" option (a
+/// mouse activate routes straight to the plugin's `runDockMenuOption`, so
+/// there's no keyboard-focus race). Returns once the dialog's body —
+/// text that lives only inside it — is on screen.
+fn open_new_folder_dialog(h: &mut EditorTestHarness) {
+    let new_row = row_of(h, "New Task") as u16;
+    h.mouse_click(4, new_row).unwrap();
+    // The create dropdown opens listing "New Task…" / "New Folder…".
+    h.wait_until(|h| h.screen_to_string().contains("New Folder"))
+        .unwrap();
+    let (fx, fy) = h
+        .find_text_on_screen("New Folder")
+        .expect("the create dropdown should list a 'New Folder…' option");
+    h.mouse_click(fx, fy).unwrap();
+    // The dialog's "Folder name" prompt and "Create Folder" button are
+    // text unique to the dialog body (not the toolbar or the dropdown).
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("Folder name") && s.contains("Create Folder")
+    })
+    .unwrap();
+}
+
+/// The "New Folder" dialog is a centered floating panel that now wears the
+/// native modal-frame chrome: its title bar + border come from the host
+/// (`mount({ title, closable })`), not a `labeledSection` faked inside the
+/// WidgetSpec. This test opens the dialog through the dock's create
+/// dropdown and asserts, on rendered cells, that (a) the dialog title
+/// renders in the native title bar (the frame's top border) and (b) a
+/// clickable native `[×]` close button is drawn there. It then confirms
+/// that clicking `[×]` — and, on a fresh open, pressing Esc — tears the
+/// dialog down through the plugin's existing cancel path, leaving the dock.
+///
+/// Before the migration the dialog faked its title with a `labeledSection`
+/// border and drew no `[×]`, so `find_text_on_screen("[×]")` would find
+/// nothing and this test would fail — the assertion catches the feature's
+/// absence.
+#[test]
+fn new_folder_dialog_wears_native_modal_frame() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    // Keep clipboard interaction internal so the test stays host-isolated.
+    h.editor_mut().set_clipboard_for_test(String::new());
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    open_new_folder_dialog(&mut h);
+
+    // (a)+(b): the native `[×]` close button is drawn, and the dialog's
+    // title text sits on the SAME row — i.e. inside the frame's top border
+    // (the native title bar), not merely somewhere in the dialog body.
+    let (cx, cy) = h
+        .find_text_on_screen("[×]")
+        .expect("the migrated folder dialog must draw a native `[×]` close button");
+    let title_row = h
+        .screen_to_string()
+        .lines()
+        .nth(cy as usize)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        title_row.contains("New Folder"),
+        "the dialog title must render in the native title bar (top border, row {cy}), \
+         alongside the `[×]`. Row: {title_row:?}\nScreen:\n{}",
+        h.screen_to_string(),
+    );
+
+    // Clicking `[×]` dismisses the dialog via the same cancel path as Esc:
+    // the body ("Create Folder" / "Folder name") and the native chrome all
+    // vanish, and the dock stays.
+    h.mouse_click(cx, cy).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Create Folder"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+    h.assert_screen_contains("Orchestrator");
+
+    // Re-open and confirm Esc dismisses it the same way (both routes fire
+    // the panel's cancel `widget_event`, which the orchestrator handles).
+    open_new_folder_dialog(&mut h);
+    h.assert_screen_contains("[×]");
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Create Folder"))
+        .unwrap();
+    h.assert_screen_not_contains("[×]");
+    h.assert_screen_contains("Orchestrator");
+}

--- a/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
+++ b/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
@@ -70,6 +70,8 @@ fn panel_mode_does_not_leak_onto_window_switched_away_from() {
             height_pct: 50,
             as_dock: false,
             focus_marker: false,
+            title: None,
+            closable: false,
         })
         .unwrap();
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -66,12 +66,15 @@ fn open_dialog_defaults_to_all_projects_then_scopes_to_current() {
     harness.render().unwrap();
 
     run_palette(&mut harness, "Orchestrator: Open");
-    // Match the title suffix specifically ("…  —  all projects"), not the
-    // bare phrase: the footer hint also renders "all projects" as the
-    // Alt+P toggle-target label whenever the scope is "current", so a bare
-    // `contains("all projects")` can't distinguish the two views.
+    // The scope now reads off the "Project:" control, not a title suffix
+    // (the dialog title is native modal-frame chrome). The control shows
+    // "All ▾" in the all-projects view and the current project's basename
+    // otherwise, so the "All ▾" marker (with its ▾ glyph, unique to the
+    // control) distinguishes the two views — unlike the footer hint, which
+    // renders the bare phrase "all projects" as the Alt+P toggle target
+    // whenever the scope is "current".
     harness
-        .wait_until(|h| h.screen_to_string().contains("—  all projects"))
+        .wait_until(|h| h.screen_to_string().contains("All ▾"))
         .expect("Orchestrator Open dialog should default to the all-projects view");
 
     // Default scope is "all": every session is listed and the Project
@@ -101,11 +104,12 @@ fn open_dialog_defaults_to_all_projects_then_scopes_to_current() {
         .send_key(KeyCode::Char('p'), KeyModifiers::ALT)
         .unwrap();
     harness.render().unwrap();
-    // The title suffix drops "—  all projects" once scoped to the current
-    // project. (The footer hint keeps the bare "all projects" affordance,
-    // so we must key off the title marker, not the bare phrase.)
+    // The "Project:" control drops "All ▾" once scoped to the current
+    // project (it switches to the project's basename). The footer hint keeps
+    // the bare "all projects" affordance, so we key off the control's "All ▾"
+    // marker, not the bare phrase.
     harness
-        .wait_until(|h| !h.screen_to_string().contains("—  all projects"))
+        .wait_until(|h| !h.screen_to_string().contains("All ▾"))
         .expect("scope toggle should switch the dialog to the current-project view");
 
     let screen = harness.screen_to_string();

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -135,6 +135,81 @@ fn tab_context_menu_grabs_keyboard_from_active_terminal() {
     );
 }
 
+/// Regression (mouse-capture bug): right-clicking the tab of a terminal that
+/// has *captured the mouse* (alternate screen + mouse reporting, like vim /
+/// htop) opens the tab context menu directly over the terminal's content —
+/// and clicking a menu item must actually run that item, not be forwarded to
+/// the terminal underneath.
+///
+/// Before the fix, `try_forward_mouse_to_terminal` ran ahead of the native
+/// context-menu click handler, so the left-click on the "Close" item was
+/// swallowed by the PTY (injected as a mouse escape sequence): the menu
+/// stayed open and the terminal tab was never closed. The fix makes an open
+/// native context menu take mouse precedence over terminal forwarding.
+///
+/// Observes rendered output only: the terminal tab label and the menu text.
+#[test]
+fn tab_context_menu_click_beats_mouse_capturing_terminal() {
+    let mut harness = harness_or_return!(120, 30);
+
+    // Focus an active (live) terminal buffer.
+    harness.editor_mut().open_terminal();
+    assert!(harness.editor().is_terminal_mode());
+    harness.render().unwrap();
+    harness.assert_screen_contains("*Terminal 0*");
+
+    // Make the terminal capture the mouse: enter the alternate screen and
+    // enable X10/normal mouse reporting (DECSET 1049 + 1000), exactly what a
+    // full-screen mouse-driven program does. With `mouse_forwarding` at its
+    // default (`Requested`), a plain left-press over the terminal content is
+    // now eligible for forwarding to the PTY.
+    let buffer_id = harness.editor().active_buffer_id();
+    let terminal_id = harness
+        .editor()
+        .active_window()
+        .get_terminal_id(buffer_id)
+        .expect("active buffer should be a terminal");
+    if let Some(handle) = harness.editor().terminal_manager().get(terminal_id) {
+        if let Ok(mut state) = handle.state.lock() {
+            state.process_output(b"\x1b[?1049h\x1b[?1000h");
+        }
+    }
+    harness.render().unwrap();
+
+    // Right-click the terminal's own tab (row 1 = tab bar, above the terminal
+    // content) so the terminal stays the focused, live buffer. The tab context
+    // menu opens just below, overlapping the terminal's content rows.
+    let screen = harness.screen_to_string();
+    let term_col = tab_row_col_of_str(&screen, "Terminal").unwrap_or_else(|| {
+        panic!("expected the '*Terminal 0*' tab on the tab row. Screen:\n{screen}")
+    });
+    harness.mouse_right_click(term_col, 1).unwrap();
+    harness.assert_screen_contains("Close Others");
+
+    // The menu's first item is "Close". It renders on a terminal-content row
+    // (row 3: tab bar row 1, menu top border row 2, first item row 3). Locate
+    // it on screen and left-click it. The first "Close" on screen is this
+    // item (the other entries read "Close Others", "Close to the Right", …).
+    let (close_col, close_row) = harness
+        .find_text_on_screen("Close")
+        .expect("the 'Close' menu item should be visible");
+    harness.mouse_click(close_col, close_row).unwrap();
+    harness.render().unwrap();
+
+    // With the fix, the click selected "Close": the menu is gone and the
+    // terminal tab was closed. Without it, the click was forwarded to the PTY,
+    // the menu stayed open, and the tab survived.
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Close Others"),
+        "clicking a menu item should close the menu, not forward to the terminal. Screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("*Terminal 0*"),
+        "clicking 'Close' should have closed the terminal tab. Screen:\n{screen}"
+    );
+}
+
 /// Test opening a terminal creates a buffer and switches to it
 #[test]
 fn test_open_terminal() {

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6054,6 +6054,12 @@ impl JsEditorApi {
         height_pct: f64,
         as_dock: rquickjs::function::Opt<bool>,
         focus_marker: rquickjs::function::Opt<bool>,
+        // Native modal-frame chrome for a centered panel: an optional title
+        // bar and an optional `[×]` close button, drawn by the host around
+        // the declarative `WidgetSpec` content. Both default off for
+        // back-compat with existing mount calls.
+        title: rquickjs::function::Opt<String>,
+        closable: rquickjs::function::Opt<bool>,
     ) -> rquickjs::Result<bool> {
         let json = js_to_json(&ctx, spec_obj);
         let spec: fresh_core::api::WidgetSpec = match serde_json::from_value(json) {
@@ -6075,6 +6081,8 @@ impl JsEditorApi {
                 height_pct,
                 as_dock: as_dock.0.unwrap_or(false),
                 focus_marker: focus_marker.0.unwrap_or(false),
+                title: title.0.filter(|s| !s.is_empty()),
+                closable: closable.0.unwrap_or(false),
             })
             .is_ok())
     }

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -216,6 +216,16 @@
     box-shadow:0 10px 36px rgba(0,0,0,.45)}
   .widget-surface.w-floatingModal.anchored .w-button{display:block;text-align:left}
   .widget-surface .w-col{gap:3px}
+  /* Native modal-frame chrome: a title bar + [×] close button the host draws
+     around the WidgetSpec content (the declarative dialog's shell). */
+  .w-modal-titlebar{display:flex;align-items:center;gap:8px;
+    padding:2px 4px 6px;margin-bottom:2px;
+    border-bottom:1px solid var(--hairline,var(--border))}
+  .w-modal-title{flex:1;font-weight:600;color:var(--fg);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .w-modal-close{cursor:pointer;user-select:none;line-height:1;
+    padding:0 6px;border-radius:4px;color:var(--muted,#9aa)}
+  .w-modal-close:hover{background:color-mix(in srgb, var(--fg) 12%, transparent);color:var(--fg)}
   /* --- Plugin dialog polish (New Folder, etc.) ---------------------------
      A floating modal whose root is a labeledSection is a small dialog. Give
      it a clean card: the section owns the padding (so its border doesn't

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -712,6 +712,22 @@ function widgetSurfaceEls(s){
     el.style.top=(px(s.rect.y,CH)-SHELL.top+4)+"px";
     el.style.height=(px(s.rect.h,CH)+SHELL.top+SHELL.bot-8)+"px";
   }
+  // Native modal-frame chrome (the declarative dialog's *shell*): a title bar
+  // and a `[×]` close button drawn by the host AROUND the WidgetSpec content,
+  // not inside the spec. The close button forwards a click to the host's
+  // recorded `closeRect` cell, which the TUI mouse hit-test resolves to the
+  // same dismiss path (`dismiss_floating_panel_with_cancel`) as Esc.
+  if(s.kind==="floatingModal" && (s.title || s.closable)){
+    const bar=div("w-modal-titlebar");
+    const ttl=div("w-modal-title"); ttl.textContent=s.title||""; bar.appendChild(ttl);
+    if(s.closable && s.closeRect){
+      const x=div("w-modal-close"); x.textContent="×"; x.title="Close";
+      const cc=rectCell(s.closeRect);
+      x.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); sendMouse({kind:"down",button:"left",col:cc.col,row:cc.row}); };
+      bar.appendChild(x);
+    }
+    el.appendChild(bar);
+  }
   if(s.kind==="floatingModal"){
     // The host sizes the panel in whole terminal cells, but the DOM adds
     // per-row gaps + padding a cell grid can't express, so a snug dialog


### PR DESCRIPTION
Gives the native context menus and the declarative dialogs a shared, web-renderable base so both frontends (TUI cells + web DOM) handle them consistently — title bar, close button, tab navigation, hit-testing — instead of each surface re-implementing its own chrome. Also fixes a real bug in the process.

## 1. Context menus → one shared `ContextMenu` core

The three native menus — the tab right-click menu, the "+" new-tab popup, and the file-explorer menu — each carried hand-copied geometry, navigation, hit-testing, rendering, hover, click, and keyboard code. The clones had already drifted (only the file-explorer menu clamped its position in hover/click; only it was an overlay layer; its key handler required an unmodified chord while the others didn't), and every tweak had to be made in triplicate.

Now there's one generic `ContextMenu` core (position, highlight, width, item_count) owning box geometry, edge-clamping, wrap-around navigation, and a single `hit()` returning `Outside` / `Border` / `Item(idx)` — the one hit-test shared by hover and click, so the drawn box and the clickable box can't disagree. A `ContextMenuKind` discriminant drives all three menus through one path:

- one `render_context_menu` (replaces three ~48-line render clones),
- one hover hit-test + one `HoverTarget::ContextMenuItem`,
- one `handle_click_context_menus`, one `handle_context_menu_key`, and a shared `activate_highlighted_context_menu` used by both Enter and click,
- `Window::open_context_menu` / `context_menu_core[_mut]` / `context_menu_labels` as the single source of "which menu is open".

`context_menu_view()` keeps returning the same `ContextMenuView`, so the web projection and `scene_parity` are unaffected; item order/labels are untouched (e2e tests address items by index). Net **−98 lines** in this part.

### Bug fix: context-menu clicks over a mouse-capturing terminal

Right-clicking the tab of a terminal that had captured the mouse (alt-screen + mouse reporting) opened the tab menu over the terminal, but clicking an item did nothing — `try_forward_mouse_to_terminal` ran *before* the native menu click handler, so the click was injected into the PTY. The precedence is now centralized at the single terminal-forward fork: an open native context menu takes mouse precedence over forwarding. Backed by an e2e reproducer (observes rendered output only) that fails without the fix and passes with it.

## 2. Modal dialogs → native frame chrome around `WidgetSpec` content

The declarative dialog system lets a plugin mount a `WidgetSpec` tree as a centered floating panel, but the panel's *shell* had no native affordance — plugins faked a title with a `labeledSection` border inside the spec, and only Esc/Cancel could dismiss it. This keeps the popup **content** a `WidgetSpec` (existing system) while making the popup **itself** (title bar, close button, lifetime) native chrome the host draws around it.

New optional mount state on a `Centered` floating panel:
- `title: Option<String>` — a left-aligned title bar in the top border;
- `closable: bool` — a `[×]` close button top-right; clicking it dismisses via the same `dismiss_floating_panel_with_cancel` path as Esc (fires the panel's `cancel` widget_event).

Plumbed end to end and back-compatible (both default off): `FloatingWidgetState` (`title`/`closable`/`close_button_rect`, recomputed each draw even under `suppress_chrome_cells`), `PluginCommand::MountFloatingWidget`, the QuickJS `mountFloatingWidget` binding (regenerated `fresh.d.ts`), TUI `render_floating_widget_panel`, the close-button mouse hit-test, the `WidgetSurfaceView` web projection (`title`/`closable`/`closeRect`), and the web frontend (native title bar + `[×]`). `FloatingWidgetPanel.mount` gains `title?` / `closable?`.

### Dialogs migrated onto the frame

- **New / Rename Folder** dialog — dropped its `labeledSection` title for the native frame.
- **New Session** ("New Workspace") form and the **Open** picker — dropped their in-body title banners for the native `title` + `closable`; the picker's `cancel` teardown is guarded on `!dockMode` so a native `[×]`/Esc tears down the modal, never the shared dock behind it.

Each migration has an e2e test that observes the rendered title bar + `[×]` and that `[×]`/Esc dismisses.

## Verification

- `cargo check --all-targets` (+ `--features gui`), `fmt --check`, `clippy --all-targets`, `check --no-default-features --features runtime --all-targets`, and `scene_parity --features web` all clean.
- Manually exercised every affected surface in **both** UIs: the TUI under tmux (context menus open/navigate/select; the native `┌ … [×]┐` dialog frames; the terminal-capture bug reproduced fixed) and the **web UI** headless via Playwright against the real editor bridge (context menus + both dialogs render the native frame and dismiss on `[×]` — 21/21 checks).
- Rebased onto latest `master`; the web-ui `index.html → css/js` split from master was reconciled by porting the modal-frame CSS/JS into `css/40-widgets.css` and `js/65-widgets.js`.

The last two commits are CI fixes surfaced by the no-plugins build and the OS test matrix (gate the modal-frame e2e behind the `plugins` feature; point the Open-dialog scope test at the `Project:` control after the title suffix moved there).

Follow-ups (not in this PR): the bespoke *native* Rust modals (workspace-trust, settings entry dialog) would need a core-owned widget-dialog path to adopt the same frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxCyqQVEJDpoEZNKysUHEt