### PR TITLE
fix(dock): keep editor split + dock alive when last editor tab closes (#2283)

### DIFF
--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -44,17 +44,35 @@ impl Editor {
                 return Err(anyhow::anyhow!("Buffer has unsaved changes"));
             }
         }
-        self.close_buffer_internal(id)
+        self.close_buffer_internal(id, false)
     }
 
     /// Force close the given buffer without checking for unsaved changes
     /// Use this when the user has already confirmed they want to discard changes
     pub fn force_close_buffer(&mut self, id: BufferId) -> anyhow::Result<()> {
-        self.close_buffer_internal(id)
+        self.close_buffer_internal(id, false)
+    }
+
+    /// Close the last editor tab while a Utility Dock is present, keeping the
+    /// editor leaf alive but empty (issue #2283). The editor leaf we intend to
+    /// keep is made the active split so the synthesized placeholder buffer
+    /// lands there rather than in the dock, then the closing buffer is torn
+    /// down with `force_empty_placeholder` so no dock terminal gets adopted.
+    pub(crate) fn close_tab_keeping_editor_leaf_empty(
+        &mut self,
+        id: BufferId,
+        split_id: LeafId,
+    ) -> anyhow::Result<()> {
+        self.split_manager_mut().set_active_split(split_id);
+        self.close_buffer_internal(id, true)
     }
 
     /// Internal helper to close a buffer (shared by close_buffer and force_close_buffer)
-    fn close_buffer_internal(&mut self, id: BufferId) -> anyhow::Result<()> {
+    fn close_buffer_internal(
+        &mut self,
+        id: BufferId,
+        force_empty_placeholder: bool,
+    ) -> anyhow::Result<()> {
         // Discard any async pastes whose anchors live in this buffer:
         // when the result arrives the buffer state will be gone, and
         // there's no useful place to land the text without it. Done
@@ -107,7 +125,7 @@ impl Editor {
             buffer: replacement_buffer,
             created_empty: created_empty_buffer,
             return_to_group,
-        } = self.resolve_close_replacement(id, active_split);
+        } = self.resolve_close_replacement(id, active_split, force_empty_placeholder);
 
         // Switch to replacement buffer BEFORE updating splits.
         // Only needed when the closing buffer is the one the user is
@@ -251,7 +269,28 @@ impl Editor {
         &mut self,
         id: BufferId,
         active_split: LeafId,
+        force_empty_placeholder: bool,
     ) -> CloseReplacement {
+        // Forced empty state (issue #2283): the caller closed the last editor
+        // tab while a Utility Dock is present and wants the editor leaf kept
+        // alive but blank — NOT re-populated with an arbitrary remaining
+        // buffer. Crucially, the normal fallbacks below would happily adopt a
+        // dock TERMINAL buffer (terminals aren't `hidden_from_tabs`), ejecting
+        // it into the editor. So synthesize a placeholder unconditionally and
+        // short-circuit before any buffer-adoption logic runs.
+        if force_empty_placeholder {
+            let new_id = self.new_buffer();
+            if let Some(meta) = self.active_window_mut().buffer_metadata.get_mut(&new_id) {
+                meta.hidden_from_tabs = true;
+                meta.synthetic_placeholder = true;
+            }
+            return CloseReplacement {
+                buffer: new_id,
+                created_empty: true,
+                return_to_group: None,
+            };
+        }
+
         let replacement_target: Option<crate::view::split::TabTarget> = self
             .windows
             .get(&self.active_window)
@@ -588,22 +627,35 @@ impl Editor {
                     return false;
                 }
             }
-            // If this is the only tab in this split AND there are other
-            // splits, close the split rather than swap it to a fallback
+            // If this is the only tab in this split AND there is another
+            // EDITOR split, close the split rather than swap it to a fallback
             // buffer.  Mirrors `close_tab()` so mouse-click close and
             // Close Buffer/Close Tab commands behave the same — without
             // this, the × button leaves a leftover split showing some
             // unrelated buffer (observed with the Search/Replace panel).
-            let has_other_splits = self
+            //
+            // The Utility Dock is a role-tagged leaf, NOT an editor split, so
+            // it must be excluded from this count (issue #2283). Counting it
+            // took the "close the whole split" path when the sole editor tab
+            // was closed, collapsing the editor leaf and promoting the dock's
+            // terminals into the main tab bar. See `LayoutRoles` below.
+            let (has_other_editor_splits, dock_present, this_is_dock) = self
                 .windows
                 .get(&self.active_window)
                 .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .root()
-                .count_leaves()
-                > 1;
-            if split_tabs.len() <= 1 && has_other_splits {
+                .map(|(mgr, _)| {
+                    use crate::view::split::SplitRole;
+                    let has_other_editor_splits = mgr.root().leaf_split_ids().iter().any(|&lid| {
+                        lid != split_id && mgr.leaf_role(lid) != Some(SplitRole::UtilityDock)
+                    });
+                    let dock_present =
+                        mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
+                    let this_is_dock =
+                        mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
+                    (has_other_editor_splits, dock_present, this_is_dock)
+                })
+                .expect("active window must have a populated split layout");
+            if split_tabs.len() <= 1 && has_other_editor_splits {
                 self.handle_close_split(split_id.into());
                 // handle_close_split also disposes the buffer-less split;
                 // buffer lifetime cleanup happens via its own path.
@@ -619,6 +671,23 @@ impl Editor {
                 // teardown can't clobber the restore (issue #2485).
                 self.sync_terminal_mode_to_active_buffer();
                 self.set_status_message(t!("buffer.tab_closed").to_string());
+                return true;
+            }
+            // Sole editor tab, a Utility Dock is the only other leaf: keep the
+            // editor leaf alive but EMPTY (placeholder empty-state) instead of
+            // collapsing it into the dock or adopting a dock terminal buffer
+            // (issue #2283).
+            if split_tabs.len() <= 1 && dock_present && !this_is_dock {
+                if let Err(e) = self.close_tab_keeping_editor_leaf_empty(buffer_id, split_id) {
+                    self.set_status_message(
+                        t!("file.cannot_close", error = e.to_string()).to_string(),
+                    );
+                } else {
+                    // Active buffer is now the hidden placeholder (non-terminal);
+                    // drop any lingering Terminal key context.
+                    self.sync_terminal_mode_to_active_buffer();
+                    self.set_status_message(t!("buffer.tab_closed").to_string());
+                }
                 return true;
             }
             if let Err(e) = self.close_buffer(buffer_id) {
@@ -945,6 +1014,35 @@ impl Editor {
                     // Skip modified buffers - don't close them
                     return false;
                 }
+            }
+            // Batch close mirror of the interactive guard (issue #2283): if
+            // this is the sole editor tab in this leaf and the only other leaf
+            // is a Utility Dock, keep the editor leaf alive but empty rather
+            // than letting `close_buffer`'s fallback adopt a dock terminal
+            // buffer into it (which would re-introduce the eject during
+            // Close All / Close Others).
+            let (has_other_editor_splits, dock_present, this_is_dock) = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.splits())
+                .map(|(mgr, _)| {
+                    use crate::view::split::SplitRole;
+                    let has_other_editor_splits = mgr.root().leaf_split_ids().iter().any(|&lid| {
+                        lid != split_id && mgr.leaf_role(lid) != Some(SplitRole::UtilityDock)
+                    });
+                    let dock_present =
+                        mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
+                    let this_is_dock =
+                        mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
+                    (has_other_editor_splits, dock_present, this_is_dock)
+                })
+                .expect("active window must have a populated split layout");
+            if split_tabs.len() <= 1 && !has_other_editor_splits && dock_present && !this_is_dock {
+                if let Err(e) = self.close_tab_keeping_editor_leaf_empty(buffer_id, split_id) {
+                    tracing::warn!("Failed to close buffer: {}", e);
+                    return false;
+                }
+                return true;
             }
             if let Err(e) = self.close_buffer(buffer_id) {
                 tracing::warn!("Failed to close buffer: {}", e);

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -648,10 +648,8 @@ impl Editor {
                     let has_other_editor_splits = mgr.root().leaf_split_ids().iter().any(|&lid| {
                         lid != split_id && mgr.leaf_role(lid) != Some(SplitRole::UtilityDock)
                     });
-                    let dock_present =
-                        mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
-                    let this_is_dock =
-                        mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
+                    let dock_present = mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
+                    let this_is_dock = mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
                     (has_other_editor_splits, dock_present, this_is_dock)
                 })
                 .expect("active window must have a populated split layout");
@@ -1030,10 +1028,8 @@ impl Editor {
                     let has_other_editor_splits = mgr.root().leaf_split_ids().iter().any(|&lid| {
                         lid != split_id && mgr.leaf_role(lid) != Some(SplitRole::UtilityDock)
                     });
-                    let dock_present =
-                        mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
-                    let this_is_dock =
-                        mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
+                    let dock_present = mgr.find_leaf_by_role(SplitRole::UtilityDock).is_some();
+                    let this_is_dock = mgr.leaf_role(split_id) == Some(SplitRole::UtilityDock);
                     (has_other_editor_splits, dock_present, this_is_dock)
                 })
                 .expect("active window must have a populated split layout");

--- a/crates/fresh-editor/tests/e2e/issue_2283_dock_last_tab_close.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2283_dock_last_tab_close.rs
@@ -1,0 +1,315 @@
+//! Regression coverage for issue #2283.
+//!
+//! Closing the last editor tab while a Utility Dock (holding terminals)
+//! is present used to collapse the editor leaf and promote the dock's
+//! terminals into the main tab bar — because the dock leaf was counted as
+//! a "peer split" in `close_tab_in_split`.
+//!
+//! Desired behaviour: keep the editor leaf alive but EMPTY (a hidden
+//! synthetic-placeholder buffer renders the centered empty-state), leave
+//! the dock and its terminals untouched, and route a subsequently-opened
+//! file back into the editor leaf (never the dock).
+//!
+//! These assert on the split-tree / view-state model directly (the same
+//! style as the dock tests in `live_grep.rs`), so they don't depend on
+//! terminal PTY rendering.
+
+use crate::common::harness::EditorTestHarness;
+use fresh::input::keybindings::Action;
+use fresh::model::event::LeafId;
+use fresh::view::split::SplitRole;
+use std::fs;
+
+/// Open a single file in the (sole) editor leaf, then open a terminal in a
+/// freshly-created Utility Dock. Returns the harness, the kept-alive temp
+/// dir, and the ids the tests assert against.
+struct DockFixture {
+    harness: EditorTestHarness,
+    _temp: tempfile::TempDir,
+    editor_leaf: LeafId,
+    dock_leaf: LeafId,
+    file_buffer: fresh::model::event::BufferId,
+    terminal_buffer: fresh::model::event::BufferId,
+}
+
+fn setup_editor_with_dock_terminal() -> DockFixture {
+    let temp = tempfile::TempDir::new().unwrap();
+    let file = temp.path().join("main.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+    harness.open_file(&file).unwrap();
+
+    let file_buffer = harness.editor().active_buffer();
+    let editor_leaf = harness.editor().split_manager_for_tests().active_split();
+
+    // Create the dock + terminal. `OpenTerminalInDock` splits at the root,
+    // tags the new leaf `UtilityDock`, and seeds it with a terminal buffer.
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::OpenTerminalInDock);
+
+    let (dock_leaf, terminal_buffer) = {
+        let sm = harness.editor().split_manager_for_tests();
+        let dock_leaf = sm
+            .find_leaf_by_role(SplitRole::UtilityDock)
+            .expect("OpenTerminalInDock must create a dock leaf");
+        let terminal_buffer = sm
+            .get_buffer_id(dock_leaf.into())
+            .expect("dock leaf must hold the terminal buffer");
+        (dock_leaf, terminal_buffer)
+    };
+
+    // Sanity: two distinct leaves; the terminal lives in the dock, and the
+    // editor leaf holds the file (not the terminal).
+    assert_ne!(editor_leaf, dock_leaf);
+    assert!(harness.editor().active_window().is_terminal_buffer(terminal_buffer));
+    assert!(
+        editor_leaf_tabs(&harness, editor_leaf).contains(&file_buffer),
+        "precondition: the editor leaf should hold the opened file"
+    );
+    assert!(
+        !editor_leaf_tabs(&harness, editor_leaf).contains(&terminal_buffer),
+        "precondition: the terminal must NOT be in the editor leaf"
+    );
+
+    DockFixture {
+        harness,
+        _temp: temp,
+        editor_leaf,
+        dock_leaf,
+        file_buffer,
+        terminal_buffer,
+    }
+}
+
+/// Buffer-tab ids currently open in a leaf.
+fn editor_leaf_tabs(
+    harness: &EditorTestHarness,
+    leaf: LeafId,
+) -> Vec<fresh::model::event::BufferId> {
+    harness
+        .editor()
+        .split_view_state_for_tests(leaf)
+        .map(|vs| vs.buffer_tab_ids_vec())
+        .unwrap_or_default()
+}
+
+fn leaf_exists(harness: &EditorTestHarness, leaf: LeafId) -> bool {
+    harness
+        .editor()
+        .split_manager_for_tests()
+        .root()
+        .leaf_split_ids()
+        .contains(&leaf)
+}
+
+/// Is `leaf`'s active buffer the hidden synthetic-placeholder that renders
+/// the empty editor state?
+fn leaf_shows_empty_placeholder(harness: &EditorTestHarness, leaf: LeafId) -> bool {
+    let Some(buf) = harness
+        .editor()
+        .split_manager_for_tests()
+        .get_buffer_id(leaf.into())
+    else {
+        return false;
+    };
+    harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .get(&buf)
+        .is_some_and(|m| m.synthetic_placeholder && m.hidden_from_tabs)
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: last editor tab close keeps an empty editor leaf; dock survives.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_closing_last_editor_tab_with_dock_keeps_empty_editor_leaf() {
+    let mut fx = setup_editor_with_dock_terminal();
+
+    // Close the sole editor tab (the file).
+    let closed = fx
+        .harness
+        .editor_mut()
+        .close_tab_in_split(fx.file_buffer, fx.editor_leaf);
+    assert!(closed, "closing the file tab should succeed");
+
+    // The editor leaf survives...
+    assert!(
+        leaf_exists(&fx.harness, fx.editor_leaf),
+        "editor leaf must NOT collapse when a dock is present"
+    );
+    // ...but empty: only the hidden placeholder, no file/terminal tab.
+    let tabs = editor_leaf_tabs(&fx.harness, fx.editor_leaf);
+    assert!(
+        !tabs.contains(&fx.file_buffer),
+        "the closed file must be gone from the editor leaf, got {tabs:?}"
+    );
+    assert!(
+        !tabs.contains(&fx.terminal_buffer),
+        "a dock terminal must NOT be adopted into the empty editor leaf, got {tabs:?}"
+    );
+    assert!(
+        leaf_shows_empty_placeholder(&fx.harness, fx.editor_leaf),
+        "the editor leaf should render the synthetic empty-state placeholder"
+    );
+
+    // The dock and its terminal are untouched.
+    assert!(
+        leaf_exists(&fx.harness, fx.dock_leaf),
+        "the dock leaf must survive"
+    );
+    assert_eq!(
+        fx.harness
+            .editor()
+            .split_manager_for_tests()
+            .find_leaf_by_role(SplitRole::UtilityDock),
+        Some(fx.dock_leaf),
+        "the dock role must still be carried by the same leaf"
+    );
+    assert!(
+        editor_leaf_tabs(&fx.harness, fx.dock_leaf).contains(&fx.terminal_buffer),
+        "the terminal must still live in the dock"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: reopening a file after the empty state lands in the editor leaf.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_reopen_file_after_empty_state_lands_in_editor_not_dock() {
+    let mut fx = setup_editor_with_dock_terminal();
+
+    fx.harness
+        .editor_mut()
+        .close_tab_in_split(fx.file_buffer, fx.editor_leaf);
+    assert!(leaf_shows_empty_placeholder(&fx.harness, fx.editor_leaf));
+
+    // Snapshot the dock tab list before reopening.
+    let dock_tabs_before = editor_leaf_tabs(&fx.harness, fx.dock_leaf);
+
+    // Reopen a (different) file.
+    let file2 = fx._temp.path().join("second.txt");
+    fs::write(&file2, "second file\n").unwrap();
+    fx.harness.open_file(&file2).unwrap();
+    let reopened = fx.harness.editor().active_buffer();
+
+    // It must land in the editor leaf, never the dock.
+    assert!(
+        editor_leaf_tabs(&fx.harness, fx.editor_leaf).contains(&reopened),
+        "the reopened file must land in the editor leaf"
+    );
+    assert!(
+        !editor_leaf_tabs(&fx.harness, fx.dock_leaf).contains(&reopened),
+        "the reopened file must NOT be mixed into the dock's tabs"
+    );
+    // The dock tab list is unchanged (no editor/terminal mixing).
+    assert_eq!(
+        editor_leaf_tabs(&fx.harness, fx.dock_leaf),
+        dock_tabs_before,
+        "the dock tab list must be unchanged after reopening a file"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: batch Close-All in the editor split with a dock present behaves the
+// same — empty editor leaf, dock survives.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_close_all_editor_tabs_with_dock_keeps_empty_editor_leaf() {
+    let mut fx = setup_editor_with_dock_terminal();
+
+    // Add a second file so the editor split has multiple tabs to batch-close.
+    // Opening a file while the dock is focused routes it to the editor leaf
+    // (the dock-redirect), so no manual focus is needed.
+    let file2 = fx._temp.path().join("extra.txt");
+    fs::write(&file2, "extra file\n").unwrap();
+    fx.harness.open_file(&file2).unwrap();
+    assert!(editor_leaf_tabs(&fx.harness, fx.editor_leaf).len() >= 2);
+
+    // Close every tab in the editor leaf at once.
+    fx.harness
+        .editor_mut()
+        .close_all_tabs_in_split(fx.editor_leaf);
+
+    // Same outcome as the interactive close: empty editor leaf, dock alive.
+    assert!(leaf_exists(&fx.harness, fx.editor_leaf));
+    assert!(
+        leaf_shows_empty_placeholder(&fx.harness, fx.editor_leaf),
+        "batch close must leave the editor leaf in the empty placeholder state"
+    );
+    let tabs = editor_leaf_tabs(&fx.harness, fx.editor_leaf);
+    assert!(
+        !tabs.contains(&fx.terminal_buffer),
+        "batch close must not adopt a dock terminal into the editor leaf, got {tabs:?}"
+    );
+    assert!(leaf_exists(&fx.harness, fx.dock_leaf));
+    assert!(editor_leaf_tabs(&fx.harness, fx.dock_leaf).contains(&fx.terminal_buffer));
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: regression — a dock must not make an editor split immortal. With
+// two editor leaves, closing the last tab of ONE still collapses it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_two_editor_leaves_with_dock_last_tab_still_collapses() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let file1 = temp.path().join("a.txt");
+    let file2 = temp.path().join("b.txt");
+    fs::write(&file1, "aaa\n").unwrap();
+    fs::write(&file2, "bbb\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+    harness.open_file(&file1).unwrap();
+    let leaf_a = harness.editor().split_manager_for_tests().active_split();
+    let file1_buffer = harness.editor().active_buffer();
+
+    // Second editor leaf (side-by-side), then give it its own distinct file.
+    harness.editor_mut().split_pane_vertical();
+    let leaf_b = harness.editor().split_manager_for_tests().active_split();
+    assert_ne!(leaf_a, leaf_b);
+    harness.open_file(&file2).unwrap();
+    let file2_buffer = harness.editor().active_buffer();
+    // Drop the duplicated file1 tab from leaf B so file2 is its only tab and
+    // is the *last viewport* of that buffer.
+    harness
+        .editor_mut()
+        .close_tab_in_split(file1_buffer, leaf_b);
+    assert_eq!(editor_leaf_tabs(&harness, leaf_b), vec![file2_buffer]);
+
+    // Add the dock.
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::OpenTerminalInDock);
+    let dock_leaf = harness
+        .editor()
+        .split_manager_for_tests()
+        .find_leaf_by_role(SplitRole::UtilityDock)
+        .expect("dock leaf must exist");
+
+    // Close leaf B's last tab. Because another EDITOR leaf (A) exists, the
+    // leaf must collapse — the dock does not keep it alive.
+    harness
+        .editor_mut()
+        .close_tab_in_split(file2_buffer, leaf_b);
+
+    assert!(
+        !leaf_exists(&harness, leaf_b),
+        "leaf B must collapse when another editor leaf exists"
+    );
+    assert!(leaf_exists(&harness, leaf_a), "leaf A must survive");
+    assert!(leaf_exists(&harness, dock_leaf), "the dock must survive");
+    assert_eq!(
+        harness
+            .editor()
+            .split_manager_for_tests()
+            .find_leaf_by_role(SplitRole::UtilityDock),
+        Some(dock_leaf)
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_2283_dock_last_tab_close.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2283_dock_last_tab_close.rs
@@ -63,7 +63,10 @@ fn setup_editor_with_dock_terminal() -> DockFixture {
     // Sanity: two distinct leaves; the terminal lives in the dock, and the
     // editor leaf holds the file (not the terminal).
     assert_ne!(editor_leaf, dock_leaf);
-    assert!(harness.editor().active_window().is_terminal_buffer(terminal_buffer));
+    assert!(harness
+        .editor()
+        .active_window()
+        .is_terminal_buffer(terminal_buffer));
     assert!(
         editor_leaf_tabs(&harness, editor_leaf).contains(&file_buffer),
         "precondition: the editor leaf should hold the opened file"

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -78,6 +78,7 @@ pub mod issue_2031_next_prev_window;
 pub mod issue_2035_preview_renders_buffer_groups;
 pub mod issue_2119_wheel_scroll;
 pub mod issue_2124_quickfix_enter;
+pub mod issue_2283_dock_last_tab_close;
 pub mod issue_2345_language_settings;
 pub mod issue_2357_shebang_interpreter;
 pub mod issue_2362_replace_toolbar_theme;


### PR DESCRIPTION
## Root cause

The Utility Dock is a normal leaf tagged `SplitRole::UtilityDock`. In `close_tab_in_split` (`crates/fresh-editor/src/app/buffer_close.rs`), `has_other_splits` was computed as `root().count_leaves() > 1` — which **counts the dock leaf**. So closing the *sole* editor tab while a dock existed took the "close the whole split" path (`handle_close_split`), collapsing the editor leaf and leaving the dock leaf as root. The dock's terminals were then promoted into the main editor tab bar. On reopen, `redirect_active_split_away_from_dock_if_needed` bailed (no editor leaf existed), so the file opened *into* the dock, mixing editor and terminal tabs.

## Chosen behavior (product decision)

When the last editor tab in an editor split is closed **while a Utility Dock exists**: keep the editor split open but **empty** — no tabs, just the `+` button and the centered floating empty-state message. The dock and its terminals stay untouched, and reopening a file lands back in the editor split, never the dock.

## Fix

- `close_tab_in_split` now counts only **non-dock (editor) peers** (`has_other_editor_splits`) when deciding whether to collapse. It only takes the `handle_close_split` path when another *editor* split exists.
- When the sole editor tab is closed and a dock is the only other leaf, a dedicated path (`close_tab_keeping_editor_leaf_empty`) keeps the editor leaf alive but empty. It forces `resolve_close_replacement` down a `force_empty_placeholder` branch that synthesizes a hidden `synthetic_placeholder` buffer — reusing Fresh's existing empty-editor render path — instead of adopting an arbitrary remaining buffer. This is critical because dock **terminal** buffers are *not* `hidden_from_tabs`, so the normal fallback would otherwise eject a terminal into the empty editor leaf.
- The same guard is mirrored in the silent batch-close path (`close_tab_in_split_silent`) so **Close All / Close Others** don't reintroduce the eject.
- `close_active_split` (the explicit "close split" command) is unchanged and still collapses.
- Terminal-mode / key-context sync is a no-op on the non-terminal placeholder, so the empty state behaves correctly.

### Empty state rendering
No new rendering code: the fix routes into the pre-existing `synthetic_placeholder` empty-editor path (`orchestration/mod.rs` → `render_placeholder_hint`, `render.rs`), the same one Fresh already uses when the last buffer overall is closed. The editor leaf's active buffer becomes a hidden placeholder, so the tab bar shows only the `+` button and the centered empty-state message renders in the middle.

## Tests

New e2e suite `issue_2283_dock_last_tab_close.rs`:
1. Closing the sole editor tab with a dock present → editor leaf survives empty (placeholder), dock leaf + terminal untouched, terminal **not** adopted into the editor leaf.
2. Reopening a file → lands in the editor leaf; dock tab list unchanged (no mixing).
3. Batch Close All in the editor split with a dock present → same empty-editor + dock-survives outcome.
4. Regression: two editor leaves + a dock → closing the last tab of one editor leaf still collapses that leaf (a dock must not make an editor split immortal).

All 4 pass; neighbouring dock/terminal/split/buffer-lifecycle/search-replace suites remain green.

Closes #2283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_