### PR TITLE
fix(input): decode modified F1–F4 (CSI 1;&lt;mod&gt; P/Q/R/S) — fixes Shift+F3 Find Previous (#699)

### DIFF
--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -376,6 +376,29 @@ impl InputParser {
             b'D' => out.push(key(KeyCode::Left, modifiers_of(&params))),
             b'H' => out.push(key(KeyCode::Home, modifiers_of(&params))),
             b'F' => out.push(key(KeyCode::End, modifiers_of(&params))),
+            // Modified F1–F4: xterm's SS3-derived form `CSI 1 ; <mod> {P,Q,R,S}`
+            // (e.g. Shift+F3 = `ESC [ 1 ; 2 R`). *Unmodified* F1–F4 arrive as
+            // SS3 (`ESC O P/Q/R/S`) and are decoded in `feed_ss3`; adding a
+            // modifier is what promotes the SS3 prefix to a CSI with a `1;<mod>`
+            // parameter, so only the modified variants land here. Without these
+            // arms every Shift/Ctrl/Alt + F1–F4 was silently dropped (#699:
+            // Shift+F3 "Find Previous" did nothing).
+            //
+            // The `1;<mod>` guard also separates these from a Cursor Position
+            // Report (`CSI <row> ; <col> R`). fresh never requests a host CPR on
+            // this input path — CPR only exists inside the integrated-terminal
+            // emulator — so a CPR can't legitimately arrive here; the guard is
+            // belt-and-suspenders that keeps a bare/foreign `CSI …R` from being
+            // misread as F3.
+            b'P' | b'Q' | b'R' | b'S' if is_modified_f1_f4(&params) => {
+                let code = match final_byte {
+                    b'P' => KeyCode::F(1),
+                    b'Q' => KeyCode::F(2),
+                    b'R' => KeyCode::F(3),
+                    _ => KeyCode::F(4), // b'S'
+                };
+                out.push(key(code, modifiers_of(&params)));
+            }
             b'~' => self.dispatch_tilde(&params, out),
             b'M' | b'm' => {
                 if params.first() == Some(&b'<') {
@@ -510,6 +533,28 @@ fn functional_or_char(codepoint: u32) -> Option<KeyCode> {
         127 => KeyCode::Backspace,
         cp => KeyCode::Char(char::from_u32(cp)?),
     })
+}
+
+/// True when a CSI parameter list has the modified-function-key shape
+/// `1 ; <mod>` that xterm uses for Shift/Ctrl/Alt + F1–F4
+/// (`CSI 1;<mod> {P,Q,R,S}`), with `<mod>` a real modifier value (2–16).
+///
+/// The leading `1` is the F1–F4 selector, not a coordinate, so this
+/// distinguishes those keys from a Cursor Position Report
+/// (`CSI <row>;<col> R`) and rejects the unmodified/`1;1` and bare `CSI R`
+/// forms (unmodified F1–F4 come through SS3, never here).
+fn is_modified_f1_f4(params: &[u8]) -> bool {
+    let s = std::str::from_utf8(params).unwrap_or("");
+    let mut fields = s.split(';');
+    if fields.next() != Some("1") {
+        return false;
+    }
+    matches!(
+        fields
+            .next()
+            .and_then(|f| first_subparam(f).parse::<u8>().ok()),
+        Some(2..=16)
+    )
 }
 
 /// Parse the modifier field (`…;mods`) of a standard CSI parameter list.

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -121,6 +121,74 @@ fn csi_modifiers_parsed() {
 }
 
 #[test]
+fn modified_f1_f4_csi_form() {
+    // Modified F1–F4 use xterm's SS3-derived CSI form `CSI 1 ; <mod> {P,Q,R,S}`.
+    // (#699: Shift+F3 was dropped, so "Find Previous" never fired.) Sequences
+    // below were captured from tmux via `cat -v`.
+    let mut p = InputParser::new();
+    // Shift+F3
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;2R")),
+        vec![(KeyCode::F(3), KeyModifiers::SHIFT)]
+    );
+    // Ctrl+F3
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;5R")),
+        vec![(KeyCode::F(3), KeyModifiers::CONTROL)]
+    );
+    // Alt+F3
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;3R")),
+        vec![(KeyCode::F(3), KeyModifiers::ALT)]
+    );
+    // Ctrl+Shift+F3
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;6R")),
+        vec![(KeyCode::F(3), KeyModifiers::SHIFT | KeyModifiers::CONTROL)]
+    );
+    // Shift+F1 / F2 / F4 (P/Q/S siblings)
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;2P")),
+        vec![(KeyCode::F(1), KeyModifiers::SHIFT)]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;2Q")),
+        vec![(KeyCode::F(2), KeyModifiers::SHIFT)]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;2S")),
+        vec![(KeyCode::F(4), KeyModifiers::SHIFT)]
+    );
+}
+
+#[test]
+fn unmodified_f1_f4_still_ss3() {
+    // Regression guard: unmodified F1–F4 must keep decoding via SS3
+    // (`ESC O P/Q/R/S`) and not be affected by the new CSI arms.
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1bOP")),
+        vec![(KeyCode::F(1), KeyModifiers::empty())]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1bOR")),
+        vec![(KeyCode::F(3), KeyModifiers::empty())]
+    );
+}
+
+#[test]
+fn bare_csi_r_is_not_f3() {
+    // A bare `CSI R` (and a `1;1R` / non-`1` first field) is *not* a modified
+    // F3 — it must not be misdecoded as a keypress. This is the Cursor
+    // Position Report shape; guarding on `1;<mod≥2>` keeps it out.
+    let mut p = InputParser::new();
+    assert!(keys(&p.parse(b"\x1b[R")).is_empty());
+    assert!(keys(&p.parse(b"\x1b[1;1R")).is_empty());
+    // A realistic CPR body `CSI <row>;<col> R` (row != 1) also stays out.
+    assert!(keys(&p.parse(b"\x1b[24;80R")).is_empty());
+}
+
+#[test]
 fn shift_tab_csi_z() {
     let mut p = InputParser::new();
     assert_eq!(


### PR DESCRIPTION
## Summary
Fixes #699 — Shift+F3 ("Find Previous") did nothing, while F3 ("Find Next") worked.

**Root cause:** `fresh-input-parser` decoded only *unmodified* F1–F4, via the SS3 form `ESC O P/Q/R/S`. Terminals send Shift/Ctrl/Alt + F1–F4 as the CSI form `CSI 1 ; <mod> {P,Q,R,S}` (e.g. Shift+F3 = `ESC [ 1 ; 2 R`). `dispatch_csi` had arms for `A/B/C/D/H/F/~/M/Z/I/O/u` but **none for `P/Q/R/S`**, so every modified F1–F4 fell through to "unknown CSI final, dropping." Since Shift+F3 is bound to `find_previous`, the keystroke never reached the editor.

## Fix
Add `P/Q/R/S` arms to `dispatch_csi`, mapping to F1–F4 with the existing `modifiers_of` decoding, gated on the `1;<mod>` function-key shape via a new `is_modified_f1_f4` helper.

The gate matters because **`CSI R` is also the Cursor Position Report** (`CSI <row>;<col> R`), so `CSI 1;2 R` is structurally ambiguous with a CPR at row 1. Two things keep this safe:
- fresh **never requests a host CPR on this input path** — CPR only exists inside the integrated-terminal *emulator* (fresh responding to child programs), which is a separate code path. So a CPR can't legitimately arrive at the keyboard parser.
- The `1;<mod≥2>` guard additionally rejects bare `CSI R`, `1;1R`, and realistic CPR bodies like `CSI 24;80R`, so none of those decode as a keypress.

Unmodified F1–F4 continue to decode via SS3 (unchanged).

## How it was researched
- **Spec:** xterm encodes modified F1–F4 as `CSI 1;<mod> {P,Q,R,S}`, `mod = 1 + shift + 2·alt + 4·ctrl` ([invisible-island ctlseqs](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)).
- **Empirical (tmux `cat -v`):** `F3=ESC O R`, `Shift+F3=ESC[1;2R`, `Ctrl+F3=ESC[1;5R`, `Alt+F3=ESC[1;3R`, `Ctrl+Shift+F3=ESC[1;6R`, `Shift+F1=ESC[1;2P`.
- **Cross-editor:** `micro` in the same tmux consumes `ESC[1;2R`/`ESC[1;5R` as key events (no text inserted), confirming the sequences are real, decodable keys that fresh was dropping.
- Mirrors crossterm's mapping of `P/Q/R/S → F1–F4`, keeping fresh's emitted events consistent with the rest of its keybinding layer.

## Test plan
- [x] `cargo test -p fresh-input-parser` — 59 passed (incl. 3 new tests: modified F1–F4 across Shift/Ctrl/Alt/Ctrl+Shift; SS3-unmodified regression guard; bare/CPR-shaped `CSI …R` stays a non-key)
- [x] `cargo fmt --check -p fresh-input-parser`, `cargo clippy -p fresh-input-parser` — clean
- [x] Manual, in tmux: open a file, `Ctrl+F` "hello", **F3** steps forward (Match 1→2→3), **Shift+F3** now steps **backward** (Match 4→3→2→1). Previously Shift+F3 was a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEtazAT4WRhYR1GMMLpzoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEtazAT4WRhYR1GMMLpzoZ)_