### PR TITLE
Core embedded-language highlighting (mixed-language files), proven on Markdown fences and Vue SFCs

### DIFF
--- a/crates/fresh-editor/build.rs
+++ b/crates/fresh-editor/build.rs
@@ -372,6 +372,7 @@ fn generate_syntax_packdump() -> Result<(), Box<dyn std::error::Error>> {
         ("src/grammars/earthfile.sublime-syntax", "Earthfile"),
         ("src/grammars/gomod.sublime-syntax", "Go Module"),
         ("src/grammars/vue.sublime-syntax", "Vue"),
+        ("src/grammars/typescript.sublime-syntax", "TypeScript"),
         ("src/grammars/svelte.sublime-syntax", "Svelte"),
         ("src/grammars/astro.sublime-syntax", "Astro"),
         ("src/grammars/hyprlang.sublime-syntax", "Hyprlang"),

--- a/crates/fresh-editor/src/grammars/typescript.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/typescript.sublime-syntax
@@ -1,0 +1,117 @@
+%YAML 1.2
+---
+# TypeScript syntax highlighting for Fresh editor.
+#
+# NOTE: `.ts` buffers are highlighted by tree-sitter, not by this grammar —
+# the grammar catalog deliberately skips "TypeScript" the same way it skips
+# "JavaScript" (see grammar/types.rs). This grammar exists for embedded
+# contexts resolved by language token: Vue `<script lang="ts">` blocks and
+# Markdown ```ts fences (docs/internal/embedded-language-highlighting.md).
+name: TypeScript
+file_extensions:
+  - ts
+  - tsx
+  - mts
+  - cts
+scope: source.ts
+
+contexts:
+  main:
+    - include: comments
+    - include: template-strings
+    - include: strings
+    - include: decorators
+    - include: keywords
+    - include: numbers
+    - include: functions
+    - include: types
+
+  comments:
+    - match: '//'
+      scope: punctuation.definition.comment.ts
+      push:
+        - meta_scope: comment.line.double-slash.ts
+        - match: '$'
+          pop: true
+    - match: '/\*'
+      scope: punctuation.definition.comment.begin.ts
+      push:
+        - meta_scope: comment.block.ts
+        - match: '\*/'
+          scope: punctuation.definition.comment.end.ts
+          pop: true
+
+  strings:
+    - match: '"'
+      scope: punctuation.definition.string.begin.ts
+      push:
+        - meta_scope: string.quoted.double.ts
+        - match: '\\.'
+          scope: constant.character.escape.ts
+        - match: '"'
+          scope: punctuation.definition.string.end.ts
+          pop: true
+        - match: '$'
+          pop: true
+    - match: "'"
+      scope: punctuation.definition.string.begin.ts
+      push:
+        - meta_scope: string.quoted.single.ts
+        - match: '\\.'
+          scope: constant.character.escape.ts
+        - match: "'"
+          scope: punctuation.definition.string.end.ts
+          pop: true
+        - match: '$'
+          pop: true
+
+  template-strings:
+    - match: '`'
+      scope: punctuation.definition.string.begin.ts
+      push:
+        - meta_scope: string.quoted.template.ts
+        - match: '\\.'
+          scope: constant.character.escape.ts
+        - match: '\$\{[^}]*\}'
+          scope: variable.interpolation.ts
+        - match: '`'
+          scope: punctuation.definition.string.end.ts
+          pop: true
+
+  decorators:
+    - match: '@[A-Za-z_$][\w$]*'
+      scope: entity.name.decorator.ts
+
+  keywords:
+    - match: '\b(import|export|from|default|as)\b'
+      scope: keyword.other.ts
+    - match: '\b(if|else|for|while|do|switch|case|break|continue|return|try|catch|finally|throw|yield|await)\b'
+      scope: keyword.control.ts
+    - match: '\b(const|let|var|function|class|extends|implements|interface|type|enum|namespace|module|declare|abstract|readonly|public|private|protected|static|get|set|async|constructor|satisfies|infer|asserts|is|keyof|override|accessor)\b'
+      scope: keyword.declaration.ts
+    - match: '\b(new|delete|typeof|instanceof|void|in|of)\b'
+      scope: keyword.operator.ts
+    - match: '\b(true|false|null|undefined|NaN|Infinity|this|super|globalThis)\b'
+      scope: constant.language.ts
+
+  numbers:
+    - match: '\b0[xX][0-9a-fA-F_]+n?\b'
+      scope: constant.numeric.hex.ts
+    - match: '\b0[bB][01_]+n?\b'
+      scope: constant.numeric.binary.ts
+    - match: '\b0[oO][0-7_]+n?\b'
+      scope: constant.numeric.octal.ts
+    - match: '\b\d[\d_]*(\.[\d_]+)?([eE][+-]?\d+)?n?\b'
+      scope: constant.numeric.decimal.ts
+
+  functions:
+    - match: '(?<=\bfunction\s)[A-Za-z_$][\w$]*'
+      scope: entity.name.function.ts
+    - match: '\b[A-Za-z_$][\w$]*(?=\s*\()'
+      scope: variable.function.ts
+
+  types:
+    - match: '\b(string|number|boolean|any|unknown|never|object|symbol|bigint)\b'
+      scope: support.type.primitive.ts
+    - match: '\b[A-Z][\w$]*\b'
+      scope: support.class.ts

--- a/crates/fresh-editor/src/grammars/vue.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/vue.sublime-syntax
@@ -1,5 +1,12 @@
 %YAML 1.2
 ---
+# Vue single-file components. Template markup is highlighted here; the
+# contents of <script> and <style> blocks are deliberately left unstyled
+# raw regions scoped `meta.embedded.block.{script,style}.vue`, with the
+# `lang` attribute value scoped `constant.other.language-name.vue` — the
+# highlight engine's embedded-language-region mechanism (see
+# docs/internal/embedded-language-highlighting.md) parses those regions
+# with the named language's grammar (default: js / css).
 name: Vue
 file_extensions: [vue]
 scope: text.html.vue
@@ -19,35 +26,57 @@ contexts:
         1: punctuation.definition.tag.begin.vue
         2: entity.name.tag.vue
   script_tag:
-    - match: '(<)(script)\b([^>]*)(>)'
+    - match: '(<)(script)\b'
       captures:
         1: punctuation.definition.tag.begin.vue
         2: entity.name.tag.vue
-        3: entity.other.attribute-name.vue
-        4: punctuation.definition.tag.end.vue
-      push:
-        - include: js_content
-        - match: '(</)(script)(>)'
-          captures:
-            1: punctuation.definition.tag.begin.vue
-            2: entity.name.tag.vue
-            3: punctuation.definition.tag.end.vue
-          pop: true
+      push: script_tag_attrs
+  script_tag_attrs:
+    - meta_scope: meta.embedded.block.script.vue
+    - match: 'lang=(["''])([\w.+-]+)\1'
+      captures:
+        2: constant.other.language-name.vue
+    - match: '/>'
+      scope: punctuation.definition.tag.end.vue
+      pop: true
+    - match: '>'
+      scope: punctuation.definition.tag.end.vue
+      set: script_content
+    - include: html_attributes
+  script_content:
+    - meta_scope: meta.embedded.block.script.vue
+    - match: '(</)(script)\s*(>)'
+      captures:
+        1: punctuation.definition.tag.begin.vue
+        2: entity.name.tag.vue
+        3: punctuation.definition.tag.end.vue
+      pop: true
   style_tag:
-    - match: '(<)(style)\b([^>]*)(>)'
+    - match: '(<)(style)\b'
       captures:
         1: punctuation.definition.tag.begin.vue
         2: entity.name.tag.vue
-        3: entity.other.attribute-name.vue
-        4: punctuation.definition.tag.end.vue
-      push:
-        - include: css_content
-        - match: '(</)(style)(>)'
-          captures:
-            1: punctuation.definition.tag.begin.vue
-            2: entity.name.tag.vue
-            3: punctuation.definition.tag.end.vue
-          pop: true
+      push: style_tag_attrs
+  style_tag_attrs:
+    - meta_scope: meta.embedded.block.style.vue
+    - match: 'lang=(["''])([\w.+-]+)\1'
+      captures:
+        2: constant.other.language-name.vue
+    - match: '/>'
+      scope: punctuation.definition.tag.end.vue
+      pop: true
+    - match: '>'
+      scope: punctuation.definition.tag.end.vue
+      set: style_content
+    - include: html_attributes
+  style_content:
+    - meta_scope: meta.embedded.block.style.vue
+    - match: '(</)(style)\s*(>)'
+      captures:
+        1: punctuation.definition.tag.begin.vue
+        2: entity.name.tag.vue
+        3: punctuation.definition.tag.end.vue
+      pop: true
   html_tags:
     - match: '(</)(\w[\w-]*)(>)'
       captures:
@@ -74,38 +103,3 @@ contexts:
       scope: string.quoted.double.vue
     - match: "'[^']*'"
       scope: string.quoted.single.vue
-  js_content:
-    - match: '//.*$'
-      scope: comment.line.double-slash.vue
-    - match: '/\*'
-      push: [{meta_scope: comment.block.vue}, {match: '\*/', pop: true}]
-    - match: "'[^']*'"
-      scope: string.quoted.single.vue
-    - match: '"[^"]*"'
-      scope: string.quoted.double.vue
-    - match: '`'
-      push:
-        - meta_scope: string.quoted.template.vue
-        - match: '\$\{[^}]+\}'
-          scope: variable.interpolation.vue
-        - match: '`'
-          pop: true
-    - match: '\b(import|export|from|default|const|let|var|function|class|return|if|else|for|while|switch|case|break|continue|try|catch|finally|throw|new|delete|typeof|instanceof|void|this|super|extends|implements|interface|type|enum|async|await|yield|of|in|as)\b'
-      scope: keyword.control.vue
-    - match: '\b(true|false|null|undefined|NaN|Infinity)\b'
-      scope: constant.language.vue
-    - match: '\b(ref|computed|reactive|watch|watchEffect|onMounted|onUnmounted|defineProps|defineEmits|defineExpose|withDefaults|toRef|toRefs|nextTick|provide|inject)\b'
-      scope: support.function.vue
-    - match: '\b\d+(\.\d+)?\b'
-      scope: constant.numeric.vue
-  css_content:
-    - match: '/\*'
-      push: [{meta_scope: comment.block.vue}, {match: '\*/', pop: true}]
-    - match: '\.[a-zA-Z_][\w-]*'
-      scope: entity.other.attribute-name.class.vue
-    - match: '#[a-zA-Z_][\w-]*'
-      scope: entity.other.attribute-name.id.vue
-    - match: '#[0-9a-fA-F]{3,8}\b'
-      scope: constant.other.color.vue
-    - match: '\b\d+(\.\d+)?(px|em|rem|%|vh|vw|pt)?\b'
-      scope: constant.numeric.vue

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -236,6 +236,11 @@ pub const EARTHFILE_GRAMMAR: &str = include_str!("../../grammars/earthfile.subli
 pub const GOMOD_GRAMMAR: &str = include_str!("../../grammars/gomod.sublime-syntax");
 /// Embedded Vue grammar
 pub const VUE_GRAMMAR: &str = include_str!("../../grammars/vue.sublime-syntax");
+
+/// Embedded TypeScript grammar. Serves embedded contexts only (Vue
+/// `lang="ts"`, Markdown ```ts fences) — `.ts` buffers stay on
+/// tree-sitter via the catalog skip below, mirroring JavaScript.
+pub const TYPESCRIPT_GRAMMAR: &str = include_str!("../../grammars/typescript.sublime-syntax");
 /// Embedded Svelte grammar
 pub const SVELTE_GRAMMAR: &str = include_str!("../../grammars/svelte.sublime-syntax");
 /// Embedded Astro grammar
@@ -754,6 +759,7 @@ impl GrammarRegistry {
             (EARTHFILE_GRAMMAR, "Earthfile"),
             (GOMOD_GRAMMAR, "Go Module"),
             (VUE_GRAMMAR, "Vue"),
+            (TYPESCRIPT_GRAMMAR, "TypeScript"),
             (SVELTE_GRAMMAR, "Svelte"),
             (ASTRO_GRAMMAR, "Astro"),
             (HYPRLANG_GRAMMAR, "Hyprlang"),
@@ -1081,8 +1087,16 @@ impl GrammarRegistry {
         // still returns syntect's grammar via the catalog's fallback path,
         // so markdown popup rendering and other code-string highlighters
         // are unaffected.
+        //
+        // TypeScript is skipped for the same reason in reverse: its bundled
+        // grammar exists only for embedded contexts (Vue `lang="ts"`,
+        // Markdown ```ts fences, resolved via `find_syntax_by_token`), and
+        // `.ts` buffers must keep the richer tree-sitter highlighting.
         for (idx, syntax) in self.syntax_set.syntaxes().iter().enumerate() {
-            if syntax.name == "Plain Text" || syntax.name == "JavaScript" {
+            if syntax.name == "Plain Text"
+                || syntax.name == "JavaScript"
+                || syntax.name == "TypeScript"
+            {
                 continue;
             }
             let (language_id, tree_sitter) = derive_language_id(&syntax.name);

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -265,13 +265,17 @@ pub struct TextMateEngine {
     syntax_set: Arc<SyntaxSet>,
     syntax_index: usize,
     checkpoint_markers: MarkerList,
-    checkpoint_states:
-        HashMap<MarkerId, (syntect::parsing::ParseState, syntect::parsing::ScopeStack)>,
+    checkpoint_states: HashMap<MarkerId, ParseSnapshot>,
     dirty_from: Option<usize>,
     cache: Option<TextMateCache>,
     last_buffer_len: usize,
     ts_language: Option<Language>,
     stats: HighlightStats,
+    // Set when this syntax hosts embedded-language regions (see
+    // `EMBEDDING_SPECS`); None for the vast majority of syntaxes.
+    embedding: Option<EmbeddingSpec>,
+    // Fence-language-token → syntax index memo (None = unrecognized).
+    embedded_syntax_memo: HashMap<String, Option<usize>>,
     // Scope→Category memo. Syntect Scope atoms are append-only-interned
     // globally, so entries never need invalidation.
     scope_category_cache: HashMap<syntect::parsing::Scope, Option<HighlightCategory>>,
@@ -298,13 +302,92 @@ struct TextMateCache {
     spans: Vec<CachedSpan>,
     // Parse state at `range.end`; powers forward extension. None when the
     // last mutation didn't end at `range.end`.
-    tail_state: Option<(syntect::parsing::ParseState, syntect::parsing::ScopeStack)>,
+    tail_state: Option<ParseSnapshot>,
 }
 
 #[derive(Debug, Clone)]
 struct CachedSpan {
     range: Range<usize>,
     category: crate::primitives::highlighter::HighlightCategory,
+}
+
+/// Declares how a host syntax delimits embedded-language regions whose
+/// language is named *by the document* (e.g. Markdown code fences). The
+/// host grammar itself must scope both the region and the language name;
+/// the engine then runs a child parser over region content lines. Hosts
+/// whose embedded language is known statically (HTML `<style>` → CSS)
+/// don't belong here — the grammar embeds those directly via the
+/// `SyntaxSet`. See `docs/internal/embedded-language-highlighting.md`.
+struct EmbeddingSpecDef {
+    host_syntax: &'static str,
+    /// Scope (prefix) the host grammar keeps on the stack for the whole
+    /// region, including its delimiter lines.
+    region_scope: &'static str,
+    /// Scope (prefix) the host grammar assigns to the language token on
+    /// the region's opening line.
+    language_scope: &'static str,
+}
+
+const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[EmbeddingSpecDef {
+    host_syntax: "Markdown",
+    region_scope: "markup.raw.code-fence",
+    language_scope: "constant.other.language-name",
+}];
+
+/// `EmbeddingSpecDef` with its scope selectors interned as syntect `Scope`
+/// atoms for cheap prefix matching in the per-line parse loop.
+#[derive(Debug, Clone, Copy)]
+struct EmbeddingSpec {
+    region_scope: syntect::parsing::Scope,
+    language_scope: syntect::parsing::Scope,
+}
+
+impl EmbeddingSpec {
+    fn for_syntax_name(name: &str) -> Option<Self> {
+        let def = EMBEDDING_SPECS.iter().find(|d| d.host_syntax == name)?;
+        Some(Self {
+            region_scope: syntect::parsing::Scope::new(def.region_scope).ok()?,
+            language_scope: syntect::parsing::Scope::new(def.language_scope).ok()?,
+        })
+    }
+}
+
+/// True when any scope on the stack has `scope` as a prefix.
+fn scopes_contain(stack: &syntect::parsing::ScopeStack, scope: syntect::parsing::Scope) -> bool {
+    stack.as_slice().iter().any(|s| scope.is_prefix_of(*s))
+}
+
+/// Parse state of an embedded-language region's child parser.
+#[derive(Debug, Clone, PartialEq)]
+struct EmbeddedParseState {
+    /// Index of the embedded syntax in the shared `SyntaxSet`. Part of the
+    /// state identity: two parses that entered the same region with
+    /// different fence languages must not be considered converged.
+    syntax_index: usize,
+    state: syntect::parsing::ParseState,
+    scopes: syntect::parsing::ScopeStack,
+}
+
+/// Complete resumable parse state: the host parser plus, while inside an
+/// embedded-language region with a recognized language, the child parser.
+/// This is what checkpoints, the cache tail, and convergence comparison
+/// carry, so all incremental paths (resume-from-checkpoint, forward
+/// extension, partial update) work identically inside embedded regions.
+#[derive(Debug, Clone, PartialEq)]
+struct ParseSnapshot {
+    state: syntect::parsing::ParseState,
+    scopes: syntect::parsing::ScopeStack,
+    embedded: Option<EmbeddedParseState>,
+}
+
+impl ParseSnapshot {
+    fn new(syntax: &syntect::parsing::SyntaxReference) -> Self {
+        Self {
+            state: syntect::parsing::ParseState::new(syntax),
+            scopes: syntect::parsing::ScopeStack::new(),
+            embedded: None,
+        }
+    }
 }
 
 /// Small/large file threshold (whole-file cache vs viewport window).
@@ -382,18 +465,7 @@ fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<Pr
 impl TextMateEngine {
     /// Create a new TextMate engine for the given syntax
     pub fn new(syntax_set: Arc<SyntaxSet>, syntax_index: usize) -> Self {
-        Self {
-            syntax_set,
-            syntax_index,
-            checkpoint_markers: MarkerList::new(),
-            checkpoint_states: HashMap::new(),
-            dirty_from: None,
-            cache: None,
-            last_buffer_len: 0,
-            ts_language: None,
-            stats: HighlightStats::default(),
-            scope_category_cache: HashMap::new(),
-        }
+        Self::with_language(syntax_set, syntax_index, None)
     }
 
     /// Create a new TextMate engine with a tree-sitter language for non-highlighting features
@@ -402,6 +474,7 @@ impl TextMateEngine {
         syntax_index: usize,
         ts_language: Option<Language>,
     ) -> Self {
+        let embedding = EmbeddingSpec::for_syntax_name(&syntax_set.syntaxes()[syntax_index].name);
         Self {
             syntax_set,
             syntax_index,
@@ -412,6 +485,8 @@ impl TextMateEngine {
             last_buffer_len: 0,
             ts_language,
             stats: HighlightStats::default(),
+            embedding,
+            embedded_syntax_memo: HashMap::new(),
             scope_category_cache: HashMap::new(),
         }
     }
@@ -495,28 +570,28 @@ impl TextMateEngine {
     /// (which would shadow it). Callers gate on
     /// `bytes_since_checkpoint >= CHECKPOINT_INTERVAL` to control
     /// spacing.
-    fn maybe_create_checkpoint(
-        &mut self,
-        current_offset: usize,
-        state: &syntect::parsing::ParseState,
-        current_scopes: &syntect::parsing::ScopeStack,
-    ) {
+    fn maybe_create_checkpoint(&mut self, current_offset: usize, snapshot: &ParseSnapshot) {
         let nearby = self.checkpoint_markers.query_range(
             current_offset.saturating_sub(CHECKPOINT_INTERVAL / 2),
             current_offset + CHECKPOINT_INTERVAL / 2,
         );
         if nearby.is_empty() {
             let marker_id = self.checkpoint_markers.create(current_offset, true);
-            self.checkpoint_states
-                .insert(marker_id, (state.clone(), current_scopes.clone()));
+            self.checkpoint_states.insert(marker_id, snapshot.clone());
         }
     }
 
     /// Drive `state.parse_line(prepared.line_for_syntect)` and emit one
     /// span per category-carrying byte range via `on_span(start, end,
-    /// category)`. Returns `false` when `parse_line` errored — caller
-    /// should advance past the line and continue (state may have been
-    /// mutated mid-parse but is left as-is, matching prior behaviour).
+    /// category)`. Returns `(false, None)` when `parse_line` errored —
+    /// caller should advance past the line and continue (state may have
+    /// been mutated mid-parse but is left as-is, matching prior
+    /// behaviour).
+    ///
+    /// When `watch_scope` is set, additionally returns the absolute byte
+    /// range of the first contiguous run where that scope was on the
+    /// stack (used to locate the language token on a region-opening
+    /// line).
     ///
     /// Span emission is in two passes: the op iterator emits the
     /// segment between consecutive ops with the scope-stack-active
@@ -528,15 +603,18 @@ impl TextMateEngine {
         current_scopes: &mut syntect::parsing::ScopeStack,
         prepared: &PreparedLine,
         current_offset: usize,
+        watch_scope: Option<syntect::parsing::Scope>,
         mut on_span: impl FnMut(usize, usize, HighlightCategory),
-    ) -> bool {
+    ) -> (bool, Option<Range<usize>>) {
         let ops = match state.parse_line(&prepared.line_for_syntect, &self.syntax_set) {
             Ok(ops) => ops,
-            Err(_) => return false,
+            Err(_) => return (false, None),
         };
 
         let line_content_len = prepared.line_content_len;
         let mut syntect_offset = 0;
+        let mut watch_run_start: Option<usize> = None;
+        let mut watched_range: Option<Range<usize>> = None;
 
         for (op_offset, op) in ops {
             let clamped_op_offset = op_offset.min(line_content_len);
@@ -552,6 +630,19 @@ impl TextMateEngine {
             syntect_offset = clamped_op_offset;
             #[allow(clippy::let_underscore_must_use)]
             let _ = current_scopes.apply(&op);
+            if let Some(watch) = watch_scope {
+                if watched_range.is_none() {
+                    let active = scopes_contain(current_scopes, watch);
+                    match (watch_run_start, active) {
+                        (None, true) => watch_run_start = Some(clamped_op_offset),
+                        (Some(start), false) => {
+                            watched_range =
+                                Some(current_offset + start..current_offset + clamped_op_offset);
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
 
         if syntect_offset < line_content_len {
@@ -563,7 +654,152 @@ impl TextMateEngine {
                 );
             }
         }
-        true
+        if let (Some(start), None) = (watch_run_start, watched_range.as_ref()) {
+            watched_range = Some(current_offset + start..current_offset + line_content_len);
+        }
+        (true, watched_range)
+    }
+
+    /// Parse one line advancing the composite `snapshot` (host parser +
+    /// optional embedded-language child parser). This is the single
+    /// per-line entry point for all parse paths, so embedded regions
+    /// behave identically under cold start, forward extension, and
+    /// partial update.
+    ///
+    /// Line classification is driven purely by the host grammar's scope
+    /// stack (no second lexer that could disagree with what the host
+    /// grammar recognizes as a region):
+    /// - region scope absent before and after → plain host line;
+    /// - absent before, present after → region opened: host-styled, and
+    ///   the language token (located by `language_scope`) selects the
+    ///   child syntax for subsequent lines;
+    /// - present before and after → region content: parsed by the child
+    ///   (host spans for the line are suppressed); when the language was
+    ///   not recognized the host's own styling (e.g. `markup.raw`) is
+    ///   kept;
+    /// - present before, absent after → closing delimiter: host-styled.
+    ///
+    /// The host parser always consumes the line first — inside a region
+    /// it is in a cheap "raw" context — because only it knows where the
+    /// region ends. Content lines therefore cost one extra (trivial)
+    /// host `parse_line` on top of the child parse.
+    fn parse_snapshot_line(
+        &mut self,
+        snapshot: &mut ParseSnapshot,
+        prepared: &PreparedLine,
+        current_offset: usize,
+        mut on_span: impl FnMut(usize, usize, HighlightCategory),
+    ) -> bool {
+        let Some(spec) = self.embedding else {
+            return self
+                .parse_line_into_spans(
+                    &mut snapshot.state,
+                    &mut snapshot.scopes,
+                    prepared,
+                    current_offset,
+                    None,
+                    on_span,
+                )
+                .0;
+        };
+
+        let was_in_region = scopes_contain(&snapshot.scopes, spec.region_scope);
+        let mut host_spans: Vec<(usize, usize, HighlightCategory)> = Vec::new();
+        let (parse_ok, language_range) = self.parse_line_into_spans(
+            &mut snapshot.state,
+            &mut snapshot.scopes,
+            prepared,
+            current_offset,
+            (!was_in_region).then_some(spec.language_scope),
+            |start, end, category| host_spans.push((start, end, category)),
+        );
+        let in_region = parse_ok && scopes_contain(&snapshot.scopes, spec.region_scope);
+
+        let content_line = was_in_region && in_region;
+        if content_line {
+            if let Some(mut embedded) = snapshot.embedded.take() {
+                let syntax_valid = embedded.syntax_index < self.syntax_set.syntaxes().len();
+                if syntax_valid {
+                    let _ = self.parse_line_into_spans(
+                        &mut embedded.state,
+                        &mut embedded.scopes,
+                        prepared,
+                        current_offset,
+                        None,
+                        &mut on_span,
+                    );
+                }
+                snapshot.embedded = Some(embedded);
+                return parse_ok;
+            }
+            // Region with an unrecognized language: keep host styling.
+        }
+
+        for (start, end, category) in host_spans {
+            on_span(start, end, category);
+        }
+        match (was_in_region, in_region) {
+            (false, true) => {
+                snapshot.embedded =
+                    self.embedded_state_for_region(prepared, current_offset, language_range);
+            }
+            (true, false) => snapshot.embedded = None,
+            _ => {}
+        }
+        parse_ok
+    }
+
+    /// Build the child parser for a region that just opened, from the
+    /// language token the host grammar scoped on the opening line.
+    fn embedded_state_for_region(
+        &mut self,
+        prepared: &PreparedLine,
+        current_offset: usize,
+        language_range: Option<Range<usize>>,
+    ) -> Option<EmbeddedParseState> {
+        let range = language_range?;
+        let rel =
+            range.start.checked_sub(current_offset)?..range.end.checked_sub(current_offset)?;
+        let token = prepared.line_for_syntect.get(rel)?;
+        let syntax_index = self.resolve_embedded_syntax(token)?;
+        Some(EmbeddedParseState {
+            syntax_index,
+            state: syntect::parsing::ParseState::new(&self.syntax_set.syntaxes()[syntax_index]),
+            scopes: syntect::parsing::ScopeStack::new(),
+        })
+    }
+
+    /// Resolve a fence-style language token ("rust", "py",
+    /// "language-c++", "{.python}") to a syntax index, memoised. Plain
+    /// text resolves to None so unrecognized fences keep the host's raw
+    /// styling instead of losing it to a no-op child parse.
+    fn resolve_embedded_syntax(&mut self, raw_token: &str) -> Option<usize> {
+        let token = raw_token.trim();
+        let token = token
+            .strip_prefix("{.")
+            .and_then(|t| t.strip_suffix('}'))
+            .unwrap_or(token);
+        let token = token.strip_prefix("language-").unwrap_or(token);
+        if token.is_empty() {
+            return None;
+        }
+        if let Some(cached) = self.embedded_syntax_memo.get(token) {
+            return *cached;
+        }
+        let plain = self.syntax_set.find_syntax_plain_text();
+        let resolved = self
+            .syntax_set
+            .find_syntax_by_token(token)
+            .filter(|found| !std::ptr::eq(*found, plain))
+            .and_then(|found| {
+                self.syntax_set
+                    .syntaxes()
+                    .iter()
+                    .position(|s| std::ptr::eq(s, found))
+            });
+        self.embedded_syntax_memo
+            .insert(token.to_string(), resolved);
+        resolved
     }
 
     /// Highlight the visible viewport. Path selection is documented in the
@@ -710,22 +946,18 @@ impl TextMateEngine {
         let syntax = &self.syntax_set.syntaxes()[self.syntax_index];
 
         // Find checkpoint before the dirty point (bounded search)
-        let (actual_start, mut state, mut current_scopes) = {
+        let (actual_start, mut snapshot) = {
             let search_start = dirty_pos.saturating_sub(MAX_PARSE_BYTES);
             let markers = self.checkpoint_markers.query_range(search_start, dirty_pos);
             let nearest = markers.into_iter().max_by_key(|(_, start, _)| *start);
             if let Some((id, cp_pos, _)) = nearest {
-                if let Some((s, sc)) = self.checkpoint_states.get(&id) {
-                    (cp_pos, s.clone(), sc.clone())
+                if let Some(snap) = self.checkpoint_states.get(&id) {
+                    (cp_pos, snap.clone())
                 } else {
                     return None; // orphan, fall back
                 }
             } else if parse_end <= MAX_PARSE_BYTES {
-                (
-                    0,
-                    syntect::parsing::ParseState::new(syntax),
-                    syntect::parsing::ScopeStack::new(),
-                )
+                (0, ParseSnapshot::new(syntax))
             } else {
                 return None; // large file, no nearby checkpoint, fall back
             }
@@ -763,7 +995,7 @@ impl TextMateEngine {
         while pos < content_bytes.len() {
             // Create checkpoints in new territory
             if bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
+                self.maybe_create_checkpoint(current_offset, &snapshot);
                 bytes_since_checkpoint = 0;
             }
 
@@ -772,9 +1004,8 @@ impl TextMateEngine {
             let collect_spans =
                 current_offset + line_byte_len > desired_parse_start.max(actual_start);
             if let Some(prepared) = prepared {
-                let _ = self.parse_line_into_spans(
-                    &mut state,
-                    &mut current_scopes,
+                let _ = self.parse_snapshot_line(
+                    &mut snapshot,
                     &prepared,
                     current_offset,
                     |byte_start, byte_end, category| {
@@ -802,15 +1033,14 @@ impl TextMateEngine {
                 let (marker_id, _) = markers_ahead[marker_idx];
                 marker_idx += 1;
                 if let Some(stored) = self.checkpoint_states.get(&marker_id) {
-                    if *stored == (state.clone(), current_scopes.clone()) {
+                    if *stored == snapshot {
                         self.stats.convergences += 1;
                         converged_at = Some(current_offset);
                         break;
                     }
                 }
                 self.stats.checkpoints_updated += 1;
-                self.checkpoint_states
-                    .insert(marker_id, (state.clone(), current_scopes.clone()));
+                self.checkpoint_states.insert(marker_id, snapshot.clone());
             }
 
             if converged_at.is_some() {
@@ -877,17 +1107,17 @@ impl TextMateEngine {
         let buf_len = buffer.len();
         let parse_end = parse_end.min(buf_len);
 
-        let (extension_start, mut state, mut current_scopes) = {
+        let (extension_start, mut snapshot) = {
             let cache = self
                 .cache
                 .as_ref()
                 .expect("extend_cache_forward: cache must exist");
-            let (s, sc) = cache
+            let snap = cache
                 .tail_state
                 .as_ref()
                 .expect("extend_cache_forward: tail_state must exist")
                 .clone();
-            (cache.range.end, s, sc)
+            (cache.range.end, snap)
         };
 
         if parse_end <= extension_start {
@@ -915,21 +1145,19 @@ impl TextMateEngine {
         // inside `+` lines. Re-parsing the trailing partial line on every
         // refresh costs at most one extra `parse_line` and is correct.
         let mut safe_offset = extension_start;
-        let mut safe_state = state.clone();
-        let mut safe_scopes = current_scopes.clone();
+        let mut safe_snapshot = snapshot.clone();
 
         while pos < content_bytes.len() {
             if bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
+                self.maybe_create_checkpoint(current_offset, &snapshot);
                 bytes_since_checkpoint = 0;
             }
 
             let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
             let mut newline_terminated = false;
             if let Some(prepared) = prepared {
-                let parse_ok = self.parse_line_into_spans(
-                    &mut state,
-                    &mut current_scopes,
+                let parse_ok = self.parse_snapshot_line(
+                    &mut snapshot,
                     &prepared,
                     current_offset,
                     |byte_start, byte_end, category| {
@@ -950,8 +1178,7 @@ impl TextMateEngine {
 
             if newline_terminated {
                 safe_offset = current_offset;
-                safe_state = state.clone();
-                safe_scopes = current_scopes.clone();
+                safe_snapshot = snapshot.clone();
             }
         }
 
@@ -975,7 +1202,7 @@ impl TextMateEngine {
         cache.spans.extend(safe_spans);
         Self::merge_adjacent_spans(&mut cache.spans);
         cache.range.end = safe_offset;
-        cache.tail_state = Some((safe_state, safe_scopes));
+        cache.tail_state = Some(safe_snapshot);
         self.last_buffer_len = buf_len;
 
         let mut result = self.filter_cached_spans(viewport_start, viewport_end, theme);
@@ -1014,7 +1241,7 @@ impl TextMateEngine {
         }
 
         let syntax = &self.syntax_set.syntaxes()[self.syntax_index];
-        let (actual_start, mut state, mut current_scopes, create_checkpoints) =
+        let (actual_start, mut snapshot, create_checkpoints) =
             self.find_parse_resume_point(desired_parse_start, parse_end, syntax);
 
         let content = buffer.slice_bytes(actual_start..parse_end);
@@ -1034,12 +1261,11 @@ impl TextMateEngine {
         // start of the trailing partial line otherwise so the next
         // refresh re-parses it from scratch.
         let mut safe_offset = actual_start;
-        let mut safe_state = state.clone();
-        let mut safe_scopes = current_scopes.clone();
+        let mut safe_snapshot = snapshot.clone();
 
         while pos < content_bytes.len() {
             if create_checkpoints && bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
+                self.maybe_create_checkpoint(current_offset, &snapshot);
                 bytes_since_checkpoint = 0;
             }
 
@@ -1050,9 +1276,8 @@ impl TextMateEngine {
             let collect_spans = current_offset + line_byte_len > desired_parse_start;
             let mut newline_terminated = false;
             if let Some(prepared) = prepared {
-                let parse_ok = self.parse_line_into_spans(
-                    &mut state,
-                    &mut current_scopes,
+                let parse_ok = self.parse_snapshot_line(
+                    &mut snapshot,
                     &prepared,
                     current_offset,
                     |byte_start, byte_end, category| {
@@ -1079,8 +1304,7 @@ impl TextMateEngine {
 
             if newline_terminated {
                 safe_offset = current_offset;
-                safe_state = state.clone();
-                safe_scopes = current_scopes.clone();
+                safe_snapshot = snapshot.clone();
             }
 
             // Update checkpoint states as we pass them. Done after the
@@ -1094,8 +1318,7 @@ impl TextMateEngine {
                 .map(|(id, start, _)| (id, start))
                 .collect();
             for (marker_id, _) in markers_here {
-                self.checkpoint_states
-                    .insert(marker_id, (state.clone(), current_scopes.clone()));
+                self.checkpoint_states.insert(marker_id, snapshot.clone());
             }
         }
 
@@ -1118,7 +1341,7 @@ impl TextMateEngine {
         self.cache = Some(TextMateCache {
             range: desired_parse_start..cache_range_end,
             spans: cached_spans,
-            tail_state: Some((safe_state, safe_scopes)),
+            tail_state: Some(safe_snapshot),
         });
         self.last_buffer_len = buffer.len();
 
@@ -1143,14 +1366,7 @@ impl TextMateEngine {
         desired_start: usize,
         parse_end: usize,
         syntax: &syntect::parsing::SyntaxReference,
-    ) -> (
-        usize,
-        syntect::parsing::ParseState,
-        syntect::parsing::ScopeStack,
-        bool,
-    ) {
-        use syntect::parsing::{ParseState, ScopeStack};
-
+    ) -> (usize, ParseSnapshot, bool) {
         // Look for a checkpoint near the desired start. For large files, only
         // consider checkpoints that are within MAX_PARSE_BYTES of desired_start
         // to avoid parsing hundreds of MB from a distant checkpoint.
@@ -1161,23 +1377,18 @@ impl TextMateEngine {
         let nearest = markers.into_iter().max_by_key(|(_, start, _)| *start);
 
         if let Some((id, cp_pos, _)) = nearest {
-            if let Some((s, sc)) = self.checkpoint_states.get(&id) {
-                return (cp_pos, s.clone(), sc.clone(), true);
+            if let Some(snap) = self.checkpoint_states.get(&id) {
+                return (cp_pos, snap.clone(), true);
             }
         }
 
         if parse_end <= MAX_PARSE_BYTES {
             // File is small enough to parse from byte 0
-            (0, ParseState::new(syntax), ScopeStack::new(), true)
+            (0, ParseSnapshot::new(syntax), true)
         } else {
             // Large file, no nearby checkpoint — start fresh from desired_start.
             // Still create checkpoints so future visits to this region can resume.
-            (
-                desired_start,
-                ParseState::new(syntax),
-                ScopeStack::new(),
-                true,
-            )
+            (desired_start, ParseSnapshot::new(syntax), true)
         }
     }
 
@@ -1668,6 +1879,262 @@ mod tests {
         assert_eq!(
             engine.category_at_position(column_zero_end),
             Some(HighlightCategory::Keyword)
+        );
+    }
+
+    /// A recognized Markdown fence language must be highlighted with that
+    /// language's grammar instead of the uniform `markup.raw` string color.
+    #[test]
+    fn test_markdown_fence_embedded_language_highlighting() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        assert_eq!(engine.backend_name(), "textmate");
+
+        let content = "# Example\n\n```rust\nfn answer() -> u32 { 42 }\n```\n\ntext\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let category_at = |needle: &str| {
+            let position = content.find(needle).unwrap();
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category)
+        };
+
+        assert_eq!(
+            category_at("fn answer"),
+            Some(HighlightCategory::Keyword),
+            "rust keyword inside the fence must use the rust grammar"
+        );
+        assert_eq!(category_at("42"), Some(HighlightCategory::Number));
+        // The fence delimiter lines still belong to the host grammar.
+        assert_eq!(category_at("```rust"), Some(HighlightCategory::String));
+        assert_eq!(
+            engine.category_at_position(content.find("fn answer").unwrap()),
+            Some(HighlightCategory::Keyword),
+            "category lookups must agree with the returned spans"
+        );
+    }
+
+    /// Fences naming an unknown language keep the host's raw-code styling.
+    #[test]
+    fn test_markdown_unknown_fence_language_keeps_raw_style() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let content = "```definitely-not-a-language\nfn answer() { 42 }\n```\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+        let position = content.find("fn answer").unwrap();
+
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::String)
+        );
+    }
+
+    /// CRLF fences must produce correctly-offset embedded spans.
+    #[test]
+    fn test_markdown_fence_crlf_offsets() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let content = "```rust\r\nfn answer() -> u32 { 42 }\r\n```\r\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = content.find("fn answer").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Keyword)
+        );
+    }
+
+    /// A fence left open at EOF (streaming, or mid-typing) still gets
+    /// embedded highlighting for the content streamed in so far.
+    #[test]
+    fn test_markdown_fence_unclosed_at_eof() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let content = "```rust\nfn answer() -> u32 { 42 }\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = content.find("fn answer").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Keyword)
+        );
+    }
+
+    /// Editing the fence's language token must re-style the whole region.
+    ///
+    /// This pins the reason checkpoints and convergence carry the
+    /// *composite* snapshot (host + embedded child state): inside a fence
+    /// the host parser's state is identical no matter which language the
+    /// fence names, so host-only convergence could falsely converge at
+    /// the first checkpoint inside the region and leave stale spans from
+    /// the old language beyond it. The fence here is longer than
+    /// CHECKPOINT_INTERVAL to guarantee such a checkpoint exists.
+    #[test]
+    fn test_markdown_fence_language_edit_restyles_whole_region() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        let code_line = "fn deep_in_the_fence() -> u32 { 42 }\n";
+        let lines = 2 * CHECKPOINT_INTERVAL / code_line.len() + 2;
+        let fence_body = code_line.repeat(lines);
+        let before = format!("```rust\n{fence_body}```\n\nafter\n");
+        let buffer = Buffer::from_str(&before, 0, test_fs());
+        let _ = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        // A position in the fence's *last* code line — past any checkpoint
+        // created inside the region.
+        let last_line_pos = before.rfind("fn deep_in_the_fence").unwrap();
+        assert_eq!(
+            engine.category_at_position(last_line_pos),
+            Some(HighlightCategory::Keyword),
+            "precondition: rust highlighting active deep in the fence"
+        );
+
+        // Delete "rust" from the opening fence line.
+        let lang_pos = before.find("rust").unwrap();
+        let after = before.replacen("rust", "", 1);
+        let buffer = Buffer::from_str(&after, 0, test_fs());
+        engine.notify_delete(lang_pos, "rust".len());
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = after.rfind("fn deep_in_the_fence").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::String),
+            "after removing the language token the whole region must fall \
+             back to raw-code styling — stale rust spans past a checkpoint \
+             inside the fence mean convergence ignored the embedded state"
+        );
+    }
+
+    /// Typing inside a fence must stay on the incremental partial-update
+    /// path — no whole-file rescan per edit (the flaw that motivated
+    /// replacing full-buffer fence detection).
+    ///
+    /// Convergence granularity note: syntect parse states carrying regex
+    /// captures (which the fence context does, for its close-marker
+    /// backreference) never compare equal across parses — `onig::Region`
+    /// equality is allocation identity, a pre-existing syntect/onig
+    /// limitation that master's tuple comparison had too. So an edit
+    /// inside a fence re-parses to the end of the *region* and converges
+    /// at the first checkpoint after it, rather than 256 bytes after the
+    /// edit. This test pins exactly that contract: the long tail after
+    /// the fence must not be re-parsed.
+    #[test]
+    fn test_markdown_fence_edit_reparses_region_not_file() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        let mut content = String::from("# Doc\n\n```rust\n");
+        for i in 0..40 {
+            content.push_str(&format!("fn f_{i}() -> u32 {{ {i} }}\n"));
+        }
+        content.push_str("```\n\n");
+        let fence_end = content.len();
+        for i in 0..400 {
+            content.push_str(&format!("plain prose line {i}\n"));
+        }
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+
+        let HighlightEngine::TextMate(ref mut tm) = engine else {
+            panic!("expected TextMate engine for .md");
+        };
+        let _ = tm.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+        let bytes_before = tm.stats().bytes_parsed;
+
+        // Simulate typing one character in the middle of the fence.
+        let edit_pos = fence_end / 2;
+        tm.notify_insert(edit_pos, 1);
+        let _ = tm.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let stats = tm.stats();
+        let parsed = stats.bytes_parsed - bytes_before;
+        let slack = 2 * CHECKPOINT_INTERVAL;
+        assert!(
+            parsed < fence_end + slack,
+            "an edit inside a fence must converge shortly after the region \
+             ends instead of re-parsing the rest of the file \
+             (parsed {parsed}, fence ends at {fence_end}, file {} bytes)",
+            content.len()
+        );
+        assert!(
+            stats.convergences >= 1,
+            "the edit must converge at a checkpoint after the fence"
+        );
+    }
+
+    /// Embedded highlighting must keep working past MAX_PARSE_BYTES — the
+    /// whole point of integrating regions into the windowed/checkpointed
+    /// engine instead of a full-buffer scan with a size cutoff.
+    #[test]
+    fn test_markdown_fence_beyond_max_parse_bytes_no_size_cliff() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        let mut content = "plain prose line\n".repeat(MAX_PARSE_BYTES / 16);
+        assert!(content.len() > MAX_PARSE_BYTES);
+        let fence_pos = content.len();
+        content.push_str("```rust\nfn deep() -> u32 { 42 }\n```\n");
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+
+        let HighlightEngine::TextMate(ref mut tm) = engine else {
+            panic!("expected TextMate engine for .md");
+        };
+
+        // Scroll from the top to the fence in steps small enough for the
+        // forward-extension path (mirrors a user paging through the file,
+        // building checkpoints along the way).
+        let context = 10_000;
+        let step = 16_000;
+        let mut viewport_start = 0;
+        loop {
+            let viewport_end = (viewport_start + 1_000).min(buffer.len());
+            let _ = tm.highlight_viewport(&buffer, viewport_start, viewport_end, &theme, context);
+            if viewport_end == buffer.len() {
+                break;
+            }
+            viewport_start += step;
+        }
+
+        let position = fence_pos + "```rust\n".len();
+        assert_eq!(
+            tm.category_at_position(position),
+            Some(HighlightCategory::Keyword),
+            "a fence starting past MAX_PARSE_BYTES must still get embedded \
+             highlighting once reached via scrolling — a size-based cutoff \
+             here means the mechanism bypassed the windowed engine"
         );
     }
 

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -2321,16 +2321,15 @@ mod tests {
         );
     }
 
-    /// A `lang` naming a language with no syntect grammar (TypeScript is
-    /// tree-sitter-only in fresh) falls back to the region's default
-    /// language rather than dropping highlighting entirely — `<script
-    /// lang=\"ts\">` is the dominant real-world Vue pattern.
+    /// A `lang` naming a language with no grammar in the set falls back
+    /// to the region's default language rather than dropping
+    /// highlighting entirely.
     #[test]
     fn test_vue_unresolvable_lang_falls_back_to_default() {
         let registry =
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
         let mut engine = HighlightEngine::for_file(Path::new("App.vue"), None, &registry);
-        let content = "<script setup lang=\"ts\">\nconst answer = 42;\n</script>\n";
+        let content = "<script setup lang=\"mysterylang\">\nconst answer = 42;\n</script>\n";
         let buffer = Buffer::from_str(content, 0, test_fs());
         let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
         let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
@@ -2343,6 +2342,62 @@ mod tests {
                 .and_then(|span| span.category),
             Some(HighlightCategory::Keyword),
             "unresolvable lang token must fall back to the spec default (js)"
+        );
+    }
+
+    /// `lang="ts"` resolves to the bundled TypeScript grammar — the
+    /// dominant real-world Vue pattern gets TS-aware highlighting
+    /// (`interface` is not a keyword to the JS default it previously
+    /// fell back to).
+    #[test]
+    fn test_vue_lang_ts_uses_typescript_grammar() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("App.vue"), None, &registry);
+        let content =
+            "<script setup lang=\"ts\">\ninterface Greeting {\n  message: string;\n}\n</script>\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let category_at = |needle: &str| {
+            let position = content.find(needle).unwrap();
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category)
+        };
+        assert_eq!(
+            category_at("interface"),
+            Some(HighlightCategory::Keyword),
+            "TS-only keyword must be styled by the TypeScript grammar"
+        );
+        assert_eq!(
+            category_at("string"),
+            Some(HighlightCategory::Type),
+            "TS primitive type must be styled by the TypeScript grammar"
+        );
+    }
+
+    /// Markdown ```ts fences resolve to the same TypeScript grammar.
+    #[test]
+    fn test_markdown_ts_fence_uses_typescript_grammar() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let content = "```ts\ntype Answer = number;\n```\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = content.find("type").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Keyword),
+            "```ts fences must be parsed with the TypeScript grammar"
         );
     }
 

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -7,7 +7,8 @@
 //! Syntect's parser is a sequential state machine — it must process bytes
 //! in order from a known parse state to track multi-line constructs and
 //! embedded language transitions. To make scrolling cheap, the engine keeps
-//! a span cache, a `(ParseState, ScopeStack)` snapshot at the cache tail,
+//! a span cache, a composite `ParseSnapshot` (host parse state plus any
+//! embedded-language child state, see `EMBEDDING_SPECS`) at the cache tail,
 //! and periodic checkpoint anchors to support resume-from-anywhere.
 //!
 //! Three render-time paths, gated by what the cache covers:
@@ -276,6 +277,10 @@ pub struct TextMateEngine {
     embedding: Option<EmbeddingSpec>,
     // Fence-language-token → syntax index memo (None = unrecognized).
     embedded_syntax_memo: HashMap<String, Option<usize>>,
+    // Reusable per-line span buffers for embedding hosts, so region
+    // classification in `parse_snapshot_line` doesn't allocate per line.
+    host_span_scratch: Vec<(usize, usize, HighlightCategory)>,
+    child_span_scratch: Vec<(usize, usize, HighlightCategory)>,
     // Scope→Category memo. Syntect Scope atoms are append-only-interned
     // globally, so entries never need invalidation.
     scope_category_cache: HashMap<syntect::parsing::Scope, Option<HighlightCategory>>,
@@ -487,6 +492,8 @@ impl TextMateEngine {
             stats: HighlightStats::default(),
             embedding,
             embedded_syntax_memo: HashMap::new(),
+            host_span_scratch: Vec::new(),
+            child_span_scratch: Vec::new(),
             scope_category_cache: HashMap::new(),
         }
     }
@@ -704,7 +711,8 @@ impl TextMateEngine {
         };
 
         let was_in_region = scopes_contain(&snapshot.scopes, spec.region_scope);
-        let mut host_spans: Vec<(usize, usize, HighlightCategory)> = Vec::new();
+        let mut host_spans = std::mem::take(&mut self.host_span_scratch);
+        host_spans.clear();
         let (parse_ok, language_range) = self.parse_line_into_spans(
             &mut snapshot.state,
             &mut snapshot.scopes,
@@ -713,29 +721,54 @@ impl TextMateEngine {
             (!was_in_region).then_some(spec.language_scope),
             |start, end, category| host_spans.push((start, end, category)),
         );
-        let in_region = parse_ok && scopes_contain(&snapshot.scopes, spec.region_scope);
-
-        let content_line = was_in_region && in_region;
-        if content_line {
-            if let Some(mut embedded) = snapshot.embedded.take() {
-                let syntax_valid = embedded.syntax_index < self.syntax_set.syntaxes().len();
-                if syntax_valid {
-                    let _ = self.parse_line_into_spans(
-                        &mut embedded.state,
-                        &mut embedded.scopes,
-                        prepared,
-                        current_offset,
-                        None,
-                        &mut on_span,
-                    );
-                }
-                snapshot.embedded = Some(embedded);
-                return parse_ok;
-            }
-            // Region with an unrecognized language: keep host styling.
+        if !parse_ok {
+            // Transient host parse error (a regex-engine failure): emit
+            // nothing for this line, matching the single-layer path, and
+            // leave region membership untouched. The host scope stack is
+            // left as-is on error, so treating the error as a region
+            // close would silently drop the child parser and
+            // de-highlight the rest of the region.
+            self.host_span_scratch = host_spans;
+            return false;
         }
+        let in_region = scopes_contain(&snapshot.scopes, spec.region_scope);
 
-        for (start, end, category) in host_spans {
+        // NOTE for future `EMBEDDING_SPECS` hosts: classification is
+        // line-granular, so a host whose regions can close AND reopen
+        // within one line reads as continuous region content here.
+        // Markdown fence delimiters occupy whole lines, so this cannot
+        // arise for it.
+        let content_line = was_in_region && in_region;
+        if content_line && snapshot.embedded.is_some() {
+            let mut embedded = snapshot
+                .embedded
+                .take()
+                .expect("checked embedded.is_some() above");
+            let mut child_spans = std::mem::take(&mut self.child_span_scratch);
+            child_spans.clear();
+            let (child_ok, _) = self.parse_line_into_spans(
+                &mut embedded.state,
+                &mut embedded.scopes,
+                prepared,
+                current_offset,
+                None,
+                |start, end, category| child_spans.push((start, end, category)),
+            );
+            // On a child parse error, fall back to the host's raw
+            // styling for the line rather than leaving it unstyled.
+            let chosen = if child_ok { &child_spans } else { &host_spans };
+            for &(start, end, category) in chosen {
+                on_span(start, end, category);
+            }
+            snapshot.embedded = Some(embedded);
+            self.child_span_scratch = child_spans;
+            self.host_span_scratch = host_spans;
+            return true;
+        }
+        // A content line in a region with an unrecognized language falls
+        // through: it keeps the host's own styling.
+
+        for &(start, end, category) in &host_spans {
             on_span(start, end, category);
         }
         match (was_in_region, in_region) {
@@ -746,7 +779,8 @@ impl TextMateEngine {
             (true, false) => snapshot.embedded = None,
             _ => {}
         }
-        parse_ok
+        self.host_span_scratch = host_spans;
+        true
     }
 
     /// Build the child parser for a region that just opened, from the

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -272,9 +272,9 @@ pub struct TextMateEngine {
     last_buffer_len: usize,
     ts_language: Option<Language>,
     stats: HighlightStats,
-    // Set when this syntax hosts embedded-language regions (see
-    // `EMBEDDING_SPECS`); None for the vast majority of syntaxes.
-    embedding: Option<EmbeddingSpec>,
+    // Region kinds this syntax hosts (see `EMBEDDING_SPECS`); empty for
+    // the vast majority of syntaxes.
+    embedding: Vec<EmbeddingSpec>,
     // Fence-language-token → syntax index memo (None = unrecognized).
     embedded_syntax_memo: HashMap<String, Option<usize>>,
     // Reusable per-line span buffers for embedding hosts, so region
@@ -331,13 +331,41 @@ struct EmbeddingSpecDef {
     /// Scope (prefix) the host grammar assigns to the language token on
     /// the region's opening line.
     language_scope: &'static str,
+    /// Language token used when the opening line names no language, or
+    /// names one that doesn't resolve to a syntax (e.g. `lang="ts"` in a
+    /// Vue `<script>` — there is no TextMate TS grammar in the set, and
+    /// JS is the standard approximation). `None` = keep the host's own
+    /// styling for such regions (Markdown's raw-code look).
+    default_language: Option<&'static str>,
 }
 
-const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[EmbeddingSpecDef {
-    host_syntax: "Markdown",
-    region_scope: "markup.raw.code-fence",
-    language_scope: "constant.other.language-name",
-}];
+/// A host may declare several region kinds (Vue: `<script>` and
+/// `<style>`), each with its own default language. Region scopes of one
+/// host must not be prefixes of each other.
+const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
+    EmbeddingSpecDef {
+        host_syntax: "Markdown",
+        region_scope: "markup.raw.code-fence",
+        language_scope: "constant.other.language-name",
+        default_language: None,
+    },
+    EmbeddingSpecDef {
+        host_syntax: "Vue",
+        region_scope: "meta.embedded.block.script",
+        language_scope: "constant.other.language-name",
+        default_language: Some("js"),
+    },
+    EmbeddingSpecDef {
+        host_syntax: "Vue",
+        region_scope: "meta.embedded.block.style",
+        language_scope: "constant.other.language-name",
+        default_language: Some("css"),
+    },
+];
+
+/// Cap on watched language scopes per host; far above any real spec
+/// table (Vue, the largest host, has one distinct language scope).
+const MAX_WATCH_SCOPES: usize = 8;
 
 /// `EmbeddingSpecDef` with its scope selectors interned as syntect `Scope`
 /// atoms for cheap prefix matching in the per-line parse loop.
@@ -345,15 +373,22 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[EmbeddingSpecDef {
 struct EmbeddingSpec {
     region_scope: syntect::parsing::Scope,
     language_scope: syntect::parsing::Scope,
+    default_language: Option<&'static str>,
 }
 
 impl EmbeddingSpec {
-    fn for_syntax_name(name: &str) -> Option<Self> {
-        let def = EMBEDDING_SPECS.iter().find(|d| d.host_syntax == name)?;
-        Some(Self {
-            region_scope: syntect::parsing::Scope::new(def.region_scope).ok()?,
-            language_scope: syntect::parsing::Scope::new(def.language_scope).ok()?,
-        })
+    fn compile_for_syntax(name: &str) -> Vec<Self> {
+        EMBEDDING_SPECS
+            .iter()
+            .filter(|d| d.host_syntax == name)
+            .filter_map(|d| {
+                Some(Self {
+                    region_scope: syntect::parsing::Scope::new(d.region_scope).ok()?,
+                    language_scope: syntect::parsing::Scope::new(d.language_scope).ok()?,
+                    default_language: d.default_language,
+                })
+            })
+            .collect()
     }
 }
 
@@ -479,7 +514,8 @@ impl TextMateEngine {
         syntax_index: usize,
         ts_language: Option<Language>,
     ) -> Self {
-        let embedding = EmbeddingSpec::for_syntax_name(&syntax_set.syntaxes()[syntax_index].name);
+        let embedding =
+            EmbeddingSpec::compile_for_syntax(&syntax_set.syntaxes()[syntax_index].name);
         Self {
             syntax_set,
             syntax_index,
@@ -595,10 +631,10 @@ impl TextMateEngine {
     /// been mutated mid-parse but is left as-is, matching prior
     /// behaviour).
     ///
-    /// When `watch_scope` is set, additionally returns the absolute byte
-    /// range of the first contiguous run where that scope was on the
-    /// stack (used to locate the language token on a region-opening
-    /// line).
+    /// When `watch_scopes` is non-empty, additionally returns the
+    /// absolute byte range of the first contiguous run where any of
+    /// those scopes was on the stack (used to locate the language token
+    /// on a region-opening line).
     ///
     /// Span emission is in two passes: the op iterator emits the
     /// segment between consecutive ops with the scope-stack-active
@@ -610,7 +646,7 @@ impl TextMateEngine {
         current_scopes: &mut syntect::parsing::ScopeStack,
         prepared: &PreparedLine,
         current_offset: usize,
-        watch_scope: Option<syntect::parsing::Scope>,
+        watch_scopes: &[syntect::parsing::Scope],
         mut on_span: impl FnMut(usize, usize, HighlightCategory),
     ) -> (bool, Option<Range<usize>>) {
         let ops = match state.parse_line(&prepared.line_for_syntect, &self.syntax_set) {
@@ -637,17 +673,17 @@ impl TextMateEngine {
             syntect_offset = clamped_op_offset;
             #[allow(clippy::let_underscore_must_use)]
             let _ = current_scopes.apply(&op);
-            if let Some(watch) = watch_scope {
-                if watched_range.is_none() {
-                    let active = scopes_contain(current_scopes, watch);
-                    match (watch_run_start, active) {
-                        (None, true) => watch_run_start = Some(clamped_op_offset),
-                        (Some(start), false) => {
-                            watched_range =
-                                Some(current_offset + start..current_offset + clamped_op_offset);
-                        }
-                        _ => {}
+            if !watch_scopes.is_empty() && watched_range.is_none() {
+                let active = watch_scopes
+                    .iter()
+                    .any(|w| scopes_contain(current_scopes, *w));
+                match (watch_run_start, active) {
+                    (None, true) => watch_run_start = Some(clamped_op_offset),
+                    (Some(start), false) => {
+                        watched_range =
+                            Some(current_offset + start..current_offset + clamped_op_offset);
                     }
+                    _ => {}
                 }
             }
         }
@@ -676,14 +712,15 @@ impl TextMateEngine {
     /// Line classification is driven purely by the host grammar's scope
     /// stack (no second lexer that could disagree with what the host
     /// grammar recognizes as a region):
-    /// - region scope absent before and after → plain host line;
-    /// - absent before, present after → region opened: host-styled, and
-    ///   the language token (located by `language_scope`) selects the
-    ///   child syntax for subsequent lines;
-    /// - present before and after → region content: parsed by the child
-    ///   (host spans for the line are suppressed); when the language was
-    ///   not recognized the host's own styling (e.g. `markup.raw`) is
-    ///   kept;
+    /// - no region scope before or after → plain host line;
+    /// - none before, one after → region opened: host-styled, and the
+    ///   language token (located by `language_scope`), or the spec's
+    ///   `default_language` when absent/unresolvable, selects the child
+    ///   syntax for subsequent lines;
+    /// - same region before and after → region content: parsed by the
+    ///   child (host spans for the line are suppressed); with no child
+    ///   (no default and no recognizable token) the host's own styling
+    ///   (e.g. `markup.raw`) is kept;
     /// - present before, absent after → closing delimiter: host-styled.
     ///
     /// The host parser always consumes the line first — inside a region
@@ -697,20 +734,36 @@ impl TextMateEngine {
         current_offset: usize,
         mut on_span: impl FnMut(usize, usize, HighlightCategory),
     ) -> bool {
-        let Some(spec) = self.embedding else {
+        if self.embedding.is_empty() {
             return self
                 .parse_line_into_spans(
                     &mut snapshot.state,
                     &mut snapshot.scopes,
                     prepared,
                     current_offset,
-                    None,
+                    &[],
                     on_span,
                 )
                 .0;
-        };
+        }
 
-        let was_in_region = scopes_contain(&snapshot.scopes, spec.region_scope);
+        let was_in = self.active_region_spec(&snapshot.scopes);
+        // Watch for a language token only on lines that could open a
+        // region. Copy the (deduplicated) language scopes to the stack so
+        // no borrow of self outlives the parse call below.
+        let mut watch_buf = [self.embedding[0].language_scope; MAX_WATCH_SCOPES];
+        let mut watch_len = 0;
+        if was_in.is_none() {
+            for spec in &self.embedding {
+                if watch_len < MAX_WATCH_SCOPES
+                    && !watch_buf[..watch_len].contains(&spec.language_scope)
+                {
+                    watch_buf[watch_len] = spec.language_scope;
+                    watch_len += 1;
+                }
+            }
+        }
+
         let mut host_spans = std::mem::take(&mut self.host_span_scratch);
         host_spans.clear();
         let (parse_ok, language_range) = self.parse_line_into_spans(
@@ -718,7 +771,7 @@ impl TextMateEngine {
             &mut snapshot.scopes,
             prepared,
             current_offset,
-            (!was_in_region).then_some(spec.language_scope),
+            &watch_buf[..watch_len],
             |start, end, category| host_spans.push((start, end, category)),
         );
         if !parse_ok {
@@ -731,71 +784,105 @@ impl TextMateEngine {
             self.host_span_scratch = host_spans;
             return false;
         }
-        let in_region = scopes_contain(&snapshot.scopes, spec.region_scope);
+        let now_in = self.active_region_spec(&snapshot.scopes);
 
         // NOTE for future `EMBEDDING_SPECS` hosts: classification is
         // line-granular, so a host whose regions can close AND reopen
-        // within one line reads as continuous region content here.
-        // Markdown fence delimiters occupy whole lines, so this cannot
-        // arise for it.
-        let content_line = was_in_region && in_region;
-        if content_line && snapshot.embedded.is_some() {
-            let mut embedded = snapshot
-                .embedded
-                .take()
-                .expect("checked embedded.is_some() above");
-            let mut child_spans = std::mem::take(&mut self.child_span_scratch);
-            child_spans.clear();
-            let (child_ok, _) = self.parse_line_into_spans(
-                &mut embedded.state,
-                &mut embedded.scopes,
-                prepared,
-                current_offset,
-                None,
-                |start, end, category| child_spans.push((start, end, category)),
-            );
-            // On a child parse error, fall back to the host's raw
-            // styling for the line rather than leaving it unstyled.
-            let chosen = if child_ok { &child_spans } else { &host_spans };
-            for &(start, end, category) in chosen {
-                on_span(start, end, category);
+        // within one line reads as continuous region content (same kind)
+        // or as a default-language restart (different kind). Markdown
+        // fences and Vue script/style tags occupy whole lines, so
+        // neither arises for the current hosts.
+        if let (Some(i), Some(j)) = (was_in, now_in) {
+            if i == j {
+                // Region content line.
+                if snapshot.embedded.is_some() {
+                    let mut embedded = snapshot
+                        .embedded
+                        .take()
+                        .expect("checked embedded.is_some() above");
+                    let mut child_spans = std::mem::take(&mut self.child_span_scratch);
+                    child_spans.clear();
+                    let (child_ok, _) = self.parse_line_into_spans(
+                        &mut embedded.state,
+                        &mut embedded.scopes,
+                        prepared,
+                        current_offset,
+                        &[],
+                        |start, end, category| child_spans.push((start, end, category)),
+                    );
+                    // On a child parse error, fall back to the host's
+                    // raw styling for the line rather than leaving it
+                    // unstyled.
+                    let chosen = if child_ok { &child_spans } else { &host_spans };
+                    for &(start, end, category) in chosen {
+                        on_span(start, end, category);
+                    }
+                    snapshot.embedded = Some(embedded);
+                    self.child_span_scratch = child_spans;
+                    self.host_span_scratch = host_spans;
+                    return true;
+                }
+                // No child (no default and no recognizable token): the
+                // line keeps the host's own styling below.
             }
-            snapshot.embedded = Some(embedded);
-            self.child_span_scratch = child_spans;
-            self.host_span_scratch = host_spans;
-            return true;
         }
-        // A content line in a region with an unrecognized language falls
-        // through: it keeps the host's own styling.
 
         for &(start, end, category) in &host_spans {
             on_span(start, end, category);
         }
-        match (was_in_region, in_region) {
-            (false, true) => {
+        match (was_in, now_in) {
+            (None, Some(j)) => {
+                // Region opened: language token if the grammar scoped
+                // one, else the spec default.
                 snapshot.embedded =
-                    self.embedded_state_for_region(prepared, current_offset, language_range);
+                    self.embedded_state_for_region(prepared, current_offset, language_range, j);
             }
-            (true, false) => snapshot.embedded = None,
+            (Some(i), Some(j)) if i != j => {
+                // One region kind closed and another opened on the same
+                // line; the opening token wasn't watched, so start the
+                // new region with its default language.
+                snapshot.embedded =
+                    self.embedded_state_for_region(prepared, current_offset, None, j);
+            }
+            (Some(_), None) => snapshot.embedded = None,
             _ => {}
         }
         self.host_span_scratch = host_spans;
         true
     }
 
+    /// Index of the spec whose region scope is on the host stack, if any.
+    fn active_region_spec(&self, scopes: &syntect::parsing::ScopeStack) -> Option<usize> {
+        self.embedding
+            .iter()
+            .position(|spec| scopes_contain(scopes, spec.region_scope))
+    }
+
     /// Build the child parser for a region that just opened, from the
-    /// language token the host grammar scoped on the opening line.
+    /// language token the host grammar scoped on the opening line, or
+    /// the spec's `default_language` when the token is absent or doesn't
+    /// resolve to a syntax.
     fn embedded_state_for_region(
         &mut self,
         prepared: &PreparedLine,
         current_offset: usize,
         language_range: Option<Range<usize>>,
+        spec_index: usize,
     ) -> Option<EmbeddedParseState> {
-        let range = language_range?;
-        let rel =
-            range.start.checked_sub(current_offset)?..range.end.checked_sub(current_offset)?;
-        let token = prepared.line_for_syntect.get(rel)?;
-        let syntax_index = self.resolve_embedded_syntax(token)?;
+        let explicit = language_range
+            .and_then(|range| {
+                let rel = range.start.checked_sub(current_offset)?
+                    ..range.end.checked_sub(current_offset)?;
+                prepared.line_for_syntect.get(rel)
+            })
+            .and_then(|token| self.resolve_embedded_syntax(token));
+        let syntax_index = match explicit {
+            Some(index) => index,
+            None => {
+                let default = self.embedding[spec_index].default_language?;
+                self.resolve_embedded_syntax(default)?
+            }
+        };
         Some(EmbeddedParseState {
             syntax_index,
             state: syntect::parsing::ParseState::new(&self.syntax_set.syntaxes()[syntax_index]),
@@ -2169,6 +2256,93 @@ mod tests {
             "a fence starting past MAX_PARSE_BYTES must still get embedded \
              highlighting once reached via scrolling — a size-based cutoff \
              here means the mechanism bypassed the windowed engine"
+        );
+    }
+
+    /// Vue `<script>`/`<style>` blocks with no `lang` attribute are
+    /// parsed with the spec's default languages (js / css) — proving the
+    /// embedding mechanism generalizes beyond Markdown with nothing but
+    /// spec-table entries and grammar scopes.
+    #[test]
+    fn test_vue_script_and_style_default_languages() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("App.vue"), None, &registry);
+        assert_eq!(engine.backend_name(), "textmate");
+
+        let content = "<template>\n  <p>hi</p>\n</template>\n\n<script>\nconst answer = 42;\n</script>\n\n<style>\n.foo { color: red; }\n</style>\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let category_at = |needle: &str| {
+            let position = content.find(needle).unwrap();
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category)
+        };
+
+        assert_eq!(
+            category_at("const"),
+            Some(HighlightCategory::Keyword),
+            "script block without lang must be parsed as JavaScript"
+        );
+        assert_eq!(category_at("42"), Some(HighlightCategory::Number));
+        assert_eq!(
+            category_at("color"),
+            Some(HighlightCategory::Type),
+            "style block without lang must be parsed as CSS"
+        );
+        // Delimiter lines stay host-styled (tag names).
+        assert_eq!(category_at("script>"), Some(HighlightCategory::Property));
+    }
+
+    /// A `lang` attribute dynamically selects the embedded language.
+    #[test]
+    fn test_vue_lang_attribute_selects_language() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("App.vue"), None, &registry);
+        let content = "<style lang=\"scss\">\n$width: 10px;\n.a { width: $width; }\n</style>\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = content.find("$width").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Variable),
+            "lang=\"scss\" must switch the style block to the SCSS grammar \
+             ($variables are not CSS syntax)"
+        );
+    }
+
+    /// A `lang` naming a language with no syntect grammar (TypeScript is
+    /// tree-sitter-only in fresh) falls back to the region's default
+    /// language rather than dropping highlighting entirely — `<script
+    /// lang=\"ts\">` is the dominant real-world Vue pattern.
+    #[test]
+    fn test_vue_unresolvable_lang_falls_back_to_default() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("App.vue"), None, &registry);
+        let content = "<script setup lang=\"ts\">\nconst answer = 42;\n</script>\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let position = content.find("const").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Keyword),
+            "unresolvable lang token must fall back to the spec default (js)"
         );
     }
 

--- a/crates/fresh-editor/tests/e2e/markdown_fenced_code_highlighting.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_fenced_code_highlighting.rs
@@ -1,0 +1,116 @@
+//! E2E: Markdown fenced code blocks are highlighted with the fenced
+//! language's grammar (issue #2689), driven end-to-end through rendering.
+//!
+//! Before the embedded-language-region mechanism, the whole fence body was
+//! painted uniformly with the raw-code (string) color, so keyword/number/
+//! string tokens inside a ```rust block all had the same foreground.
+//! These tests assert on rendered cell styles only.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::style::Color;
+use std::path::PathBuf;
+
+fn fixture_path(filename: &str) -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir)
+        .join("tests/fixtures/syntax_highlighting")
+        .join(filename)
+}
+
+fn create_harness() -> EditorTestHarness {
+    EditorTestHarness::create(
+        120,
+        40,
+        HarnessOptions::new()
+            .with_project_root()
+            .with_full_grammar_registry(),
+    )
+    .unwrap()
+}
+
+/// Foreground color of the first cell of `text` on screen.
+fn fg_at(harness: &EditorTestHarness, text: &str) -> Color {
+    let (col, row) = harness
+        .find_text_on_screen(text)
+        .unwrap_or_else(|| panic!("'{text}' not found on screen"));
+    harness
+        .get_cell_style(col, row)
+        .and_then(|s| s.fg)
+        .unwrap_or_else(|| panic!("no fg style at '{text}' ({col},{row})"))
+}
+
+/// Tokens of different kinds inside a ```rust fence must render with
+/// different foregrounds (keyword vs string vs number). With the old
+/// uniform raw-code styling they were all the same color.
+#[test]
+fn test_markdown_rust_fence_has_language_colors() {
+    let mut harness = create_harness();
+    harness.open_file(&fixture_path("fenced_code.md")).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("fn answer");
+    let keyword_fg = fg_at(&harness, "fn answer");
+    let string_fg = fg_at(&harness, "hello");
+    let number_fg = fg_at(&harness, "42");
+
+    assert_ne!(
+        keyword_fg, string_fg,
+        "keyword and string inside a rust fence must differ — a uniform \
+         color means the fence body still uses raw-code styling"
+    );
+    assert_ne!(keyword_fg, number_fg, "keyword vs number must differ");
+}
+
+/// A fence naming an unknown language keeps the uniform raw-code styling.
+#[test]
+fn test_markdown_unknown_fence_language_stays_uniform() {
+    let mut harness = create_harness();
+    harness.open_file(&fixture_path("fenced_code.md")).unwrap();
+    harness.render().unwrap();
+
+    // The nosuchlanguage block contains "fn answer() -> u32 { 42 }" on one
+    // line; keyword and number positions must render identically there.
+    let (col, row) = harness
+        .find_text_on_screen("fn answer() -> u32 { 42 }")
+        .expect("unknown-language fence content not on screen");
+    let fg_fn = harness.get_cell_style(col, row).and_then(|s| s.fg);
+    let number_col = col + "fn answer() -> u32 { ".len() as u16;
+    let fg_num = harness.get_cell_style(number_col, row).and_then(|s| s.fg);
+    assert_eq!(
+        fg_fn, fg_num,
+        "unknown fence language must keep uniform raw-code styling"
+    );
+}
+
+/// Typing new code inside a fence gets language highlighting immediately
+/// (exercises the engine's incremental partial-update path end-to-end).
+#[test]
+fn test_typing_inside_fence_is_highlighted() {
+    let mut harness = create_harness();
+    harness.open_file(&fixture_path("fenced_code.md")).unwrap();
+    harness.render().unwrap();
+
+    // Move to the "42" line (line 8) inside the rust fence and add a line
+    // below it.
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("8").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("    return 7;").unwrap();
+    harness.render().unwrap();
+
+    let keyword_fg = fg_at(&harness, "return");
+    let number_fg = fg_at(&harness, "7;");
+    assert_ne!(
+        keyword_fg, number_fg,
+        "code typed into a fence must be highlighted by the fence language"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/markdown_fenced_code_highlighting.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_fenced_code_highlighting.rs
@@ -1,10 +1,12 @@
-//! E2E: Markdown fenced code blocks are highlighted with the fenced
-//! language's grammar (issue #2689), driven end-to-end through rendering.
+//! E2E: embedded-language regions are highlighted with the named
+//! language's grammar, driven end-to-end through rendering — Markdown
+//! fenced code blocks (issue #2689) and Vue `<script>`/`<style>` blocks.
 //!
-//! Before the embedded-language-region mechanism, the whole fence body was
-//! painted uniformly with the raw-code (string) color, so keyword/number/
-//! string tokens inside a ```rust block all had the same foreground.
-//! These tests assert on rendered cell styles only.
+//! Before the embedded-language-region mechanism, a fence body was
+//! painted uniformly with the raw-code (string) color, and Vue blocks
+//! were styled by a hand-rolled keyword list that left identifiers and
+//! CSS properties unstyled. These tests assert on rendered cell styles
+//! only.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -80,6 +82,47 @@ fn test_markdown_unknown_fence_language_stays_uniform() {
     assert_eq!(
         fg_fn, fg_num,
         "unknown fence language must keep uniform raw-code styling"
+    );
+}
+
+/// Vue `<script>`/`<style>` blocks are parsed with real JS/CSS grammars.
+/// The fixture's script is `lang="ts"` (no TextMate TS grammar exists),
+/// exercising the fall-back-to-default-language path end-to-end. On the
+/// old hand-rolled Vue grammar, function names and CSS property names
+/// rendered with the default foreground.
+#[test]
+fn test_vue_script_and_style_blocks_are_language_highlighted() {
+    let mut harness = create_harness();
+    harness.open_file(&fixture_path("hello.vue")).unwrap();
+    harness.render().unwrap();
+
+    // Reference color: plain template text, unstyled by any grammar.
+    let plain_fg = fg_at(&harness, "Click me");
+
+    // `function greet() {` — the *name* is entity.name.function under the
+    // real JS grammar; find the unique "function greet" occurrence and
+    // probe the name's first cell.
+    let (col, row) = harness
+        .find_text_on_screen("function greet")
+        .expect("script content not on screen");
+    let name_col = col + "function ".len() as u16;
+    let name_fg = harness
+        .get_cell_style(name_col, row)
+        .and_then(|s| s.fg)
+        .expect("no fg at function name");
+    assert_ne!(
+        name_fg, plain_fg,
+        "JS function name inside <script lang=\"ts\"> must be highlighted \
+         (default-language fallback); default fg means the block wasn't \
+         parsed by a real grammar"
+    );
+
+    // `color: blue;` — property names are support.type under the real CSS
+    // grammar; the old grammar left them unstyled.
+    let css_fg = fg_at(&harness, "color: blue");
+    assert_ne!(
+        css_fg, plain_fg,
+        "CSS property name inside <style> must be highlighted"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -147,6 +147,7 @@ pub mod markdown_compose;
 pub mod markdown_compose_diagnostics;
 pub mod markdown_compose_scroll_reach;
 pub mod markdown_compose_table_border;
+pub mod markdown_fenced_code_highlighting;
 pub mod memory_scroll_leak;
 pub mod menu_bar;
 pub mod menu_cursor_bleed;

--- a/crates/fresh-editor/tests/fixtures/syntax_highlighting/fenced_code.md
+++ b/crates/fresh-editor/tests/fixtures/syntax_highlighting/fenced_code.md
@@ -1,0 +1,18 @@
+# Fenced code demo
+
+Some prose before the code.
+
+```rust
+fn answer() -> u32 {
+    let greeting = "hello";
+    42
+}
+```
+
+Prose between blocks.
+
+```nosuchlanguage
+fn answer() -> u32 { 42 }
+```
+
+Trailing prose.

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -50,6 +50,7 @@ other docs assume.
 | Doc | What it covers |
 |-----|----------------|
 | [rendering-and-layout.md](rendering-and-layout.md) | The per-frame render loop, the token→`ViewLine` pipeline, the line-wrap and visual-row caches that make huge files scroll cheaply, folding/conceal/virtual-text, split-pane layout, and the `Scene` projection shared with the web frontend. |
+| [embedded-language-highlighting.md](embedded-language-highlighting.md) | Mixed/embedded-language files (Markdown fences, HTML+CSS, templating): the composite-snapshot region mechanism in the TextMate engine, and the rule of thumb for grammar-level embedding vs engine-level regions vs `highlight_string`. |
 | [syntax-highlighting.md](syntax-highlighting.md) | The engine-selection rule (syntect TextMate grammars by default, tree-sitter for the gaps, and why), the checkpoint/convergence incremental-highlight algorithm, viewport-only scaling, category→theme mapping, and reference/bracket overlays. |
 | [lsp.md](lsp.md) | The multi-server LSP client: `(language, feature)` routing, the gate-and-retry concurrency model, async result flow, diagnostics-as-markers, completion-source merging, and feature concessions. |
 | [web-ui.md](web-ui.md) | The non-terminal (web) frontend: the unified-scene architecture and what ships today, plus the design gaps and implementation gaps between the current prototype and desktop-grade (VS Code-level) polish. |

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -1,0 +1,136 @@
+# Embedded-Language Highlighting (Mixed-Language Files)
+
+> _AI-generated: describes Fresh's architecture and design rationale, not implementation details; where it disagrees with the source, the source is authoritative._
+
+**Status: IMPLEMENTED** for TextMate-engine hosts, with Markdown fenced code
+blocks as the first (and motivating) case — issue #2689. Companion to
+[`syntax-highlighting.md`](syntax-highlighting.md), which describes the
+checkpoint/incremental engine this mechanism extends.
+
+## The problem
+
+Some files legitimately contain more than one language: Markdown fences,
+HTML `<script>`/`<style>`, Vue/Svelte components, templating languages. The
+highlighting engine is deliberately incremental and viewport-bounded
+(checkpoints + windowed parsing, no full-buffer rescans on edit), so any
+mixed-language support has to preserve those properties. A point fix that
+scans the whole buffer for fences on every edit, caches per buffer version,
+and turns itself off above a size threshold breaks both design rules
+("avoid full-buffer scans", no size cliff) — that's what this mechanism
+replaces.
+
+## Three existing tools, and when to use which
+
+There are now three ways to get a second language highlighted, and they are
+**not** interchangeable. Rule of thumb for future mixed-language cases:
+
+1. **The grammar itself embeds the other language** (via the shared
+   `SyntaxSet`): HTML embedding CSS/JS, PHP embedding HTML, and most
+   templating languages work this way already, because TextMate grammars
+   can push contexts from *another* grammar in the same set. The engine's
+   sequential `ParseState` tracks those transitions natively — checkpoints,
+   forward extension and convergence all just work (see the embedded-CSS
+   e2e tests). **Reach for this first** whenever the embedded language is
+   *statically known to the host grammar*. It's pure grammar data: add or
+   extend a `.sublime-syntax` in the build-time dump; zero engine changes.
+   This is also the answer for genuinely *interleaved* templating (Jinja,
+   ERB, Twig-style): a template grammar that switches contexts mid-line
+   between template markers and host text is exactly what TextMate
+   grammars are good at, and the engine already supports it.
+
+2. **The engine-level embedded-region mechanism** (this doc): for hosts
+   where the embedded language is *named by the document*, so no grammar
+   can enumerate it statically. Markdown fences are the canonical case:
+   the info string ("```rust", "```py", "~~~{.python}") can name any of
+   the ~140 syntaxes in the set, including user/plugin-registered ones.
+   Block-delimited, line-granular regions only.
+
+3. **`highlight_string`**: one-shot highlighting of a detached string
+   (hover popups, the markdown *preview* renderer). Never use it for
+   buffer content — it has no incrementality and no cache.
+
+## How the engine-level mechanism works
+
+The TextMate engine's resumable parse state is a **composite snapshot**:
+the host parser's `(ParseState, ScopeStack)` plus, while inside a
+recognized region, an embedded child parser's `(syntax, ParseState,
+ScopeStack)`. That snapshot — not just the host state — is what
+checkpoints, the cache tail state, and the convergence comparison carry.
+Because every incremental path already flows through those snapshots, the
+mechanism inherits the engine's whole lifecycle for free: resume-from-
+checkpoint into the middle of a region, forward extension while scrolling,
+partial update with convergence after edits, and the streaming-tail rules.
+
+Region detection is driven by the **host grammar's own scopes**, not by a
+second lexer. A small per-host spec table declares two scope selectors:
+
+- `region_scope` — the scope the host grammar keeps on the stack for the
+  whole region (Markdown: `markup.raw.code-fence`);
+- `language_scope` — the scope the host grammar puts on the language
+  token of the opening line (Markdown: `constant.other.language-name`).
+
+Per line, the host parser runs first (inside a region it is in a cheap
+"raw" context — it must run regardless, because only the host knows where
+the region ends), and the region-scope presence at line start vs end
+classifies the line:
+
+| region scope before → after | meaning | styled by |
+|---|---|---|
+| absent → absent | ordinary host line | host |
+| absent → present | region opened; language token resolved via `find_syntax_by_token` | host |
+| present → present | region content | child (host, if language unrecognized) |
+| present → absent | closing delimiter; child state dropped | host |
+
+Driving detection off the host grammar's scopes has a correctness property
+worth preserving: the highlighted region is *exactly* what the grammar
+recognizes as a region (marker-length rules, indentation quirks and all),
+so region styling can never disagree with the fence rendering itself. It
+also means zero extra scanning: detection rides along the line parse the
+engine was doing anyway.
+
+Unrecognized languages (and fences with no info string, and anything
+resolving to plain text) keep the host's own styling (`markup.raw` →
+string color), so nothing regresses.
+
+### Costs and limits
+
+- Content lines are parsed twice (host raw-context + child), but the host
+  side is a near-no-op; measured behavior is dominated by the child parse
+  the feature exists to perform.
+- Snapshots inside regions are roughly twice the size; checkpoint spacing
+  is unchanged.
+- One nesting level: the child parser is never itself region-scanned.
+  (A fence inside a fence is host-terminated at the first closing marker
+  anyway, so deeper nesting cannot arise for line-delimited regions.)
+- **Convergence granularity**: syntect states that carry regex captures
+  compare unequal even when logically identical (`onig::Region` equality
+  is allocation identity — a clone is already unequal to its original;
+  pre-existing, also true on the host-only tuple this replaced). The fence
+  context holds captures for its close-marker backreference, so an edit
+  inside a region re-parses to the *region's end* and converges at the
+  first checkpoint after it, still bounded per pass by the convergence
+  budget. Fixing that requires value-equality regions upstream (syntect's
+  `regex-fancy` backend has them; `regex-onig` does not).
+- Cold-starting a viewport in the middle of a huge region without nearby
+  checkpoints shows host-default styling until checkpoints exist — the
+  same documented trade-off the engine already makes for all multi-line
+  constructs (strings, block comments, HTML `<style>`).
+
+### Adding a new host
+
+Add one `EmbeddingSpecDef` entry (host syntax name + the two scope
+selectors) in the engine, and unit tests mirroring the Markdown ones:
+recognized region, unrecognized language fallback, an edit to the
+language token restyling the whole region, and a region past
+`MAX_PARSE_BYTES`. If the host grammar doesn't scope a language token or
+region, fix the grammar first (tool 1) — the engine mechanism assumes the
+host grammar tells the truth about regions.
+
+### Non-goals / future
+
+- The tree-sitter backend (JS/TS/JSON/Templ/Go fallback) has injections
+  explicitly disabled and none of those languages currently host embedded
+  regions; if one ever does, tree-sitter injection queries are the natural
+  analogue there.
+- The WASM-reserved `textmate_engine.rs` mirror does not implement the
+  mechanism yet.

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -77,10 +77,16 @@ script and style), each with two scope selectors and an optional default:
 - `language_scope` — the scope the host grammar puts on the language
   token of the opening line (`constant.other.language-name` for both);
 - `default_language` — used when the opening line names no language *or*
-  names one that doesn't resolve to a syntax in the set. Vue uses js/css
-  (so `lang="ts"` — TypeScript has no TextMate grammar in fresh — gets
-  the standard JS approximation instead of nothing); Markdown uses
-  `None`, meaning such regions keep the host's own raw-code styling.
+  names one that doesn't resolve to a syntax in the set. Vue uses js/css;
+  Markdown uses `None`, meaning such regions keep the host's own raw-code
+  styling.
+
+A compact TextMate TypeScript grammar is bundled *solely* for embedded
+contexts (`lang="ts"` in Vue, ```ts fences): the grammar catalog skips it
+by name — mirroring the JavaScript skip — so `.ts` buffers keep the richer
+tree-sitter highlighting, while `find_syntax_by_token("ts")` still
+resolves it for regions. (Vendoring Sublime's official TS grammar is not
+an option: it needs `branch_point`, which no released syntect supports.)
 
 Per line, the host parser runs first (inside a region it is in a cheap
 "raw" context — it must run regardless, because only the host knows where

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -2,8 +2,11 @@
 
 > _AI-generated: describes Fresh's architecture and design rationale, not implementation details; where it disagrees with the source, the source is authoritative._
 
-**Status: IMPLEMENTED** for TextMate-engine hosts, with Markdown fenced code
-blocks as the first (and motivating) case — issue #2689. Companion to
+**Status: IMPLEMENTED** for TextMate-engine hosts: Markdown fenced code
+blocks (the motivating case — issue #2689) and Vue `<script>`/`<style>`
+blocks (the proof of generality: two region kinds in one host, `lang`
+attributes, and default languages, added with spec-table entries plus
+grammar scopes and no engine control-flow changes). Companion to
 [`syntax-highlighting.md`](syntax-highlighting.md), which describes the
 checkpoint/incremental engine this mechanism extends.
 
@@ -43,7 +46,10 @@ There are now three ways to get a second language highlighted, and they are
    can enumerate it statically. Markdown fences are the canonical case:
    the info string ("```rust", "```py", "~~~{.python}") can name any of
    the ~140 syntaxes in the set, including user/plugin-registered ones.
-   Block-delimited, line-granular regions only.
+   Vue single-file components are the second: `<script lang="...">` /
+   `<style lang="...">` name the language, with js/css as per-region
+   defaults when no `lang` is given. Block-delimited, line-granular
+   regions only.
 
 3. **`highlight_string`**: one-shot highlighting of a detached string
    (hover popups, the markdown *preview* renderer). Never use it for
@@ -62,12 +68,19 @@ checkpoint into the middle of a region, forward extension while scrolling,
 partial update with convergence after edits, and the streaming-tail rules.
 
 Region detection is driven by the **host grammar's own scopes**, not by a
-second lexer. A small per-host spec table declares two scope selectors:
+second lexer. A host declares one spec per region *kind* (Vue has two:
+script and style), each with two scope selectors and an optional default:
 
 - `region_scope` — the scope the host grammar keeps on the stack for the
-  whole region (Markdown: `markup.raw.code-fence`);
+  whole region (Markdown: `markup.raw.code-fence`; Vue:
+  `meta.embedded.block.script` / `meta.embedded.block.style`);
 - `language_scope` — the scope the host grammar puts on the language
-  token of the opening line (Markdown: `constant.other.language-name`).
+  token of the opening line (`constant.other.language-name` for both);
+- `default_language` — used when the opening line names no language *or*
+  names one that doesn't resolve to a syntax in the set. Vue uses js/css
+  (so `lang="ts"` — TypeScript has no TextMate grammar in fresh — gets
+  the standard JS approximation instead of nothing); Markdown uses
+  `None`, meaning such regions keep the host's own raw-code styling.
 
 Per line, the host parser runs first (inside a region it is in a cheap
 "raw" context — it must run regardless, because only the host knows where
@@ -118,13 +131,17 @@ string color), so nothing regresses.
 
 ### Adding a new host
 
-Add one `EmbeddingSpecDef` entry (host syntax name + the two scope
-selectors) in the engine, and unit tests mirroring the Markdown ones:
+Add one `EmbeddingSpecDef` entry per region kind (host syntax name, the
+two scope selectors, and the optional default language) in the engine,
+and unit tests mirroring the Markdown/Vue ones:
 recognized region, unrecognized language fallback, an edit to the
 language token restyling the whole region, and a region past
 `MAX_PARSE_BYTES`. If the host grammar doesn't scope a language token or
 region, fix the grammar first (tool 1) — the engine mechanism assumes the
-host grammar tells the truth about regions.
+host grammar tells the truth about regions. That is exactly what the Vue
+grammar needed: its hand-rolled pseudo-JS/CSS contexts were replaced with
+honestly-scoped raw regions (`meta.embedded.block.*`) plus a scoped `lang`
+attribute value, and the engine does the rest.
 
 ### Non-goals / future
 

--- a/docs/internal/syntax-highlighting.md
+++ b/docs/internal/syntax-highlighting.md
@@ -121,7 +121,10 @@ order from a known `(ParseState, ScopeStack)` to correctly track multi-line
 constructs (comments, strings) and embedded-language transitions (CSS-in-HTML,
 code-in-markdown-fences). The engine makes scrolling and editing cheap with a
 span cache + periodic parse-state checkpoints + convergence-based incremental
-re-highlight. This is the **implemented v2 design**; the source design doc
+re-highlight. Mixed-language files (Markdown fences and friends) are handled
+by an embedded-region layer on top of this state machine — see
+[embedded-language-highlighting.md](embedded-language-highlighting.md) for
+that mechanism and for when to use grammar-level embedding instead. This is the **implemented v2 design**; the source design doc
 describes both the superseded v1 (a flat checkpoint vector at a coarse byte
 interval, discarded after every edit) and the v2 approach the code now realizes.
 


### PR DESCRIPTION
## Motivation

Fixes #2689. Markdown fenced code blocks render in the uniform raw-string color because syntect's bundled Markdown grammar can't know which language a fence names. Per the review direction on #2724 ("this needs a core feature for multi language highlighting"), this adds a general engine-level mechanism instead of a markdown point fix — no per-edit full-buffer scans, no size threshold where the feature stops working. To prove the mechanism is genuinely general, the PR also converts **Vue single-file components** to it as a second host, and bundles a compact **TextMate TypeScript grammar** so `lang="ts"` (the dominant real-world Vue pattern) and ```` ```ts ```` fences get real TS highlighting.

## Design

Full design note (including the rule of thumb for future mixed-language cases): [`docs/internal/embedded-language-highlighting.md`](https://github.com/sinelaw/fresh/blob/claude/mixed-embedded-highlighting-yl6jsg/docs/internal/embedded-language-highlighting.md). Summary:

**Composite parse snapshots.** The TextMate engine's resumable state becomes host `(ParseState, ScopeStack)` *plus*, while inside a recognized region, an embedded child parser for the language the document names. Checkpoints, the cache tail state, and convergence comparison all carry the composite snapshot, so every existing incremental path — resume-from-checkpoint, forward extension while scrolling, partial update with convergence, streaming-tail handling — works identically inside embedded regions. A fence starting past `MAX_PARSE_BYTES` highlights once reached via scrolling, exactly like embedded CSS in HTML does today (there is a test for this).

**Region detection from the host grammar's own scopes.** A host declares one `EmbeddingSpecDef` per region kind: a region scope, a language-token scope, and an optional default language. Line classification uses region-scope presence at line start vs end (absent→present = opening line, present→present = content parsed by the child, present→absent = closing delimiter). No second fence lexer exists, so the highlighted region can never disagree with what the grammar recognizes as a region (verified empirically: the bundled Markdown grammar handles marker-length rules like ` ``` ` inside a ` ```` ` fence correctly, and detection inherits that for free).

**Hosts implemented:**
- **Markdown** — `markup.raw.code-fence` / `constant.other.language-name`, no default: unknown fences keep raw styling.
- **Vue** — two region kinds (`meta.embedded.block.script`, `meta.embedded.block.style`) with `lang="..."` selecting the language and js/css defaults. The Vue grammar's hand-rolled pseudo-JS/CSS keyword contexts are replaced by honestly-scoped raw regions; real JS/TS/CSS/SCSS grammars now style the content. Adding Vue required no host-specific engine control flow — just the spec entries plus the two extensions a second host naturally demanded (multiple region kinds per host, per-region defaults).

**Bundled TypeScript grammar (embedded contexts only).** A compact house-style TS grammar (like the existing dart/kotlin ones) makes `lang="ts"` and ```` ```ts ```` resolve to TS-aware highlighting. `.ts` **buffers** are untouched: the grammar catalog skips "TypeScript" by name — mirroring the existing "JavaScript" skip (#899) — so they keep the richer tree-sitter highlighting; the pre-existing backend-selection test pins this. Vendoring Sublime's official TS syntax isn't possible: it requires `branch_point`, which no released syntect supports (fresh is already on the latest, 5.3.0).

**Rule of thumb** (from the design note):
1. Embedded language *statically known* to the host (HTML→CSS/JS, PHP, interleaved templating like Jinja/ERB): do it in the grammar via the shared `SyntaxSet` — zero engine changes.
2. Embedded language *named by the document* (Markdown fences, Vue `lang=` attributes): the engine-level region mechanism, one spec entry per region kind.
3. Detached strings (hover popups, previews): `highlight_string`, never for buffer content.

## Known limitation (pre-existing, now pinned by a test)

Syntect parse states carrying regex captures never compare equal across parses — `onig::Region`'s derived `PartialEq` compares raw capture-buffer pointers, so even `state.clone() != state`. The fence context holds captures for its close-marker backreference, so an edit inside a fence converges at the first checkpoint *after the region* rather than ~256 bytes after the edit (still bounded per pass by the convergence budget). This affected the previous `(ParseState, ScopeStack)` tuple comparison identically; fixing it needs value-equality regions upstream (syntect's `regex-fancy` backend has them; no released syntect changes this — 5.3.0 is current).

## Code review

A standalone adversarial review pass over the branch confirmed no correctness defects and produced four hardening changes (all applied): transient host parse errors inside a region no longer drop the child parser for the region's remainder; a child parse error falls back to host raw styling instead of leaving the line unstyled; the stale module-doc description of the cache tail was updated; and per-line span buffering on embedding hosts now reuses scratch buffers instead of allocating per line.

## Testing

Reproduce-before-claiming was verified by removing the spec-table entries (= master behavior): 5 of 7 markdown unit tests, all Vue unit tests, and 3 of 4 e2e tests fail without the mechanism; the passers are intentional behavior-preservation/perf-contract guards.

- Unit (markdown): fence highlighting, unknown-language fallback, CRLF offsets, unclosed-fence-at-EOF, language-token edit restyles the whole region (composite-checkpoint correctness), edit re-parses region-not-file (stats-based), fence past `MAX_PARSE_BYTES` (no size cliff), ```` ```ts ```` fence uses the TS grammar.
- Unit (Vue): default js/css selection, `lang="scss"` switches the style block to the SCSS grammar, `lang="ts"` uses the TS grammar (TS-only constructs get categories the JS fallback never gave), unresolvable `lang` falls back to the region default.
- E2E (rendered output only): keyword/string/number foregrounds differ inside a ```` ```rust ```` fence; unknown-language block stays uniform; typing inside a fence highlights immediately; Vue function names and CSS properties get non-default colors in `hello.vue`.
- Regression: 3018 lib tests, the highlighting/markdown e2e subset incl. the pre-existing Vue and TypeScript coverage tests (`.ts` still tree-sitter), `cargo clippy --all-targets` clean, `cargo fmt`, trimmed feature set (`--no-default-features --features runtime`) compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKX2Du2zizG7k9yZgMeZvS