### PR TITLE
Fix dropdown popover positioning to anchor under trigger button

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4266,6 +4266,16 @@ impl Editor {
             } else {
                 false
             }
+        } else if hit_kind == "dropdown" && hit_event == "dropdown_toggle" {
+            // Clicking the `[value ▼]` trigger toggles the option list open.
+            // Focus moved to this dropdown just above, so `focused_dropdown_open`
+            // reads *this* widget's state. Without this the click only focused
+            // the dropdown and fired the event to the plugin, never opening the
+            // list (the shared `deliver_widget_hit` path handled this; this
+            // TUI-native click path did not).
+            let now_open = !self.focused_dropdown_open(&panel_key);
+            self.set_dropdown_open(&panel_key, &hit_key, now_open);
+            true
         } else {
             false
         };

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4830,7 +4830,11 @@ impl Editor {
                 } else {
                     anchor_screen_y.saturating_sub(h)
                 };
-                let x = inner.x.min(area.x + area.width.saturating_sub(w));
+                // Anchor the box under the trigger's `[` (its display column
+                // within the row) rather than at the panel's left edge, then
+                // clamp so it stays inside the frame.
+                let anchor_screen_x = inner.x.saturating_add(dp.anchor_col as u16);
+                let x = anchor_screen_x.min(area.x + area.width.saturating_sub(w));
                 let y = y.clamp(area.y, area.y + area.height.saturating_sub(h));
                 let popup_rect = ratatui::layout::Rect {
                     x,

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -203,13 +203,17 @@ pub struct RenderOutput {
 /// floating pop-over. `anchor_row` is the 0-based row of the `[value ▼]`
 /// trigger within the panel's inner area (the host adds `inner.y` to get
 /// the screen row and draws the box one row below, flipping above when
-/// there's no room). `options`/`selected`/`scroll` mirror the inline
+/// there's no room). `anchor_col` is the 0-based **display column** of the
+/// trigger's `[` bracket within the row (the host adds `inner.x` to get the
+/// screen column), so the box drops directly under the button instead of at
+/// the panel's left edge. `options`/`selected`/`scroll` mirror the inline
 /// list's model so the box renders and hit-tests identically — just at
 /// screen coordinates instead of panel-clipped ones.
 #[derive(Debug, Clone)]
 pub struct DropdownPopup {
     pub widget_key: String,
     pub anchor_row: u32,
+    pub anchor_col: u32,
     pub options: Vec<String>,
     pub selected: usize,
     pub scroll: usize,
@@ -1436,9 +1440,21 @@ fn collect_dropdown(
     // areas are registered by the host draw pass, not here (they live
     // outside the panel's buffer rows).
     if open {
+        // Anchor column = the display width of the row text before the
+        // button's `[`, so the pop-over drops directly under the value cell
+        // rather than at the panel's left content edge. `button_range.0` is a
+        // byte offset into `entry.text`; measure its display width (the focus
+        // marker `▸ ` is 4 bytes but 2 columns, so byte length would misalign).
+        use crate::primitives::display_width::str_width;
+        let anchor_col = entry
+            .text
+            .get(..button_range.0)
+            .map(|prefix| str_width(prefix) as u32)
+            .unwrap_or(0);
         out.dropdown_popups.push(DropdownPopup {
             widget_key,
             anchor_row: 0,
+            anchor_col,
             options: options.to_vec(),
             selected: cur as usize,
             scroll: scroll_offset,

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -1312,6 +1312,117 @@ fn agent_dropdown_opens_as_floating_popover() {
     }
 }
 
+/// Clicking the *closed* `Agent: [<value> ▼]` trigger opens the option
+/// pop-over. The trigger is not focused when the form opens (Project Path
+/// is), so the click must BOTH move focus to the dropdown AND toggle its
+/// list open. Regression: the TUI floating-panel click path only focused
+/// the dropdown and fired the event to the plugin — it never called
+/// `set_dropdown_open`, so a click left the list closed (the pop-over only
+/// opened via the keyboard `Enter` path). A second click on the now-open,
+/// focused trigger must close it again.
+#[test]
+fn clicking_agent_dropdown_trigger_toggles_popover() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+
+    // Distinctive preset names: the closed trigger shows exactly one (the
+    // selected value), the open pop-over lists several.
+    let names = ["terminal", "claude", "codex", "opencode"];
+    let count_names = |screen: &str| names.iter().filter(|n| screen.contains(**n)).count();
+    let closed_before = count_names(&harness.screen_to_string());
+
+    // Locate the closed trigger by its selected value and click it. `terminal`
+    // is the default Agent value and (with Advanced collapsed) appears only in
+    // the dropdown trigger, so its cell is inside the `[terminal ▼]` button.
+    let (col, row) = harness
+        .find_text_on_screen("terminal")
+        .expect("the Agent dropdown trigger `[terminal ▼]` must be visible");
+    harness.mouse_click(col, row).unwrap();
+    harness.tick_and_render().unwrap();
+
+    let open_screen = harness.screen_to_string();
+    let open_count = count_names(&open_screen);
+    assert!(
+        open_count >= 3 && open_count > closed_before,
+        "clicking the Agent dropdown trigger must open the option pop-over \
+         (many presets visible at once); before={closed_before}, open={open_count}. \
+         Screen:\n{open_screen}",
+    );
+
+    // Click the trigger again (now focused + open) — it must close.
+    let (col2, row2) = harness
+        .find_text_on_screen("terminal")
+        .expect("the Agent trigger stays visible while open");
+    harness.mouse_click(col2, row2).unwrap();
+    harness.tick_and_render().unwrap();
+    assert!(
+        count_names(&harness.screen_to_string()) < open_count,
+        "a second click on the open trigger must close the pop-over. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// The open Agent pop-over box anchors its top-left corner directly under
+/// the trigger's `[` bracket, not at the panel's left content edge.
+/// Regression: the host drew the floating box at `inner.x` (panel left)
+/// regardless of the trigger's column, so a labeled `Agent: [terminal ▼]`
+/// dropdown showed its option list shifted far to the left of the button.
+#[test]
+fn agent_dropdown_popover_anchored_under_trigger() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+    focus_agent_preset_stop(&mut harness);
+
+    // Open the pop-over. The trigger arrow flips `▼` → `▲` and the option
+    // list surfaces below.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("opencode"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+
+    // The focused `▸ Agent: [<value> ▲]` trigger row. Its `[` marks the
+    // button's start column (all leading glyphs — `│`, `▸`, spaces, letters
+    // — are one display column wide, so a char count == display column).
+    let trigger_row = lines
+        .iter()
+        .position(|l| l.contains("Agent:") && l.contains('▲'))
+        .expect("the open Agent trigger row (`▸ Agent: [.. ▲]`) must be on screen");
+    let bracket_col = lines[trigger_row]
+        .chars()
+        .position(|c| c == '[')
+        .expect("the trigger row must contain the `[` button bracket");
+
+    // The dialog's own left border is the first `│` on the trigger row; the
+    // pop-over must NOT anchor there (that was the bug).
+    let dialog_left = lines[trigger_row]
+        .chars()
+        .position(|c| c == '│')
+        .expect("the dialog left border `│` must be on the trigger row");
+    assert!(
+        bracket_col > dialog_left + 2,
+        "precondition: the labeled trigger's `[` ({bracket_col}) sits well right \
+         of the dialog's left border ({dialog_left}).",
+    );
+
+    // The pop-over opens one row below the trigger; its top-left corner `┌`
+    // must land exactly on the trigger's `[` column.
+    let corner = harness.get_cell(bracket_col as u16, (trigger_row + 1) as u16);
+    assert_eq!(
+        corner.as_deref(),
+        Some("┌"),
+        "the pop-over's top-left corner `┌` must sit under the trigger's `[` \
+         (col {bracket_col}, row {}); found {:?}. The box must anchor under the \
+         button, not at the panel's left edge.\nScreen:\n{screen}",
+        trigger_row + 1,
+        corner,
+    );
+}
+
 /// Picking a coding agent surfaces its per-agent controls — an "Auto
 /// mode" checkbox and a "Start prompt" box — which are hidden for the
 /// bare `terminal` default. Stepping ←/→ off `terminal` onto the first

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -99,7 +99,7 @@
   .settings-modal .set-item-head{display:flex;align-items:center;gap:12px}
   .settings-modal .set-name{flex:1;min-width:0} .settings-modal .set-desc{color:var(--muted);white-space:normal;margin-top:1px}
   .settings-modal .set-ctl-wrap{flex:0 0 auto;max-width:50%;text-align:right;display:flex;justify-content:flex-end;align-items:center}
-  .settings-modal .set-ctl{display:inline-flex;align-items:center;gap:4px;position:relative}
+  .settings-modal .set-ctl{display:inline-flex;align-items:center;gap:4px}
   .settings-modal .set-ctl.set-dim{color:var(--muted);font-style:italic}
   /* toggle switch */
   .settings-modal .set-switch{width:26px;height:14px;border-radius:8px;background:#555;position:relative;display:inline-block;transition:background .1s}
@@ -111,8 +111,12 @@
   /* dropdown pill + text field */
   .settings-modal .set-pill{padding:1px 8px;border:1px solid #5a5a5a;border-radius:4px;background:var(--bg)}
   .settings-modal .set-field{padding:1px 8px;border:1px solid #5a5a5a;border-radius:4px;background:var(--bg);max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .settings-modal .set-dd{position:absolute;top:100%;left:0;background:var(--bg2);border:1px solid #5a5a5a;border-radius:4px;max-height:200px;overflow:auto;margin-top:2px;z-index:3}
-  .settings-modal .set-dd-row{padding:1px 10px} .settings-modal .set-dd-row.sel{background:var(--accent);color:#fff}
+  /* Floating option list: `position:fixed` (positioned by JS —
+     positionFloatingPopover) so the Settings list's `overflow:auto` never
+     clips it. The list grows to fit its widest option and shifts to stay in
+     view — see the JS for the anchor/flip/shift rationale. */
+  .set-dd{position:fixed;left:0;top:0;background:var(--bg2);border:1px solid #5a5a5a;border-radius:4px;max-height:200px;overflow:auto;margin-top:2px;z-index:200}
+  .set-dd-row{padding:1px 10px} .set-dd-row.sel{background:var(--accent);color:#fff}
   /* composite list controls */
   .settings-modal .set-item-block .set-list{margin:4px 0 2px 8px;border:1px solid var(--border);border-radius:6px;overflow:hidden}
   .settings-modal .set-list-row{display:flex;align-items:center;gap:8px;padding:2px 10px;border-bottom:1px solid rgba(255,255,255,.05)}
@@ -296,6 +300,10 @@
      so the option list extends past the dialog border (parity with the TUI
      floating popover). JS sets left/top/min-width from the pill's rect. */
   .w-dd-floating{position:fixed;top:0;left:0;z-index:200;min-width:0}
+  /* Body-level portal host for dropdown option lists (widget + Settings), so
+     no `transform`/`overflow` modal ancestor can clip them. Zero-size (its
+     children are all position:fixed); high z-index sits above every modal. */
+  #fresh-popover-host{position:fixed;left:0;top:0;width:0;height:0;z-index:100000}
   .w-dd-row{padding:1px 10px;white-space:nowrap}
   .w-dd-row.sel{background:var(--menuhi);color:var(--on-sel,#fff)}
   .w-dual-cols{display:flex;gap:10px}

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -99,7 +99,7 @@
   .settings-modal .set-item-head{display:flex;align-items:center;gap:12px}
   .settings-modal .set-name{flex:1;min-width:0} .settings-modal .set-desc{color:var(--muted);white-space:normal;margin-top:1px}
   .settings-modal .set-ctl-wrap{flex:0 0 auto;max-width:50%;text-align:right;display:flex;justify-content:flex-end;align-items:center}
-  .settings-modal .set-ctl{display:inline-flex;align-items:center;gap:4px}
+  .settings-modal .set-ctl{display:inline-flex;align-items:center;gap:4px;position:relative}
   .settings-modal .set-ctl.set-dim{color:var(--muted);font-style:italic}
   /* toggle switch */
   .settings-modal .set-switch{width:26px;height:14px;border-radius:8px;background:#555;position:relative;display:inline-block;transition:background .1s}
@@ -111,7 +111,7 @@
   /* dropdown pill + text field */
   .settings-modal .set-pill{padding:1px 8px;border:1px solid #5a5a5a;border-radius:4px;background:var(--bg)}
   .settings-modal .set-field{padding:1px 8px;border:1px solid #5a5a5a;border-radius:4px;background:var(--bg);max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .settings-modal .set-dd{position:absolute;background:var(--bg2);border:1px solid #5a5a5a;border-radius:4px;max-height:200px;overflow:auto;margin-top:2px;z-index:3}
+  .settings-modal .set-dd{position:absolute;top:100%;left:0;background:var(--bg2);border:1px solid #5a5a5a;border-radius:4px;max-height:200px;overflow:auto;margin-top:2px;z-index:3}
   .settings-modal .set-dd-row{padding:1px 10px} .settings-modal .set-dd-row.sel{background:var(--accent);color:#fff}
   /* composite list controls */
   .settings-modal .set-item-block .set-list{margin:4px 0 2px 8px;border:1px solid var(--border);border-radius:6px;overflow:hidden}

--- a/web-ui/css/60-polish.css
+++ b/web-ui/css/60-polish.css
@@ -13,7 +13,7 @@
   /* Floating surfaces: one elevation language — soft hairline edge + real
      shadow + a consistent large radius, so menus/popups/palette/modals feel
      like the same family of cards. */
-  .dropdown,.popup,.ctxmenu,.palette,.settings-modal .set-dd{
+  .dropdown,.popup,.ctxmenu,.palette,.set-dd{
     border:1px solid var(--hairline);border-radius:var(--r-md);box-shadow:var(--shadow)}
   .settings-modal,.kbedit,.auxmodal.centered,.trustdialog,.widget-surface.w-floatingModal{
     border:1px solid var(--hairline);border-radius:var(--r-lg);box-shadow:var(--shadow)}
@@ -38,7 +38,7 @@
   .settings-modal .set-item-block .set-list,.settings-modal .set-list-row,
   .settings-modal .set-list-add,.settings-modal .set-dual-col,.settings-modal .set-dual-coltitle,
   .settings-modal .set-field,.settings-modal .set-pill,.settings-modal .set-step,
-  .settings-modal .set-dd-row,.settings-modal .btn{border-color:var(--hairline)}
+  .set-dd-row,.settings-modal .btn{border-color:var(--hairline)}
   .kbedit .kb-title,.kbedit .kb-header,.kbedit .kb-footer,.kbedit .kb-table .kb-row.kb-head,
   .kbedit .kb-btn,.kbedit .kb-field,.kbedit .kb-autocomplete{border-color:var(--hairline)}
   .auxmodal .am-title,.auxmodal .am-footer{border-color:var(--hairline)}
@@ -56,13 +56,13 @@
   .settings-modal .set-pill,.settings-modal .set-field,.settings-modal .set-step,
   .settings-modal .btn,.kbedit .kb-btn,.w-button,.td-btn,.w-toggle,.pkey,.tab .x{border-radius:var(--r-sm)}
   .settings-modal .set-item-block .set-list,.settings-modal .set-dual-col,
-  .w-section,.w-list-card,.settings-modal .set-dd{border-radius:var(--r-md)}
+  .w-section,.w-list-card,.set-dd{border-radius:var(--r-md)}
 
   /* Readable text/fills ON accent-coloured backgrounds (fixes the white-on-white
      primary button under high-contrast). */
   .settings-modal .btn.primary,.w-button.primary,.trustdialog .td-btn.primary{color:var(--on-accent)}
   .settings-modal .set-switch.on::after{background:var(--on-accent)}
-  .settings-modal .set-dd-row.sel,.kbedit .kb-btn.focus{color:var(--on-accent)}
+  .set-dd-row.sel,.kbedit .kb-btn.focus{color:var(--on-accent)}
 
   /* Quiet, uniform hover affordance. */
   .menu:hover{background:var(--hover)}
@@ -226,7 +226,7 @@
      key chip) → the hairline language instead of a fixed grey. */
   .trustdialog .td-btn,.w-button,.palette .prow .pkey,
   .settings-modal .set-step,.settings-modal .set-pill,.settings-modal .set-field,
-  .settings-modal .set-dd,.settings-modal .set-dual-btn,.settings-modal .btn,
+  .set-dd,.settings-modal .set-dual-btn,.settings-modal .btn,
   .settings-modal .set-overlay,.kbedit .kb-btn,.kbedit .kb-overlay{
     border-color:var(--hairline-strong)}
   /* Primary text on the menuHi / --sel highlight pill → readable in any theme. */

--- a/web-ui/css/80-skin.css
+++ b/web-ui/css/80-skin.css
@@ -77,7 +77,7 @@
   .settings-modal .set-sresult.sel,.kbedit .kb-field.focus{
     background:var(--sel);box-shadow:var(--sel-ring)}
   .menu.open{background:var(--sel);color:var(--fg)}
-  .settings-modal .set-dd-row.sel,.kbedit .kb-ac-row.sel{
+  .set-dd-row.sel,.kbedit .kb-ac-row.sel{
     background:var(--sel);box-shadow:var(--sel-ring);color:var(--fg)}
 
   /* The dock's selected card is the signature moment: a soft teal glow

--- a/web-ui/css/92-theme-macos.css
+++ b/web-ui/css/92-theme-macos.css
@@ -137,7 +137,7 @@
   body.macfam .kbedit .kb-row.sel,body.macfam .w-list-row.sel,
   body.macfam .auxmodal .am-line.sel,body.macfam .settings-modal .set-sresult.sel,
   body.macfam .menu.open,
-  body.macfam .settings-modal .set-dd-row.sel{
+  body.macfam .set-dd-row.sel{
     background:var(--ui-accent);color:#fff;box-shadow:none}
   body.macfam .palette .prow.sel .pdesc,body.macfam .palette .prow.sel .pkey{
     color:rgba(255,255,255,.82);border-color:rgba(255,255,255,.4)}
@@ -200,11 +200,11 @@
      colour) — repoint them at the light/dark chrome so they read as macOS
      pop-up buttons and text fields, not black chips. */
   body.macfam .settings-modal .set-pill,body.macfam .settings-modal .set-field,
-  body.macfam .settings-modal .set-step,body.macfam .settings-modal .set-dd,
-  body.macfam .settings-modal .set-dd-row{
+  body.macfam .settings-modal .set-step,body.macfam .set-dd,
+  body.macfam .set-dd-row{
     background:var(--mac-btn);border-color:var(--hairline-strong);color:var(--fg)}
-  body.macfam .settings-modal .set-dd{background:color-mix(in srgb,var(--bg2) 97%,transparent)}
-  body.macfam .settings-modal .set-dd-row{background:transparent;border:none}
+  body.macfam .set-dd{background:color-mix(in srgb,var(--bg2) 97%,transparent)}
+  body.macfam .set-dd-row{background:transparent;border:none}
   /* Off-state toggle track: a neutral system gray (on-state stays accent —
      scope to :not(.on) so it doesn't out-specify the .on fill). */
   body.macfam .settings-modal .set-switch:not(.on),

--- a/web-ui/js/30-render.js
+++ b/web-ui/js/30-render.js
@@ -1,6 +1,10 @@
 // Per-region DOM patching, motion (FX), render().
 // (web-ui/js — concatenated in filename order into the page's single
 // <script> by crates/fresh-editor/build.rs; all files share one scope.)
+// The region whose fill is currently running, so a dropdown pop-over portaled
+// to the body-level host during that fill can be tagged with (and later reaped
+// by) its owning region. See renderRegion + the popoverHost callers.
+let popoverRegionOwner=null;
 // ---- per-region DOM patching (docs §3.4, the frontend half) ----------------
 // Frames arrive as per-region diffs (see applyFrame), so the DOM is patched
 // per region too: #app holds one stable display:contents container per region
@@ -240,7 +244,16 @@ function renderRegion(name){
     if(name==="palette"){ const s=c.querySelector(".modal-scrim"); if(s) fxExit(s,"fx-out"); }
   }
   if(name!=="caret") c.textContent="";     // the caret patches its own child in place
+  // Reap this region's portaled dropdown pop-overs before the rebuild: if a
+  // dropdown is still open, REGION_FILL re-mounts a fresh one below; otherwise
+  // it stays gone. Per-region (not a blanket clear) so a frame that only
+  // repaints some OTHER region can't drop an open list. `popoverRegionOwner`
+  // tags any pop-over mounted during this fill (see popoverHost callers).
+  const _ph=document.getElementById("fresh-popover-host");
+  if(_ph) _ph.querySelectorAll('[data-popover-region="'+name+'"]').forEach(e=>e.remove());
+  popoverRegionOwner=name;
   REGION_FILL[name](c, scene.regions);
+  popoverRegionOwner=null;
   if(fx&&willHave){
     const el=c.querySelector(fx.sel);
     if(el&&!hadEl){
@@ -293,6 +306,8 @@ function render(){
   applyTheme(scene.theme);
   applyWebTheme();   // layer the frontend web-theme chrome tokens over the TUI theme
   ensureContainers();
+  // Each region reaps + re-mounts its own portaled dropdown pop-overs as it
+  // renders below (see renderRegion), so no blanket clear is needed here.
   for(const n of REGION_ORDER) renderRegion(n);
   renderedRegions=REGION_ORDER.slice();
   // Native touch shell on narrow/portrait viewports (desktop is untouched).

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -105,6 +105,84 @@ function utf16ToByte(s,idx){
   return b;
 }
 
+// A single body-level host for dropdown option lists. Portaling the list OUT
+// of its modal is what lets it never be clipped: a floating modal / the
+// Settings dialog is a `transform`ed, `overflow`-clipping box, so ANY
+// descendant (even `position:fixed`) is clipped to it. As a child of <body>
+// the list has the viewport as its containing block and nothing clips it — the
+// approach every portal-based design system (Radix, MUI, …) uses. The host is
+// 0×0 (its children are all fixed-positioned), so it never intercepts clicks.
+function popoverHost(){
+  let h=document.getElementById("fresh-popover-host");
+  if(!h){ h=document.createElement("div"); h.id="fresh-popover-host"; document.body.appendChild(h); }
+  return h;
+}
+// Mount a dropdown option list into the body-level host, tagged with the region
+// currently rendering (renderRegion sets `popoverRegionOwner`). That region
+// reaps its own tagged pop-overs on its next fill, so the list disappears the
+// moment the dropdown closes and can never leak/accumulate across frames.
+function mountPopover(el){
+  el.dataset.popoverRegion=(typeof popoverRegionOwner!=="undefined"&&popoverRegionOwner)||"";
+  popoverHost().appendChild(el);
+}
+
+// Position a `position:fixed` popover (dropdown option list) under its trigger
+// so it is never clipped by an ancestor's scroll/overflow — a fixed box is only
+// clipped by its containing block, not by intervening `overflow` scrollers like
+// the Settings list or a plugin panel body. Mirrors what native macOS pop-up
+// menus and Windows combo dropdowns do when items are wider than the closed
+// control: the list is AT LEAST the trigger width and grows to fit its widest
+// item, opens under the trigger, and SHIFTS/FLIPS to stay on screen rather than
+// truncating. (Apple HIG: "the width of a pop-up menu should be wide enough to
+// accommodate the longest item"; WinUI: dropdown min-width = control width,
+// grows with content — neither forces the closed control to the widest item.)
+//   - min-width = trigger width (never narrower than the trigger);
+//   - left-align the list under the trigger; if that would spill past the
+//     right edge, right-align it (grow leftward) — the shift a right-flush
+//     control needs (e.g. the Settings controls, which sit at the dialog edge);
+//   - flip above when there is no room below;
+//   - clamp to the viewport so it's never pushed off-screen.
+// Callers portal the list to the body-level host (see mountPopover), so the
+// fixed containing block is the viewport; the ancestor walk below is a
+// defensive fallback for any future in-tree caller.
+function positionFloatingPopover(anchor, popup, opts){
+  if(!anchor||!anchor.isConnected||!popup) return;
+  opts=opts||{};
+  // Fixed-positioning containing block: the viewport, unless an ancestor
+  // establishes one (transform / filter / backdrop-filter / perspective /
+  // will-change). Portaled popovers live under <body> so this is normally the
+  // viewport; the walk stays for robustness (and for any non-portaled caller).
+  let cb={left:0,top:0,right:window.innerWidth,bottom:window.innerHeight};
+  for(let el=popup.parentElement; el; el=el.parentElement){
+    const cs=getComputedStyle(el);
+    if(cs.transform!=="none"||cs.perspective!=="none"
+       ||(cs.filter&&cs.filter!=="none")
+       ||(cs.backdropFilter&&cs.backdropFilter!=="none")
+       ||(cs.webkitBackdropFilter&&cs.webkitBackdropFilter!=="none")
+       ||/transform|filter|perspective/.test(cs.willChange||"")){
+      cb=el.getBoundingClientRect(); break;
+    }
+  }
+  const a=anchor.getBoundingClientRect();
+  popup.style.minWidth=a.width+"px";       // >= trigger, grow-to-content past it
+  const w=popup.offsetWidth, h=popup.offsetHeight, M=4;
+  // Horizontal alignment to the trigger. `align:"end"` aligns the right edges
+  // (list grows leftward) — the right thing for a control flush against a
+  // container's right edge (the Settings controls), so the wider list opens
+  // INTO the dialog rather than spilling past it. Default `"start"` aligns the
+  // left edges (grows rightward) for controls with room to their right (the
+  // plugin form dropdowns). Either way, clamp to the viewport so it's never
+  // pushed off-screen.
+  let left = (opts.align==="end") ? (a.right-w) : a.left;
+  left=Math.max(cb.left+M, Math.min(left, cb.right-w-M));
+  // Vertical: prefer below the trigger; flip above when there is no room.
+  let top=a.bottom+2;
+  if(top+h > cb.bottom-M && a.top-h-2 >= cb.top+M) top=a.top-h-2;
+  top=Math.max(cb.top+M, Math.min(top, cb.bottom-h-M));
+  popup.style.left=(left-cb.left)+"px";
+  popup.style.top=(top-cb.top)+"px";
+}
+
 // After a widgets-region rebuild: hand real DOM focus to the host-focused
 // text widget's input (so the native caret blinks and IME composes there),
 // pin its caret to the host TextEdit's cursor, and fall back to the hidden
@@ -270,7 +348,11 @@ function widgetEl(spec, ctx){
       else { const l=document.createElement("span"); l.className="w-text-label"; l.textContent=spec.label+": "; el.appendChild(l); }
     }
     const pill=document.createElement("span"); pill.className="w-dd-pill";
-    pill.textContent=((spec.options||[])[selIdx]??"—")+(open?" ▲":" ▾");
+    // Small up/down chevrons — a MATCHED-SIZE pair (▴ U+25B4 / ▾ U+25BE). The
+    // full-size ▲ (U+25B2) is ~2× the width of the small ▾ in a proportional
+    // font (e.g. the macOS skin's -apple-system), so pairing it with ▾ made the
+    // pill jump ~6px wider on open; the small ▴ keeps the width stable.
+    pill.textContent=((spec.options||[])[selIdx]??"—")+(open?" ▴":" ▾");
     pill.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_toggle",{}); };
     el.appendChild(pill);
     if(open){
@@ -280,41 +362,12 @@ function widgetEl(spec, ctx){
         r.onmousedown=e=>{ e.preventDefault(); e.stopPropagation(); if(spec.key) routeControl(ctx,spec.key,"dropdown_select",{index:i}); };
         dd.appendChild(r);
       });
-      el.appendChild(dd);
-      // Float the option list as a screen-level pop-over so it extends PAST
-      // the modal's border instead of growing/clipping inside it (parity
-      // with the TUI popover). `position:fixed` escapes the surface's
-      // `overflow` clip; we anchor it under the pill after layout, flipping
-      // above when there's no room below.
-      requestAnimationFrame(()=>{
-        if(!pill.isConnected) return;
-        const r=pill.getBoundingClientRect();
-        // `position:fixed` normally resolves against the viewport, BUT an
-        // ancestor with transform/filter/backdrop-filter/perspective becomes
-        // the fixed element's containing block instead — the macOS skin's
-        // vibrancy modal (`backdrop-filter:blur(...)`) does exactly this, so a
-        // naive viewport-relative left/top lands the list offset by the
-        // modal's origin (way off, effectively invisible). Subtract the
-        // containing block's origin so the popover sits under the pill in any
-        // skin. No such ancestor ⇒ (0,0), i.e. plain viewport coordinates.
-        let cbLeft=0, cbTop=0;
-        for(let a=dd.parentElement; a; a=a.parentElement){
-          const cs=getComputedStyle(a);
-          if(cs.transform!=="none"||cs.perspective!=="none"
-             ||(cs.filter&&cs.filter!=="none")
-             ||(cs.backdropFilter&&cs.backdropFilter!=="none")
-             ||(cs.webkitBackdropFilter&&cs.webkitBackdropFilter!=="none")
-             ||/transform|filter|perspective/.test(cs.willChange||"")){
-            const cb=a.getBoundingClientRect(); cbLeft=cb.left; cbTop=cb.top; break;
-          }
-        }
-        dd.style.left=(r.left-cbLeft)+"px";
-        dd.style.minWidth=r.width+"px";
-        const h=dd.offsetHeight;
-        let top=r.bottom+2;
-        if(top+h>window.innerHeight && r.top-h-2>0) top=r.top-h-2;
-        dd.style.top=(top-cbTop)+"px";
-      });
+      // Portal the option list to the body-level host so it extends PAST the
+      // modal's border and is never clipped by the surface's overflow (parity
+      // with the TUI popover). Shared positioner anchors it under the pill,
+      // grows it to fit the widest item, and flips/shifts to stay on screen.
+      mountPopover(dd);
+      requestAnimationFrame(()=>positionFloatingPopover(pill, dd));
     }
     return el;
   }
@@ -499,7 +552,15 @@ function settingControlEl(c, idx, live){
     el.appendChild(mk("−","set-step","controlDecrement")); const v=document.createElement("span"); v.className="set-num-v"; v.textContent=c.value; el.appendChild(v); el.appendChild(mk("+","set-step","controlIncrement"));
   }
   else if(k==="dropdown"){ const p=document.createElement("span"); p.className="set-pill"; p.textContent=(c.options[c.selected]||"—")+" ▾"; if(live) p.onmousedown=setHit("controlDropdown",idx); el.appendChild(p);
-    if(c.open){ const d=div("set-dd"); c.options.forEach((o,i)=>{const r=div("set-dd-row"+(i===c.selected?" sel":""));r.textContent=o;if(live)r.onmousedown=setHit("controlDropdownOption",idx,i);d.appendChild(r);}); el.appendChild(d);} }
+    if(c.open){ const d=div("set-dd"); c.options.forEach((o,i)=>{const r=div("set-dd-row"+(i===c.selected?" sel":""));r.textContent=o;if(live)r.onmousedown=setHit("controlDropdownOption",idx,i);d.appendChild(r);});
+      // Portal to the body-level host (same as the plugin Dropdown): the
+      // Settings dialog is a transformed, overflow-clipping box with a
+      // scrolling list, so an in-place list is cut off at the dialog edge (a
+      // long option set — e.g. Default Language — is far wider than the compact
+      // pill). Out of the modal it grows to fit the widest option and shifts to
+      // stay in view (right-aligning under the flush-right control).
+      mountPopover(d);
+      requestAnimationFrame(()=>positionFloatingPopover(p, d, {align:"end"})); } }
   else if(k==="text"){ const f=document.createElement("span"); f.className="set-field"; f.textContent=(c.value||c.placeholder||"")+(c.editing?"▌":""); if(live) f.onmousedown=setHit("controlText",idx); el.appendChild(f); }
   else if(k==="json"){ const f=document.createElement("span"); f.className="set-field mono"; f.textContent=(c.value||"").slice(0,80)||"{}"; if(live) f.onmousedown=setHit("controlText",idx); el.appendChild(f); }
   else if(k==="complex"){ el.textContent="‹"+c.typeName+"›"; el.classList.add("set-dim"); }

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -289,12 +289,31 @@ function widgetEl(spec, ctx){
       requestAnimationFrame(()=>{
         if(!pill.isConnected) return;
         const r=pill.getBoundingClientRect();
-        dd.style.left=r.left+"px";
+        // `position:fixed` normally resolves against the viewport, BUT an
+        // ancestor with transform/filter/backdrop-filter/perspective becomes
+        // the fixed element's containing block instead — the macOS skin's
+        // vibrancy modal (`backdrop-filter:blur(...)`) does exactly this, so a
+        // naive viewport-relative left/top lands the list offset by the
+        // modal's origin (way off, effectively invisible). Subtract the
+        // containing block's origin so the popover sits under the pill in any
+        // skin. No such ancestor ⇒ (0,0), i.e. plain viewport coordinates.
+        let cbLeft=0, cbTop=0;
+        for(let a=dd.parentElement; a; a=a.parentElement){
+          const cs=getComputedStyle(a);
+          if(cs.transform!=="none"||cs.perspective!=="none"
+             ||(cs.filter&&cs.filter!=="none")
+             ||(cs.backdropFilter&&cs.backdropFilter!=="none")
+             ||(cs.webkitBackdropFilter&&cs.webkitBackdropFilter!=="none")
+             ||/transform|filter|perspective/.test(cs.willChange||"")){
+            const cb=a.getBoundingClientRect(); cbLeft=cb.left; cbTop=cb.top; break;
+          }
+        }
+        dd.style.left=(r.left-cbLeft)+"px";
         dd.style.minWidth=r.width+"px";
         const h=dd.offsetHeight;
         let top=r.bottom+2;
         if(top+h>window.innerHeight && r.top-h-2>0) top=r.top-h-2;
-        dd.style.top=top+"px";
+        dd.style.top=(top-cbTop)+"px";
       });
     }
     return el;

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -863,6 +863,68 @@ await page.screenshot({ path: `${SHOTS}/34-theme-cosmos.png` });
 
 check('no JS page errors', errs.length === 0, errs.join(' | '));
 
+// ---------------------------------------------------------------------------
+// Dropdown pop-over placement, macOS skin. The macOS vibrancy modal uses
+// `backdrop-filter`, which makes it the containing block for any
+// `position:fixed` descendant — so a naive viewport-anchored option list
+// lands offset by the modal's origin (off in a corner, effectively
+// invisible). The widget Dropdown must compensate for that so its list opens
+// directly under the pill; the Settings `.set-dd` must drop BELOW its pill,
+// not overlap/precede it.
+console.log('\n[dropdown pop-overs anchor under their trigger (macOS skin)]');
+await page.keyboard.press('Escape'); await page.waitForTimeout(120);
+// Skin is read from localStorage at boot; single-client bridge → /reset first,
+// then set the skin and reload so the vibrancy modal is in play.
+await page.request.post(URL + '/reset', { data: {} });
+await page.evaluate(() => { try { localStorage.setItem('fresh.webtheme', 'macos'); } catch (_) {} });
+await page.reload({ waitUntil: 'networkidle' });
+await page.waitForFunction(() => window.fresh && window.fresh.wsOpen && window.fresh.scene && window.fresh.scene.regions.panes.length > 0, null, { timeout: 20000 });
+await page.waitForTimeout(400);
+check('macOS skin active (vibrancy modal in play)',
+  await page.evaluate(() => document.body.classList.contains('theme-macos')));
+
+// (a) Orchestrator "Run Agent" widget dropdown, mounted inside the
+// backdrop-filter modal — the case that regressed.
+await page.request.post(URL + '/action', { data: { action: 'orchestrator_run_agent' } });
+await page.waitForFunction(() => document.querySelectorAll('.w-dropdown .w-dd-pill').length > 0, null, { timeout: 8000 }).catch(() => {});
+const raBox = await page.locator('.w-dropdown .w-dd-pill').first().boundingBox();
+if (raBox) {
+  await page.mouse.click(raBox.x + raBox.width / 2, raBox.y + raBox.height / 2);
+  await page.waitForFunction(() => !!document.querySelector('.w-dd.w-dd-floating'), null, { timeout: 5000 }).catch(() => {});
+  const w = await page.evaluate(() => {
+    const list = document.querySelector('.w-dd.w-dd-floating'), pill = document.querySelector('.w-dd-pill');
+    if (!list || !pill) return null;
+    const lr = list.getBoundingClientRect(), pr = pill.getBoundingClientRect();
+    return { dx: Math.round(lr.left - pr.left), dy: Math.round(lr.top - pr.bottom) };
+  });
+  await page.screenshot({ path: `${SHOTS}/34-macos-widget-dropdown.png` });
+  check('Run-Agent widget dropdown opens directly under its pill (not offset by the modal)',
+    !!w && Math.abs(w.dx) <= 4 && w.dy >= -2 && w.dy <= 8, JSON.stringify(w));
+}
+await page.keyboard.press('Escape'); await page.waitForTimeout(100);
+await page.keyboard.press('Escape'); await page.waitForTimeout(200);
+
+// (b) Settings `.set-dd` must drop BELOW its `.set-pill` (skin-independent,
+// but exercised here in the same macOS session).
+await page.request.post(URL + '/action', { data: { action: 'open_settings' } });
+await page.waitForFunction(() => !!window.fresh.scene.regions.settings, { timeout: 8000 }).catch(() => {});
+await page.waitForTimeout(300);
+const spBox = await page.locator('.settings-modal .set-pill').first().boundingBox();
+if (spBox) {
+  await page.mouse.click(spBox.x + spBox.width / 2, spBox.y + spBox.height / 2);
+  await page.waitForFunction(() => !!document.querySelector('.settings-modal .set-dd'), null, { timeout: 5000 }).catch(() => {});
+  const sd = await page.evaluate(() => {
+    const dd = document.querySelector('.settings-modal .set-dd'), pill = document.querySelector('.settings-modal .set-pill');
+    if (!dd || !pill) return null;
+    const dr = dd.getBoundingClientRect(), pr = pill.getBoundingClientRect();
+    return { ddTop: Math.round(dr.top), pillBottom: Math.round(pr.bottom), dx: Math.round(dr.left - pr.left) };
+  });
+  await page.screenshot({ path: `${SHOTS}/35-macos-settings-dropdown.png` });
+  check('Settings dropdown list drops BELOW its pill (not overlapping/above it)',
+    !!sd && sd.ddTop >= sd.pillBottom - 2 && Math.abs(sd.dx) <= 6, JSON.stringify(sd));
+}
+await page.keyboard.press('Escape'); await page.waitForTimeout(120);
+
 console.log('\n[touch pan/scroll on mobile (hasTouch context)]');
 // The bridge is single-client: close the desktop page (frees /ws) before
 // opening a touch context against the same server.

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -865,13 +865,13 @@ check('no JS page errors', errs.length === 0, errs.join(' | '));
 
 // ---------------------------------------------------------------------------
 // Dropdown pop-over placement, macOS skin. The macOS vibrancy modal uses
-// `backdrop-filter`, which makes it the containing block for any
-// `position:fixed` descendant — so a naive viewport-anchored option list
-// lands offset by the modal's origin (off in a corner, effectively
-// invisible). The widget Dropdown must compensate for that so its list opens
-// directly under the pill; the Settings `.set-dd` must drop BELOW its pill,
-// not overlap/precede it.
-console.log('\n[dropdown pop-overs anchor under their trigger (macOS skin)]');
+// `backdrop-filter`, making it the containing block for `position:fixed`
+// descendants; the Settings modal is a `transform`ed, `overflow:hidden` box
+// with a scrolling item list. A dropdown's floating option list must, in both:
+// open under its trigger (not offset by the modal origin), never be clipped by
+// those scroll/overflow containers, and grow to fit its widest option. The
+// closed pill's width must also stay stable open↔closed.
+console.log('\n[dropdown pop-overs anchor under their trigger, never clip (macOS skin)]');
 await page.keyboard.press('Escape'); await page.waitForTimeout(120);
 // Skin is read from localStorage at boot; single-client bridge → /reset first,
 // then set the skin and reload so the vibrancy modal is in play.
@@ -889,39 +889,57 @@ await page.request.post(URL + '/action', { data: { action: 'orchestrator_run_age
 await page.waitForFunction(() => document.querySelectorAll('.w-dropdown .w-dd-pill').length > 0, null, { timeout: 8000 }).catch(() => {});
 const raBox = await page.locator('.w-dropdown .w-dd-pill').first().boundingBox();
 if (raBox) {
+  const closedW = await page.evaluate(() => document.querySelector('.w-dd-pill').getBoundingClientRect().width);
   await page.mouse.click(raBox.x + raBox.width / 2, raBox.y + raBox.height / 2);
   await page.waitForFunction(() => !!document.querySelector('.w-dd.w-dd-floating'), null, { timeout: 5000 }).catch(() => {});
   const w = await page.evaluate(() => {
     const list = document.querySelector('.w-dd.w-dd-floating'), pill = document.querySelector('.w-dd-pill');
     if (!list || !pill) return null;
     const lr = list.getBoundingClientRect(), pr = pill.getBoundingClientRect();
-    return { dx: Math.round(lr.left - pr.left), dy: Math.round(lr.top - pr.bottom) };
+    return { dx: Math.round(lr.left - pr.left), dy: Math.round(lr.top - pr.bottom), openW: pr.width };
   });
   await page.screenshot({ path: `${SHOTS}/34-macos-widget-dropdown.png` });
   check('Run-Agent widget dropdown opens directly under its pill (not offset by the modal)',
     !!w && Math.abs(w.dx) <= 4 && w.dy >= -2 && w.dy <= 8, JSON.stringify(w));
+  // The open (▴) and closed (▾) chevrons must be the same width so the pill
+  // doesn't jump — regressed when open used the full-size ▲ vs the small ▾.
+  check('closed pill width stays stable when opened (matched-size chevron)',
+    !!w && Math.abs(w.openW - closedW) <= 1, JSON.stringify({ closedW: Math.round(closedW), openW: Math.round(w.openW) }));
 }
 await page.keyboard.press('Escape'); await page.waitForTimeout(100);
 await page.keyboard.press('Escape'); await page.waitForTimeout(200);
 
-// (b) Settings `.set-dd` must drop BELOW its `.set-pill` (skin-independent,
-// but exercised here in the same macOS session).
+// (b) Settings "Default Language" dropdown: a long option list far wider than
+// its compact "(none)" pill, with the control flush against the dialog's right
+// edge — the exact case that used to run off the edge and get clipped by the
+// scroll container. It must open below the pill, grow WIDER than the pill (to
+// fit option text), and sit fully inside the modal (no clipping on any side).
 await page.request.post(URL + '/action', { data: { action: 'open_settings' } });
 await page.waitForFunction(() => !!window.fresh.scene.regions.settings, { timeout: 8000 }).catch(() => {});
 await page.waitForTimeout(300);
-const spBox = await page.locator('.settings-modal .set-pill').first().boundingBox();
-if (spBox) {
-  await page.mouse.click(spBox.x + spBox.width / 2, spBox.y + spBox.height / 2);
-  await page.waitForFunction(() => !!document.querySelector('.settings-modal .set-dd'), null, { timeout: 5000 }).catch(() => {});
+const langPill = page.locator('.settings-modal .set-item', { hasText: 'Default Language' }).locator('.set-pill');
+await langPill.scrollIntoViewIfNeeded().catch(() => {});
+const lpBox = await langPill.boundingBox();
+if (lpBox) {
+  await page.mouse.click(lpBox.x + lpBox.width / 2, lpBox.y + lpBox.height / 2);
+  await page.waitForFunction(() => !!document.querySelector('.set-dd'), null, { timeout: 5000 }).catch(() => {});
   const sd = await page.evaluate(() => {
-    const dd = document.querySelector('.settings-modal .set-dd'), pill = document.querySelector('.settings-modal .set-pill');
-    if (!dd || !pill) return null;
-    const dr = dd.getBoundingClientRect(), pr = pill.getBoundingClientRect();
-    return { ddTop: Math.round(dr.top), pillBottom: Math.round(pr.bottom), dx: Math.round(dr.left - pr.left) };
+    const item = [...document.querySelectorAll('.settings-modal .set-item')].find(r => r.textContent.includes('Default Language'));
+    // The option list is portaled to the body-level host, not inside the modal.
+    const dd = document.querySelector('#fresh-popover-host .set-dd'), pill = item && item.querySelector('.set-pill');
+    const modal = document.querySelector('.settings-modal');
+    if (!dd || !pill || !modal) return null;
+    const d = dd.getBoundingClientRect(), p = pill.getBoundingClientRect(), m = modal.getBoundingClientRect();
+    return {
+      below: Math.round(d.top - p.bottom), grewWiderBy: Math.round(d.width - p.width),
+      insideModal: d.left >= m.left - 1 && d.right <= m.right + 1 && d.top >= m.top - 1 && d.bottom <= m.bottom + 1,
+      d: { l: Math.round(d.left), r: Math.round(d.right), b: Math.round(d.bottom) }, m: { l: Math.round(m.left), r: Math.round(m.right), b: Math.round(m.bottom) },
+    };
   });
   await page.screenshot({ path: `${SHOTS}/35-macos-settings-dropdown.png` });
-  check('Settings dropdown list drops BELOW its pill (not overlapping/above it)',
-    !!sd && sd.ddTop >= sd.pillBottom - 2 && Math.abs(sd.dx) <= 6, JSON.stringify(sd));
+  check('Settings "Default Language" list opens below its pill', !!sd && sd.below >= -1 && sd.below <= 8, JSON.stringify(sd));
+  check('Settings dropdown grows wider than its compact pill to fit options', !!sd && sd.grewWiderBy > 8, JSON.stringify(sd));
+  check('Settings dropdown is NOT clipped — fully inside the dialog', !!sd && sd.insideModal, JSON.stringify(sd));
 }
 await page.keyboard.press('Escape'); await page.waitForTimeout(120);
 


### PR DESCRIPTION
## Summary
Fixes dropdown popover positioning in both the TUI editor and web UI so that option lists anchor directly under their trigger buttons instead of at the panel/modal left edge. This resolves regressions where popovers appeared misaligned or invisible, particularly in the macOS skin where `backdrop-filter` creates a containing block for fixed-position elements.

## Key Changes

### TUI Editor (Rust)
- **Dropdown trigger click handling** (`mouse_input.rs`): Added missing `set_dropdown_open` call when clicking a dropdown trigger via the TUI-native click path. Previously, clicks only focused the dropdown and fired events to the plugin without actually toggling the list open.

- **Popover anchor column tracking** (`render.rs`): 
  - Added `anchor_col` field to `DropdownPopup` struct to track the display column of the trigger's `[` bracket
  - Calculate anchor column by measuring the display width of text before the button (accounting for multi-byte UTF-8 characters)
  - Use this column when positioning the popover so it aligns under the button, not the panel edge

- **Popover positioning** (`render.rs`): Updated screen coordinate calculation to add `inner.x + anchor_col` instead of just `inner.x`, then clamp to frame bounds.

### Web UI (JavaScript/CSS)
- **Widget dropdown positioning** (`65-widgets.js`):
  - Detect containing block ancestors with `transform`, `filter`, `backdrop-filter`, `perspective`, or `will-change` properties
  - Subtract the containing block's origin from viewport coordinates so `position:fixed` elements position correctly relative to the button
  - Fixes the macOS vibrancy modal case where `backdrop-filter:blur()` creates a containing block

- **Settings dropdown layout** (`40-widgets.css`): Added `position:relative` to `.set-ctl` to establish a positioning context for dropdown lists, ensuring they drop below the pill rather than overlapping it.

### Tests
- Added `clicking_agent_dropdown_trigger_toggles_popover()` test to verify click-to-toggle behavior
- Added `agent_dropdown_popover_anchored_under_trigger()` test to verify popover anchors under the `[` bracket, not the panel edge
- Added web UI e2e tests for both widget and settings dropdowns on macOS skin

## Implementation Details
The core issue was that `position:fixed` elements don't always position relative to the viewport—ancestors with certain CSS properties (transform, filter, backdrop-filter, perspective) become the containing block instead. The fix walks up the DOM/widget tree to find such ancestors and compensates by subtracting their bounding box origin from the calculated position.

https://claude.ai/code/session_01NzJnUVTrhPLwT29FZGPCYK