### PR TITLE
Polish the Winamp Classic web theme (pixel-matched to reference)

### DIFF
--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -1,202 +1,183 @@
-  /* Web theme: Winamp Classic — brushed metal, hard bevels, LCD green.
+  /* Web theme: Winamp Classic — copper metal, hard bevels, LCD green.
      (web-ui/css — concatenated in filename order into the page's single
      <style> block by crates/fresh-editor/build.rs; order is load-bearing:
      later files deliberately override earlier ones.) */
   /* ======================================================================
      Gated on body.theme-winamp (set by js/15-theme.js). A SHELL theme: it
      reuses the COSMOS layout — the grid stays inset inside #device and the
-     dock floats beside it (see SHELL_THEMES / layoutShell / widgetSurfaceEls)
-     — but dresses both as classic skin windows: the bezel becomes the main
-     player (title bar, window buttons, LCD readout, spectrum analyser), the
-     dock becomes the playlist editor. COLOURS come from applyWebTheme()'s
-     inline tokens; this file owns the metal, the bevels and the decoration.
-     Everything painted over the cell grid avoids layout-affecting properties
-     (borders/padding on chrome rows would slide the DOM off the cell pitch),
-     so bevels are drawn with inset box-shadows.
+     dock floats beside it (SHELL_THEMES / layoutShell / widgetSurfaceEls) —
+     but dresses both as skin windows: the bezel is the CODE STUDIO player
+     (rail title bar, LCD readout, analyser, transport) and the dock is the
+     ORCHESTRATOR playlist window. Its decoration is DECLARED as theme
+     furniture (WEB_THEME_FURNITURE.winamp), not baked into shell.html.
+     COLOURS come from applyWebTheme()'s inline tokens; this file owns the
+     metal, the bevels and the furniture.
+     Anything painted over the cell grid uses colour + inset shadows only —
+     borders or padding on chrome rows would slide the DOM off the cell pitch.
      ====================================================================== */
 
   body.theme-winamp{
-    --wa-lt:rgba(255,255,255,.30);       /* bevel highlight (top-left)  */
-    --wa-dk:rgba(0,0,0,.78);             /* bevel shadow    (bottom-right) */
-    --wa-metal:linear-gradient(180deg,#4b4e59,#3a3d47 14%,#31343d 62%,#25272e);
-    --wa-metal-flat:#33363f;
-    --wa-led:#2bf573;                    /* the display's phosphor green */
-    --wa-led-dim:#128d3f;
-    --wa-amber:#f6d24d;
-    /* Raised / recessed hardware, drawn without touching layout. */
+    --wa-face:linear-gradient(180deg,#6d4527,#513120 46%,#3b2417);   /* window metal */
+    --wa-face-flat:#4a2d1c;
+    --wa-plate:linear-gradient(180deg,#7d5230,#583520);              /* raised parts */
+    --wa-sunken:#050705;                                             /* LCD / code wells */
+    --wa-lt:rgba(255,208,150,.34);      /* bevel highlight (top-left)     */
+    --wa-dk:rgba(0,0,0,.80);            /* bevel shadow    (bottom-right) */
     --wa-out:inset 1px 1px 0 var(--wa-lt),inset -1px -1px 0 var(--wa-dk);
     --wa-in:inset 1px 1px 0 var(--wa-dk),inset -1px -1px 0 var(--wa-lt);
-    /* Bar visualiser: one gradient reused at 16 different heights. */
-    --wa-bar:linear-gradient(180deg,#eaff5c,#2bf573 42%,#0aa93f)}
+    --wa-amber:#f6c471;                 /* title / caption lettering */
+    --wa-green:#4ef07f;                 /* phosphor readouts */
+    --wa-green-dim:#1a8f43;
+    --wa-drop:8px 10px 0 rgba(0,0,0,.45),0 34px 80px rgba(0,0,0,.72)}
 
-  /* ---- the desk the windows sit on: near-black with a faint green bloom ---- */
+  /* ---- the desk: near-black with a warm bloom under the windows ---- */
   body.theme-winamp:not(.mobile){background:
-    radial-gradient(60rem 40rem at 18% -10%, rgba(43,245,115,.10), transparent 62%),
-    radial-gradient(50rem 40rem at 108% 108%, rgba(60,110,255,.10), transparent 60%),
-    repeating-linear-gradient(135deg,rgba(255,255,255,.017) 0 2px,transparent 2px 5px),
-    linear-gradient(180deg,#15171c,#0a0b0e) #0a0b0e}
-  /* Same clip as COSMOS: the menubar row spans the full grid width, so the
-     strip behind the floating dock must be carved out (layoutShell keeps
-     --clip-left at the dock's pixel width). */
+    radial-gradient(70rem 45rem at 20% -12%, rgba(255,150,60,.10), transparent 62%),
+    radial-gradient(55rem 42rem at 110% 110%, rgba(78,240,127,.07), transparent 60%),
+    repeating-linear-gradient(135deg,rgba(255,255,255,.016) 0 2px,transparent 2px 5px),
+    linear-gradient(180deg,#1a1512,#0b0a09) #0b0a09}
+  /* Same clip as COSMOS: the menubar row spans the whole grid, so the strip
+     behind the floating dock is carved out (--clip-left = dock width). */
   body.theme-winamp:not(.mobile) .menubar{clip-path:inset(0 0 0 var(--clip-left,0px))}
 
-  /* ======================= the main player window ======================= */
-  body.theme-winamp #device{border-radius:0;letter-spacing:.14em;color:var(--wa-led-dim);
-    background:var(--wa-metal);
-    box-shadow:10px 12px 0 rgba(0,0,0,.45),0 40px 90px rgba(0,0,0,.7),var(--wa-out)}
-  body.theme-winamp #device::before{display:none}     /* machined rim → hard bevel */
-  /* The screen well: a black LCD cavity, recessed by a reversed bevel. */
-  body.theme-winamp #device .dv-screen{border-radius:0;background:#000;
-    box-shadow:var(--wa-in),0 0 0 1px rgba(0,0,0,.9),inset 0 0 90px rgba(43,245,115,.05)}
+  /* ==================== CODE STUDIO — the player window ================== */
+  body.theme-winamp #device{border-radius:6px;letter-spacing:normal;
+    background:var(--wa-face);box-shadow:var(--wa-drop),var(--wa-out)}
+  body.theme-winamp #device::before{display:none}   /* machined rim → bevel */
+  /* The code well: black, recessed, with a faint phosphor bloom. */
+  body.theme-winamp #device .dv-screen{border-radius:2px;background:var(--wa-sunken);
+    box-shadow:var(--wa-in),inset 0 0 90px rgba(78,240,127,.05)}
 
-  /* ---- title bar: the classic gradient strip + window buttons ---- */
-  body.theme-winamp #device .dv-top{left:7px;right:7px;top:7px;
-    height:calc(var(--bezel-top) - 28px);padding:0 6px;gap:8px;
-    background:linear-gradient(180deg,#6a7080,#474b57 40%,#2f323b);
-    box-shadow:var(--wa-out)}
-  /* Title text: the markup's COSMOS labels are neutralised and re-lettered
-     here, so the shell HTML stays theme-agnostic. */
-  body.theme-winamp #device .dv-label{font-size:0}
-  body.theme-winamp #device .dv-top .dv-label::before{content:"FRESH — MAIN WINDOW";
-    font-size:11px;letter-spacing:.22em;color:#cfd5e2;text-shadow:0 1px 0 #000}
-  /* The three "LEDs" become square minimise / shade / close boxes. */
-  body.theme-winamp #device .dv-leds{gap:3px}
-  body.theme-winamp #device .dv-leds i{width:12px;height:11px;border-radius:0;
-    background:linear-gradient(180deg,#5b606d,#3b3f49);
-    box-shadow:var(--wa-out);position:relative}
-  body.theme-winamp #device .dv-leds i::after{content:"";position:absolute;
-    background:#d7dce8;box-shadow:0 1px 0 rgba(0,0,0,.6)}
-  body.theme-winamp #device .dv-leds .g::after{left:3px;right:3px;bottom:2px;height:2px}
-  body.theme-winamp #device .dv-leds .y::after{left:3px;right:3px;top:4px;height:2px}
-  /* Close: two crossed bars (::before is the second stroke). */
-  body.theme-winamp #device .dv-leds .a::before,
-  body.theme-winamp #device .dv-leds .a::after{content:"";position:absolute;
-    left:2px;right:2px;top:5px;height:2px;background:#f2c3c3}
-  body.theme-winamp #device .dv-leds .a::before{transform:rotate(45deg)}
-  body.theme-winamp #device .dv-leds .a::after{transform:rotate(-45deg)}
-  /* A slim LCD strip under the title bar: the "now playing" readout. */
-  body.theme-winamp #device .dv-top::after{content:"128 KBPS  44 KHZ  STEREO  ▶ EDITING";
-    position:absolute;left:-1px;right:-1px;top:calc(100% + 3px);height:11px;
-    font-size:9px;letter-spacing:.28em;line-height:11px;padding:0 7px;
-    color:var(--wa-led);background:#000;box-shadow:var(--wa-in);
-    text-shadow:0 0 6px rgba(43,245,115,.75);overflow:hidden;white-space:nowrap}
-
-  /* ---- bottom bar: spectrum analyser + transport legend + seek slider ---- */
-  body.theme-winamp #device .dv-bottom{left:7px;right:7px;bottom:7px;
-    height:calc(var(--bezel-bot) - 16px);padding:0 8px;gap:14px;
-    background:var(--wa-metal);box-shadow:var(--wa-out)}
-  /* 16 bars: one shared gradient, sized per bar and pinned to the baseline,
-     with a segment mask painted over the top (Winamp's analyser is banded). */
-  body.theme-winamp #device .dv-bottom .dv-label:first-of-type{position:relative;
-    width:102px;height:26px;align-self:center;background:#000;box-shadow:var(--wa-in)}
-  body.theme-winamp #device .dv-bottom .dv-label:first-of-type::after{content:"";
-    position:absolute;inset:3px 4px;
-    background-image:
-      repeating-linear-gradient(180deg,rgba(0,0,0,.9) 0 1px,transparent 1px 3px),
-      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
-      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
-      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
-      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar);
-    background-repeat:repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,
-      no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,
-      no-repeat,no-repeat,no-repeat,no-repeat;
-    background-position:0 0,
-      0 100%,6px 100%,12px 100%,18px 100%,24px 100%,30px 100%,36px 100%,42px 100%,
-      48px 100%,54px 100%,60px 100%,66px 100%,72px 100%,78px 100%,84px 100%,90px 100%;
-    background-size:100% 100%,
-      4px 55%,4px 82%,4px 38%,4px 96%,4px 64%,4px 44%,4px 88%,4px 30%,
-      4px 72%,4px 50%,4px 92%,4px 34%,4px 68%,4px 46%,4px 78%,4px 26%}
-  /* Right-hand legend + a seek bar under it (the slider's knob is the notch). */
-  body.theme-winamp #device .dv-bottom .dv-label:last-of-type{position:relative;
-    font-size:0;color:var(--wa-led)}
-  body.theme-winamp #device .dv-bottom .dv-label:last-of-type::before{
-    content:"◀◀  ▶  ▮▮  ■  ▶▶";font-size:11px;letter-spacing:.3em;
-    color:#c3c9d6;text-shadow:0 1px 0 #000}
-  body.theme-winamp #device .dv-bottom .dv-label:last-of-type::after{content:"";
-    position:absolute;left:0;right:0;top:calc(100% + 5px);height:8px;
-    background:linear-gradient(90deg,var(--wa-led-dim) 0 62%,#1b1d22 62%),#1b1d22;
+  /* ---- title bar: pinstripe rails either side of the caption ---- */
+  body.theme-winamp #device .wa-title{position:absolute;left:6px;right:6px;top:5px;
+    height:calc(var(--bezel-top) - 13px);
+    display:flex;align-items:center;gap:9px;padding:0 7px;border-radius:3px;
+    background:linear-gradient(90deg,#6a4326,#3a2416);box-shadow:var(--wa-out)}
+  body.theme-winamp #device .wa-rail{flex:1;height:9px;border-radius:1px;
+    background:repeating-linear-gradient(180deg,
+      rgba(246,196,113,.55) 0 1px,rgba(0,0,0,.45) 1px 3px);
     box-shadow:var(--wa-in)}
+  body.theme-winamp #device .wa-title-text{flex:0 0 auto;font-size:11px;font-weight:700;
+    letter-spacing:.22em;color:var(--wa-amber);text-shadow:0 1px 0 rgba(0,0,0,.8)}
+  /* Window buttons: three little pressed plates (minimise / shade / close). */
+  body.theme-winamp #device .wa-wbtns{display:flex;gap:3px;flex:0 0 auto}
+  body.theme-winamp #device .wa-wbtns i{position:relative;width:13px;height:12px;
+    border-radius:2px;background:var(--wa-plate);box-shadow:var(--wa-out)}
+  body.theme-winamp #device .wa-wbtns i::before,
+  body.theme-winamp #device .wa-wbtns i::after{content:"";position:absolute;
+    background:#f3ddc0;box-shadow:0 1px 0 rgba(0,0,0,.55)}
+  body.theme-winamp #device .wa-min::before{left:3px;right:3px;bottom:3px;height:2px}
+  body.theme-winamp #device .wa-min::after{display:none}
+  body.theme-winamp #device .wa-shade::before{left:3px;right:3px;top:4px;height:2px}
+  body.theme-winamp #device .wa-shade::after{display:none}
+  body.theme-winamp #device .wa-close::before,
+  body.theme-winamp #device .wa-close::after{left:2px;right:2px;top:5px;height:2px;
+    background:#ffd0c4}
+  body.theme-winamp #device .wa-close::before{transform:rotate(45deg)}
+  body.theme-winamp #device .wa-close::after{transform:rotate(-45deg)}
 
-  /* ---- side rails: engraved legends, phosphor green ---- */
-  body.theme-winamp #device .dv-side{justify-content:center;gap:18px}
-  body.theme-winamp #device .dv-side span{color:#7f8695;letter-spacing:.34em;font-size:9px}
-  body.theme-winamp #device .dv-side.dv-l span::before{content:"FRESH 2.95 ";color:var(--wa-led-dim)}
-  body.theme-winamp #device .dv-side i{width:5px;height:5px;border-radius:0;
-    background:var(--wa-led);box-shadow:0 0 6px rgba(43,245,115,.9)}
-  /* No screws — this is a skin, not a machine. */
-  body.theme-winamp #device .dv-screw{display:none}
+  /* ---- foot: a plain rail across the bottom bar (no transport, no meters) ---- */
+  body.theme-winamp #device .wa-foot{position:absolute;left:6px;right:6px;bottom:6px;
+    height:calc(var(--bezel-bot) - 14px);display:flex;align-items:center;
+    padding:0 10px;border-radius:3px;background:var(--wa-face);box-shadow:var(--wa-out)}
+  body.theme-winamp #device .wa-foot .wa-rail{flex:1}
 
-  /* ======================= the playlist-editor dock ===================== */
+  /* ---- side edges: plain copper rails (no rack hardware, no screws) ---- */
+  body.theme-winamp #device .wa-edge{position:absolute;top:var(--bezel-top);
+    bottom:var(--bezel-bot);width:calc(var(--bezel-side) - 10px);
+    background:var(--wa-face);box-shadow:var(--wa-out);border-radius:2px}
+  body.theme-winamp #device .wa-edge.wa-l{left:5px}
+  body.theme-winamp #device .wa-edge.wa-r{right:5px}
+
+  /* ==================== ORCHESTRATOR — the playlist window =============== */
   body.theme-winamp:not(.mobile) .widget-surface.w-dock{
-    background:#0a0b0e;border-radius:0;padding:6px 5px 5px;color:#c7ffd8;
-    box-shadow:10px 12px 0 rgba(0,0,0,.45),0 40px 90px rgba(0,0,0,.7),
-      var(--wa-out),inset 0 0 0 4px var(--wa-metal-flat)}
-  /* The dock's own title row is the playlist window's title bar. */
+    background:var(--wa-face);border-radius:6px;padding:5px 5px 6px;color:#cfe9d6;
+    box-shadow:var(--wa-drop),var(--wa-out)}
+  /* The dock's own first raw row becomes the window's caption bar. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-raw:first-child{
-    background:linear-gradient(180deg,#6a7080,#474b57 40%,#2f323b);
-    box-shadow:var(--wa-out);color:#cfd5e2;text-align:center;
-    letter-spacing:.2em;text-transform:uppercase;margin:-1px 0 6px;padding:1px 6px}
-  /* Controls: hardware switches and a black query box with green text. */
+    background:linear-gradient(90deg,#6a4326,#3a2416);box-shadow:var(--wa-out);
+    border-radius:3px;color:var(--wa-amber);text-align:center;font-weight:700;
+    letter-spacing:.22em;text-transform:uppercase;margin:0 0 6px;padding:1px 6px}
+  /* New Task: the green lit plate from the reference. */
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary{flex:1 1 100%;text-align:center;
-    font-weight:700;color:#eafff1;background:linear-gradient(180deg,#2a9b52,#14622f);
-    border:none;border-radius:0;box-shadow:var(--wa-out);padding:4px 0}
-  body.theme-winamp .w-dock .w-text{flex:1 1 100%;background:#000;color:var(--wa-led);
-    border:none;border-radius:0;box-shadow:var(--wa-in);padding:3px 8px;margin:4px 0}
-  body.theme-winamp .w-dock .w-text::before{content:"⌕";color:var(--wa-led-dim)}
-  body.theme-winamp .w-dock .w-text-input::placeholder{color:rgba(43,245,115,.4)}
-  body.theme-winamp .w-dock .w-divider{border-color:rgba(255,255,255,.12)}
-  body.theme-winamp .w-dock .w-hintbar{color:#6f7686}
-  body.theme-winamp .w-dock .w-hint b{color:var(--wa-led)}
-  /* Playlist rows: green mono entries, navy selection bar, square everything. */
+    font-weight:700;color:#eafff1;background:linear-gradient(180deg,#5fbf6d,#1f7a37);
+    border:none;border-radius:3px;box-shadow:var(--wa-out);padding:3px 0;
+    text-shadow:0 1px 0 rgba(0,0,0,.45)}
+  body.theme-winamp .w-dock .w-text{flex:1 1 100%;background:var(--wa-sunken);
+    color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in);
+    padding:3px 8px;margin:4px 0}
+  body.theme-winamp .w-dock .w-text::before{content:"⌕";color:var(--wa-green-dim)}
+  body.theme-winamp .w-dock .w-text-input::placeholder{color:rgba(78,240,127,.4)}
+  /* Controls: pressed metal plates; toggles read as little lit LEDs. */
+  body.theme-winamp .w-dock .w-button{background:var(--wa-plate);color:#f0dcc2;
+    border:none;border-radius:3px;box-shadow:var(--wa-out)}
+  body.theme-winamp .w-dock .w-button:active{box-shadow:var(--wa-in)}
+  body.theme-winamp .w-dock .w-toggle{color:#c9b69c}
+  body.theme-winamp .w-dock .w-toggle.on{color:var(--wa-amber);
+    text-shadow:0 0 7px rgba(246,196,113,.6)}
+  body.theme-winamp .w-dock .w-divider{border-color:rgba(255,208,150,.16)}
+  body.theme-winamp .w-dock .w-hintbar{color:#9b856a}
+  body.theme-winamp .w-dock .w-hint b{color:var(--wa-amber)}
+  /* The playlist pane itself: a sunken black list of green entries. */
+  body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-tree,
+  body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-list{background:var(--wa-sunken);
+    box-shadow:var(--wa-in);padding:3px 2px}
   body.theme-winamp .w-dock .w-tree-row,body.theme-winamp .w-dock .w-list-row{
     border-radius:0;padding:1px 6px;color:#8fe8ab}
   body.theme-winamp .w-dock .w-tree-xrow{color:#5f8a6e}
   body.theme-winamp .w-dock .w-tree-row.sel,body.theme-winamp .w-dock .w-list-row.sel,
   body.theme-winamp .w-dock .w-tree-xrow.sel{background:var(--sel);color:#fff;box-shadow:none}
-  body.theme-winamp .w-dock .w-tree-card{border:none;border-radius:0;margin:2px 0;padding:1px 0;
-    background:rgba(255,255,255,.03);box-shadow:inset 0 0 0 1px rgba(255,255,255,.06)}
-  body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(28,47,168,.35);
+  body.theme-winamp .w-dock .w-tree-disc,body.theme-winamp .w-dock .w-tree-check{
+    color:var(--wa-green-dim)}
+  body.theme-winamp .w-dock .w-tree-card{border:none;border-radius:0;margin:1px 0;padding:1px 0;
+    background:rgba(255,208,150,.03);box-shadow:inset 0 0 0 1px rgba(255,208,150,.07)}
+  body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(45,68,134,.45);
     box-shadow:var(--wa-out);border:none}
-  body.theme-winamp .w-dock .w-tree-card.sel .w-tree-xrow{color:#b9c4ff}
-  /* Dock menus: little skin windows in their own right. */
+  body.theme-winamp .w-dock .w-tree-card.sel .w-tree-xrow{color:#c3ccf5}
+  /* Dock menus: small skin windows of their own. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col{position:relative}
-  body.theme-winamp .w-dock .w-overlay{background:var(--wa-metal-flat);border:none;
-    border-radius:0;box-shadow:var(--wa-out),4px 4px 0 rgba(0,0,0,.5);padding:4px;margin:0;z-index:6}
+  body.theme-winamp .w-dock .w-overlay{background:var(--wa-face-flat);border:none;
+    border-radius:3px;box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5);
+    padding:4px;margin:0;z-index:6}
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-row.wrap+.w-overlay{
     position:absolute;left:0;right:0;top:44px}
   body.theme-winamp .w-dock .w-overlay .w-section{border:none;padding:1px}
-  body.theme-winamp .w-dock .w-overlay .w-section-label{color:#9aa1b0;
+  body.theme-winamp .w-dock .w-overlay .w-section-label{color:var(--wa-amber);
     text-transform:uppercase;font-size:.85em;letter-spacing:.12em;margin:2px 6px 4px}
   body.theme-winamp .w-dock .w-overlay .w-row{gap:0}
   body.theme-winamp .w-dock .w-overlay .w-button{flex:1;text-align:left;border:none;
-    background:transparent;box-shadow:none;color:#dfe4ee;padding:3px 8px;border-radius:0}
+    background:transparent;box-shadow:none;color:#e9d9c2;padding:3px 8px;border-radius:0}
   body.theme-winamp .w-dock .w-overlay .w-button:hover{background:var(--sel);color:#fff}
 
-  /* ===================== chrome inside the screen ====================== */
+  /* ===================== chrome inside the code well ==================== */
   /* Cell-aligned rows: colour + inset bevels only, never box metrics. */
-  body.theme-winamp .menubar{background:var(--wa-metal);box-shadow:var(--wa-out);border-bottom:none}
-  body.theme-winamp .menu{color:#d3d8e4;text-shadow:0 1px 0 rgba(0,0,0,.7)}
-  body.theme-winamp .menu:hover{background:rgba(255,255,255,.10)}
+  body.theme-winamp .menubar{background:var(--wa-face);box-shadow:var(--wa-out);
+    border-bottom:none}
+  body.theme-winamp .menu{color:#e7d6bd;text-shadow:0 1px 0 rgba(0,0,0,.7)}
+  body.theme-winamp .menu:hover{background:rgba(255,208,150,.12)}
   body.theme-winamp .menu.open{background:var(--sel);color:#fff}
-  body.theme-winamp .tabbar{background:var(--wa-metal-flat);box-shadow:inset 0 -1px 0 rgba(0,0,0,.8)}
-  body.theme-winamp .tab{color:#a7adba;background:linear-gradient(180deg,#464a55,#33363f);
-    box-shadow:var(--wa-out);border-right:1px solid #16181d}
-  body.theme-winamp .tab:not(.active):hover{background:linear-gradient(180deg,#525765,#3b3f49)}
+  body.theme-winamp .tabbar{background:var(--wa-face-flat);
+    box-shadow:inset 0 -1px 0 rgba(0,0,0,.85)}
+  body.theme-winamp .tab{color:#c2ab90;background:var(--wa-plate);
+    box-shadow:var(--wa-out);border-right:1px solid #241509}
+  body.theme-winamp .tab:not(.active):hover{background:linear-gradient(180deg,#8d5c36,#65401f)}
   /* The active tab is the lit display: pressed in, black, phosphor label. */
-  body.theme-winamp .tab.active{background:#000;color:var(--wa-led);
-    text-shadow:0 0 7px rgba(43,245,115,.6);box-shadow:var(--wa-in)}
+  body.theme-winamp .tab.active{background:var(--wa-sunken);color:var(--wa-green);
+    text-shadow:0 0 7px rgba(78,240,127,.6);box-shadow:var(--wa-in)}
   body.theme-winamp .tab.active::after{display:none}
   body.theme-winamp .tab .x:hover{background:var(--sel);color:#fff}
   /* Status bar: the kbps/kHz readout — black LCD with scanlines. */
   body.theme-winamp .statusbar{background:
-    repeating-linear-gradient(180deg,rgba(255,255,255,.035) 0 1px,transparent 1px 3px),#000;
-    color:var(--wa-led-dim);box-shadow:var(--wa-in);border-top:none}
-  body.theme-winamp .statusbar .txt{color:var(--wa-led);text-shadow:0 0 6px rgba(43,245,115,.5)}
+    repeating-linear-gradient(180deg,rgba(255,255,255,.04) 0 1px,transparent 1px 3px),
+    var(--wa-sunken);
+    color:var(--wa-green-dim);box-shadow:var(--wa-in);border-top:none}
+  body.theme-winamp .statusbar .txt{color:var(--wa-green);
+    text-shadow:0 0 6px rgba(78,240,127,.5)}
   body.theme-winamp .statusbar .seg{border-radius:0}
-  body.theme-winamp .statusbar .seg:hover{background:rgba(43,245,115,.16);color:var(--wa-led)}
-  /* File explorer: another black playlist pane, framed by the metal rail. */
-  body.theme-winamp .fileexplorer{background:#0a0b0e;color:#8fe8ab;
-    border-right:1px solid #14161b;box-shadow:inset -3px 0 0 var(--wa-metal-flat)}
+  body.theme-winamp .statusbar .seg:hover{background:rgba(78,240,127,.16);color:var(--wa-green)}
+  /* File explorer: another sunken playlist pane behind a copper rail. */
+  body.theme-winamp .fileexplorer{background:var(--wa-sunken);color:#8fe8ab;
+    border-right:1px solid #1b1109;box-shadow:inset -3px 0 0 var(--wa-face-flat)}
   body.theme-winamp .fileexplorer .fx-title{color:var(--wa-amber);text-transform:uppercase}
   body.theme-winamp .fileexplorer .fx-row{border-radius:0;margin:0}
   body.theme-winamp .fileexplorer .fx-row.sel{background:var(--sel);color:#fff;box-shadow:none}
@@ -209,12 +190,14 @@
   body.theme-winamp .settings-modal,body.theme-winamp .m-sheet,
   body.theme-winamp .widget-surface.w-floatingModal,body.theme-winamp .pbrowser{
     -webkit-backdrop-filter:none;backdrop-filter:none;
-    background:var(--wa-metal-flat);color:#dfe4ee;border:none;border-radius:0;
+    background:var(--wa-face);color:#e9d9c2;border:none;border-radius:4px;
     box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5)}
   /* Their list bodies are LCD panes. */
   body.theme-winamp .palette .plist,body.theme-winamp .palette .pinput,
-  body.theme-winamp .palette .ppreview{background:#000}
-  body.theme-winamp .palette .pinput .q{color:var(--wa-led)}
+  body.theme-winamp .palette .ppreview{background:var(--wa-sunken)}
+  body.theme-winamp .palette .ptitle,body.theme-winamp .palette .ptitlebar{
+    color:var(--wa-amber);letter-spacing:.12em;text-transform:uppercase}
+  body.theme-winamp .palette .pinput .q{color:var(--wa-green)}
   body.theme-winamp .palette .prow{color:#9fdcb4;border-radius:0}
   body.theme-winamp .palette .prow.sel,body.theme-winamp .ctxmenu .ctxitem.sel,
   body.theme-winamp .popup .popup-row.sel,body.theme-winamp .settings-modal .set-cat.sel,
@@ -222,24 +205,23 @@
   body.theme-winamp .mitem.hi{background:var(--sel);color:#fff;border-radius:0}
   body.theme-winamp .mitem.hi::before,body.theme-winamp .ctxmenu .ctxitem.sel::before,
   body.theme-winamp .popup .popup-row.sel::before{display:none}
-  body.theme-winamp .palette .prow .pkey{border-radius:0;border-color:#5b606d}
-  /* Text fields: recessed black wells with phosphor text. */
+  body.theme-winamp .palette .prow .pkey{border-radius:2px;border-color:#7d5230}
+  /* Text fields: recessed wells with phosphor text. */
   body.theme-winamp .palette .pinput,body.theme-winamp .w-text,
   body.theme-winamp .settings-modal .set-field,body.theme-winamp .settings-modal .set-search{
-    color:var(--wa-led);border:none;border-radius:0;box-shadow:var(--wa-in)}
+    color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in)}
   /* Buttons: beveled hardware switches that press in. */
   body.theme-winamp .settings-modal .btn,body.theme-winamp .w-button,
-  body.theme-winamp .trustdialog .td-btn{
-    background:linear-gradient(180deg,#4b4f5b,#383b45);color:#e6eaf2;
-    border:none;border-radius:0;box-shadow:var(--wa-out)}
+  body.theme-winamp .trustdialog .td-btn{background:var(--wa-plate);color:#f0dcc2;
+    border:none;border-radius:3px;box-shadow:var(--wa-out)}
   body.theme-winamp .settings-modal .btn:active,body.theme-winamp .w-button:active{
     box-shadow:var(--wa-in)}
   body.theme-winamp .settings-modal .btn.primary,body.theme-winamp .w-button.primary,
   body.theme-winamp .trustdialog .td-btn.primary{
-    background:linear-gradient(180deg,#2a9b52,#14622f);color:#eafff1;box-shadow:var(--wa-out)}
+    background:linear-gradient(180deg,#5fbf6d,#1f7a37);color:#eafff1;box-shadow:var(--wa-out)}
 
   /* Chunky beveled scrollbars. */
-  body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;background:#16181d}
-  body.theme-winamp *::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#4b4f5b,#383b45);
+  body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;background:#1b1109}
+  body.theme-winamp *::-webkit-scrollbar-thumb{background:var(--wa-plate);
     border-radius:0;box-shadow:var(--wa-out)}
   body.theme-winamp *::-webkit-scrollbar-thumb:active{box-shadow:var(--wa-in)}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -17,18 +17,28 @@
      ====================================================================== */
 
   body.theme-winamp{
-    --wa-face:linear-gradient(180deg,#6d4527,#513120 46%,#3b2417);   /* window metal */
-    --wa-face-flat:#4a2d1c;
-    --wa-plate:linear-gradient(180deg,#7d5230,#583520);              /* raised parts */
+    /* Window metal: a darker, cooler bronze-graphite than a flat copper — top
+       catches a warm sheen, the body sinks toward near-black at the foot. */
+    --wa-face:linear-gradient(180deg,#6a482a 0%,#472e1c 44%,#2c1d12 100%);
+    --wa-face-flat:#3f2819;
+    --wa-plate:linear-gradient(180deg,#7a5030 0%,#5a3820 55%,#432a18 100%); /* raised parts */
     --wa-sunken:#050705;                                             /* LCD / code wells */
-    --wa-lt:rgba(255,208,150,.34);      /* bevel highlight (top-left)     */
-    --wa-dk:rgba(0,0,0,.80);            /* bevel shadow    (bottom-right) */
+    /* Vertical brushed-metal striations, layered over any face fill. */
+    --wa-brush:repeating-linear-gradient(90deg,
+      rgba(255,236,204,.035) 0 1px,rgba(0,0,0,.05) 1px 2px,transparent 2px 4px);
+    --wa-metal:var(--wa-brush),var(--wa-face);
+    --wa-plate-brush:var(--wa-brush),var(--wa-plate);
+    --wa-lt:rgba(255,214,158,.40);      /* bevel highlight (top-left)     */
+    --wa-dk:rgba(0,0,0,.82);            /* bevel shadow    (bottom-right) */
     --wa-out:inset 1px 1px 0 var(--wa-lt),inset -1px -1px 0 var(--wa-dk);
     --wa-in:inset 1px 1px 0 var(--wa-dk),inset -1px -1px 0 var(--wa-lt);
-    --wa-amber:#f6c471;                 /* title / caption lettering */
+    /* Crisp dark seam that rings each window against the desk (Winamp windows
+       read as cut-outs, not soft cards). */
+    --wa-seam:0 0 0 1px rgba(0,0,0,.55);
+    --wa-amber:#f7c978;                 /* title / caption lettering */
     --wa-green:#4ef07f;                 /* phosphor readouts */
     --wa-green-dim:#1a8f43;
-    --wa-drop:8px 10px 0 rgba(0,0,0,.45),0 34px 80px rgba(0,0,0,.72)}
+    --wa-drop:6px 8px 0 rgba(0,0,0,.42),0 30px 74px rgba(0,0,0,.72)}
 
   /* ---- the desk: near-black with a warm bloom under the windows ---- */
   body.theme-winamp:not(.mobile){background:
@@ -41,8 +51,11 @@
   body.theme-winamp:not(.mobile) .menubar{clip-path:inset(0 0 0 var(--clip-left,0px))}
 
   /* ==================== CODE STUDIO — the player window ================== */
-  body.theme-winamp #device{border-radius:6px;letter-spacing:normal;
-    background:var(--wa-face);box-shadow:var(--wa-drop),var(--wa-out)}
+  body.theme-winamp #device{border-radius:7px;letter-spacing:normal;
+    background:
+      radial-gradient(120% 70% at 50% 118%,rgba(78,240,127,.06),transparent 60%),
+      var(--wa-metal);
+    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-out)}
   body.theme-winamp #device::before{display:none}   /* machined rim → bevel */
   /* The code well: black, recessed, with a faint phosphor bloom. */
   body.theme-winamp #device .dv-screen{border-radius:2px;background:var(--wa-sunken);
@@ -52,13 +65,16 @@
   body.theme-winamp #device .wa-title{position:absolute;left:6px;right:6px;top:5px;
     height:calc(var(--bezel-top) - 13px);
     display:flex;align-items:center;gap:9px;padding:0 7px;border-radius:3px;
-    background:linear-gradient(90deg,#6a4326,#3a2416);box-shadow:var(--wa-out)}
+    background:var(--wa-brush),linear-gradient(180deg,#6d4a29,#3a2416);
+    box-shadow:var(--wa-out)}
+  /* Pinstripe rails: tight gold-on-black grooves flanking the caption. */
   body.theme-winamp #device .wa-rail{flex:1;height:9px;border-radius:1px;
     background:repeating-linear-gradient(180deg,
-      rgba(246,196,113,.55) 0 1px,rgba(0,0,0,.45) 1px 3px);
+      rgba(247,201,120,.62) 0 1px,rgba(0,0,0,.5) 1px 3px);
     box-shadow:var(--wa-in)}
   body.theme-winamp #device .wa-title-text{flex:0 0 auto;font-size:11px;font-weight:700;
-    letter-spacing:.22em;color:var(--wa-amber);text-shadow:0 1px 0 rgba(0,0,0,.8)}
+    letter-spacing:.24em;color:var(--wa-amber);
+    text-shadow:0 1px 0 rgba(0,0,0,.85),0 0 8px rgba(247,201,120,.25)}
   /* Window buttons: three little pressed plates (minimise / shade / close). */
   body.theme-winamp #device .wa-wbtns{display:flex;gap:3px;flex:0 0 auto}
   body.theme-winamp #device .wa-wbtns i{position:relative;width:13px;height:12px;
@@ -79,42 +95,68 @@
   /* ---- foot: a plain rail across the bottom bar (no transport, no meters) ---- */
   body.theme-winamp #device .wa-foot{position:absolute;left:6px;right:6px;bottom:6px;
     height:calc(var(--bezel-bot) - 14px);display:flex;align-items:center;
-    padding:0 10px;border-radius:3px;background:var(--wa-face);box-shadow:var(--wa-out)}
+    padding:0 10px;border-radius:3px;background:var(--wa-metal);box-shadow:var(--wa-out)}
   body.theme-winamp #device .wa-foot .wa-rail{flex:1}
 
   /* ---- side edges: plain copper rails (no rack hardware, no screws) ---- */
   body.theme-winamp #device .wa-edge{position:absolute;top:var(--bezel-top);
     bottom:var(--bezel-bot);width:calc(var(--bezel-side) - 10px);
-    background:var(--wa-face);box-shadow:var(--wa-out);border-radius:2px}
+    background:var(--wa-metal);box-shadow:var(--wa-out);border-radius:2px}
   body.theme-winamp #device .wa-edge.wa-l{left:5px}
   body.theme-winamp #device .wa-edge.wa-r{right:5px}
 
   /* ==================== ORCHESTRATOR — the playlist window =============== */
   body.theme-winamp:not(.mobile) .widget-surface.w-dock{
-    background:var(--wa-face);border-radius:6px;padding:5px 5px 6px;color:#cfe9d6;
-    box-shadow:var(--wa-drop),var(--wa-out)}
+    background:
+      radial-gradient(130% 60% at 50% 118%,rgba(78,240,127,.06),transparent 58%),
+      var(--wa-metal);
+    border-radius:7px;padding:5px 5px 6px;color:#cfe9d6;
+    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-out)}
   /* The dock's own first raw row becomes the window's caption bar. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-raw:first-child{
-    background:linear-gradient(90deg,#6a4326,#3a2416);box-shadow:var(--wa-out);
+    background:var(--wa-brush),linear-gradient(180deg,#6d4a29,#3a2416);
+    box-shadow:var(--wa-out);
     border-radius:3px;color:var(--wa-amber);text-align:center;font-weight:700;
-    letter-spacing:.22em;text-transform:uppercase;margin:0 0 6px;padding:1px 6px}
+    letter-spacing:.24em;text-transform:uppercase;margin:0 0 6px;padding:1px 6px;
+    text-shadow:0 1px 0 rgba(0,0,0,.85),0 0 8px rgba(247,201,120,.25)}
   /* New Task: the green lit plate from the reference. */
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary{flex:1 1 100%;text-align:center;
-    font-weight:700;color:#eafff1;background:linear-gradient(180deg,#5fbf6d,#1f7a37);
-    border:none;border-radius:3px;box-shadow:var(--wa-out);padding:3px 0;
-    text-shadow:0 1px 0 rgba(0,0,0,.45)}
+    font-weight:700;color:#eafff1;
+    background:linear-gradient(180deg,#78d886 0%,#3fa457 46%,#1c7233 100%);
+    border:none;border-radius:3px;padding:3px 0;
+    text-shadow:0 1px 0 rgba(0,0,0,.45);
+    box-shadow:var(--wa-out),inset 0 1px 0 rgba(255,255,255,.35)}
+  body.theme-winamp .w-dock .w-row.wrap .w-button.primary:hover{
+    background:linear-gradient(180deg,#84e492 0%,#48b160 46%,#227e39 100%)}
+  body.theme-winamp .w-dock .w-row.wrap .w-button.primary:active{
+    box-shadow:var(--wa-in)}
   body.theme-winamp .w-dock .w-text{flex:1 1 100%;background:var(--wa-sunken);
     color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in);
     padding:3px 8px;margin:4px 0}
   body.theme-winamp .w-dock .w-text::before{content:"⌕";color:var(--wa-green-dim)}
   body.theme-winamp .w-dock .w-text-input::placeholder{color:rgba(78,240,127,.4)}
   /* Controls: pressed metal plates; toggles read as little lit LEDs. */
-  body.theme-winamp .w-dock .w-button{background:var(--wa-plate);color:#f0dcc2;
-    border:none;border-radius:3px;box-shadow:var(--wa-out)}
+  body.theme-winamp .w-dock .w-button{background:var(--wa-plate-brush);color:#f0dcc2;
+    border:none;border-radius:3px;box-shadow:var(--wa-out);
+    text-shadow:0 1px 0 rgba(0,0,0,.5)}
+  body.theme-winamp .w-dock .w-button:hover{background:var(--wa-brush),
+    linear-gradient(180deg,#8a5c38,#5f3d22)}
   body.theme-winamp .w-dock .w-button:active{box-shadow:var(--wa-in)}
   body.theme-winamp .w-dock .w-toggle{color:#c9b69c}
-  body.theme-winamp .w-dock .w-toggle.on{color:var(--wa-amber);
-    text-shadow:0 0 7px rgba(246,196,113,.6)}
+  body.theme-winamp .w-dock .w-toggle.on{color:#d8f0df}
+  /* Toggle switch → a recessed slot with a green phosphor LED when lit. */
+  body.theme-winamp .w-toggle .w-box{background:#0a0d0a;box-shadow:var(--wa-in)}
+  body.theme-winamp .w-toggle .w-box::after{background:#b6a487;box-shadow:0 1px 1px rgba(0,0,0,.6)}
+  body.theme-winamp .w-toggle.on .w-box{
+    background:linear-gradient(180deg,#5ff08a,#1a8f43);
+    box-shadow:var(--wa-in),0 0 7px rgba(78,240,127,.55)}
+  body.theme-winamp .w-toggle.on .w-box::after{background:#eafff1}
+  body.theme-winamp .settings-modal .set-switch{background:#0a0d0a;box-shadow:var(--wa-in)}
+  body.theme-winamp .settings-modal .set-switch::after{background:#b6a487}
+  body.theme-winamp .settings-modal .set-switch.on{
+    background:linear-gradient(180deg,#5ff08a,#1a8f43);
+    box-shadow:var(--wa-in),0 0 7px rgba(78,240,127,.55)}
+  body.theme-winamp .settings-modal .set-switch.on::after{background:#eafff1}
   body.theme-winamp .w-dock .w-divider{border-color:rgba(255,208,150,.16)}
   body.theme-winamp .w-dock .w-hintbar{color:#9b856a}
   body.theme-winamp .w-dock .w-hint b{color:var(--wa-amber)}
@@ -151,11 +193,14 @@
 
   /* ===================== chrome inside the code well ==================== */
   /* Cell-aligned rows: colour + inset bevels only, never box metrics. */
-  body.theme-winamp .menubar{background:var(--wa-face);box-shadow:var(--wa-out);
+  body.theme-winamp .menubar{background:var(--wa-metal);box-shadow:var(--wa-out);
     border-bottom:none}
   body.theme-winamp .menu{color:#e7d6bd;text-shadow:0 1px 0 rgba(0,0,0,.7)}
   body.theme-winamp .menu:hover{background:rgba(255,208,150,.12)}
   body.theme-winamp .menu.open{background:var(--sel);color:#fff}
+  /* Engraved menu separators: a dark groove capped by a thin warm highlight. */
+  body.theme-winamp .msep{background:rgba(0,0,0,.6);
+    box-shadow:0 1px 0 rgba(255,214,158,.16);margin:4px 8px}
   body.theme-winamp .tabbar{background:var(--wa-face-flat);
     box-shadow:inset 0 -1px 0 rgba(0,0,0,.85)}
   body.theme-winamp .tab{color:#c2ab90;background:var(--wa-plate);
@@ -190,8 +235,8 @@
   body.theme-winamp .settings-modal,body.theme-winamp .m-sheet,
   body.theme-winamp .widget-surface.w-floatingModal,body.theme-winamp .pbrowser{
     -webkit-backdrop-filter:none;backdrop-filter:none;
-    background:var(--wa-face);color:#e9d9c2;border:none;border-radius:4px;
-    box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5)}
+    background:var(--wa-metal);color:#e9d9c2;border:none;border-radius:4px;
+    box-shadow:var(--wa-seam),var(--wa-out),6px 8px 0 rgba(0,0,0,.5)}
   /* Their list bodies are LCD panes. */
   body.theme-winamp .palette .plist,body.theme-winamp .palette .pinput,
   body.theme-winamp .palette .ppreview{background:var(--wa-sunken)}
@@ -212,16 +257,25 @@
     color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in)}
   /* Buttons: beveled hardware switches that press in. */
   body.theme-winamp .settings-modal .btn,body.theme-winamp .w-button,
-  body.theme-winamp .trustdialog .td-btn{background:var(--wa-plate);color:#f0dcc2;
-    border:none;border-radius:3px;box-shadow:var(--wa-out)}
+  body.theme-winamp .trustdialog .td-btn{background:var(--wa-plate-brush);color:#f0dcc2;
+    border:none;border-radius:3px;box-shadow:var(--wa-out);
+    text-shadow:0 1px 0 rgba(0,0,0,.5)}
+  body.theme-winamp .settings-modal .btn:hover,body.theme-winamp .w-button:hover,
+  body.theme-winamp .trustdialog .td-btn:hover{background:var(--wa-brush),
+    linear-gradient(180deg,#8a5c38,#5f3d22)}
   body.theme-winamp .settings-modal .btn:active,body.theme-winamp .w-button:active{
     box-shadow:var(--wa-in)}
   body.theme-winamp .settings-modal .btn.primary,body.theme-winamp .w-button.primary,
   body.theme-winamp .trustdialog .td-btn.primary{
-    background:linear-gradient(180deg,#5fbf6d,#1f7a37);color:#eafff1;box-shadow:var(--wa-out)}
+    background:linear-gradient(180deg,#78d886 0%,#3fa457 46%,#1c7233 100%);color:#eafff1;
+    box-shadow:var(--wa-out),inset 0 1px 0 rgba(255,255,255,.35)}
 
   /* Chunky beveled scrollbars. */
-  body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;background:#1b1109}
-  body.theme-winamp *::-webkit-scrollbar-thumb{background:var(--wa-plate);
+  body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;
+    background:repeating-linear-gradient(90deg,#241610 0 1px,#140c07 1px 2px)}
+  body.theme-winamp *::-webkit-scrollbar-thumb{background:var(--wa-plate-brush);
     border-radius:0;box-shadow:var(--wa-out)}
+  body.theme-winamp *::-webkit-scrollbar-thumb:hover{background:var(--wa-brush),
+    linear-gradient(180deg,#8a5c38,#5f3d22)}
   body.theme-winamp *::-webkit-scrollbar-thumb:active{box-shadow:var(--wa-in)}
+  body.theme-winamp *::-webkit-scrollbar-corner{background:#140c07}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -20,9 +20,9 @@
     /* Window metal: a MUTED warm taupe-brown (sampled from the reference skin —
        desaturated, not a saturated copper), with a light sheen along the top and
        a modest darkening toward the foot so it reads as a machined slab. */
-    --wa-face:linear-gradient(180deg,#5b4636 0%,#48352b 46%,#382a21 100%);
-    --wa-face-flat:#453329;
-    --wa-plate:linear-gradient(180deg,#5a4634 0%,#48362b 54%,#3a2c22 100%); /* raised parts */
+    --wa-face:linear-gradient(180deg,#503d2f 0%,#3f2e25 46%,#2c2019 100%);
+    --wa-face-flat:#3c2c23;
+    --wa-plate:linear-gradient(180deg,#54402f 0%,#403026 54%,#342820 100%); /* raised parts */
     --wa-sunken:#070606;                                             /* LCD / code wells */
     /* Vertical brushed-metal striations, layered over any face fill — fine and
        low-contrast so it reads as brushed grain, not stripes. */
@@ -62,9 +62,9 @@
     --wa-ctl-press:var(--wa-ring),var(--wa-in),0 1px 2px rgba(0,0,0,.4);
     /* Dramatic top-lit sheen across the big panels: a warm glow high-centre that
        falls off to the darker edges + foot (the reference's lighting). */
-    --wa-light:radial-gradient(120% 78% at 50% -6%,rgba(255,224,172,.28),transparent 50%),
-      linear-gradient(180deg,rgba(255,220,170,.05),transparent 30%,rgba(0,0,0,.14) 100%),
-      radial-gradient(120% 60% at 50% 116%,rgba(78,240,127,.06),transparent 58%)}
+    --wa-light:radial-gradient(96% 62% at 50% -2%,rgba(255,231,184,.56),transparent 48%),
+      linear-gradient(180deg,rgba(255,224,176,.08) 0%,transparent 22%,rgba(0,0,0,.22) 70%,rgba(0,0,0,.38) 100%),
+      radial-gradient(120% 60% at 50% 118%,rgba(78,240,127,.055),transparent 58%)}
 
   /* ---- the desk: near-black with a warm bloom under the windows ---- */
   body.theme-winamp:not(.mobile){background:

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -24,10 +24,11 @@
     --wa-face-flat:#3c2c23;
     --wa-plate:linear-gradient(180deg,#54402f 0%,#403026 54%,#342820 100%); /* raised parts */
     --wa-sunken:#070606;                                             /* LCD / code wells */
-    /* Vertical brushed-metal striations, layered over any face fill — fine and
-       low-contrast so it reads as brushed grain, not stripes. */
-    --wa-brush:repeating-linear-gradient(90deg,
-      rgba(255,240,214,.016) 0 1px,rgba(0,0,0,.024) 1px 2px,transparent 2px 6px);
+    /* Brushed-metal grain: an organic SVG fractal-noise texture stretched into
+       fine vertical streaks (high horizontal / low vertical frequency), grayscale
+       and very low alpha — real brushed metal, not the banded stripes a repeating
+       gradient produces. */
+    --wa-brush:url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%27180%27%20height%3D%27180%27%3E%3Cfilter%20id%3D%27b%27%3E%3CfeTurbulence%20type%3D%27fractalNoise%27%20baseFrequency%3D%270.62%200.012%27%20numOctaves%3D%272%27%20seed%3D%2711%27%20stitchTiles%3D%27stitch%27%2F%3E%3CfeColorMatrix%20type%3D%27saturate%27%20values%3D%270%27%2F%3E%3CfeComponentTransfer%3E%3CfeFuncA%20type%3D%27linear%27%20slope%3D%270.07%27%20intercept%3D%270%27%2F%3E%3C%2FfeComponentTransfer%3E%3C%2Ffilter%3E%3Crect%20width%3D%27180%27%20height%3D%27180%27%20filter%3D%27url%28%23b%29%27%2F%3E%3C%2Fsvg%3E");
     --wa-metal:var(--wa-brush),var(--wa-face);
     --wa-plate-brush:var(--wa-brush),var(--wa-plate);
     --wa-lt:rgba(255,232,198,.55);      /* bevel highlight (top-left)     */
@@ -55,16 +56,24 @@
     --wa-gloss:linear-gradient(180deg,rgba(255,248,232,.1) 0%,rgba(255,248,232,.02) 46%,
       rgba(0,0,0,.07) 100%);
     /* Control chrome: a dark groove ring ALL AROUND the chip (the reference cuts
-       each button into the metal), then a crisp raised bevel, then a soft drop
-       shadow so it floats off the panel. */
+       each button into the metal), then a TOP-LIT bevel (bright top edge, dark
+       bottom edge — left/right symmetric, mirrored about the vertical axis), then
+       a soft drop shadow so it floats off the panel. */
     --wa-ring:0 0 0 1px rgba(0,0,0,.62);
-    --wa-ctl:var(--wa-ring),var(--wa-out),0 2px 4px rgba(0,0,0,.45);
-    --wa-ctl-press:var(--wa-ring),var(--wa-in),0 1px 2px rgba(0,0,0,.4);
+    --wa-vbevel:inset 0 1px 0 var(--wa-lt),inset 0 -1px 0 var(--wa-dk);
+    --wa-ctl:var(--wa-ring),var(--wa-vbevel),0 2px 4px rgba(0,0,0,.45);
+    --wa-ctl-press:var(--wa-ring),inset 0 1px 0 var(--wa-dk),inset 0 -1px 0 var(--wa-lt),
+      0 1px 2px rgba(0,0,0,.4);
     /* Dramatic top-lit sheen across the big panels: a warm glow high-centre that
        falls off to the darker edges + foot (the reference's lighting). */
-    --wa-light:radial-gradient(96% 62% at 50% -2%,rgba(255,231,184,.56),transparent 48%),
-      linear-gradient(180deg,rgba(255,224,176,.08) 0%,transparent 22%,rgba(0,0,0,.22) 70%,rgba(0,0,0,.38) 100%),
-      radial-gradient(120% 60% at 50% 118%,rgba(78,240,127,.055),transparent 58%)}
+    --wa-light:radial-gradient(64% 46% at 50% -5%,rgba(255,234,188,.34),transparent 60%),
+      linear-gradient(180deg,transparent 30%,rgba(0,0,0,.10) 78%,rgba(0,0,0,.18) 100%),
+      radial-gradient(120% 60% at 50% 118%,rgba(78,240,127,.055),transparent 58%);
+    /* The SAME light, but painted as an OVERLAY on top of the panel's content so
+       the caption + control chips in the lit zone are lifted too — not just the
+       bare metal behind them (a real light falls on everything). */
+    --wa-light-top:radial-gradient(60% 42% at 50% -6%,rgba(255,236,197,.36),transparent 62%);
+    --wa-light-bot:linear-gradient(180deg,transparent 44%,rgba(0,0,0,.32) 100%)}
 
   /* ---- the desk: near-black with a warm bloom under the windows ---- */
   body.theme-winamp:not(.mobile){background:
@@ -77,10 +86,16 @@
   body.theme-winamp:not(.mobile) .menubar{clip-path:inset(0 0 0 var(--clip-left,0px))}
 
   /* ==================== CODE STUDIO — the player window ================== */
-  body.theme-winamp #device{border-radius:8px;letter-spacing:normal;
+  body.theme-winamp #device{border-radius:8px;letter-spacing:normal;position:relative;
     background:var(--wa-light),var(--wa-metal);
     box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-frame)}
-  body.theme-winamp #device::before{display:none}   /* machined rim → bevel */
+  /* Lighting overlays — painted ABOVE the bezel furniture (title bar, edges) so
+     the light falls on them too. Screen brightens the top, multiply shades the
+     foot. Pointer-transparent, clipped to the rounded window. */
+  body.theme-winamp #device::before,body.theme-winamp #device::after{content:"";
+    position:absolute;inset:0;pointer-events:none;border-radius:inherit;z-index:4}
+  body.theme-winamp #device::after{background:var(--wa-light-top);mix-blend-mode:screen}
+  body.theme-winamp #device::before{background:var(--wa-light-bot);mix-blend-mode:multiply}
   /* The code well: black, recessed, with a faint phosphor bloom. */
   body.theme-winamp #device .dv-screen{border-radius:3px;background:var(--wa-sunken);
     box-shadow:var(--wa-well),inset 0 0 90px rgba(78,240,127,.05)}
@@ -133,10 +148,20 @@
   body.theme-winamp #device .wa-edge.wa-r{right:5px}
 
   /* ==================== ORCHESTRATOR — the playlist window =============== */
-  body.theme-winamp:not(.mobile) .widget-surface.w-dock{
+  body.theme-winamp:not(.mobile) .widget-surface.w-dock{position:relative;
     background:var(--wa-light),var(--wa-metal);
     border-radius:8px;padding:6px 6px 7px;color:#cfe9d6;
     box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-frame)}
+  /* The light falls on the whole playlist window — caption + control chips in
+     the lit top zone are lifted, the foot is shaded — via overlays above the
+     content (screen top, multiply foot). Dropdown menus sit above the light. */
+  body.theme-winamp:not(.mobile) .w-dock::before,
+  body.theme-winamp:not(.mobile) .w-dock::after{content:"";position:absolute;inset:0;
+    pointer-events:none;border-radius:inherit;z-index:6}
+  body.theme-winamp:not(.mobile) .w-dock::after{background:var(--wa-light-top);
+    mix-blend-mode:screen}
+  body.theme-winamp:not(.mobile) .w-dock::before{background:var(--wa-light-bot);
+    mix-blend-mode:multiply}
   /* The dock's own first raw row becomes the window's caption bar: a recessed
      bevelled bar lit by a thin green reflection along its top edge. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-raw:first-child{
@@ -155,7 +180,7 @@
       linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);
     border:none;border-radius:3px;padding:3px 0;
     text-shadow:0 1px 0 rgba(0,0,0,.4);
-    box-shadow:var(--wa-ring),var(--wa-out),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
+    box-shadow:var(--wa-ring),var(--wa-vbevel),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary:hover{
     background:
       radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.45),transparent 62%),
@@ -221,7 +246,7 @@
   body.theme-winamp:not(.mobile) .w-dock>.w-col{position:relative}
   body.theme-winamp .w-dock .w-overlay{background:var(--wa-face-flat);border:none;
     border-radius:3px;box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5);
-    padding:4px;margin:0;z-index:6}
+    padding:4px;margin:0;z-index:30}
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-row.wrap+.w-overlay{
     position:absolute;left:0;right:0;top:44px}
   body.theme-winamp .w-dock .w-overlay .w-section{border:none;padding:1px}
@@ -310,7 +335,7 @@
     background:
       radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.4),transparent 62%),
       linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);color:#f4f6df;
-    box-shadow:var(--wa-ring),var(--wa-out),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
+    box-shadow:var(--wa-ring),var(--wa-vbevel),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
 
   /* Chunky beveled scrollbars. */
   body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -17,28 +17,54 @@
      ====================================================================== */
 
   body.theme-winamp{
-    /* Window metal: a darker, cooler bronze-graphite than a flat copper — top
-       catches a warm sheen, the body sinks toward near-black at the foot. */
-    --wa-face:linear-gradient(180deg,#6a482a 0%,#472e1c 44%,#2c1d12 100%);
-    --wa-face-flat:#3f2819;
-    --wa-plate:linear-gradient(180deg,#7a5030 0%,#5a3820 55%,#432a18 100%); /* raised parts */
-    --wa-sunken:#050705;                                             /* LCD / code wells */
-    /* Vertical brushed-metal striations, layered over any face fill. */
+    /* Window metal: a MUTED warm taupe-brown (sampled from the reference skin —
+       desaturated, not a saturated copper), with a light sheen along the top and
+       a modest darkening toward the foot so it reads as a machined slab. */
+    --wa-face:linear-gradient(180deg,#5b4636 0%,#48352b 46%,#382a21 100%);
+    --wa-face-flat:#453329;
+    --wa-plate:linear-gradient(180deg,#5a4634 0%,#48362b 54%,#3a2c22 100%); /* raised parts */
+    --wa-sunken:#070606;                                             /* LCD / code wells */
+    /* Vertical brushed-metal striations, layered over any face fill — fine and
+       low-contrast so it reads as brushed grain, not stripes. */
     --wa-brush:repeating-linear-gradient(90deg,
-      rgba(255,236,204,.035) 0 1px,rgba(0,0,0,.05) 1px 2px,transparent 2px 4px);
+      rgba(255,240,214,.016) 0 1px,rgba(0,0,0,.024) 1px 2px,transparent 2px 6px);
     --wa-metal:var(--wa-brush),var(--wa-face);
     --wa-plate-brush:var(--wa-brush),var(--wa-plate);
-    --wa-lt:rgba(255,214,158,.40);      /* bevel highlight (top-left)     */
+    --wa-lt:rgba(255,232,198,.55);      /* bevel highlight (top-left)     */
     --wa-dk:rgba(0,0,0,.82);            /* bevel shadow    (bottom-right) */
     --wa-out:inset 1px 1px 0 var(--wa-lt),inset -1px -1px 0 var(--wa-dk);
     --wa-in:inset 1px 1px 0 var(--wa-dk),inset -1px -1px 0 var(--wa-lt);
+    /* Chunky raised FRAME bevel for the big windows: a bright 1px rim + a softer
+       2nd highlight, and a dark 1px rim + soft inner shadow — real machined depth. */
+    --wa-frame:inset 1px 1px 0 rgba(255,236,204,.7),inset 2px 2px 0 rgba(255,226,184,.22),
+      inset 0 3px 4px -2px rgba(255,232,196,.28),
+      inset -1px -1px 0 rgba(0,0,0,.82),inset -2px -2px 0 rgba(0,0,0,.45);
+    /* Deep recessed WELL: dark sunken rim + inner shadow bloom. */
+    --wa-well:inset 2px 2px 4px rgba(0,0,0,.85),inset -1px -1px 0 rgba(255,214,158,.12);
     /* Crisp dark seam that rings each window against the desk (Winamp windows
        read as cut-outs, not soft cards). */
-    --wa-seam:0 0 0 1px rgba(0,0,0,.55);
+    --wa-seam:0 0 0 1px rgba(0,0,0,.6);
     --wa-amber:#f7c978;                 /* title / caption lettering */
     --wa-green:#4ef07f;                 /* phosphor readouts */
     --wa-green-dim:#1a8f43;
-    --wa-drop:6px 8px 0 rgba(0,0,0,.42),0 30px 74px rgba(0,0,0,.72)}
+    /* Green sheen line for lit caption-bar top edges (the reference's reflection). */
+    --wa-lit:inset 0 1px 0 rgba(120,240,150,.28);
+    --wa-drop:6px 8px 0 rgba(0,0,0,.42),0 30px 74px rgba(0,0,0,.72);
+    /* Subtle top sheen for raised controls — a soft highlight, kept matte to
+       match the reference's chips (not a glassy shine). */
+    --wa-gloss:linear-gradient(180deg,rgba(255,248,232,.1) 0%,rgba(255,248,232,.02) 46%,
+      rgba(0,0,0,.07) 100%);
+    /* Control chrome: a dark groove ring ALL AROUND the chip (the reference cuts
+       each button into the metal), then a crisp raised bevel, then a soft drop
+       shadow so it floats off the panel. */
+    --wa-ring:0 0 0 1px rgba(0,0,0,.62);
+    --wa-ctl:var(--wa-ring),var(--wa-out),0 2px 4px rgba(0,0,0,.45);
+    --wa-ctl-press:var(--wa-ring),var(--wa-in),0 1px 2px rgba(0,0,0,.4);
+    /* Dramatic top-lit sheen across the big panels: a warm glow high-centre that
+       falls off to the darker edges + foot (the reference's lighting). */
+    --wa-light:radial-gradient(120% 78% at 50% -6%,rgba(255,224,172,.28),transparent 50%),
+      linear-gradient(180deg,rgba(255,220,170,.05),transparent 30%,rgba(0,0,0,.14) 100%),
+      radial-gradient(120% 60% at 50% 116%,rgba(78,240,127,.06),transparent 58%)}
 
   /* ---- the desk: near-black with a warm bloom under the windows ---- */
   body.theme-winamp:not(.mobile){background:
@@ -51,44 +77,45 @@
   body.theme-winamp:not(.mobile) .menubar{clip-path:inset(0 0 0 var(--clip-left,0px))}
 
   /* ==================== CODE STUDIO — the player window ================== */
-  body.theme-winamp #device{border-radius:7px;letter-spacing:normal;
-    background:
-      radial-gradient(120% 70% at 50% 118%,rgba(78,240,127,.06),transparent 60%),
-      var(--wa-metal);
-    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-out)}
+  body.theme-winamp #device{border-radius:8px;letter-spacing:normal;
+    background:var(--wa-light),var(--wa-metal);
+    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-frame)}
   body.theme-winamp #device::before{display:none}   /* machined rim → bevel */
   /* The code well: black, recessed, with a faint phosphor bloom. */
-  body.theme-winamp #device .dv-screen{border-radius:2px;background:var(--wa-sunken);
-    box-shadow:var(--wa-in),inset 0 0 90px rgba(78,240,127,.05)}
+  body.theme-winamp #device .dv-screen{border-radius:3px;background:var(--wa-sunken);
+    box-shadow:var(--wa-well),inset 0 0 90px rgba(78,240,127,.05)}
 
   /* ---- title bar: pinstripe rails either side of the caption ---- */
   body.theme-winamp #device .wa-title{position:absolute;left:6px;right:6px;top:5px;
     height:calc(var(--bezel-top) - 13px);
     display:flex;align-items:center;gap:9px;padding:0 7px;border-radius:3px;
-    background:var(--wa-brush),linear-gradient(180deg,#6d4a29,#3a2416);
-    box-shadow:var(--wa-out)}
-  /* Pinstripe rails: tight gold-on-black grooves flanking the caption. */
-  body.theme-winamp #device .wa-rail{flex:1;height:9px;border-radius:1px;
+    background:var(--wa-brush),linear-gradient(180deg,#4c3928 0%,#3a2a1e 55%,#2a1e15 100%);
+    box-shadow:var(--wa-out),var(--wa-lit)}
+  /* Pinstripe rails: a fine gold-on-black grille flanking the caption (the
+     classic Winamp titlebar texture — many thin lines, not a few fat ones). */
+  body.theme-winamp #device .wa-rail{flex:1;height:11px;border-radius:1px;
     background:repeating-linear-gradient(180deg,
-      rgba(247,201,120,.62) 0 1px,rgba(0,0,0,.5) 1px 3px);
+      rgba(247,205,135,.6) 0 1px,rgba(0,0,0,.55) 1px 2px);
     box-shadow:var(--wa-in)}
   body.theme-winamp #device .wa-title-text{flex:0 0 auto;font-size:11px;font-weight:700;
-    letter-spacing:.24em;color:var(--wa-amber);
-    text-shadow:0 1px 0 rgba(0,0,0,.85),0 0 8px rgba(247,201,120,.25)}
-  /* Window buttons: three little pressed plates (minimise / shade / close). */
-  body.theme-winamp #device .wa-wbtns{display:flex;gap:3px;flex:0 0 auto}
-  body.theme-winamp #device .wa-wbtns i{position:relative;width:13px;height:12px;
-    border-radius:2px;background:var(--wa-plate);box-shadow:var(--wa-out)}
+    letter-spacing:.26em;color:var(--wa-amber);
+    text-shadow:0 1px 0 rgba(0,0,0,.9),0 0 9px rgba(247,201,120,.3)}
+  /* Window buttons: thin cream line-icons (minimise / shade / close), no plate —
+     matching the reference's minimal titlebar controls. */
+  body.theme-winamp #device .wa-wbtns{display:flex;gap:7px;flex:0 0 auto;
+    align-items:center;padding-left:3px}
+  body.theme-winamp #device .wa-wbtns i{position:relative;width:13px;height:13px;
+    border-radius:0;background:none;box-shadow:none}
   body.theme-winamp #device .wa-wbtns i::before,
   body.theme-winamp #device .wa-wbtns i::after{content:"";position:absolute;
-    background:#f3ddc0;box-shadow:0 1px 0 rgba(0,0,0,.55)}
-  body.theme-winamp #device .wa-min::before{left:3px;right:3px;bottom:3px;height:2px}
+    background:#efe0c8;box-shadow:0 1px 0 rgba(0,0,0,.6)}
+  body.theme-winamp #device .wa-min::before{left:2px;right:2px;bottom:2px;height:1.5px}
   body.theme-winamp #device .wa-min::after{display:none}
-  body.theme-winamp #device .wa-shade::before{left:3px;right:3px;top:4px;height:2px}
+  body.theme-winamp #device .wa-shade::before{left:2px;right:2px;top:3px;height:1.5px}
   body.theme-winamp #device .wa-shade::after{display:none}
   body.theme-winamp #device .wa-close::before,
-  body.theme-winamp #device .wa-close::after{left:2px;right:2px;top:5px;height:2px;
-    background:#ffd0c4}
+  body.theme-winamp #device .wa-close::after{left:1px;right:1px;top:6px;height:1.5px;
+    background:#f6ddd2}
   body.theme-winamp #device .wa-close::before{transform:rotate(45deg)}
   body.theme-winamp #device .wa-close::after{transform:rotate(-45deg)}
 
@@ -107,63 +134,77 @@
 
   /* ==================== ORCHESTRATOR — the playlist window =============== */
   body.theme-winamp:not(.mobile) .widget-surface.w-dock{
-    background:
-      radial-gradient(130% 60% at 50% 118%,rgba(78,240,127,.06),transparent 58%),
-      var(--wa-metal);
-    border-radius:7px;padding:5px 5px 6px;color:#cfe9d6;
-    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-out)}
-  /* The dock's own first raw row becomes the window's caption bar. */
+    background:var(--wa-light),var(--wa-metal);
+    border-radius:8px;padding:6px 6px 7px;color:#cfe9d6;
+    box-shadow:var(--wa-drop),var(--wa-seam),var(--wa-frame)}
+  /* The dock's own first raw row becomes the window's caption bar: a recessed
+     bevelled bar lit by a thin green reflection along its top edge. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-raw:first-child{
-    background:var(--wa-brush),linear-gradient(180deg,#6d4a29,#3a2416);
-    box-shadow:var(--wa-out);
+    background:var(--wa-brush),linear-gradient(180deg,#4c3928 0%,#3a2a1e 55%,#2a1e15 100%);
+    box-shadow:var(--wa-out),var(--wa-lit);
     border-radius:3px;color:var(--wa-amber);text-align:center;font-weight:700;
-    letter-spacing:.24em;text-transform:uppercase;margin:0 0 6px;padding:1px 6px;
-    text-shadow:0 1px 0 rgba(0,0,0,.85),0 0 8px rgba(247,201,120,.25)}
+    letter-spacing:.26em;text-transform:uppercase;margin:0 0 6px;padding:2px 6px;
+    text-shadow:0 1px 0 rgba(0,0,0,.9),0 0 9px rgba(247,201,120,.3)}
   /* New Task: the green lit plate from the reference. */
+  /* The green plate — an OLIVE/khaki gradient sampled from the reference (a lit
+     military-green, not a vivid spring green). */
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary{flex:1 1 100%;text-align:center;
-    font-weight:700;color:#eafff1;
-    background:linear-gradient(180deg,#78d886 0%,#3fa457 46%,#1c7233 100%);
+    font-weight:700;color:#f4f6df;
+    background:
+      radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.4),transparent 62%),
+      linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);
     border:none;border-radius:3px;padding:3px 0;
-    text-shadow:0 1px 0 rgba(0,0,0,.45);
-    box-shadow:var(--wa-out),inset 0 1px 0 rgba(255,255,255,.35)}
+    text-shadow:0 1px 0 rgba(0,0,0,.4);
+    box-shadow:var(--wa-ring),var(--wa-out),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary:hover{
-    background:linear-gradient(180deg,#84e492 0%,#48b160 46%,#227e39 100%)}
+    background:
+      radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.45),transparent 62%),
+      linear-gradient(180deg,#a6b058 0%,#8f9848 44%,#5e6530 100%)}
   body.theme-winamp .w-dock .w-row.wrap .w-button.primary:active{
-    box-shadow:var(--wa-in)}
+    box-shadow:var(--wa-ctl-press)}
   body.theme-winamp .w-dock .w-text{flex:1 1 100%;background:var(--wa-sunken);
-    color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in);
+    color:var(--wa-green);border:none;border-radius:3px;box-shadow:var(--wa-well);
     padding:3px 8px;margin:4px 0}
   body.theme-winamp .w-dock .w-text::before{content:"⌕";color:var(--wa-green-dim)}
   body.theme-winamp .w-dock .w-text-input::placeholder{color:rgba(78,240,127,.4)}
-  /* Controls: pressed metal plates; toggles read as little lit LEDs. */
-  body.theme-winamp .w-dock .w-button{background:var(--wa-plate-brush);color:#f0dcc2;
-    border:none;border-radius:3px;box-shadow:var(--wa-out);
+  /* Controls: glossy raised metal chips that float off the panel (a light top
+     sheen, a crisp bevel and a soft drop shadow). */
+  body.theme-winamp .w-dock .w-button{background:var(--wa-gloss),var(--wa-plate);
+    color:#f0dcc2;border:none;border-radius:3px;box-shadow:var(--wa-ctl);
     text-shadow:0 1px 0 rgba(0,0,0,.5)}
-  body.theme-winamp .w-dock .w-button:hover{background:var(--wa-brush),
-    linear-gradient(180deg,#8a5c38,#5f3d22)}
-  body.theme-winamp .w-dock .w-button:active{box-shadow:var(--wa-in)}
+  body.theme-winamp .w-dock .w-button:hover{background:var(--wa-gloss),linear-gradient(180deg,#67503b,#4d392a)}
+  body.theme-winamp .w-dock .w-button:active{box-shadow:var(--wa-ctl-press)}
   body.theme-winamp .w-dock .w-toggle{color:#c9b69c}
   body.theme-winamp .w-dock .w-toggle.on{color:#d8f0df}
-  /* Toggle switch → a recessed slot with a green phosphor LED when lit. */
-  body.theme-winamp .w-toggle .w-box{background:#0a0d0a;box-shadow:var(--wa-in)}
-  body.theme-winamp .w-toggle .w-box::after{background:#b6a487;box-shadow:0 1px 1px rgba(0,0,0,.6)}
+  /* Toggle switch → a recessed slot with a glossy knob; a green phosphor LED
+     when lit. The track sits in a bevelled well; the knob is a raised bead. */
+  body.theme-winamp .w-toggle .w-box{background:linear-gradient(180deg,#463c33,#332b25);
+    box-shadow:var(--wa-ring),var(--wa-in)}
+  body.theme-winamp .w-toggle .w-box::after{
+    background:radial-gradient(120% 120% at 50% 20%,#d8c6a6,#9c8a6d);
+    box-shadow:0 1px 2px rgba(0,0,0,.7),inset 0 1px 0 rgba(255,255,255,.4)}
   body.theme-winamp .w-toggle.on .w-box{
-    background:linear-gradient(180deg,#5ff08a,#1a8f43);
-    box-shadow:var(--wa-in),0 0 7px rgba(78,240,127,.55)}
-  body.theme-winamp .w-toggle.on .w-box::after{background:#eafff1}
-  body.theme-winamp .settings-modal .set-switch{background:#0a0d0a;box-shadow:var(--wa-in)}
-  body.theme-winamp .settings-modal .set-switch::after{background:#b6a487}
+    background:linear-gradient(180deg,#6ff394,#189040);
+    box-shadow:var(--wa-in),0 0 8px rgba(78,240,127,.6),inset 0 1px 0 rgba(255,255,255,.4)}
+  body.theme-winamp .w-toggle.on .w-box::after{
+    background:radial-gradient(120% 120% at 50% 20%,#ffffff,#cfeede)}
+  body.theme-winamp .settings-modal .set-switch{
+    background:linear-gradient(180deg,#463c33,#332b25);box-shadow:var(--wa-ring),var(--wa-in)}
+  body.theme-winamp .settings-modal .set-switch::after{
+    background:radial-gradient(120% 120% at 50% 20%,#d8c6a6,#9c8a6d);
+    box-shadow:0 1px 2px rgba(0,0,0,.7),inset 0 1px 0 rgba(255,255,255,.4)}
   body.theme-winamp .settings-modal .set-switch.on{
-    background:linear-gradient(180deg,#5ff08a,#1a8f43);
-    box-shadow:var(--wa-in),0 0 7px rgba(78,240,127,.55)}
-  body.theme-winamp .settings-modal .set-switch.on::after{background:#eafff1}
+    background:linear-gradient(180deg,#6ff394,#189040);
+    box-shadow:var(--wa-in),0 0 8px rgba(78,240,127,.6),inset 0 1px 0 rgba(255,255,255,.4)}
+  body.theme-winamp .settings-modal .set-switch.on::after{
+    background:radial-gradient(120% 120% at 50% 20%,#ffffff,#cfeede)}
   body.theme-winamp .w-dock .w-divider{border-color:rgba(255,208,150,.16)}
   body.theme-winamp .w-dock .w-hintbar{color:#9b856a}
   body.theme-winamp .w-dock .w-hint b{color:var(--wa-amber)}
   /* The playlist pane itself: a sunken black list of green entries. */
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-tree,
   body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-list{background:var(--wa-sunken);
-    box-shadow:var(--wa-in);padding:3px 2px}
+    border-radius:3px;box-shadow:var(--wa-well);padding:3px 2px}
   body.theme-winamp .w-dock .w-tree-row,body.theme-winamp .w-dock .w-list-row{
     border-radius:0;padding:1px 6px;color:#8fe8ab}
   body.theme-winamp .w-dock .w-tree-xrow{color:#5f8a6e}
@@ -173,7 +214,7 @@
     color:var(--wa-green-dim)}
   body.theme-winamp .w-dock .w-tree-card{border:none;border-radius:0;margin:1px 0;padding:1px 0;
     background:rgba(255,208,150,.03);box-shadow:inset 0 0 0 1px rgba(255,208,150,.07)}
-  body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(45,68,134,.45);
+  body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(58,87,209,.5);
     box-shadow:var(--wa-out);border:none}
   body.theme-winamp .w-dock .w-tree-card.sel .w-tree-xrow{color:#c3ccf5}
   /* Dock menus: small skin windows of their own. */
@@ -235,7 +276,7 @@
   body.theme-winamp .settings-modal,body.theme-winamp .m-sheet,
   body.theme-winamp .widget-surface.w-floatingModal,body.theme-winamp .pbrowser{
     -webkit-backdrop-filter:none;backdrop-filter:none;
-    background:var(--wa-metal);color:#e9d9c2;border:none;border-radius:4px;
+    background:var(--wa-metal);color:#e9d9c2;border:none;border-radius:3px;
     box-shadow:var(--wa-seam),var(--wa-out),6px 8px 0 rgba(0,0,0,.5)}
   /* Their list bodies are LCD panes. */
   body.theme-winamp .palette .plist,body.theme-winamp .palette .pinput,
@@ -257,18 +298,19 @@
     color:var(--wa-green);border:none;border-radius:2px;box-shadow:var(--wa-in)}
   /* Buttons: beveled hardware switches that press in. */
   body.theme-winamp .settings-modal .btn,body.theme-winamp .w-button,
-  body.theme-winamp .trustdialog .td-btn{background:var(--wa-plate-brush);color:#f0dcc2;
-    border:none;border-radius:3px;box-shadow:var(--wa-out);
+  body.theme-winamp .trustdialog .td-btn{background:var(--wa-gloss),var(--wa-plate);
+    color:#f0dcc2;border:none;border-radius:3px;box-shadow:var(--wa-ctl);
     text-shadow:0 1px 0 rgba(0,0,0,.5)}
   body.theme-winamp .settings-modal .btn:hover,body.theme-winamp .w-button:hover,
-  body.theme-winamp .trustdialog .td-btn:hover{background:var(--wa-brush),
-    linear-gradient(180deg,#8a5c38,#5f3d22)}
+  body.theme-winamp .trustdialog .td-btn:hover{background:var(--wa-gloss),linear-gradient(180deg,#67503b,#4d392a)}
   body.theme-winamp .settings-modal .btn:active,body.theme-winamp .w-button:active{
-    box-shadow:var(--wa-in)}
+    box-shadow:var(--wa-ctl-press)}
   body.theme-winamp .settings-modal .btn.primary,body.theme-winamp .w-button.primary,
   body.theme-winamp .trustdialog .td-btn.primary{
-    background:linear-gradient(180deg,#78d886 0%,#3fa457 46%,#1c7233 100%);color:#eafff1;
-    box-shadow:var(--wa-out),inset 0 1px 0 rgba(255,255,255,.35)}
+    background:
+      radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.4),transparent 62%),
+      linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);color:#f4f6df;
+    box-shadow:var(--wa-ring),var(--wa-out),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
 
   /* Chunky beveled scrollbars. */
   body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;
@@ -276,6 +318,6 @@
   body.theme-winamp *::-webkit-scrollbar-thumb{background:var(--wa-plate-brush);
     border-radius:0;box-shadow:var(--wa-out)}
   body.theme-winamp *::-webkit-scrollbar-thumb:hover{background:var(--wa-brush),
-    linear-gradient(180deg,#8a5c38,#5f3d22)}
+    linear-gradient(180deg,#634d39,#4a3729)}
   body.theme-winamp *::-webkit-scrollbar-thumb:active{box-shadow:var(--wa-in)}
   body.theme-winamp *::-webkit-scrollbar-corner{background:#140c07}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -1,0 +1,245 @@
+  /* Web theme: Winamp Classic — brushed metal, hard bevels, LCD green.
+     (web-ui/css — concatenated in filename order into the page's single
+     <style> block by crates/fresh-editor/build.rs; order is load-bearing:
+     later files deliberately override earlier ones.) */
+  /* ======================================================================
+     Gated on body.theme-winamp (set by js/15-theme.js). A SHELL theme: it
+     reuses the COSMOS layout — the grid stays inset inside #device and the
+     dock floats beside it (see SHELL_THEMES / layoutShell / widgetSurfaceEls)
+     — but dresses both as classic skin windows: the bezel becomes the main
+     player (title bar, window buttons, LCD readout, spectrum analyser), the
+     dock becomes the playlist editor. COLOURS come from applyWebTheme()'s
+     inline tokens; this file owns the metal, the bevels and the decoration.
+     Everything painted over the cell grid avoids layout-affecting properties
+     (borders/padding on chrome rows would slide the DOM off the cell pitch),
+     so bevels are drawn with inset box-shadows.
+     ====================================================================== */
+
+  body.theme-winamp{
+    --wa-lt:rgba(255,255,255,.30);       /* bevel highlight (top-left)  */
+    --wa-dk:rgba(0,0,0,.78);             /* bevel shadow    (bottom-right) */
+    --wa-metal:linear-gradient(180deg,#4b4e59,#3a3d47 14%,#31343d 62%,#25272e);
+    --wa-metal-flat:#33363f;
+    --wa-led:#2bf573;                    /* the display's phosphor green */
+    --wa-led-dim:#128d3f;
+    --wa-amber:#f6d24d;
+    /* Raised / recessed hardware, drawn without touching layout. */
+    --wa-out:inset 1px 1px 0 var(--wa-lt),inset -1px -1px 0 var(--wa-dk);
+    --wa-in:inset 1px 1px 0 var(--wa-dk),inset -1px -1px 0 var(--wa-lt);
+    /* Bar visualiser: one gradient reused at 16 different heights. */
+    --wa-bar:linear-gradient(180deg,#eaff5c,#2bf573 42%,#0aa93f)}
+
+  /* ---- the desk the windows sit on: near-black with a faint green bloom ---- */
+  body.theme-winamp:not(.mobile){background:
+    radial-gradient(60rem 40rem at 18% -10%, rgba(43,245,115,.10), transparent 62%),
+    radial-gradient(50rem 40rem at 108% 108%, rgba(60,110,255,.10), transparent 60%),
+    repeating-linear-gradient(135deg,rgba(255,255,255,.017) 0 2px,transparent 2px 5px),
+    linear-gradient(180deg,#15171c,#0a0b0e) #0a0b0e}
+  /* Same clip as COSMOS: the menubar row spans the full grid width, so the
+     strip behind the floating dock must be carved out (layoutShell keeps
+     --clip-left at the dock's pixel width). */
+  body.theme-winamp:not(.mobile) .menubar{clip-path:inset(0 0 0 var(--clip-left,0px))}
+
+  /* ======================= the main player window ======================= */
+  body.theme-winamp #device{border-radius:0;letter-spacing:.14em;color:var(--wa-led-dim);
+    background:var(--wa-metal);
+    box-shadow:10px 12px 0 rgba(0,0,0,.45),0 40px 90px rgba(0,0,0,.7),var(--wa-out)}
+  body.theme-winamp #device::before{display:none}     /* machined rim → hard bevel */
+  /* The screen well: a black LCD cavity, recessed by a reversed bevel. */
+  body.theme-winamp #device .dv-screen{border-radius:0;background:#000;
+    box-shadow:var(--wa-in),0 0 0 1px rgba(0,0,0,.9),inset 0 0 90px rgba(43,245,115,.05)}
+
+  /* ---- title bar: the classic gradient strip + window buttons ---- */
+  body.theme-winamp #device .dv-top{left:7px;right:7px;top:7px;
+    height:calc(var(--bezel-top) - 28px);padding:0 6px;gap:8px;
+    background:linear-gradient(180deg,#6a7080,#474b57 40%,#2f323b);
+    box-shadow:var(--wa-out)}
+  /* Title text: the markup's COSMOS labels are neutralised and re-lettered
+     here, so the shell HTML stays theme-agnostic. */
+  body.theme-winamp #device .dv-label{font-size:0}
+  body.theme-winamp #device .dv-top .dv-label::before{content:"FRESH — MAIN WINDOW";
+    font-size:11px;letter-spacing:.22em;color:#cfd5e2;text-shadow:0 1px 0 #000}
+  /* The three "LEDs" become square minimise / shade / close boxes. */
+  body.theme-winamp #device .dv-leds{gap:3px}
+  body.theme-winamp #device .dv-leds i{width:12px;height:11px;border-radius:0;
+    background:linear-gradient(180deg,#5b606d,#3b3f49);
+    box-shadow:var(--wa-out);position:relative}
+  body.theme-winamp #device .dv-leds i::after{content:"";position:absolute;
+    background:#d7dce8;box-shadow:0 1px 0 rgba(0,0,0,.6)}
+  body.theme-winamp #device .dv-leds .g::after{left:3px;right:3px;bottom:2px;height:2px}
+  body.theme-winamp #device .dv-leds .y::after{left:3px;right:3px;top:4px;height:2px}
+  /* Close: two crossed bars (::before is the second stroke). */
+  body.theme-winamp #device .dv-leds .a::before,
+  body.theme-winamp #device .dv-leds .a::after{content:"";position:absolute;
+    left:2px;right:2px;top:5px;height:2px;background:#f2c3c3}
+  body.theme-winamp #device .dv-leds .a::before{transform:rotate(45deg)}
+  body.theme-winamp #device .dv-leds .a::after{transform:rotate(-45deg)}
+  /* A slim LCD strip under the title bar: the "now playing" readout. */
+  body.theme-winamp #device .dv-top::after{content:"128 KBPS  44 KHZ  STEREO  ▶ EDITING";
+    position:absolute;left:-1px;right:-1px;top:calc(100% + 3px);height:11px;
+    font-size:9px;letter-spacing:.28em;line-height:11px;padding:0 7px;
+    color:var(--wa-led);background:#000;box-shadow:var(--wa-in);
+    text-shadow:0 0 6px rgba(43,245,115,.75);overflow:hidden;white-space:nowrap}
+
+  /* ---- bottom bar: spectrum analyser + transport legend + seek slider ---- */
+  body.theme-winamp #device .dv-bottom{left:7px;right:7px;bottom:7px;
+    height:calc(var(--bezel-bot) - 16px);padding:0 8px;gap:14px;
+    background:var(--wa-metal);box-shadow:var(--wa-out)}
+  /* 16 bars: one shared gradient, sized per bar and pinned to the baseline,
+     with a segment mask painted over the top (Winamp's analyser is banded). */
+  body.theme-winamp #device .dv-bottom .dv-label:first-of-type{position:relative;
+    width:102px;height:26px;align-self:center;background:#000;box-shadow:var(--wa-in)}
+  body.theme-winamp #device .dv-bottom .dv-label:first-of-type::after{content:"";
+    position:absolute;inset:3px 4px;
+    background-image:
+      repeating-linear-gradient(180deg,rgba(0,0,0,.9) 0 1px,transparent 1px 3px),
+      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
+      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
+      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar),
+      var(--wa-bar),var(--wa-bar),var(--wa-bar),var(--wa-bar);
+    background-repeat:repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,
+      no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,no-repeat,
+      no-repeat,no-repeat,no-repeat,no-repeat;
+    background-position:0 0,
+      0 100%,6px 100%,12px 100%,18px 100%,24px 100%,30px 100%,36px 100%,42px 100%,
+      48px 100%,54px 100%,60px 100%,66px 100%,72px 100%,78px 100%,84px 100%,90px 100%;
+    background-size:100% 100%,
+      4px 55%,4px 82%,4px 38%,4px 96%,4px 64%,4px 44%,4px 88%,4px 30%,
+      4px 72%,4px 50%,4px 92%,4px 34%,4px 68%,4px 46%,4px 78%,4px 26%}
+  /* Right-hand legend + a seek bar under it (the slider's knob is the notch). */
+  body.theme-winamp #device .dv-bottom .dv-label:last-of-type{position:relative;
+    font-size:0;color:var(--wa-led)}
+  body.theme-winamp #device .dv-bottom .dv-label:last-of-type::before{
+    content:"◀◀  ▶  ▮▮  ■  ▶▶";font-size:11px;letter-spacing:.3em;
+    color:#c3c9d6;text-shadow:0 1px 0 #000}
+  body.theme-winamp #device .dv-bottom .dv-label:last-of-type::after{content:"";
+    position:absolute;left:0;right:0;top:calc(100% + 5px);height:8px;
+    background:linear-gradient(90deg,var(--wa-led-dim) 0 62%,#1b1d22 62%),#1b1d22;
+    box-shadow:var(--wa-in)}
+
+  /* ---- side rails: engraved legends, phosphor green ---- */
+  body.theme-winamp #device .dv-side{justify-content:center;gap:18px}
+  body.theme-winamp #device .dv-side span{color:#7f8695;letter-spacing:.34em;font-size:9px}
+  body.theme-winamp #device .dv-side.dv-l span::before{content:"FRESH 2.95 ";color:var(--wa-led-dim)}
+  body.theme-winamp #device .dv-side i{width:5px;height:5px;border-radius:0;
+    background:var(--wa-led);box-shadow:0 0 6px rgba(43,245,115,.9)}
+  /* No screws — this is a skin, not a machine. */
+  body.theme-winamp #device .dv-screw{display:none}
+
+  /* ======================= the playlist-editor dock ===================== */
+  body.theme-winamp:not(.mobile) .widget-surface.w-dock{
+    background:#0a0b0e;border-radius:0;padding:6px 5px 5px;color:#c7ffd8;
+    box-shadow:10px 12px 0 rgba(0,0,0,.45),0 40px 90px rgba(0,0,0,.7),
+      var(--wa-out),inset 0 0 0 4px var(--wa-metal-flat)}
+  /* The dock's own title row is the playlist window's title bar. */
+  body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-raw:first-child{
+    background:linear-gradient(180deg,#6a7080,#474b57 40%,#2f323b);
+    box-shadow:var(--wa-out);color:#cfd5e2;text-align:center;
+    letter-spacing:.2em;text-transform:uppercase;margin:-1px 0 6px;padding:1px 6px}
+  /* Controls: hardware switches and a black query box with green text. */
+  body.theme-winamp .w-dock .w-row.wrap .w-button.primary{flex:1 1 100%;text-align:center;
+    font-weight:700;color:#eafff1;background:linear-gradient(180deg,#2a9b52,#14622f);
+    border:none;border-radius:0;box-shadow:var(--wa-out);padding:4px 0}
+  body.theme-winamp .w-dock .w-text{flex:1 1 100%;background:#000;color:var(--wa-led);
+    border:none;border-radius:0;box-shadow:var(--wa-in);padding:3px 8px;margin:4px 0}
+  body.theme-winamp .w-dock .w-text::before{content:"⌕";color:var(--wa-led-dim)}
+  body.theme-winamp .w-dock .w-text-input::placeholder{color:rgba(43,245,115,.4)}
+  body.theme-winamp .w-dock .w-divider{border-color:rgba(255,255,255,.12)}
+  body.theme-winamp .w-dock .w-hintbar{color:#6f7686}
+  body.theme-winamp .w-dock .w-hint b{color:var(--wa-led)}
+  /* Playlist rows: green mono entries, navy selection bar, square everything. */
+  body.theme-winamp .w-dock .w-tree-row,body.theme-winamp .w-dock .w-list-row{
+    border-radius:0;padding:1px 6px;color:#8fe8ab}
+  body.theme-winamp .w-dock .w-tree-xrow{color:#5f8a6e}
+  body.theme-winamp .w-dock .w-tree-row.sel,body.theme-winamp .w-dock .w-list-row.sel,
+  body.theme-winamp .w-dock .w-tree-xrow.sel{background:var(--sel);color:#fff;box-shadow:none}
+  body.theme-winamp .w-dock .w-tree-card{border:none;border-radius:0;margin:2px 0;padding:1px 0;
+    background:rgba(255,255,255,.03);box-shadow:inset 0 0 0 1px rgba(255,255,255,.06)}
+  body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(28,47,168,.35);
+    box-shadow:var(--wa-out);border:none}
+  body.theme-winamp .w-dock .w-tree-card.sel .w-tree-xrow{color:#b9c4ff}
+  /* Dock menus: little skin windows in their own right. */
+  body.theme-winamp:not(.mobile) .w-dock>.w-col{position:relative}
+  body.theme-winamp .w-dock .w-overlay{background:var(--wa-metal-flat);border:none;
+    border-radius:0;box-shadow:var(--wa-out),4px 4px 0 rgba(0,0,0,.5);padding:4px;margin:0;z-index:6}
+  body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-row.wrap+.w-overlay{
+    position:absolute;left:0;right:0;top:44px}
+  body.theme-winamp .w-dock .w-overlay .w-section{border:none;padding:1px}
+  body.theme-winamp .w-dock .w-overlay .w-section-label{color:#9aa1b0;
+    text-transform:uppercase;font-size:.85em;letter-spacing:.12em;margin:2px 6px 4px}
+  body.theme-winamp .w-dock .w-overlay .w-row{gap:0}
+  body.theme-winamp .w-dock .w-overlay .w-button{flex:1;text-align:left;border:none;
+    background:transparent;box-shadow:none;color:#dfe4ee;padding:3px 8px;border-radius:0}
+  body.theme-winamp .w-dock .w-overlay .w-button:hover{background:var(--sel);color:#fff}
+
+  /* ===================== chrome inside the screen ====================== */
+  /* Cell-aligned rows: colour + inset bevels only, never box metrics. */
+  body.theme-winamp .menubar{background:var(--wa-metal);box-shadow:var(--wa-out);border-bottom:none}
+  body.theme-winamp .menu{color:#d3d8e4;text-shadow:0 1px 0 rgba(0,0,0,.7)}
+  body.theme-winamp .menu:hover{background:rgba(255,255,255,.10)}
+  body.theme-winamp .menu.open{background:var(--sel);color:#fff}
+  body.theme-winamp .tabbar{background:var(--wa-metal-flat);box-shadow:inset 0 -1px 0 rgba(0,0,0,.8)}
+  body.theme-winamp .tab{color:#a7adba;background:linear-gradient(180deg,#464a55,#33363f);
+    box-shadow:var(--wa-out);border-right:1px solid #16181d}
+  body.theme-winamp .tab:not(.active):hover{background:linear-gradient(180deg,#525765,#3b3f49)}
+  /* The active tab is the lit display: pressed in, black, phosphor label. */
+  body.theme-winamp .tab.active{background:#000;color:var(--wa-led);
+    text-shadow:0 0 7px rgba(43,245,115,.6);box-shadow:var(--wa-in)}
+  body.theme-winamp .tab.active::after{display:none}
+  body.theme-winamp .tab .x:hover{background:var(--sel);color:#fff}
+  /* Status bar: the kbps/kHz readout — black LCD with scanlines. */
+  body.theme-winamp .statusbar{background:
+    repeating-linear-gradient(180deg,rgba(255,255,255,.035) 0 1px,transparent 1px 3px),#000;
+    color:var(--wa-led-dim);box-shadow:var(--wa-in);border-top:none}
+  body.theme-winamp .statusbar .txt{color:var(--wa-led);text-shadow:0 0 6px rgba(43,245,115,.5)}
+  body.theme-winamp .statusbar .seg{border-radius:0}
+  body.theme-winamp .statusbar .seg:hover{background:rgba(43,245,115,.16);color:var(--wa-led)}
+  /* File explorer: another black playlist pane, framed by the metal rail. */
+  body.theme-winamp .fileexplorer{background:#0a0b0e;color:#8fe8ab;
+    border-right:1px solid #14161b;box-shadow:inset -3px 0 0 var(--wa-metal-flat)}
+  body.theme-winamp .fileexplorer .fx-title{color:var(--wa-amber);text-transform:uppercase}
+  body.theme-winamp .fileexplorer .fx-row{border-radius:0;margin:0}
+  body.theme-winamp .fileexplorer .fx-row.sel{background:var(--sel);color:#fff;box-shadow:none}
+  body.theme-winamp .fileexplorer .fx-row.sel .fx-icon,
+  body.theme-winamp .fileexplorer .fx-icon.dir{color:var(--wa-amber)}
+
+  /* ---- floating surfaces: skin windows, not frosted glass ---- */
+  body.theme-winamp .dropdown,body.theme-winamp .popup,body.theme-winamp .ctxmenu,
+  body.theme-winamp .palette,body.theme-winamp .palette.centered,
+  body.theme-winamp .settings-modal,body.theme-winamp .m-sheet,
+  body.theme-winamp .widget-surface.w-floatingModal,body.theme-winamp .pbrowser{
+    -webkit-backdrop-filter:none;backdrop-filter:none;
+    background:var(--wa-metal-flat);color:#dfe4ee;border:none;border-radius:0;
+    box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5)}
+  /* Their list bodies are LCD panes. */
+  body.theme-winamp .palette .plist,body.theme-winamp .palette .pinput,
+  body.theme-winamp .palette .ppreview{background:#000}
+  body.theme-winamp .palette .pinput .q{color:var(--wa-led)}
+  body.theme-winamp .palette .prow{color:#9fdcb4;border-radius:0}
+  body.theme-winamp .palette .prow.sel,body.theme-winamp .ctxmenu .ctxitem.sel,
+  body.theme-winamp .popup .popup-row.sel,body.theme-winamp .settings-modal .set-cat.sel,
+  body.theme-winamp .settings-modal .set-item.sel,body.theme-winamp .w-list-row.sel,
+  body.theme-winamp .mitem.hi{background:var(--sel);color:#fff;border-radius:0}
+  body.theme-winamp .mitem.hi::before,body.theme-winamp .ctxmenu .ctxitem.sel::before,
+  body.theme-winamp .popup .popup-row.sel::before{display:none}
+  body.theme-winamp .palette .prow .pkey{border-radius:0;border-color:#5b606d}
+  /* Text fields: recessed black wells with phosphor text. */
+  body.theme-winamp .palette .pinput,body.theme-winamp .w-text,
+  body.theme-winamp .settings-modal .set-field,body.theme-winamp .settings-modal .set-search{
+    color:var(--wa-led);border:none;border-radius:0;box-shadow:var(--wa-in)}
+  /* Buttons: beveled hardware switches that press in. */
+  body.theme-winamp .settings-modal .btn,body.theme-winamp .w-button,
+  body.theme-winamp .trustdialog .td-btn{
+    background:linear-gradient(180deg,#4b4f5b,#383b45);color:#e6eaf2;
+    border:none;border-radius:0;box-shadow:var(--wa-out)}
+  body.theme-winamp .settings-modal .btn:active,body.theme-winamp .w-button:active{
+    box-shadow:var(--wa-in)}
+  body.theme-winamp .settings-modal .btn.primary,body.theme-winamp .w-button.primary,
+  body.theme-winamp .trustdialog .td-btn.primary{
+    background:linear-gradient(180deg,#2a9b52,#14622f);color:#eafff1;box-shadow:var(--wa-out)}
+
+  /* Chunky beveled scrollbars. */
+  body.theme-winamp *::-webkit-scrollbar{width:14px;height:14px;background:#16181d}
+  body.theme-winamp *::-webkit-scrollbar-thumb{background:linear-gradient(180deg,#4b4f5b,#383b45);
+    border-radius:0;box-shadow:var(--wa-out)}
+  body.theme-winamp *::-webkit-scrollbar-thumb:active{box-shadow:var(--wa-in)}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -96,9 +96,21 @@
     position:absolute;inset:0;pointer-events:none;border-radius:inherit;z-index:4}
   body.theme-winamp #device::after{background:var(--wa-light-top);mix-blend-mode:screen}
   body.theme-winamp #device::before{background:var(--wa-light-bot);mix-blend-mode:multiply}
-  /* The code well: black, recessed, with a faint phosphor bloom. */
-  body.theme-winamp #device .dv-screen{border-radius:3px;background:var(--wa-sunken);
-    box-shadow:var(--wa-well),inset 0 0 90px rgba(78,240,127,.05)}
+  /* The code well: a black screen recessed into the metal, framed the way the
+     reference frames it — a bright LIT rim on the metal side, a dark groove, then
+     the recessed black with a faint phosphor bloom. */
+  body.theme-winamp #device .dv-screen{border-radius:4px;background:var(--wa-sunken);
+    box-shadow:
+      /* machined groove channel engraved in the metal frame (bright/dark/bright),
+         then the lit screen rim — the reference's framed-screen look. */
+      0 0 0 1px rgba(0,0,0,.6),                     /* dark line hugging the screen   */
+      0 0 0 2px rgba(255,230,190,.34),              /* bright bevel on the metal      */
+      0 0 0 4px rgba(0,0,0,.42),                    /* dark groove                     */
+      0 0 0 5px rgba(255,228,186,.22),              /* faint outer bright             */
+      inset 2px 2px 0 rgba(255,236,198,.34),        /* inner lit rim, top-left         */
+      inset -2px -2px 0 rgba(0,0,0,.5),            /* inner shade, bottom-right       */
+      inset 6px 6px 11px rgba(0,0,0,.85),           /* recessed screen depth           */
+      inset 0 0 90px rgba(78,240,127,.05)}
 
   /* ---- title bar: pinstripe rails either side of the caption ---- */
   body.theme-winamp #device .wa-title{position:absolute;left:6px;right:6px;top:5px;
@@ -140,12 +152,11 @@
     padding:0 10px;border-radius:3px;background:var(--wa-metal);box-shadow:var(--wa-out)}
   body.theme-winamp #device .wa-foot .wa-rail{flex:1}
 
-  /* ---- side edges: plain copper rails (no rack hardware, no screws) ---- */
-  body.theme-winamp #device .wa-edge{position:absolute;top:var(--bezel-top);
-    bottom:var(--bezel-bot);width:calc(var(--bezel-side) - 10px);
-    background:var(--wa-metal);box-shadow:var(--wa-out);border-radius:2px}
-  body.theme-winamp #device .wa-edge.wa-l{left:5px}
-  body.theme-winamp #device .wa-edge.wa-r{right:5px}
+  /* ---- side edges: hidden. The #device metal already fills the side margins,
+     and the frame around the code is the recessed, lit .dv-screen bevel — so the
+     old raised side rails (which covered the screen's lit rim and left a seam)
+     are dropped, matching the reference's single solid bevelled frame. ---- */
+  body.theme-winamp #device .wa-edge{display:none}
 
   /* ==================== ORCHESTRATOR — the playlist window =============== */
   body.theme-winamp:not(.mobile) .widget-surface.w-dock{position:relative;

--- a/web-ui/js/10-core.js
+++ b/web-ui/js/10-core.js
@@ -94,10 +94,11 @@ function layoutShell(){
   syncAppOrigin();
   const dev=document.getElementById("device");
   if(!dev) return;
-  // The COSMOS hardware bezel is a cosmos-theme decoration; the macOS / compact
-  // web themes run full-bleed, so the device is hidden and the menubar clip
-  // (which carves out the dock↔bezel gap) is neutralised for them.
-  if(isMobile()||!scene||webTheme!=="cosmos"){
+  // The bezel is a shell-theme decoration (COSMOS hardware / Winamp skin
+  // window); the macOS / compact web themes run full-bleed, so the device is
+  // hidden and the menubar clip (which carves out the dock↔bezel gap) is
+  // neutralised for them.
+  if(isMobile()||!scene||!shellTheme()){
     dev.classList.remove("on");
     document.documentElement.style.setProperty("--clip-left","0px");
     return;

--- a/web-ui/js/10-core.js
+++ b/web-ui/js/10-core.js
@@ -73,9 +73,14 @@ measureMetrics();
 // #app rule); SHELL mirrors the CSS vars so JS can position the bezel and
 // inset the dock card. APPX/APPY is #app's live viewport origin — every
 // pixel→cell conversion (cellAt, border drags) maps through it.
-const SHELL=(()=>{ const n=k=>parseFloat(rootCss.getPropertyValue(k))||0;
-  return { pad:n("--shell-pad"), top:n("--bezel-top"), bot:n("--bezel-bot"),
-           side:n("--bezel-side"), gap:n("--dock-gap") }; })();
+// Read LIVE (getters), not once at parse: a web theme may override the bezel
+// geometry inline on :root (e.g. Winamp uses a thinner frame than Cosmos), and
+// layoutShell()/resize() must see the active theme's values. rootCss is a live
+// getComputedStyle, so each access reflects the current (possibly overridden) var.
+const shellN=k=>parseFloat(rootCss.getPropertyValue(k))||0;
+const SHELL={ get pad(){return shellN("--shell-pad");}, get top(){return shellN("--bezel-top");},
+  get bot(){return shellN("--bezel-bot");}, get side(){return shellN("--bezel-side");},
+  get gap(){return shellN("--dock-gap");} };
 let APPX=0, APPY=0;
 function syncAppOrigin(){ const r=document.getElementById("app").getBoundingClientRect(); APPX=r.left; APPY=r.top; }
 const appH=()=>document.getElementById("app").clientHeight;

--- a/web-ui/js/15-theme.js
+++ b/web-ui/js/15-theme.js
@@ -22,6 +22,10 @@
 //     window chrome and the wallpaper/bezel opt-out off that class. Cosmos needs
 //     no rules of its own: it IS the base look, so its class only marks the
 //     switcher's active row and gates the hardware bezel in layoutShell().
+//   • Furniture — decorative DOM inside the bezel host, declared per theme in
+//     WEB_THEME_FURNITURE and built by renderFurniture(). shell.html ships an
+//     empty #device, so a theme's title bars / readouts / knobs live with the
+//     theme instead of in the page.
 const WEB_THEMES = ["cosmos", "macos", "macos-dark", "compact", "winamp"];
 const WEB_THEME_LABELS = { cosmos: "Cosmos", macos: "macOS Light", "macos-dark": "macOS Dark", compact: "Compact", winamp: "Winamp Classic" };
 const WEB_THEME_DESC = {
@@ -122,22 +126,79 @@ const WEB_THEME_VARS = {
   // hard offset drop shadow instead of a soft one. Structure (bevels, metal
   // gradients, scanlines) lives in css/95-theme-winamp.css.
   winamp: {
-    "--fg": "#d5d9e0", "--muted": "#8e94a0",
-    "--bg2": "#3a3d47", "--bg3": "#2c2f37",
-    "--menuhi": "#1c2fa8", "--border": "#14161b",
-    "--status-bg": "#000000", "--status-fg": "#3bd76e",
-    "--shell": "#33363f",
-    "--accent": "#2bf573", "--ui-accent": "#2bf573",
-    "--on-ui-accent": "#04140a", "--on-accent": "#04140a", "--on-sel": "#ffffff",
-    "--ok": "#2bf573",
-    "--surface": "#3a3d47", "--surface-2": "#2c2f37",
-    "--hairline": "rgba(255,255,255,.10)", "--hairline-strong": "rgba(255,255,255,.22)",
-    "--hover": "rgba(255,255,255,.09)",
-    "--sel": "#1c2fa8", "--sel-ring": "none",
-    "--shadow": "4px 4px 0 rgba(0,0,0,.55), 0 0 0 1px #14161b",
-    "--r-sm": "0px", "--r-md": "0px", "--r-lg": "0px",
+    "--fg": "#e9d9c2", "--muted": "#9b856a",
+    "--bg2": "#4a2d1c", "--bg3": "#3b2417",
+    "--menuhi": "#2d4486", "--border": "#1b1109",
+    "--status-bg": "#050705", "--status-fg": "#1a8f43",
+    "--shell": "#4a2d1c",
+    "--accent": "#4ef07f", "--ui-accent": "#f6c471",
+    "--on-ui-accent": "#2a1608", "--on-accent": "#04140a", "--on-sel": "#ffffff",
+    "--ok": "#4ef07f",
+    "--surface": "#4a2d1c", "--surface-2": "#3b2417",
+    "--hairline": "rgba(255,208,150,.12)", "--hairline-strong": "rgba(255,208,150,.26)",
+    "--hover": "rgba(255,208,150,.10)",
+    "--sel": "#2d4486", "--sel-ring": "none",
+    "--shadow": "6px 6px 0 rgba(0,0,0,.5), 0 0 0 1px #1b1109",
+    "--r-sm": "2px", "--r-md": "3px", "--r-lg": "4px",
   },
 };
+// ---- theme FURNITURE (declarative bezel decoration) ------------------------
+// Purely decorative DOM a theme wants inside #device — title bars, readouts,
+// analysers, transport clusters. Modelled on Winamp's *modern* skins: a classic
+// 2.x skin could only re-bitmap a hardcoded widget layout, while skin.xml let a
+// skin declare its own object tree. Same idea here — shell.html ships an EMPTY
+// #device and each theme declares what lives in it, so no theme's chrome is
+// baked into the page.
+//
+// A node is [ "tag.class.class", ...children ], where a child is another node
+// or a string (text). "×N" after the selector repeats the node (bar arrays).
+// Everything is decoration: the host is pointer-transparent, aria-hidden, and
+// nothing here may affect the cell grid's geometry.
+const WEB_THEME_FURNITURE = {
+  cosmos: [
+    ["div.dv-screen"],
+    ["div.dv-top", ["span.dv-label", "SPEC: COSMOS-991"], ["span.dv-grow"],
+      ["span.dv-leds", ["i.g"], ["i.y"], ["i.a"]]],
+    ["div.dv-side.dv-l", ["i"], ["span", "SPEC: COSMOS-991"]],
+    ["div.dv-side.dv-r", ["i"], ["span", "PROJECT: INFERNU.NIU"]],
+    ["div.dv-bottom", ["span.dv-label", "SPEC: COSMOS-991"], ["span.dv-grow"],
+      ["span.dv-label", "PROJECT: INFERNU CORE"]],
+    ["i.dv-screw.tl"], ["i.dv-screw.tr"], ["i.dv-screw.bl"], ["i.dv-screw.br"],
+  ],
+  // Winamp Classic — the editor is the "CODE STUDIO" skin window: window
+  // DECORATION only (rail title bar, caption, window buttons, side rails). No
+  // fake instrumentation — no analyser, no transport, no meters.
+  winamp: [
+    ["div.dv-screen"],
+    ["div.wa-title", ["i.wa-rail"], ["span.wa-title-text", "CODE STUDIO"], ["i.wa-rail"],
+      ["span.wa-wbtns", ["i.wa-min"], ["i.wa-shade"], ["i.wa-close"]]],
+    ["div.wa-edge.wa-l"], ["div.wa-edge.wa-r"], ["div.wa-foot", ["i.wa-rail"]],
+  ],
+};
+// Build a theme's furniture into #device. Called from applyWebTheme when the
+// theme changes (the tree is static per theme, so it is not rebuilt per frame).
+function renderFurniture() {
+  const host = document.getElementById("device");
+  if (!host) return;
+  if (host.dataset.theme === webTheme) return;
+  host.dataset.theme = webTheme;
+  host.textContent = "";
+  const build = (node, parent) => {
+    let [sel, ...kids] = node;
+    let times = 1;
+    const rep = sel.indexOf("×");
+    if (rep >= 0) { times = parseInt(sel.slice(rep + 1), 10) || 1; sel = sel.slice(0, rep); }
+    const parts = sel.split(".");
+    for (let i = 0; i < times; i++) {
+      const el = document.createElement(parts[0] || "div");
+      if (parts.length > 1) el.className = parts.slice(1).join(" ");
+      for (const k of kids) typeof k === "string" ? (el.textContent = k) : build(k, el);
+      parent.appendChild(el);
+    }
+  };
+  for (const node of (WEB_THEME_FURNITURE[webTheme] || [])) build(node, host);
+}
+
 // Union of every override key, for stale-clearing on theme switch.
 const WEB_THEME_ALL_KEYS = (() => {
   const s = new Set();
@@ -158,6 +219,7 @@ function applyWebTheme() {
   for (const n of WEB_THEMES) b.classList.toggle("theme-" + n, n === webTheme);
   // Family marker so the two macOS variants share one structural stylesheet.
   b.classList.toggle("macfam", MACOS_THEMES.includes(webTheme));
+  renderFurniture();
   const r = document.documentElement.style;
   const vars = WEB_THEME_VARS[webTheme] || {};
   for (const k of WEB_THEME_ALL_KEYS) {

--- a/web-ui/js/15-theme.js
+++ b/web-ui/js/15-theme.js
@@ -128,7 +128,7 @@ const WEB_THEME_VARS = {
   winamp: {
     "--fg": "#e9d9c2", "--muted": "#9b856a",
     "--bg2": "#4a2d1c", "--bg3": "#3b2417",
-    "--menuhi": "#2d4486", "--border": "#1b1109",
+    "--menuhi": "#313c90", "--border": "#1b1109",
     "--status-bg": "#050705", "--status-fg": "#1a8f43",
     "--shell": "#4a2d1c",
     "--accent": "#4ef07f", "--ui-accent": "#f6c471",
@@ -137,7 +137,7 @@ const WEB_THEME_VARS = {
     "--surface": "#4a2d1c", "--surface-2": "#3b2417",
     "--hairline": "rgba(255,208,150,.12)", "--hairline-strong": "rgba(255,208,150,.26)",
     "--hover": "rgba(255,208,150,.10)",
-    "--sel": "#2d4486", "--sel-ring": "none",
+    "--sel": "#313c90", "--sel-ring": "none",
     "--shadow": "6px 6px 0 rgba(0,0,0,.5), 0 0 0 1px #1b1109",
     "--r-sm": "2px", "--r-md": "3px", "--r-lg": "4px",
   },

--- a/web-ui/js/15-theme.js
+++ b/web-ui/js/15-theme.js
@@ -22,24 +22,30 @@
 //     window chrome and the wallpaper/bezel opt-out off that class. Cosmos needs
 //     no rules of its own: it IS the base look, so its class only marks the
 //     switcher's active row and gates the hardware bezel in layoutShell().
-const WEB_THEMES = ["cosmos", "macos", "macos-dark", "compact"];
-const WEB_THEME_LABELS = { cosmos: "Cosmos", macos: "macOS Light", "macos-dark": "macOS Dark", compact: "Compact" };
+const WEB_THEMES = ["cosmos", "macos", "macos-dark", "compact", "winamp"];
+const WEB_THEME_LABELS = { cosmos: "Cosmos", macos: "macOS Light", "macos-dark": "macOS Dark", compact: "Compact", winamp: "Winamp Classic" };
 const WEB_THEME_DESC = {
   cosmos: "Wallpaper, glass & hardware bezel",
   macos: "Native macOS — light & vibrant",
   "macos-dark": "Native macOS — dark & vibrant",
   compact: "Dense, chrome-light IDE",
+  winamp: "Brushed metal, bevels & LCD green",
 };
 // The macOS variants share one structural stylesheet (title bar, traffic
 // lights, system font, control shapes); only their colour tokens differ.
 const MACOS_THEMES = ["macos", "macos-dark"];
+// Themes built on the COSMOS shell layout: the grid is inset inside the #device
+// bezel and the dock floats beside it as its own panel (Cosmos dresses that as
+// hardware, Winamp as a stack of skin windows). macOS / Compact run full-bleed.
+const SHELL_THEMES = ["cosmos", "winamp"];
+function shellTheme() { return SHELL_THEMES.includes(webTheme); }
 // The inline custom properties applyTheme() (js/20-cells.js) owns. applyWebTheme
 // must NOT clear these when a theme leaves them unset — applyTheme just re-wrote
 // them from the live TUI theme, and that is exactly what Cosmos wants.
 const THEME_KEYS = ["--bg", "--fg", "--accent", "--muted", "--bg2", "--bg3",
   "--menuhi", "--border", "--status-bg", "--status-fg", "--on-accent", "--on-sel", "--shell"];
 // Density multiplier per theme (layered under user zoom in measureMetrics).
-const WEB_THEME_SCALE = { cosmos: 1, macos: 1, "macos-dark": 1, compact: 0.92 };
+const WEB_THEME_SCALE = { cosmos: 1, macos: 1, "macos-dark": 1, compact: 0.92, winamp: 1 };
 
 // Per-theme chrome palettes. Cosmos = {} (identity — inherit the TUI theme).
 // The macOS variants are fixed "System" palettes (light / dark) built from the
@@ -110,6 +116,26 @@ const WEB_THEME_VARS = {
     "--sel-ring": "inset 0 0 0 1px color-mix(in srgb, var(--ui-accent) 42%, transparent)",
     "--shadow": "0 10px 28px rgba(0,0,0,.5)",
     "--r-sm": "3px", "--r-md": "4px", "--r-lg": "6px",
+  },
+  // Winamp Classic — the base skin's palette: brushed-graphite chrome, LCD
+  // green readouts, the playlist editor's navy selection, square corners and a
+  // hard offset drop shadow instead of a soft one. Structure (bevels, metal
+  // gradients, scanlines) lives in css/95-theme-winamp.css.
+  winamp: {
+    "--fg": "#d5d9e0", "--muted": "#8e94a0",
+    "--bg2": "#3a3d47", "--bg3": "#2c2f37",
+    "--menuhi": "#1c2fa8", "--border": "#14161b",
+    "--status-bg": "#000000", "--status-fg": "#3bd76e",
+    "--shell": "#33363f",
+    "--accent": "#2bf573", "--ui-accent": "#2bf573",
+    "--on-ui-accent": "#04140a", "--on-accent": "#04140a", "--on-sel": "#ffffff",
+    "--ok": "#2bf573",
+    "--surface": "#3a3d47", "--surface-2": "#2c2f37",
+    "--hairline": "rgba(255,255,255,.10)", "--hairline-strong": "rgba(255,255,255,.22)",
+    "--hover": "rgba(255,255,255,.09)",
+    "--sel": "#1c2fa8", "--sel-ring": "none",
+    "--shadow": "4px 4px 0 rgba(0,0,0,.55), 0 0 0 1px #14161b",
+    "--r-sm": "0px", "--r-md": "0px", "--r-lg": "0px",
   },
 };
 // Union of every override key, for stale-clearing on theme switch.

--- a/web-ui/js/15-theme.js
+++ b/web-ui/js/15-theme.js
@@ -140,6 +140,10 @@ const WEB_THEME_VARS = {
     "--sel": "#313c90", "--sel-ring": "none",
     "--shadow": "6px 6px 0 rgba(0,0,0,.5), 0 0 0 1px #1b1109",
     "--r-sm": "2px", "--r-md": "3px", "--r-lg": "4px",
+    // Thinner window frame than Cosmos — the reference's CODE STUDIO frames the
+    // screen with a slim bezel, so the content sits close to the window edges.
+    // SHELL reads these live (js/10-core.js), so #device + the grid re-fit.
+    "--bezel-side": "17px", "--bezel-top": "42px", "--bezel-bot": "44px",
   },
 };
 // ---- theme FURNITURE (declarative bezel decoration) ------------------------

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -830,14 +830,14 @@ function widgetSurfaceEls(s){
     out.push(scrim);
   }
   const el=div("region widget-surface w-"+s.kind+(s.anchored?" anchored":"")); place(el,s.rect);
-  if(s.kind==="dock" && !isMobile() && s.rect.x===0 && webTheme==="cosmos"){
-    // COSMOS shell: the dock keeps its cell rect for hit-testing (widget
+  if(s.kind==="dock" && !isMobile() && s.rect.x===0 && shellTheme()){
+    // Shell themes: the dock keeps its cell rect for hit-testing (widget
     // clicks forward LOGICAL cells, never pixel-derived ones), but its
     // visual card is inset from the device — a gap on the right where the
     // bezel's left rail lands — and stretched to the bezel's vertical
-    // extents so it reads as its own floating glass panel. Cosmos-only: the
-    // macOS / compact themes have no bezel, so their dock keeps its plain
-    // cell rect (a flush full-height sidebar).
+    // extents so it reads as its own floating panel. Shell-only: the macOS /
+    // compact themes have no bezel, so their dock keeps its plain cell rect
+    // (a flush full-height sidebar).
     el.style.width=Math.max(140, px(s.rect.w,CW)-SHELL.side-SHELL.gap)+"px";
     el.style.top=(px(s.rect.y,CH)-SHELL.top+4)+"px";
     el.style.height=(px(s.rect.h,CH)+SHELL.top+SHELL.bot-8)+"px";

--- a/web-ui/shell.html
+++ b/web-ui/shell.html
@@ -36,19 +36,11 @@
 </style>
 </head>
 <body>
-<!-- Decorative hardware bezel (COSMOS shell). Positioned by layoutShell()
-     to wrap the grid minus the floating dock; pointer-transparent, painted
-     behind #app by document order. -->
-<div id="device" aria-hidden="true">
-  <div class="dv-screen"></div>
-  <div class="dv-top"><span class="dv-label">SPEC: COSMOS-991</span><span class="dv-grow"></span>
-    <span class="dv-leds"><i class="g"></i><i class="y"></i><i class="a"></i></span></div>
-  <div class="dv-side dv-l"><i></i><span>SPEC: COSMOS-991</span></div>
-  <div class="dv-side dv-r"><i></i><span>PROJECT: INFERNU.NIU</span></div>
-  <div class="dv-bottom"><span class="dv-label">SPEC: COSMOS-991</span><span class="dv-grow"></span>
-    <span class="dv-label">PROJECT: INFERNU CORE</span></div>
-  <i class="dv-screw tl"></i><i class="dv-screw tr"></i><i class="dv-screw bl"></i><i class="dv-screw br"></i>
-</div>
+<!-- Decorative bezel host. EMPTY on purpose: its contents are the active web
+     theme's FURNITURE, declared in js/15-theme.js and built by renderFurniture()
+     (see the note there). Positioned by layoutShell() to wrap the grid minus the
+     floating dock; pointer-transparent, painted behind #app by document order. -->
+<div id="device" aria-hidden="true"></div>
 <div id="app"></div>
 <!-- macOS theme title bar (window controls + document title). Shown only under
      body.theme-macos; #app is inset below it. Decorative — pointer-transparent. -->

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -815,7 +815,7 @@ console.log('\n[web-UI theme system: switch chrome look without touching the buf
 // it re-skins the native chrome and never reaches the editor. Default is Cosmos
 // (the hardware-bezel shell); macOS and Compact are the added looks.
 check('theme API is exposed (setWebTheme / webTheme / webThemes)', await page.evaluate(() =>
-  typeof window.fresh.setWebTheme === 'function' && Array.isArray(window.fresh.webThemes) && window.fresh.webThemes.length === 4));
+  typeof window.fresh.setWebTheme === 'function' && Array.isArray(window.fresh.webThemes) && window.fresh.webThemes.length === 5));
 check('default theme is Cosmos with the hardware bezel on', await page.evaluate(() =>
   window.fresh.webTheme === 'cosmos' && document.body.classList.contains('theme-cosmos') && document.getElementById('device').classList.contains('on')));
 // The buffer stays the TUI monospace stack regardless of the chrome font.
@@ -851,10 +851,25 @@ check('Compact: theme class set, bezel off, denser grid (cell width shrank)', aw
   (await page.evaluate(() => window.fresh.metrics)).cw < cwCosmos);
 // The switch is persisted as a pure view preference in localStorage.
 check('theme choice persists in localStorage', await page.evaluate(() => localStorage.getItem('fresh.webtheme') === 'compact'));
+// → Winamp: a SHELL theme (like Cosmos) — the hardware bezel host is on and
+// dressed as the "CODE STUDIO" skin window (furniture), and its own chrome
+// palette is layered inline (navy playlist selection, LCD-green accent). The
+// BUFFER stays the TUI monospace stack, same as every other web theme.
+await page.evaluate(() => window.fresh.setWebTheme('winamp'));
+await page.waitForTimeout(400);
+check('Winamp: theme class set, shell bezel ON, skin furniture built', await page.evaluate(() =>
+  document.body.classList.contains('theme-winamp') && document.getElementById('device').classList.contains('on') &&
+  !!document.querySelector('#device .wa-title .wa-title-text')));
+check('Winamp: chrome palette layered inline (navy selection + LCD-green accent), buffer stays monospace',
+  await page.evaluate(() => {
+    const r = document.documentElement.style;
+    return r.getPropertyValue('--sel').trim() === '#2d4486' && r.getPropertyValue('--accent').trim() === '#4ef07f';
+  }) && (await svgFamily()) === cosmosBufFont);
+await page.screenshot({ path: `${SHOTS}/33b-theme-winamp.png` });
 // The floating switcher: clicking the pill opens a 3-row menu; a row switches.
 await page.locator('#themebtn').click();
 await page.waitForTimeout(150);
-check('theme switcher menu opens with all four themes', (await page.locator('#thememenu.open .ts-row').count()) === 4);
+check('theme switcher menu opens with all five themes', (await page.locator('#thememenu.open .ts-row').count()) === 5);
 await page.locator('#thememenu .ts-row', { hasText: 'Cosmos' }).first().click();
 await page.waitForTimeout(400);
 check('picking Cosmos from the menu restores the bezel shell', await page.evaluate(() =>

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -863,7 +863,7 @@ check('Winamp: theme class set, shell bezel ON, skin furniture built', await pag
 check('Winamp: chrome palette layered inline (navy selection + LCD-green accent), buffer stays monospace',
   await page.evaluate(() => {
     const r = document.documentElement.style;
-    return r.getPropertyValue('--sel').trim() === '#2d4486' && r.getPropertyValue('--accent').trim() === '#4ef07f';
+    return r.getPropertyValue('--sel').trim() === '#313c90' && r.getPropertyValue('--accent').trim() === '#4ef07f';
   }) && (await svgFamily()) === cosmosBufFont);
 await page.screenshot({ path: `${SHOTS}/33b-theme-winamp.png` });
 // The floating switcher: clicking the pill opens a 3-row menu; a row switches.


### PR DESCRIPTION
Polishes the **Winamp Classic** web-UI theme (the `winamp` web theme for the browser chrome) so it genuinely reads like a classic Winamp 2.x skinned player, matched pixel-for-pixel against reference screenshots.

## What changed

All changes are scoped to the Winamp theme — its `web-ui/css/95-theme-winamp.css` structural stylesheet and its token block / furniture in `web-ui/js/15-theme.js`, plus one small shared-JS change to make bezel geometry theme-aware (see below). Other themes (Cosmos, macOS, Compact) are untouched and verified unregressed.

### Palette & materials
- Metal recoloured to the reference's **muted taupe-brown** (`#48352b`), not a saturated copper; **olive-green** primary plate (`#868e41`→`#555b29`) instead of a vivid spring green; **muted indigo** playlist selection (`#2f398c` → token `#313c90`). All sampled from the reference image, not eyeballed.
- Brushed-metal grain replaced: the old repeating-gradient stripes banded into venetian-blind lines; now an **organic SVG fractal-noise** texture stretched into fine vertical streaks.

### Lighting
- A **dramatic top-lit falloff** painted as a blend-mode overlay *above* each window's content (screen at the top, multiply at the foot) so the light falls on the caption and control chips too, not just the bare metal — concentrated top-centre to match the reference (measured top→bottom luminance ~75→27).

### Controls
- Buttons read as chips **cut into the metal**: a dark groove ring all around, a **top-lit, vertically-symmetric bevel** (bright top edge, dark bottom, mirrored left/right), a soft drop shadow, and a matte (not glassy) sheen.
- Toggles: recessed gray-taupe OFF track, glossy bead knob, **green phosphor LED** when lit (dock + Settings).
- Engraved menu separators; glossy olive primary buttons; beveled scrollbars.

### Code window ("CODE STUDIO") frame
- The black screen is now framed the way the reference frames it: a **machined groove channel** engraved in the metal (bright/dark/bright) + a lit inner rim + a recessed screen.
- Dropped the separate raised side rails (they covered the rim and left a seam) — the frame is now one solid bevelled band.
- **Thinner frame**: Winamp gets slimmer `--bezel-side/top/bot`, and `SHELL` (`web-ui/js/10-core.js`) now reads the bezel vars **live** so `#device` and the grid re-fit per theme. Cosmos keeps its 34px hardware bezel.

### Tests
- Updated `web-ui/test/drive.mjs` for the (already-registered) 5th theme: theme-count assertions bumped to five, plus new Winamp coverage (shell bezel on + furniture built, inline navy/LCD-green palette, buffer stays monospace). Full suite green on a fresh server.

## Surfaces covered
Full window, ORCHESTRATOR dock (caption, New Task, search, filters, toggles, Move/Manage, tree + selection), menu bar + dropdowns + submenu, command palette, Settings modal, context menus, tab bar, status bar (LCD), and the CODE STUDIO code window frame.

---

## Guide for coding agents: pixel-matching a themed UI against a reference

This theme was converged by **measuring the reference, not eyeballing it**. If you pick up work like this, follow the same loop — it's what made the difference between "looks vaguely Winamp" and "matches the screenshot".

**1. Stand up a real render loop first.**
- Build the bridge: `cargo build --features web -p fresh-editor --example webui_server`, serve it (`./target/debug/examples/webui_server 127.0.0.1:PORT crates/fresh-editor/src/view/scene.rs`), and drive it headless with the pre-installed Chromium via Playwright. Switch theme with `page.evaluate(() => window.fresh.setWebTheme('winamp'))`.
- **The HTML/CSS/JS is embedded at build time** — rebuild after every CSS/JS edit, then re-serve. Use a *fresh* server port per run for anything that inspects editor state: the server is **stateful and long-lived**, so a prior screenshot run that expanded the dock will pollute the next run (this caused a false test failure early on).
- `sleep` in the foreground is blocked in this sandbox; run the server via the background-task mechanism and poll readiness with a `curl` until-loop.

**2. Sample the reference; don't guess colors.** Install Pillow + numpy and pull real pixels:
- Median-sample clean patches for base colors (metal, button, selection) — averages get contaminated by text/edges, so prefer median and small clean rectangles.
- Scan a line across a *border* to read its bevel structure (bright rim → dark groove → face) — this is how the button-ring, code-screen frame, and machined groove were reverse-engineered.
- Profile luminance top→bottom / left→right to quantify *lighting* (falloff shape, center-lift), not just flat colors.

**3. Compare with numbers and montages.** After each rebuild, screenshot the same surface, scale reference + render to equal height, and stack them side by side; re-measure the same regions and compare values. "Center-lift +24 vs +22" beats "looks about right."

**4. Respect the architecture.**
- CSS lives in `web-ui/css/NN-*.css` concatenated in filename order (later wins); per-theme rules gate on a `body.theme-NAME` class (e.g. `theme-winamp`). Prefer **consolidated, token-driven** rules (`--wa-*` variables) so new surfaces inherit the look.
- Keep changes scoped to the theme's `9x-theme-*.css` + its `15-theme.js` token/furniture block. Chrome painted over the terminal **cell grid** must use color + inset shadows only — borders/padding there shift the DOM off the cell pitch.
- Geometry (`SHELL`, `--bezel-*`) is shared across shell themes; if a theme needs different frame metrics, make the shared reader theme-aware (live-read) rather than hard-coding — and verify the other themes still render.

**5. Techniques that worked here (reusable):**
- Organic texture → inline **SVG `feTurbulence`** data-URI, not repeating gradients (which band).
- "Light on everything" → a **blend-mode overlay** (`screen`/`multiply`) above content, not just a background gradient the opaque controls hide.
- Beveled chip "cut into metal" → outer dark ring (`0 0 0 1px`) + inset top-lit bevel + soft drop shadow, all in one `box-shadow` stack.
- Symmetry matters: a diagonal top-left bevel is *not* mirror-symmetric; use a vertical (top/bottom) bevel when the reference is symmetric about the vertical axis.

**6. Keep the suite green.** Run `web-ui/test/drive.mjs` against a *fresh* bridge; if you legitimately change theme count / tokens, update the assertions in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)