### PR TITLE
fix(orchestrator): stop dock flicker and repair web-UI dock chrome/menus

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1958,7 +1958,12 @@ function gitLineParts(s: AgentSession): { left: Entry[]; right: Entry[] } {
   // (only the very first probe, with no prior info, shows the spinner).
   const g = probe?.info;
   if (!g) {
-    if (probe?.status === "loading") {
+    // Show the spinner only on the genuinely FIRST probe (never completed yet,
+    // so `fetchedAt` is still 0). A directory that simply isn't a git repo
+    // never gains `info`, so re-probing it every TTL would otherwise re-enter
+    // "loading" and blink "…" back on each poll — a serialized change that
+    // pushed a redundant widgets frame (dock flicker) every ~15s per session.
+    if (probe?.status === "loading" && !probe.fetchedAt) {
       right.push({ text: "…", style: { fg: dim, italic: true } });
     }
     return { left, right };
@@ -3399,10 +3404,13 @@ async function probeGit(s: AgentSession): Promise<void> {
     s.git = { status: "ok", fetchedAt: Date.now(), info: s.git?.info };
   } finally {
     gitProbesInFlight.delete(s.id);
-    scheduleProbeRefresh();
-    // Refill the slot this probe just freed so the pool keeps draining
-    // between polls (preserves throughput under the concurrency cap).
+    // Refill the slot this probe just freed FIRST, so the pool keeps draining
+    // between polls (preserves throughput under the concurrency cap) and, more
+    // importantly, so the quiescence check in `scheduleProbeRefresh` sees the
+    // newly-started probes — otherwise the last completion of a wave would look
+    // idle while more sessions are still queued, and refresh mid-batch.
     drainGitProbes();
+    scheduleProbeRefresh();
   }
 }
 
@@ -3438,15 +3446,39 @@ function startProbePolling(): void {
   tick();
 }
 
-// Coalesce the re-renders triggered by probe completions: a batch of
-// probes finishing together collapses into one refresh rather than one
-// per probe (the open-time storm that made the panel feel unresponsive).
+// Coalesce the re-renders triggered by probe completions into ONE atomic
+// update per batch. A poll cycle can re-probe many sessions (git + pr), and
+// they finish at different times — a bounded git pool drains in waves, gh is
+// network-latent. Refreshing per completion trickled a frame each, so the
+// dock visibly repainted several times per cycle (flicker, and any in-flight
+// scroll gesture dropped). Instead we hold the refresh until every probe has
+// settled (`gitProbesInFlight` and `prProbesInFlight` both empty) and then
+// repaint once, so the whole batch of new git/pr summaries lands together.
+// The `finally` blocks call this AFTER re-draining, so a still-queued session
+// keeps the pool non-empty and defers the refresh to the true end of the wave.
+//
+// On top of batching, the probe-driven repaint is RATE-LIMITED: a fresh round
+// starts at most once per `PROBE_REFRESH_MIN_INTERVAL_MS`. Even if waves keep
+// settling back-to-back, the dock never repaints from probes more often than
+// this, which caps any residual churn to a slow, unnoticeable cadence. Only
+// this probe path is throttled — interactive updates call `refreshOpenDialog`
+// directly and stay instant.
+const PROBE_REFRESH_MIN_INTERVAL_MS = 4000;
 let probeRefreshPending = false;
+let lastProbeRefreshAt = 0;
 function scheduleProbeRefresh(): void {
+  // Not yet quiescent — a later completion will call back in and land the one
+  // refresh once the batch fully settles.
+  if (gitProbesInFlight.size > 0 || prProbesInFlight.size > 0) return;
   if (probeRefreshPending) return;
   probeRefreshPending = true;
-  void editor.delay(150).then(() => {
+  // Honour both the coalescing debounce (150ms) and the minimum spacing since
+  // the last probe refresh, whichever is longer.
+  const sinceLast = Date.now() - lastProbeRefreshAt;
+  const wait = Math.max(150, PROBE_REFRESH_MIN_INTERVAL_MS - sinceLast);
+  void editor.delay(wait).then(() => {
     probeRefreshPending = false;
+    lastProbeRefreshAt = Date.now();
     if (openPanel) refreshOpenDialog();
   });
 }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -3367,7 +3367,12 @@ async function probeGit(s: AgentSession): Promise<void> {
       s.root,
     );
     if (st.exit_code !== 0) {
-      s.git = { status: "ok", fetchedAt: Date.now() }; // not a git dir → empty summary
+      // `git status` failed. This is usually transient — an agent holding
+      // `.git/index.lock`, a mid-checkout worktree, etc. — so KEEP the last
+      // known summary instead of blanking it (a genuine non-git dir simply
+      // never had `info`, so this stays empty there). Dropping it made the
+      // card's git segment blink on every failed poll (TUI + web churn).
+      s.git = { status: "ok", fetchedAt: Date.now(), info: s.git?.info };
       return;
     }
     const info = parsePorcelainV2(st.stdout || "");
@@ -3382,7 +3387,9 @@ async function probeGit(s: AgentSession): Promise<void> {
     }
     s.git = { status: "ok", fetchedAt: Date.now(), info };
   } catch (_e) {
-    s.git = { status: "ok", fetchedAt: Date.now() };
+    // Spawn/parse error (git missing, killed, etc.) — same as above: keep the
+    // last known summary rather than blanking the card on a transient failure.
+    s.git = { status: "ok", fetchedAt: Date.now(), info: s.git?.info };
   } finally {
     gitProbesInFlight.delete(s.id);
     scheduleProbeRefresh();

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1587,11 +1587,18 @@ function sessionState(s: AgentSession): AgentState {
   return Date.now() - s.lastOutputAt < IDLE_AFTER_MS ? "working" : "idle";
 }
 
+// Age is shown at DAY granularity on purpose. A finer (s/m/h) counter ticks
+// every second/minute, and because the dock re-renders on the probe-poll
+// cadence, each tick changed the serialized card → a real frame → a full
+// dock teardown/rebuild, i.e. a scrollbar flicker and a dropped scroll
+// gesture for a purely cosmetic counter. At day granularity the string is
+// stable across the whole session's normal lifetime, so idle re-renders
+// diff to nothing and the panel stays still.
 function ageString(createdAt: number): string {
-  const sec = Math.max(0, Math.floor((Date.now() - createdAt) / 1000));
-  if (sec < 60) return `${sec}s`;
-  if (sec < 3600) return `${Math.floor(sec / 60)}m`;
-  return `${Math.floor(sec / 3600)}h`;
+  const days = Math.max(0, Math.floor((Date.now() - createdAt) / 86_400_000));
+  if (days <= 0) return "today";
+  if (days === 1) return "1d";
+  return `${days}d`;
 }
 
 // =============================================================================

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -15,6 +15,7 @@ use crate::app::Editor;
 use fresh_core::LeafId;
 use ratatui::layout::Rect;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 /// A cell rectangle, serialized as `{x, y, w, h}` (matching the bridge's
@@ -905,7 +906,13 @@ pub struct WidgetSurfaceView {
     pub focus_key: String,
     /// The raw, already-serializable `WidgetSpec` tree — rendered natively.
     pub spec: fresh_core::api::WidgetSpec,
-    pub instances: HashMap<String, WidgetInstanceView>,
+    /// Keyed by widget key. A `BTreeMap` (not `HashMap`) so serialization is
+    /// key-ordered and therefore STABLE across scene builds: the region-diff
+    /// hashes the serialized bytes, and a randomized map order made an
+    /// otherwise-unchanged panel hash differently every tick, pushing a
+    /// redundant `regions.widgets` frame ~once a second — a full dock rebuild
+    /// (scrollbar flicker, dropped scroll gesture) for no real change.
+    pub instances: BTreeMap<String, WidgetInstanceView>,
     pub hits: Vec<WidgetHitView>,
     /// Native modal-frame title (the declarative dialog's *shell*, drawn by
     /// the frontend as a title bar — not part of the `spec`). `None` for the
@@ -943,7 +950,7 @@ impl Editor {
             let Some(panel) = self.widget_registry.get(&fwp.panel_key) else {
                 continue;
             };
-            let mut instances = HashMap::new();
+            let mut instances = BTreeMap::new();
             for (key, st) in &panel.instance_states {
                 use crate::widgets::WidgetInstanceState as W;
                 let view = match st {

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -3176,3 +3176,85 @@ fn modal_picker_wears_native_modal_frame() {
         .unwrap();
     h.assert_screen_not_contains("[×]");
 }
+
+/// A committed, clean git project (has a HEAD) + the orchestrator plugin.
+fn setup_committed_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let root = temp_dir.path().join(name);
+    fs::create_dir(&root).unwrap();
+    let plugins_dir = root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+    fs::write(root.join("readme.txt"), "a\nb\nc\n").unwrap();
+    let git = |args: &[&str]| {
+        let ok = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok, "git {args:?} failed");
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "t@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["add", "-A"]);
+    git(&["commit", "-q", "-m", "init"]);
+    (temp_dir, root)
+}
+
+/// A transient git-probe failure (an agent momentarily holding
+/// `.git/index.lock`, or any other transient `git` error) must NOT erase the
+/// card's last-known git summary. Before the fix, `probeGit`'s error paths
+/// dropped the cached `info`, so the summary blinked away on every failed
+/// poll — visible churn in the TUI and, on the web, a dock rebuild that reset
+/// the session-list scroll. Drives only the dock open and asserts on rendered
+/// output, per CONTRIBUTING §2.
+///
+/// Non-vacuous by construction: a second "witness" session proves a probe
+/// re-runs (its TTL expiring drives the same poll cycle that re-probes the
+/// target), so when the witness updates the target has been re-probed too —
+/// no vacuous pass. The git-probe TTL is on the wall clock, so `wait_until`
+/// (which pumps real time) is what expires it; there's no fixed timeout.
+#[test]
+fn dock_git_summary_survives_transient_probe_failure() {
+    // Target session: a committed repo dirtied to a distinctive "+2" summary.
+    let (_tmp_a, root_a) = setup_committed_project("gitproj");
+    fs::write(root_a.join("readme.txt"), "a\nb\nc\nd\ne\n").unwrap();
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root_a.clone())
+            .unwrap();
+
+    // Witness session: a second committed repo, used only to prove a re-probe
+    // cycle actually ran (it shares the wall-clock TTL with the target).
+    let (_tmp_b, root_b) = setup_committed_project("witness");
+    h.editor_mut()
+        .create_window_at(root_b.clone(), "witness".to_string());
+
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // First probes (no TTL gate): target shows "+2", witness shows "clean".
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("+2") && s.contains("clean")
+    })
+    .unwrap();
+
+    // Force the target's NEXT probe to FAIL (remove its `.git` so `git status`
+    // exits non-zero — the same class as a transient lock/error), and give the
+    // witness a new, distinctive summary ("+7") to change to.
+    fs::remove_dir_all(root_a.join(".git")).unwrap();
+    fs::write(root_b.join("readme.txt"), "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n").unwrap();
+
+    // Wait for the witness to re-probe to "+7": the same poll cycle re-probes
+    // the target (whose probe now fails). This can't pass vacuously — if
+    // probes never re-ran, "+7" would never appear and this would hang.
+    h.wait_until(|h| h.screen_to_string().contains("+7"))
+        .unwrap();
+    h.wait_until_stable(|_| true).unwrap();
+
+    // The target's failed re-probe must NOT have wiped its last-known summary.
+    h.assert_screen_contains("+2");
+}

--- a/web-ui/css/20-chrome.css
+++ b/web-ui/css/20-chrome.css
@@ -17,7 +17,7 @@
      to the right so it doesn't darken the parent panel across the seam. */
   .dropdown.submenu{box-shadow:8px 14px 40px rgba(0,0,0,.45)}
   .mitem,.msep,.mlabel{position:absolute;z-index:81}
-  .mitem{display:flex;align-items:center;gap:18px;padding:0 14px;white-space:nowrap;cursor:default;color:var(--fg)}
+  .mitem{display:flex;align-items:center;gap:16px;padding:0 10px;white-space:nowrap;cursor:default;color:var(--fg)}
   .mitem.hi{background:var(--menuhi);color:#fff}
   .mitem.disabled{color:#6a6a6a}
   /* The label takes the row and the accel sits in a fixed right-hand column.
@@ -29,7 +29,7 @@
   .mitem .accel{flex:0 0 auto;color:var(--muted)}
   .mitem.hi .accel{color:#dfe8ff}
   .mitem .arrow{color:var(--muted)}
-  .mitem .check{width:12px;display:inline-block;text-align:center;margin-right:6px}
+  .mitem .check{width:11px;display:inline-block;text-align:center;margin-right:3px}
   .msep{height:1px;background:#4a4a4a;margin:4px 8px}
   .mlabel{padding:0 14px;color:var(--muted);font-style:italic}
 

--- a/web-ui/css/20-chrome.css
+++ b/web-ui/css/20-chrome.css
@@ -20,11 +20,16 @@
   .mitem{display:flex;align-items:center;gap:18px;padding:0 14px;white-space:nowrap;cursor:default;color:var(--fg)}
   .mitem.hi{background:var(--menuhi);color:#fff}
   .mitem.disabled{color:#6a6a6a}
-  .mitem .lab{flex:1;display:flex;align-items:center;gap:6px}
-  .mitem .accel{color:var(--muted)}
+  /* The label takes the row and the accel sits in a fixed right-hand column.
+     `min-width:0` + ellipsis lets a long label truncate cleanly (…) instead of
+     shoving the accel past the panel's right edge (the proportional chrome font
+     can exceed the pipeline's monospace cell box), so the shortcuts stay
+     column-aligned. `.lab` is a block (not flex) so text-overflow works. */
+  .mitem .lab{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .mitem .accel{flex:0 0 auto;color:var(--muted)}
   .mitem.hi .accel{color:#dfe8ff}
   .mitem .arrow{color:var(--muted)}
-  .mitem .check{width:12px;display:inline-block;text-align:center}
+  .mitem .check{width:12px;display:inline-block;text-align:center;margin-right:6px}
   .msep{height:1px;background:#4a4a4a;margin:4px 8px}
   .mlabel{padding:0 14px;color:var(--muted);font-style:italic}
 

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -211,14 +211,35 @@
      the fallback for list-less panels taller than their rect; when a list is
      present the flex chain makes the content fit exactly, so the surface
      never scrolls. */
-  .widget-surface{background:var(--bg2);overflow:auto;z-index:40;padding:4px 6px;
+  /* Vertical scroll is the fallback for list-less panels; horizontal is
+     never wanted in a fixed-width dock — a row a shade too wide (a `pre`
+     tree line) must ellipsis-clip, not raise a flickering h-scrollbar. */
+  .widget-surface{background:var(--bg2);overflow-y:auto;overflow-x:hidden;z-index:40;padding:4px 6px;
     display:flex;flex-direction:column}
   .widget-surface>.w-col,.widget-surface>.w-row{flex:1 1 auto;min-height:0}
-  .widget-surface .w-list,.widget-surface .w-tree{flex:1 1 auto;min-height:0;overflow-y:auto}
+  .widget-surface .w-list,.widget-surface .w-tree{flex:1 1 auto;min-height:0;overflow-y:auto;overflow-x:hidden}
   /* rows/cards keep their natural height — the LIST scrolls, its items never
      squash to fit the flex-constrained track */
   .widget-surface .w-list>*,.widget-surface .w-tree>*{flex:0 0 auto}
   .widget-surface.w-dock{border-right:1px solid var(--border)}
+  /* The dock column is the positioning context for its floating dropdowns
+     (New Task…, project filter, Move to folder…); js/65-widgets.js pins each
+     to the top of the row it belongs above so they overlay content instead
+     of reflowing the session list. */
+  .widget-surface.w-dock>.w-col{position:relative}
+  .widget-surface.w-dock>.w-col>.w-overlay{z-index:20}
+  /* Dock dropdown options are full-width menu rows, like the context menu:
+     each option is a `row(button, flexSpacer)`, and the spacer used to eat
+     half the row so hover/selection only highlighted the text. Drop the
+     spacer and let the button fill its row. */
+  .widget-surface.w-dock .w-overlay .w-row>.w-spacer{display:none}
+  .widget-surface.w-dock .w-overlay .w-row>.w-button{flex:1 1 100%;text-align:left}
+  /* The plugin pads the space under the tree with blank rows so the TUI can
+     pin its hint bar to the panel's bottom edge. In the web the flex column
+     already bottom-aligns the hints, so that filler would only steal the
+     vertical space the session list is meant to fill — drop it. */
+  .widget-surface.w-dock>.w-col>.w-tree+.w-raw,
+  .widget-surface.w-dock>.w-col>.w-list+.w-raw{display:none}
   .widget-surface.w-floatingModal{border:1px solid #5a5a5a;border-radius:8px;box-shadow:0 16px 60px rgba(0,0,0,.55);z-index:96}
   /* Anchored popup (right-click context menu): undimmed backdrop that still
      catches outside-clicks (dismiss), and a snug menu card — content-sized

--- a/web-ui/css/40-widgets.css
+++ b/web-ui/css/40-widgets.css
@@ -217,7 +217,10 @@
   .widget-surface{background:var(--bg2);overflow-y:auto;overflow-x:hidden;z-index:40;padding:4px 6px;
     display:flex;flex-direction:column}
   .widget-surface>.w-col,.widget-surface>.w-row{flex:1 1 auto;min-height:0}
-  .widget-surface .w-list,.widget-surface .w-tree{flex:1 1 auto;min-height:0;overflow-y:auto;overflow-x:hidden}
+  /* `scrollbar-gutter:stable` reserves the scrollbar's column so a re-render
+     that briefly changes content height can't pop the bar in/out and shove
+     the rows sideways (a flicker on the dock's frequent repaints). */
+  .widget-surface .w-list,.widget-surface .w-tree{flex:1 1 auto;min-height:0;overflow-y:auto;overflow-x:hidden;scrollbar-gutter:stable}
   /* rows/cards keep their natural height — the LIST scrolls, its items never
      squash to fit the flex-constrained track */
   .widget-surface .w-list>*,.widget-surface .w-tree>*{flex:0 0 auto}

--- a/web-ui/css/90-cosmos.css
+++ b/web-ui/css/90-cosmos.css
@@ -139,15 +139,12 @@
   body.theme-cosmos:not(.mobile) .w-dock .w-hint b{color:rgba(240,248,255,.8)}
   /* Dock dropdowns (New Task… / Move to folder…): a frosted menu card in
      place of the flat --bg2 overlay, with plain menu rows instead of the
-     editor's filled buttons. The New-Task menu (the overlay right after the
-     toolbar row) is pinned under its button — in flow it would land below
-     the wrapped search field. */
-  body.theme-cosmos:not(.mobile) .w-dock>.w-col{position:relative}
+     editor's filled buttons. Positioning (float over content, no reflow) is
+     owned by js/65-widgets.js `layoutDockOverlays`. */
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay{background:rgba(16,26,40,.92);
     -webkit-backdrop-filter:blur(18px) saturate(1.3);backdrop-filter:blur(18px) saturate(1.3);
     border:1px solid rgba(255,255,255,.22);border-radius:14px;
-    box-shadow:0 18px 50px rgba(2,6,14,.6);padding:6px;margin:0;z-index:6}
-  body.theme-cosmos:not(.mobile) .w-dock>.w-col>.w-row.wrap+.w-overlay{position:absolute;left:0;right:0;top:46px}
+    box-shadow:0 18px 50px rgba(2,6,14,.6);padding:6px;margin:0;z-index:20}
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-section{border:none;padding:2px}
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-section-label{color:rgba(232,240,248,.55);
     text-transform:uppercase;font-size:.85em;letter-spacing:.07em;margin:2px 8px 6px}
@@ -157,6 +154,23 @@
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button:hover{background:rgba(255,255,255,.10)}
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button.primary{background:rgba(255,255,255,.16);
     box-shadow:inset 0 0 0 1px rgba(255,255,255,.28);color:#fff}
+  /* The anchored context menu (right-click a session) wears the SAME frosted
+     card + borderless menu rows as the dock dropdowns, so the two read as one
+     component instead of the flat bordered-button box the base modal gives. */
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored{
+    background:rgba(16,26,40,.92);
+    -webkit-backdrop-filter:blur(18px) saturate(1.3);backdrop-filter:blur(18px) saturate(1.3);
+    border:1px solid rgba(255,255,255,.22);border-radius:14px;
+    box-shadow:0 18px 50px rgba(2,6,14,.6);padding:6px}
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button{
+    border:none;background:transparent;color:#e8eef5;padding:6px 10px;border-radius:9px;
+    text-align:left;box-shadow:none}
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button:hover{
+    background:rgba(255,255,255,.10)}
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button.primary{
+    background:rgba(255,255,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.28);color:#fff}
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button.danger{
+    background:transparent;color:#ff9b9b}
 
   /* Cell-painted file-browser band (OpenFile / SaveFileAs / SwitchProject):
      real pipeline cells, framed as a floating card above the panes and the

--- a/web-ui/css/90-cosmos.css
+++ b/web-ui/css/90-cosmos.css
@@ -151,8 +151,12 @@
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-row{gap:0}
   body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button{flex:1;text-align:left;border:none;
     background:transparent;color:#e8eef5;padding:6px 10px;border-radius:9px}
-  body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button:hover{background:rgba(255,255,255,.10)}
-  body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button.primary{background:rgba(255,255,255,.16);
+  /* Highlight follows the mouse (hover), not the keyboard cursor: the primary
+     (cursor) row renders like any other so nothing is pre-selected on open,
+     and the hovered row lights up. */
+  body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button.primary{
+    background:transparent;box-shadow:none;color:#e8eef5}
+  body.theme-cosmos:not(.mobile) .w-dock .w-overlay .w-button:hover{background:rgba(255,255,255,.16);
     box-shadow:inset 0 0 0 1px rgba(255,255,255,.28);color:#fff}
   /* The anchored context menu (right-click a session) wears the SAME frosted
      card + borderless menu rows as the dock dropdowns, so the two read as one
@@ -165,9 +169,10 @@
   body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button{
     border:none;background:transparent;color:#e8eef5;padding:6px 10px;border-radius:9px;
     text-align:left;box-shadow:none}
-  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button:hover{
-    background:rgba(255,255,255,.10)}
+  /* Hover-driven highlight (see the dock dropdown above): no stuck cursor row. */
   body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button.primary{
+    background:transparent;box-shadow:none;color:#e8eef5}
+  body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button:hover{
     background:rgba(255,255,255,.16);box-shadow:inset 0 0 0 1px rgba(255,255,255,.28);color:#fff}
   body.theme-cosmos:not(.mobile) .widget-surface.w-floatingModal.anchored .w-button.danger{
     background:transparent;color:#ff9b9b}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -340,8 +340,16 @@
   body.theme-winamp .palette .prow{color:#9fdcb4;border-radius:0}
   body.theme-winamp .palette .prow.sel,body.theme-winamp .ctxmenu .ctxitem.sel,
   body.theme-winamp .popup .popup-row.sel,body.theme-winamp .settings-modal .set-cat.sel,
-  body.theme-winamp .settings-modal .set-item.sel,body.theme-winamp .w-list-row.sel,
-  body.theme-winamp .mitem.hi{background:var(--sel);color:#fff;border-radius:0}
+  body.theme-winamp .settings-modal .set-item.sel,body.theme-winamp .w-list-row.sel{background:var(--sel);color:#fff;border-radius:0}
+  /* Menu-bar dropdown highlight: the theme's lit olive-green plate (the same
+     highlight as the right-click context menu), not the blue list-selection —
+     which read as foreign in the warm chrome. */
+  body.theme-winamp .mitem.hi{
+    background:
+      radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.35),transparent 62%),
+      linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);
+    color:#f6f2df;border-radius:0}
+  body.theme-winamp .mitem.hi .accel{color:rgba(246,242,223,.72)}
   body.theme-winamp .mitem.hi::before,body.theme-winamp .ctxmenu .ctxitem.sel::before,
   body.theme-winamp .popup .popup-row.sel::before{display:none}
   body.theme-winamp .palette .prow .pkey{border-radius:2px;border-color:#7d5230}

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -253,20 +253,23 @@
   body.theme-winamp .w-dock .w-tree-card.sel{background:rgba(58,87,209,.5);
     box-shadow:var(--wa-out);border:none}
   body.theme-winamp .w-dock .w-tree-card.sel .w-tree-xrow{color:#c3ccf5}
-  /* Dock menus: small skin windows of their own. */
-  body.theme-winamp:not(.mobile) .w-dock>.w-col{position:relative}
-  body.theme-winamp .w-dock .w-overlay{background:var(--wa-face-flat);border:none;
-    border-radius:3px;box-shadow:var(--wa-out),6px 6px 0 rgba(0,0,0,.5);
+  /* Dock menus are the SAME skin window as the anchored context menu — a
+     metal card with full-width beveled menu buttons — so the New Task /
+     Move-to-folder dropdowns read like the right-click menu. Positioning
+     (float over content, no reflow) is owned by js/65-widgets.js
+     `layoutDockOverlays`. */
+  body.theme-winamp .w-dock .w-overlay{background:var(--wa-metal);border:none;
+    border-radius:3px;box-shadow:var(--wa-seam),var(--wa-out),6px 8px 0 rgba(0,0,0,.5);
     padding:4px;margin:0;z-index:30}
-  body.theme-winamp:not(.mobile) .w-dock>.w-col>.w-row.wrap+.w-overlay{
-    position:absolute;left:0;right:0;top:44px}
   body.theme-winamp .w-dock .w-overlay .w-section{border:none;padding:1px}
   body.theme-winamp .w-dock .w-overlay .w-section-label{color:var(--wa-amber);
     text-transform:uppercase;font-size:.85em;letter-spacing:.12em;margin:2px 6px 4px}
   body.theme-winamp .w-dock .w-overlay .w-row{gap:0}
-  body.theme-winamp .w-dock .w-overlay .w-button{flex:1;text-align:left;border:none;
-    background:transparent;box-shadow:none;color:#e9d9c2;padding:3px 8px;border-radius:0}
-  body.theme-winamp .w-dock .w-overlay .w-button:hover{background:var(--sel);color:#fff}
+  /* Options keep the default beveled .w-button skin — regular plate, green
+     primary plate for the cursor row — exactly like the context menu (the
+     flat transparent override that used to sit here is gone). Width comes
+     from the base full-width rule. */
+  body.theme-winamp .w-dock .w-overlay .w-button{padding:3px 10px}
 
   /* ===================== chrome inside the code well ==================== */
   /* Cell-aligned rows: colour + inset bevels only, never box metrics. */

--- a/web-ui/css/95-theme-winamp.css
+++ b/web-ui/css/95-theme-winamp.css
@@ -270,6 +270,20 @@
      flat transparent override that used to sit here is gone). Width comes
      from the base full-width rule. */
   body.theme-winamp .w-dock .w-overlay .w-button{padding:3px 10px}
+  /* Highlight follows the mouse (hover), not a stuck keyboard cursor: the
+     primary (cursor) row renders as a plain plate so nothing is pre-selected
+     on open, and the hovered row lights up with the green primary plate.
+     Applies to the dock dropdowns AND the anchored right-click context menu. */
+  body.theme-winamp .w-dock .w-overlay .w-button.primary,
+  body.theme-winamp .widget-surface.w-floatingModal.anchored .w-button.primary{
+    background:var(--wa-gloss),var(--wa-plate);color:#f0dcc2;
+    box-shadow:var(--wa-ctl);text-shadow:0 1px 0 rgba(0,0,0,.5)}
+  body.theme-winamp .w-dock .w-overlay .w-button:hover,
+  body.theme-winamp .widget-surface.w-floatingModal.anchored .w-button:hover{
+    background:
+      radial-gradient(90% 130% at 50% -22%,rgba(255,255,214,.4),transparent 62%),
+      linear-gradient(180deg,#96a04c 0%,#7f8a3e 46%,#565c29 100%);color:#f4f6df;
+    box-shadow:var(--wa-ring),var(--wa-vbevel),inset 0 1px 0 rgba(255,255,255,.32),0 2px 4px rgba(0,0,0,.45)}
 
   /* ===================== chrome inside the code well ==================== */
   /* Cell-aligned rows: colour + inset bevels only, never box metrics. */

--- a/web-ui/js/20-cells.js
+++ b/web-ui/js/20-cells.js
@@ -146,5 +146,8 @@ function applyTheme(t){
 // per-region patching the snapshot/restore is scoped to the one region
 // container actually being rebuilt — untouched regions keep their scroll
 // positions by simply not being touched.
-const SCROLL_KEEP = ".set-items,.set-cats,.w-list,.widget-surface";
+// `.w-tree` is the orchestrator dock's session-list scroll container (the
+// list is rendered in full and scrolls natively); it must survive the dock's
+// frequent re-renders or the list snaps to the top mid-scroll.
+const SCROLL_KEEP = ".set-items,.set-cats,.w-list,.w-tree,.widget-surface";
 

--- a/web-ui/js/30-render.js
+++ b/web-ui/js/30-render.js
@@ -101,7 +101,10 @@ const REGION_FILL={
   // native menu bar + dropdown (one family: menuOpen/menuHighlight/submenuPath/
   // dropdown/menus all redraw together)
   menu(c,reg){ if(reg.menubar) c.appendChild(menuBarEl(reg));
-    for(const d of menuDropdownEls(reg)) c.appendChild(d); },
+    for(const d of menuDropdownEls(reg)) c.appendChild(d);
+    // Fit each open dropdown to its widest row's real (proportional) content
+    // once laid out, so accelerators stay column-aligned in any chrome font.
+    if(reg.menuOpen!=null) requestAnimationFrame(()=>fitMenuWidths(c)); },
   statusbar(c,reg){ if(reg.statusbar) c.appendChild(statusBarEl(reg.statusbar)); },
   // native popups (completion / hover / action / list / text) — semantic, not cells
   popups(c,reg){ for(const p of (reg.popups||[])) c.appendChild(popupEl(p)); },

--- a/web-ui/js/40-menu.js
+++ b/web-ui/js/40-menu.js
@@ -140,6 +140,41 @@ function itemRow(item, rect, hi, comp, depth){
   return row;
 }
 
+// Widen each dropdown panel (and its rows) to fit the WIDEST row's real
+// rendered content. The core sizes menus in monospace cells, but web chrome
+// draws in a proportional font, so the char-count box can be too narrow — the
+// longest label+accelerator would overflow the panel (or, with the ellipsis
+// guard, truncate). Measuring the natural width here keeps the accelerators in
+// one right-aligned column without hard-coding any width or touching the core.
+// Placement (top/left, and the click cell) is unchanged, so hit-testing — which
+// forwards the item's logical cell, not a pixel — is unaffected.
+function fitMenuWidths(host){
+  host.querySelectorAll(".dropdown").forEach(panel=>{
+    const pr=panel.getBoundingClientRect();
+    const rows=[...host.querySelectorAll(".mitem,.msep,.mlabel")].filter(m=>{
+      const r=m.getBoundingClientRect();
+      return r.left>=pr.left-2 && r.left<pr.right && r.top>=pr.top-2 && r.bottom<=pr.bottom+2;
+    });
+    const items=rows.filter(m=>m.classList.contains("mitem"));
+    if(!items.length) return;
+    // Rows are inset within the panel (the cell box reserves a border column);
+    // widen the ROWS to their content but grow the PANEL by that same inset on
+    // each side, so a widened row never spills past the panel's edge (which
+    // made the selection bar overhang the right border).
+    const inset=Math.max(0, Math.round(items[0].getBoundingClientRect().left - pr.left));
+    let content=0;
+    for(const m of items){
+      const w0=m.style.width;
+      m.style.width="max-content";
+      content=Math.max(content, Math.ceil(m.getBoundingClientRect().width));
+      m.style.width=w0;
+    }
+    if(content+inset*2<=Math.ceil(pr.width)) return;   // the cell box already fits
+    panel.style.width=(content+inset*2)+"px";
+    for(const m of rows) m.style.width=content+"px";
+  });
+}
+
 function menuDropdownEls(reg){
   const out=[];
   if(reg.menuOpen==null || !reg.dropdown) return out;

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -953,7 +953,16 @@ function widgetSurfaceEls(s){
   // A left dock's rightmost column is an editor resize border (dock_resizing);
   // give it an explicit grip since the .widget-surface is in onChrome.
   if(s.kind==="dock"){
-    el.appendChild(borderDragHandle(s.rect.x + s.rect.w - 1, s.rect.y, s.rect.h));
+    const grip=borderDragHandle(s.rect.x + s.rect.w - 1, s.rect.y, s.rect.h);
+    // A shell-inset dock's visual card is NARROWER than its logical cell rect
+    // (the bezel gap on the right). The grip is placed at the logical edge, so
+    // it would jut past the card and give the panel a phantom horizontal
+    // scroll region (an "empty" strip you can scroll to). Pin it to the card's
+    // own right edge instead; the drag still forwards the logical resize col.
+    if(!isMobile() && s.rect.x===0 && shellTheme()){
+      grip.style.left=(Math.max(140, px(s.rect.w,CW)-SHELL.side-SHELL.gap)-px(1,CW))+"px";
+    }
+    el.appendChild(grip);
     // Position the dock dropdowns after layout (offsetTop needs the panel in
     // the document) and arm outside-click dismissal.
     if(!isMobile()){

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -810,6 +810,67 @@ function contextMenuEl(cm){
   return el;
 }
 
+// Float the dock's toolbar dropdowns (New Task… / project filter / Move to
+// folder…) over the panel content instead of letting them reflow the session
+// list. Each `overlay()` widget is a flex child of the dock column; flexbox
+// would place an absolutely-positioned flex child at the column's TOP (its
+// static position is the flex start, not its in-flow spot), so we can't lean
+// on `top:auto`. Instead we pin each overlay to the top of the row that took
+// its place in flow — its next in-flow sibling's `offsetTop` — which is
+// exactly where the dropdown belongs: New-Task under its toolbar row, the
+// project menu under its button, Move-to-folder at the head of the tree.
+function layoutDockOverlays(surface){
+  const col=surface.querySelector(":scope > .w-col");
+  if(!col) return;
+  const overlays=[...col.querySelectorAll(":scope > .w-overlay")];
+  if(!overlays.length) return;
+  // Take every overlay OUT of flow first, so the rows below it collapse up to
+  // their true positions. Measuring `next.offsetTop` while the overlay is
+  // still in flow would read the row shoved down by the overlay's own height,
+  // dropping the menu far below where it belongs.
+  overlays.forEach(ov=>{
+    ov.style.position="absolute";
+    ov.style.left="0"; ov.style.right="0";
+    ov.style.margin="0"; ov.style.top="0";
+  });
+  // Now pin each to where it belongs. The New-Task create menu hangs off its
+  // button: its toolbar row also holds the search field (which wraps below
+  // the button on a narrow dock), so anchoring to the next sibling would drop
+  // a gap — the search field — between the button and its dropdown. Anchor it
+  // to the button's bottom instead. The project and Move-to-folder menus have
+  // no such split, so they pin to the top of the row that took their place in
+  // flow (project under its button, Move at the head of the session tree).
+  overlays.forEach(ov=>{
+    const prev=ov.previousElementSibling, next=ov.nextElementSibling;
+    let top;
+    if(prev && prev.classList.contains("w-row") && prev.classList.contains("wrap")){
+      const btn=prev.querySelector(".w-button");
+      top=btn ? btn.offsetTop+btn.offsetHeight : (next ? next.offsetTop : 0);
+    } else {
+      top=next ? next.offsetTop : 0;
+    }
+    ov.style.top=top+"px";
+  });
+}
+
+// Outside-click dismiss for the dock dropdowns. They carry no scrim (a dock
+// is not a modal), so without this a click outside the open menu leaves it
+// stranded. A press anywhere outside an open dock overlay sends Escape, which
+// the host translates to `dock_menu_cancel` while the menu owns the keyboard
+// (same dismissal the anchored context-menu scrim uses). Attached once.
+let dockOverlayDismissWired=false;
+function wireDockOverlayDismiss(){
+  if(dockOverlayDismissWired) return;
+  dockOverlayDismissWired=true;
+  document.addEventListener("mousedown",e=>{
+    const open=document.querySelector(".widget-surface.w-dock > .w-col > .w-overlay");
+    if(!open) return;
+    if(open.contains(e.target)) return; // a click on an option runs normally
+    e.preventDefault(); e.stopPropagation();
+    sendKey({key:"Escape"});
+  },true);
+}
+
 // A floating / dock plugin widget panel, rendered natively at its cell rect.
 // Returns [scrim?, panel]: a `floatingModal` is a blocking dialog, so it gets a
 // dimming `.modal-scrim` behind it (same pattern as the trust / settings /
@@ -885,7 +946,15 @@ function widgetSurfaceEls(s){
   el.appendChild(widgetEl(s.spec, ctx));
   // A left dock's rightmost column is an editor resize border (dock_resizing);
   // give it an explicit grip since the .widget-surface is in onChrome.
-  if(s.kind==="dock") el.appendChild(borderDragHandle(s.rect.x + s.rect.w - 1, s.rect.y, s.rect.h));
+  if(s.kind==="dock"){
+    el.appendChild(borderDragHandle(s.rect.x + s.rect.w - 1, s.rect.y, s.rect.h));
+    // Position the dock dropdowns after layout (offsetTop needs the panel in
+    // the document) and arm outside-click dismissal.
+    if(!isMobile()){
+      wireDockOverlayDismiss();
+      requestAnimationFrame(()=>layoutDockOverlays(el));
+    }
+  }
   out.push(el);
   return out;
 }

--- a/web-ui/js/65-widgets.js
+++ b/web-ui/js/65-widgets.js
@@ -855,9 +855,14 @@ function layoutDockOverlays(surface){
 
 // Outside-click dismiss for the dock dropdowns. They carry no scrim (a dock
 // is not a modal), so without this a click outside the open menu leaves it
-// stranded. A press anywhere outside an open dock overlay sends Escape, which
-// the host translates to `dock_menu_cancel` while the menu owns the keyboard
-// (same dismissal the anchored context-menu scrim uses). Attached once.
+// stranded. A press outside an open dock overlay sends Escape, which the host
+// translates to `dock_menu_cancel` while the menu owns the keyboard (same
+// dismissal the anchored context-menu scrim uses). Attached once.
+//
+// Clicks on a dock *button* (the "New Task… ▾" trigger, the project pill, …)
+// are LET THROUGH untouched: the plugin's own handler toggles/closes the menu
+// (clicking the open trigger must close it, not be swallowed here). Only
+// clicks on inert space — the tree, the editor, empty chrome — dismiss.
 let dockOverlayDismissWired=false;
 function wireDockOverlayDismiss(){
   if(dockOverlayDismissWired) return;
@@ -865,7 +870,8 @@ function wireDockOverlayDismiss(){
   document.addEventListener("mousedown",e=>{
     const open=document.querySelector(".widget-surface.w-dock > .w-col > .w-overlay");
     if(!open) return;
-    if(open.contains(e.target)) return; // a click on an option runs normally
+    if(open.contains(e.target)) return;                       // option click → runs normally
+    if(e.target.closest(".widget-surface.w-dock .w-button")) return; // trigger button → plugin toggles it
     e.preventDefault(); e.stopPropagation();
     sendKey({key:"Escape"});
   },true);

--- a/web-ui/test/drive.mjs
+++ b/web-ui/test/drive.mjs
@@ -281,6 +281,90 @@ await page.keyboard.press('End');
 for (let i = 0; i < 3; i++) await page.keyboard.press('Backspace');
 await page.keyboard.press('Escape'); await page.waitForTimeout(200);
 
+console.log('\n[dock chrome polish: no h-scroll, list fills, dropdowns float over content]');
+// Regression cover for the orchestrator-dock visual fixes: the dock never
+// raises a spurious horizontal scrollbar; the session tree fills the panel
+// (the TUI hint-padding rows are dropped in the web); and the toolbar
+// dropdowns float over the content (positioned by `layoutDockOverlays`)
+// instead of reflowing the list, with a full-width option highlight and an
+// outside-click dismiss.
+const dockOverlay = () => page.locator('.widget-surface.w-dock > .w-col > .w-overlay');
+const treeHeight = () => page.evaluate(() => {
+  const t = document.querySelector('.widget-surface.w-dock .w-tree');
+  return t ? Math.round(t.getBoundingClientRect().height) : -1;
+});
+
+// (1) No horizontal scrollbar: over-wide `pre` tree rows ellipsis-clip.
+const dockOverflowX = await page.evaluate(() =>
+  getComputedStyle(document.querySelector('.widget-surface.w-dock')).overflowX);
+check('dock never scrolls horizontally (overflow-x: hidden)', dockOverflowX === 'hidden', dockOverflowX);
+
+// (2) The session list fills the panel (no blank filler stealing the space).
+const fillRatio = await page.evaluate(() => {
+  const dock = document.querySelector('.widget-surface.w-dock');
+  const tree = document.querySelector('.widget-surface.w-dock .w-tree');
+  return tree ? tree.getBoundingClientRect().height / dock.getBoundingClientRect().height : 0;
+});
+check('session list fills the dock (tree ≥ 55% of dock height)', fillRatio >= 0.55, `ratio=${fillRatio.toFixed(2)}`);
+
+// (3) New Task… dropdown floats flush under its button (never on top of it),
+//     and its option highlight fills the row instead of hugging the text.
+await page.locator('.widget-surface.w-dock .w-button.primary', { hasText: 'New Task' }).first().click();
+await page.waitForFunction(() => !!document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay'),
+  { timeout: 8000 }).catch(() => {});
+const newInfo = await page.evaluate(() => {
+  const ov = document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay');
+  const btn = [...document.querySelectorAll('.widget-surface.w-dock .w-button.primary')]
+    .find(b => /New Task/.test(b.textContent));
+  if (!ov || !btn) return null;
+  const o = ov.getBoundingClientRect(), b = btn.getBoundingClientRect();
+  const opt = ov.querySelector('.w-button'), row = opt && opt.closest('.w-row');
+  return {
+    floats: getComputedStyle(ov).position === 'absolute',
+    belowButton: o.top >= b.bottom - 2,
+    optionFillsRow: !!row && opt.getBoundingClientRect().width >= row.getBoundingClientRect().width - 2,
+  };
+});
+check('New Task dropdown floats absolutely, flush below its button', !!newInfo && newInfo.floats && newInfo.belowButton, JSON.stringify(newInfo));
+check('dropdown option highlight fills the row (no half-width spacer)', !!newInfo && newInfo.optionFillsRow, JSON.stringify(newInfo));
+await page.keyboard.press('Escape');
+await page.waitForFunction(() => !document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay'),
+  { timeout: 8000 }).catch(() => {});
+
+// (4) Move to Folder… floats over the tree without reflowing it, and an
+//     outside click dismisses it (the dropdowns carry no scrim of their own).
+await page.locator('.widget-surface.w-dock .w-tree-row').first().click({ button: 'right' });
+await page.waitForFunction(() => (window.fresh.scene.regions.widgets || []).some(w => w.kind === 'floatingModal'),
+  { timeout: 8000 }).catch(() => {});
+const treeBeforeMove = await treeHeight();
+await page.locator('.widget-surface.w-floatingModal .w-button', { hasText: 'Move to Folder' }).first().click();
+await page.waitForFunction(() => !!document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay'),
+  { timeout: 8000 }).catch(() => {});
+const moveInfo = await page.evaluate(() => {
+  const ov = document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay');
+  const tree = document.querySelector('.widget-surface.w-dock .w-tree');
+  const div = document.querySelector('.widget-surface.w-dock .w-divider');
+  if (!ov) return null;
+  const ovTop = Math.round(ov.getBoundingClientRect().top);
+  // The menu is pinned to the divider at the head of the tree (a small
+  // divider gap sits above the first tree row); the pre-fix bug parked it at
+  // the panel top over the toolbar, which this catches.
+  return {
+    floats: getComputedStyle(ov).position === 'absolute',
+    atTreeHead: !!div && Math.abs(ovTop - Math.round(div.getBoundingClientRect().top)) <= 3
+      && (!tree || ovTop >= Math.round(tree.getBoundingClientRect().top) - 16),
+    treeH: tree ? Math.round(tree.getBoundingClientRect().height) : -1,
+  };
+});
+check('Move to Folder floats absolutely at the head of the tree', !!moveInfo && moveInfo.floats && moveInfo.atTreeHead, JSON.stringify(moveInfo));
+check('Move to Folder does not collapse the session list', !!moveInfo && moveInfo.treeH >= treeBeforeMove * 0.7, `tree ${treeBeforeMove} -> ${moveInfo && moveInfo.treeH}`);
+await page.screenshot({ path: `${SHOTS}/30-dock-move-dropdown.png` });
+await page.mouse.click(1000, 700); // click in the editor, outside the dock
+await page.waitForFunction(() => !document.querySelector('.widget-surface.w-dock > .w-col > .w-overlay'),
+  { timeout: 8000 }).catch(() => {});
+check('outside-click dismisses the Move to Folder dropdown', (await dockOverlay().count()) === 0);
+await page.keyboard.press('Escape'); await page.waitForTimeout(150);
+
 console.log('\n[keybinding editor = full native modal incl. edit dialog]');
 // Start clean: dismiss any focused dock/floating panel so keys reach the editor.
 await page.keyboard.press('Escape'); await page.waitForTimeout(120);


### PR DESCRIPTION
## Summary

Fixes the orchestrator dock's visual glitches — a flickering panel, spurious horizontal scroll, misplaced/unstyled dropdowns, and unstable session-list sizing — plus the underlying reason the dock (and the TUI card list) re-rendered constantly when nothing had changed.

Changes fall into two buckets: **frontend-only** web-UI chrome, and **shared plugin/serialization** logic that also affects the TUI (called out in its own section).

## Dock no longer re-renders when nothing changed

The dock repainted (a blinking scrollbar, and any in-progress scroll gesture dropped) roughly once a second even while idle. Three things made an unchanged dock look changed; all are now stable:

- **Deterministic serialization.** The scene's per-panel `instances` map is a `BTreeMap` (was a `HashMap`, which `serde_json` emits in randomized key order). The region-diff hashes serialized bytes to decide what to push, so a stable order means an unchanged panel hashes identically and emits no frame.
- **First-probe-only spinner.** The git pill shows its `…` loading glyph only on the genuinely first probe of a session. A path that isn't a git repo no longer re-blinks `…` on every re-probe.
- **Batched, rate-limited probe refreshes.** Background git/PR probes coalesce into one atomic dock repaint per wave (held until all probes settle) and cannot repaint more often than a fixed minimum interval. Interactive updates bypass this path and stay instant.

## Changes that also affect the TUI

These live in the shared `orchestrator.ts` plugin, which renders the session cards for **both** the TUI and the web UI:

- **Git summary is stable across a transient probe failure.** A failed `git status` poll (index lock, mid-checkout, …) keeps the last known summary instead of blanking the card's git segment — this is the "git info shows, hides, shows" instability that was visible in the TUI as well as the web.
- **Session age is shown at day granularity** (`today` / `1d` / `Nd`) instead of a per-second/minute counter that re-rendered the card on every tick.
- **Probe refreshes are batched and rate-limited**, reducing card-list churn in the TUI too.
- **The loading spinner is gated to the first probe** — same shared card-rendering path.

Covered by an e2e test (`crates/fresh-editor/tests/e2e/orchestrator_dock.rs`): the git summary survives a transient probe failure while a witness session keeps refreshing.

## Web-UI dock chrome (frontend-only)

- **No horizontal scrollbar or dead space.** The dock is `overflow-x:hidden` with ellipsis-clipped rows, and the resize grip no longer overhangs the shell-inset card (which had been triggering a phantom horizontal scroll into empty panel).
- **Session list fills the panel at a stable size.** The plugin's blank bottom-filler rows (a TUI cell-layout need) are dropped in the web, where the flex column already bottom-aligns the hint bar — so the list fills the dock and stops resizing unpredictably.
- **Dock dropdowns float correctly.** New Task, the project filter, and Move-to-folder are positioned by `layoutDockOverlays()` (a two-pass measure) at the row each belongs above, instead of collapsing to the flex origin and reflowing the tree. A second click on a trigger toggles it closed, and a click outside dismisses it.
- **New Task dropdown** anchors flush under its button (no gap, no search field between) and its option highlight fills the row.
- **Menubar dropdowns** align accelerators in a column by measuring the widest row's real (proportional) width (`fitMenuWidths`), match the workspace context-menu styling, and dismiss when the editor buffer is clicked.
- **Highlighting is hover-driven** across the dropdowns and context menu (no always-on first-row highlight).

### Menu styling per theme

- **Winamp:** dock dropdowns share the metal-window + beveled-plate look of the anchored context menu (green plate on the cursor row); the highlight no longer overhangs the panel's right edge.
- **Cosmos:** the anchored context menu shares the frosted card + borderless flat rows of the dock dropdowns.

## Files

- `crates/fresh-editor/plugins/orchestrator.ts` — git-summary preservation, day-granular age, first-probe spinner gate, batched + rate-limited probe refresh.
- `crates/fresh-editor/src/view/scene.rs` — `instances` → `BTreeMap` for stable serialization.
- `crates/fresh-editor/tests/e2e/orchestrator_dock.rs` — e2e coverage for the git-summary stability.
- `web-ui/css/{20-chrome,40-widgets,90-cosmos,95-theme-winamp}.css`, `web-ui/js/{20-cells,30-render,40-menu,65-widgets}.js` — dock chrome, overlay positioning, menu sizing/theming.
- `web-ui/test/drive.mjs` — coverage for the dock chrome fixes.

## Testing

Each "re-render when nothing changed" source was reproduced with a headless Chromium driver against `webui_server`, tapping the WebSocket: consecutive idle `regions.widgets` frames differed only in `instances` key order and the toggling `…` spinner beforehand, and stop entirely after the fixes. Dock chrome verified interactively across the Cosmos and Winamp themes; plugin behaviour covered by the e2e test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013JWA2bVNc8v6WUKZstmU2a)_