### PR TITLE
feat(widgets): host-native floating pop-over for the Dropdown widget

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5639,6 +5639,13 @@ const HISTORY_CAP = 100;
 /// keys this form actually binds it stays in sync.
 let formFocusCycle: string[] = [];
 let formFocusIndex = 0;
+// Mirror of the Agent dropdown's option pop-over open/closed state, kept in
+// sync from the host's `dropdown_open` widget_event (fired on every open/close
+// — keyboard, trigger click, or an option pick). The form's Enter/Escape key
+// handlers read it to route those keys correctly: an open pop-over swallows
+// Enter/Escape into the list (commit / dismiss), a closed one lets them
+// activate / cancel the dialog.
+let agentDropdownOpen = false;
 
 function rebuildFormFocusCycle(): void {
   if (!form) {
@@ -7619,6 +7626,7 @@ function closeForm(): void {
     formPanel = null;
   }
   form = null;
+  agentDropdownOpen = false;
   editor.setEditorMode(null);
 }
 
@@ -8627,6 +8635,16 @@ registerHandler("orchestrator_form_key_enter", () => {
     dispatchFormKey("Enter");
     return;
   }
+  // Focused Agent dropdown: Enter opens the option pop-over (and, when it's
+  // already open, commits the highlighted option and closes). `activate()` is
+  // a no-op on a Dropdown, so route the raw key to the host's smart-key
+  // dispatch instead — `set_dropdown_open` / the open-list short-circuit
+  // handle both directions. (Mouse click on the `[value ▼]` trigger already
+  // opens it via the host's `dropdown_toggle` hit.)
+  if (formFocusedKey() === "agent_dropdown") {
+    dispatchFormKey("Enter");
+    return;
+  }
   // Popup closed: Enter must NOT advance focus (Tab / Shift-Tab are the only
   // field movers). Activate the focused control instead — `activate()` fires
   // a Button's "activate" event (Create / Cancel / Advanced / the type tabs)
@@ -8651,6 +8669,14 @@ registerHandler("orchestrator_form_key_escape", () => {
   // resync happens in the widget_event handler. Only when
   // the popup is already closed does Escape cancel the form.
   if (completionVisibleForFocused()) {
+    dispatchFormKey("Escape");
+    return;
+  }
+  // An open Agent dropdown pop-over swallows the first Escape: route it to
+  // the host's dropdown short-circuit (which closes the list) instead of
+  // cancelling the dialog. A second Escape — now that the list is closed —
+  // falls through to `cancelForm` below.
+  if (agentDropdownOpen && formFocusedKey() === "agent_dropdown") {
     dispatchFormKey("Escape");
     return;
   }
@@ -8981,6 +9007,15 @@ editor.on("widget_event", (e) => {
       // that mirror from the authoritative signal here so the
       // plugin never has to predict host-side focus rules.
       snapFormFocusTo(e.widget_key);
+      // Leaving the Agent dropdown (Tab / click elsewhere) closes its
+      // pop-over host-side; keep the local mirror honest.
+      if (e.widget_key !== "agent_dropdown") agentDropdownOpen = false;
+      return;
+    }
+    if (e.event_type === "dropdown_open" && e.widget_key === "agent_dropdown") {
+      // Host-authoritative open/closed signal for the option pop-over.
+      const payload = (e.payload ?? {}) as Record<string, unknown>;
+      agentDropdownOpen = payload.open === true;
       return;
     }
     if (e.event_type === "change" && e.widget_key === "agent_dropdown") {

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1314,6 +1314,33 @@ pub(crate) struct FloatingWidgetState {
     /// (web mode) since geometry is computed there without painting cells.
     /// `None` when the panel isn't a closable `Centered` modal.
     pub close_button_rect: Option<ratatui::layout::Rect>,
+    /// The open `Dropdown`'s option list, surfaced by the widget renderer
+    /// for a screen-level floating pop-over (drawn by
+    /// `render_floating_widget_panel` at the trigger's screen row, clipped
+    /// to the terminal so it extends past the panel/modal frame). `None`
+    /// when no keyed Dropdown in this panel is open. Refreshed on every
+    /// render alongside `entries`.
+    pub dropdown_popup: Option<crate::widgets::DropdownPopup>,
+    /// Screen-space hit rectangles for the open dropdown pop-over's option
+    /// rows, recomputed on every draw (like `close_button_rect`). Each maps
+    /// a terminal rect to the absolute option index; the mouse hit-test
+    /// checks these BEFORE the panel-inner gate so a click on an option
+    /// below the modal border still selects it. Empty when no pop-over is
+    /// drawn.
+    pub dropdown_popup_hits: Vec<DropdownPopupOptionHit>,
+    /// Full screen rect of the drawn dropdown pop-over box (border
+    /// included), so a click anywhere inside it is consumed rather than
+    /// dismissing the modal. `None` when no pop-over is drawn.
+    pub dropdown_popup_rect: Option<ratatui::layout::Rect>,
+}
+
+/// One option row of the open dropdown pop-over, captured at draw time as
+/// a screen rect → absolute option index, so the mouse hit-test can route
+/// a click on the (panel-escaping) pop-over back to `dropdown_select`.
+#[derive(Debug, Clone)]
+pub(crate) struct DropdownPopupOptionHit {
+    pub rect: ratatui::layout::Rect,
+    pub index: usize,
 }
 
 /// How long the dock's overlay scrollbar stays visible after a keyboard
@@ -1856,6 +1883,9 @@ mod tests {
             title: None,
             closable: false,
             close_button_rect: None,
+            dropdown_popup: None,
+            dropdown_popup_hits: Vec::new(),
+            dropdown_popup_rect: None,
         }
     }
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4110,7 +4110,58 @@ impl Editor {
 
     /// `handle_editor_click` uses; clicks outside the rect are
     /// swallowed without dismissing the panel.
+    /// Resolve a click against the open dropdown pop-over's screen rects
+    /// (recorded by the last draw). A click on an option row delivers the
+    /// same `dropdown_select` hit a TUI cell click on the old inline list
+    /// would; a click elsewhere inside the box (border) is swallowed so it
+    /// neither selects nor dismisses the modal. Returns true when the click
+    /// was inside the pop-over box (and thus consumed).
+    fn try_dropdown_popup_click(&mut self, slot: super::PanelSlot, col: u16, row: u16) -> bool {
+        let (panel_key, key, hits, popup_rect) = match self.panel(slot) {
+            Some(f) => (
+                f.panel_key.clone(),
+                f.dropdown_popup.as_ref().map(|d| d.widget_key.clone()),
+                f.dropdown_popup_hits.clone(),
+                f.dropdown_popup_rect,
+            ),
+            None => return false,
+        };
+        let popup_rect = match popup_rect {
+            Some(r) => r,
+            None => return false,
+        };
+        let key = match key {
+            Some(k) if !k.is_empty() => k,
+            _ => return false,
+        };
+        // Option row → select that index (fires `change`) and close.
+        if let Some(hit) = hits.iter().find(|h| in_rect(col, row, h.rect)) {
+            let ha = crate::widgets::HitArea {
+                widget_key: key,
+                widget_kind: "dropdown",
+                buffer_row: 0,
+                byte_start: 0,
+                byte_end: 0,
+                payload: serde_json::json!({ "index": hit.index }),
+                event_type: "dropdown_select",
+            };
+            self.deliver_widget_hit(&panel_key, &ha, None);
+            return true;
+        }
+        // Inside the box but not on a row (its border): consume so the
+        // modal isn't dismissed and the list stays open.
+        in_rect(col, row, popup_rect)
+    }
+
     fn handle_floating_widget_click(&mut self, slot: super::PanelSlot, col: u16, row: u16) {
+        // An open dropdown's option list floats as a screen-level pop-over
+        // that extends PAST the panel/modal border, so a click on one of
+        // its option rows lands outside the panel's inner rect and would be
+        // dropped by the gate below. Resolve it first, against the screen
+        // rects recorded at draw time.
+        if self.try_dropdown_popup_click(slot, col, row) {
+            return;
+        }
         // Scrollbar press wins over row hit-testing (the bar overlaps
         // the list's rightmost column).
         if self.try_widget_scrollbar_press(slot, col, row) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5010,6 +5010,9 @@ impl Editor {
             title: if as_dock { None } else { title },
             closable: !as_dock && closable,
             close_button_rect: None,
+            dropdown_popup: None,
+            dropdown_popup_hits: Vec::new(),
+            dropdown_popup_rect: None,
         });
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
@@ -5026,6 +5029,7 @@ impl Editor {
         let embeds = out.embeds;
         let overlays = out.overlays;
         let scroll_regions = out.scroll_regions;
+        let dropdown_popup = out.dropdown_popup;
         self.widget_registry.mount(
             panel_key.clone(),
             buffer_id,
@@ -5041,6 +5045,7 @@ impl Editor {
             fwp.embeds = embeds;
             fwp.overlays = overlays;
             fwp.scroll_regions = scroll_regions;
+            fwp.dropdown_popup = dropdown_popup;
         }
         tracing::debug!(
             "Mounted floating widget panel {} ({}%x{}%)",
@@ -5094,6 +5099,7 @@ impl Editor {
         let embeds = out.embeds;
         let overlays = out.overlays;
         let scroll_regions = out.scroll_regions;
+        let dropdown_popup = out.dropdown_popup;
         if self
             .widget_registry
             .update(
@@ -5118,6 +5124,7 @@ impl Editor {
             fwp.embeds = embeds;
             fwp.overlays = overlays;
             fwp.scroll_regions = scroll_regions;
+            fwp.dropdown_popup = dropdown_popup;
         }
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4379,6 +4379,7 @@ impl Editor {
             scrollbar_flash_until,
             title,
             closable,
+            dropdown_popup,
         ) = match self.panel(slot) {
             Some(fwp) => (
                 fwp.width_pct,
@@ -4394,6 +4395,7 @@ impl Editor {
                 fwp.scrollbar_flash_until,
                 fwp.title.clone(),
                 fwp.closable,
+                fwp.dropdown_popup.clone(),
             ),
             None => return,
         };
@@ -4781,6 +4783,110 @@ impl Editor {
             );
         }
 
+        // ---- Open-Dropdown floating pop-over ---------------------------
+        // Painted AFTER the panel content, at the trigger's SCREEN row and
+        // clamped to the whole frame (`area`) rather than the panel — so
+        // the option list extends past the panel/modal border instead of
+        // growing/clipping it. Geometry mirrors the
+        // `PanelPlacement::Anchored` popup: hug the content, and flip above
+        // the trigger when there's no room below. Each option's screen rect
+        // is recorded so the mouse hit-test can route a click (which lands
+        // outside the panel's inner rect) back to `dropdown_select`.
+        let mut dropdown_popup_hits: Vec<super::DropdownPopupOptionHit> = Vec::new();
+        let mut dropdown_popup_rect: Option<ratatui::layout::Rect> = None;
+        if let Some(dp) = dropdown_popup.as_ref() {
+            use crate::primitives::display_width::{byte_offset_at_visual_column, str_width};
+            use ratatui::style::{Modifier, Style};
+            let visible = dp
+                .options
+                .len()
+                .min(crate::widgets::DROPDOWN_VISIBLE_OPTIONS);
+            if visible > 0 {
+                let max_scroll = dp.options.len().saturating_sub(visible);
+                let scroll = dp.scroll.min(max_scroll);
+                // Box width = widest visible option + 1 col of left padding,
+                // + 2 for the borders; clamped to the frame.
+                let content_w = dp
+                    .options
+                    .iter()
+                    .skip(scroll)
+                    .take(visible)
+                    .map(|o| str_width(o) as u16)
+                    .max()
+                    .unwrap_or(0);
+                let w = content_w
+                    .saturating_add(1)
+                    .saturating_add(2)
+                    .clamp(4, area.width);
+                let h = (visible as u16).saturating_add(2).clamp(3, area.height);
+                // Anchor to the trigger's screen row; prefer opening below
+                // (one row under the trigger), flipping above when the box
+                // would run off the bottom of the frame.
+                let anchor_screen_y = inner.y.saturating_add(dp.anchor_row as u16);
+                let below_y = anchor_screen_y.saturating_add(1);
+                let bottom = area.y + area.height;
+                let y = if below_y.saturating_add(h) <= bottom {
+                    below_y
+                } else {
+                    anchor_screen_y.saturating_sub(h)
+                };
+                let x = inner.x.min(area.x + area.width.saturating_sub(w));
+                let y = y.clamp(area.y, area.y + area.height.saturating_sub(h));
+                let popup_rect = ratatui::layout::Rect {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                };
+                frame.render_widget(Clear, popup_rect);
+                let popup_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(ratatui::style::Style::default().fg(theme.popup_border_fg))
+                    .style(ratatui::style::Style::default().bg(theme.suggestion_bg));
+                let popup_inner = popup_block.inner(popup_rect);
+                frame.render_widget(popup_block, popup_rect);
+                for (row_i, idx) in (scroll..scroll + visible).enumerate() {
+                    let ry = popup_inner.y + row_i as u16;
+                    if ry >= popup_inner.y + popup_inner.height {
+                        break;
+                    }
+                    let row_rect = ratatui::layout::Rect {
+                        x: popup_inner.x,
+                        y: ry,
+                        width: popup_inner.width,
+                        height: 1,
+                    };
+                    let selected = idx == dp.selected;
+                    let row_bg = if selected {
+                        theme.suggestion_selected_bg
+                    } else {
+                        theme.suggestion_bg
+                    };
+                    frame.render_widget(
+                        Block::default().style(ratatui::style::Style::default().bg(row_bg)),
+                        row_rect,
+                    );
+                    // One col of left padding, truncated to the interior.
+                    let avail = popup_inner.width.saturating_sub(1) as usize;
+                    let opt = dp.options.get(idx).map(|s| s.as_str()).unwrap_or("");
+                    let cut = byte_offset_at_visual_column(opt, avail);
+                    let text = &opt[..cut];
+                    let mut style = Style::default().fg(theme.suggestion_fg).bg(row_bg);
+                    if selected {
+                        style = style.add_modifier(Modifier::BOLD);
+                    }
+                    frame
+                        .buffer_mut()
+                        .set_string(popup_inner.x + 1, ry, text, style);
+                    dropdown_popup_hits.push(super::DropdownPopupOptionHit {
+                        rect: row_rect,
+                        index: idx,
+                    });
+                }
+                dropdown_popup_rect = Some(popup_rect);
+            }
+        }
+
         if let Some(fc) = focus_cursor {
             let cx = inner.x.saturating_add(byte_to_screen_col(
                 entries
@@ -4811,6 +4917,8 @@ impl Editor {
             fwp.close_button_rect = close_button_rect;
             fwp.scrollbar_tracks = scrollbar_tracks;
             fwp.scrollbar_hover_zones = scrollbar_hover_zones;
+            fwp.dropdown_popup_hits = dropdown_popup_hits;
+            fwp.dropdown_popup_rect = dropdown_popup_rect;
         }
     }
 

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -866,6 +866,7 @@ impl Editor {
         let embeds = out_pieces.embeds;
         let overlays = out_pieces.overlays;
         let scroll_regions = out_pieces.scroll_regions;
+        let dropdown_popup = out_pieces.dropdown_popup;
         if self
             .widget_registry
             .update_side_effects(
@@ -888,6 +889,7 @@ impl Editor {
                     fwp.embeds = embeds;
                     fwp.overlays = overlays;
                     fwp.scroll_regions = scroll_regions;
+                    fwp.dropdown_popup = dropdown_popup;
                 }
             }
             return;
@@ -1960,11 +1962,12 @@ impl Editor {
             Some(fresh_core::api::WidgetSpec::Dropdown { selected_index, .. }) => *selected_index,
             _ => return,
         };
-        let cur = match panel.instance_states.get(widget_key) {
-            Some(crate::widgets::WidgetInstanceState::Dropdown { selected_index, .. }) => {
-                *selected_index
-            }
-            _ => spec_sel,
+        let (cur, prev_open) = match panel.instance_states.get(widget_key) {
+            Some(crate::widgets::WidgetInstanceState::Dropdown {
+                selected_index,
+                open,
+            }) => (*selected_index, *open),
+            _ => (spec_sel, false),
         };
         if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             panel_mut.instance_states.insert(
@@ -1976,6 +1979,21 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_key);
+        // Notify the plugin when the option pop-over actually opens or
+        // closes (any path: keyboard, a `[value ▼]` trigger click, or an
+        // option pick that closes it). The plugin mirrors this so its own
+        // key handlers can tell "dropdown open" apart from "dropdown
+        // closed" — e.g. Escape closes the open list but cancels the
+        // dialog when it's already closed. Not a value edit, so it's a
+        // distinct `dropdown_open` event, never `change`.
+        if open != prev_open {
+            self.fire_widget_event(
+                panel_key,
+                widget_key.to_string(),
+                "dropdown_open".into(),
+                serde_json::json!({ "open": open }),
+            );
+        }
     }
 
     /// Apply a `DualList` interaction, update the host-owned instance

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -30,7 +30,7 @@ pub use registry::{
 pub use render::{
     clamp_number, dual_available_values, dual_label, dual_sanitize_included, format_number_value,
     render_dropdown, render_number, render_spec, render_spec_no_autofocus, render_spec_with_marker,
-    wrap_index, EmbedRect, FocusCursor, OverlayRow, RenderOutput, ScrollRegion,
+    wrap_index, DropdownPopup, EmbedRect, FocusCursor, OverlayRow, RenderOutput, ScrollRegion,
     DROPDOWN_VISIBLE_OPTIONS,
 };
 pub use text_click::{row_byte_to_value_byte, WidgetTextClickGeometry};

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -189,6 +189,30 @@ pub struct RenderOutput {
     /// with the geometry + state the host needs to paint and drag a
     /// scrollbar. Empty for lists that fit.
     pub scroll_regions: Vec<ScrollRegion>,
+    /// The open `Dropdown`'s option list, surfaced for a screen-level
+    /// floating pop-over instead of inline panel rows. `Some` only when a
+    /// keyed Dropdown is open; the panel `entries` then hold just the
+    /// compact `[value ▼]` trigger. The host draws this as a bordered box
+    /// anchored to the trigger's screen row, clipped to the terminal (not
+    /// the panel), so the list extends past the panel/modal frame. Only
+    /// one can be open at a time (the focused widget). See [`DropdownPopup`].
+    pub dropdown_popup: Option<DropdownPopup>,
+}
+
+/// The open `Dropdown`'s option list, projected for a host-native
+/// floating pop-over. `anchor_row` is the 0-based row of the `[value ▼]`
+/// trigger within the panel's inner area (the host adds `inner.y` to get
+/// the screen row and draws the box one row below, flipping above when
+/// there's no room). `options`/`selected`/`scroll` mirror the inline
+/// list's model so the box renders and hit-tests identically — just at
+/// screen coordinates instead of panel-clipped ones.
+#[derive(Debug, Clone)]
+pub struct DropdownPopup {
+    pub widget_key: String,
+    pub anchor_row: u32,
+    pub options: Vec<String>,
+    pub selected: usize,
+    pub scroll: usize,
 }
 
 /// One row produced by an `Overlay` widget. `buffer_row` is the
@@ -249,6 +273,11 @@ struct CollectedOutput {
     embeds: Vec<EmbedRect>,
     overlays: Vec<OverlayRow>,
     scroll_regions: Vec<ScrollRegion>,
+    /// Open-Dropdown pop-overs, each anchored to its trigger row. Shifted
+    /// through Col/Row/Section collapse exactly like `overlays`'
+    /// `buffer_row`, then collapsed to `RenderOutput::dropdown_popup`
+    /// (only one Dropdown is open at a time — the focused one).
+    dropdown_popups: Vec<DropdownPopup>,
 }
 
 /// Render a spec to a [`RenderOutput`].
@@ -371,6 +400,9 @@ fn render_spec_inner(
         embeds: collected.embeds,
         overlays: collected.overlays,
         scroll_regions: collected.scroll_regions,
+        // At most one Dropdown is open at a time (the focused one); take
+        // the first if the spec somehow produced several.
+        dropdown_popup: collected.dropdown_popups.into_iter().next(),
     }
 }
 
@@ -772,6 +804,7 @@ fn collect_row(
     let mut embeds: Vec<EmbedRect> = Vec::new();
     let mut overlays: Vec<OverlayRow> = Vec::new();
     let mut scroll_regions: Vec<ScrollRegion> = Vec::new();
+    let mut dropdown_popups: Vec<DropdownPopup> = Vec::new();
 
     // Two-pass layout for Row:
     //  1. Walk children, render each. Track flex spacers
@@ -811,6 +844,10 @@ fn collect_row(
         // a row-offset adjustment — Row pieces all sit
         // on the same buffer-row as the merged row.
         overlays.extend(child_out.overlays);
+        // A Dropdown in a Row collapses onto the row's single line, so
+        // its pop-over anchors at the row's `buffer_row` (row 0 here;
+        // the caller shifts it up). Forward unshifted, like overlays.
+        dropdown_popups.extend(child_out.dropdown_popups);
         if child_out.entries.is_empty() {
             debug_assert!(child_out.hits.is_empty(), "empty children produce no hits");
             continue;
@@ -888,6 +925,7 @@ fn collect_row(
         embeds,
         overlays,
         scroll_regions,
+        dropdown_popups,
     }
 }
 
@@ -1075,6 +1113,7 @@ fn collect_col(
     let mut embeds: Vec<EmbedRect> = Vec::new();
     let mut overlays: Vec<OverlayRow> = Vec::new();
     let mut scroll_regions: Vec<ScrollRegion> = Vec::new();
+    let mut dropdown_popups: Vec<DropdownPopup> = Vec::new();
 
     for child in children {
         // Overlay children DO NOT contribute vertical
@@ -1128,6 +1167,10 @@ fn collect_col(
                 sr.buffer_row += row_offset;
                 scroll_regions.push(sr);
             }
+            for mut dp in child_out.dropdown_popups {
+                dp.anchor_row += row_offset;
+                dropdown_popups.push(dp);
+            }
             continue;
         }
         for mut h in child_out.hits {
@@ -1146,6 +1189,10 @@ fn collect_col(
             sr.buffer_row += row_offset;
             scroll_regions.push(sr);
         }
+        for mut dp in child_out.dropdown_popups {
+            dp.anchor_row += row_offset;
+            dropdown_popups.push(dp);
+        }
         overlays.extend(child_out.overlays.into_iter().map(|mut o| {
             o.buffer_row += row_offset;
             o
@@ -1160,6 +1207,7 @@ fn collect_col(
         embeds,
         overlays,
         scroll_regions,
+        dropdown_popups,
     }
 }
 
@@ -1361,6 +1409,13 @@ fn collect_dropdown(
         open,
         spec_scroll,
     );
+    // The open list now floats as a screen-level pop-over
+    // (`out.dropdown_popups`) instead of growing inline, so the panel
+    // keeps only the compact `[value ▲]` trigger row and never
+    // grows/clips inside the frame. `render_dropdown`'s inline
+    // `option_rows` are discarded here (the Settings dialog, which calls
+    // `render_dropdown` directly, still uses them for its inline list).
+    let _ = option_rows;
     let widget_key = key.unwrap_or("").to_string();
     // A click on the `[value ▼]` button toggles the option list open
     // (see `deliver_widget_hit`'s `dropdown_toggle` special case).
@@ -1373,22 +1428,21 @@ fn collect_dropdown(
         payload: json!({}),
         event_type: "dropdown_toggle",
     });
-    let _ = scroll_offset;
-    for (row_i, (idx, mut opt_entry)) in option_rows.into_iter().enumerate() {
-        // Each visible option row is a full-width click target that
-        // selects that option and closes the list.
-        let row_len = opt_entry.text.len();
-        out.hits.push(HitArea {
-            widget_key: widget_key.clone(),
-            widget_kind: "dropdown",
-            buffer_row: (1 + row_i) as u32,
-            byte_start: 0,
-            byte_end: row_len,
-            payload: json!({ "index": idx }),
-            event_type: "dropdown_select",
+    // Open: surface the option list as a floating pop-over anchored to
+    // the trigger's row (row 0 within this sub-render; Col/Row/Section
+    // collapse shifts `anchor_row` up to the panel-inner row). The host
+    // draws + hit-tests it at screen coordinates, so it extends past the
+    // panel/modal border instead of reflowing the panel. Option hit
+    // areas are registered by the host draw pass, not here (they live
+    // outside the panel's buffer rows).
+    if open {
+        out.dropdown_popups.push(DropdownPopup {
+            widget_key,
+            anchor_row: 0,
+            options: options.to_vec(),
+            selected: cur as usize,
+            scroll: scroll_offset,
         });
-        ensure_trailing_newline(&mut opt_entry);
-        out.entries.push(opt_entry);
     }
     ensure_trailing_newline(&mut entry);
     out.entries.insert(0, entry);
@@ -1891,6 +1945,7 @@ fn collect_list(
         embeds: Vec::new(),
         overlays: Vec::new(),
         scroll_regions,
+        dropdown_popups: Vec::new(),
     }
 }
 
@@ -1909,6 +1964,7 @@ fn collect_labeled_section(
     let mut embeds: Vec<EmbedRect> = Vec::new();
     let mut overlays: Vec<OverlayRow> = Vec::new();
     let mut scroll_regions: Vec<ScrollRegion> = Vec::new();
+    let mut dropdown_popups: Vec<DropdownPopup> = Vec::new();
 
     // Inner area: 1 column of border + 1 column of
     // padding on each side ⇒ 4 columns of chrome.
@@ -1927,6 +1983,13 @@ fn collect_labeled_section(
         o.buffer_row += 1;
         o
     }));
+    // Same +1 shift for a Dropdown pop-over nested in a section: the top
+    // border occupies row 0, so the child's row 0 (its trigger) is the
+    // section's row 1.
+    for mut dp in child_out.dropdown_popups {
+        dp.anchor_row += 1;
+        dropdown_popups.push(dp);
+    }
 
     // Render the top border with the label embedded as a
     // legend: `╭─ <label> ─...─╮`. When the label is empty,
@@ -1992,6 +2055,7 @@ fn collect_labeled_section(
         embeds,
         overlays,
         scroll_regions,
+        dropdown_popups,
     }
 }
 
@@ -2071,6 +2135,7 @@ fn collect_overlay(
         embeds: child_out.embeds,
         overlays: child_out.overlays,
         scroll_regions: child_out.scroll_regions,
+        dropdown_popups: child_out.dropdown_popups,
     }
 }
 
@@ -8686,7 +8751,7 @@ mod tests {
     }
 
     #[test]
-    fn dropdown_emits_button_and_option_hit_areas() {
+    fn dropdown_open_emits_toggle_hit_and_floating_popup() {
         let spec = WidgetSpec::Dropdown {
             label_width: 0,
             open: true,
@@ -8695,20 +8760,27 @@ mod tests {
             selected_index: 0,
             label: String::new(),
             focused: true,
-            key: None,
+            key: Some("d".into()),
         };
-        let (_out, hits, _state) = render_no_focus(&spec, &HashMap::new());
-        let toggles: Vec<_> = hits
+        let out = render_spec(&spec, &HashMap::new(), "d", u32::MAX);
+        let toggles = out
+            .hits
             .iter()
             .filter(|h| h.event_type == "dropdown_toggle")
-            .collect();
-        let selects: Vec<_> = hits
-            .iter()
-            .filter(|h| h.event_type == "dropdown_select")
-            .collect();
-        assert_eq!(toggles.len(), 1);
-        assert_eq!(selects.len(), 2);
-        assert_eq!(selects[1].payload["index"], 1);
+            .count();
+        assert_eq!(toggles, 1, "the trigger button stays a toggle hit");
+        // Options no longer render inline — they surface on the floating
+        // pop-over instead, so the panel has NO `dropdown_select` hits.
+        assert!(
+            !out.hits.iter().any(|h| h.event_type == "dropdown_select"),
+            "open dropdown must not emit inline option hits"
+        );
+        let dp = out
+            .dropdown_popup
+            .expect("an open dropdown surfaces a floating pop-over");
+        assert_eq!(dp.widget_key, "d");
+        assert_eq!(dp.options, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(dp.anchor_row, 0, "trigger is the panel's row 0");
     }
 
     #[test]
@@ -8744,10 +8816,10 @@ mod tests {
     }
 
     #[test]
-    fn dropdown_open_emits_inline_option_rows() {
+    fn dropdown_open_surfaces_popup_not_inline_rows() {
         let spec = make_dropdown(&["a", "b", "c"], 1, Some("d"));
-        // Focused + open in instance state → inline option rows below
-        // the value button.
+        // Focused + open in instance state → the option list floats as a
+        // screen-level pop-over; the panel keeps only the compact trigger.
         let mut prev = HashMap::new();
         prev.insert(
             "d".to_string(),
@@ -8757,15 +8829,22 @@ mod tests {
             },
         );
         let out = render_spec(&spec, &prev, "d", u32::MAX);
-        assert_eq!(out.entries.len(), 4, "button row + one row per option");
-        assert!(out.entries[2].text.contains('b'));
-        // Each option row is a full-width select hit.
-        let selects: Vec<_> = out
-            .hits
-            .iter()
-            .filter(|h| h.event_type == "dropdown_select")
-            .collect();
-        assert_eq!(selects.len(), 3);
+        assert_eq!(
+            out.entries.len(),
+            1,
+            "open dropdown keeps only the trigger row (no inline options)"
+        );
+        assert!(
+            !out.hits.iter().any(|h| h.event_type == "dropdown_select"),
+            "options moved to the pop-over — no inline select hits"
+        );
+        let dp = out.dropdown_popup.expect("open dropdown surfaces a popup");
+        assert_eq!(
+            dp.options,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert_eq!(dp.selected, 1);
+        assert_eq!(dp.anchor_row, 0);
     }
 
     #[test]
@@ -8783,6 +8862,10 @@ mod tests {
         // (no-autofocus so the sole tabbable isn't auto-selected).
         let out = render_spec_no_autofocus(&spec, &prev, "", u32::MAX);
         assert!(out.overlays.is_empty());
+        assert!(
+            out.dropdown_popup.is_none(),
+            "an unfocused (closed) dropdown surfaces no pop-over"
+        );
         match out.instance_states.get("d") {
             Some(WidgetInstanceState::Dropdown { open, .. }) => assert!(!open),
             other => panic!("expected Dropdown state, got {other:?}"),

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -1198,6 +1198,120 @@ fn preset_row_lists_prioritised_agents_in_order() {
     );
 }
 
+/// The Agent selector opens its option list as a screen-level FLOATING
+/// pop-over: Enter (routed to the host's `set_dropdown_open`, not the
+/// no-op `activate()`) reveals every preset at once, layered on top of
+/// the form rather than reflowing it, and Esc closes it back to the
+/// single compact `Agent: [<selected> ▼]` trigger. A click on an option
+/// row selects it and closes the list.
+#[test]
+fn agent_dropdown_opens_as_floating_popover() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+
+    focus_agent_preset_stop(&mut harness);
+
+    // Distinctive preset names; the closed trigger shows exactly one of
+    // them (the selected value), the open pop-over lists several.
+    let names = ["terminal", "claude", "codex", "opencode"];
+    let count_names = |screen: &str| names.iter().filter(|n| screen.contains(**n)).count();
+
+    let closed_before = count_names(&harness.screen_to_string());
+
+    // Enter opens the pop-over. Before the fix, Enter hit `activate()` — a
+    // no-op on a Dropdown — so the list never opened.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    let open_screen = harness.screen_to_string();
+    let open_count = count_names(&open_screen);
+    assert!(
+        open_count >= 3 && open_count > closed_before,
+        "Enter must float the agent option list open (many presets visible \
+         at once); before={closed_before}, open={open_count}. Screen:\n{open_screen}",
+    );
+
+    // Web-scene parity: the projection the web frontend renders from (the
+    // `/state` route → `widgets_view`) must report the dropdown as OPEN, so
+    // the web floats its own native option pop-over from the same state.
+    {
+        let surfaces = harness.editor().widgets_view();
+        let modal = surfaces
+            .iter()
+            .find(|s| s.kind == "floatingModal")
+            .expect("the New-Workspace form must appear as a floatingModal in the web scene");
+        let inst = modal
+            .instances
+            .get("agent_dropdown")
+            .expect("the web scene must carry the agent_dropdown instance state");
+        assert_eq!(
+            inst.dropdown_open,
+            Some(true),
+            "the web scene must report the agent dropdown as open (so the web \
+             frontend renders the floating option list)",
+        );
+    }
+
+    // Esc closes the pop-over, back to the single-value trigger.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.tick_and_render().unwrap();
+    let closed_screen = harness.screen_to_string();
+    assert!(
+        count_names(&closed_screen) < open_count,
+        "Esc must close the pop-over back to the compact trigger. Screen:\n{closed_screen}",
+    );
+
+    // Re-open and pick an option by clicking its row. `claude` is a stable
+    // preset that is not the default selection (`terminal`), so clicking it
+    // both changes the value and closes the list.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    let (col, row) = harness
+        .find_text_on_screen("claude")
+        .expect("`claude` option row must be visible in the open pop-over");
+    harness.mouse_click(col, row).unwrap();
+    harness.tick_and_render().unwrap();
+    let after_click = harness.screen_to_string();
+    assert!(
+        count_names(&after_click) < open_count,
+        "clicking an option must close the pop-over. Screen:\n{after_click}",
+    );
+    assert!(
+        focused_line(&after_click).contains("claude"),
+        "clicking the `claude` option must select it as the Agent value. Screen:\n{after_click}",
+    );
+
+    // Web-scene parity again: after the click the projection must show the
+    // pop-over closed and the newly-selected index committed — the same
+    // state the web `/state` route would report so selection round-trips.
+    {
+        let surfaces = harness.editor().widgets_view();
+        let modal = surfaces
+            .iter()
+            .find(|s| s.kind == "floatingModal")
+            .expect("form surface in web scene after selection");
+        let inst = modal
+            .instances
+            .get("agent_dropdown")
+            .expect("agent_dropdown instance in web scene after selection");
+        assert_eq!(
+            inst.dropdown_open,
+            Some(false),
+            "picking an option must close the pop-over in the web scene too",
+        );
+        // `claude` is index 1 in the prioritised preset order (terminal, claude,
+        // codex, …), so a successful click committed that selection.
+        assert_eq!(
+            inst.selected_index,
+            Some(1),
+            "the clicked `claude` option must be the committed selection in the web scene",
+        );
+    }
+}
+
 /// Picking a coding agent surfaces its per-agent controls — an "Auto
 /// mode" checkbox and a "Start prompt" box — which are hidden for the
 /// bare `terminal` default. Stepping ←/→ off `terminal` onto the first

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -284,6 +284,10 @@
   .w-dd{position:absolute;left:0;top:100%;z-index:98;background:var(--bg2);
     border:1px solid var(--hairline,var(--border));border-radius:4px;max-height:200px;overflow-y:auto;
     box-shadow:0 8px 24px rgba(0,0,0,.4);min-width:100%}
+  /* Screen-level pop-over: `position:fixed` escapes the modal's overflow clip
+     so the option list extends past the dialog border (parity with the TUI
+     floating popover). JS sets left/top/min-width from the pill's rect. */
+  .w-dd-floating{position:fixed;top:0;left:0;z-index:200;min-width:0}
   .w-dd-row{padding:1px 10px;white-space:nowrap}
   .w-dd-row.sel{background:var(--menuhi);color:var(--on-sel,#fff)}
   .w-dual-cols{display:flex;gap:10px}

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -239,13 +239,28 @@ function widgetEl(spec, ctx){
     pill.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_toggle",{}); };
     el.appendChild(pill);
     if(open){
-      const dd=div("w-dd");
+      const dd=div("w-dd w-dd-floating");
       (spec.options||[]).forEach((o,i)=>{
         const r=div("w-dd-row"+(i===selIdx?" sel":"")); r.textContent=o;
         r.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_select",{index:i}); };
         dd.appendChild(r);
       });
       el.appendChild(dd);
+      // Float the option list as a screen-level pop-over so it extends PAST
+      // the modal's border instead of growing/clipping inside it (parity
+      // with the TUI popover). `position:fixed` escapes the surface's
+      // `overflow` clip; we anchor it under the pill after layout, flipping
+      // above when there's no room below.
+      requestAnimationFrame(()=>{
+        if(!pill.isConnected) return;
+        const r=pill.getBoundingClientRect();
+        dd.style.left=r.left+"px";
+        dd.style.minWidth=r.width+"px";
+        const h=dd.offsetHeight;
+        let top=r.bottom+2;
+        if(top+h>window.innerHeight && r.top-h-2>0) top=r.top-h-2;
+        dd.style.top=top+"px";
+      });
     }
     return el;
   }


### PR DESCRIPTION
An open declarative `Dropdown` (`WidgetSpec::Dropdown`) now opens its option list as a **screen-level floating pop-over that extends past the containing panel/modal border**, instead of the old inline expansion that grew and clipped inside the frame. This fixes the New Workspace dialog's "Agent" selector, whose list previously ran off the modal.

## Changes

**Renderer** (`widgets/render.rs`)
- New `DropdownPopup { widget_key, anchor_row, options, selected, scroll }` on `RenderOutput`, collapsed from a per-`CollectedOutput` list whose `anchor_row` is shifted through Col/Row/Section collapse exactly like overlays.
- `collect_dropdown` no longer appends option rows to the panel entries when open; it keeps the compact `[value ▲]` trigger and emits the pop-over. `render_dropdown` is unchanged, so the **Settings dialog's inline dropdown path (which calls it directly) is untouched**.

**Host TUI** (`app/render.rs`, `app/mod.rs`)
- After painting the panel, `render_floating_widget_panel` draws a bordered list box at the trigger's **screen** position, clamped to the terminal (flipping above when there's no room below) and drawn on top — screen-clipped, not panel-clipped. Each option's screen rect is recorded on the panel.

**Mouse** (`app/mouse_input.rs`)
- Clicks on the pop-over's screen rects route through `deliver_widget_hit` → `dropdown_select` **before** the panel-inner gate, so an option below the modal border still selects.

**Web parity** (`web-ui/js/65-widgets.js`, `web-ui/css/40-widgets.css`)
- The web frontend renders the open option list as a `position:fixed` pop-over so it escapes the modal's `overflow` clip. `widgets_view` already projects `dropdownOpen`/`selectedIndex`, so no scene-schema change is needed.

**Plugin** (`plugins/orchestrator.ts`)
- Route Enter on the focused `agent_dropdown` to the host's dropdown-open (Enter was a no-op `activate()`).
- Via a new host `dropdown_open` widget_event the plugin mirrors, the first Escape closes the open list while a second cancels the dialog.

## Validation

- **New e2e** (`orchestrator_new_dialog.rs`) covering open via Enter, ↑/↓ selection, Esc close, and click-select — plus assertions on the web-scene projection (`widgets_view` reports `dropdownOpen` true/false and the committed `selectedIndex`). Scene-parity and the widgets unit tests pass.
- **Interactive TUI (tmux):** confirmed the list floats past the modal's bottom border (the `aider` / `custom…` rows render below the frame), ↑/↓ update the selection live, and Esc closes the list then cancels the dialog.
- **Headless Chromium** test of the real frontend CSS + positioning JS: the old inline list is clipped by the modal's `overflow`, while the new `position:fixed` list is visible and hit-testable past the border.

## Notes

- Keeps TUI + web scene parity (the `scene parity (web/TUI)` job passes).
- The Settings dialog's `render_dropdown` (`DROPDOWN_VISIBLE_OPTIONS`) stays on the inline path, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014anvBwU7Uh5MMiPRPtgdNJ