### PR TITLE
Fix Escape being swallowed until the next key press on Unix

### DIFF
--- a/crates/fresh-editor/src/services/tty_input.rs
+++ b/crates/fresh-editor/src/services/tty_input.rs
@@ -31,6 +31,12 @@ use std::time::Duration;
 use crossterm::event::{Event as CrosstermEvent, MouseEventKind};
 use fresh_input_parser::InputParser;
 
+/// How long a buffered lone `ESC` waits for a continuation before being
+/// reported as the Escape key. Terminals emit a sequence in one write, so the
+/// continuation (if any) is already queued; this only has to cover a read
+/// landing mid-sequence, and must stay well below human key-repeat latency.
+const ESC_GRACE: Duration = Duration::from_millis(15);
+
 /// Set to true by the `SIGWINCH` handler; consumed by [`TtyReader::take_resize`].
 static SIGWINCH_PENDING: AtomicBool = AtomicBool::new(false);
 
@@ -120,7 +126,24 @@ impl TtyReader {
     /// parser. The caller must have observed the fd readable; because stdin is
     /// in raw mode with at least one byte available, the `read` returns
     /// promptly without blocking.
+    ///
+    /// A lone trailing `ESC` is ambiguous — the Escape key, or the head of a
+    /// sequence split across reads — so it is held back until either the rest
+    /// arrives within [`ESC_GRACE`] or the grace window expires, at which point
+    /// it is flushed as an Escape key press.
     pub fn drain_stdin(&mut self) {
+        while self.read_once() {
+            if !self.parser.escape_pending() || !poll_readable(self.stdin_fd, ESC_GRACE) {
+                break;
+            }
+        }
+        for ev in self.parser.flush() {
+            self.push_coalesced(ev);
+        }
+    }
+
+    /// One `read()` + parse pass. Returns whether any bytes were read.
+    fn read_once(&mut self) -> bool {
         let mut buf = [0u8; 4096];
         // SAFETY: reading into a stack buffer we own, length-bounded.
         let n = unsafe {
@@ -130,12 +153,14 @@ impl TtyReader {
                 buf.len(),
             )
         };
-        if n > 0 {
-            let events = self.parser.parse(&buf[..n as usize]);
-            for ev in events {
-                self.push_coalesced(ev);
-            }
+        if n <= 0 {
+            return false;
         }
+        let events = self.parser.parse(&buf[..n as usize]);
+        for ev in events {
+            self.push_coalesced(ev);
+        }
+        true
     }
 
     /// Queue an event, collapsing a run of mouse-move events down to the latest

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -111,15 +111,42 @@ impl InputParser {
     ///
     /// Partial sequences are retained across calls, so splitting a sequence
     /// across chunks at any byte boundary yields the same events as delivering
-    /// it whole. Calling with an empty slice is a no-op (it never flushes a
-    /// buffered `ESC` as a standalone Escape — that only happens once the next
-    /// byte disambiguates it), matching the previous parser's contract.
+    /// it whole. Calling with an empty slice is a no-op; a buffered `ESC` is
+    /// only resolved by the next byte or by an explicit [`InputParser::flush`].
     pub fn parse(&mut self, bytes: &[u8]) -> Vec<Event> {
         let mut events = Vec::new();
         for &byte in bytes {
             self.feed(byte, &mut events);
         }
         events
+    }
+
+    /// True while a lone `ESC` is buffered, waiting for the next byte to say
+    /// whether it was the Escape key or the head of an escape sequence.
+    ///
+    /// A caller reading from a live tty uses this to decide when to
+    /// [`flush`](InputParser::flush): a standalone Escape has no continuation,
+    /// so once no more input arrives the ambiguity resolves to the key press.
+    pub fn escape_pending(&self) -> bool {
+        self.state == State::Escape
+    }
+
+    /// Resolve a buffered lone `ESC` as a standalone Escape key press.
+    ///
+    /// Returns the `Esc` key event (and returns to ground) when
+    /// [`escape_pending`](InputParser::escape_pending) is true; empty
+    /// otherwise. Only the `Escape` state is flushable — a partial CSI or
+    /// UTF-8 sequence keeps waiting, since its bytes must never surface as
+    /// literal keystrokes.
+    pub fn flush(&mut self) -> Vec<Event> {
+        if !self.escape_pending() {
+            return Vec::new();
+        }
+        self.state = State::Ground;
+        vec![Event::Key(KeyEvent::new(
+            KeyCode::Esc,
+            KeyModifiers::empty(),
+        ))]
     }
 
     /// Process a single byte, appending any completed events to `out`.

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -319,6 +319,35 @@ fn esc_waits_for_next_byte() {
 }
 
 #[test]
+fn flush_emits_standalone_esc() {
+    let mut p = InputParser::new();
+    assert!(p.parse(&[0x1b]).is_empty());
+    assert!(p.escape_pending());
+    assert_eq!(
+        keys(&p.flush()),
+        vec![(KeyCode::Esc, KeyModifiers::empty())]
+    );
+    // Flushed once: the ESC is gone, and a following key stands alone.
+    assert!(!p.escape_pending());
+    assert!(p.flush().is_empty());
+    assert_eq!(
+        keys(&p.parse(b"a")),
+        vec![(KeyCode::Char('a'), KeyModifiers::empty())]
+    );
+}
+
+#[test]
+fn flush_never_breaks_up_a_partial_sequence() {
+    // Mid-CSI and mid-UTF-8 bytes must keep waiting, never surface as keys.
+    for partial in [&b"\x1b[<35;67"[..], &b"\x1b[1;5"[..], &[0xe2, 0x82][..]] {
+        let mut p = InputParser::new();
+        p.parse(partial);
+        assert!(!p.escape_pending(), "{partial:02x?} is not a lone ESC");
+        assert!(p.flush().is_empty(), "flush emitted from {partial:02x?}");
+    }
+}
+
+#[test]
 fn esc_then_mouse_same_chunk() {
     let mut p = InputParser::new();
     let ev = p.parse(b"\x1b\x1b[<35;67;18M");


### PR DESCRIPTION
## Problem

Regression from #2745 (`64933d0`). Pressing <kbd>Esc</kbd> in the TUI does nothing — the command palette stays open — and the *next* key press is eaten too, with input behaving oddly until a few more characters are typed.

That commit moved standalone Unix host input off crossterm's parser and onto `InputParser`. The state machine parks a lone `ESC` in the `Escape` state until the next byte says whether it was the Escape key, a CSI/SS3 sequence, or Alt+key. Correct for a byte stream; wrong for a live tty, where nothing else was going to resolve it: the Escape emits no event, and the next key press gets consumed as the disambiguator and reported as Alt+key.

## Fix

- `InputParser::escape_pending()` / `InputParser::flush()` — an explicit resolution point that turns a buffered lone `ESC` into an `Esc` key event. Only the `Escape` state is flushable; a partial CSI or UTF-8 sequence keeps waiting, so the #2745 invariant (control-sequence bytes never surface as literal keys) is untouched.
- `TtyReader::drain_stdin` resolves it against the fd: with an ESC pending it polls once more for a continuation (a `read()` can land mid-sequence), and flushes the Escape key press if none arrives within a 15ms grace.

## Tests

Two parser tests: flush emits a standalone `Esc` exactly once, and flush never breaks up a partial CSI/UTF-8 sequence. `cargo nextest run -p fresh-input-parser`: 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)