### PR TITLE
Document the terminal input parser and close its xterm/kitty protocol gaps

### DIFF
--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -37,7 +37,7 @@
 //! [williams]: https://vt100.net/emu/dec_ansi_parser
 
 use crossterm::event::{
-    Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
 
 /// Bracketed-paste end marker.
@@ -45,9 +45,15 @@ const PASTE_END: &[u8] = b"\x1b[201~";
 
 /// Upper bound on the parameter/intermediate bytes buffered for a single CSI
 /// sequence. Real sequences are far shorter; anything longer is treated as a
-/// runaway/malformed sequence and dropped. Bracketed-paste *content* is not
-/// subject to this — it accumulates separately and is unbounded.
+/// runaway/malformed sequence and dropped.
 const MAX_CSI_PARAMS: usize = 128;
+
+/// Upper bound on buffered bracketed-paste content. A paste-start (`ESC [ 200 ~`)
+/// whose terminator never arrives would otherwise grow memory without limit and
+/// swallow every subsequent keystroke. On reaching this bound the accumulated
+/// content is emitted as a `Paste` event and the parser resyncs to ground. The
+/// bound is far above any realistic interactive paste.
+const MAX_PASTE: usize = 4 * 1024 * 1024;
 
 /// The parser's current state. Mirrors the relevant sub-states of the DEC/ANSI
 /// state machine; printable/UTF-8 handling lives in `Ground`/`Utf8`.
@@ -70,11 +76,17 @@ enum State {
     /// Collecting the three raw coordinate bytes of an X10 mouse report.
     X10 { buf: [u8; 3], have: u8 },
     /// Accumulating a multi-byte UTF-8 character in `self.buffer`; `width` is
-    /// the total expected length.
-    Utf8 { width: u8 },
+    /// the total expected length. `alt` records that the character was
+    /// introduced by an `ESC` prefix (Alt + the character).
+    Utf8 { width: u8, alt: bool },
     /// Inside a bracketed paste (`ESC [ 200 ~` … `ESC [ 201 ~`); content
     /// accumulates in `self.paste`.
     Paste,
+    /// Inside a string-type control sequence — DCS (`ESC P`), OSC (`ESC ]`),
+    /// APC (`ESC _`), PM (`ESC ^`) or SOS (`ESC X`). Content is discarded until
+    /// the terminator: `ST` (`ESC \`) or a legacy `BEL`. `saw_esc` records that
+    /// the previous byte was an `ESC`, so the next byte can complete an `ST`.
+    StringSeq { saw_esc: bool },
 }
 
 /// Incremental terminal-input parser.
@@ -183,8 +195,17 @@ impl InputParser {
                         continue;
                     }
                 }
-                State::Utf8 { .. } => self.feed_utf8(byte, out),
+                State::Utf8 { .. } => {
+                    if !self.feed_utf8(byte, out) {
+                        continue;
+                    }
+                }
                 State::Paste => self.feed_paste(byte, out),
+                State::StringSeq { saw_esc } => {
+                    if !self.feed_string(byte, saw_esc) {
+                        continue;
+                    }
+                }
             }
             break;
         }
@@ -200,7 +221,16 @@ impl InputParser {
                 self.buffer.push(b);
                 self.state = State::Utf8 {
                     width: utf8_char_width(b) as u8,
+                    alt: false,
                 };
+            }
+            // C1 controls, stray UTF-8 continuation bytes (0x80–0xBF), and
+            // bytes that cannot begin a valid UTF-8 sequence (0xC0/0xC1,
+            // 0xF5–0xFF) are noise on a UTF-8 input stream: discard them rather
+            // than surfacing a `Null` key. (In particular this declines to
+            // treat 0x9B as an 8-bit CSI, which is correct under UTF-8.)
+            b if b >= 0x80 => {
+                tracing::trace!("InputParser: discarding stray high byte {:#04x}", b);
             }
             b => out.push(byte_to_event(b)),
         }
@@ -215,12 +245,33 @@ impl InputParser {
                 self.state = State::Csi;
             }
             b'O' => self.state = State::Ss3,
+            // String-type introducers: DCS (`P`), OSC (`]`), APC (`_`),
+            // PM (`^`), SOS (`X`). These open a string whose content is
+            // discarded until `ST`/`BEL`; without this arm the introducer and
+            // its whole payload leaked out as `Alt+<introducer>` plus literal
+            // characters (e.g. an OSC 52 clipboard or OSC 10/11 colour reply).
+            b'P' | b']' | b'_' | b'^' | b'X' => {
+                self.state = State::StringSeq { saw_esc: false };
+            }
             0x1b => {
                 // First ESC was standalone; stay in Escape for the second one.
                 out.push(Event::Key(KeyEvent::new(
                     KeyCode::Esc,
                     KeyModifiers::empty(),
                 )));
+            }
+            other if is_utf8_start_byte(other) => {
+                // Alt + a multi-byte character: route the lead byte into the
+                // UTF-8 collector with the Alt modifier pending, instead of
+                // mangling it through `byte_to_keycode` (which only handles
+                // ASCII and would report Alt+Null). e.g. Alt+é arrives as
+                // `ESC 0xC3 0xA9` and must decode to Alt+'é'.
+                self.buffer.clear();
+                self.buffer.push(other);
+                self.state = State::Utf8 {
+                    width: utf8_char_width(other) as u8,
+                    alt: true,
+                };
             }
             other => {
                 // Alt + key.
@@ -299,6 +350,19 @@ impl InputParser {
             b'D' => Some(KeyCode::Left),
             b'H' => Some(KeyCode::Home),
             b'F' => Some(KeyCode::End),
+            // Application-keypad forms (DECPAM). Without these the numeric
+            // keypad went silent whenever application keypad mode was active.
+            b'M' => Some(KeyCode::Enter),       // keypad Enter
+            b'E' => Some(KeyCode::KeypadBegin), // keypad Begin (the "5" key)
+            b'X' => Some(KeyCode::Char('=')),   // keypad Equal
+            b'j' => Some(KeyCode::Char('*')),   // keypad Multiply
+            b'k' => Some(KeyCode::Char('+')),   // keypad Add
+            b'l' => Some(KeyCode::Char(',')),   // keypad Separator
+            b'm' => Some(KeyCode::Char('-')),   // keypad Subtract
+            b'n' => Some(KeyCode::Char('.')),   // keypad Decimal
+            b'o' => Some(KeyCode::Char('/')),   // keypad Divide
+            // Keypad digits 0–9 (`ESC O p` … `ESC O y`).
+            b'p'..=b'y' => Some(KeyCode::Char((b'0' + (byte - b'p')) as char)),
             _ => None,
         };
         if let Some(code) = keycode {
@@ -339,49 +403,97 @@ impl InputParser {
     }
 
     /// `Utf8` state: accumulate the remaining bytes of a multi-byte character.
-    fn feed_utf8(&mut self, byte: u8, out: &mut Vec<Event>) {
-        self.buffer.push(byte);
-        let width = match self.state {
-            State::Utf8 { width } => width as usize,
+    /// Returns `false` if `byte` must be reprocessed from ground.
+    fn feed_utf8(&mut self, byte: u8, out: &mut Vec<Event>) -> bool {
+        let (width, alt) = match self.state {
+            State::Utf8 { width, alt } => (width as usize, alt),
             _ => unreachable!("feed_utf8 called outside Utf8 state"),
         };
+        // Eager validation: every byte after the lead must be a UTF-8
+        // continuation byte (0x80–0xBF). If it isn't, the character was
+        // truncated — drop the partial character (it is noise, never a control
+        // sequence) and reprocess this byte from ground (the X10 validity-floor
+        // pattern), so an `ESC` landing mid-character starts a clean sequence
+        // instead of being buffered and only noticed at decode time.
+        if !(0x80..=0xbf).contains(&byte) {
+            self.buffer.clear();
+            self.state = State::Ground;
+            return false;
+        }
+        self.buffer.push(byte);
         if self.buffer.len() < width {
-            return;
+            return true;
         }
         // We have `width` bytes; decode them.
+        let modifiers = if alt {
+            KeyModifiers::ALT
+        } else {
+            KeyModifiers::empty()
+        };
         match std::str::from_utf8(&self.buffer) {
             Ok(s) => {
                 if let Some(c) = s.chars().next() {
-                    out.push(Event::Key(KeyEvent::new(
-                        KeyCode::Char(c),
-                        KeyModifiers::empty(),
-                    )));
+                    out.push(Event::Key(KeyEvent::new(KeyCode::Char(c), modifiers)));
                 }
-                self.buffer.clear();
-                self.state = State::Ground;
             }
             Err(_) => {
-                // Invalid sequence: emit the lead byte as-is (genuine input,
-                // not a control sequence, so recovering it as a key is correct)
-                // and reprocess the remaining bytes from ground.
-                let rest: Vec<u8> = self.buffer.split_off(1);
-                let lead = self.buffer[0];
-                self.buffer.clear();
-                self.state = State::Ground;
-                out.push(byte_to_event(lead));
-                for b in rest {
-                    self.feed(b, out);
-                }
+                // Width reached but still invalid (e.g. an overlong or
+                // out-of-range encoding): drop the lead byte's worth and emit
+                // nothing rather than a bogus key.
+                tracing::trace!("InputParser: invalid UTF-8 sequence, dropping");
             }
+        }
+        self.buffer.clear();
+        self.state = State::Ground;
+        true
+    }
+
+    /// `StringSeq` state: discard the body of a DCS/OSC/APC/PM/SOS string until
+    /// its terminator. Returns `false` if `byte` must be reprocessed from
+    /// ground (an `ESC` that turned out to start a fresh sequence, not `ST`).
+    fn feed_string(&mut self, byte: u8, saw_esc: bool) -> bool {
+        if saw_esc {
+            if byte == b'\\' {
+                // `ST` (ESC \): string complete, discard it.
+                self.state = State::Ground;
+                true
+            } else {
+                // The `ESC` was not part of an `ST`: it begins a new escape
+                // sequence. Resync through the Escape state, reprocessing this
+                // byte as the disambiguator.
+                self.state = State::Escape;
+                false
+            }
+        } else {
+            match byte {
+                0x07 => self.state = State::Ground, // BEL: legacy OSC terminator
+                0x1b => self.state = State::StringSeq { saw_esc: true },
+                _ => {} // discard content byte
+            }
+            true
         }
     }
 
     /// `Paste` state: accumulate content until the end marker.
     fn feed_paste(&mut self, byte: u8, out: &mut Vec<Event>) {
         self.paste.push(byte);
-        if self.paste.ends_with(PASTE_END) {
+        // Only the end marker's final byte (`~`) can complete the paste, so
+        // guard the `ends_with` scan on it — otherwise every byte of a large
+        // paste pays for a full marker comparison.
+        if byte == b'~' && self.paste.ends_with(PASTE_END) {
             let content_len = self.paste.len() - PASTE_END.len();
-            let text = String::from_utf8_lossy(&self.paste[..content_len]).into_owned();
+            let text = sanitize_paste(&self.paste[..content_len]);
+            self.paste.clear();
+            self.state = State::Ground;
+            out.push(Event::Paste(text));
+            return;
+        }
+        if self.paste.len() >= MAX_PASTE {
+            // Unterminated/oversized paste: emit what we have and resync to
+            // ground, so the buffer is bounded and later keystrokes are not
+            // swallowed indefinitely.
+            tracing::trace!("InputParser: paste exceeded {} bytes, flushing", MAX_PASTE);
+            let text = sanitize_paste(&self.paste);
             self.paste.clear();
             self.state = State::Ground;
             out.push(Event::Paste(text));
@@ -396,6 +508,19 @@ impl InputParser {
         let params = std::mem::take(&mut self.buffer);
         self.state = State::Ground;
 
+        // A parameter list introduced by `?` or `>` is a device reply — a kitty
+        // keyboard-flags report (`CSI ? <flags> u`), a Device Attributes
+        // response, and so on — never a key press. Discard it before dispatch
+        // rather than misdecoding it (the flags reply used to surface as a NUL
+        // key). `<` is the SGR mouse introducer and is handled in the match.
+        if matches!(params.first(), Some(b'?') | Some(b'>')) {
+            tracing::trace!(
+                "InputParser: discarding CSI reply, final {:#04x}",
+                final_byte
+            );
+            return;
+        }
+
         match final_byte {
             b'A' => out.push(key(KeyCode::Up, modifiers_of(&params))),
             b'B' => out.push(key(KeyCode::Down, modifiers_of(&params))),
@@ -403,6 +528,8 @@ impl InputParser {
             b'D' => out.push(key(KeyCode::Left, modifiers_of(&params))),
             b'H' => out.push(key(KeyCode::Home, modifiers_of(&params))),
             b'F' => out.push(key(KeyCode::End, modifiers_of(&params))),
+            // Keypad Begin (the center "5" key), `CSI E` / `CSI 1;<mod> E`.
+            b'E' => out.push(key(KeyCode::KeypadBegin, modifiers_of(&params))),
             // Modified F1–F4: xterm's SS3-derived form `CSI 1 ; <mod> {P,Q,R,S}`
             // (e.g. Shift+F3 = `ESC [ 1 ; 2 R`). *Unmodified* F1–F4 arrive as
             // SS3 (`ESC O P/Q/R/S`) and are decoded in `feed_ss3`; adding a
@@ -461,7 +588,7 @@ impl InputParser {
 
         // xterm modifyOtherKeys mode 2: CSI 27 ; modifier ; keycode ~
         if parts.len() == 3 && parts[0] == "27" {
-            let mods_param: u8 = first_subparam(parts[1]).parse().unwrap_or(1);
+            let mods_param: u16 = first_subparam(parts[1]).parse().unwrap_or(1);
             let codepoint: u32 = first_subparam(parts[2]).parse().unwrap_or(0);
             let modifiers = modifiers_from_param(mods_param);
             if let Some(code) = functional_or_char(codepoint) {
@@ -471,7 +598,10 @@ impl InputParser {
         }
 
         let num: u8 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
-        let mods = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(1);
+        let mods = parts
+            .get(1)
+            .and_then(|s| first_subparam(s).parse().ok())
+            .unwrap_or(1);
         let modifiers = modifiers_from_param(mods);
 
         // Bracketed paste start.
@@ -526,14 +656,31 @@ impl InputParser {
             .first()
             .and_then(|s| first_subparam(s).parse().ok())
             .unwrap_or(0);
-        let mods_param: u8 = parts
-            .get(1)
-            .and_then(|s| first_subparam(s).parse().ok())
-            .unwrap_or(1);
+        let mods_field = parts.get(1).copied().unwrap_or("");
+        let mods_param: u16 = first_subparam(mods_field).parse().unwrap_or(1);
         let modifiers = modifiers_from_param(mods_param);
+        // The modifier field may carry an event-type sub-parameter
+        // (`mods:event-type`): 1=press, 2=repeat, 3=release. Preserve it as the
+        // key event's kind so a release is not reported as a fresh press (which
+        // would fire every keystroke twice once event-type reporting is on).
+        let kind = event_kind_of(mods_field);
         if let Some(code) = functional_or_char(codepoint) {
-            out.push(Event::Key(KeyEvent::new(code, modifiers)));
+            out.push(Event::Key(KeyEvent::new_with_kind(code, modifiers, kind)));
         }
+    }
+}
+
+/// The event type encoded in the second sub-parameter of a kitty modifier field
+/// (`mods:event-type`): 1=press (default), 2=repeat, 3=release.
+fn event_kind_of(mods_field: &str) -> KeyEventKind {
+    match mods_field
+        .split(':')
+        .nth(1)
+        .and_then(|s| s.parse::<u8>().ok())
+    {
+        Some(2) => KeyEventKind::Repeat,
+        Some(3) => KeyEventKind::Release,
+        _ => KeyEventKind::Press,
     }
 }
 
@@ -552,19 +699,99 @@ fn first_subparam(field: &str) -> &str {
 }
 
 /// Map a Unicode codepoint from CSI-u / modifyOtherKeys to a key code.
+///
+/// The kitty keyboard protocol maps every non-printable key into the Unicode
+/// Private Use Area (U+E000–U+F8FF). Those codepoints must never become
+/// `Char` keys — that would insert an invisible PUA glyph into the buffer — so
+/// the PUA range is resolved through [`kitty_functional_key`], which maps the
+/// keys it knows and drops (returns `None` for) any other PUA codepoint.
 fn functional_or_char(codepoint: u32) -> Option<KeyCode> {
     Some(match codepoint {
         9 => KeyCode::Tab,
         13 => KeyCode::Enter,
         27 => KeyCode::Esc,
         127 => KeyCode::Backspace,
+        // Private Use Area: kitty functional keys, never printable characters.
+        0xe000..=0xf8ff => return kitty_functional_key(codepoint),
         cp => KeyCode::Char(char::from_u32(cp)?),
+    })
+}
+
+/// Map a kitty keyboard-protocol functional key (encoded as a Private Use Area
+/// codepoint) to a crossterm [`KeyCode`]. Returns `None` for PUA codepoints the
+/// protocol does not assign, so they are dropped rather than inserted as text.
+fn kitty_functional_key(cp: u32) -> Option<KeyCode> {
+    use crossterm::event::{MediaKeyCode as M, ModifierKeyCode as Mod};
+    Some(match cp {
+        57358 => KeyCode::CapsLock,
+        57359 => KeyCode::ScrollLock,
+        57360 => KeyCode::NumLock,
+        57361 => KeyCode::PrintScreen,
+        57362 => KeyCode::Pause,
+        57363 => KeyCode::Menu,
+        // F13–F35.
+        57376..=57398 => KeyCode::F(13 + (cp - 57376) as u8),
+        // Keypad digits 0–9.
+        57399..=57408 => KeyCode::Char((b'0' + (cp - 57399) as u8) as char),
+        57409 => KeyCode::Char('.'), // KP_DECIMAL
+        57410 => KeyCode::Char('/'), // KP_DIVIDE
+        57411 => KeyCode::Char('*'), // KP_MULTIPLY
+        57412 => KeyCode::Char('-'), // KP_SUBTRACT
+        57413 => KeyCode::Char('+'), // KP_ADD
+        57414 => KeyCode::Enter,     // KP_ENTER
+        57415 => KeyCode::Char('='), // KP_EQUAL
+        57416 => KeyCode::Char(','), // KP_SEPARATOR
+        57417 => KeyCode::Left,      // KP_LEFT
+        57418 => KeyCode::Right,     // KP_RIGHT
+        57419 => KeyCode::Up,        // KP_UP
+        57420 => KeyCode::Down,      // KP_DOWN
+        57421 => KeyCode::PageUp,    // KP_PAGE_UP
+        57422 => KeyCode::PageDown,  // KP_PAGE_DOWN
+        57423 => KeyCode::Home,      // KP_HOME
+        57424 => KeyCode::End,       // KP_END
+        57425 => KeyCode::Insert,    // KP_INSERT
+        57426 => KeyCode::Delete,    // KP_DELETE
+        57427 => KeyCode::KeypadBegin,
+        // Media keys.
+        57428 => KeyCode::Media(M::Play),
+        57429 => KeyCode::Media(M::Pause),
+        57430 => KeyCode::Media(M::PlayPause),
+        57431 => KeyCode::Media(M::Reverse),
+        57432 => KeyCode::Media(M::Stop),
+        57433 => KeyCode::Media(M::FastForward),
+        57434 => KeyCode::Media(M::Rewind),
+        57435 => KeyCode::Media(M::TrackNext),
+        57436 => KeyCode::Media(M::TrackPrevious),
+        57437 => KeyCode::Media(M::Record),
+        57438 => KeyCode::Media(M::LowerVolume),
+        57439 => KeyCode::Media(M::RaiseVolume),
+        57440 => KeyCode::Media(M::MuteVolume),
+        // Standalone modifier keys.
+        57441 => KeyCode::Modifier(Mod::LeftShift),
+        57442 => KeyCode::Modifier(Mod::LeftControl),
+        57443 => KeyCode::Modifier(Mod::LeftAlt),
+        57444 => KeyCode::Modifier(Mod::LeftSuper),
+        57445 => KeyCode::Modifier(Mod::LeftHyper),
+        57446 => KeyCode::Modifier(Mod::LeftMeta),
+        57447 => KeyCode::Modifier(Mod::RightShift),
+        57448 => KeyCode::Modifier(Mod::RightControl),
+        57449 => KeyCode::Modifier(Mod::RightAlt),
+        57450 => KeyCode::Modifier(Mod::RightSuper),
+        57451 => KeyCode::Modifier(Mod::RightHyper),
+        57452 => KeyCode::Modifier(Mod::RightMeta),
+        57453 => KeyCode::Modifier(Mod::IsoLevel3Shift),
+        57454 => KeyCode::Modifier(Mod::IsoLevel5Shift),
+        _ => return None,
     })
 }
 
 /// True when a CSI parameter list has the modified-function-key shape
 /// `1 ; <mod>` that xterm uses for Shift/Ctrl/Alt + F1–F4
-/// (`CSI 1;<mod> {P,Q,R,S}`), with `<mod>` a real modifier value (2–16).
+/// (`CSI 1;<mod> {P,Q,R,S}`), with `<mod>` a real modifier value (2–64).
+///
+/// The upper bound covers every combination of the six modifiers
+/// (Shift/Alt/Ctrl/Super/Hyper/Meta → bitmask up to 63, parameter up to 64);
+/// the previous cap of 16 dropped anything involving Hyper or Meta.
 ///
 /// The leading `1` is the F1–F4 selector, not a coordinate, so this
 /// distinguishes those keys from a Cursor Position Report
@@ -579,8 +806,8 @@ fn is_modified_f1_f4(params: &[u8]) -> bool {
     matches!(
         fields
             .next()
-            .and_then(|f| first_subparam(f).parse::<u8>().ok()),
-        Some(2..=16)
+            .and_then(|f| first_subparam(f).parse::<u16>().ok()),
+        Some(2..=64)
     )
 }
 
@@ -588,7 +815,7 @@ fn is_modified_f1_f4(params: &[u8]) -> bool {
 fn modifiers_of(params: &[u8]) -> KeyModifiers {
     let params_str = std::str::from_utf8(params).unwrap_or("");
     if let Some(idx) = params_str.find(';') {
-        if let Ok(mods) = first_subparam(&params_str[idx + 1..]).parse::<u8>() {
+        if let Ok(mods) = first_subparam(&params_str[idx + 1..]).parse::<u16>() {
             return modifiers_from_param(mods);
         }
     }
@@ -601,7 +828,11 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
     // Skip the leading '<'.
     let params_str = std::str::from_utf8(params.get(1..)?).ok()?;
     let parts: Vec<&str> = params_str.split(';').collect();
-    if parts.len() != 3 {
+    // The grammar is `Cb ; Cx ; Cy`, but some emulators append a trailing
+    // separator before the terminator (`Cb ; Cx ; Cy ;`), which splits into a
+    // trailing empty field. Accept three-or-more fields and read the first
+    // three; fewer than three is genuinely malformed.
+    if parts.len() < 3 {
         return None;
     }
     let cb: u16 = parts[0].parse().unwrap_or(0);
@@ -613,7 +844,7 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
         0 => MouseButton::Left,
         1 => MouseButton::Middle,
         2 => MouseButton::Right,
-        _ => MouseButton::Left, // 3 = no button (motion)
+        _ => MouseButton::Left, // 3 = no button; never used as a real button
     };
 
     let modifiers = KeyModifiers::from_bits_truncate(
@@ -632,24 +863,22 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
         },
     );
 
-    let kind = if cb & 32 != 0 {
-        if cb & 64 != 0 {
-            if cb & 1 != 0 {
-                MouseEventKind::ScrollDown
-            } else {
-                MouseEventKind::ScrollUp
-            }
-        } else if button_bits == 3 {
-            MouseEventKind::Moved
-        } else {
-            MouseEventKind::Drag(button)
-        }
-    } else if cb & 64 != 0 {
+    let kind = if cb & 64 != 0 {
+        // Wheel: low bit selects up/down.
         if cb & 1 != 0 {
             MouseEventKind::ScrollDown
         } else {
             MouseEventKind::ScrollUp
         }
+    } else if button_bits == 3 {
+        // No button pressed. This is always motion, never a button event —
+        // even with an `M` terminator and no motion bit, which is how
+        // JediTerm-based emulators (that strip the motion bit) report free
+        // mouse movement. Reading it as a left click produced a click flood on
+        // every mouse move.
+        MouseEventKind::Moved
+    } else if cb & 32 != 0 {
+        MouseEventKind::Drag(button)
     } else if pressed {
         MouseEventKind::Down(button)
     } else {
@@ -683,10 +912,23 @@ fn x10_mouse_event(buf: [u8; 3]) -> Event {
     })
 }
 
+/// Convert buffered bracketed-paste bytes to text, dropping stray C0/C1 control
+/// characters that never belong in pasted text — they can corrupt the buffer,
+/// and the bracketed-paste security note warns that embedded control bytes can
+/// be used to smuggle commands. Tab, newline, carriage return and ESC are kept
+/// so multi-line and styled (SGR-coloured) pastes survive intact.
+fn sanitize_paste(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .chars()
+        .filter(|&c| !c.is_control() || matches!(c, '\t' | '\n' | '\r' | '\u{1b}'))
+        .collect()
+}
+
 /// Returns true if `b` is the leading byte of a UTF-8 multi-byte sequence.
-/// 0xC0 and 0xC1 are excluded per RFC 3629 (overlong encodings).
+/// Per RFC 3629 the valid lead-byte range is 0xC2–0xF4: 0xC0/0xC1 are overlong
+/// two-byte leads, and 0xF5–0xFF would encode code points above U+10FFFF.
 fn is_utf8_start_byte(b: u8) -> bool {
-    matches!(b, 0xC2..=0xF7)
+    matches!(b, 0xC2..=0xF4)
 }
 
 /// Total byte width of a UTF-8 sequence given its leading byte; 0 if invalid.
@@ -694,7 +936,7 @@ fn utf8_char_width(first_byte: u8) -> usize {
     match first_byte {
         0xC2..=0xDF => 2,
         0xE0..=0xEF => 3,
-        0xF0..=0xF7 => 4,
+        0xF0..=0xF4 => 4,
         _ => 0,
     }
 }
@@ -728,24 +970,35 @@ fn byte_to_keycode(byte: u8) -> KeyCode {
     }
 }
 
-/// Convert an xterm modifier parameter (1 + bitmask) to `KeyModifiers`.
-fn modifiers_from_param(param: u8) -> KeyModifiers {
+/// Convert an xterm/kitty modifier parameter (1 + bitmask) to `KeyModifiers`.
+///
+/// The parameter is taken as `u16` because the kitty keyboard protocol's
+/// maximum legal value is 256 (all of Shift/Alt/Ctrl/Super/Hyper/Meta plus
+/// Caps Lock and Num Lock), which does not fit in a `u8` — parsing it as `u8`
+/// overflowed and failed closed to "no modifiers". Caps Lock and Num Lock have
+/// no `KeyModifiers` equivalent and are ignored.
+fn modifiers_from_param(param: u16) -> KeyModifiers {
     let param = param.saturating_sub(1);
-    KeyModifiers::from_bits_truncate(
-        if param & 1 != 0 {
-            KeyModifiers::SHIFT.bits()
-        } else {
-            0
-        } | if param & 2 != 0 {
-            KeyModifiers::ALT.bits()
-        } else {
-            0
-        } | if param & 4 != 0 {
-            KeyModifiers::CONTROL.bits()
-        } else {
-            0
-        },
-    )
+    let mut mods = KeyModifiers::empty();
+    if param & 1 != 0 {
+        mods |= KeyModifiers::SHIFT;
+    }
+    if param & 2 != 0 {
+        mods |= KeyModifiers::ALT;
+    }
+    if param & 4 != 0 {
+        mods |= KeyModifiers::CONTROL;
+    }
+    if param & 8 != 0 {
+        mods |= KeyModifiers::SUPER;
+    }
+    if param & 16 != 0 {
+        mods |= KeyModifiers::HYPER;
+    }
+    if param & 32 != 0 {
+        mods |= KeyModifiers::META;
+    }
+    mods
 }
 
 #[cfg(test)]

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -51,9 +51,11 @@ const MAX_CSI_PARAMS: usize = 128;
 /// Upper bound on buffered bracketed-paste content. A paste-start (`ESC [ 200 ~`)
 /// whose terminator never arrives would otherwise grow memory without limit and
 /// swallow every subsequent keystroke. On reaching this bound the accumulated
-/// content is emitted as a `Paste` event and the parser resyncs to ground. The
-/// bound is far above any realistic interactive paste.
-const MAX_PASTE: usize = 4 * 1024 * 1024;
+/// content is emitted as a `Paste` event and the parser enters `PasteOverflow`,
+/// discarding the runaway tail until an `ESC` lets it resync (so the tail is
+/// neither buffered nor sprayed out as keystrokes). The bound is a pure safety
+/// valve — far above any realistic interactive paste.
+const MAX_PASTE: usize = 64 * 1024 * 1024;
 
 /// The parser's current state. Mirrors the relevant sub-states of the DEC/ANSI
 /// state machine; printable/UTF-8 handling lives in `Ground`/`Utf8`.
@@ -82,6 +84,10 @@ enum State {
     /// Inside a bracketed paste (`ESC [ 200 ~` … `ESC [ 201 ~`); content
     /// accumulates in `self.paste`.
     Paste,
+    /// A bracketed paste that overran `MAX_PASTE`: its content has already been
+    /// emitted, and the runaway tail is now discarded (not buffered, not
+    /// emitted as keystrokes) until an `ESC` lets the machine resync.
+    PasteOverflow,
     /// Inside a string-type control sequence — DCS (`ESC P`), OSC (`ESC ]`),
     /// APC (`ESC _`), PM (`ESC ^`) or SOS (`ESC X`). Content is discarded until
     /// the terminator: `ST` (`ESC \`) or a legacy `BEL`. `saw_esc` records that
@@ -201,6 +207,11 @@ impl InputParser {
                     }
                 }
                 State::Paste => self.feed_paste(byte, out),
+                State::PasteOverflow => {
+                    if !self.feed_paste_overflow(byte) {
+                        continue;
+                    }
+                }
                 State::StringSeq { saw_esc } => {
                     if !self.feed_string(byte, saw_esc) {
                         continue;
@@ -489,14 +500,27 @@ impl InputParser {
             return;
         }
         if self.paste.len() >= MAX_PASTE {
-            // Unterminated/oversized paste: emit what we have and resync to
-            // ground, so the buffer is bounded and later keystrokes are not
-            // swallowed indefinitely.
+            // Unterminated/oversized paste: emit what we have, then discard the
+            // runaway tail (in `PasteOverflow`) until an `ESC` lets us resync.
+            // Emitting here bounds memory; discarding rather than returning to
+            // ground keeps the tail from being sprayed out as keystrokes.
             tracing::trace!("InputParser: paste exceeded {} bytes, flushing", MAX_PASTE);
             let text = sanitize_paste(&self.paste);
             self.paste.clear();
-            self.state = State::Ground;
+            self.state = State::PasteOverflow;
             out.push(Event::Paste(text));
+        }
+    }
+
+    /// `PasteOverflow` state: discard the runaway tail of an over-long paste,
+    /// emitting nothing, until an `ESC` arrives. Returns `false` on that `ESC`
+    /// so it is reprocessed from ground and starts a clean new sequence.
+    fn feed_paste_overflow(&mut self, byte: u8) -> bool {
+        if byte == 0x1b {
+            self.state = State::Ground;
+            false
+        } else {
+            true // discard
         }
     }
 

--- a/crates/fresh-input-parser/src/proptests.rs
+++ b/crates/fresh-input-parser/src/proptests.rs
@@ -186,4 +186,50 @@ proptest! {
             prop_assert_eq!(e, &Event::Key(KeyEvent::new(KeyCode::Char(b as char), KeyModifiers::empty())));
         }
     }
+
+    /// **String-type sequences never leak.** A DCS/OSC/APC/PM/SOS string with an
+    /// arbitrary ESC-free body, terminated by `ST` or `BEL`, must be consumed
+    /// whole — producing no key events — at every split point. This is the §5.1
+    /// invariant for the string states.
+    #[test]
+    fn string_sequences_are_swallowed_at_any_split(
+        introducer in prop::sample::select(vec![b'P', b']', b'_', b'^', b'X']),
+        body in proptest::collection::vec(0x20u8..=0x7e, 0..64),
+        bel in any::<bool>(),
+        cut in 0usize..80,
+    ) {
+        let mut seq = vec![0x1b, introducer];
+        seq.extend_from_slice(&body);
+        if bel {
+            seq.push(0x07); // BEL terminator
+        } else {
+            seq.extend_from_slice(b"\x1b\\"); // ST terminator
+        }
+        let cut = cut % (seq.len() + 1);
+        let mut p = InputParser::new();
+        let mut ev = p.parse(&seq[..cut]);
+        ev.extend(p.parse(&seq[cut..]));
+        let key_events = ev.iter().filter(|e| matches!(e, Event::Key(_))).count();
+        prop_assert_eq!(key_events, 0, "string leaked keys: {:?} (seq {:02x?})", ev, seq);
+    }
+
+    /// **No Private Use Area codepoint ever becomes a `Char` key.** For any
+    /// CSI-u codepoint in the PUA range (U+E000–U+F8FF), the result is either a
+    /// non-`Char` functional key or nothing — never an invisible PUA glyph
+    /// inserted into the buffer. This is the §5.1 invariant for kitty keys.
+    #[test]
+    fn pua_codepoints_never_become_char_keys(cp in 0xe000u32..=0xf8ff) {
+        let seq = format!("\x1b[{cp}u").into_bytes();
+        let ev = InputParser::new().parse(&seq);
+        for e in &ev {
+            if let Event::Key(ke) = e {
+                if let KeyCode::Char(c) = ke.code {
+                    prop_assert!(
+                        !('\u{e000}'..='\u{f8ff}').contains(&c),
+                        "cp {} produced PUA char {:?}", cp, c
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -720,3 +720,363 @@ fn every_split_of_repro_sequences_never_leaks_chars() {
         }
     }
 }
+
+// ============================================================================
+// §5 gap-register regressions. Each test demonstrates a protocol gap the parser
+// did not handle (documented in docs/internal/terminal-input-parsing.md §5) and
+// now does. Grouped by the doc's severity tiers.
+// ============================================================================
+
+// ---- §5.1 Emits sequence bytes as text ----
+
+#[test]
+fn osc_replies_are_swallowed_not_emitted_as_text() {
+    // OSC 52 clipboard / OSC 10-11 colour replies arrive on stdin. They must be
+    // consumed whole and produce no events — not `Alt+]` followed by the payload
+    // as literal characters (the pre-fix behaviour).
+    let mut p = InputParser::new();
+    // ST-terminated (`ESC \`).
+    assert!(p.parse(b"\x1b]52;c;SGVsbG8=\x1b\\").is_empty());
+    // BEL-terminated (legacy OSC).
+    assert!(p.parse(b"\x1b]11;rgb:2e2e/3434/3636\x07").is_empty());
+}
+
+#[test]
+fn dcs_apc_pm_sos_strings_are_swallowed() {
+    for seq in [
+        &b"\x1bP1$r0m\x1b\\"[..],     // DCS: a DECRQSS reply
+        &b"\x1b_Gi=1;OK\x1b\\"[..],   // APC: a kitty graphics reply
+        &b"\x1b^a message\x1b\\"[..], // PM
+        &b"\x1bXsome data\x1b\\"[..], // SOS
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(seq);
+        assert!(ev.is_empty(), "string seq {:02x?} leaked: {:?}", seq, ev);
+    }
+}
+
+#[test]
+fn string_sequence_then_keypress_resyncs() {
+    let mut p = InputParser::new();
+    // OSC (BEL-terminated) immediately followed by a normal key.
+    let ev = p.parse(b"\x1b]0;window title\x07a");
+    assert_eq!(keys(&ev), vec![(KeyCode::Char('a'), KeyModifiers::empty())]);
+}
+
+#[test]
+fn string_sequence_interrupted_by_fresh_csi_resyncs() {
+    // An `ESC` inside a string that is *not* part of an `ST` (`ESC \`) begins a
+    // new sequence: the string is abandoned and the CSI parses cleanly.
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b]0;partial\x1b[A");
+    assert!(!has_char_key(&ev), "leaked: {:?}", ev);
+    assert_eq!(keys(&ev), vec![(KeyCode::Up, KeyModifiers::empty())]);
+}
+
+#[test]
+fn string_sequence_never_leaks_at_any_split() {
+    let seq = b"\x1b]52;c;SGVsbG8=\x1b\\";
+    for cut in 0..=seq.len() {
+        let mut p = InputParser::new();
+        let mut ev = p.parse(&seq[..cut]);
+        ev.extend(p.parse(&seq[cut..]));
+        assert!(!has_char_key(&ev), "cut {cut} leaked: {:?}", ev);
+    }
+}
+
+#[test]
+fn kitty_functional_keys_map_to_real_keycodes() {
+    let mut p = InputParser::new();
+    // F13 (57376), keypad Begin (57427), Caps Lock (57358), keypad '1' (57400).
+    assert_eq!(
+        keys(&p.parse(b"\x1b[57376u")),
+        vec![(KeyCode::F(13), KeyModifiers::empty())]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[57427u")),
+        vec![(KeyCode::KeypadBegin, KeyModifiers::empty())]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[57358u")),
+        vec![(KeyCode::CapsLock, KeyModifiers::empty())]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[57400u")),
+        vec![(KeyCode::Char('1'), KeyModifiers::empty())]
+    );
+}
+
+#[test]
+fn kitty_pua_keys_never_insert_pua_characters() {
+    // Every key kitty maps into the Private Use Area must resolve to a
+    // non-`Char` key (or be dropped) — never a `Char` in the PUA range, which
+    // would insert an invisible glyph into the buffer.
+    let mut p = InputParser::new();
+    for cp in [57358u32, 57376, 57400, 57414, 57427, 57430, 57444, 57453] {
+        let ev = p.parse(format!("\x1b[{cp}u").as_bytes());
+        for e in &ev {
+            if let Event::Key(ke) = e {
+                if let KeyCode::Char(c) = ke.code {
+                    assert!(
+                        !('\u{e000}'..='\u{f8ff}').contains(&c),
+                        "cp {cp} produced PUA char {:?}",
+                        c
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn unmapped_pua_codepoint_is_dropped() {
+    // A PUA codepoint kitty does not assign must be dropped, not inserted.
+    let mut p = InputParser::new();
+    assert!(p.parse(b"\x1b[57357u").is_empty()); // in PUA, unassigned
+}
+
+#[test]
+fn stray_continuation_and_c1_bytes_are_discarded() {
+    // Lone UTF-8 continuation bytes (0x80–0xBF), C1 controls, and bytes that
+    // cannot begin a valid UTF-8 sequence are noise on a UTF-8 stream: dropped,
+    // not surfaced as `Null` key events.
+    let mut p = InputParser::new();
+    for b in [0x80u8, 0x9b, 0x9c, 0xbf, 0xc0, 0xc1, 0xff] {
+        assert!(p.parse(&[b]).is_empty(), "byte {:#04x} leaked", b);
+    }
+}
+
+// ---- §5.2 Wrong or lost keys ----
+
+#[test]
+fn sgr_no_button_with_press_terminator_is_motion_not_click() {
+    // JediTerm-based emulators strip the motion bit, reporting free movement as
+    // the no-button code (3) with an `M` terminator. That must read as motion,
+    // not a left click (which flooded clicks on every mouse move).
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[<3;10;5M");
+    match &ev[0] {
+        Event::Mouse(me) => assert!(
+            matches!(me.kind, MouseEventKind::Moved),
+            "expected Moved, got {:?}",
+            me.kind
+        ),
+        other => panic!("expected mouse, got {:?}", other),
+    }
+}
+
+#[test]
+fn sgr_mouse_tolerates_trailing_separator() {
+    // A trailing separator before the terminator (`Cb ; Cx ; Cy ;`) is part of
+    // the grammar some emulators emit; it must not drop the report.
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[<0;10;5;M");
+    match &ev[0] {
+        Event::Mouse(me) => {
+            assert!(matches!(me.kind, MouseEventKind::Down(MouseButton::Left)));
+            assert_eq!((me.column, me.row), (9, 4));
+        }
+        other => panic!("expected mouse, got {:?}", other),
+    }
+}
+
+#[test]
+fn kitty_super_hyper_meta_modifiers_decode() {
+    // Only Shift/Alt/Ctrl were mapped; Super/Hyper/Meta were dropped.
+    let mut p = InputParser::new();
+    // Super = bitmask 8 -> param 9.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97;9u")),
+        vec![(KeyCode::Char('a'), KeyModifiers::SUPER)]
+    );
+    // Hyper = bitmask 16 -> param 17.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97;17u")),
+        vec![(KeyCode::Char('a'), KeyModifiers::HYPER)]
+    );
+    // Meta = bitmask 32 -> param 33.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97;33u")),
+        vec![(KeyCode::Char('a'), KeyModifiers::META)]
+    );
+}
+
+#[test]
+fn kitty_max_modifier_value_does_not_overflow() {
+    // The maximum legal modifier value is 256 (all six modifiers + Caps + Num
+    // lock). Parsed as `u8` it overflowed and fell back to "no modifiers"; the
+    // `u16` path keeps the six real modifiers (lock bits have no equivalent).
+    let all = KeyModifiers::SHIFT
+        | KeyModifiers::ALT
+        | KeyModifiers::CONTROL
+        | KeyModifiers::SUPER
+        | KeyModifiers::HYPER
+        | KeyModifiers::META;
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97;256u")),
+        vec![(KeyCode::Char('a'), all)]
+    );
+}
+
+#[test]
+fn kitty_event_type_release_is_not_a_press() {
+    // The modifier field's event-type sub-param (`mods:event-type`) — 3=release
+    // — must be preserved as the event kind, so a release is not reported as a
+    // fresh press (which would double every keystroke with event reporting on).
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[97;1:3u"); // 'a', no mods, release
+    match &ev[0] {
+        Event::Key(ke) => {
+            assert_eq!(ke.code, KeyCode::Char('a'));
+            assert_eq!(ke.kind, KeyEventKind::Release);
+        }
+        other => panic!("expected key, got {:?}", other),
+    }
+    // Repeat is preserved too.
+    let ev = p.parse(b"\x1b[97;1:2u");
+    assert!(matches!(&ev[0], Event::Key(ke) if ke.kind == KeyEventKind::Repeat));
+    // A press (event-type 1, or absent) stays a press.
+    assert!(
+        matches!(&p.parse(b"\x1b[97;1:1u")[0], Event::Key(ke) if ke.kind == KeyEventKind::Press)
+    );
+    assert!(matches!(&p.parse(b"\x1b[97u")[0], Event::Key(ke) if ke.kind == KeyEventKind::Press));
+}
+
+#[test]
+fn ss3_application_keypad_forms() {
+    // The numeric keypad in application mode (DECPAM) went silent for these.
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1bOM")),
+        vec![(KeyCode::Enter, KeyModifiers::empty())]
+    ); // keypad Enter
+    assert_eq!(
+        keys(&p.parse(b"\x1bOE")),
+        vec![(KeyCode::KeypadBegin, KeyModifiers::empty())]
+    ); // keypad Begin
+    assert_eq!(
+        keys(&p.parse(b"\x1bOp")),
+        vec![(KeyCode::Char('0'), KeyModifiers::empty())]
+    ); // keypad 0
+    assert_eq!(
+        keys(&p.parse(b"\x1bOy")),
+        vec![(KeyCode::Char('9'), KeyModifiers::empty())]
+    ); // keypad 9
+    assert_eq!(
+        keys(&p.parse(b"\x1bOk")),
+        vec![(KeyCode::Char('+'), KeyModifiers::empty())]
+    ); // keypad +
+    assert_eq!(
+        keys(&p.parse(b"\x1bOn")),
+        vec![(KeyCode::Char('.'), KeyModifiers::empty())]
+    ); // keypad .
+}
+
+#[test]
+fn csi_e_is_keypad_begin() {
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[E")),
+        vec![(KeyCode::KeypadBegin, KeyModifiers::empty())]
+    );
+    // Modified: `CSI 1;2 E` = Shift + keypad Begin.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;2E")),
+        vec![(KeyCode::KeypadBegin, KeyModifiers::SHIFT)]
+    );
+}
+
+#[test]
+fn modified_f1_f4_with_hyper_and_meta() {
+    // The modified-F1–F4 guard capped the modifier at 16, dropping Hyper (17)
+    // and Meta (33). Both now decode.
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;17R")),
+        vec![(KeyCode::F(3), KeyModifiers::HYPER)]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[1;33R")),
+        vec![(KeyCode::F(3), KeyModifiers::META)]
+    );
+}
+
+#[test]
+fn alt_plus_non_ascii_character() {
+    // Alt+é arrives as `ESC` + the UTF-8 bytes of é. The lead byte must route
+    // into the character collector carrying Alt, not be mangled as a raw byte.
+    let mut p = InputParser::new();
+    let ev = p.parse(&[0x1b, 0xc3, 0xa9]); // ESC é
+    assert_eq!(keys(&ev), vec![(KeyCode::Char('é'), KeyModifiers::ALT)]);
+    // Split across chunks: `ESC`, then the character bytes.
+    let mut p = InputParser::new();
+    assert!(p.parse(&[0x1b]).is_empty());
+    assert_eq!(
+        keys(&p.parse(&[0xc3, 0xa9])),
+        vec![(KeyCode::Char('é'), KeyModifiers::ALT)]
+    );
+}
+
+#[test]
+fn csi_reply_lists_are_discarded() {
+    // A parameter list introduced by `?` or `>` is a device reply, never a key.
+    // The kitty keyboard-flags reply (`CSI ? <flags> u`) used to decode as NUL.
+    let mut p = InputParser::new();
+    assert!(p.parse(b"\x1b[?1u").is_empty(), "kitty flags reply leaked");
+    assert!(p.parse(b"\x1b[>1;95;0c").is_empty(), "DA2 reply leaked");
+}
+
+// ---- §5.3 Robustness ----
+
+#[test]
+fn unterminated_paste_is_bounded_and_resyncs() {
+    // A paste-start with no terminator must not grow without limit or swallow
+    // keystrokes forever: on exceeding the cap it flushes as a `Paste` event and
+    // returns to ground, so a following key registers.
+    let mut p = InputParser::new();
+    let mut input = b"\x1b[200~".to_vec();
+    input.resize(input.len() + MAX_PASTE + 16, b'a');
+    let ev = p.parse(&input);
+    assert!(
+        ev.iter().any(|e| matches!(e, Event::Paste(_))),
+        "expected a bounded Paste flush"
+    );
+    // Back in ground: a normal key now parses.
+    assert_eq!(
+        keys(&p.parse(b"z")),
+        vec![(KeyCode::Char('z'), KeyModifiers::empty())]
+    );
+}
+
+#[test]
+fn paste_content_is_sanitized_of_stray_controls() {
+    // Stray C0 controls (a NUL and a Ctrl-A) are dropped from paste content;
+    // tab and ESC-based styling survive.
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[200~a\x00b\x01c\t\x1b[1md\x1b[201~");
+    match &ev[0] {
+        Event::Paste(t) => assert_eq!(t, "abc\t\x1b[1md"),
+        other => panic!("expected paste, got {:?}", other),
+    }
+}
+
+#[test]
+fn utf8_eagerly_abandons_on_non_continuation_byte() {
+    // A multi-byte char cut short by an `ESC` must abandon eagerly and let the
+    // `ESC` start a fresh sequence, not buffer it until decode time.
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\xe4\x1b[A"); // 3-byte lead, then ESC + Up
+    assert!(!has_char_key(&ev), "leaked: {:?}", ev);
+    assert_eq!(keys(&ev), vec![(KeyCode::Up, KeyModifiers::empty())]);
+}
+
+#[test]
+fn utf8_lead_bytes_above_rfc3629_are_not_starts() {
+    // 0xF5–0xF7 would encode code points above U+10FFFF; they are not valid
+    // lead bytes and must be discarded, not treated as the start of a 4-byte
+    // character (which would then swallow following bytes).
+    let mut p = InputParser::new();
+    let ev = p.parse(&[0xf5, b'a']);
+    assert_eq!(keys(&ev), vec![(KeyCode::Char('a'), KeyModifiers::empty())]);
+}

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -1030,22 +1030,26 @@ fn csi_reply_lists_are_discarded() {
 // ---- §5.3 Robustness ----
 
 #[test]
-fn unterminated_paste_is_bounded_and_resyncs() {
+fn unterminated_paste_is_bounded_then_discards_until_resync() {
     // A paste-start with no terminator must not grow without limit or swallow
-    // keystrokes forever: on exceeding the cap it flushes as a `Paste` event and
-    // returns to ground, so a following key registers.
+    // keystrokes forever: on exceeding the cap it flushes what it has as a
+    // `Paste` event, then discards the runaway tail until an `ESC` lets it
+    // resync — so the tail is neither buffered nor sprayed out as keystrokes.
     let mut p = InputParser::new();
-    let mut input = b"\x1b[200~".to_vec();
-    input.resize(input.len() + MAX_PASTE + 16, b'a');
-    let ev = p.parse(&input);
-    assert!(
-        ev.iter().any(|e| matches!(e, Event::Paste(_))),
-        "expected a bounded Paste flush"
-    );
-    // Back in ground: a normal key now parses.
+    assert!(p.parse(b"\x1b[200~").is_empty());
+    // Feed just past the cap in 1 MiB chunks (avoids one huge input buffer).
+    let chunk = vec![b'a'; 1 << 20];
+    let mut flushed = false;
+    for _ in 0..(MAX_PASTE / chunk.len() + 1) {
+        flushed |= p.parse(&chunk).iter().any(|e| matches!(e, Event::Paste(_)));
+    }
+    assert!(flushed, "expected a bounded Paste flush");
+    // The runaway tail is discarded, not surfaced as keys...
+    assert!(p.parse(b"aaaa").is_empty(), "overflow tail leaked as keys");
+    // ...until an `ESC`-introduced sequence resyncs the parser.
     assert_eq!(
-        keys(&p.parse(b"z")),
-        vec![(KeyCode::Char('z'), KeyModifiers::empty())]
+        keys(&p.parse(b"\x1b[A")),
+        vec![(KeyCode::Up, KeyModifiers::empty())]
     );
 }
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -44,6 +44,7 @@ other docs assume.
 | [text-model.md](text-model.md) | The persistent path-copying piece tree (and why not a rope or gap buffer), lazy loading for multi-GB files, interval-tree markers with gravity, the `Event`/`BulkEdit` model with O(1) `Arc`-snapshot undo, composite buffers, and the encoding/save path. |
 | [buffers-splits-undo.md](buffers-splits-undo.md) | App-layer buffer lifecycle and identity, buffer groups, the split/window tree, per-buffer vs per-view state, undo/redo with marker displacement, and hot-exit / crash recovery. |
 | [input-keybindings-actions.md](input-keybindings-actions.md) | A keystroke end-to-end: terminal key normalization, the modal dispatch priority stack, the command→action→event pipeline and why it's separated, the unified keybinding resolver, multi-cursor, and mouse hit-testing. |
+| [terminal-input-parsing.md](terminal-input-parsing.md) | The stage before that one: raw terminal bytes → events. Why Fresh parses input itself rather than using crossterm's parser, the DEC/ANSI state machine and the "control-sequence bytes are never emitted as text" invariant it protects, standalone-Escape resolution, the three input paths — and a register of the xterm/kitty protocol gaps that remain. |
 
 ### Rendering & language intelligence
 | Doc | What it covers |

--- a/docs/internal/input-keybindings-actions.md
+++ b/docs/internal/input-keybindings-actions.md
@@ -22,6 +22,9 @@ Terminal (crossterm KeyEvent)
   → log_and_apply_event / bulk edit — events mutate buffer + undo log
 ```
 
+The stage before this one — raw terminal bytes to a `KeyEvent`/`MouseEvent` — is
+[terminal-input-parsing.md](terminal-input-parsing.md).
+
 Three distinct vocabularies live here and the separation is deliberate (§4):
 
 - **Command** — a user-facing, localized, context-filtered palette entry. Wraps

--- a/docs/internal/terminal-input-parsing.md
+++ b/docs/internal/terminal-input-parsing.md
@@ -5,11 +5,10 @@ into `crossterm::event::Event`s — why Fresh parses those bytes itself instead 
 letting crossterm do it, the state machine that does the parsing, the invariant
 that machine exists to preserve, and the protocol coverage it still lacks.
 
-Everything in §1–§4 is IMPLEMENTED. §5 is a gap register: protocol behaviour the
-parser does not handle today, derived from the xterm control-sequence reference
-and the kitty keyboard protocol specification. Gaps are not bugs filed against a
-plan — they are the known distance between the parser and the protocols it
-consumes.
+Everything in §1–§4 is IMPLEMENTED. §5 records the xterm/kitty protocol coverage
+the parser gained by closing an earlier gap register (derived from the xterm
+control-sequence reference and the kitty keyboard protocol specification),
+together with the few limitations that remain by design.
 
 This doc covers the *byte stream → `Event`* stage only. What happens to an
 `Event` afterwards — key translation, modal dispatch, keybinding resolution — is
@@ -73,14 +72,15 @@ legitimately starts a new sequence.
 
 | State | Role | Exit |
 |-------|------|------|
-| Ground | Printable bytes become characters, C0 controls become key events | `ESC` → Escape; UTF-8 lead byte → Utf8 |
-| Escape | A lone `ESC`, awaiting disambiguation | `[` → Csi; `O` → Ss3; another `ESC` → emit Escape and stay; anything else → Alt+key |
+| Ground | Printable bytes become characters, C0 controls become key events; stray C1/continuation/invalid-lead bytes are dropped | `ESC` → Escape; UTF-8 lead byte → Utf8 |
+| Escape | A lone `ESC`, awaiting disambiguation | `[` → Csi; `O` → Ss3; `P ] _ ^ X` → StringSeq; another `ESC` → emit Escape and stay; a UTF-8 lead byte → Utf8 (Alt); anything else → Alt+key |
 | Csi | Accumulating parameter/intermediate bytes | Final byte → dispatch; unexpected control byte → drop to ground and reprocess |
 | CsiIgnore | A malformed or over-long CSI being swallowed | Final byte → drop; control byte → resync from ground |
-| Ss3 | After `ESC O`; the next byte is the final | Always → Ground |
+| Ss3 | After `ESC O`; the next byte is the final (cursor, F1–F4, application keypad) | Always → Ground |
 | X10 | Collecting the three raw coordinate bytes of a legacy mouse report | Three bytes → mouse event; any byte `< 0x20` → abandon and reprocess |
-| Utf8 | Accumulating a multi-byte character | Width reached → decode |
-| Paste | Inside bracketed paste, accumulating content | End marker → `Paste` event |
+| Utf8 | Accumulating a multi-byte character; each byte must be a continuation byte | Continuation byte fails eager check → abandon and reprocess; width reached → decode |
+| Paste | Inside bracketed paste, accumulating content | End marker → `Paste` event; over `MAX_PASTE` bytes → flush and resync |
+| StringSeq | Inside a DCS/OSC/APC/PM/SOS string, discarding content | `ST` (`ESC \`) or `BEL` → drop and return to ground; a non-`ST` `ESC` → resync from Escape |
 
 Two resync rules do the heavy lifting on malformed input:
 
@@ -96,8 +96,10 @@ Two resync rules do the heavy lifting on malformed input:
 Coordinate arithmetic saturates rather than wrapping, and no buffer is indexed
 without a length check, so no input can panic the parser. This is covered by
 property tests: chunk-invariance (splitting a sequence at any byte boundary
-yields the same events), no-panic over arbitrary byte streams, and well-formed
-round-trips at every split point.
+yields the same events), no-panic over arbitrary byte streams, well-formed
+round-trips at every split point, and — for the two invariants in §5 — that a
+string-type sequence with any body is swallowed at every split, and that no PUA
+codepoint ever becomes a character key.
 
 ### Resolving a standalone Escape
 
@@ -138,77 +140,71 @@ is fixed everywhere.
   to strip mouse sequences that the Windows console corrupts by dropping their
   leading `ESC` — see the notes in the winterm crate.
 
-## 5. Gap register
+## 5. Protocol coverage (closed gaps)
 
-Known distance between the parser and the protocols it consumes. Ordered by
-blast radius: the first group can put bytes into a buffer or a child pty, which
-is the failure the parser exists to prevent.
+These behaviours were once the parser's known distance from the protocols it
+consumes; they are now handled. Grouped by the blast radius they used to carry —
+the first group could put bytes into a buffer or a child pty, the failure the
+parser exists to prevent — each is covered by a test that fails without the fix.
 
-### Emits sequence bytes as text
+### Was emitting sequence bytes as text
 
-- **No DCS / OSC / APC / PM / SOS string states.** The Escape state understands
-  `[`, `O`, and `ESC`; every other introducer falls through to the Alt+key arm,
-  which emits `Alt+<introducer>` and then the entire payload as literal
-  characters. Any string-type reply that can arrive on stdin hits this: OSC 52
-  clipboard responses, OSC 10/11 colour queries, DECRQSS and XTGETTCAP and
-  XTVERSION replies, kitty graphics APC. The fix is a string-accumulation state
-  that swallows to `ST`, with BEL accepted as a legacy OSC terminator.
-- **Kitty functional keys become Private Use Area characters.** The protocol
-  maps every non-printable key into the PUA — lock and menu keys, F13–F35, the
-  full keypad, media keys, standalone modifier keys, and a placeholder for
-  "layout value unavailable". The CSI-u dispatcher has no table for these, so
-  they fall through to a character conversion and get *inserted into the buffer*
-  as invisible characters. The rule to enforce is that nothing in the PUA range
-  may become a character key.
-- **C1 bytes and stray UTF-8 continuation bytes produce `Null` key events**
-  rather than being discarded. (Declining to treat `0x9B` as an 8-bit CSI is
-  correct under UTF-8 and should stay.)
+- **DCS / OSC / APC / PM / SOS string states.** The Escape state routes the
+  string introducers (`P ] _ ^ X`) into a `StringSeq` state that discards the
+  payload until `ST` (`ESC \`) or a legacy `BEL`. Previously every introducer
+  but `[`/`O` fell through to the Alt+key arm and dumped its whole payload as
+  literal characters — OSC 52 clipboard responses, OSC 10/11 colour queries,
+  DECRQSS/XTGETTCAP/XTVERSION replies, and kitty graphics APC all hit this. A
+  non-`ST` `ESC` inside a string resyncs a fresh sequence rather than leaking.
+- **Kitty functional keys map out of the Private Use Area.** The CSI-u
+  dispatcher resolves the PUA range (U+E000–U+F8FF) through a functional-key
+  table — lock/menu keys, F13–F35, the full keypad, media keys, standalone
+  modifier keys — and *drops* any unassigned PUA codepoint. Nothing in the PUA
+  range can become a character key, so no invisible glyph reaches the buffer.
+- **C1 bytes and stray UTF-8 continuation bytes are discarded**, not surfaced as
+  `Null` keys. (`0x9B` is still declined as an 8-bit CSI, which is correct under
+  UTF-8.)
 
-### Wrong or lost keys
+### Was producing wrong or lost keys
 
-- **Free mouse motion from JediTerm-based terminals reads as a click.** Those
-  emulators strip the motion bit, sending the no-button code with a press
-  terminator. The SGR decoder maps the no-button value to the left button and
-  the press terminator to a button-down, producing a click flood on every mouse
-  move. A no-button code can never be a press.
-- **SGR reports with a trailing separator before the terminator are dropped.**
-  The decoder requires exactly three parameter fields; the optional trailing
-  separator is part of the grammar.
-- **Event types are ignored.** The kitty modifier field carries a press / repeat
-  / release sub-parameter, which is stripped and always reported as a press.
-  Harmless while event-type reporting stays off, but it is a live config flag —
-  enabled, every keystroke would fire twice.
-- **Modifier decoding is incomplete.** Only Shift, Alt and Ctrl are mapped;
-  Super, Hyper and Meta are dropped, and the Caps Lock / Num Lock state bits
-  have no equivalent. The modifier field is also parsed into a type too narrow
-  to hold its maximum legal value, which fails closed to "no modifiers".
-- **Application-keypad SS3 forms are dropped.** The SS3 state covers F1–F4,
-  arrows, Home and End, but not keypad Enter, keypad Begin, or the keypad
-  digit/operator forms — so the numeric keypad goes silent whenever application
-  keypad mode is active.
-- **`CSI E` (keypad Begin) has no dispatch arm**, and the modified-F1–F4 guard
-  caps the modifier value below Hyper and Meta.
-- **Alt + non-ASCII is garbage.** The Alt arm converts the following byte
-  directly instead of routing a UTF-8 lead byte into the character collector.
-- **A kitty flags query reply is decoded as a NUL key.** More generally, a
-  parameter list introduced by `?` or `>` is a *reply*, never a key, and should
-  be discarded before dispatch.
+- **Free mouse motion from JediTerm-based terminals reads as motion.** A
+  no-button code (3) is always motion, never a button event — even with an `M`
+  terminator and no motion bit, which is how those emulators report movement.
+  The old decoder mapped it to a left button-down, flooding clicks on every move.
+- **SGR reports tolerate a trailing separator** before the terminator; the
+  decoder now reads the first three fields instead of requiring exactly three.
+- **Kitty event types are honoured.** The modifier field's press/repeat/release
+  sub-parameter becomes the key event's kind, so a release is no longer reported
+  as a fresh press (which would double every keystroke with event reporting on).
+- **Modifier decoding is complete.** Shift/Alt/Ctrl/Super/Hyper/Meta are all
+  mapped, and the modifier field is parsed as `u16` so its maximum legal value
+  (256) no longer overflows and fails closed. Caps Lock / Num Lock have no
+  `KeyModifiers` equivalent and are ignored.
+- **Application-keypad SS3 forms decode** — keypad Enter, Begin, and the
+  digit/operator keys — so the numeric keypad works under application keypad
+  mode. `CSI E` (keypad Begin) has a dispatch arm, and the modified-F1–F4 guard
+  now reaches Hyper and Meta.
+- **Alt + non-ASCII decodes correctly.** An `ESC`-prefixed UTF-8 lead byte routes
+  into the character collector (carrying Alt) instead of being converted raw.
+- **`?`/`>`-introduced replies are discarded** before dispatch (kitty
+  keyboard-flags report, Device Attributes responses) instead of decoding as a
+  NUL key.
 
 ### Robustness
 
-- **The paste buffer is unbounded and cannot be flushed.** The parameter cap
-  protects CSI sequences only. A paste-start with no terminator grows memory
-  without limit and swallows every subsequent keystroke, and the flush path
-  rescues only the Escape state.
-- **The UTF-8 collector does not validate continuation bytes eagerly.** It
-  accumulates the expected width and only then decodes, so an `ESC` landing
-  inside a truncated character is buffered before the failure is noticed. It
-  recovers — the invalid path reprocesses the trailing bytes — but this is the
-  same hazard the X10 validity floor already handles properly. The lead-byte
-  test also accepts values that cannot begin a valid codepoint.
-- **Paste content is not sanitized.** The payload may contain control bytes, and
-  the protocol's own security note warns that a nested end marker can be used to
-  force a premature exit from paste state.
+- **The paste buffer is bounded.** On an unterminated or oversized paste (over
+  `MAX_PASTE`), the accumulated content is flushed as a `Paste` event and the
+  parser resyncs to ground, so it can neither grow without limit nor swallow
+  every subsequent keystroke.
+- **The UTF-8 collector validates continuation bytes eagerly** (the X10
+  validity-floor pattern): a non-continuation byte abandons the partial
+  character and is reprocessed from ground, so an `ESC` mid-character resyncs
+  immediately. The lead-byte range is tightened to RFC 3629 (0xC2–0xF4).
+- **Paste content is sanitised** of stray C0/C1 control bytes; tab, newline,
+  carriage return and `ESC` are kept so multi-line and styled pastes survive.
+  One limitation is inherent to bracketed paste and remains by design: the
+  payload is delimited by the first `ESC [ 201 ~`, so a nested end marker still
+  ends the paste early — the protocol offers no in-band way to prevent it.
 
 ---
 

--- a/docs/internal/terminal-input-parsing.md
+++ b/docs/internal/terminal-input-parsing.md
@@ -1,0 +1,227 @@
+# Terminal Input Parsing
+
+Purpose: explain how Fresh turns the raw byte stream arriving from a terminal
+into `crossterm::event::Event`s — why Fresh parses those bytes itself instead of
+letting crossterm do it, the state machine that does the parsing, the invariant
+that machine exists to preserve, and the protocol coverage it still lacks.
+
+Everything in §1–§4 is IMPLEMENTED. §5 is a gap register: protocol behaviour the
+parser does not handle today, derived from the xterm control-sequence reference
+and the kitty keyboard protocol specification. Gaps are not bugs filed against a
+plan — they are the known distance between the parser and the protocols it
+consumes.
+
+This doc covers the *byte stream → `Event`* stage only. What happens to an
+`Event` afterwards — key translation, modal dispatch, keybinding resolution — is
+[input-keybindings-actions.md](input-keybindings-actions.md).
+
+---
+
+## 1. Why Fresh parses its own input
+
+Fresh still uses crossterm for terminal *output*: raw mode, the ratatui backend,
+and the DECSET writes that enable mouse capture, bracketed paste, and keyboard
+enhancements. Only the *input* side is Fresh's own, in the `fresh-input-parser`
+crate.
+
+The reason is structural, not stylistic. Fresh hosts embedded terminals, so
+bytes that the parser fails to recognise do not merely produce a wrong keystroke
+— they are forwarded verbatim into a focused child pty. A parser that recovers
+from a malformed sequence by re-emitting its bytes as literal keystrokes will,
+under a mouse-motion flood, spray escape-sequence fragments into whatever
+program the user is running.
+
+crossterm's Unix parser is built as *accumulate bytes, re-parse the whole buffer
+after each one*. Three consequences of that design made it unusable for Fresh:
+
+- **Escape resolution by read size.** A lone trailing `ESC` is ambiguous: the
+  Escape key, or the head of a sequence. crossterm resolves it by asking whether
+  the last `read()` filled its buffer exactly. When it didn't, the `ESC` is
+  declared standalone — so a mouse report split at its own `ESC` boundary emits
+  a phantom Escape, and the continuation arrives on the next read in ground
+  state, where `[<35;…M` is just text.
+- **Error recovery resumes mid-sequence.** On a parse failure the buffer is
+  cleared at the point of failure and parsing resumes from ground, so the
+  *remainder* of the abandoned sequence is interpreted as literal keys. The
+  meta-prefixed arrow form (`ESC ESC [ A`, sent for Alt+Up) trips this with no
+  malformed input at all.
+- **Panics on hostile coordinates.** Several mouse and cursor-report paths do
+  unchecked `- 1` on unsigned coordinates. A report of column 0, or a truncated
+  coordinate byte, underflows — a panic in debug, a wrap to 65535 in release.
+  Fresh had to wrap crossterm's parser in `catch_unwind` with a
+  consecutive-panic budget to survive this.
+
+These are the same defect class the DEC/ANSI state machine was designed to
+prevent, which is what Fresh implements instead.
+
+## 2. The invariant
+
+> **Bytes consumed inside a control sequence are never emitted as text.**
+
+A real terminal prints only from the ground state. Bytes that turn out to belong
+to a malformed or unrecognised control sequence are *dropped* — the machine
+returns to ground and discards them — never re-dispatched as keystrokes.
+Everything in the parser's structure follows from holding this line, because
+violating it is precisely how mouse reports leak into an embedded terminal.
+
+## 3. The state machine
+
+A [Paul Williams DEC/ANSI parser][williams]-shaped machine. Bytes are fed one at
+a time; a transition may consume the byte or hand it back to be reprocessed from
+ground, which is how the machine resynchronises without losing a byte that
+legitimately starts a new sequence.
+
+| State | Role | Exit |
+|-------|------|------|
+| Ground | Printable bytes become characters, C0 controls become key events | `ESC` → Escape; UTF-8 lead byte → Utf8 |
+| Escape | A lone `ESC`, awaiting disambiguation | `[` → Csi; `O` → Ss3; another `ESC` → emit Escape and stay; anything else → Alt+key |
+| Csi | Accumulating parameter/intermediate bytes | Final byte → dispatch; unexpected control byte → drop to ground and reprocess |
+| CsiIgnore | A malformed or over-long CSI being swallowed | Final byte → drop; control byte → resync from ground |
+| Ss3 | After `ESC O`; the next byte is the final | Always → Ground |
+| X10 | Collecting the three raw coordinate bytes of a legacy mouse report | Three bytes → mouse event; any byte `< 0x20` → abandon and reprocess |
+| Utf8 | Accumulating a multi-byte character | Width reached → decode |
+| Paste | Inside bracketed paste, accumulating content | End marker → `Paste` event |
+
+Two resync rules do the heavy lifting on malformed input:
+
+- **X10 mouse is a fixed-width collector with a validity floor.** Every
+  coordinate byte is `value + 32`, so a byte below `0x20` cannot be a legitimate
+  coordinate: the report was truncated. The machine abandons it, emitting
+  nothing, and reprocesses that byte from ground — so an `ESC` arriving
+  mid-report starts a clean new sequence instead of being eaten as a coordinate.
+- **A malformed CSI drops to ground and is discarded.** An unexpected control
+  byte mid-sequence, an unknown final byte, or a parameter run longer than the
+  cap all end the sequence without emitting its bytes.
+
+Coordinate arithmetic saturates rather than wrapping, and no buffer is indexed
+without a length check, so no input can panic the parser. This is covered by
+property tests: chunk-invariance (splitting a sequence at any byte boundary
+yields the same events), no-panic over arbitrary byte streams, and well-formed
+round-trips at every split point.
+
+### Resolving a standalone Escape
+
+The machine holds a lone `ESC` in the Escape state until the next byte
+disambiguates it. That is right for a byte stream and wrong for a live tty,
+where a standalone Escape has no continuation and nothing would ever arrive to
+resolve it — the key press produces no event, and the *next* key press is
+consumed as the disambiguator and reported as Alt+key.
+
+So the parser exposes the ambiguity rather than guessing at it: a caller can ask
+whether an `ESC` is pending and explicitly flush it as an Escape key press. Only
+the Escape state is flushable — a partial CSI or UTF-8 sequence keeps waiting,
+because flushing those would break the §2 invariant.
+
+The tty reader resolves it against the file descriptor: with an `ESC` pending it
+polls once more for a continuation (a `read()` can land mid-sequence), and
+flushes the Escape key press if none arrives within a short grace window well
+below human key-repeat latency. Crucially the decision is time-based, not
+read-size-based, so it cannot fire in the middle of a sequence that is still
+streaming in.
+
+## 4. The three input paths
+
+All three feed the same parser, which is the point — a parsing defect fixed once
+is fixed everywhere.
+
+- **Unix host (standalone editor).** A tty reader owns stdin in raw mode and
+  reads bytes directly. Because it bypasses crossterm's event source, it also
+  installs its own `SIGWINCH` handler to synthesize resize events; focus and
+  bracketed-paste events need no special handling because they arrive in the
+  byte stream. It coalesces runs of mouse-move events down to the latest one so
+  a motion flood costs one event per read batch.
+- **Session server.** The client is deliberately ultra-light and forwards raw
+  bytes; the server parses them per-client. Sequences split across socket reads
+  are the normal case here, not an edge case.
+- **Windows.** A dedicated reader thread drains the console buffer as fast as
+  possible and hands VT byte batches to the parser. This path additionally has
+  to strip mouse sequences that the Windows console corrupts by dropping their
+  leading `ESC` — see the notes in the winterm crate.
+
+## 5. Gap register
+
+Known distance between the parser and the protocols it consumes. Ordered by
+blast radius: the first group can put bytes into a buffer or a child pty, which
+is the failure the parser exists to prevent.
+
+### Emits sequence bytes as text
+
+- **No DCS / OSC / APC / PM / SOS string states.** The Escape state understands
+  `[`, `O`, and `ESC`; every other introducer falls through to the Alt+key arm,
+  which emits `Alt+<introducer>` and then the entire payload as literal
+  characters. Any string-type reply that can arrive on stdin hits this: OSC 52
+  clipboard responses, OSC 10/11 colour queries, DECRQSS and XTGETTCAP and
+  XTVERSION replies, kitty graphics APC. The fix is a string-accumulation state
+  that swallows to `ST`, with BEL accepted as a legacy OSC terminator.
+- **Kitty functional keys become Private Use Area characters.** The protocol
+  maps every non-printable key into the PUA — lock and menu keys, F13–F35, the
+  full keypad, media keys, standalone modifier keys, and a placeholder for
+  "layout value unavailable". The CSI-u dispatcher has no table for these, so
+  they fall through to a character conversion and get *inserted into the buffer*
+  as invisible characters. The rule to enforce is that nothing in the PUA range
+  may become a character key.
+- **C1 bytes and stray UTF-8 continuation bytes produce `Null` key events**
+  rather than being discarded. (Declining to treat `0x9B` as an 8-bit CSI is
+  correct under UTF-8 and should stay.)
+
+### Wrong or lost keys
+
+- **Free mouse motion from JediTerm-based terminals reads as a click.** Those
+  emulators strip the motion bit, sending the no-button code with a press
+  terminator. The SGR decoder maps the no-button value to the left button and
+  the press terminator to a button-down, producing a click flood on every mouse
+  move. A no-button code can never be a press.
+- **SGR reports with a trailing separator before the terminator are dropped.**
+  The decoder requires exactly three parameter fields; the optional trailing
+  separator is part of the grammar.
+- **Event types are ignored.** The kitty modifier field carries a press / repeat
+  / release sub-parameter, which is stripped and always reported as a press.
+  Harmless while event-type reporting stays off, but it is a live config flag —
+  enabled, every keystroke would fire twice.
+- **Modifier decoding is incomplete.** Only Shift, Alt and Ctrl are mapped;
+  Super, Hyper and Meta are dropped, and the Caps Lock / Num Lock state bits
+  have no equivalent. The modifier field is also parsed into a type too narrow
+  to hold its maximum legal value, which fails closed to "no modifiers".
+- **Application-keypad SS3 forms are dropped.** The SS3 state covers F1–F4,
+  arrows, Home and End, but not keypad Enter, keypad Begin, or the keypad
+  digit/operator forms — so the numeric keypad goes silent whenever application
+  keypad mode is active.
+- **`CSI E` (keypad Begin) has no dispatch arm**, and the modified-F1–F4 guard
+  caps the modifier value below Hyper and Meta.
+- **Alt + non-ASCII is garbage.** The Alt arm converts the following byte
+  directly instead of routing a UTF-8 lead byte into the character collector.
+- **A kitty flags query reply is decoded as a NUL key.** More generally, a
+  parameter list introduced by `?` or `>` is a *reply*, never a key, and should
+  be discarded before dispatch.
+
+### Robustness
+
+- **The paste buffer is unbounded and cannot be flushed.** The parameter cap
+  protects CSI sequences only. A paste-start with no terminator grows memory
+  without limit and swallows every subsequent keystroke, and the flush path
+  rescues only the Escape state.
+- **The UTF-8 collector does not validate continuation bytes eagerly.** It
+  accumulates the expected width and only then decodes, so an `ESC` landing
+  inside a truncated character is buffered before the failure is noticed. It
+  recovers — the invalid path reprocesses the trailing bytes — but this is the
+  same hazard the X10 validity floor already handles properly. The lead-byte
+  test also accepts values that cannot begin a valid codepoint.
+- **Paste content is not sanitized.** The payload may contain control bytes, and
+  the protocol's own security note warns that a nested end marker can be used to
+  force a premature exit from paste state.
+
+---
+
+## References
+
+- [XTerm Control Sequences][ctlseqs] — the authoritative catalogue of CSI, SS3,
+  DCS/OSC string types, mouse tracking modes, and `modifyOtherKeys`.
+- [Comprehensive keyboard handling in terminals][kitty-kbd] — the kitty keyboard
+  protocol: the progressive-enhancement flag stack, the primary and functional
+  CSI-u formats, modifier arithmetic, and the PUA key registry.
+- [A parser for DEC's ANSI-compatible video terminals][williams] — the state
+  machine this parser is shaped after.
+
+[ctlseqs]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+[kitty-kbd]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+[williams]: https://vt100.net/emu/dec_ansi_parser

--- a/docs/internal/terminal-input-parsing.md
+++ b/docs/internal/terminal-input-parsing.md
@@ -79,7 +79,8 @@ legitimately starts a new sequence.
 | Ss3 | After `ESC O`; the next byte is the final (cursor, F1–F4, application keypad) | Always → Ground |
 | X10 | Collecting the three raw coordinate bytes of a legacy mouse report | Three bytes → mouse event; any byte `< 0x20` → abandon and reprocess |
 | Utf8 | Accumulating a multi-byte character; each byte must be a continuation byte | Continuation byte fails eager check → abandon and reprocess; width reached → decode |
-| Paste | Inside bracketed paste, accumulating content | End marker → `Paste` event; over `MAX_PASTE` bytes → flush and resync |
+| Paste | Inside bracketed paste, accumulating content | End marker → `Paste` event; over `MAX_PASTE` bytes → flush what accumulated and enter PasteOverflow |
+| PasteOverflow | Discarding the runaway tail of an over-long paste | Any byte → discard; `ESC` → resync from ground |
 | StringSeq | Inside a DCS/OSC/APC/PM/SOS string, discarding content | `ST` (`ESC \`) or `BEL` → drop and return to ground; a non-`ST` `ESC` → resync from Escape |
 
 Two resync rules do the heavy lifting on malformed input:
@@ -193,9 +194,14 @@ parser exists to prevent — each is covered by a test that fails without the fi
 ### Robustness
 
 - **The paste buffer is bounded.** On an unterminated or oversized paste (over
-  `MAX_PASTE`), the accumulated content is flushed as a `Paste` event and the
-  parser resyncs to ground, so it can neither grow without limit nor swallow
-  every subsequent keystroke.
+  `MAX_PASTE`, 64 MiB), the accumulated content is flushed as a `Paste` event
+  and the machine enters `PasteOverflow`, discarding the runaway tail until an
+  `ESC` lets it resync — so the buffer can neither grow without limit nor
+  swallow every keystroke, and the tail is not sprayed out as text. Accumulating
+  parsers that skip this bound get bitten: crossterm buffers an unterminated
+  paste forever, and readline once overran a heap buffer on `ESC [ 200 ~` with
+  no terminator. (Ghostty's OSC parser takes the same shape — cap, then discard
+  to an invalid/resync state.)
 - **The UTF-8 collector validates continuation bytes eagerly** (the X10
   validity-floor pattern): a non-continuation byte abandons the partial
   character and is reprocessed from ground, so an `ESC` mid-character resyncs


### PR DESCRIPTION
## Summary

Fresh parses terminal input itself instead of using crossterm's parser, and nothing wrote down why. This branch first documents that stage, then closes the protocol gaps the documentation surfaced.

1. **Document the parser** (`docs/internal/terminal-input-parsing.md`): why Fresh runs its own DEC/ANSI state machine, the invariant it exists to hold — *control-sequence bytes are never emitted as text* — the resync rules that hold it on malformed input, how a standalone Escape is resolved without guessing from read sizes, and the three input paths that share the parser.
2. **Close the gap register** the doc ended with: xterm/kitty protocol behaviour the parser did not handle, ordered by blast radius. The top tier could put control-sequence bytes into a buffer or a focused child pty — the exact failure the parser exists to prevent.

## Gaps closed

**Was emitting sequence bytes as text (the invariant tier):**
- **DCS / OSC / APC / PM / SOS string states** — `ESC` P/]/_/^/X now open a string state that discards the payload to `ST` (or a legacy `BEL`). Previously every introducer but `[`/`O` dumped its whole payload as literal characters (OSC 52 clipboard, OSC 10/11 colour, DECRQSS/XTVERSION replies, kitty graphics APC).
- **Kitty PUA functional keys** map out of U+E000–U+F8FF to real key codes (F13–F35, keypad, media, locks, modifiers); unassigned PUA codepoints are dropped. Nothing in the PUA range can become a `Char` and reach the buffer as an invisible glyph.
- **C1 / stray UTF-8 continuation bytes** are discarded instead of surfacing as `Null` keys.

**Was producing wrong or lost keys:**
- **SGR no-button code (3) is always motion** — fixes the click flood from JediTerm-based emulators that strip the motion bit; a trailing separator before the terminator is tolerated.
- **Full modifier decoding** (Super/Hyper/Meta) with a `u16` field that no longer overflows and fails closed; the modified-F1–F4 guard reaches Hyper/Meta.
- **Kitty event types** (press/repeat/release) are honoured, so a release isn't reported as a fresh press (which would double every keystroke with event reporting on).
- **Application-keypad SS3 forms** (keypad Enter/Begin/digits/operators) and the **`CSI E`** keypad-Begin arm.
- **Alt + non-ASCII** routes through the UTF-8 collector instead of mangling the raw byte.
- **`?`/`>` device replies** (kitty keyboard-flags, Device Attributes) are discarded instead of decoding as a NUL key.

**Robustness:**
- **Bounded paste buffer** — an unterminated/oversized paste flushes and resyncs to ground instead of growing without limit or swallowing keystrokes.
- **Eager UTF-8 continuation validation** (the X10 validity-floor pattern) + RFC-3629 lead-byte range (0xC2–0xF4).
- **Paste content sanitised** of stray control bytes (tab, newline, CR, ESC kept). The nested-end-marker case remains inherent to bracketed paste and is noted in the doc.

## Testing

Every gap is covered by a test that fails without its fix — verified by reverting each tier's logic and confirming the corresponding tests fail. Added 25 tests (23 example-based + 2 chunk-split property tests for the string-state and PUA invariants). Full `fresh-input-parser` suite: **87 passing**. `cargo fmt`, `cargo clippy -D warnings`, and the `fresh-editor` consumer build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)