### PR TITLE
fix(lsp): refresh inlay hints on buffer edits (#2744)

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -4229,4 +4229,69 @@ mod tests {
         let result = space_doc_paragraphs(input);
         assert_eq!(result, "Just a single line of docs.");
     }
+
+    fn timer_test_editor() -> Editor {
+        use crate::config::Config;
+        use crate::config_io::DirectoryContext;
+        let temp = tempfile::tempdir().unwrap();
+        let dir_context = DirectoryContext::for_testing(temp.path());
+        // Keep the temp dir alive for the editor's lifetime.
+        std::mem::forget(temp);
+        let mut config = Config::default();
+        config.editor.enable_inlay_hints = true;
+        Editor::for_test(
+            config,
+            80,
+            24,
+            None,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            Arc::new(StdFileSystem),
+            None,
+            None,
+            false,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_check_inlay_hints_timer_fires_and_clears_slot_after_deadline() {
+        // With the debounce slot's deadline already in the past, the consumer
+        // must clear the slot (the request is dispatched, but arrives async).
+        let mut editor = timer_test_editor();
+        let buffer_id = editor.active_buffer();
+        editor.active_window_mut().scheduled_inlay_hints_request = Some((
+            buffer_id,
+            std::time::Instant::now() - std::time::Duration::from_millis(1),
+        ));
+
+        editor.check_inlay_hints_timer();
+
+        assert!(
+            editor
+                .active_window()
+                .scheduled_inlay_hints_request
+                .is_none(),
+            "consumer should clear the debounce slot after the deadline passes"
+        );
+    }
+
+    #[test]
+    fn test_check_inlay_hints_timer_noop_before_deadline() {
+        // A future deadline must be left untouched so the debounce actually
+        // debounces instead of firing on the first idle tick.
+        let mut editor = timer_test_editor();
+        let buffer_id = editor.active_buffer();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        editor.active_window_mut().scheduled_inlay_hints_request = Some((buffer_id, deadline));
+
+        editor.check_inlay_hints_timer();
+
+        assert_eq!(
+            editor.active_window().scheduled_inlay_hints_request,
+            Some((buffer_id, deadline)),
+            "consumer must be a no-op while the deadline is still in the future"
+        );
+    }
 }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -3308,6 +3308,27 @@ impl Editor {
         }
     }
 
+    /// If a per-edit inlay-hints debounce has fired, send a fresh
+    /// `textDocument/inlayHint` request for the scheduled buffer. Mirrors
+    /// [`Window::check_diagnostic_pull_timer`]: the edit path writes the
+    /// debounce slot but nothing consumed it, so hints never refreshed after
+    /// an edit (sinelaw/fresh#2744). The response arrives asynchronously and
+    /// its handler is version-guarded, so no redraw is triggered here.
+    pub(crate) fn check_inlay_hints_timer(&mut self) {
+        let Some((buffer_id, trigger_time)) = self.active_window().scheduled_inlay_hints_request
+        else {
+            return;
+        };
+
+        if std::time::Instant::now() < trigger_time {
+            return;
+        }
+
+        self.active_window_mut().scheduled_inlay_hints_request = None;
+
+        self.request_inlay_hints_for_buffer(buffer_id);
+    }
+
     /// Issue a debounced folding range request if the timer has elapsed.
     pub(crate) fn maybe_request_folding_ranges_debounced(&mut self, buffer_id: BufferId) {
         let Some(ready_at) = self

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -170,6 +170,7 @@ pub fn editor_tick(
         needs_render = true;
     }
     editor.active_window_mut().check_diagnostic_pull_timer();
+    editor.check_inlay_hints_timer();
     if editor.check_warning_log() {
         needs_render = true;
     }

--- a/crates/fresh-editor/tests/e2e/lsp_inlay_hints_refresh_on_edit.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_inlay_hints_refresh_on_edit.rs
@@ -1,0 +1,144 @@
+//! Regression test for sinelaw/fresh#2744: inlay hints must refresh after a
+//! buffer edit.
+//!
+//! Root cause: the edit path (`send_lsp_changes_for_buffer`) writes the
+//! `scheduled_inlay_hints_request` debounce slot, but nothing ever consumed
+//! it (diagnostics work because `check_diagnostic_pull_timer` consumes their
+//! slot). `check_inlay_hints_timer`, called from the idle tick, is the
+//! missing consumer.
+//!
+//! These tests drive a fake LSP that advertises `inlayHintProvider` and
+//! assert on the debounce slot end-to-end:
+//!   * with hints enabled, an edit arms the slot and the idle tick (run by
+//!     `wait_until`) consumes it — proving a fresh request is dispatched;
+//!   * with hints disabled, edits never arm the slot.
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::EditorTestHarness;
+
+fn inlay_lsp_config(temp: &std::path::Path, enable_inlay_hints: bool) -> fresh::config::Config {
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_inlay_hints = enable_inlay_hints;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::inlay_hints_script_path(temp)
+                .to_string_lossy()
+                .to_string(),
+            args: None,
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("fake-rust-inlay".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+    config
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "FakeLspServer uses Bash")]
+fn test_inlay_hints_refresh_after_edit_when_enabled() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_with_inlay_hints(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("main.rs");
+    std::fs::write(&test_file, "let x = 1;\nfoo();\n")?;
+
+    let config = inlay_lsp_config(temp_dir.path(), true);
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        crate::common::harness::HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the initial inlay-hint round trip to land: virtual texts only
+    // appear once the server has been spawned, the buffer opened (didOpen),
+    // and hints applied. This guarantees a subsequent edit takes the
+    // didChange path (not the first-time didOpen path).
+    harness.wait_until(|h| !h.editor().active_state().virtual_texts.is_empty())?;
+
+    // A real edit must arm the debounce slot (the producer gates on
+    // enable_inlay_hints and only sets it once a didChange was sent).
+    harness.type_text("z")?;
+    assert!(
+        harness
+            .editor()
+            .active_window()
+            .scheduled_inlay_hints_request
+            .is_some(),
+        "editing an enabled buffer must schedule an inlay-hints refresh"
+    );
+
+    // The idle tick (run each iteration by wait_until) must consume the slot
+    // once the debounce deadline passes — this is the missing consumer under
+    // test. Without it the slot would stay Some forever and hints never refresh.
+    harness.wait_until(|h| {
+        h.editor()
+            .active_window()
+            .scheduled_inlay_hints_request
+            .is_none()
+    })?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "FakeLspServer uses Bash")]
+fn test_inlay_hints_slot_never_armed_when_disabled() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_with_inlay_hints(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("main.rs");
+    std::fs::write(&test_file, "let x = 1;\nfoo();\n")?;
+
+    let config = inlay_lsp_config(temp_dir.path(), false);
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        crate::common::harness::HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the server to spin up so edits actually produce didChange
+    // notifications (any_sent == true) — otherwise the "disabled" assertion
+    // would pass vacuously for the wrong reason.
+    harness.wait_until(|h| {
+        h.editor()
+            .active_window()
+            .running_lsp_servers()
+            .contains(&"rust".to_string())
+    })?;
+    harness.wait_for_async_quiescence(4)?;
+
+    // Several real edits, each flushing a didChange. With hints disabled the
+    // producer must never arm the debounce slot.
+    for ch in ["a", "b", "c"] {
+        harness.type_text(ch)?;
+        assert!(
+            harness
+                .editor()
+                .active_window()
+                .scheduled_inlay_hints_request
+                .is_none(),
+            "editing with inlay hints disabled must not schedule a refresh"
+        );
+        harness.wait_for_async_quiescence(2)?;
+    }
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -128,6 +128,7 @@ pub mod lsp_goto_implementation;
 pub mod lsp_indicator_click_bugs;
 pub mod lsp_indicator_click_to_open;
 pub mod lsp_inlay_hints_capability;
+pub mod lsp_inlay_hints_refresh_on_edit;
 pub mod lsp_lifecycle_visibility;
 pub mod lsp_missing_binary_and_dismiss;
 pub mod lsp_multi_semantic_tokens;


### PR DESCRIPTION
## Root cause

Inlay hints did not refresh after editing a buffer. The edit path (`send_lsp_changes_for_buffer`) *writes* a debounce slot, `Window::scheduled_inlay_hints_request`, but nothing ever *consumed* it — so the follow-up `textDocument/inlayHint` request was never sent. Pull diagnostics work only because they have a matching consumer (`check_diagnostic_pull_timer`) that the inlay path was missing.

## Fix

Add the missing consumer, `Editor::check_inlay_hints_timer`, modeled exactly on `check_diagnostic_pull_timer`:

- reads `self.active_window().scheduled_inlay_hints_request`; returns if the slot is `None` or its deadline is still in the future;
- clears the slot and calls the existing `request_inlay_hints_for_buffer(buffer_id)` (full-document range).

It is called from the idle tick (`app::editor_tick`) immediately after `check_diagnostic_pull_timer()`.

No new invalidation or debounce is introduced: the existing 500ms `INLAY_HINTS_DEBOUNCE_MS` slot is reused, the producer already gates on `enable_inlay_hints`, the response handler is already version-guarded, and cancel-on-close already clears the slot. The change mirrors the diagnostic timer's active-window-only scope.

## Tests

- **Unit** (`app::lsp_requests::tests`): consumer clears the slot after the deadline passes; consumer is a no-op while the deadline is in the future.
- **E2E** (`lsp_inlay_hints_refresh_on_edit`, fake `inlayHint`-capable LSP): editing an enabled buffer arms the slot and the idle tick consumes it (fresh request dispatched); with inlay hints disabled, edits never arm the slot.

All four new tests pass; the affected crate builds clean.

Closes #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_