### PR TITLE
fix(tabs): truncate long tab names and fix per-split scroll width (#2650)

### DIFF
--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -162,8 +162,10 @@ impl Window {
             self.resize_visible_terminals();
         }
 
-        // Ensure the newly active tab is visible
-        let tabs_width = self.effective_tabs_width();
+        // Ensure the newly active tab is visible. Use the focused split's real
+        // pane width, not the whole-editor width, so vertical splits scroll
+        // correctly (issue #2650).
+        let tabs_width = self.split_tabs_width(active_split);
         self.ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 
         if self.file_explorer_visible

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -947,7 +947,7 @@ impl Editor {
         else {
             return;
         };
-        let tabs_width = self.active_window().effective_tabs_width();
+        let tabs_width = self.active_window().split_tabs_width(split_id);
         self.active_window_mut()
             .ensure_active_tab_visible(split_id, active_buffer, tabs_width);
     }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -393,6 +393,17 @@ impl Editor {
                 blocks_terminal_input: true,
             });
         }
+        // The close-split confirmation popup gets the same treatment as the
+        // other native context menus: a custom key dispatcher owns the keyboard
+        // while it's open and it blocks PTY routing.
+        if self.active_window().close_split_menu.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::CloseSplitMenu,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
         // The centered widget modal (picker / new-session form / plugin
         // overlay) owns the keyboard when focused. It resolves as `Normal`
         // regardless of the underlying buffer's (possibly stale) context so

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -3910,6 +3910,55 @@ mod tests {
         assert!(view_state.tab_scroll_offset <= total_width);
     }
 
+    /// Regression for sinelaw/fresh#2650 (Part 2).
+    ///
+    /// In a vertical split each pane's tab bar is only as wide as the pane,
+    /// but `ensure_active_tab_visible` used to be fed `effective_tabs_width`
+    /// (the whole editor width), so the scroll math ran against ~2x the real
+    /// width. `split_tabs_width` must report the focused split's real pane
+    /// width instead — roughly half the editor after a vertical split.
+    #[test]
+    fn split_tabs_width_reports_per_split_pane_width() {
+        let config = Config::default();
+        let (dir_context, _temp) = test_dir_context();
+        let mut editor = Editor::new(
+            config,
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap();
+
+        let full_width = editor.active_window().effective_tabs_width();
+
+        // Split vertically into two side-by-side panes.
+        editor.split_pane_vertical();
+
+        let panes: Vec<(crate::model::event::LeafId, u16)> = editor
+            .split_manager()
+            .get_visible_buffers(editor.active_window().editor_content_area())
+            .into_iter()
+            .map(|(leaf, _buf, area)| (leaf, area.width))
+            .collect();
+        assert_eq!(panes.len(), 2, "vertical split should yield two panes");
+
+        for (leaf, pane_width) in &panes {
+            let w = editor.active_window().split_tabs_width(*leaf);
+            assert_eq!(
+                w, *pane_width,
+                "split_tabs_width must equal the pane's real width"
+            );
+            assert!(
+                w < full_width,
+                "each pane width ({}) must be narrower than the whole editor ({})",
+                w,
+                full_width
+            );
+        }
+    }
+
     /// Regression for sinelaw/fresh#2229.
     ///
     /// When the tab strip is scrolled (many tabs open) and the user invokes

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -3916,7 +3916,8 @@ mod tests {
     /// but `ensure_active_tab_visible` used to be fed `effective_tabs_width`
     /// (the whole editor width), so the scroll math ran against ~2x the real
     /// width. `split_tabs_width` must report the focused split's real pane
-    /// width instead — roughly half the editor after a vertical split.
+    /// width (minus the split-control button columns, which the tab bar
+    /// reserves) instead — roughly half the editor after a vertical split.
     #[test]
     fn split_tabs_width_reports_per_split_pane_width() {
         let config = Config::default();
@@ -3944,11 +3945,15 @@ mod tests {
             .collect();
         assert_eq!(panes.len(), 2, "vertical split should yield two panes");
 
+        // Two side-by-side splits show the maximize + close buttons, so the tab
+        // bar reserves those columns; split_tabs_width reflects that.
+        let reserve = crate::view::ui::tabs::split_control_reserve(true, true);
         for (leaf, pane_width) in &panes {
             let w = editor.active_window().split_tabs_width(*leaf);
             assert_eq!(
-                w, *pane_width,
-                "split_tabs_width must equal the pane's real width"
+                w,
+                pane_width.saturating_sub(reserve),
+                "split_tabs_width must equal the pane's real width minus the control-button reserve"
             );
             assert!(
                 w < full_width,

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2535,48 +2535,25 @@ impl Editor {
     }
 
     fn handle_click_split_controls(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        let close_split_id = self
+        let close_split_hit = self
             .active_layout()
             .close_split_areas
             .iter()
             .find(|(_, btn_row, start_col, end_col)| {
                 row == *btn_row && col >= *start_col && col < *end_col
             })
-            .map(|(split_id, _, _, _)| *split_id);
-        if let Some(split_id) = close_split_id {
-            if let Err(e) = self
-                .windows
-                .get_mut(&self.active_window)
-                .and_then(|w| w.split_manager_mut())
-                .expect("active window must have a populated split layout")
-                .close_split(split_id)
-            {
-                self.set_status_message(
-                    t!("error.cannot_close_split", error = e.to_string()).to_string(),
-                );
-            } else {
-                // Drop the closed split from every terminal's scrollback set.
-                self.active_window_mut()
-                    .forget_split_terminal_modes(split_id);
-                let new_active = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.buffers.splits())
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .active_split();
-                if let Some(buffer_id) = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.buffers.splits())
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .buffer_for_split(new_active)
-                {
-                    self.set_active_buffer(buffer_id);
-                }
-                self.set_status_message(t!("split.closed").to_string());
-            }
+            .map(|(split_id, btn_row, start_col, _)| (*split_id, *btn_row, *start_col));
+        if let Some((split_id, btn_row, start_col)) = close_split_hit {
+            // Closing a split isn't undoable, so don't act on the raw click —
+            // pop a small confirmation just below the `×` button offering
+            // "Close split" / "Cancel". Dismiss any other native menu first so
+            // only one popup is visible.
+            self.active_window_mut().close_context_menus();
+            self.active_window_mut().close_split_menu = Some(super::types::CloseSplitMenu::new(
+                split_id,
+                start_col,
+                btn_row + 1,
+            ));
             return Some(Ok(()));
         }
 
@@ -3323,9 +3300,10 @@ impl Editor {
 
     /// Handle right-click event
     pub(super) fn handle_right_click(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
-        // A right-click anywhere dismisses the "+" new-tab popup (it's a
-        // left-click-only menu).
+        // A right-click anywhere dismisses the left-click-only popups (the "+"
+        // new-tab menu and the close-split confirmation).
         self.active_window_mut().new_tab_menu = None;
+        self.active_window_mut().close_split_menu = None;
 
         // Right-click inside the orchestrator dock column → let the plugin
         // raise a per-session context menu. Mirrors the left-click path:
@@ -3587,8 +3565,73 @@ impl Editor {
                     self.execute_file_explorer_context_menu_action(item);
                 }
             }
+            ContextMenuKind::CloseSplit => {
+                let selected = self
+                    .active_window()
+                    .close_split_menu
+                    .as_ref()
+                    .map(|m| (m.highlighted_item(), m.split_id));
+                self.active_window_mut().close_context_menus();
+                if let Some((item, split_id)) = selected {
+                    self.execute_close_split_menu_action(item, split_id);
+                }
+            }
         }
         Ok(())
+    }
+
+    /// Execute a close-split confirmation choice. "Cancel" is a no-op (the menu
+    /// was already dismissed by the caller); "Close split" runs the actual
+    /// close.
+    fn execute_close_split_menu_action(
+        &mut self,
+        item: super::types::CloseSplitMenuItem,
+        split_id: LeafId,
+    ) {
+        use super::types::CloseSplitMenuItem;
+        match item {
+            CloseSplitMenuItem::Cancel => {}
+            CloseSplitMenuItem::CloseSplit => self.close_split_confirmed(split_id),
+        }
+    }
+
+    /// Close a split for real (after the confirmation popup). Mirrors the
+    /// keyboard "Close Split" command: close the pane, forget its terminal
+    /// scrollback modes, and refocus whichever split becomes active.
+    fn close_split_confirmed(&mut self, split_id: LeafId) {
+        if let Err(e) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_manager_mut())
+            .expect("active window must have a populated split layout")
+            .close_split(split_id)
+        {
+            self.set_status_message(
+                t!("error.cannot_close_split", error = e.to_string()).to_string(),
+            );
+            return;
+        }
+        // Drop the closed split from every terminal's scrollback set.
+        self.active_window_mut()
+            .forget_split_terminal_modes(split_id);
+        let new_active = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(mgr, _)| mgr)
+            .expect("active window must have a populated split layout")
+            .active_split();
+        if let Some(buffer_id) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(mgr, _)| mgr)
+            .expect("active window must have a populated split layout")
+            .buffer_for_split(new_active)
+        {
+            self.set_active_buffer(buffer_id);
+        }
+        self.set_status_message(t!("split.closed").to_string());
     }
 
     fn execute_file_explorer_context_menu_action(

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -57,6 +57,11 @@ pub(crate) enum LayerKind {
     /// dispatcher, transparent to `KeyContext` resolution but blocking PTY
     /// routing while open.
     FileExplorerContextMenu,
+    /// The close-split confirmation popup (`active_window().close_split_menu`),
+    /// same treatment as the other native context menus: a modal chrome menu
+    /// with a custom key dispatcher, transparent to `KeyContext` resolution but
+    /// blocking PTY routing while open.
+    CloseSplitMenu,
     /// The centered widget modal (`floating_widget_panel`).
     FloatingModal,
     /// The editor-global left dock (`dock`).

--- a/crates/fresh-editor/src/app/scroll_sync.rs
+++ b/crates/fresh-editor/src/app/scroll_sync.rs
@@ -54,6 +54,7 @@ impl crate::app::window::Window {
                 composites,
                 &group_names,
                 preview_buffer,
+                available_width as usize,
             );
 
             let total_tabs_width: usize = tab_widths.iter().sum();

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -308,7 +308,7 @@ impl Editor {
         self.active_window_mut()
             .promote_preview_if_not_in_split(split_id);
         let buffer = self.active_buffer();
-        let tabs_width = self.active_window().effective_tabs_width();
+        let tabs_width = self.active_window().split_tabs_width(split_id);
         self.active_window_mut()
             .ensure_active_tab_visible(split_id, buffer, tabs_width);
 
@@ -611,7 +611,7 @@ impl Editor {
 
         // Keep the newly active tab scrolled into view within its split,
         // matching `switch_split` and `set_active_buffer`.
-        let tabs_width = self.active_window().effective_tabs_width();
+        let tabs_width = self.active_window().split_tabs_width(next_split);
         self.active_window_mut()
             .ensure_active_tab_visible(next_split, next_buf, tabs_width);
 

--- a/crates/fresh-editor/src/app/types/context_menu.rs
+++ b/crates/fresh-editor/src/app/types/context_menu.rs
@@ -10,6 +10,9 @@ pub const NEW_TAB_MENU_WIDTH: u16 = 18;
 /// "Extract to New Workspace" + padding).
 pub const TAB_CONTEXT_MENU_WIDTH: u16 = 28;
 
+/// Width of the close-split confirmation popup (fits "Close split" + padding).
+pub const CLOSE_SPLIT_MENU_WIDTH: u16 = 16;
+
 /// Shared geometry + navigation + hit-testing core for the native context
 /// menus.
 ///
@@ -140,6 +143,8 @@ pub enum ContextMenuKind {
     NewTab,
     /// The file-explorer right-click context menu.
     FileExplorer,
+    /// The close-split confirmation popup (clicking the split's `×` button).
+    CloseSplit,
 }
 
 /// Tab context menu items
@@ -288,6 +293,68 @@ impl NewTabMenu {
     }
 }
 
+/// Items in the close-split confirmation popup (shown when clicking the split
+/// tab bar's `×` button). Closing a split is not immediately reversible, so the
+/// click pops this two-item confirm instead of acting at once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseSplitMenuItem {
+    /// Confirm: close the split.
+    CloseSplit,
+    /// Dismiss without closing.
+    Cancel,
+}
+
+impl CloseSplitMenuItem {
+    /// Get all menu items in order (confirm first, then cancel).
+    pub fn all() -> &'static [Self] {
+        &[Self::CloseSplit, Self::Cancel]
+    }
+
+    /// Get the display label for this menu item.
+    pub fn label(&self) -> String {
+        match self {
+            Self::CloseSplit => t!("action.close_split").to_string(),
+            Self::Cancel => t!("confirm.cancel").to_string(),
+        }
+    }
+}
+
+/// State for the close-split confirmation popup (left-click on a split tab
+/// bar's `×` button).
+#[derive(Debug, Clone)]
+pub struct CloseSplitMenu {
+    /// The split whose `×` button was clicked (the split to close on confirm).
+    pub split_id: LeafId,
+    /// Shared geometry + navigation core (position, highlight, width, items).
+    pub menu: ContextMenu,
+}
+
+impl CloseSplitMenu {
+    /// Create a new close-split confirmation popup anchored at the given
+    /// screen position.
+    pub fn new(split_id: LeafId, x: u16, y: u16) -> Self {
+        Self {
+            split_id,
+            menu: ContextMenu::new(
+                x,
+                y,
+                CLOSE_SPLIT_MENU_WIDTH,
+                CloseSplitMenuItem::all().len(),
+            ),
+        }
+    }
+
+    /// The items this menu presents, in display order.
+    pub fn items(&self) -> &'static [CloseSplitMenuItem] {
+        CloseSplitMenuItem::all()
+    }
+
+    /// Get the currently highlighted item.
+    pub fn highlighted_item(&self) -> CloseSplitMenuItem {
+        CloseSplitMenuItem::all()[self.menu.highlighted]
+    }
+}
+
 /// File explorer context menu items
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileExplorerContextMenuItem {
@@ -404,5 +471,42 @@ impl FileExplorerContextMenu {
     /// Get the currently highlighted item.
     pub fn highlighted_item(&self) -> FileExplorerContextMenuItem {
         self.items()[self.menu.highlighted]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::event::SplitId;
+
+    #[test]
+    fn close_split_menu_presents_confirm_then_cancel() {
+        // The confirm popup offers exactly two choices, "Close split" first
+        // (the default highlight) and "Cancel" second. The order is what the
+        // renderer and hit-test rely on (fresh#2768).
+        assert_eq!(
+            CloseSplitMenuItem::all(),
+            &[CloseSplitMenuItem::CloseSplit, CloseSplitMenuItem::Cancel]
+        );
+        assert!(!CloseSplitMenuItem::CloseSplit.label().is_empty());
+        assert!(!CloseSplitMenuItem::Cancel.label().is_empty());
+
+        let split_id = LeafId(SplitId(7));
+        let menu = CloseSplitMenu::new(split_id, 10, 4);
+        assert_eq!(menu.split_id, split_id);
+        assert_eq!(menu.menu.item_count, 2);
+        // Default highlight is the first item — "Close split".
+        assert_eq!(menu.highlighted_item(), CloseSplitMenuItem::CloseSplit);
+        assert_eq!(menu.items().len(), 2);
+    }
+
+    #[test]
+    fn close_split_menu_navigation_reaches_cancel() {
+        let mut menu = CloseSplitMenu::new(LeafId(SplitId(1)), 0, 0);
+        menu.menu.next_item();
+        assert_eq!(menu.highlighted_item(), CloseSplitMenuItem::Cancel);
+        menu.menu.next_item();
+        // Wraps back to the confirm item.
+        assert_eq!(menu.highlighted_item(), CloseSplitMenuItem::CloseSplit);
     }
 }

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -23,8 +23,9 @@ pub use context_menu::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
 pub use context_menu::NEW_TAB_MENU_WIDTH;
 pub use context_menu::TAB_CONTEXT_MENU_WIDTH;
 pub use context_menu::{
-    ContextMenu, ContextMenuHit, ContextMenuKind, FileExplorerContextMenu,
-    FileExplorerContextMenuItem, NewTabMenu, NewTabMenuItem, TabContextMenu, TabContextMenuItem,
+    CloseSplitMenu, CloseSplitMenuItem, ContextMenu, ContextMenuHit, ContextMenuKind,
+    FileExplorerContextMenu, FileExplorerContextMenuItem, NewTabMenu, NewTabMenuItem,
+    TabContextMenu, TabContextMenuItem,
 };
 
 // drag re-exports

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2292,6 +2292,30 @@ impl Window {
         }
     }
 
+    /// Width of the tab bar for a *specific* split.
+    ///
+    /// [`effective_tabs_width`](Self::effective_tabs_width) returns the whole
+    /// editor-content width; but in a vertical split each pane's tab strip is
+    /// only as wide as that pane (`tabs_rect.width == split_area.width`).
+    /// Feeding the full width to the tab-scroll math makes a half-width split
+    /// scroll against ~2x its real width, so it under-scrolls and the ">"
+    /// overflow indicator disagrees with what's visible. This returns the
+    /// focused split's real pane width, falling back to
+    /// [`effective_tabs_width`](Self::effective_tabs_width) when the split
+    /// isn't in the current visible layout (e.g. hidden behind a maximized
+    /// sibling).
+    pub fn split_tabs_width(&self, split_id: LeafId) -> u16 {
+        match self.buffers.splits() {
+            Some((mgr, _)) => mgr
+                .get_visible_buffers(self.editor_content_area())
+                .into_iter()
+                .find(|(id, _, _)| *id == split_id)
+                .map(|(_, _, area)| area.width)
+                .unwrap_or_else(|| self.effective_tabs_width()),
+            None => self.effective_tabs_width(),
+        }
+    }
+
     /// The split id whose `SplitViewState` owns the currently-focused
     /// cursors/viewport for this window.
     #[inline]

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -885,6 +885,10 @@ pub struct Window {
     /// File-explorer context menu state (right-click in the explorer).
     pub file_explorer_context_menu: Option<crate::app::types::FileExplorerContextMenu>,
 
+    /// Close-split confirmation popup state (left-click on a split tab bar's
+    /// `×` button). Offers "Close split" / "Cancel".
+    pub close_split_menu: Option<crate::app::types::CloseSplitMenu>,
+
     /// Theme inspector popup (Ctrl+Right-Click) anchored in this window.
     pub theme_info_popup: Option<crate::app::types::ThemeInfoPopup>,
 
@@ -1089,6 +1093,9 @@ impl Window {
         if let Some(m) = &self.tab_context_menu {
             return Some((ContextMenuKind::Tab, &m.menu));
         }
+        if let Some(m) = &self.close_split_menu {
+            return Some((ContextMenuKind::CloseSplit, &m.menu));
+        }
         None
     }
 
@@ -1108,6 +1115,9 @@ impl Window {
             return Some(&mut m.menu);
         }
         if let Some(m) = self.tab_context_menu.as_mut() {
+            return Some(&mut m.menu);
+        }
+        if let Some(m) = self.close_split_menu.as_mut() {
             return Some(&mut m.menu);
         }
         None
@@ -1141,6 +1151,13 @@ impl Window {
                 .iter()
                 .map(|i| i.label())
                 .collect(),
+            ContextMenuKind::CloseSplit => self
+                .close_split_menu
+                .as_ref()?
+                .items()
+                .iter()
+                .map(|i| i.label())
+                .collect(),
         })
     }
 
@@ -1150,6 +1167,7 @@ impl Window {
         self.tab_context_menu = None;
         self.new_tab_menu = None;
         self.file_explorer_context_menu = None;
+        self.close_split_menu = None;
     }
 
     /// Apply LSP folding ranges to the named buffer's `folding_ranges`
@@ -2125,6 +2143,7 @@ impl Window {
             tab_context_menu: None,
             new_tab_menu: None,
             file_explorer_context_menu: None,
+            close_split_menu: None,
             theme_info_popup: None,
             event_debug: None,
             file_open_state: None,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2306,12 +2306,24 @@ impl Window {
     /// sibling).
     pub fn split_tabs_width(&self, split_id: LeafId) -> u16 {
         match self.buffers.splits() {
-            Some((mgr, _)) => mgr
-                .get_visible_buffers(self.editor_content_area())
-                .into_iter()
-                .find(|(id, _, _)| *id == split_id)
-                .map(|(_, _, area)| area.width)
-                .unwrap_or_else(|| self.effective_tabs_width()),
+            Some((mgr, _)) => {
+                let visible = mgr.get_visible_buffers(self.editor_content_area());
+                let Some((_, _, area)) = visible.iter().find(|(id, _, _)| *id == split_id) else {
+                    return self.effective_tabs_width();
+                };
+                // The split-control (maximize / close) buttons are painted over
+                // the right edge of the tab row; reserve their columns here so
+                // the scroll math measures against the same width the tab bar
+                // actually lays tabs into (fresh#2768). Mirror the show-flags in
+                // `render_split_tab_bar`.
+                let has_multiple_splits = visible.len() > 1;
+                let is_maximized = mgr.is_maximized();
+                let show_maximize = has_multiple_splits || is_maximized;
+                let show_close = has_multiple_splits && !is_maximized;
+                let reserve =
+                    crate::view::ui::tabs::split_control_reserve(show_maximize, show_close);
+                area.width.saturating_sub(reserve)
+            }
             None => self.effective_tabs_width(),
         }
     }

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -1084,6 +1084,7 @@ impl Editor {
             ContextMenuKind::FileExplorer => "fileExplorer",
             ContextMenuKind::NewTab => "newTab",
             ContextMenuKind::Tab => "tab",
+            ContextMenuKind::CloseSplit => "closeSplit",
         };
         Some(ContextMenuView {
             kind,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -760,10 +760,14 @@ fn render_split_tab_bar(
     //   Close: shown when multiple splits exist AND not maximized.
     let show_maximize_btn = has_multiple_splits || is_maximized;
     let show_close_btn = has_multiple_splits && !is_maximized;
+    // When a split has any control button the whole right cluster
+    // (`□ + [sep] > ×`) is owned here (drawn on top after the tabs); the tab
+    // renderer then skips its own `+`/`>`. A single, unmaximized split has no
+    // cluster and lets the tab renderer draw its own inline `+`/`>` (fresh#2768).
+    let external_controls = show_maximize_btn || show_close_btn;
 
-    // Reserve the control-button columns from the tab bar's width so the tab
-    // scroll indicators (`<` / `>`) and the pinned "+" never render underneath
-    // the buttons (fresh#2768). The buttons are painted on top afterwards.
+    // Reserve the cluster columns from the tab bar's width so the scrolling
+    // tabs and the `<` left indicator never render underneath the cluster.
     let reserve = crate::view::ui::tabs::split_control_reserve(show_maximize_btn, show_close_btn);
     let tabs_area = Rect::new(
         layout.tabs_rect.x,
@@ -776,7 +780,7 @@ fn render_split_tab_bar(
     // theme-key runs into a local vec as it paints; apply them to the per-cell
     // map afterward (the map isn't borrowed here).
     let mut tab_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
-    let tab_layout = {
+    let mut tab_layout = {
         let mut rec = crate::app::types::CellThemeRecorder::new(&mut tab_runs);
         TabsRenderer::render_for_split(
             buf,
@@ -794,34 +798,41 @@ fn render_split_tab_bar(
             preview_buffer,
             Some(&mut rec),
             draw_tab_bar,
+            external_controls,
         )
     };
     crate::app::types::apply_theme_runs(cell_theme_map, screen_width, &tab_runs);
 
-    tab_layouts.insert(split_id, tab_layout);
     let tab_row = layout.tabs_rect.y;
 
-    if !show_maximize_btn && !show_close_btn {
+    // Single, unmaximized split: no cluster — the tab renderer already drew its
+    // own `+`/`<`/`>`. Record the layout and stop.
+    if !external_controls {
+        tab_layouts.insert(split_id, tab_layout);
         return;
     }
 
-    // Grouped at the right edge, close outermost: [maximize][close][blank]. The
-    // buttons sit adjacent (no gap) so they read as one control cluster; the
-    // reserve above keeps a 1-column gap between them and the tab content.
-    let mut btn_x = layout.tabs_rect.x + layout.tabs_rect.width.saturating_sub(2);
-    if show_close_btn {
-        let is_hovered = hovered_close_split == Some(split_id);
-        let close_fg = if is_hovered {
-            theme.tab_close_hover_fg
-        } else {
-            theme.line_number_fg
-        };
-        let close_button =
-            Paragraph::new("×").style(Style::default().fg(close_fg).bg(theme.tab_separator_bg));
-        close_button.render(Rect::new(btn_x, tab_row, 1, 1), buf);
-        close_split_areas.push((split_id, tab_row, btn_x, btn_x + 1));
-        btn_x = btn_x.saturating_sub(1); // adjacent to the maximize button
-    }
+    // Draw the right-side control cluster on top of the reserved columns, in
+    // visual order `□ + [sep] > ×` (fresh#2768):
+    //
+    //   [gap] □ + [sep] > ×  [trail]
+    //
+    // `□` (maximize) is present only when `show_maximize_btn`, `×` (close) only
+    // when `show_close_btn`, `+` (new buffer) is always present, and the `>`
+    // right-overflow indicator is drawn only when the tabs overflow (its column
+    // is reserved either way). Hit areas are stored so a click on each glyph
+    // routes to its action: `+` → `new_tab_area`, `>` → `right_scroll_area`,
+    // `□` → `maximize_split_areas`, `×` → `close_split_areas` (which now pops a
+    // confirm menu rather than closing immediately).
+    let overflow = tab_layout.right_overflow;
+    let cluster_x = layout.tabs_rect.x + layout.tabs_rect.width.saturating_sub(reserve);
+    // Paint the whole cluster background first (separator surface) so the gap /
+    // separator / trailing columns are clean regardless of prior cell content.
+    Paragraph::new(" ".repeat(reserve as usize))
+        .style(Style::default().bg(theme.tab_separator_bg))
+        .render(Rect::new(cluster_x, tab_row, reserve, 1), buf);
+
+    let mut cx = cluster_x + 1; // skip the leading gap
     if show_maximize_btn {
         let is_hovered = hovered_maximize_split == Some(split_id);
         let max_fg = if is_hovered {
@@ -831,11 +842,53 @@ fn render_split_tab_bar(
         };
         // □ = maximize, ⧉ = unmaximize (restore).
         let icon = if is_maximized { "⧉" } else { "□" };
-        let max_button =
-            Paragraph::new(icon).style(Style::default().fg(max_fg).bg(theme.tab_separator_bg));
-        max_button.render(Rect::new(btn_x, tab_row, 1, 1), buf);
-        maximize_split_areas.push((split_id, tab_row, btn_x, btn_x + 1));
+        Paragraph::new(icon)
+            .style(Style::default().fg(max_fg).bg(theme.tab_separator_bg))
+            .render(Rect::new(cx, tab_row, 1, 1), buf);
+        maximize_split_areas.push((split_id, tab_row, cx, cx + 1));
+        cx += 1;
     }
+    // "+" new-buffer button — styled like an inactive tab so it reads as a
+    // button, immediately to the right of the maximize glyph.
+    Paragraph::new("+")
+        .style(
+            Style::default()
+                .fg(theme.tab_inactive_fg)
+                .bg(theme.tab_inactive_bg),
+        )
+        .render(Rect::new(cx, tab_row, 1, 1), buf);
+    tab_layout.new_tab_area = Some(Rect::new(cx, tab_row, 1, 1));
+    cx += 1;
+    // Separator gap so `+` is visually distinct from the `> ×` group.
+    cx += 1;
+    // ">" right-overflow indicator — glyph only when tabs overflow; the column
+    // is reserved either way so the cluster never shifts as you scroll.
+    if overflow {
+        let gt_rect = Rect::new(cx, tab_row, 1, 1);
+        Paragraph::new(">")
+            .style(
+                Style::default()
+                    .fg(theme.line_number_fg)
+                    .bg(theme.tab_separator_bg),
+            )
+            .render(gt_rect, buf);
+        tab_layout.right_scroll_area = Some(gt_rect);
+    }
+    cx += 1;
+    if show_close_btn {
+        let is_hovered = hovered_close_split == Some(split_id);
+        let close_fg = if is_hovered {
+            theme.tab_close_hover_fg
+        } else {
+            theme.line_number_fg
+        };
+        Paragraph::new("×")
+            .style(Style::default().fg(close_fg).bg(theme.tab_separator_bg))
+            .render(Rect::new(cx, tab_row, 1, 1), buf);
+        close_split_areas.push((split_id, tab_row, cx, cx + 1));
+    }
+
+    tab_layouts.insert(split_id, tab_layout);
 }
 
 /// Render a composite (side-by-side panes) buffer for one split, plus its

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -755,6 +755,23 @@ fn render_split_tab_bar(
             }
         })
         .collect();
+    // Split control buttons live at the right side of the tabs row.
+    //   Maximize/unmaximize: shown when multiple splits exist OR maximized.
+    //   Close: shown when multiple splits exist AND not maximized.
+    let show_maximize_btn = has_multiple_splits || is_maximized;
+    let show_close_btn = has_multiple_splits && !is_maximized;
+
+    // Reserve the control-button columns from the tab bar's width so the tab
+    // scroll indicators (`<` / `>`) and the pinned "+" never render underneath
+    // the buttons (fresh#2768). The buttons are painted on top afterwards.
+    let reserve = crate::view::ui::tabs::split_control_reserve(show_maximize_btn, show_close_btn);
+    let tabs_area = Rect::new(
+        layout.tabs_rect.x,
+        layout.tabs_rect.y,
+        layout.tabs_rect.width.saturating_sub(reserve),
+        layout.tabs_rect.height,
+    );
+
     // Render tabs for this split and collect hit areas. The tab bar records its
     // theme-key runs into a local vec as it paints; apply them to the per-cell
     // map afterward (the map isn't borrowed here).
@@ -763,7 +780,7 @@ fn render_split_tab_bar(
         let mut rec = crate::app::types::CellThemeRecorder::new(&mut tab_runs);
         TabsRenderer::render_for_split(
             buf,
-            layout.tabs_rect,
+            tabs_area,
             split_buffers,
             buffers,
             buffer_metadata,
@@ -784,16 +801,13 @@ fn render_split_tab_bar(
     tab_layouts.insert(split_id, tab_layout);
     let tab_row = layout.tabs_rect.y;
 
-    // Split control buttons at the right side of the tabs row.
-    //   Maximize/unmaximize: shown when multiple splits exist OR maximized.
-    //   Close: shown when multiple splits exist AND not maximized.
-    let show_maximize_btn = has_multiple_splits || is_maximized;
-    let show_close_btn = has_multiple_splits && !is_maximized;
     if !show_maximize_btn && !show_close_btn {
         return;
     }
 
-    // Layout from the right edge: [maximize] [space] [close] |
+    // Grouped at the right edge, close outermost: [maximize][close][blank]. The
+    // buttons sit adjacent (no gap) so they read as one control cluster; the
+    // reserve above keeps a 1-column gap between them and the tab content.
     let mut btn_x = layout.tabs_rect.x + layout.tabs_rect.width.saturating_sub(2);
     if show_close_btn {
         let is_hovered = hovered_close_split == Some(split_id);
@@ -806,7 +820,7 @@ fn render_split_tab_bar(
             Paragraph::new("×").style(Style::default().fg(close_fg).bg(theme.tab_separator_bg));
         close_button.render(Rect::new(btn_x, tab_row, 1, 1), buf);
         close_split_areas.push((split_id, tab_row, btn_x, btn_x + 1));
-        btn_x = btn_x.saturating_sub(2); // 1 space before the next button
+        btn_x = btn_x.saturating_sub(1); // adjacent to the maximize button
     }
     if show_maximize_btn {
         let is_hovered = hovered_maximize_split == Some(split_id);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -761,7 +761,7 @@ fn render_split_tab_bar(
     let show_maximize_btn = has_multiple_splits || is_maximized;
     let show_close_btn = has_multiple_splits && !is_maximized;
     // When a split has any control button the whole right cluster
-    // (`□ + [sep] > ×`) is owned here (drawn on top after the tabs); the tab
+    // (`+ [sep] > □ ×`) is owned here (drawn on top after the tabs); the tab
     // renderer then skips its own `+`/`>`. A single, unmaximized split has no
     // cluster and lets the tab renderer draw its own inline `+`/`>` (fresh#2768).
     let external_controls = show_maximize_btn || show_close_btn;
@@ -813,9 +813,9 @@ fn render_split_tab_bar(
     }
 
     // Draw the right-side control cluster on top of the reserved columns, in
-    // visual order `□ + [sep] > ×` (fresh#2768):
+    // visual order `+ [sep] > □ ×` (fresh#2768):
     //
-    //   [gap] □ + [sep] > ×  [trail]
+    //   [gap] + [sep] > □ ×  [trail]
     //
     // `□` (maximize) is present only when `show_maximize_btn`, `×` (close) only
     // when `show_close_btn`, `+` (new buffer) is always present, and the `>`
@@ -832,24 +832,10 @@ fn render_split_tab_bar(
         .style(Style::default().bg(theme.tab_separator_bg))
         .render(Rect::new(cluster_x, tab_row, reserve, 1), buf);
 
-    let mut cx = cluster_x + 1; // skip the leading gap
-    if show_maximize_btn {
-        let is_hovered = hovered_maximize_split == Some(split_id);
-        let max_fg = if is_hovered {
-            theme.tab_close_hover_fg
-        } else {
-            theme.line_number_fg
-        };
-        // □ = maximize, ⧉ = unmaximize (restore).
-        let icon = if is_maximized { "⧉" } else { "□" };
-        Paragraph::new(icon)
-            .style(Style::default().fg(max_fg).bg(theme.tab_separator_bg))
-            .render(Rect::new(cx, tab_row, 1, 1), buf);
-        maximize_split_areas.push((split_id, tab_row, cx, cx + 1));
-        cx += 1;
-    }
+    // Skip the leading gap.
+    let mut cx = cluster_x + 1;
     // "+" new-buffer button — styled like an inactive tab so it reads as a
-    // button, immediately to the right of the maximize glyph.
+    // button, at the left of the cluster.
     Paragraph::new("+")
         .style(
             Style::default()
@@ -859,7 +845,7 @@ fn render_split_tab_bar(
         .render(Rect::new(cx, tab_row, 1, 1), buf);
     tab_layout.new_tab_area = Some(Rect::new(cx, tab_row, 1, 1));
     cx += 1;
-    // Separator gap so `+` is visually distinct from the `> ×` group.
+    // Separator gap so `+` is visually distinct from the `> □ ×` group.
     cx += 1;
     // ">" right-overflow indicator — glyph only when tabs overflow; the column
     // is reserved either way so the cluster never shifts as you scroll.
@@ -875,6 +861,21 @@ fn render_split_tab_bar(
         tab_layout.right_scroll_area = Some(gt_rect);
     }
     cx += 1;
+    // "□" maximize / "⧉" unmaximize (restore) — just before the close button.
+    if show_maximize_btn {
+        let is_hovered = hovered_maximize_split == Some(split_id);
+        let max_fg = if is_hovered {
+            theme.tab_close_hover_fg
+        } else {
+            theme.line_number_fg
+        };
+        let icon = if is_maximized { "⧉" } else { "□" };
+        Paragraph::new(icon)
+            .style(Style::default().fg(max_fg).bg(theme.tab_separator_bg))
+            .render(Rect::new(cx, tab_row, 1, 1), buf);
+        maximize_split_areas.push((split_id, tab_row, cx, cx + 1));
+        cx += 1;
+    }
     if show_close_btn {
         let is_hovered = hovered_close_split == Some(split_id);
         let close_fg = if is_hovered {

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -71,6 +71,12 @@ pub struct TabLayout {
     pub right_scroll_area: Option<Rect>,
     /// Hit area for the trailing "+" new-tab button (if visible)
     pub new_tab_area: Option<Rect>,
+    /// Whether the tabs overflow the right edge of the bar (later tabs are
+    /// scrolled off). When the split-control cluster is drawn externally (see
+    /// [`render_for_split`]'s `external_controls`), the `>` glyph is painted by
+    /// the orchestration layer, not here, so it consults this flag to decide
+    /// whether to draw a right-scroll indicator in the cluster.
+    pub right_overflow: bool,
 }
 
 /// Hit test result for tab interactions
@@ -99,6 +105,7 @@ impl TabLayout {
             left_scroll_area: None,
             right_scroll_area: None,
             new_tab_area: None,
+            right_overflow: false,
         }
     }
 
@@ -165,22 +172,33 @@ const NEW_TAB_BUTTON_TEXT: &str = " + ";
 /// Display width (columns) of [`NEW_TAB_BUTTON_TEXT`].
 pub const NEW_TAB_BUTTON_WIDTH: usize = 3;
 
-/// Columns reserved at the right edge of a split's tab row for the split-control
-/// (maximize / close) buttons. The tab bar lays out — and the tab-scroll math
-/// measures against — the pane width *minus* this reserve, so the `<`/`>` scroll
-/// indicators and the pinned "+" never end up underneath the control buttons
-/// (which are painted on top of the row afterwards). Without the reserve the
-/// maximize button lands on the exact column the `>` right-overflow indicator
-/// wants, hiding it (fresh#2768). The block is `[gap][buttons][trailing blank]`.
+/// Columns reserved at the right edge of a split's tab row for the whole
+/// right-side control cluster, drawn on top of the row afterwards by the
+/// orchestration layer. When a split has any control button the cluster reads
+/// `□ + [sep] > ×` (fresh#2768):
+///
+/// ```text
+///   [gap] □ + [sep] > ×
+/// ```
+///
+/// where `□` (maximize) is present only when `show_maximize`, `×` (close) only
+/// when `show_close`, `+` (new buffer) is always present, and the `>`
+/// right-overflow slot is always reserved (the glyph is drawn only when the
+/// tabs actually overflow, but the column is held so the layout doesn't jump as
+/// you scroll). The tab bar lays out — and the tab-scroll math measures against
+/// — the pane width *minus* this reserve, so the scrolling tabs and the `<`
+/// left-overflow indicator never end up underneath the cluster.
+///
+/// A pane with no control buttons (a single, unmaximized split) reserves
+/// nothing: there is no cluster, and `render_for_split` draws its own inline /
+/// pinned `+` and `<`/`>` indicators exactly as an unsplit editor does.
 pub fn split_control_reserve(show_maximize: bool, show_close: bool) -> u16 {
-    let n = show_maximize as u16 + show_close as u16;
-    if n == 0 {
-        0
-    } else {
-        // 1 leading gap so the tabs don't butt against the buttons + 1 trailing
-        // blank at the pane's right edge.
-        n + 2
+    if !show_maximize && !show_close {
+        return 0;
     }
+    // gap(1) + maximize + plus(1) + sep(1) + right-overflow slot(1) + close
+    // + trailing blank(1).
+    1 + show_maximize as u16 + 1 + 1 + 1 + show_close as u16 + 1
 }
 
 /// Glyph drawn at the left edge when earlier tabs are scrolled off.
@@ -932,6 +950,14 @@ impl TabsRenderer {
         // cells — the web renders the tab bar natively from `tab_bar_view`. The
         // TUI always passes `true`.
         draw: bool,
+        // When true the split-control cluster (`□ + [sep] > ×`) is owned by the
+        // orchestration layer, so this renderer skips its own trailing `+` and
+        // right-overflow `>` (the orchestration draws them in the reserved
+        // cluster instead). It still draws the `<` left indicator and the
+        // scrolling tabs, and reports overflow via `TabLayout::right_overflow`.
+        // A pane with no control buttons passes `false` and keeps the original
+        // inline/pinned `+` and `>` behaviour.
+        external_controls: bool,
     ) -> TabLayout {
         let mut layout = TabLayout::new(area);
         // Seed the whole bar with the separator surface (the block bg); each
@@ -1018,12 +1044,20 @@ impl TabsRenderer {
         // sits right after the last tab. When they overflow, the "+" is pinned
         // to the right edge of the bar (`tabs_render_width` reserves its
         // column) and drawn on top after the main paragraph render below.
+        //
+        // With `external_controls` the orchestration layer owns the whole right
+        // cluster (`□ + [sep] > ×`), so this renderer draws no `+` of its own
+        // and the full bar width is available to the tabs.
         let tabs_total: usize = final_spans.iter().map(|(_, w)| w).sum();
-        let max_width = tabs_render_width(tabs_total, area.width as usize);
-        let pin_plus = max_width < area.width as usize;
+        let (max_width, pin_plus) = if external_controls {
+            (area.width as usize, false)
+        } else {
+            let mw = tabs_render_width(tabs_total, area.width as usize);
+            (mw, mw < area.width as usize)
+        };
 
         let mut inline_plus_range: Option<(usize, usize)> = None;
-        if !pin_plus {
+        if !external_controls && !pin_plus {
             let plus_start = if !rendered_targets.is_empty() {
                 // Separator between the last real tab and the "+" button
                 final_spans.push((
@@ -1055,11 +1089,19 @@ impl TabsRenderer {
             "render_for_split: tab_scroll_offset={}, max_offset={}, offset={}, total={}, max_width={}",
             tab_scroll_offset, max_offset, offset, total_width, max_width
         );
-        // Indicators reserve space based on scroll position.
+        // Indicators reserve space based on scroll position. The `<` left
+        // indicator is always drawn here. The `>` right indicator is drawn here
+        // only when this renderer owns the cluster; with `external_controls`
+        // the orchestration draws `>` in the reserved cluster instead, so we
+        // don't reserve a column for it — we only record that the tabs overflow
+        // (`right_overflow`) so the orchestration knows whether to draw it.
         let show_left = offset > 0;
-        let show_right = total_width.saturating_sub(offset) > max_width;
+        let overflow_right = total_width.saturating_sub(offset) > max_width;
+        layout.right_overflow = overflow_right;
+        let draw_right_indicator = overflow_right && !external_controls;
         let available = max_width
-            .saturating_sub((show_left as usize + show_right as usize) * SCROLL_INDICATOR_WIDTH);
+            .saturating_sub((show_left as usize) * SCROLL_INDICATOR_WIDTH)
+            .saturating_sub((draw_right_indicator as usize) * SCROLL_INDICATOR_WIDTH);
 
         // Phase 4: clip the spans to the viewport and paint the bar.
         let (current_spans, right_indicator_x) = build_visible_line(
@@ -1068,7 +1110,7 @@ impl TabsRenderer {
             offset,
             max_width,
             show_left,
-            show_right,
+            draw_right_indicator,
             theme,
         );
 
@@ -1467,13 +1509,16 @@ mod tests {
     }
 
     #[test]
-    fn split_control_reserve_matches_button_count() {
-        // No buttons (single pane): no reservation.
+    fn split_control_reserve_matches_cluster_width() {
+        // No buttons (single pane): no reservation — the tab renderer draws its
+        // own inline/pinned `+` and `<`/`>` indicators.
         assert_eq!(split_control_reserve(false, false), 0);
-        // Maximized single pane: only the maximize/restore button.
-        assert_eq!(split_control_reserve(true, false), 3);
-        // Multiple splits, not maximized: maximize + close grouped.
-        assert_eq!(split_control_reserve(true, true), 4);
+        // Maximized single pane: cluster is `□ + [sep] >` (no close), i.e.
+        // gap + □ + `+` + sep + `>` slot + trail = 6.
+        assert_eq!(split_control_reserve(true, false), 6);
+        // Multiple splits, not maximized: full cluster `□ + [sep] > ×`, i.e.
+        // gap + □ + `+` + sep + `>` slot + × + trail = 7.
+        assert_eq!(split_control_reserve(true, true), 7);
     }
 
     #[test]
@@ -1507,21 +1552,23 @@ mod tests {
         );
     }
 
-    /// Paint `render_for_split` into a fresh buffer and return row-0 as a string.
-    fn render_row0(
+    /// Paint `render_for_split` into a fresh buffer and return row-0 as a
+    /// string plus the resulting `TabLayout`.
+    fn render_row0_ext(
         area: Rect,
         targets: &[TabTarget],
         group_names: &HashMap<LeafId, String>,
         active: TabTarget,
         offset: usize,
-    ) -> String {
+        external_controls: bool,
+    ) -> (String, TabLayout) {
         let buffers = HashMap::new();
         let meta = HashMap::new();
         let comp = HashMap::new();
         let theme =
             crate::view::theme::Theme::load_builtin(crate::view::theme::THEME_DARK).unwrap();
         let mut buf = ratatui::buffer::Buffer::empty(area);
-        TabsRenderer::render_for_split(
+        let layout = TabsRenderer::render_for_split(
             &mut buf,
             area,
             targets,
@@ -1537,10 +1584,23 @@ mod tests {
             None,
             None,
             true,
+            external_controls,
         );
-        (0..area.width)
+        let row = (0..area.width)
             .map(|x| buf[(area.x + x, area.y)].symbol().to_string())
-            .collect()
+            .collect();
+        (row, layout)
+    }
+
+    /// Paint `render_for_split` into a fresh buffer and return row-0 as a string.
+    fn render_row0(
+        area: Rect,
+        targets: &[TabTarget],
+        group_names: &HashMap<LeafId, String>,
+        active: TabTarget,
+        offset: usize,
+    ) -> String {
+        render_row0_ext(area, targets, group_names, active, offset, false).0
     }
 
     #[test]
@@ -1607,6 +1667,59 @@ mod tests {
             !row.contains('>'),
             "no right indicator once fully scrolled right, got {row:?}"
         );
+    }
+
+    #[test]
+    fn external_controls_suppress_plus_and_right_indicator() {
+        // With `external_controls`, the orchestration layer owns the `+`/`>`
+        // cluster, so the tab renderer draws neither glyph itself even when the
+        // tabs overflow — it only reports overflow via `right_overflow`.
+        let names = [
+            "alpha.rs",
+            "bravo.rs",
+            "charlie.rs",
+            "delta.rs",
+            "echo.rs",
+            "foxtrot.rs",
+        ];
+        let (targets, group_names) = build_group_inputs(&names);
+        let area = Rect::new(0, 0, 24, 1);
+
+        let (row, layout) = render_row0_ext(area, &targets, &group_names, targets[2], 14, true);
+        // Overflow is reported so the caller can draw `>` in its cluster.
+        assert!(layout.right_overflow, "expected overflow to be reported");
+        // But this renderer painted no `>` and pinned no `+`.
+        assert!(
+            !row.contains('>'),
+            "external controls must not draw the `>` indicator here, got {row:?}"
+        );
+        assert!(
+            !row.contains('+'),
+            "external controls must not draw the `+` button here, got {row:?}"
+        );
+        assert!(
+            layout.new_tab_area.is_none(),
+            "no pinned `+` in external mode"
+        );
+        assert!(
+            layout.right_scroll_area.is_none(),
+            "no `>` hit area in external mode (the cluster owns it)"
+        );
+        // The `<` left indicator is still owned by the tab renderer.
+        assert!(
+            row.contains('<'),
+            "left indicator stays with the tab renderer, got {row:?}"
+        );
+    }
+
+    #[test]
+    fn external_controls_report_no_overflow_when_tabs_fit() {
+        // A single short tab in a wide bar: no overflow, so `right_overflow` is
+        // false and the cluster won't draw a `>`.
+        let (targets, group_names) = build_group_inputs(&["only.rs"]);
+        let area = Rect::new(0, 0, 40, 1);
+        let (_row, layout) = render_row0_ext(area, &targets, &group_names, targets[0], 0, true);
+        assert!(!layout.right_overflow, "no overflow expected when tabs fit");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -165,6 +165,24 @@ const NEW_TAB_BUTTON_TEXT: &str = " + ";
 /// Display width (columns) of [`NEW_TAB_BUTTON_TEXT`].
 pub const NEW_TAB_BUTTON_WIDTH: usize = 3;
 
+/// Columns reserved at the right edge of a split's tab row for the split-control
+/// (maximize / close) buttons. The tab bar lays out — and the tab-scroll math
+/// measures against — the pane width *minus* this reserve, so the `<`/`>` scroll
+/// indicators and the pinned "+" never end up underneath the control buttons
+/// (which are painted on top of the row afterwards). Without the reserve the
+/// maximize button lands on the exact column the `>` right-overflow indicator
+/// wants, hiding it (fresh#2768). The block is `[gap][buttons][trailing blank]`.
+pub fn split_control_reserve(show_maximize: bool, show_close: bool) -> u16 {
+    let n = show_maximize as u16 + show_close as u16;
+    if n == 0 {
+        0
+    } else {
+        // 1 leading gap so the tabs don't butt against the buttons + 1 trailing
+        // blank at the pane's right edge.
+        n + 2
+    }
+}
+
 /// Glyph drawn at the left edge when earlier tabs are scrolled off.
 const SCROLL_INDICATOR_LEFT: &str = "<";
 /// Glyph drawn at the right edge when later tabs are scrolled off.
@@ -301,6 +319,85 @@ fn elided_tab_name(name: &str, max_cols: usize) -> String {
     body
 }
 
+/// Full (uncapped) display width of one tab's label — the name portion plus the
+/// close button, excluding the inter-tab separator. Mirrors the label format
+/// both builders paint, so the "do all tabs fit?" pre-pass measures exactly what
+/// the row would render at full names.
+fn full_tab_label_width(
+    t: &TabTarget,
+    name: &str,
+    buffers: &HashMap<BufferId, EditorState>,
+    buffer_metadata: &HashMap<BufferId, BufferMetadata>,
+    composite_buffers: &HashMap<BufferId, crate::model::composite_buffer::CompositeBuffer>,
+    preview_buffer: Option<BufferId>,
+) -> usize {
+    let modified = match t {
+        TabTarget::Buffer(id) if !composite_buffers.contains_key(id) => buffers
+            .get(id)
+            .filter(|state| state.buffer.is_modified())
+            .map(|_| "*")
+            .unwrap_or(""),
+        _ => "",
+    };
+    let binary = match t {
+        TabTarget::Buffer(id) if buffer_metadata.get(id).map(|m| m.binary).unwrap_or(false) => {
+            " [BIN]"
+        }
+        _ => "",
+    };
+    let preview_indicator = preview_suffix(t, preview_buffer);
+    let tab_name_text = format!(" {name}{modified}{preview_indicator}{binary} ");
+    str_width(&tab_name_text) + str_width("× ")
+}
+
+/// Decide the per-name elision cap for a split's tab bar.
+///
+/// When every tab fits at its FULL name within `available_width` (accounting for
+/// the inter-tab separators and the pinned "+" reservation) the names are shown
+/// untruncated (cap = `usize::MAX`, i.e. no elision). Only when the tabs would
+/// overflow — the bar is "full" — is each name capped at [`TAB_NAME_MAX_COLS`]
+/// so one long filename can't hide every other tab (issue #2650).
+///
+/// Both label builders ([`build_tab_spans`] and [`calculate_tab_widths`]) derive
+/// their cap from this with the same `available_width`, so their computed widths
+/// stay in lockstep.
+fn tab_name_cap(
+    tab_targets: &[TabTarget],
+    resolved_names: &HashMap<TabTarget, String>,
+    buffers: &HashMap<BufferId, EditorState>,
+    buffer_metadata: &HashMap<BufferId, BufferMetadata>,
+    composite_buffers: &HashMap<BufferId, crate::model::composite_buffer::CompositeBuffer>,
+    preview_buffer: Option<BufferId>,
+    available_width: usize,
+) -> usize {
+    let mut full_total = 0usize;
+    let mut count = 0usize;
+    for t in tab_targets.iter() {
+        let Some(name) = resolved_names.get(t) else {
+            continue;
+        };
+        full_total += full_tab_label_width(
+            t,
+            name,
+            buffers,
+            buffer_metadata,
+            composite_buffers,
+            preview_buffer,
+        );
+        count += 1;
+    }
+    let full_total_with_seps = full_total + count.saturating_sub(1);
+    // `tabs_render_width` returns the columns actually available for tabs after
+    // reserving the pinned "+" (when they overflow). If the full-name total fits
+    // in that, nothing scrolls and we show full names.
+    let render_w = tabs_render_width(full_total_with_seps, available_width);
+    if full_total_with_seps <= render_w {
+        usize::MAX
+    } else {
+        TAB_NAME_MAX_COLS
+    }
+}
+
 /// Resolve display names for tab targets, disambiguating duplicates by appending a number.
 /// For example, if there are three unnamed buffers, they become "[No Name]", "[No Name] 2", "[No Name] 3".
 /// Similarly, duplicate filenames get numbered: "main.rs", "main.rs 2".
@@ -391,6 +488,7 @@ pub fn calculate_tab_widths(
     composite_buffers: &HashMap<BufferId, crate::model::composite_buffer::CompositeBuffer>,
     group_names: &HashMap<LeafId, String>,
     preview_buffer: Option<BufferId>,
+    available_width: usize,
 ) -> (Vec<usize>, Vec<TabTarget>) {
     let mut tab_widths: Vec<usize> = Vec::new();
     let mut rendered_targets: Vec<TabTarget> = Vec::new();
@@ -402,14 +500,24 @@ pub fn calculate_tab_widths(
         group_names,
     );
 
+    // Full names when they all fit, otherwise cap each at TAB_NAME_MAX_COLS.
+    // Must mirror `build_tab_spans` exactly (same cap) or widths drift.
+    let name_cap = tab_name_cap(
+        tab_targets,
+        &resolved_names,
+        buffers,
+        buffer_metadata,
+        composite_buffers,
+        preview_buffer,
+        available_width,
+    );
+
     for t in tab_targets.iter() {
         // Skip targets we couldn't resolve a name for (hidden, missing, etc.)
         let Some(name) = resolved_names.get(t) else {
             continue;
         };
-        // Bound the name so one long filename can't hide every other tab. Must
-        // mirror `build_tab_spans` exactly (same cap) or widths drift.
-        let name = elided_tab_name(name, TAB_NAME_MAX_COLS);
+        let name = elided_tab_name(name, name_cap);
 
         // Calculate modified indicator (groups and composite buffers don't show it)
         let modified = match t {
@@ -536,6 +644,7 @@ fn build_tab_spans(
     preview_buffer: Option<BufferId>,
     is_active_split: bool,
     theme: &crate::view::theme::Theme,
+    name_cap: usize,
 ) -> TabSpanLayout {
     let mut all_tab_spans: Vec<(Span<'static>, usize)> = Vec::new();
     let mut tab_ranges: Vec<(usize, usize, usize)> = Vec::new();
@@ -546,10 +655,10 @@ fn build_tab_spans(
         let Some(name_owned) = resolved_names.get(t).cloned() else {
             continue;
         };
-        // Bound the name so one long filename can't hide every other tab. Must
-        // mirror `calculate_tab_widths` exactly (same cap) or widths drift and
-        // hit-testing/scroll positions diverge from what's painted.
-        let name = elided_tab_name(&name_owned, TAB_NAME_MAX_COLS);
+        // Elide with the caller's shared cap. Must mirror `calculate_tab_widths`
+        // exactly (same cap) or widths drift and hit-testing/scroll positions
+        // diverge from what's painted.
+        let name = elided_tab_name(&name_owned, name_cap);
         let name = name.as_str();
         rendered_targets.push(*t);
 
@@ -715,6 +824,7 @@ fn map_tab_hit_areas(
     left_indicator_offset: usize,
     active_target: TabTarget,
     is_active_split: bool,
+    name_cap: usize,
     mut rec: Option<&mut CellThemeRecorder>,
 ) {
     let visible_start = offset;
@@ -778,7 +888,7 @@ fn map_tab_hit_areas(
             // hit-testing match the string the TUI actually draws.
             label: resolved_names
                 .get(target)
-                .map(|n| elided_tab_name(n, TAB_NAME_MAX_COLS))
+                .map(|n| elided_tab_name(n, name_cap))
                 .unwrap_or_default(),
             tab_area: Rect::new(screen_start, area.y, tab_width, 1),
             close_area: Rect::new(screen_close_start, area.y, close_width, 1),
@@ -844,6 +954,19 @@ impl TabsRenderer {
             group_names,
         );
 
+        // Full names when they all fit in this split's tab-bar width, otherwise
+        // cap each at TAB_NAME_MAX_COLS. Computed once here and threaded into the
+        // span builder and hit-area mapper so every consumer uses one cap.
+        let name_cap = tab_name_cap(
+            tab_targets,
+            &resolved_names,
+            buffers,
+            buffer_metadata,
+            composite_buffers,
+            preview_buffer,
+            area.width as usize,
+        );
+
         // Phase 1: build each tab's styled name + close spans and logical
         // column ranges (unresolvable targets are skipped, so the vectors
         // index by rendered position).
@@ -858,6 +981,7 @@ impl TabsRenderer {
             preview_buffer,
             is_active_split,
             theme,
+            name_cap,
         );
 
         // Phase 2: add separators between tabs (we do this after the loop to handle hidden buffers correctly)
@@ -1005,6 +1129,7 @@ impl TabsRenderer {
             left_indicator_offset,
             active_target,
             is_active_split,
+            name_cap,
             rec.as_deref_mut(),
         );
 
@@ -1261,9 +1386,11 @@ mod tests {
         let meta = HashMap::new();
         let comp = HashMap::new();
 
+        // A narrow bar (40) forces the long name to overflow -> capped.
+        let bar = 40;
         // calculate_tab_widths: single tab, no separator.
         let (widths, rendered) =
-            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None);
+            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None, bar);
         assert_eq!(rendered.len(), 1);
         assert_eq!(widths.len(), 1);
         // Full tab width = leading+trailing pad (2) + name (<=cap) + "× " (2).
@@ -1275,12 +1402,13 @@ mod tests {
         );
 
         // build_tab_spans must compute the identical width for the same input,
-        // or hit-testing/scroll drift.
+        // or hit-testing/scroll drift. Same cap decision as calculate_tab_widths.
         let resolved = resolve_tab_names(&targets, &buffers, &meta, &comp, &group_names);
+        let cap = tab_name_cap(&targets, &resolved, &buffers, &meta, &comp, None, bar);
         let theme =
             crate::view::theme::Theme::load_builtin(crate::view::theme::THEME_DARK).unwrap();
         let (_spans, ranges, rendered2) = build_tab_spans(
-            &targets, &resolved, &buffers, &meta, &comp, targets[0], None, None, true, &theme,
+            &targets, &resolved, &buffers, &meta, &comp, targets[0], None, None, true, &theme, cap,
         );
         assert_eq!(rendered2.len(), 1);
         let span_width = ranges[0].1 - ranges[0].0;
@@ -1299,10 +1427,17 @@ mod tests {
         let buffers = HashMap::new();
         let meta = HashMap::new();
         let comp = HashMap::new();
-        let (tab_widths, rendered) =
-            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None);
-
         let max_width = 40;
+        let (tab_widths, rendered) = calculate_tab_widths(
+            &targets,
+            &buffers,
+            &meta,
+            &comp,
+            &group_names,
+            None,
+            max_width,
+        );
+
         let total: usize = tab_widths.iter().sum();
         for i in 0..rendered.len() {
             let width_idx = if i == 0 { 0 } else { i * 2 };
@@ -1329,6 +1464,149 @@ mod tests {
                 offset
             );
         }
+    }
+
+    #[test]
+    fn split_control_reserve_matches_button_count() {
+        // No buttons (single pane): no reservation.
+        assert_eq!(split_control_reserve(false, false), 0);
+        // Maximized single pane: only the maximize/restore button.
+        assert_eq!(split_control_reserve(true, false), 3);
+        // Multiple splits, not maximized: maximize + close grouped.
+        assert_eq!(split_control_reserve(true, true), 4);
+    }
+
+    #[test]
+    fn tab_names_full_when_they_fit_and_capped_when_overflowing() {
+        // A single name longer than the cap (30 cols) but shorter than a wide
+        // bar: it fits, so it is shown in full (no elision).
+        let name = "n".repeat(30);
+        let (targets, group_names) = build_group_inputs(&[name.as_str()]);
+        let buffers = HashMap::new();
+        let meta = HashMap::new();
+        let comp = HashMap::new();
+
+        let (wide_widths, _) =
+            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None, 100);
+        // pad(2) + full name(30) + "× "(2) = 34, untruncated.
+        assert_eq!(wide_widths[0], 34, "wide bar should show the full name");
+
+        // The same name in a narrow bar overflows, so it is capped.
+        let (narrow_widths, _) =
+            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None, 20);
+        assert!(
+            narrow_widths[0] <= TAB_NAME_MAX_COLS + 4,
+            "narrow bar should cap the name (width {})",
+            narrow_widths[0]
+        );
+        assert!(
+            narrow_widths[0] < wide_widths[0],
+            "capped width {} must be narrower than full width {}",
+            narrow_widths[0],
+            wide_widths[0]
+        );
+    }
+
+    /// Paint `render_for_split` into a fresh buffer and return row-0 as a string.
+    fn render_row0(
+        area: Rect,
+        targets: &[TabTarget],
+        group_names: &HashMap<LeafId, String>,
+        active: TabTarget,
+        offset: usize,
+    ) -> String {
+        let buffers = HashMap::new();
+        let meta = HashMap::new();
+        let comp = HashMap::new();
+        let theme =
+            crate::view::theme::Theme::load_builtin(crate::view::theme::THEME_DARK).unwrap();
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        TabsRenderer::render_for_split(
+            &mut buf,
+            area,
+            targets,
+            &buffers,
+            &meta,
+            &comp,
+            active,
+            &theme,
+            true,
+            offset,
+            None,
+            group_names,
+            None,
+            None,
+            true,
+        );
+        (0..area.width)
+            .map(|x| buf[(area.x + x, area.y)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn right_indicator_renders_when_scrolled_off_right() {
+        // Enough same-width tabs to overflow a narrow bar several times over.
+        let names = [
+            "alpha.rs",
+            "bravo.rs",
+            "charlie.rs",
+            "delta.rs",
+            "echo.rs",
+            "foxtrot.rs",
+        ];
+        let (targets, group_names) = build_group_inputs(&names);
+        let area = Rect::new(0, 0, 24, 1);
+
+        // Scroll so earlier tabs are off the left AND later tabs off the right.
+        let row = render_row0(area, &targets, &group_names, targets[2], 14);
+        assert!(
+            row.contains('<'),
+            "expected left overflow indicator, got {row:?}"
+        );
+        assert!(
+            row.contains('>'),
+            "expected right overflow indicator when tabs are scrolled off the right, got {row:?}"
+        );
+    }
+
+    #[test]
+    fn no_right_indicator_at_the_right_end() {
+        let names = [
+            "alpha.rs",
+            "bravo.rs",
+            "charlie.rs",
+            "delta.rs",
+            "echo.rs",
+            "foxtrot.rs",
+        ];
+        let (targets, group_names) = build_group_inputs(&names);
+        let area = Rect::new(0, 0, 24, 1);
+        // A large offset parks the bar at its right end: `<` shows, `>` must not.
+        let (widths, _) = calculate_tab_widths(
+            &targets,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &group_names,
+            None,
+            area.width as usize,
+        );
+        let total: usize = widths.iter().sum();
+        let row = render_row0(
+            area,
+            &targets,
+            &group_names,
+            *targets.last().unwrap(),
+            total,
+        );
+        assert!(
+            row.contains('<'),
+            "expected left indicator at the right end"
+        );
+        assert!(
+            !row.contains('>'),
+            "no right indicator once fully scrolled right, got {row:?}"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -3,7 +3,7 @@
 use crate::app::types::CellThemeRecorder;
 use crate::app::BufferMetadata;
 use crate::model::event::{BufferId, LeafId};
-use crate::primitives::display_width::str_width;
+use crate::primitives::display_width::{char_width, str_width};
 use crate::state::EditorState;
 use crate::view::split::TabTarget;
 use crate::view::ui::layout::point_in_rect;
@@ -263,6 +263,44 @@ pub fn scroll_to_show_tab(
     result
 }
 
+/// Single-character ellipsis (U+2026) appended when a tab name is elided.
+const TAB_NAME_ELLIPSIS: &str = "…";
+
+/// Maximum display width, in columns, for the *name* portion of a tab label.
+/// The surrounding pad, the modified/preview/binary indicators and the close
+/// button are budgeted separately, so this caps only the filename/group name.
+/// Without a cap a single very long name (e.g. 151 chars) consumes the whole
+/// strip and hides every other tab (issue #2650).
+const TAB_NAME_MAX_COLS: usize = 25;
+
+/// Elide `name` to at most `max_cols` display columns, keeping the leading
+/// characters and appending a single `…` when it is truncated. Width is
+/// measured with `char_width`/`str_width` (not bytes), so multibyte / CJK /
+/// emoji names are truncated on whole characters and never split mid-codepoint.
+/// Returns `name` unchanged when it already fits.
+///
+/// Both label builders — [`build_tab_spans`] and [`calculate_tab_widths`] — run
+/// the resolved name through this so their computed widths stay in lockstep; a
+/// mismatch would drift hit-testing and the scroll math.
+fn elided_tab_name(name: &str, max_cols: usize) -> String {
+    if str_width(name) <= max_cols {
+        return name.to_string();
+    }
+    let budget = max_cols.saturating_sub(str_width(TAB_NAME_ELLIPSIS));
+    let mut width = 0;
+    let mut body = String::new();
+    for ch in name.chars() {
+        let w = char_width(ch);
+        if width + w > budget {
+            break;
+        }
+        width += w;
+        body.push(ch);
+    }
+    body.push_str(TAB_NAME_ELLIPSIS);
+    body
+}
+
 /// Resolve display names for tab targets, disambiguating duplicates by appending a number.
 /// For example, if there are three unnamed buffers, they become "[No Name]", "[No Name] 2", "[No Name] 3".
 /// Similarly, duplicate filenames get numbered: "main.rs", "main.rs 2".
@@ -369,6 +407,9 @@ pub fn calculate_tab_widths(
         let Some(name) = resolved_names.get(t) else {
             continue;
         };
+        // Bound the name so one long filename can't hide every other tab. Must
+        // mirror `build_tab_spans` exactly (same cap) or widths drift.
+        let name = elided_tab_name(name, TAB_NAME_MAX_COLS);
 
         // Calculate modified indicator (groups and composite buffers don't show it)
         let modified = match t {
@@ -505,7 +546,11 @@ fn build_tab_spans(
         let Some(name_owned) = resolved_names.get(t).cloned() else {
             continue;
         };
-        let name = name_owned.as_str();
+        // Bound the name so one long filename can't hide every other tab. Must
+        // mirror `calculate_tab_widths` exactly (same cap) or widths drift and
+        // hit-testing/scroll positions diverge from what's painted.
+        let name = elided_tab_name(&name_owned, TAB_NAME_MAX_COLS);
+        let name = name.as_str();
         rendered_targets.push(*t);
 
         // Composite buffers and groups never show as modified.
@@ -729,7 +774,12 @@ fn map_tab_hit_areas(
 
         layout.tabs.push(TabHitArea {
             target: *target,
-            label: resolved_names.get(target).cloned().unwrap_or_default(),
+            // Store the *elided* label so the web frontend and mouse
+            // hit-testing match the string the TUI actually draws.
+            label: resolved_names
+                .get(target)
+                .map(|n| elided_tab_name(n, TAB_NAME_MAX_COLS))
+                .unwrap_or_default(),
             tab_area: Rect::new(screen_start, area.y, tab_width, 1),
             close_area: Rect::new(screen_close_start, area.y, close_width, 1),
         });

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -1201,6 +1201,136 @@ mod tests {
         }
     }
 
+    // --- Tab name elision (issue #2650) ---------------------------------
+
+    #[test]
+    fn elided_tab_name_leaves_short_names_untouched() {
+        assert_eq!(elided_tab_name("main.rs", TAB_NAME_MAX_COLS), "main.rs");
+        // Exactly at the cap is not truncated.
+        let exact = "a".repeat(TAB_NAME_MAX_COLS);
+        assert_eq!(elided_tab_name(&exact, TAB_NAME_MAX_COLS), exact);
+    }
+
+    #[test]
+    fn elided_tab_name_caps_long_name_and_ends_with_ellipsis() {
+        let name = "a".repeat(151);
+        let out = elided_tab_name(&name, TAB_NAME_MAX_COLS);
+        assert!(
+            str_width(&out) <= TAB_NAME_MAX_COLS,
+            "elided width {} exceeds cap {}",
+            str_width(&out),
+            TAB_NAME_MAX_COLS
+        );
+        assert!(out.ends_with('…'), "elided label must end with U+2026");
+    }
+
+    #[test]
+    fn elided_tab_name_multibyte_stays_within_cap_without_panic() {
+        // Wide CJK glyphs (2 cols each) plus multi-codepoint emoji, well over
+        // the cap: must truncate on whole characters and never split a
+        // codepoint (which would panic) or exceed the display-width cap.
+        let name = format!("{}🎉🎊🚀", "日本語のファイル".repeat(6));
+        let out = elided_tab_name(&name, TAB_NAME_MAX_COLS);
+        assert!(
+            str_width(&out) <= TAB_NAME_MAX_COLS,
+            "elided width {} exceeds cap {}",
+            str_width(&out),
+            TAB_NAME_MAX_COLS
+        );
+        assert!(out.ends_with('…'));
+    }
+
+    /// Build `TabTarget::Group` inputs (one per name) so the label builders can
+    /// be exercised without constructing real buffers/`EditorState`.
+    fn build_group_inputs(names: &[&str]) -> (Vec<TabTarget>, HashMap<LeafId, String>) {
+        let mut group_names = HashMap::new();
+        let mut targets = Vec::new();
+        for (i, n) in names.iter().enumerate() {
+            let leaf = LeafId(crate::model::event::SplitId(i));
+            group_names.insert(leaf, n.to_string());
+            targets.push(TabTarget::Group(leaf));
+        }
+        (targets, group_names)
+    }
+
+    #[test]
+    fn long_tab_name_bounded_and_builders_stay_in_sync() {
+        let long = "a".repeat(151);
+        let (targets, group_names) = build_group_inputs(&[long.as_str()]);
+        let buffers = HashMap::new();
+        let meta = HashMap::new();
+        let comp = HashMap::new();
+
+        // calculate_tab_widths: single tab, no separator.
+        let (widths, rendered) =
+            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None);
+        assert_eq!(rendered.len(), 1);
+        assert_eq!(widths.len(), 1);
+        // Full tab width = leading+trailing pad (2) + name (<=cap) + "× " (2).
+        assert!(
+            widths[0] <= TAB_NAME_MAX_COLS + 4,
+            "tab width {} exceeds cap {} + indicators",
+            widths[0],
+            TAB_NAME_MAX_COLS
+        );
+
+        // build_tab_spans must compute the identical width for the same input,
+        // or hit-testing/scroll drift.
+        let resolved = resolve_tab_names(&targets, &buffers, &meta, &comp, &group_names);
+        let theme =
+            crate::view::theme::Theme::load_builtin(crate::view::theme::THEME_DARK).unwrap();
+        let (_spans, ranges, rendered2) = build_tab_spans(
+            &targets, &resolved, &buffers, &meta, &comp, targets[0], None, None, true, &theme,
+        );
+        assert_eq!(rendered2.len(), 1);
+        let span_width = ranges[0].1 - ranges[0].0;
+        assert_eq!(
+            span_width, widths[0],
+            "build_tab_spans width ({}) must match calculate_tab_widths ({})",
+            span_width, widths[0]
+        );
+    }
+
+    #[test]
+    fn over_long_tabs_are_elided_and_scroll_into_view() {
+        let long = "z".repeat(151);
+        let (targets, group_names) =
+            build_group_inputs(&[long.as_str(), "short.rs", long.as_str(), "other.txt"]);
+        let buffers = HashMap::new();
+        let meta = HashMap::new();
+        let comp = HashMap::new();
+        let (tab_widths, rendered) =
+            calculate_tab_widths(&targets, &buffers, &meta, &comp, &group_names, None);
+
+        let max_width = 40;
+        let total: usize = tab_widths.iter().sum();
+        for i in 0..rendered.len() {
+            let width_idx = if i == 0 { 0 } else { i * 2 };
+            let w = tab_widths[width_idx];
+            assert!(
+                w <= TAB_NAME_MAX_COLS + 4,
+                "tab {} width {} exceeds cap",
+                i,
+                w
+            );
+            // With names bounded, the active tab always fully scrolls into view.
+            let offset = scroll_to_show_tab(&tab_widths, width_idx, 0, max_width);
+            let (vis_start, vis_end) = visible_range(offset, total, max_width);
+            let start: usize = tab_widths[..width_idx].iter().sum();
+            let end = start + w;
+            assert!(
+                start >= vis_start && end <= vis_end,
+                "tab {} ({}..{}) not fully visible in {}..{} (offset={})",
+                i,
+                start,
+                end,
+                vis_start,
+                vis_end,
+                offset
+            );
+        }
+    }
+
     #[test]
     fn test_tab_layout_hit_test() {
         let bar_area = Rect::new(0, 0, 80, 1);

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -175,10 +175,10 @@ pub const NEW_TAB_BUTTON_WIDTH: usize = 3;
 /// Columns reserved at the right edge of a split's tab row for the whole
 /// right-side control cluster, drawn on top of the row afterwards by the
 /// orchestration layer. When a split has any control button the cluster reads
-/// `□ + [sep] > ×` (fresh#2768):
+/// `+ [sep] > □ ×` (fresh#2768):
 ///
 /// ```text
-///   [gap] □ + [sep] > ×
+///   [gap] + [sep] > □ ×
 /// ```
 ///
 /// where `□` (maximize) is present only when `show_maximize`, `×` (close) only
@@ -196,9 +196,9 @@ pub fn split_control_reserve(show_maximize: bool, show_close: bool) -> u16 {
     if !show_maximize && !show_close {
         return 0;
     }
-    // gap(1) + maximize + plus(1) + sep(1) + right-overflow slot(1) + close
+    // gap(1) + plus(1) + sep(1) + right-overflow slot(1) + maximize + close
     // + trailing blank(1).
-    1 + show_maximize as u16 + 1 + 1 + 1 + show_close as u16 + 1
+    1 + 1 + 1 + 1 + show_maximize as u16 + show_close as u16 + 1
 }
 
 /// Glyph drawn at the left edge when earlier tabs are scrolled off.
@@ -950,7 +950,7 @@ impl TabsRenderer {
         // cells — the web renders the tab bar natively from `tab_bar_view`. The
         // TUI always passes `true`.
         draw: bool,
-        // When true the split-control cluster (`□ + [sep] > ×`) is owned by the
+        // When true the split-control cluster (`+ [sep] > □ ×`) is owned by the
         // orchestration layer, so this renderer skips its own trailing `+` and
         // right-overflow `>` (the orchestration draws them in the reserved
         // cluster instead). It still draws the `<` left indicator and the
@@ -1046,7 +1046,7 @@ impl TabsRenderer {
         // column) and drawn on top after the main paragraph render below.
         //
         // With `external_controls` the orchestration layer owns the whole right
-        // cluster (`□ + [sep] > ×`), so this renderer draws no `+` of its own
+        // cluster (`+ [sep] > □ ×`), so this renderer draws no `+` of its own
         // and the full bar width is available to the tabs.
         let tabs_total: usize = final_spans.iter().map(|(_, w)| w).sum();
         let (max_width, pin_plus) = if external_controls {
@@ -1513,11 +1513,11 @@ mod tests {
         // No buttons (single pane): no reservation — the tab renderer draws its
         // own inline/pinned `+` and `<`/`>` indicators.
         assert_eq!(split_control_reserve(false, false), 0);
-        // Maximized single pane: cluster is `□ + [sep] >` (no close), i.e.
-        // gap + □ + `+` + sep + `>` slot + trail = 6.
+        // Maximized single pane: cluster is `+ [sep] > □` (no close), i.e.
+        // gap + `+` + sep + `>` slot + □ + trail = 6.
         assert_eq!(split_control_reserve(true, false), 6);
-        // Multiple splits, not maximized: full cluster `□ + [sep] > ×`, i.e.
-        // gap + □ + `+` + sep + `>` slot + × + trail = 7.
+        // Multiple splits, not maximized: full cluster `+ [sep] > □ ×`, i.e.
+        // gap + `+` + sep + `>` slot + □ + × + trail = 7.
         assert_eq!(split_control_reserve(true, true), 7);
     }
 

--- a/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
+++ b/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/fresh-editor/tests/common/visual_testing.rs
-assertion_line: 69
 expression: "&screen_text"
 ---
  File   Edit   View   Selection   Go   LSP   Help                                                                       
- file1.rs ×   +                                                                                                     □ × 
+ file1.rs ×   +                                                                                                      □× 
   1 │ // File 1 - Contains a very long line that will require horizontal scrolling to see the end of it completely when 
 ▾ 2 │ fn main() {                                                                                                       
   3 │     let very_long_variable_name_that_extends_beyond_normal_view = "This is a string with a lot of content that go 

--- a/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
+++ b/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
@@ -3,7 +3,7 @@ source: crates/fresh-editor/tests/common/visual_testing.rs
 expression: "&screen_text"
 ---
  File   Edit   View   Selection   Go   LSP   Help                                                                       
- file1.rs ×   +                                                                                                      □× 
+ file1.rs ×                                                                                                       +  □× 
   1 │ // File 1 - Contains a very long line that will require horizontal scrolling to see the end of it completely when 
 ▾ 2 │ fn main() {                                                                                                       
   3 │     let very_long_variable_name_that_extends_beyond_normal_view = "This is a string with a lot of content that go 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -233,6 +233,7 @@ pub mod shift_backspace;
 pub mod slow_filesystem;
 pub mod smart_editing;
 pub mod smart_home;
+pub mod split_close_confirm;
 pub mod split_focus_tab_click;
 pub mod split_tabs;
 pub mod split_view;

--- a/crates/fresh-editor/tests/e2e/split_close_confirm.rs
+++ b/crates/fresh-editor/tests/e2e/split_close_confirm.rs
@@ -1,0 +1,125 @@
+//! Clicking a split's `×` (close-split) button must not close the split
+//! immediately — it pops a "Close split" / "Cancel" confirmation first
+//! (fresh#2768). Only confirming closes the split; cancelling leaves both
+//! panes in place.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Create a vertical split via the command palette (two side-by-side panes).
+fn split_vertical(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("split vert").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// Number of split leaves in the active window.
+fn leaf_count(harness: &EditorTestHarness) -> usize {
+    harness
+        .editor()
+        .active_window()
+        .buffers
+        .split_manager()
+        .expect("split layout")
+        .root()
+        .count_leaves()
+}
+
+/// Locate the left pane's close-split `×` button by finding the cluster's
+/// maximize glyph `□`. The cluster is laid out `[gap] □ + [sep] > ×`, so the
+/// `×` sits four columns to the right of the `□` (fresh#2768).
+fn close_button_pos(harness: &EditorTestHarness) -> (u16, u16) {
+    let height = harness.buffer().area.height;
+    for row in 0..height {
+        let text = harness.get_row_text(row);
+        if let Some(idx) = text.find('□') {
+            // `idx` is a byte offset; count chars up to it to get the column
+            // (everything left of the cluster is ASCII, so this equals the
+            // display column).
+            let col = text[..idx].chars().count() as u16;
+            return (col + 4, row);
+        }
+    }
+    panic!("could not find the maximize glyph (□) in any row");
+}
+
+#[test]
+fn clicking_close_split_pops_confirmation_not_immediate_close() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    split_vertical(&mut harness);
+    assert_eq!(leaf_count(&harness), 2, "precondition: two split panes");
+
+    let (x, row) = close_button_pos(&harness);
+    harness.mouse_click(x, row).unwrap();
+    harness.render().unwrap();
+
+    // The confirmation popup is presented and the split is still open.
+    assert!(
+        harness.editor().active_window().close_split_menu.is_some(),
+        "clicking × must present the close-split confirmation"
+    );
+    assert_eq!(
+        leaf_count(&harness),
+        2,
+        "the split must not close until the user confirms"
+    );
+    harness.assert_screen_contains("Close split");
+    harness.assert_screen_contains("Cancel");
+}
+
+#[test]
+fn confirming_close_split_closes_the_pane() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    split_vertical(&mut harness);
+    assert_eq!(leaf_count(&harness), 2);
+
+    let (x, row) = close_button_pos(&harness);
+    harness.mouse_click(x, row).unwrap();
+    harness.render().unwrap();
+    assert!(harness.editor().active_window().close_split_menu.is_some());
+
+    // The confirm item ("Close split") is highlighted by default; Enter
+    // activates it through the shared context-menu key path.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.editor().active_window().close_split_menu.is_none(),
+        "the confirmation dismisses after choosing an item"
+    );
+    assert_eq!(leaf_count(&harness), 1, "confirming must close the split");
+}
+
+#[test]
+fn cancelling_close_split_keeps_both_panes() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    split_vertical(&mut harness);
+    assert_eq!(leaf_count(&harness), 2);
+
+    let (x, row) = close_button_pos(&harness);
+    harness.mouse_click(x, row).unwrap();
+    harness.render().unwrap();
+    assert!(harness.editor().active_window().close_split_menu.is_some());
+
+    // Esc dismisses the confirmation without closing anything.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.editor().active_window().close_split_menu.is_none(),
+        "Esc must dismiss the confirmation"
+    );
+    assert_eq!(
+        leaf_count(&harness),
+        2,
+        "cancelling must leave both panes open"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/split_close_confirm.rs
+++ b/crates/fresh-editor/tests/e2e/split_close_confirm.rs
@@ -32,8 +32,8 @@ fn leaf_count(harness: &EditorTestHarness) -> usize {
 }
 
 /// Locate the left pane's close-split `×` button by finding the cluster's
-/// maximize glyph `□`. The cluster is laid out `[gap] □ + [sep] > ×`, so the
-/// `×` sits four columns to the right of the `□` (fresh#2768).
+/// maximize glyph `□`. The cluster is laid out `[gap] + [sep] > □ ×`, so the
+/// `×` sits immediately to the right of the `□` (fresh#2768).
 fn close_button_pos(harness: &EditorTestHarness) -> (u16, u16) {
     let height = harness.buffer().area.height;
     for row in 0..height {
@@ -43,7 +43,7 @@ fn close_button_pos(harness: &EditorTestHarness) -> (u16, u16) {
             // (everything left of the cluster is ASCII, so this equals the
             // display column).
             let col = text[..idx].chars().count() as u16;
-            return (col + 4, row);
+            return (col + 1, row);
         }
     }
     panic!("could not find the maximize glyph (□) in any row");

--- a/crates/fresh-editor/tests/semantic/migrated_tab_scrolling.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_tab_scrolling.rs
@@ -105,6 +105,30 @@ fn create_dummy_files(temp_dir: &TempDir) -> Vec<std::path::PathBuf> {
     files
 }
 
+/// Display-width cap the tab bar applies to a tab's *name* portion
+/// (mirrors `view::ui::tabs::TAB_NAME_MAX_COLS`, which is private).
+const TAB_NAME_MAX_COLS: usize = 25;
+
+/// The on-screen label the tab bar actually paints for a file.
+///
+/// Since issue #2650, a name wider than [`TAB_NAME_MAX_COLS`] columns is
+/// elided to its leading `TAB_NAME_MAX_COLS - 1` columns plus a single `…`
+/// so one long filename can't consume the whole strip and hide every other
+/// tab. Every dummy filename here (`long_file_name_number_NN.txt`, 28 chars)
+/// exceeds the cap, so each renders as its 24-char prefix + `…`. That prefix
+/// still carries the two-digit index, so the elided labels stay unique per
+/// file and the "active tab is visible" claim holds — we just assert on the
+/// label the editor actually draws instead of the full, now-elided filename.
+fn expected_tab_label(file_path: &std::path::Path) -> String {
+    let name = file_path.file_name().unwrap().to_str().unwrap();
+    if name.chars().count() <= TAB_NAME_MAX_COLS {
+        name.to_string()
+    } else {
+        let prefix: String = name.chars().take(TAB_NAME_MAX_COLS - 1).collect();
+        format!("{prefix}…")
+    }
+}
+
 #[test]
 fn migrated_active_tab_visibility_with_scrolling() {
     // Original: `test_active_tab_visibility_with_scrolling`. The
@@ -123,15 +147,13 @@ fn migrated_active_tab_visibility_with_scrolling() {
     for file_path in &files {
         harness.open_file(file_path).unwrap();
         harness.render().unwrap();
-        let active_file_name = file_path.file_name().unwrap().to_str().unwrap();
-        harness.assert_screen_contains(active_file_name);
+        harness.assert_screen_contains(&expected_tab_label(file_path));
     }
 
     // Initial check: Last opened file is active.
     let mut active_idx = NUM_FILES - 1;
     harness.render().unwrap();
-    let active_file_name = files[active_idx].file_name().unwrap().to_str().unwrap();
-    harness.assert_screen_contains(active_file_name);
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
     if active_idx < NUM_FILES - 1 {
         assert!(
             harness.screen_to_string().contains(">"),
@@ -148,8 +170,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         active_idx = (active_idx + 1) % NUM_FILES;
 
         harness.render().unwrap();
-        let active_file_name = files[active_idx].file_name().unwrap().to_str().unwrap();
-        harness.assert_screen_contains(active_file_name);
+        harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
 
         let screen = harness.screen_to_string();
         // The e2e only enforces the no-left-indicator-on-first edge.
@@ -157,7 +178,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
             assert!(
                 !screen.contains("<"),
                 "Expected no left scroll indicator for file: {}",
-                active_file_name
+                expected_tab_label(&files[active_idx])
             );
         }
     }
@@ -170,22 +191,21 @@ fn migrated_active_tab_visibility_with_scrolling() {
         active_idx = (active_idx + NUM_FILES - 1) % NUM_FILES;
 
         harness.render().unwrap();
-        let active_file_name = files[active_idx].file_name().unwrap().to_str().unwrap();
-        harness.assert_screen_contains(active_file_name);
+        harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
 
         let screen = harness.screen_to_string();
         if active_idx == 0 {
             assert!(
                 !screen.contains("<"),
                 "Expected no left scroll indicator for file: {}",
-                active_file_name
+                expected_tab_label(&files[active_idx])
             );
         }
         if active_idx == NUM_FILES - 1 {
             assert!(
                 !screen.contains(">"),
                 "Expected no right scroll indicator for file: {}",
-                active_file_name
+                expected_tab_label(&files[active_idx])
             );
         }
     }
@@ -202,7 +222,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         harness.render().unwrap();
     }
     assert_eq!(active_idx, middle_idx, "Failed to activate middle tab");
-    harness.assert_screen_contains(files[active_idx].file_name().unwrap().to_str().unwrap());
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
 
     // Scroll right manually — active tab may scroll out of view.
     for _ in 0..5 {
@@ -226,7 +246,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         .unwrap();
     harness.render().unwrap();
     active_idx = (active_idx + 1) % NUM_FILES;
-    harness.assert_screen_contains(files[active_idx].file_name().unwrap().to_str().unwrap());
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
 }
 
 #[test]

--- a/crates/fresh-editor/tests/semantic/migrated_tab_scrolling.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_tab_scrolling.rs
@@ -119,9 +119,29 @@ const TAB_NAME_MAX_COLS: usize = 25;
 /// still carries the two-digit index, so the elided labels stay unique per
 /// file and the "active tab is visible" claim holds — we just assert on the
 /// label the editor actually draws instead of the full, now-elided filename.
-fn expected_tab_label(file_path: &std::path::Path) -> String {
+///
+/// Since the follow-up to #2650 the cap is *conditional*: a name is elided only
+/// when this split's tabs overflow the bar. With `num_open` tabs of this same
+/// (uniform) filename in a `NARROW_WIDTH` bar, opening the very first file still
+/// fits, so it renders in full; from the second tab on they overflow and are
+/// capped. This mirrors that decision so the assertions track what's painted.
+fn expected_tab_label(file_path: &std::path::Path, num_open: usize) -> String {
     let name = file_path.file_name().unwrap().to_str().unwrap();
-    if name.chars().count() <= TAB_NAME_MAX_COLS {
+    let len = name.chars().count();
+    // Full-name tab width: " {name} " (len + 2) + "× " (2).
+    let full_tab = len + 4;
+    let full_total = full_tab * num_open + num_open.saturating_sub(1);
+    // Mirror `tabs_render_width`: reserve the pinned "+" (3 cols) on overflow.
+    // This is the unsplit editor, so the bar is the full NARROW_WIDTH.
+    let bar = NARROW_WIDTH as usize;
+    let inline_total = full_total + usize::from(full_total > 0) + 3;
+    let render_w = if inline_total > bar && bar > 3 {
+        bar - 3
+    } else {
+        bar
+    };
+    let fits = full_total <= render_w;
+    if fits || len <= TAB_NAME_MAX_COLS {
         name.to_string()
     } else {
         let prefix: String = name.chars().take(TAB_NAME_MAX_COLS - 1).collect();
@@ -144,16 +164,16 @@ fn migrated_active_tab_visibility_with_scrolling() {
     let mut harness = EditorTestHarness::new(NARROW_WIDTH, TEST_HEIGHT).unwrap();
 
     // Open all dummy files
-    for file_path in &files {
+    for (i, file_path) in files.iter().enumerate() {
         harness.open_file(file_path).unwrap();
         harness.render().unwrap();
-        harness.assert_screen_contains(&expected_tab_label(file_path));
+        harness.assert_screen_contains(&expected_tab_label(file_path, i + 1));
     }
 
     // Initial check: Last opened file is active.
     let mut active_idx = NUM_FILES - 1;
     harness.render().unwrap();
-    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx], NUM_FILES));
     if active_idx < NUM_FILES - 1 {
         assert!(
             harness.screen_to_string().contains(">"),
@@ -170,7 +190,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         active_idx = (active_idx + 1) % NUM_FILES;
 
         harness.render().unwrap();
-        harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
+        harness.assert_screen_contains(&expected_tab_label(&files[active_idx], NUM_FILES));
 
         let screen = harness.screen_to_string();
         // The e2e only enforces the no-left-indicator-on-first edge.
@@ -178,7 +198,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
             assert!(
                 !screen.contains("<"),
                 "Expected no left scroll indicator for file: {}",
-                expected_tab_label(&files[active_idx])
+                expected_tab_label(&files[active_idx], NUM_FILES)
             );
         }
     }
@@ -191,21 +211,21 @@ fn migrated_active_tab_visibility_with_scrolling() {
         active_idx = (active_idx + NUM_FILES - 1) % NUM_FILES;
 
         harness.render().unwrap();
-        harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
+        harness.assert_screen_contains(&expected_tab_label(&files[active_idx], NUM_FILES));
 
         let screen = harness.screen_to_string();
         if active_idx == 0 {
             assert!(
                 !screen.contains("<"),
                 "Expected no left scroll indicator for file: {}",
-                expected_tab_label(&files[active_idx])
+                expected_tab_label(&files[active_idx], NUM_FILES)
             );
         }
         if active_idx == NUM_FILES - 1 {
             assert!(
                 !screen.contains(">"),
                 "Expected no right scroll indicator for file: {}",
-                expected_tab_label(&files[active_idx])
+                expected_tab_label(&files[active_idx], NUM_FILES)
             );
         }
     }
@@ -222,7 +242,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         harness.render().unwrap();
     }
     assert_eq!(active_idx, middle_idx, "Failed to activate middle tab");
-    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx], NUM_FILES));
 
     // Scroll right manually — active tab may scroll out of view.
     for _ in 0..5 {
@@ -246,7 +266,7 @@ fn migrated_active_tab_visibility_with_scrolling() {
         .unwrap();
     harness.render().unwrap();
     active_idx = (active_idx + 1) % NUM_FILES;
-    harness.assert_screen_contains(&expected_tab_label(&files[active_idx]));
+    harness.assert_screen_contains(&expected_tab_label(&files[active_idx], NUM_FILES));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause

Issue #2650: a single long filename broke the tab bar. Two independent defects:

1. **Unbounded tab labels.** Tab labels were used at full length with no cap, so one 151-char name consumed the entire strip and hid every other tab.
2. **Per-split scroll width bug.** `ensure_active_tab_visible` was fed `effective_tabs_width()` (the whole editor-content width), but a split's real tab bar is only as wide as its pane (`tabs_rect.width == split_area.width`). In a vertical split the scroll math ran against ~2x the real width, so it under-scrolled and the `>` overflow indicator disagreed with what was visible, sometimes hiding the active tab.

## Fix

**Part 1 — bound each tab label.** Added a shared `elided_tab_name(name, max_cols)` helper in `view/ui/tabs.rs` that truncates the name portion to a fixed 25-column cap by **display width** (not bytes, so CJK/emoji are multibyte-safe), keeping the leading characters and appending a single `…` (U+2026). Applied to the name portion in both label builders — `build_tab_spans` and `calculate_tab_widths` — so their widths stay in lockstep (a mismatch would drift hit-testing/scroll). Also stored into `TabHitArea.label` so mouse hit-testing and the web frontend match the TUI. Disambiguation numbers from `resolve_tab_names` are applied **before** elision so they aren't chopped.

**Part 2 — per-split scroll width.** Added `Window::split_tabs_width(split_id)`, which looks up the focused split's real pane width via `get_visible_buffers` (falling back to `effective_tabs_width` when the split isn't in the visible layout), and fed it to `ensure_active_tab_visible` at the switch/close/focus call sites (`active_focus.rs`, `buffer_close.rs`, `split_actions.rs` x2). The resize path in `lifecycle.rs` already used per-split widths.

Ctrl+scroll-to-switch is intentionally out of scope for this PR.

## Tests

- `elided_tab_name`: short names untouched; 151-char name bounded to the cap and ends with `…`; multibyte/CJK/emoji stays within the width cap without panicking.
- `calculate_tab_widths` and `build_tab_spans` compute matching widths for the same long-named input (the sync invariant).
- Over-long tabs are elided so the active tab always scrolls fully into view in a normal-width bar.
- `split_tabs_width` reports each pane's real width in a vertical split, narrower than the whole-editor `effective_tabs_width`.

All new and existing tab tests pass (`cargo test -p fresh-editor --lib tabs::` and the `ensure_active_tab_visible` / close-others regression tests).

Closes #2650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_