### PR TITLE
web-ui(macos): tighten menu padding, fix dock context-menu chrome, macOS control shapes

### DIFF
--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -63,6 +63,15 @@
   body.macfam .mitem .lab{gap:3px}
   body.macfam .mitem .check{width:10px}
 
+  /* List/row hover: the shared --hover reads heavy and muddy over the light macOS
+     chrome; use a whisper of neutral tint instead (the accent stays reserved for
+     the actual selection). */
+  body.macfam .palette .prow:not(.sel):hover,
+  body.macfam .popup .popup-row:not(.sel):not(.disabled):hover,
+  body.macfam .settings-modal .set-cat:not(.sel):hover,
+  body.macfam .kbedit .kb-row:not(.sel):not(.kb-head):hover{
+    background:color-mix(in srgb,var(--fg) 7%,transparent)}
+
   /* ---- menu bar: a light unified toolbar beneath the title bar ---- */
   body.macfam .menubar{background:var(--shell);border-bottom:1px solid var(--hairline-strong)}
   body.macfam .menu{color:var(--fg);font-weight:500}

--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -262,9 +262,19 @@
   body.macfam .w-dock .w-button.primary{
     background:var(--ui-accent);border:1px solid color-mix(in srgb,var(--ui-accent) 78%,#000);color:#fff;
     box-shadow:inset 0 1px 0 rgba(255,255,255,.22),0 1px 1.5px rgba(0,0,0,.14)}
+  /* Text fields, in ONE place. The base styles `.w-text` per surface with
+     background:var(--bg) — the dark BUFFER colour — so any surface macOS didn't
+     explicitly repoint (e.g. the plugin dialog fields in the New Workspace modal)
+     rendered as black chips. Repoint every text field here so they all read as
+     one light macOS text field and a new field inherits it automatically. The
+     dock search field below only adds its magnifier + radius on top. */
+  body.macfam .w-text,
+  body.macfam .w-floatingModal .w-text,
+  body.macfam .w-floatingModal>.w-section .w-text,
+  body.macfam .trustdialog .w-text,body.macfam .auxmodal .w-text{
+    background:var(--surface);border:1px solid var(--hairline-strong);color:var(--fg)}
   /* Search field: a macOS rounded search field with a leading magnifier. */
-  body.macfam .w-dock .w-text{background:var(--surface);border:1px solid var(--hairline-strong);
-    color:var(--fg);border-radius:7px;padding:2px 8px}
+  body.macfam .w-dock .w-text{border-radius:7px;padding:2px 8px}
   body.macfam .w-dock .w-text::before{content:"⌕";color:var(--muted);font-size:1.2em;line-height:1;margin-right:2px}
   body.macfam .w-dock .w-button{background:var(--mac-btn);border:1px solid var(--hairline-strong);color:var(--mac-btn-fg)}
   body.macfam .w-dock .w-toggle{color:var(--fg)}

--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -167,6 +167,15 @@
   body.macfam .w-floatingModal.anchored .w-button.focus,
   body.macfam .w-floatingModal.anchored .w-button.sel,
   body.macfam .w-floatingModal.anchored .w-button.primary{box-shadow:none;outline:none}
+  /* The header row (workspace name / "create") and the footer hint ("Esc to
+     close") are `.w-raw` captions, not selectable rows — make them read as
+     chrome: small and muted, the header a semibold caption, the footer set off
+     by a hairline. Otherwise they look like plain disabled menu items. */
+  body.macfam .w-floatingModal.anchored .w-raw{font-size:11px;color:var(--muted);padding:1px 12px}
+  body.macfam .w-floatingModal.anchored .w-raw:first-child{
+    font-weight:600;padding:3px 12px 3px;letter-spacing:.02em}
+  body.macfam .w-floatingModal.anchored .w-raw:last-child{
+    padding-top:4px;margin-top:3px;border-top:1px solid var(--hairline)}
   body.macfam .w-floatingModal.anchored .w-button.primary,
   body.macfam .w-floatingModal.anchored .w-button.sel,
   body.macfam .w-floatingModal.anchored .w-button:hover{color:#fff}
@@ -188,7 +197,7 @@
      scope to :not(.on) so it doesn't out-specify the .on fill). */
   body.macfam .settings-modal .set-switch:not(.on),
   body.macfam .w-toggle:not(.on) .w-box{
-    background:color-mix(in srgb,var(--fg) 24%,transparent)}
+    background:color-mix(in srgb,var(--fg) 19%,transparent)}   /* light neutral, ~macOS #E9E9EA */
   body.macfam .settings-modal .set-switch.on{background:var(--ui-accent)}
   /* Switch shape — the base 26×14 with a 10px knob reads thin and the knob
      floats; macOS System Settings switches are a chunkier ~1.75:1 pill whose

--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -52,6 +52,17 @@
   body.macfam #mactitle .mt-name{margin:0 auto;font-weight:590;color:var(--mac-title-fg);
     letter-spacing:.01em;max-width:56%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 
+  /* ---- dropdown item horizontal rhythm ----
+     The base row stacked the TUI's phantom 1-cell border inset (~9.5px, a real
+     border glyph in the terminal but only a 1px CSS border here) + 14px padding
+     + a 12px checkmark gutter + 6px gap → labels landed ~41px from the panel
+     edge, roughly 2× a native menu. Trim the CSS padding and the checkmark
+     gutter so labels sit ~24px in (the ✓ still fits), and pull the right pad in
+     to match — the accelerator stays right-aligned via the flexed .lab. */
+  body.macfam .mitem{padding:0 12px 0 3px}
+  body.macfam .mitem .lab{gap:3px}
+  body.macfam .mitem .check{width:10px}
+
   /* ---- menu bar: a light unified toolbar beneath the title bar ---- */
   body.macfam .menubar{background:var(--shell);border-bottom:1px solid var(--hairline-strong)}
   body.macfam .menu{color:var(--fg);font-weight:500}
@@ -131,6 +142,10 @@
   body.macfam .popup .popup-row.sel::before{
     content:"";position:absolute;left:5px;right:5px;top:1px;bottom:1px;
     border-radius:5px;background:var(--ui-accent);z-index:-1}
+  /* A dropdown .mitem already sits one CELL (~9.5px) inside its panel, so the
+     +5px pill above floated ~14px from the edge — far looser than a native menu.
+     Pull it back out so the accent bar hugs the panel at ~6px, like macOS. */
+  body.macfam .mitem.hi::before{left:-3px;right:-3px}
   body.macfam .mitem.hi .accel,body.macfam .mitem.hi .arrow{color:rgba(255,255,255,.82)}
   /* Focused Settings row: subtle tint, dark label kept. */
   body.macfam .settings-modal .set-item.sel{
@@ -140,10 +155,18 @@
      near-opaque menu material and BORDERLESS rows with an inset highlight,
      instead of a stack of bordered push-buttons. */
   body.macfam .widget-surface.w-floatingModal.anchored{
-    background:color-mix(in srgb,var(--bg2) 97%,transparent);border:1px solid var(--hairline-strong)}
+    background:color-mix(in srgb,var(--bg2) 92%,transparent);border:1px solid var(--hairline-strong);
+    border-radius:8px;   /* was the base 12px — too bubbly for a menu; match .ctxmenu */
+    -webkit-backdrop-filter:blur(28px) saturate(1.6);backdrop-filter:blur(28px) saturate(1.6)}
   body.macfam .w-floatingModal.anchored .w-button{
-    background:transparent;border:none;border-radius:5px;padding:4px 12px;
+    background:transparent;border:none;border-radius:5px;padding:3px 12px;
     position:relative;z-index:0;color:var(--fg)}
+  /* The selected/hovered row shows ONLY the inset accent pill — kill the generic
+     focus box-shadow ring (60-polish.css) that otherwise draws a second, softer
+     rectangle OUTSIDE the pill (the "double border"). */
+  body.macfam .w-floatingModal.anchored .w-button.focus,
+  body.macfam .w-floatingModal.anchored .w-button.sel,
+  body.macfam .w-floatingModal.anchored .w-button.primary{box-shadow:none;outline:none}
   body.macfam .w-floatingModal.anchored .w-button.primary,
   body.macfam .w-floatingModal.anchored .w-button.sel,
   body.macfam .w-floatingModal.anchored .w-button:hover{color:#fff}
@@ -167,6 +190,17 @@
   body.macfam .w-toggle:not(.on) .w-box{
     background:color-mix(in srgb,var(--fg) 24%,transparent)}
   body.macfam .settings-modal .set-switch.on{background:var(--ui-accent)}
+  /* Switch shape — the base 26×14 with a 10px knob reads thin and the knob
+     floats; macOS System Settings switches are a chunkier ~1.75:1 pill whose
+     knob nearly fills the track (~1.5px margin) with a faint drop shadow. */
+  body.macfam .settings-modal .set-switch,
+  body.macfam .w-toggle .w-box{width:30px;height:18px;border-radius:9px}   /* ~1.7:1, full pill */
+  body.macfam .settings-modal .set-switch::after,
+  body.macfam .w-toggle .w-box::after{
+    width:15px;height:15px;top:1.5px;left:1.5px;   /* knob fills ~0.85, ~1.5px inset */
+    box-shadow:0 1px 2px rgba(0,0,0,.18),0 0 0 .5px rgba(0,0,0,.04)}
+  body.macfam .settings-modal .set-switch.on::after,
+  body.macfam .w-toggle.on .w-box::after{left:13.5px}   /* travel = 30−15−1.5−1.5 */
 
   /* Buttons: a macOS push button (light or dark) + a filled-accent primary. */
   body.macfam .settings-modal .btn,body.macfam .trustdialog .td-btn,

--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -107,14 +107,14 @@
      Settings, dialogs) use a more translucent vibrancy. Both get the macOS
      shadow + a hairline edge. */
   body.macfam .dropdown,body.macfam .popup,body.macfam .ctxmenu{
-    background:color-mix(in srgb,var(--bg2) 97%,transparent);color:var(--fg);
-    -webkit-backdrop-filter:blur(28px) saturate(1.6);backdrop-filter:blur(28px) saturate(1.6);
+    background:color-mix(in srgb,var(--bg2) 84%,transparent);color:var(--fg);
+    -webkit-backdrop-filter:blur(50px) saturate(1.9);backdrop-filter:blur(50px) saturate(1.9);
     border:1px solid var(--hairline-strong)}
   body.macfam .palette,body.macfam .settings-modal,body.macfam .kbedit,
   body.macfam .trustdialog,body.macfam .auxmodal,
   body.macfam .widget-surface.w-floatingModal,body.macfam .palette.centered{
     background:var(--mac-panel);color:var(--fg);
-    -webkit-backdrop-filter:blur(32px) saturate(1.7);backdrop-filter:blur(32px) saturate(1.7);
+    -webkit-backdrop-filter:blur(60px) saturate(2);backdrop-filter:blur(60px) saturate(2);
     border:1px solid var(--hairline-strong)}
 
   /* Selection language, macOS-accurate:
@@ -155,9 +155,9 @@
      near-opaque menu material and BORDERLESS rows with an inset highlight,
      instead of a stack of bordered push-buttons. */
   body.macfam .widget-surface.w-floatingModal.anchored{
-    background:color-mix(in srgb,var(--bg2) 92%,transparent);border:1px solid var(--hairline-strong);
+    background:color-mix(in srgb,var(--bg2) 84%,transparent);border:1px solid var(--hairline-strong);
     border-radius:8px;   /* was the base 12px — too bubbly for a menu; match .ctxmenu */
-    -webkit-backdrop-filter:blur(28px) saturate(1.6);backdrop-filter:blur(28px) saturate(1.6)}
+    -webkit-backdrop-filter:blur(50px) saturate(1.9);backdrop-filter:blur(50px) saturate(1.9)}
   body.macfam .w-floatingModal.anchored .w-button{
     background:transparent;border:none;border-radius:5px;padding:3px 12px;
     position:relative;z-index:0;color:var(--fg)}
@@ -171,11 +171,14 @@
      close") are `.w-raw` captions, not selectable rows — make them read as
      chrome: small and muted, the header a semibold caption, the footer set off
      by a hairline. Otherwise they look like plain disabled menu items. */
-  body.macfam .w-floatingModal.anchored .w-raw{font-size:11px;color:var(--muted);padding:1px 12px}
+  body.macfam .w-floatingModal.anchored .w-raw{color:var(--muted);padding:1px 12px}
+  /* Header (the context name): near item size so it doesn't read as a jarringly
+     smaller line — differentiated by weight + muted colour, not by shrinking. */
   body.macfam .w-floatingModal.anchored .w-raw:first-child{
-    font-weight:600;padding:3px 12px 3px;letter-spacing:.02em}
+    font-size:13px;font-weight:600;padding:3px 12px 4px}
+  /* Footer hint: a genuine secondary hint, so a step smaller, set off by a rule. */
   body.macfam .w-floatingModal.anchored .w-raw:last-child{
-    padding-top:4px;margin-top:3px;border-top:1px solid var(--hairline)}
+    font-size:11px;padding:4px 12px 2px;margin-top:3px;border-top:1px solid var(--hairline)}
   body.macfam .w-floatingModal.anchored .w-button.primary,
   body.macfam .w-floatingModal.anchored .w-button.sel,
   body.macfam .w-floatingModal.anchored .w-button:hover{color:#fff}

--- a/web-ui/js/40-menu.js
+++ b/web-ui/js/40-menu.js
@@ -58,6 +58,7 @@ function submenuItems(reg, depth){
 function menuCompression(reg){
   const SEP_PX = Math.max(8, Math.round(CH*0.52));   // compact separator slot
   const rowExtra = CH - SEP_PX;                        // px removed per sep row
+  const PAD = Math.max(4, Math.round(CH*0.26));        // target panel top/bottom inset (~5px)
   const sepByDepth = {};                              // depth -> Set(cell-y of seps)
   const addSep=(d,y)=>{ (sepByDepth[d]=sepByDepth[d]||new Set()).add(y); };
   const topItems = reg.menus[reg.menuOpen]?.items||[];
@@ -66,25 +67,45 @@ function menuCompression(reg){
     if(list[su.index]?.kind==="sep") addSep(su.depth, su.rect.y); }
   // Sum the sep-shrink accumulated ABOVE cell-y within one depth's own stack.
   const shrinkAbove=(d,y)=>{ let s=0; const set=sepByDepth[d]; if(set) for(const sy of set) if(sy<y) s+=rowExtra; return s; };
-  // Each depth's stack starts shifted up by the shrink its parent applied at the
-  // submenu's anchor row (depth 0 anchors at 0).
-  const boxTop={0: reg.dropdown?.rect?.y ?? 0};
-  for(const b of (reg.dropdown?.submenuBoxes||[])) boxTop[b.depth]=b.rect.y;
-  const anchor={0:0};
-  for(const d of Object.keys(boxTop).map(Number).sort((a,b)=>a-b)){
-    if(d===0) continue; anchor[d]=(anchor[d-1]||0)+shrinkAbove(d-1, boxTop[d]);
+  // Per-depth backing box + item extents (cells), to compress the panel's own
+  // top/bottom padding row (~1 full cell in the TUI border) down to PAD.
+  const box={}; if(reg.dropdown?.rect) box[0]=reg.dropdown.rect;
+  for(const b of (reg.dropdown?.submenuBoxes||[])) box[b.depth]=b.rect;
+  const itemYs={};
+  for(const di of (reg.dropdown?.items||[])) (itemYs[0]=itemYs[0]||[]).push(di.rect.y);
+  for(const su of (reg.dropdown?.submenus||[])) (itemYs[su.depth]=itemYs[su.depth]||[]).push(su.rect.y);
+  const topCut={}, botCut={};   // px removed from a depth's top / bottom padding
+  for(const d of Object.keys(box).map(Number)){
+    const bx=box[d], ys=itemYs[d];
+    if(!bx || !ys || !ys.length){ topCut[d]=0; botCut[d]=0; continue; }
+    topCut[d]=Math.max(0, (Math.min(...ys)-bx.y)*CH - PAD);
+    botCut[d]=Math.max(0, ((bx.y+bx.h)-(Math.max(...ys)+1))*CH - PAD);
   }
-  const shiftFor=(d,y)=>(anchor[d]||0)+shrinkAbove(d,y);
+  // panelShift: how far each depth's PANEL moves up. Depth 0's panel top stays
+  // anchored under the menu bar; a submenu's panel tracks its parent item's total
+  // upward shift so it stays aligned (the −topCut[d] cancels the extra its own
+  // items get, keeping the submenu's first item level with the parent row).
+  const boxTop={0: box[0]?.y ?? 0};
+  for(const d in box) boxTop[d]=box[d].y;
+  const panelShift={0:0};
+  for(const d of Object.keys(box).map(Number).sort((a,b)=>a-b)){
+    if(d===0) continue;
+    panelShift[d]=(panelShift[d-1]||0)+shrinkAbove(d-1, boxTop[d])+(topCut[d-1]||0)-(topCut[d]||0);
+  }
+  // Items shift by their panel's shift + own seps above + their own top-pad cut.
+  const itemShift=(d,y)=>(panelShift[d]||0)+shrinkAbove(d,y)+(topCut[d]||0);
+  const sepsInside=(d,rect)=>{ let e=0; const set=sepByDepth[d];
+    if(set) for(const sy of set) if(sy>=rect.y && sy<rect.y+rect.h) e+=rowExtra; return e; };
   return {
     SEP_PX,
     isSep:(d,y)=> sepByDepth[d]?.has(y)||false,
-    top:(d,y)=> px(y,CH) - shiftFor(d,y),
-    height:(d,rect)=>{
-      if(sepByDepth[d]?.has(rect.y)) return SEP_PX;
-      let extra=0; const set=sepByDepth[d];             // a panel spans several rows
-      if(set) for(const sy of set) if(sy>=rect.y && sy<rect.y+rect.h) extra+=rowExtra;
-      return px(rect.h,CH) - extra;
-    },
+    // items / separators / labels
+    top:(d,y)=> px(y,CH) - itemShift(d,y),
+    height:(d,rect)=> sepByDepth[d]?.has(rect.y) ? SEP_PX : px(rect.h,CH) - sepsInside(d,rect),
+    // backing panels — top tracks the parent shift (no per-item pad cut), height
+    // hugs the now-compressed content (drop the excess top+bottom padding + seps).
+    panelTop:(d,y)=> px(y,CH) - (panelShift[d]||0),
+    panelH:(d,rect)=> px(rect.h,CH) - sepsInside(d,rect) - (topCut[d]||0) - (botCut[d]||0),
   };
 }
 
@@ -197,7 +218,7 @@ function dropdownPanels(reg, comp, shiftsOut){
     }
     prevRight=b.rect.x + b.rect.w;
     const p=div("dropdown"+(b.depth>=1?" submenu":"")); place(p,b.rect);
-    if(comp){ p.style.top=comp.top(b.depth,b.rect.y)+"px"; p.style.height=comp.height(b.depth,b.rect)+"px"; }
+    if(comp){ p.style.top=comp.panelTop(b.depth,b.rect.y)+"px"; p.style.height=comp.panelH(b.depth,b.rect)+"px"; }
     panels.push(p);
   }
   return panels;

--- a/web-ui/js/40-menu.js
+++ b/web-ui/js/40-menu.js
@@ -123,7 +123,8 @@ function menuDropdownEls(reg){
   const out=[];
   if(reg.menuOpen==null || !reg.dropdown) return out;
   const comp=menuCompression(reg);
-  for(const grp of dropdownPanels(reg, comp)) out.push(grp);   // solid backing panels
+  const xshift={};   // depth -> cells the panel was nudged right (submenu seam fix)
+  for(const grp of dropdownPanels(reg, comp, xshift)) out.push(grp);   // solid backing panels
   const path=reg.submenuPath||[];
   // top-level items: highlighted = menuHighlight when no submenu is deeper,
   // otherwise the parent of the open submenu (path[0]).
@@ -137,7 +138,15 @@ function menuDropdownEls(reg){
     const list=submenuItems(reg, su.depth);
     const deepest = su.depth===path.length;
     const hi = deepest ? su.index===reg.menuHighlight : su.index===path[su.depth];
-    const el=itemRow(list[su.index], su.rect, hi, comp, su.depth); if(el) out.push(el);
+    const el=itemRow(list[su.index], su.rect, hi, comp, su.depth); if(el){
+      // Move the item right with its nudged panel (see dropdownPanels) so the
+      // 1-cell left inset — and thus the label rhythm and highlight pill — match
+      // the top-level menu. The right edge is preserved (width shrinks by the
+      // same amount); the click cell (rectCell) is untouched.
+      const sh=(xshift[su.depth]||0)*CW;
+      if(sh>0){ el.style.left=(px(su.rect.x,CW)+sh)+"px"; el.style.width=Math.max(0,px(su.rect.w,CW)-sh)+"px"; }
+      out.push(el);
+    }
   }
   return out;
 }
@@ -147,7 +156,7 @@ function menuDropdownEls(reg){
 // `submenuBoxes`) — the same footprint the TUI border occupies, so the panel
 // sits flush under the menu bar instead of leaving the border row as a gap.
 // Item-union fallback kept for scenes predating the recorded boxes.
-function dropdownPanels(reg, comp){
+function dropdownPanels(reg, comp, shiftsOut){
   const panels=[];
   const union=(rects)=>{
     if(!rects.length) return null;
@@ -180,6 +189,11 @@ function dropdownPanels(reg, comp){
     if(b.depth>=1 && prevRight!=null && b.rect.x<prevRight){
       const shift=prevRight-b.rect.x;
       b.rect.x=prevRight; b.rect.w=Math.max(0, b.rect.w-shift);
+      // Record the shift so the item rects (placed separately in
+      // menuDropdownEls) can move with the panel — otherwise the submenu items
+      // lose the 1-cell inset the panel had, so their labels and the accent
+      // highlight would hug (and overhang) the panel's left edge.
+      if(shiftsOut) shiftsOut[b.depth]=shift;
     }
     prevRight=b.rect.x + b.rect.w;
     const p=div("dropdown"+(b.depth>=1?" submenu":"")); place(p,b.rect);

--- a/web-ui/js/40-menu.js
+++ b/web-ui/js/40-menu.js
@@ -42,15 +42,70 @@ function submenuItems(reg, depth){
   return items;
 }
 
+// Vertical compression for the open menu tree. In the TUI a separator is a full
+// character row, so the core emits it as a 1-cell row — on the web that renders
+// as a hairline floating in a ~21px void, which reads as "menus have way too
+// much padding". This shrinks every separator row to a compact macOS separator
+// (~11px) and pulls the rows below it up, so groups sit tight the way a native
+// AppKit menu does. Item rows keep their full cell height (already ~correct).
+//
+// Everything — items, separators, backing panels, submenu boxes — is placed
+// through this same per-depth remap, so alignment is preserved: a submenu
+// re-anchors to its (now shifted) parent row, and each level compresses its own
+// separators on top of that anchor. Hit-testing is unaffected: clicks/hover are
+// dispatched by each row's STORED cell (rectCell), never by its pixel position,
+// so moving the box up doesn't change which item the editor resolves.
+function menuCompression(reg){
+  const SEP_PX = Math.max(8, Math.round(CH*0.52));   // compact separator slot
+  const rowExtra = CH - SEP_PX;                        // px removed per sep row
+  const sepByDepth = {};                              // depth -> Set(cell-y of seps)
+  const addSep=(d,y)=>{ (sepByDepth[d]=sepByDepth[d]||new Set()).add(y); };
+  const topItems = reg.menus[reg.menuOpen]?.items||[];
+  for(const di of (reg.dropdown?.items||[])) if(topItems[di.index]?.kind==="sep") addSep(0, di.rect.y);
+  for(const su of (reg.dropdown?.submenus||[])){ const list=submenuItems(reg, su.depth);
+    if(list[su.index]?.kind==="sep") addSep(su.depth, su.rect.y); }
+  // Sum the sep-shrink accumulated ABOVE cell-y within one depth's own stack.
+  const shrinkAbove=(d,y)=>{ let s=0; const set=sepByDepth[d]; if(set) for(const sy of set) if(sy<y) s+=rowExtra; return s; };
+  // Each depth's stack starts shifted up by the shrink its parent applied at the
+  // submenu's anchor row (depth 0 anchors at 0).
+  const boxTop={0: reg.dropdown?.rect?.y ?? 0};
+  for(const b of (reg.dropdown?.submenuBoxes||[])) boxTop[b.depth]=b.rect.y;
+  const anchor={0:0};
+  for(const d of Object.keys(boxTop).map(Number).sort((a,b)=>a-b)){
+    if(d===0) continue; anchor[d]=(anchor[d-1]||0)+shrinkAbove(d-1, boxTop[d]);
+  }
+  const shiftFor=(d,y)=>(anchor[d]||0)+shrinkAbove(d,y);
+  return {
+    SEP_PX,
+    isSep:(d,y)=> sepByDepth[d]?.has(y)||false,
+    top:(d,y)=> px(y,CH) - shiftFor(d,y),
+    height:(d,rect)=>{
+      if(sepByDepth[d]?.has(rect.y)) return SEP_PX;
+      let extra=0; const set=sepByDepth[d];             // a panel spans several rows
+      if(set) for(const sy of set) if(sy>=rect.y && sy<rect.y+rect.h) extra+=rowExtra;
+      return px(rect.h,CH) - extra;
+    },
+  };
+}
+
 // One native dropdown row, positioned at the pipeline's cell rect.
-// `hi` says whether the editor currently highlights this row.
-function itemRow(item, rect, hi){
+// `hi` says whether the editor currently highlights this row. `comp`/`depth`
+// apply the separator compression above (top/height are remapped, x/width and
+// the click cell stay exactly as the editor reported them).
+function itemRow(item, rect, hi, comp, depth){
   if(!item) return null;
-  if(item.kind==="sep"){ const s=div("msep"); place(s,rect); s.style.height="1px"; s.style.top=px(rect.y+0.5,CH)+"px"; return s; }
-  if(item.kind==="label"){ const l=div("mlabel"); place(l,rect); l.style.lineHeight=CH+"px"; l.textContent=item.label; return l; }
+  if(item.kind==="sep"){ const s=div("msep"); place(s,rect);
+    const slot = comp ? comp.SEP_PX : CH;
+    const top  = comp ? comp.top(depth,rect.y) : px(rect.y,CH);
+    s.style.height="1px"; s.style.top=(top+(slot-1)/2)+"px"; return s; }
+  if(item.kind==="label"){ const l=div("mlabel"); place(l,rect);
+    if(comp){ l.style.top=comp.top(depth,rect.y)+"px"; l.style.height=comp.height(depth,rect)+"px"; }
+    l.style.lineHeight=CH+"px"; l.textContent=item.label; return l; }
   const cell=rectCell(rect);
   const row=div("mitem"+(hi?" hi":"")+(item.enabled===false?" disabled":""));
-  place(row,rect); row.style.lineHeight=CH+"px";
+  place(row,rect);
+  if(comp){ row.style.top=comp.top(depth,rect.y)+"px"; row.style.height=comp.height(depth,rect)+"px"; }
+  row.style.lineHeight=CH+"px";
   const check = item.checked===true?"✓":"";
   const arrow = item.kind==="submenu"?'<span class="arrow">›</span>':"";
   const accel = item.accel?`<span class="accel">${esc(item.accel)}</span>`:"";
@@ -67,21 +122,22 @@ function itemRow(item, rect, hi){
 function menuDropdownEls(reg){
   const out=[];
   if(reg.menuOpen==null || !reg.dropdown) return out;
-  for(const grp of dropdownPanels(reg)) out.push(grp);      // solid backing panels
+  const comp=menuCompression(reg);
+  for(const grp of dropdownPanels(reg, comp)) out.push(grp);   // solid backing panels
   const path=reg.submenuPath||[];
   // top-level items: highlighted = menuHighlight when no submenu is deeper,
   // otherwise the parent of the open submenu (path[0]).
   const items=reg.menus[reg.menuOpen]?.items||[];
   for(const di of reg.dropdown.items){
     const hi = path.length===0 ? di.index===reg.menuHighlight : di.index===path[0];
-    const el=itemRow(items[di.index], di.rect, hi); if(el) out.push(el);
+    const el=itemRow(items[di.index], di.rect, hi, comp, 0); if(el) out.push(el);
   }
   // expanded submenu levels
   for(const su of (reg.dropdown.submenus||[])){
     const list=submenuItems(reg, su.depth);
     const deepest = su.depth===path.length;
     const hi = deepest ? su.index===reg.menuHighlight : su.index===path[su.depth];
-    const el=itemRow(list[su.index], su.rect, hi); if(el) out.push(el);
+    const el=itemRow(list[su.index], su.rect, hi, comp, su.depth); if(el) out.push(el);
   }
   return out;
 }
@@ -91,7 +147,7 @@ function menuDropdownEls(reg){
 // `submenuBoxes`) — the same footprint the TUI border occupies, so the panel
 // sits flush under the menu bar instead of leaving the border row as a gap.
 // Item-union fallback kept for scenes predating the recorded boxes.
-function dropdownPanels(reg){
+function dropdownPanels(reg, comp){
   const panels=[];
   const union=(rects)=>{
     if(!rects.length) return null;
@@ -126,7 +182,9 @@ function dropdownPanels(reg){
       b.rect.x=prevRight; b.rect.w=Math.max(0, b.rect.w-shift);
     }
     prevRight=b.rect.x + b.rect.w;
-    const p=div("dropdown"+(b.depth>=1?" submenu":"")); place(p,b.rect); panels.push(p);
+    const p=div("dropdown"+(b.depth>=1?" submenu":"")); place(p,b.rect);
+    if(comp){ p.style.top=comp.top(b.depth,b.rect.y)+"px"; p.style.height=comp.height(b.depth,b.rect)+"px"; }
+    panels.push(p);
   }
   return panels;
 }

--- a/web-ui/js/80-input.js
+++ b/web-ui/js/80-input.js
@@ -131,7 +131,13 @@ let dragging=false, lastCell=null;
 // forwards them to the editor at the exact cell rects the pipeline reported.
 // The document-level handlers are the fallback for buffer interiors, scrollbars
 // and separators, so they ignore anything that lands on a chrome element.
-const onChrome = e => e.target.closest("#mobile,.menubar,.dropdown,.tabbar,.statusbar,.palette,.popup,.fileexplorer,.trustdialog,.modal-scrim,.widget-surface,.ctxmenu,.auxmodal,.kbedit,.settings-modal");
+// NB: dropdown ITEMS (.mitem/.msep/.mlabel) are siblings of the .dropdown backing
+// panel, not children, so they must be listed explicitly. They own their own
+// hover/click at the exact cell the editor reported (rectCell); without them the
+// document fallback would forward a LINEAR pixel→cell hover (cellAt) that is
+// wrong once the menu reflow makes an item's screen position differ from
+// cell×CH — sending a bogus cell that e.g. closes a submenu the item just opened.
+const onChrome = e => e.target.closest("#mobile,.menubar,.dropdown,.mitem,.msep,.mlabel,.tabbar,.statusbar,.palette,.popup,.fileexplorer,.trustdialog,.modal-scrim,.widget-surface,.ctxmenu,.auxmodal,.kbedit,.settings-modal");
 // `count` carries the browser's click count (event.detail); the bridge primes
 // the editor's own double/triple-click detection with it (see apply_mouse).
 document.addEventListener("mousedown",e=>{ if(onChrome(e)) return; if(mSheetOpen){ mSheetOpen=false; render(); } const c=cellAt(e); dragging=true; lastCell=c; sendMouse({kind:"down",button:btn(e),col:c.col,row:c.row,count:e.detail,ctrl:e.ctrlKey,shift:e.shiftKey,alt:e.altKey}); });


### PR DESCRIPTION
Menu-bar dropdowns (js/40-menu.js): compress separators from a full ~21px cell
row to a compact ~11px slot and reflow the rows below, so grouped menus sit
tight like a native AppKit menu instead of floating in blank rows. Every element
(items, separators, backing panels, submenu boxes) is placed through one
per-depth remap, and hit-testing is unchanged (clicks dispatch by each row's
stored cell, not its pixel position).

macOS theme (css/92-theme-macos.css):
- Dropdown item rhythm: trim the stacked left inset (phantom cell border + 14px
  pad + 12px check gutter ≈ 41px) so labels sit ~25px in, and pull the accent
  highlight pill back so it hugs the panel edge (~6px) instead of ~14px.
- Plugin (dock) context menu: drop the too-round 12px radius to 8px to match
  .ctxmenu, kill the stray focus box-shadow ring that drew a second border
  outside the selection pill, add the menu blur/vibrancy material, tighten rows.
- Switch control: chunkier ~1.7:1 pill (30x18) with a knob that nearly fills the
  track (15px, ~1.5px inset) and a faint drop shadow, matching System Settings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019VpvuNkgJ4NPB2W7YeeKBX