### PR TITLE
Fix Ctrl+Click/Ctrl+hover file links in terminal with mouse reporting

### DIFF
--- a/crates/fresh-editor/src/app/terminal_link.rs
+++ b/crates/fresh-editor/src/app/terminal_link.rs
@@ -1,9 +1,12 @@
 //! Ctrl+Click / Ctrl+hover to open file paths printed in the embedded terminal.
 //!
-//! When the focused terminal is in live mode (not an alternate-screen program
-//! like vim), a Ctrl+Click on text that resolves to a real file opens it in
-//! Fresh, jumping to any `:line:col` the text encoded. Ctrl+hover underlines
-//! such a path to signal it's clickable.
+//! When the focused terminal is in live mode, a Ctrl+Click on text that
+//! resolves to a real file opens it in Fresh, jumping to any `:line:col` the
+//! text encoded. Ctrl+hover underlines such a path to signal it's clickable.
+//! The Ctrl gesture is reserved for links even while a full-screen or
+//! mouse-reporting program (vim/less/htop, or anything that enabled DECSET
+//! 1000/1002/1003) runs — it is withheld from the PTY rather than forwarded,
+//! so links work everywhere, not just at a bare shell prompt.
 //!
 //! Relative paths are resolved against, in order: the terminal's working
 //! directory as reported via OSC 7 (tracks `cd`), then Fresh's working

--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -30,6 +30,29 @@ impl Window {
             return None;
         }
 
+        // Ctrl reserves the Left-button / motion gesture for Fresh's own
+        // file-link hover + open (the xterm/VS Code convention: Ctrl/Cmd+Click
+        // opens links, overriding the inner program's mouse capture). Never
+        // forward those to the PTY — otherwise a program that enabled mouse
+        // reporting (DECSET 1000/1002/1003) or is in the alternate screen would
+        // swallow the click before `try_open_terminal_link` /
+        // `update_terminal_link_hover` (mouse_input.rs) ever see it, and links
+        // would only work at a bare shell prompt. Non-Ctrl events still forward
+        // normally, so the program keeps its ordinary mouse behaviour.
+        if mouse_event
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL)
+            && matches!(
+                mouse_event.kind,
+                MouseEventKind::Down(MouseButton::Left)
+                    | MouseEventKind::Up(MouseButton::Left)
+                    | MouseEventKind::Drag(MouseButton::Left)
+                    | MouseEventKind::Moved
+            )
+        {
+            return None;
+        }
+
         // Find terminal buffer at this position.
         let (buffer_id, content_rect) = self.get_terminal_content_area_at_position(col, row)?;
 
@@ -117,9 +140,12 @@ impl Window {
     /// detected link (path + optional line/col + column span), and the
     /// terminal's OSC 7 working directory (for resolving relative paths).
     ///
-    /// Only fires in live terminal mode and *not* in alternate-screen mode
-    /// (where mouse events are forwarded to the running full-screen program).
-    /// The returned link is textual only — the caller resolves and checks it.
+    /// Only fires in live terminal mode (not the read-only scrollback view).
+    /// It intentionally *does* fire for alternate-screen / mouse-reporting
+    /// programs: the Ctrl gesture is reserved for links and withheld from the
+    /// PTY (see `try_forward_mouse_to_terminal`), so a path printed by such a
+    /// program stays Ctrl-hoverable / Ctrl-clickable. The returned link is
+    /// textual only — the caller resolves and checks it.
     pub(crate) fn detect_terminal_link_at(
         &self,
         col: u16,
@@ -134,10 +160,11 @@ impl Window {
             return None;
         }
         let (buffer_id, content_rect) = self.get_terminal_content_area_at_position(col, row)?;
-        // Alternate-screen programs own the mouse; don't shadow their clicks.
-        if self.is_terminal_in_alternate_screen(buffer_id) {
-            return None;
-        }
+        // Detection runs even for alternate-screen / mouse-reporting programs:
+        // this is only reached for Ctrl-held gestures (see the callers in
+        // `terminal_link.rs`, both Ctrl-gated), which `try_forward_mouse_to_terminal`
+        // deliberately withholds from the PTY so a path shown by vim/less/htop or
+        // any mouse-capturing program is still Ctrl-hoverable and Ctrl-clickable.
         let term_col = col.saturating_sub(content_rect.x) as usize;
         let term_row = row.saturating_sub(content_rect.y);
 

--- a/crates/fresh-editor/src/services/terminal/path_link.rs
+++ b/crates/fresh-editor/src/services/terminal/path_link.rs
@@ -75,6 +75,25 @@ pub fn detect_link_at(line: &str, col: usize) -> Option<DetectedLink> {
         end += 1;
     }
 
+    // Narrow to a parenthesised path when the token wraps one — e.g. Claude
+    // Code's `Read(src/main.rs)` / `Update(src/foo.rs:12)`, or a bare
+    // `(src/main.rs:12)`. Without this the leading prefix (`Read(`) or the
+    // trailing `)` glues onto the path and it never resolves. Only narrow when
+    // the parenthesised content is itself path-like, so a `name(line,col)`
+    // location suffix (e.g. `Program.cs(34,12)`) keeps its meaning and is parsed
+    // by `split_location_suffix` below instead.
+    if let Some(lp) = (start..end).find(|&i| chars[i] == '(') {
+        if let Some(rp) = (lp + 1..end).rev().find(|&i| chars[i] == ')') {
+            if lp + 1 < rp {
+                let inner: String = chars[lp + 1..rp].iter().collect();
+                if parenthesized_is_path(&inner) {
+                    start = lp + 1;
+                    end = rp;
+                }
+            }
+        }
+    }
+
     // Peel leading wrappers (quotes/brackets) off the front.
     while start < end && is_opener(chars[start]) {
         start += 1;
@@ -210,6 +229,22 @@ fn rfind_digit_run(chars: &[char], end: usize) -> usize {
         i -= 1;
     }
     i
+}
+
+/// Heuristic for the content inside a `(...)`: is it a *path* (so the token is
+/// `prefix(path)` / `(path)`, e.g. Claude Code's `Read(src/main.rs:12)`), rather
+/// than a numeric `(line,col)` / `(line)` location suffix (e.g.
+/// `Program.cs(34,12)`)?
+///
+/// Path-like: contains a separator or `~`, or a dotted name with a letter
+/// (`main.rs`). Deliberately rejects pure-numeric content (`34`, `34,12`) and
+/// dotted numbers (`1.5`) so a real location suffix isn't mistaken for a path.
+fn parenthesized_is_path(inner: &str) -> bool {
+    let inner = inner.trim();
+    inner.contains('/')
+        || inner.contains('\\')
+        || inner.contains('~')
+        || (inner.contains('.') && inner.chars().any(|c| c.is_alphabetic()))
 }
 
 /// Heuristic: does this token look like a file path rather than, say, a bare
@@ -367,5 +402,54 @@ mod tests {
         let line = "x.rs";
         let got = detect_link_at(line, 999).unwrap();
         assert_eq!(got.path, "x.rs");
+    }
+
+    /// Claude Code's tool-call rendering `Read(path)`: the `Read(` prefix must
+    /// not glue onto the path — the parenthesised path is what resolves.
+    /// (ASCII-only so char offsets equal byte offsets for the range slice.)
+    #[test]
+    fn tool_call_parenthesized_path() {
+        let line = "- Read(src/main.rs)";
+        // Click inside the path (col 10) and, separately, on the `Read` prefix
+        // (col 3) — both resolve to the parenthesised path.
+        for col in [10, 3] {
+            let got = detect_link_at(line, col).unwrap();
+            assert_eq!(got.path, "src/main.rs", "col {col}");
+            assert_eq!(got.line, None);
+            assert_eq!(&line[got.range], "src/main.rs");
+        }
+    }
+
+    /// `Tool(path:line:col)`: the location suffix inside the parens is parsed
+    /// and the trailing `)` doesn't block it.
+    #[test]
+    fn tool_call_parenthesized_path_with_location() {
+        let line = "Update(crates/app/src/foo.rs:12:3)";
+        let got = detect_link_at(line, 20).unwrap();
+        assert_eq!(got.path, "crates/app/src/foo.rs");
+        assert_eq!(got.line, Some(12));
+        assert_eq!(got.column, Some(3));
+        assert_eq!(&line[got.range], "crates/app/src/foo.rs:12:3");
+    }
+
+    /// A bare `(path:line)` — a filename wrapped in parens with a line ref.
+    #[test]
+    fn bare_parenthesized_path_with_line() {
+        let line = "see (src/main.rs:2) now";
+        let got = detect_link_at(line, 6).unwrap();
+        assert_eq!(got.path, "src/main.rs");
+        assert_eq!(got.line, Some(2));
+        assert_eq!(&line[got.range], "src/main.rs:2");
+    }
+
+    /// The `name(line,col)` location form must NOT be reinterpreted as a
+    /// parenthesised path (the inner `34,12` is numeric, not path-like).
+    #[test]
+    fn numeric_paren_suffix_not_treated_as_inner_path() {
+        let line = "Program.cs(34,12): warning";
+        let got = detect_link_at(line, 3).unwrap();
+        assert_eq!(got.path, "Program.cs");
+        assert_eq!(got.line, Some(34));
+        assert_eq!(got.column, Some(12));
     }
 }

--- a/crates/fresh-editor/tests/e2e/terminal_link.rs
+++ b/crates/fresh-editor/tests/e2e/terminal_link.rs
@@ -313,6 +313,43 @@ fn ctrl_click_on_nonexistent_path_is_inert() {
     feed_output_until_visible(&mut harness, terminal_id, output, "does/not/exist.rs");
 }
 
+/// The real Claude-Code scenario: a full-screen mouse-driven TUI (alt screen +
+/// all-motion tracking + SGR) rendering a file reference in its `Tool(path:line)`
+/// form. Ctrl+Click on it opens the file — the parenthesised path is detected
+/// despite the `Update(` prefix and trailing `)`, and the click isn't forwarded
+/// to the program.
+#[test]
+fn ctrl_click_opens_parenthesized_tool_call_path_in_tui() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(
+        tmp.path().join("src/main.rs"),
+        "line one\nline two TARGET\nline three\n",
+    )
+    .unwrap();
+
+    let mut harness = match harness_or_skip(100, 24, tmp.path().to_path_buf()) {
+        Some(h) => h,
+        None => return,
+    };
+
+    // Alt screen (1049) + all-motion tracking (1003) + SGR (1006), then a
+    // tool-call line as Claude Code renders it.
+    open_terminal_with_output(
+        &mut harness,
+        b"\x1b[?1049h\x1b[?1003h\x1b[?1006h\x1b[H  Update(src/main.rs:2:6)\n",
+        "src/main.rs:2:6",
+    );
+
+    // Click inside the parenthesised path.
+    let (col, row) = find_on_screen(&harness, "src/main.rs:2:6").expect("path on screen");
+    ctrl_left_click(&mut harness, col + 2, row);
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("line two TARGET");
+    harness.assert_screen_contains("Ln 2");
+}
+
 /// A program that enabled mouse reporting (DECSET 1000/1006 — a "raw mode" TUI
 /// that grabbed the mouse) must not steal Ctrl+Click: the click opens the path
 /// link instead of being forwarded into the program's stdin. Before the fix,

--- a/crates/fresh-editor/tests/e2e/terminal_link.rs
+++ b/crates/fresh-editor/tests/e2e/terminal_link.rs
@@ -144,6 +144,30 @@ fn ctrl_left_click(harness: &mut EditorTestHarness, col: u16, row: u16) {
     }
 }
 
+/// Send a Ctrl+move (buttonless motion) at the given cell — the hover gesture.
+fn ctrl_move(harness: &mut EditorTestHarness, col: u16, row: u16) {
+    harness
+        .send_mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: col,
+            row,
+            modifiers: KeyModifiers::CONTROL,
+        })
+        .unwrap();
+}
+
+/// Whether the rendered cell at `(x, y)` is underlined — how the Ctrl+hover
+/// link highlight paints a clickable path (observe rendered output, not state).
+fn cell_underlined(harness: &EditorTestHarness, x: u16, y: u16) -> bool {
+    harness
+        .get_cell_style(x, y)
+        .map(|s| {
+            s.add_modifier
+                .contains(ratatui::style::Modifier::UNDERLINED)
+        })
+        .unwrap_or(false)
+}
+
 /// Ctrl+Click on a `path:line:col` printed in the terminal opens the file
 /// (resolved against Fresh's working directory) and jumps to that line.
 #[test]
@@ -287,4 +311,144 @@ fn ctrl_click_on_nonexistent_path_is_inert() {
     // And the live terminal is still the active view: its grid still renders
     // to the screen (re-feed in case a racing repaint wiped it).
     feed_output_until_visible(&mut harness, terminal_id, output, "does/not/exist.rs");
+}
+
+/// A program that enabled mouse reporting (DECSET 1000/1006 — a "raw mode" TUI
+/// that grabbed the mouse) must not steal Ctrl+Click: the click opens the path
+/// link instead of being forwarded into the program's stdin. Before the fix,
+/// `try_forward_mouse_to_terminal` ran ahead of the link opener and swallowed
+/// the Ctrl+press (`wants_mouse && !shift`), so links only worked at a bare
+/// shell prompt.
+#[test]
+fn ctrl_click_opens_path_under_mouse_reporting_program() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(
+        tmp.path().join("src/main.rs"),
+        "line one\nline two TARGET\nline three\n",
+    )
+    .unwrap();
+
+    let mut harness = match harness_or_skip(100, 24, tmp.path().to_path_buf()) {
+        Some(h) => h,
+        None => return,
+    };
+
+    // Enable click + SGR mouse reporting (1000 + 1006), then print the path —
+    // exactly what a mouse-driven program on the main screen does.
+    open_terminal_with_output(
+        &mut harness,
+        b"\x1b[?1000h\x1b[?1006hbuild error at src/main.rs:2:6 here\n",
+        "src/main.rs:2:6",
+    );
+
+    let (col, row) = find_on_screen(&harness, "src/main.rs:2:6").expect("path on screen");
+    ctrl_left_click(&mut harness, col + 4, row);
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("line two TARGET");
+    harness.assert_screen_contains("Ln 2");
+}
+
+/// Ctrl+Click opens a path even while an alternate-screen program (vim/less/
+/// htop) is running. Before the fix, `detect_terminal_link_at` bailed on
+/// alternate-screen, so both the click and the hover highlight were dead there.
+#[test]
+fn ctrl_click_opens_path_in_alternate_screen() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(
+        tmp.path().join("src/main.rs"),
+        "line one\nline two TARGET\nline three\n",
+    )
+    .unwrap();
+
+    let mut harness = match harness_or_skip(100, 24, tmp.path().to_path_buf()) {
+        Some(h) => h,
+        None => return,
+    };
+
+    // Enter the alternate screen (1049), home the cursor, then print the path
+    // onto it — like a full-screen program showing a build error.
+    open_terminal_with_output(
+        &mut harness,
+        b"\x1b[?1049h\x1b[Hbuild error at src/main.rs:2:6 here\n",
+        "src/main.rs:2:6",
+    );
+
+    let (col, row) = find_on_screen(&harness, "src/main.rs:2:6").expect("path on screen");
+    ctrl_left_click(&mut harness, col + 4, row);
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("line two TARGET");
+    harness.assert_screen_contains("Ln 2");
+}
+
+/// Ctrl+hover underlines a path shown by an alternate-screen program. Before the
+/// fix, `detect_terminal_link_at` bailed on alternate-screen, so hover never
+/// highlighted there even though the click's Moved event reached it.
+#[test]
+fn ctrl_hover_highlights_path_in_alternate_screen() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/main.rs"), "x\n").unwrap();
+
+    let mut harness = match harness_or_skip(100, 24, tmp.path().to_path_buf()) {
+        Some(h) => h,
+        None => return,
+    };
+
+    open_terminal_with_output(
+        &mut harness,
+        b"\x1b[?1049h\x1b[Hopen src/main.rs:2:6 to jump\n",
+        "src/main.rs:2:6",
+    );
+
+    let (col, row) = find_on_screen(&harness, "src/main.rs:2:6").expect("path on screen");
+    // Not underlined until we Ctrl+hover it.
+    assert!(
+        !cell_underlined(&harness, col + 2, row),
+        "path should not be underlined before hovering"
+    );
+
+    ctrl_move(&mut harness, col + 2, row);
+    harness.render().unwrap();
+
+    assert!(
+        cell_underlined(&harness, col, row) && cell_underlined(&harness, col + 4, row),
+        "Ctrl+hover should underline the path span in an alternate-screen program"
+    );
+}
+
+/// Ctrl+hover underlines a path even when the program subscribed to all-motion
+/// mouse tracking (DECSET 1003). Before the fix, the buttonless Moved event was
+/// forwarded to the PTY (`terminal_wants_mouse_motion`) before the hover code
+/// ran, so the highlight never appeared.
+#[test]
+fn ctrl_hover_highlights_path_under_all_motion_tracking() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/main.rs"), "x\n").unwrap();
+
+    let mut harness = match harness_or_skip(100, 24, tmp.path().to_path_buf()) {
+        Some(h) => h,
+        None => return,
+    };
+
+    // All-motion tracking (1003) + SGR (1006): the mode that legitimately
+    // receives buttonless motion — yet Ctrl+move must still drive link hover.
+    open_terminal_with_output(
+        &mut harness,
+        b"\x1b[?1003h\x1b[?1006hopen src/main.rs:2:6 to jump\n",
+        "src/main.rs:2:6",
+    );
+
+    let (col, row) = find_on_screen(&harness, "src/main.rs:2:6").expect("path on screen");
+    ctrl_move(&mut harness, col + 2, row);
+    harness.render().unwrap();
+
+    assert!(
+        cell_underlined(&harness, col, row) && cell_underlined(&harness, col + 4, row),
+        "Ctrl+hover should underline the path span under all-motion tracking"
+    );
 }

--- a/web-ui/js/80-input.js
+++ b/web-ui/js/80-input.js
@@ -157,9 +157,13 @@ document.addEventListener("mousemove",e=>{
     return;
   }
   if(onChrome(e)) return;
-  if(lastMoveCell&&c.col===lastMoveCell.col&&c.row===lastMoveCell.row) return;
-  lastMoveCell=c;
-  sendMouse({kind:"moved",col:c.col,row:c.row});
+  // Carry the modifiers on `moved` too (not just down/drag): Ctrl+hover over a
+  // file path in the embedded terminal underlines it, and the server only
+  // computes that highlight when CONTROL is held. Ctrl is part of the de-dupe
+  // key so pressing/releasing it re-sends even within the same cell.
+  if(lastMoveCell&&c.col===lastMoveCell.col&&c.row===lastMoveCell.row&&lastMoveCell.ctrl===e.ctrlKey) return;
+  lastMoveCell={col:c.col,row:c.row,ctrl:e.ctrlKey};
+  sendMouse({kind:"moved",col:c.col,row:c.row,ctrl:e.ctrlKey,shift:e.shiftKey,alt:e.altKey});
 });
 document.addEventListener("mouseup",e=>{ dragging=false; if(onChrome(e)) return; const c=cellAt(e); sendMouse({kind:"up",button:btn(e),col:c.col,row:c.row}); });
 document.addEventListener("contextmenu",e=>e.preventDefault());

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -861,6 +861,82 @@ check('picking Cosmos from the menu restores the bezel shell', await page.evalua
   window.fresh.webTheme === 'cosmos' && document.getElementById('device').classList.contains('on')));
 await page.screenshot({ path: `${SHOTS}/34-theme-cosmos.png` });
 
+console.log('\n[embedded terminal: Ctrl+hover carries the modifier and underlines a path link]');
+// Regression: the frontend used to send `moved` events WITHOUT the ctrl flag,
+// so Ctrl+hover over a file path in the embedded terminal never underlined it
+// (the server only computes the link highlight while CONTROL is held), even
+// though Ctrl+click — whose `down` event DID carry ctrl — worked. Open a real
+// terminal, print a path that resolves at the server's cwd (repo root), and
+// Ctrl-move over it.
+await page.keyboard.press('Escape'); await page.waitForTimeout(150);
+await page.request.post(URL + '/action', { data: { action: 'open_terminal' } });
+await page.waitForFunction(() => window.fresh.scene.regions.panes.some(p =>
+  p.cells.some(r => r.map(x => x.t).join('').match(/[#$]/))), { timeout: 8000 }).catch(() => {});
+await page.waitForTimeout(500);
+// Capture outgoing WS mouse messages so we can see what the frontend emits.
+await page.evaluate(() => {
+  window.__mouse = [];
+  const orig = WebSocket.prototype.send;
+  WebSocket.prototype.send = function (data) {
+    try { const o = JSON.parse(data); if (o && o.type === 'mouse') window.__mouse.push(o); } catch {}
+    return orig.call(this, data);
+  };
+});
+// Create a real file and print its ABSOLUTE path, so the link resolves
+// regardless of the terminal's cwd.
+const PROBE = '/tmp/fresh_link_probe.txt';
+await page.keyboard.type(`touch ${PROBE} && echo "see ${PROBE}:1:1 here"`);
+await page.keyboard.press('Enter');
+await page.waitForFunction(() => window.fresh.scene.regions.panes.some(p =>
+  p.cells.some(r => r.map(x => x.t).join('').includes('see /tmp/fresh_link_probe.txt:1:1 here'))), { timeout: 6000 }).catch(() => {});
+await page.waitForTimeout(300);
+// Locate the OUTPUT line's path (last occurrence; the first is the typed echo).
+{
+  const NEEDLE = 'fresh_link_probe.txt:1:1';
+  // The web terminal grid is run-encoded (each cell is a styled run, not one
+  // char), so a cell's column is the sum of the preceding runs' text lengths.
+  // Locate the needle by accumulating run widths, prefer the OUTPUT line (last
+  // occurrence), and report whether the runs covering it are underlined.
+  const findLink = s => {
+    let best = null;
+    for (const pane of s.regions.panes) {
+      for (let r = 0; r < pane.cells.length; r++) {
+        const row = pane.cells[r];
+        let text = '', starts = [], col = 0;
+        for (const cell of row) { starts.push(col); text += cell.t; col += cell.t.length; }
+        const i = text.indexOf(NEEDLE);
+        if (i < 0) continue;
+        const underlinedAt = ci => {
+          for (let k = 0; k < row.length; k++) { if (ci >= starts[k] && ci < starts[k] + row[k].t.length) return !!row[k].u; }
+          return false;
+        };
+        best = { pane, r, col: pane.content.x + i, row: pane.content.y + r,
+                 underlined: [0, 2, 4, NEEDLE.length - 1].every(k => underlinedAt(i + k)) };
+      }
+    }
+    return best;
+  };
+  const tm2 = await page.evaluate(() => window.fresh.metrics);
+  const h = findLink(await scene(page));
+  if (h) {
+    await page.keyboard.down('Control');
+    await page.mouse.move(gx(tm2, h.col + 2 + 0.5), gy(tm2, h.row + 0.5));
+    await page.mouse.move(gx(tm2, h.col + 3 + 0.5), gy(tm2, h.row + 0.5)); // cross a cell so the de-dupe re-sends
+    await page.waitForTimeout(400);
+    const movedCtrl = await page.evaluate(() => (window.__mouse || []).some(m => m.kind === 'moved' && m.ctrl === true));
+    check('Ctrl+move over the terminal emits a `moved` event carrying ctrl:true', movedCtrl,
+      JSON.stringify(await page.evaluate(() => (window.__mouse || []).filter(m => m.kind === 'moved').slice(-2))));
+    // Observe rendered output: the path span is underlined in the scene cells.
+    const u = findLink(await scene(page));
+    check('Ctrl+hover underlines the resolvable path in the terminal (scene cells)', !!(u && u.underlined),
+      JSON.stringify(u && { row: u.row, col: u.col, underlined: u.underlined }));
+    await page.keyboard.up('Control');
+    await page.screenshot({ path: `${SHOTS}/35-terminal-ctrl-hover.png` });
+  } else {
+    check('embedded terminal printed the path link', false, `path "${NEEDLE}" not found in terminal cells`);
+  }
+}
+
 check('no JS page errors', errs.length === 0, errs.join(' | '));
 
 console.log('\n[touch pan/scroll on mobile (hasTouch context)]');


### PR DESCRIPTION
## Summary

Fix file link detection and highlighting (Ctrl+Click to open, Ctrl+hover to underline) in the embedded terminal when running programs with mouse reporting enabled or in alternate-screen mode. Previously, these gestures only worked at a bare shell prompt because mouse events were forwarded to the PTY before link detection could run.

## Key Changes

- **Reserve Ctrl gesture for links**: Modified `try_forward_mouse_to_terminal` to never forward Ctrl+Left-button or Ctrl+motion events to the PTY, ensuring they reach the link handler instead. This allows links to work even when programs have enabled mouse reporting (DECSET 1000/1002/1003) or are running in alternate-screen mode.

- **Enable link detection in alternate-screen**: Removed the alternate-screen check in `detect_terminal_link_at` that was preventing link detection when full-screen programs (vim, less, htop) were running. Since Ctrl events are now withheld from the PTY, it's safe to detect links there.

- **Carry modifiers on mousemove events**: Updated the web frontend to include `ctrl`, `shift`, and `alt` flags on `moved` mouse events (previously only sent on down/drag). This allows the server to compute link highlights while Ctrl is held. Updated the de-dupe logic to include the ctrl flag so pressing/releasing Ctrl re-sends the event even within the same cell.

- **Add comprehensive test coverage**: Added four new e2e tests covering:
  - Ctrl+Click opening paths under mouse-reporting programs
  - Ctrl+Click opening paths in alternate-screen mode
  - Ctrl+hover highlighting paths in alternate-screen mode
  - Ctrl+hover highlighting paths under all-motion tracking (DECSET 1003)
  - Web UI test verifying Ctrl+move emits the ctrl flag and underlines paths

- **Update documentation**: Clarified in module and function docs that the Ctrl gesture is reserved for links everywhere, not just at a shell prompt.

## Implementation Details

The fix works by establishing a clear priority: Ctrl+Left-button and Ctrl+motion gestures are reserved for Fresh's link handling and never forwarded to the PTY. This is consistent with the xterm/VS Code convention where Ctrl/Cmd+Click opens links. Non-Ctrl mouse events continue to forward normally, preserving the program's ordinary mouse behavior.

The web frontend now properly propagates modifier keys on all mouse event types, enabling the server to make decisions based on whether Ctrl is held at the time of motion events, not just at click time.

https://claude.ai/code/session_01MxXEj7N4XrZtifRYDULha5