### PR TITLE
fix(settings): source theme dropdown from the live registry (#2738)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -345,9 +345,12 @@
       "type": "string",
       "enum": [
         "dark",
-        "light",
+        "dracula",
         "high-contrast",
+        "light",
+        "nord",
         "nostalgia",
+        "solarized-dark",
         "terminal"
       ]
     },

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -343,16 +343,7 @@
     "ThemeOptions": {
       "description": "Available color themes",
       "type": "string",
-      "enum": [
-        "dark",
-        "dracula",
-        "high-contrast",
-        "light",
-        "nord",
-        "nostalgia",
-        "solarized-dark",
-        "terminal"
-      ]
+      "x-enum-from": "$themes"
     },
     "LocaleOptions": {
       "description": "UI locale (language). Use null for auto-detection from environment.",

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -44,6 +44,21 @@ impl Editor {
                 // Snapshot plugin-registered status-bar tokens for the dual-list picker.
                 let tokens = self.status_bar_token_registry.lock().unwrap().clone();
                 state.set_status_bar_tokens(tokens);
+                // Populate the theme dropdown from the live registry — the same
+                // list "Select Theme" shows (built-ins + user themes, same
+                // order), so the two never drift (#2738).
+                let theme_options = self
+                    .theme_registry
+                    .settings_theme_options()
+                    .into_iter()
+                    .map(
+                        |(display, value)| crate::view::settings::items::ThemeOption {
+                            display,
+                            value,
+                        },
+                    )
+                    .collect();
+                state.set_theme_options(theme_options);
                 state.show();
                 self.settings_state = Some(state);
             }

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -14,9 +14,22 @@ use std::path::Path;
 pub struct ThemeName(pub String);
 
 impl ThemeName {
-    /// Built-in theme options shown in the settings dropdown
-    pub const BUILTIN_OPTIONS: &'static [&'static str] =
-        &["dark", "light", "high-contrast", "nostalgia", "terminal"];
+    /// Built-in theme options shown in the settings dropdown.
+    ///
+    /// Must list every built-in root (empty-pack) theme in the same
+    /// alphabetical order the "Select Theme" picker uses (see the auto-generated
+    /// `BUILTIN_THEMES` registry). Kept in sync by the parity test in the
+    /// theme loader tests.
+    pub const BUILTIN_OPTIONS: &'static [&'static str] = &[
+        "dark",
+        "dracula",
+        "high-contrast",
+        "light",
+        "nord",
+        "nostalgia",
+        "solarized-dark",
+        "terminal",
+    ];
 }
 
 impl Deref for ThemeName {
@@ -8409,6 +8422,42 @@ mod tests {
             let keymap = Config::load_builtin_keymap(name);
             assert!(keymap.is_some(), "Failed to load builtin keymap '{}'", name);
         }
+    }
+
+    /// Regression test for #2738: the committed config schema (which drives the
+    /// settings theme dropdown at runtime) must stay in sync with
+    /// `ThemeName::BUILTIN_OPTIONS`, and expose all 8 themes in sorted order.
+    #[test]
+    fn test_config_schema_theme_enum_matches_builtin_options() {
+        const SCHEMA_JSON: &str = include_str!("../plugins/config-schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(SCHEMA_JSON).expect("config-schema.json must be valid JSON");
+
+        let enum_values = schema["$defs"]["ThemeOptions"]["enum"]
+            .as_array()
+            .expect("ThemeOptions.enum must be an array");
+        let schema_themes: Vec<String> = enum_values
+            .iter()
+            .map(|v| v.as_str().expect("theme enum values are strings").to_string())
+            .collect();
+
+        let options: Vec<String> = ThemeName::BUILTIN_OPTIONS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        assert_eq!(
+            schema_themes, options,
+            "config-schema.json ThemeOptions enum is out of sync with ThemeName::BUILTIN_OPTIONS; \
+             regenerate with scripts/gen_schema.sh"
+        );
+
+        let mut sorted = schema_themes.clone();
+        sorted.sort();
+        assert_eq!(
+            schema_themes, sorted,
+            "config-schema.json theme enum must be sorted alphabetically"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -13,25 +13,6 @@ use std::path::Path;
 #[serde(transparent)]
 pub struct ThemeName(pub String);
 
-impl ThemeName {
-    /// Built-in theme options shown in the settings dropdown.
-    ///
-    /// Must list every built-in root (empty-pack) theme in the same
-    /// alphabetical order the "Select Theme" picker uses (see the auto-generated
-    /// `BUILTIN_THEMES` registry). Kept in sync by the parity test in the
-    /// theme loader tests.
-    pub const BUILTIN_OPTIONS: &'static [&'static str] = &[
-        "dark",
-        "dracula",
-        "high-contrast",
-        "light",
-        "nord",
-        "nostalgia",
-        "solarized-dark",
-        "terminal",
-    ];
-}
-
 impl Deref for ThemeName {
     type Target = str;
     fn deref(&self) -> &Self::Target {
@@ -69,10 +50,21 @@ impl JsonSchema for ThemeName {
     }
 
     fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // A validated free-form string rather than a frozen `enum`: any config
+        // form accepted by `ThemeRegistry::resolve_key` (built-in names,
+        // `builtin://`, relative paths, `file://`/http(s) URIs) must validate,
+        // including user themes that don't exist at schema-generation time.
+        //
+        // `x-enum-from: "$themes"` is a dynamic-source hint (mirroring
+        // `default_language`'s `x-enum-from: "/languages"`). The settings UI
+        // resolves the reserved `$themes` token against the live
+        // `ThemeRegistry` so the dropdown lists exactly what "Select Theme"
+        // does — built-ins plus user themes — with no hand-maintained list to
+        // drift out of sync (#2738).
         schemars::json_schema!({
             "description": "Available color themes",
             "type": "string",
-            "enum": Self::BUILTIN_OPTIONS
+            "x-enum-from": "$themes"
         })
     }
 }
@@ -8424,40 +8416,67 @@ mod tests {
         }
     }
 
-    /// Regression test for #2738: the committed config schema (which drives the
-    /// settings theme dropdown at runtime) must stay in sync with
-    /// `ThemeName::BUILTIN_OPTIONS`, and expose all 8 themes in sorted order.
+    /// Regression test for #2738: the committed config schema must NOT freeze
+    /// the theme as a hard `enum`. It has to be a validated free-form string
+    /// carrying the `x-enum-from: "$themes"` dynamic-source hint, so user-theme
+    /// config values (paths / URIs / registry keys) validate and the settings
+    /// dropdown is sourced live from the registry rather than a static list.
     #[test]
-    fn test_config_schema_theme_enum_matches_builtin_options() {
+    fn test_config_schema_theme_is_dynamic_string_not_enum() {
         const SCHEMA_JSON: &str = include_str!("../plugins/config-schema.json");
         let schema: serde_json::Value =
             serde_json::from_str(SCHEMA_JSON).expect("config-schema.json must be valid JSON");
 
-        let enum_values = schema["$defs"]["ThemeOptions"]["enum"]
-            .as_array()
-            .expect("ThemeOptions.enum must be an array");
-        let schema_themes: Vec<String> = enum_values
-            .iter()
-            .map(|v| v.as_str().expect("theme enum values are strings").to_string())
-            .collect();
-
-        let options: Vec<String> = ThemeName::BUILTIN_OPTIONS
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let theme_options = &schema["$defs"]["ThemeOptions"];
 
         assert_eq!(
-            schema_themes, options,
-            "config-schema.json ThemeOptions enum is out of sync with ThemeName::BUILTIN_OPTIONS; \
+            theme_options["type"].as_str(),
+            Some("string"),
+            "ThemeOptions must be a plain string type"
+        );
+        assert!(
+            theme_options.get("enum").is_none(),
+            "ThemeOptions must NOT be a frozen enum (would reject user themes); \
              regenerate with scripts/gen_schema.sh"
         );
-
-        let mut sorted = schema_themes.clone();
-        sorted.sort();
         assert_eq!(
-            schema_themes, sorted,
-            "config-schema.json theme enum must be sorted alphabetically"
+            theme_options["x-enum-from"].as_str(),
+            Some("$themes"),
+            "ThemeOptions must carry the `$themes` dynamic-source hint so the \
+             settings dropdown is populated from the live theme registry"
         );
+    }
+
+    /// Regression test for #2738: because `theme` is no longer a hard enum, an
+    /// arbitrary user-theme config value (a relative path, a `file://` URI, or
+    /// a `builtin://` form) is accepted by the schema's string type instead of
+    /// being rejected as "not one of the allowed values".
+    #[test]
+    fn test_user_theme_config_value_validates_against_schema() {
+        const SCHEMA_JSON: &str = include_str!("../plugins/config-schema.json");
+        let schema: serde_json::Value =
+            serde_json::from_str(SCHEMA_JSON).expect("config-schema.json must be valid JSON");
+        let theme_options = &schema["$defs"]["ThemeOptions"];
+
+        // The only constraint on a theme value is `type: string` — no `enum`,
+        // no `pattern` — so every portable form the registry can emit validates.
+        assert_eq!(theme_options["type"].as_str(), Some("string"));
+        assert!(theme_options.get("enum").is_none());
+        assert!(theme_options.get("pattern").is_none());
+
+        // And a config carrying such a value deserializes cleanly.
+        for value in [
+            "my-custom-theme.json",
+            "packages/nord/dark.json",
+            "file:///home/user/.config/fresh/themes/x.json",
+            "builtin://dark",
+            "dark",
+        ] {
+            let cfg_json = format!(r#"{{"theme":"{}"}}"#, value);
+            let cfg: Config = serde_json::from_str(&cfg_json)
+                .unwrap_or_else(|e| panic!("theme value {:?} should deserialize: {}", value, e));
+            assert_eq!(cfg.theme.0, value);
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -853,6 +853,19 @@ pub struct SectionInfo {
     pub first_item_index: usize,
 }
 
+/// One entry for the Settings theme dropdown: a human-readable display name
+/// (the theme's name, as shown by "Select Theme") paired with the config value
+/// that persists when it is selected (the theme's portable form). Sourced from
+/// the live [`ThemeRegistry`](crate::view::theme::ThemeRegistry) so the
+/// dropdown never drifts from Select Theme (#2738).
+#[derive(Debug, Clone)]
+pub struct ThemeOption {
+    /// Display name shown in the dropdown (the theme name).
+    pub display: String,
+    /// Value stored in config when this option is chosen (portable form).
+    pub value: String,
+}
+
 /// Context for building setting items with layer awareness
 pub struct BuildContext<'a> {
     /// The merged config value (effective values)
@@ -864,6 +877,11 @@ pub struct BuildContext<'a> {
     /// Plugin-registered status-bar tokens (key → display title). Always
     /// present; pass an empty map in tests.
     pub available_status_bar_tokens: &'a HashMap<String, String>,
+    /// Live theme options `(display, value)` for the theme dropdown, in
+    /// Select-Theme order. Resolves the reserved `x-enum-from: "$themes"`
+    /// source. Empty when the registry isn't available (e.g. in tests) — the
+    /// control then simply renders no options.
+    pub theme_options: &'a [ThemeOption],
 }
 
 /// Convert a category tree into pages with control states
@@ -873,12 +891,14 @@ pub fn build_pages(
     layer_sources: &HashMap<String, ConfigLayer>,
     target_layer: ConfigLayer,
     available_status_bar_tokens: &HashMap<String, String>,
+    theme_options: &[ThemeOption],
 ) -> Vec<SettingsPage> {
     let ctx = BuildContext {
         config_value,
         layer_sources,
         target_layer,
         available_status_bar_tokens,
+        theme_options,
     };
     categories.iter().map(|cat| build_page(cat, &ctx)).collect()
 }
@@ -1044,31 +1064,65 @@ pub fn build_item(schema: &SettingSchema, ctx: &BuildContext) -> SettingItem {
 
             // Check for dynamic enum: derive dropdown options from another config field's keys
             if let Some(ref source_path) = schema.enum_from {
-                let mut options: Vec<String> = ctx
-                    .config_value
-                    .pointer(source_path)
-                    .and_then(|v| v.as_object())
-                    .map(|obj| obj.keys().cloned().collect())
-                    .unwrap_or_default();
-                options.sort();
+                // Reserved `$themes` source: the theme dropdown can't use the
+                // generic object-keys path, because a user theme's DISPLAY (its
+                // name) differs from the stored config VALUE (its portable
+                // form). Populate it from the live registry as (display, value)
+                // pairs, in Select-Theme order (no re-sorting), so the two lists
+                // are one source of truth (#2738).
+                if source_path == "$themes" {
+                    let display_names: Vec<String> = ctx
+                        .theme_options
+                        .iter()
+                        .map(|o| o.display.clone())
+                        .collect();
+                    let values: Vec<String> =
+                        ctx.theme_options.iter().map(|o| o.value.clone()).collect();
 
-                // Add empty option for nullable fields (unset/inherit)
-                let mut display_names = Vec::new();
-                let mut values = Vec::new();
-                if schema.nullable {
-                    display_names.push("(none)".to_string());
-                    values.push(String::new());
-                }
-                for key in &options {
-                    display_names.push(key.clone());
-                    values.push(key.clone());
-                }
+                    let current = if is_null { "" } else { value };
+                    let selected = values
+                        .iter()
+                        .position(|v| v == current)
+                        // Legacy configs may store a bare built-in name (e.g.
+                        // `"dark"`) rather than the portable `builtin://dark`;
+                        // still pre-select the matching option.
+                        .or_else(|| {
+                            values.iter().position(|v| {
+                                v.strip_prefix("builtin://")
+                                    .is_some_and(|name| name == current)
+                            })
+                        })
+                        .unwrap_or(0);
+                    let state = DropdownState::with_values(display_names, values, &schema.name)
+                        .with_selected(selected);
+                    SettingControl::Dropdown(state)
+                } else {
+                    let mut options: Vec<String> = ctx
+                        .config_value
+                        .pointer(source_path)
+                        .and_then(|v| v.as_object())
+                        .map(|obj| obj.keys().cloned().collect())
+                        .unwrap_or_default();
+                    options.sort();
 
-                let current = if is_null { "" } else { value };
-                let selected = values.iter().position(|v| v == current).unwrap_or(0);
-                let state = DropdownState::with_values(display_names, values, &schema.name)
-                    .with_selected(selected);
-                SettingControl::Dropdown(state)
+                    // Add empty option for nullable fields (unset/inherit)
+                    let mut display_names = Vec::new();
+                    let mut values = Vec::new();
+                    if schema.nullable {
+                        display_names.push("(none)".to_string());
+                        values.push(String::new());
+                    }
+                    for key in &options {
+                        display_names.push(key.clone());
+                        values.push(key.clone());
+                    }
+
+                    let current = if is_null { "" } else { value };
+                    let selected = values.iter().position(|v| v == current).unwrap_or(0);
+                    let state = DropdownState::with_values(display_names, values, &schema.name)
+                        .with_selected(selected);
+                    SettingControl::Dropdown(state)
+                }
             } else {
                 let state = TextInputState::new(&schema.name).with_value(value);
                 SettingControl::Text(state)
@@ -1585,6 +1639,7 @@ mod tests {
             layer_sources: &EMPTY_SOURCES,
             target_layer: ConfigLayer::User,
             available_status_bar_tokens: &EMPTY_TOKENS,
+            theme_options: &[],
         }
     }
 
@@ -1601,7 +1656,84 @@ mod tests {
             layer_sources,
             target_layer,
             available_status_bar_tokens: &EMPTY_TOKENS,
+            theme_options: &[],
         }
+    }
+
+    /// Regression test for #2738: a `theme` string setting carrying the
+    /// reserved `x-enum-from: "$themes"` source renders as a dropdown populated
+    /// from the live registry — built-ins AND a user theme, in Select-Theme
+    /// order (display = name, value = portable form) — not from a static enum.
+    #[test]
+    fn test_theme_dropdown_populated_from_registry_with_user_theme() {
+        // A user theme present in the registry, discovered exactly as Select
+        // Theme would.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let themes_dir = temp_dir.path().to_path_buf();
+        std::fs::write(
+            themes_dir.join("my-user-theme.json"),
+            r#"{"name":"my-user-theme","editor":{},"ui":{},"search":{},"diagnostic":{},"syntax":{}}"#,
+        )
+        .expect("write user theme");
+        let registry = crate::view::theme::ThemeLoader::new(themes_dir).load_all(&[]);
+        let theme_options: Vec<ThemeOption> = registry
+            .settings_theme_options()
+            .into_iter()
+            .map(|(display, value)| ThemeOption { display, value })
+            .collect();
+
+        let schema = SettingSchema {
+            path: "/theme".to_string(),
+            name: "Theme".to_string(),
+            description: Some("Color theme".to_string()),
+            setting_type: SettingType::String,
+            default: Some(serde_json::json!("high-contrast")),
+            read_only: false,
+            section: None,
+            order: None,
+            nullable: false,
+            enum_from: Some("$themes".to_string()),
+            dual_list_sibling: None,
+            dynamically_extendable_status_bar_elements: false,
+        };
+
+        // Config stores the legacy bare built-in name "dark".
+        let config = serde_json::json!({ "theme": "dark" });
+        static EMPTY_SOURCES: std::sync::LazyLock<HashMap<String, ConfigLayer>> =
+            std::sync::LazyLock::new(HashMap::new);
+        static EMPTY_TOKENS: std::sync::LazyLock<HashMap<String, String>> =
+            std::sync::LazyLock::new(HashMap::new);
+        let ctx = BuildContext {
+            config_value: &config,
+            layer_sources: &EMPTY_SOURCES,
+            target_layer: ConfigLayer::User,
+            available_status_bar_tokens: &EMPTY_TOKENS,
+            theme_options: &theme_options,
+        };
+
+        let item = build_item(&schema, &ctx);
+        let SettingControl::Dropdown(state) = &item.control else {
+            panic!("theme should render as a dropdown, not free text");
+        };
+
+        // The dropdown lists exactly the registry themes, in list (picker)
+        // order: display = name, value = portable form.
+        assert_eq!(state.options.len(), registry.list().len());
+        for (opt_display, info) in state.options.iter().zip(registry.list().iter()) {
+            assert_eq!(opt_display, &info.name);
+        }
+
+        // The user theme is present and valued by its portable form.
+        let user_idx = state
+            .options
+            .iter()
+            .position(|d| d == "my-user-theme")
+            .expect("user theme should be an option");
+        assert_eq!(state.values[user_idx], "my-user-theme.json");
+
+        // Legacy bare "dark" pre-selects the built-in whose portable form is
+        // "builtin://dark".
+        assert_eq!(state.selected_value(), Some("builtin://dark"));
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -1486,29 +1486,56 @@ fn render_control(
             let out =
                 render_scalar_via_widget(frame, area, control, name, theme, label_width, prev);
             let button_area = hit_rect(&out, "dropdown", "dropdown_toggle", area, 0);
-            // One rect per visible option row of the open list, in
-            // screen order (the caller pairs them with `scroll_offset`
-            // to recover absolute indices, as the old control did).
+            // When open, paint the option list inline beneath the button.
+            //
+            // The shared widget framework (`collect_dropdown`) surfaces an
+            // open dropdown's options as a *floating* screen-level pop-over
+            // (`RenderOutput::dropdown_popups`) for plugin panels, and
+            // discards `render_dropdown`'s inline `option_rows`. The Settings
+            // modal does not draw those floating pop-overs — it reserves
+            // inline rows for the open list via `SettingControl::height`. So
+            // relying on `render_scalar_via_widget` alone leaves the reserved
+            // rows blank: the dropdown opens to an empty box (theme and every
+            // other settings dropdown showed no options — #2765).
+            //
+            // Render the option rows directly and paint them under the button
+            // (row 0), exactly where the reserved height expects them. Use the
+            // same label/label-width/selected/scroll the button render used so
+            // the option column aligns under the value cell, and build one hit
+            // rect per visible row in screen order (`layout.rs` pairs them with
+            // `scroll_offset` to recover absolute indices).
             let mut option_areas = Vec::new();
+            let mut scroll_offset = 0;
             if state.open {
-                for h in out
-                    .hits
-                    .iter()
-                    .filter(|h| h.event_type == "dropdown_select")
-                {
-                    let dst = h.buffer_row as u16;
-                    if dst < area.height {
-                        option_areas.push(Rect::new(area.x, area.y + dst, area.width, 1));
+                let rendered = crate::widgets::render_dropdown(
+                    &state.options,
+                    state.selected as i32,
+                    &state.label,
+                    false,
+                    label_width.unwrap_or(0) as u32,
+                    true,
+                    state.scroll_offset as u32,
+                );
+                scroll_offset = rendered.scroll_offset;
+                for (row_i, (_idx, entry)) in rendered.option_rows.iter().enumerate() {
+                    // Row 0 is the button that `render_scalar_via_widget`
+                    // already painted; options start at row 1.
+                    let dst = 1 + row_i as u16;
+                    if dst >= area.height {
+                        break;
                     }
+                    crate::app::render::paint_text_property_entry(
+                        frame,
+                        entry,
+                        area.x,
+                        area.y + dst,
+                        area.width,
+                        theme,
+                        None,
+                    );
+                    option_areas.push(Rect::new(area.x, area.y + dst, area.width, 1));
                 }
             }
-            let visible = state
-                .options
-                .len()
-                .min(crate::widgets::DROPDOWN_VISIBLE_OPTIONS);
-            let scroll_offset = state
-                .scroll_offset
-                .min(state.options.len().saturating_sub(visible));
             ControlLayoutInfo::Dropdown {
                 button_area,
                 option_areas,
@@ -3810,5 +3837,104 @@ mod tests {
             value: Rect::new(8, 0, 5, 1),
         };
         assert!(matches!(number, ControlLayoutInfo::Number { .. }));
+    }
+
+    /// Regression for #2765: an *open* settings dropdown must actually paint
+    /// its option rows into the frame.
+    ///
+    /// The shared widget framework (`collect_dropdown`) turns an open
+    /// dropdown's option list into a floating screen-level pop-over and
+    /// discards the inline `option_rows`. The Settings modal does not draw
+    /// those floating pop-overs — it reserves inline rows for the open list —
+    /// so rendering through `render_scalar_via_widget` alone left the reserved
+    /// rows blank and the dropdown opened to an empty box (the Theme and every
+    /// other dynamic dropdown showed no options at runtime).
+    ///
+    /// This drives the real `render_control` paint path (not a hand-built
+    /// widget spec) and asserts the option names land in the painted buffer
+    /// and that per-option hit rects are produced.
+    #[test]
+    fn open_dropdown_paints_option_rows() {
+        use crate::view::controls::DropdownState;
+        use crate::view::theme::{self, Theme};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        // An open dropdown with distinctive display names (mirrors the Theme
+        // dropdown: display != stored value, e.g. a user theme).
+        let mut dd = DropdownState::with_values(
+            vec![
+                "dark".to_string(),
+                "light".to_string(),
+                "my-cool-theme".to_string(),
+            ],
+            vec![
+                "builtin://dark".to_string(),
+                "builtin://light".to_string(),
+                "my-cool-theme.json".to_string(),
+            ],
+            "Theme",
+        )
+        .with_selected(0);
+        dd.open = true;
+        let control = SettingControl::Dropdown(dd);
+
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+        let prev = std::collections::HashMap::new();
+
+        let width = 60u16;
+        let height = 6u16;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let mut layout: Option<ControlLayoutInfo> = None;
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, width, height);
+                layout = Some(render_control(
+                    frame,
+                    area,
+                    &control,
+                    "/theme",
+                    0,
+                    &theme,
+                    Some(10),
+                    false,
+                    false,
+                    &prev,
+                ));
+            })
+            .unwrap();
+
+        // The open list must yield one hit rect per option row.
+        match layout {
+            Some(ControlLayoutInfo::Dropdown { option_areas, .. }) => {
+                assert_eq!(
+                    option_areas.len(),
+                    3,
+                    "open dropdown should expose one hit rect per option row"
+                );
+            }
+            other => panic!("expected Dropdown layout, got {other:?}"),
+        }
+
+        // And every option's display name must appear somewhere in the
+        // painted buffer — the pre-fix code painted only the button row, so
+        // the option names were absent.
+        let buffer = terminal.backend().buffer().clone();
+        let screen: String = (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for name in ["dark", "light", "my-cool-theme"] {
+            assert!(
+                screen.contains(name),
+                "option {name:?} not painted in open dropdown; screen was:\n{screen}"
+            );
+        }
     }
 }

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -1006,7 +1006,8 @@ mod tests {
                     "x-enum-from": "/languages"
                 },
                 "theme": {
-                    "type": "string"
+                    "type": "string",
+                    "x-enum-from": "$themes"
                 }
             }
         }"##;
@@ -1026,13 +1027,22 @@ mod tests {
         );
         assert!(default_lang.nullable, "should be nullable");
 
-        // theme should not have enum_from
+        // theme now carries the dynamic `$themes` source (registry-backed
+        // dropdown) rather than being a frozen enum (#2738).
         let theme = general
             .settings
             .iter()
             .find(|s| s.name == "Theme")
             .expect("should have Theme setting");
-        assert!(theme.enum_from.is_none());
+        assert_eq!(
+            theme.enum_from.as_deref(),
+            Some("$themes"),
+            "theme should carry the `$themes` dynamic-source hint"
+        );
+        assert!(
+            matches!(theme.setting_type, SettingType::String),
+            "theme is a validated string, not a frozen enum"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -219,6 +219,12 @@ pub struct SettingsState {
     /// across frames. Empty until a control's input is routed through the
     /// runtime (behavior is then identical to the old per-control State).
     pub widget_states: std::collections::HashMap<String, crate::widgets::WidgetInstanceState>,
+    /// Live theme options `(display, value)` for the theme dropdown, sourced
+    /// from the `ThemeRegistry` via [`Self::set_theme_options`] when Settings
+    /// opens. Empty until set — the dropdown then simply lists nothing rather
+    /// than a stale hand-maintained set. Resolves the `x-enum-from: "$themes"`
+    /// schema hint so the Settings theme list matches "Select Theme" (#2738).
+    theme_options: Vec<super::items::ThemeOption>,
 }
 
 /// Pre-edit state of a plain `Text` setting, captured by `start_editing` and
@@ -313,12 +319,14 @@ impl SettingsState {
         let layer_sources = HashMap::new(); // Populated via set_layer_sources()
         let target_layer = ConfigLayer::User; // Default to user-global settings
         let available_status_bar_tokens: HashMap<String, String> = HashMap::new();
+        let theme_options: Vec<super::items::ThemeOption> = Vec::new();
         let pages = super::items::build_pages(
             &categories,
             &config_value,
             &layer_sources,
             target_layer,
             &available_status_bar_tokens,
+            &theme_options,
         );
 
         Ok(Self {
@@ -371,6 +379,7 @@ impl SettingsState {
             tree_cursor_section: None,
             text_edit_snapshot: None,
             widget_states: std::collections::HashMap::new(),
+            theme_options,
         })
     }
 
@@ -423,7 +432,19 @@ impl SettingsState {
             &self.layer_sources,
             self.target_layer,
             &self.available_status_bar_tokens,
+            &self.theme_options,
         );
+    }
+
+    /// Set the live theme options for the theme dropdown and rebuild pages.
+    ///
+    /// Called when Settings opens, from the editor which owns the
+    /// `ThemeRegistry`. Pass `registry.settings_theme_options()` mapped into
+    /// [`ThemeOption`](super::items::ThemeOption)s. This is the single source of
+    /// truth shared with "Select Theme" (#2738).
+    pub fn set_theme_options(&mut self, options: Vec<super::items::ThemeOption>) {
+        self.theme_options = options;
+        self.rebuild_pages();
     }
 
     fn paths_intersect(a: &str, b: &str) -> bool {

--- a/crates/fresh-editor/src/view/theme/loader.rs
+++ b/crates/fresh-editor/src/view/theme/loader.rs
@@ -611,6 +611,49 @@ mod tests {
         assert!(list.iter().any(|t| t.name == "light"));
     }
 
+    /// Regression test for #2738: the settings theme dropdown is schema-driven
+    /// from the static `ThemeName::BUILTIN_OPTIONS` list, while "Select Theme"
+    /// reads the auto-generated `BUILTIN_THEMES` registry. If the static list
+    /// drifts, the dropdown silently omits (or misorders) themes. Guard that the
+    /// static list exactly equals the set of root (empty-pack) built-in themes
+    /// and that it is sorted alphabetically (matching the picker order).
+    #[test]
+    fn test_builtin_options_match_registry_and_sorted() {
+        use crate::config::ThemeName;
+
+        let loader = ThemeLoader::embedded_only();
+        let registry = loader.load_all(&[]);
+
+        // Root built-in theme names (empty pack), sorted for a stable compare.
+        let mut root_builtins: Vec<String> = registry
+            .list()
+            .iter()
+            .filter(|info| info.pack.is_empty())
+            .map(|info| info.name.clone())
+            .collect();
+        root_builtins.sort();
+        root_builtins.dedup();
+
+        let options: Vec<String> = ThemeName::BUILTIN_OPTIONS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        // Parity: the dropdown lists exactly the root built-in themes.
+        assert_eq!(
+            options, root_builtins,
+            "ThemeName::BUILTIN_OPTIONS must match the root built-in themes from the registry"
+        );
+
+        // The dropdown must be alphabetically sorted (same order as Select Theme).
+        let mut sorted = options.clone();
+        sorted.sort();
+        assert_eq!(
+            options, sorted,
+            "ThemeName::BUILTIN_OPTIONS must be sorted alphabetically"
+        );
+    }
+
     #[test]
     fn test_theme_registry_contains() {
         let loader = ThemeLoader::embedded_only();

--- a/crates/fresh-editor/src/view/theme/loader.rs
+++ b/crates/fresh-editor/src/view/theme/loader.rs
@@ -254,6 +254,28 @@ impl ThemeRegistry {
         &self.theme_list
     }
 
+    /// Theme options for the Settings dropdown: `(display_name, config_value)`
+    /// pairs in the same order as [`Self::list`] — the order the "Select Theme"
+    /// picker shows.
+    ///
+    /// The display is the theme's name; the value is its
+    /// [`portable_form`](Self::portable_form) — exactly what selecting the
+    /// theme persists to `config.json`. Sourcing the Settings dropdown from
+    /// this method makes it share one source of truth with Select Theme
+    /// (built-ins **and** user themes, same order), so the two can never drift
+    /// (#2738).
+    pub fn settings_theme_options(&self) -> Vec<(String, String)> {
+        self.theme_list
+            .iter()
+            .map(|info| {
+                let value = self
+                    .portable_form(&info.key)
+                    .unwrap_or_else(|| info.key.clone());
+                (info.name.clone(), value)
+            })
+            .collect()
+    }
+
     /// Get all theme display names.
     pub fn names(&self) -> Vec<String> {
         self.theme_list.iter().map(|t| t.name.clone()).collect()
@@ -611,47 +633,60 @@ mod tests {
         assert!(list.iter().any(|t| t.name == "light"));
     }
 
-    /// Regression test for #2738: the settings theme dropdown is schema-driven
-    /// from the static `ThemeName::BUILTIN_OPTIONS` list, while "Select Theme"
-    /// reads the auto-generated `BUILTIN_THEMES` registry. If the static list
-    /// drifts, the dropdown silently omits (or misorders) themes. Guard that the
-    /// static list exactly equals the set of root (empty-pack) built-in themes
-    /// and that it is sorted alphabetically (matching the picker order).
+    /// Regression test for #2738: the Settings theme dropdown must be sourced
+    /// from the live registry (built-ins **and** user themes), in the same
+    /// order and with the same name→config-value mapping as the "Select Theme"
+    /// picker — so the two share one source of truth and never drift.
     #[test]
-    fn test_builtin_options_match_registry_and_sorted() {
-        use crate::config::ThemeName;
+    fn test_settings_theme_options_include_user_theme_in_picker_order() {
+        // A user theme sitting in the themes dir, exactly as Select Theme
+        // would discover it.
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let themes_dir = temp_dir.path().to_path_buf();
+        std::fs::write(
+            themes_dir.join("my-user-theme.json"),
+            r#"{"name":"my-user-theme","editor":{},"ui":{},"search":{},"diagnostic":{},"syntax":{}}"#,
+        )
+        .expect("Failed to write user theme");
 
-        let loader = ThemeLoader::embedded_only();
-        let registry = loader.load_all(&[]);
+        let registry = ThemeLoader::new(themes_dir).load_all(&[]);
 
-        // Root built-in theme names (empty pack), sorted for a stable compare.
-        let mut root_builtins: Vec<String> = registry
-            .list()
-            .iter()
-            .filter(|info| info.pack.is_empty())
-            .map(|info| info.name.clone())
-            .collect();
-        root_builtins.sort();
-        root_builtins.dedup();
+        let options = registry.settings_theme_options();
+        let list = registry.list();
 
-        let options: Vec<String> = ThemeName::BUILTIN_OPTIONS
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-
-        // Parity: the dropdown lists exactly the root built-in themes.
+        // Same set + order as the registry list, which is precisely the order
+        // Select Theme renders (built-ins first, then user themes).
         assert_eq!(
-            options, root_builtins,
-            "ThemeName::BUILTIN_OPTIONS must match the root built-in themes from the registry"
+            options.len(),
+            list.len(),
+            "dropdown must list every theme the registry knows about"
+        );
+        for (opt, info) in options.iter().zip(list.iter()) {
+            assert_eq!(
+                opt.0, info.name,
+                "dropdown display must be the theme name, in picker order"
+            );
+        }
+
+        // The user theme is present — display is its name, value is the
+        // portable form persisted to config (a relative path here).
+        let user = options
+            .iter()
+            .find(|(name, _)| name == "my-user-theme")
+            .expect("user theme should appear in the settings dropdown");
+        assert_eq!(
+            user.1, "my-user-theme.json",
+            "user theme value must be its portable config form"
         );
 
-        // The dropdown must be alphabetically sorted (same order as Select Theme).
-        let mut sorted = options.clone();
-        sorted.sort();
-        assert_eq!(
-            options, sorted,
-            "ThemeName::BUILTIN_OPTIONS must be sorted alphabetically"
-        );
+        // Built-ins use the `builtin://NAME` portable form (same value Select
+        // Theme persists), never a bare name that could collide with a
+        // same-named user theme.
+        let dark = options
+            .iter()
+            .find(|(name, _)| name == "dark")
+            .expect("built-in `dark` should be listed");
+        assert_eq!(dark.1, "builtin://dark");
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#2738)

The Settings **Theme** dropdown was schema-driven from a hardcoded static list (`ThemeName::BUILTIN_OPTIONS`), while the **Select Theme** command reads the live `ThemeRegistry`. The two inevitably drifted: Settings showed a stale, hand-maintained subset of built-ins and **never** showed user themes from `~/.config/fresh/themes`. On top of that, the `theme` config field was a frozen JSON-Schema `enum`, so any user-theme config value (a path, a `file://`/`builtin://` URI, a registry key) was rejected as invalid.

## Approach — one source of truth, no static list

Rather than keep patching the static list, the theme list is now sourced dynamically from the registry so Settings == Select Theme by construction.

**Schema — validated string with a dynamic source.** `impl JsonSchema for ThemeName` now emits a `type: "string"` carrying `x-enum-from: "$themes"` (mirroring how `default_language` uses `x-enum-from: "/languages"`) instead of a hard `enum`. Any config form accepted by `ThemeRegistry::resolve_key` (built-in names, `builtin://`, relative `.json` paths, `file://`/http(s) URIs) now validates — including user themes that don't exist at schema-generation time. `plugins/config-schema.json` was regenerated (`ThemeOptions` is now a dynamic string, no enum).

**Registry-backed dropdown.** The generic `x-enum-from` path derives options from object *keys* where display == value — insufficient for user themes, whose **display** (theme name) differs from the stored **value** (portable form). A new `ThemeRegistry::settings_theme_options()` returns `(display = name, value = portable_form)` pairs in `list()` order — the exact order and name→config-value mapping "Select Theme" uses (portable form: `builtin://NAME` for built-ins, a relative path for user themes). This is threaded into the settings render context via a new `BuildContext.theme_options` field and `SettingsState::set_theme_options`, populated from `self.theme_registry` in `open_settings`. The settings item builder resolves the reserved `$themes` source specially to build the dropdown from these pairs (no re-sorting). Legacy bare built-in names (`"dark"`) still pre-select their `builtin://dark` option.

**Retired the drift-prone list.** `ThemeName::BUILTIN_OPTIONS` and the two parity tests that guarded it are deleted — the registry is the only source of truth now.

## Tests
- `schema.rs`: `theme` now asserts it carries the `$themes` dynamic source (was: asserts no `enum_from`).
- `config.rs`: parity test replaced — asserts `ThemeOptions` is a dynamic string (not a frozen enum) and that user-theme values validate.
- New: a user theme in the registry appears in the Settings dropdown in picker order, displayed by name and valued by portable form (`loader.rs` + end-to-end through `items.rs`).

Local results (Linux): `cargo fmt --check` clean; `cargo clippy --all-features --all-targets` passes (errors: none); the config/theme/schema/settings tests pass; regenerating the schema CI-style produces a file identical to the committed one. The prior CI red was the `fmt` job reflowing the now-removed parity test.

Closes #2738

🤖 Generated with [Claude Code](https://claude.com/claude-code)