### PR TITLE
fix(lsp): merge hover across all capable servers (#2635)

### DIFF
--- a/crates/fresh-editor/src/app/hover.rs
+++ b/crates/fresh-editor/src/app/hover.rs
@@ -17,16 +17,40 @@
 //! is pure data with no `Editor` or I/O access.
 
 use crate::view::overlay::OverlayHandle;
+use std::collections::HashSet;
 
-/// Owner of in-flight hover request and highlighted-symbol tracking.
+/// One server's contribution to a hover card. Several servers may answer a
+/// single hover request; their non-null payloads are accumulated and merged
+/// into one popup.
+#[derive(Debug, Clone)]
+pub(crate) struct HoverPayload {
+    /// Raw hover body text (markdown or plain), already normalized so that
+    /// null / empty LSP hovers never reach here.
+    pub(crate) contents: String,
+    /// Whether `contents` should be rendered as markdown.
+    pub(crate) is_markdown: bool,
+    /// LSP range of the hovered symbol, if the server provided one.
+    pub(crate) range: Option<((u32, u32), (u32, u32))>,
+    /// Originating server name. Carried so per-server labels can be added
+    /// later; unused for rendering today.
+    #[allow(dead_code)]
+    pub(crate) server_name: Option<String>,
+}
+
+/// Owner of in-flight hover request(s) and highlighted-symbol tracking.
 #[derive(Debug, Default)]
 pub(crate) struct HoverState {
-    /// LSP request id of the in-flight hover request, if any.
-    pending_request: Option<u64>,
-    /// LSP position `(line, character)` of the in-flight request. Retained
+    /// LSP request ids of the in-flight hover requests. Hover fans out to
+    /// every capable server, so multiple ids may be outstanding at once.
+    /// Used to ignore stale responses from earlier mouse moves.
+    pending_requests: HashSet<u64>,
+    /// LSP position `(line, character)` of the in-flight batch. Retained
     /// so the response handler can correlate diagnostics with the hover
     /// point and fuse them into the hover card.
     pending_position: Option<(u32, u32)>,
+    /// Non-null hover payloads collected so far for the current batch, in
+    /// arrival order. Merged into a single popup once responses are in.
+    accumulated: Vec<HoverPayload>,
     /// Byte range `(start, end)` of the currently-highlighted symbol.
     /// Used by mouse-move handlers to detect "still on same symbol" and
     /// skip re-querying.
@@ -43,31 +67,54 @@ pub(crate) struct HoverState {
 impl HoverState {
     // ---- Pending-request correlation --------------------------------------
 
-    /// Record that a hover request with `request_id` was sent at LSP
-    /// position `(line, character)`.
-    pub(crate) fn record_request(&mut self, request_id: u64, line: u32, character: u32) {
-        self.pending_request = Some(request_id);
+    /// Record that a batch of hover requests (`ids`) was sent at LSP
+    /// position `(line, character)`. Replaces any previous batch and clears
+    /// the accumulator so responses from the prior batch are ignored.
+    pub(crate) fn record_requests(&mut self, ids: &[u64], line: u32, character: u32) {
+        self.pending_requests = ids.iter().copied().collect();
         self.pending_position = Some((line, character));
+        self.accumulated.clear();
     }
 
-    /// Claim a response as matching the in-flight request. If it matches,
-    /// both `pending_request` and `pending_position` are cleared, and the
-    /// position is returned for the caller's use (diagnostic correlation).
+    /// Claim a response as belonging to the in-flight batch. If `request_id`
+    /// is one of the outstanding ids it is removed and the batch position is
+    /// returned for diagnostic correlation. The position is only drained once
+    /// the last outstanding id is claimed, so every response in the batch can
+    /// still correlate diagnostics.
     ///
     /// Returns `None` if the response is stale — the caller should drop it.
     pub(crate) fn claim_pending(&mut self, request_id: u64) -> Option<(u32, u32)> {
-        if self.pending_request != Some(request_id) {
+        if !self.pending_requests.remove(&request_id) {
             return None;
         }
-        self.pending_request = None;
-        self.pending_position.take()
+        if self.pending_requests.is_empty() {
+            self.pending_position.take()
+        } else {
+            self.pending_position
+        }
     }
 
-    /// Clear any in-flight request without consuming a position — used
+    /// Whether every outstanding request in the batch has been claimed.
+    pub(crate) fn pending_is_empty(&self) -> bool {
+        self.pending_requests.is_empty()
+    }
+
+    /// Append a non-null hover payload to the current batch's accumulator.
+    pub(crate) fn push_payload(&mut self, payload: HoverPayload) {
+        self.accumulated.push(payload);
+    }
+
+    /// Payloads accumulated for the current batch, in arrival order.
+    pub(crate) fn accumulated(&self) -> &[HoverPayload] {
+        &self.accumulated
+    }
+
+    /// Clear any in-flight batch without consuming a position — used
     /// when focus is lost or the user cancels hover.
     pub(crate) fn clear_pending(&mut self) {
-        self.pending_request = None;
+        self.pending_requests.clear();
         self.pending_position = None;
+        self.accumulated.clear();
     }
 
     // ---- Symbol range -----------------------------------------------------
@@ -117,16 +164,31 @@ mod tests {
     #[test]
     fn claim_pending_returns_position_and_clears_state() {
         let mut h = HoverState::default();
-        h.record_request(7, 10, 20);
+        h.record_requests(&[7], 10, 20);
+        assert!(!h.pending_is_empty());
         assert_eq!(h.claim_pending(7), Some((10, 20)));
-        // Subsequent claim for the same id returns None — position drained.
+        // Batch now empty.
+        assert!(h.pending_is_empty());
+        // Subsequent claim for the same id returns None — id removed.
         assert_eq!(h.claim_pending(7), None);
+    }
+
+    #[test]
+    fn claim_pending_across_multi_server_batch_keeps_position_until_last() {
+        let mut h = HoverState::default();
+        h.record_requests(&[1, 2], 3, 4);
+        // First response: position returned, batch not yet empty.
+        assert_eq!(h.claim_pending(1), Some((3, 4)));
+        assert!(!h.pending_is_empty());
+        // Second (last) response: position still returned, batch now empty.
+        assert_eq!(h.claim_pending(2), Some((3, 4)));
+        assert!(h.pending_is_empty());
     }
 
     #[test]
     fn claim_pending_rejects_stale_response() {
         let mut h = HoverState::default();
-        h.record_request(7, 10, 20);
+        h.record_requests(&[7], 10, 20);
         // Older response arrives after a newer request went out.
         assert_eq!(h.claim_pending(3), None);
         // Correct one still works.
@@ -134,19 +196,58 @@ mod tests {
     }
 
     #[test]
-    fn record_request_overwrites_previous_pending() {
+    fn record_requests_overwrites_previous_batch() {
         let mut h = HoverState::default();
-        h.record_request(1, 0, 0);
-        h.record_request(2, 5, 5);
+        h.record_requests(&[1], 0, 0);
+        h.record_requests(&[2], 5, 5);
         assert_eq!(h.claim_pending(1), None);
         assert_eq!(h.claim_pending(2), Some((5, 5)));
     }
 
     #[test]
+    fn record_requests_clears_accumulator() {
+        let mut h = HoverState::default();
+        h.record_requests(&[1], 0, 0);
+        h.push_payload(HoverPayload {
+            contents: "a".to_string(),
+            is_markdown: false,
+            range: None,
+            server_name: None,
+        });
+        assert_eq!(h.accumulated().len(), 1);
+        h.record_requests(&[2], 0, 0);
+        assert!(h.accumulated().is_empty());
+    }
+
+    #[test]
+    fn push_payload_accumulates_in_order() {
+        let mut h = HoverState::default();
+        h.record_requests(&[1, 2], 0, 0);
+        h.push_payload(HoverPayload {
+            contents: "first".to_string(),
+            is_markdown: false,
+            range: None,
+            server_name: Some("A".to_string()),
+        });
+        h.push_payload(HoverPayload {
+            contents: "second".to_string(),
+            is_markdown: true,
+            range: Some(((1, 2), (3, 4))),
+            server_name: Some("B".to_string()),
+        });
+        let acc = h.accumulated();
+        assert_eq!(acc.len(), 2);
+        assert_eq!(acc[0].contents, "first");
+        assert_eq!(acc[1].contents, "second");
+        assert_eq!(acc[1].range, Some(((1, 2), (3, 4))));
+    }
+
+    #[test]
     fn clear_pending_drops_without_returning_position() {
         let mut h = HoverState::default();
-        h.record_request(7, 10, 20);
+        h.record_requests(&[7], 10, 20);
         h.clear_pending();
+        assert!(h.pending_is_empty());
         assert_eq!(h.claim_pending(7), None);
     }
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -979,9 +979,11 @@ impl Editor {
             );
         }
 
-        let buffer_id = self.active_buffer();
-
-        // Fan out to every capable server (see `request_hover`).
+        // Fan out to every capable server (see `request_hover`). Query the
+        // buffer the pointer is over (the `buffer_id` argument), not the active
+        // buffer, so the hover card never leaks in from another buffer (#2572).
+        // (Reassigning `buffer_id` to `self.active_buffer()` here was the source
+        // of that leak.)
         let base_request_id = self.active_window_mut().next_lsp_request_id;
         let counter = std::sync::atomic::AtomicU64::new(0);
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -938,9 +938,11 @@ impl Editor {
         self.active_window_mut().next_lsp_request_id = base_request_id + results.len() as u64;
 
         if !sent_ids.is_empty() {
-            self.active_window_mut()
-                .hover
-                .record_requests(&sent_ids, line as u32, character as u32);
+            self.active_window_mut().hover.record_requests(
+                &sent_ids,
+                line as u32,
+                character as u32,
+            );
         }
 
         Ok(())
@@ -1020,9 +1022,11 @@ impl Editor {
         self.active_window_mut().next_lsp_request_id = base_request_id + results.len() as u64;
 
         if !sent_ids.is_empty() {
-            self.active_window_mut()
-                .hover
-                .record_requests(&sent_ids, line as u32, character as u32);
+            self.active_window_mut().hover.record_requests(
+                &sent_ids,
+                line as u32,
+                character as u32,
+            );
         }
 
         Ok(!sent_ids.is_empty())

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -897,11 +897,20 @@ impl Editor {
         }
 
         let buffer_id = self.active_buffer();
-        let request_id = self.active_window_mut().next_lsp_request_id;
 
-        // Use helper to ensure didOpen is sent before the request
-        let sent = self
-            .with_lsp_for_buffer(buffer_id, LspFeature::Hover, |handle, uri, _language| {
+        // Fan out to every capable server so non-null hovers can be merged
+        // (a first server returning null must not hide a second server's
+        // hover — sinelaw/fresh#2635). Pre-allocate ids and advance the
+        // counter past all of them.
+        let base_request_id = self.active_window_mut().next_lsp_request_id;
+        let counter = std::sync::atomic::AtomicU64::new(0);
+
+        let results = self.with_all_lsp_for_buffer_feature(
+            buffer_id,
+            LspFeature::Hover,
+            |handle, uri, _language| {
+                let idx = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let request_id = base_request_id + idx;
                 let result = handle.hover(
                     request_id,
                     uri.as_uri().clone(),
@@ -910,24 +919,28 @@ impl Editor {
                 );
                 if result.is_ok() {
                     tracing::info!(
-                        "Requested hover at {}:{}:{} (byte_pos={})",
+                        "Requested hover at {}:{}:{} (request_id={}, byte_pos={})",
                         uri.as_str(),
                         line,
                         character,
+                        request_id,
                         cursor_pos
                     );
                 }
-                result.is_ok()
-            })
-            .unwrap_or(false);
+                (request_id, result.is_ok())
+            },
+        );
 
-        if sent {
-            self.active_window_mut().next_lsp_request_id += 1;
-            self.active_window_mut().hover.record_request(
-                request_id,
-                line as u32,
-                character as u32,
-            );
+        let sent_ids: Vec<u64> = results
+            .iter()
+            .filter_map(|(id, ok)| ok.then_some(*id))
+            .collect();
+        self.active_window_mut().next_lsp_request_id = base_request_id + results.len() as u64;
+
+        if !sent_ids.is_empty() {
+            self.active_window_mut()
+                .hover
+                .record_requests(&sent_ids, line as u32, character as u32);
         }
 
         Ok(())
@@ -966,11 +979,18 @@ impl Editor {
             );
         }
 
-        let request_id = self.active_window_mut().next_lsp_request_id;
+        let buffer_id = self.active_buffer();
 
-        // Use helper to ensure didOpen is sent before the request
-        let sent = self
-            .with_lsp_for_buffer(buffer_id, LspFeature::Hover, |handle, uri, _language| {
+        // Fan out to every capable server (see `request_hover`).
+        let base_request_id = self.active_window_mut().next_lsp_request_id;
+        let counter = std::sync::atomic::AtomicU64::new(0);
+
+        let results = self.with_all_lsp_for_buffer_feature(
+            buffer_id,
+            LspFeature::Hover,
+            |handle, uri, _language| {
+                let idx = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let request_id = base_request_id + idx;
                 let result = handle.hover(
                     request_id,
                     uri.as_uri().clone(),
@@ -979,27 +999,31 @@ impl Editor {
                 );
                 if result.is_ok() {
                     tracing::trace!(
-                        "Mouse hover requested at {}:{}:{} (byte_pos={})",
+                        "Mouse hover requested at {}:{}:{} (request_id={}, byte_pos={})",
                         uri.as_str(),
                         line,
                         character,
+                        request_id,
                         byte_pos
                     );
                 }
-                result.is_ok()
-            })
-            .unwrap_or(false);
+                (request_id, result.is_ok())
+            },
+        );
 
-        if sent {
-            self.active_window_mut().next_lsp_request_id += 1;
-            self.active_window_mut().hover.record_request(
-                request_id,
-                line as u32,
-                character as u32,
-            );
+        let sent_ids: Vec<u64> = results
+            .iter()
+            .filter_map(|(id, ok)| ok.then_some(*id))
+            .collect();
+        self.active_window_mut().next_lsp_request_id = base_request_id + results.len() as u64;
+
+        if !sent_ids.is_empty() {
+            self.active_window_mut()
+                .hover
+                .record_requests(&sent_ids, line as u32, character as u32);
         }
 
-        Ok(sent)
+        Ok(!sent_ids.is_empty())
     }
 
     /// Handle hover response from LSP
@@ -1010,9 +1034,11 @@ impl Editor {
         is_markdown: bool,
         range: Option<((u32, u32), (u32, u32))>,
     ) {
-        // Check if this response is for the current pending request.
-        // `claim_pending` also drains the stored LSP position, which we keep
-        // around for diagnostic correlation below.
+        // Check if this response belongs to the current in-flight batch.
+        // Hover fans out to every capable server, so several responses may
+        // arrive for one batch; `claim_pending` returns the batch position
+        // (kept until the last response is claimed) for diagnostic
+        // correlation, and `None` for stale responses.
         let Some(position) = self.active_window_mut().hover.claim_pending(request_id) else {
             tracing::debug!("Ignoring stale hover response: {}", request_id);
             return;
@@ -1025,31 +1051,65 @@ impl Editor {
             self.active_window_mut().hover.set_symbol_range(None);
             return;
         }
-        let hover_lsp_position = Some(position);
+
+        // Accumulate this server's non-null contribution. Null / empty hovers
+        // (already normalized in `parse_hover_response`) are dropped here so a
+        // server that returns null cannot suppress another server's hover
+        // (sinelaw/fresh#2635).
+        if !contents.is_empty() {
+            tracing::debug!(
+                "LSP hover content (markdown={}, request_id={}):\n{}",
+                is_markdown,
+                request_id,
+                contents
+            );
+            self.active_window_mut()
+                .hover
+                .push_payload(crate::app::hover::HoverPayload {
+                    contents,
+                    is_markdown,
+                    range,
+                    server_name: None,
+                });
+        }
+
+        let all_in = self.active_window().hover.pending_is_empty();
+        let accumulated_empty = self.active_window().hover.accumulated().is_empty();
 
         // Gather any diagnostics whose range overlaps the hover position so
         // they can be fused into the top of the hover card. Without this the
         // user has to leave hover and go chase the error elsewhere in the UI
         // even though the cursor is already on the offending symbol.
-        let diagnostic_lines = hover_lsp_position
-            .map(|pos| self.compose_hover_diagnostic_lines(pos))
-            .unwrap_or_default();
+        let diagnostic_lines = self.compose_hover_diagnostic_lines(position);
 
-        if contents.is_empty() && diagnostic_lines.is_empty() {
+        if all_in && accumulated_empty && diagnostic_lines.is_empty() {
+            // Every capable server answered and none returned a hover, and
+            // there are no overlapping diagnostics — report "no hover" exactly
+            // once (only fires on the final response of the batch).
             self.set_status_message(t!("lsp.no_hover").to_string());
             self.active_window_mut().hover.set_symbol_range(None);
             return;
         }
 
-        // Debug: log raw hover content to diagnose formatting issues
-        tracing::debug!(
-            "LSP hover content (markdown={}):\n{}",
-            is_markdown,
-            contents
-        );
+        if accumulated_empty && !all_in {
+            // No hover content yet and more servers are still outstanding —
+            // wait for them rather than flashing a diagnostics-only or empty
+            // popup that a later non-null hover would immediately replace.
+            return;
+        }
 
-        // Convert LSP range to byte offsets for highlighting
-        if let Some(((start_line, start_char), (end_line, end_char))) = range {
+        // Rebuild the popup from ALL accumulated payloads. This runs on every
+        // response that has (or follows) content, so the card grows as
+        // additional servers answer.
+        let payloads: Vec<crate::app::hover::HoverPayload> =
+            self.active_window().hover.accumulated().to_vec();
+
+        // Symbol range/overlay: use the FIRST payload that carries a range.
+        // Because we always scan the whole accumulator, a range set by an
+        // earlier server is never clobbered by a later rangeless server's
+        // word-boundary fallback.
+        let first_range = payloads.iter().find_map(|p| p.range);
+        if let Some(((start_line, start_char), (end_line, end_char))) = first_range {
             let state = self.active_state();
             let start_byte = state
                 .buffer
@@ -1125,7 +1185,7 @@ impl Editor {
                 .set_symbol_range(computed_range);
         }
 
-        // Create a popup with the hover contents.
+        // Create a popup with the merged hover contents.
         //
         // When a diagnostic overlaps the hover position, we pre-style its
         // lines (severity-colored header + plain message) and concatenate
@@ -1135,48 +1195,71 @@ impl Editor {
         // input — which rendered as uncolored bold text + a thick 40-cell
         // divider with blank-line padding, wasting vertical space and
         // losing the "this is an error" visual signal.
+        //
+        // Multiple servers' hover bodies are joined with the same one-row
+        // separator used between diagnostics and hover.
         use crate::view::markdown::{parse_markdown, StyledLine};
         use crate::view::popup::{Popup, PopupContent, PopupPosition};
         use ratatui::style::Style;
         use unicode_width::UnicodeWidthStr;
 
-        let hover_lines: Vec<StyledLine> = if contents.is_empty() {
-            Vec::new()
-        } else if is_markdown {
-            parse_markdown(
-                &contents,
-                &self.theme.read().unwrap(),
-                Some(&self.grammar_registry),
-            )
-        } else {
-            contents
-                .lines()
-                .map(|s| {
-                    let mut sl = StyledLine::new();
-                    sl.push(
-                        s.to_string(),
-                        Style::default().fg(self.theme.read().unwrap().popup_text_fg),
-                    );
-                    sl
-                })
-                .collect()
-        };
+        let is_markdown = payloads.iter().any(|p| p.is_markdown);
 
-        let has_diagnostic = !diagnostic_lines.is_empty();
-        let mut all_lines: Vec<StyledLine> = Vec::new();
-        all_lines.extend(diagnostic_lines);
-        if has_diagnostic && !hover_lines.is_empty() {
-            // Compact single-line separator — no blank padding, no 40-cell
-            // dash run. One row of dashes the width of the content, in the
-            // popup border color so it reads as "same card, new section."
+        // Build one styled block per non-empty payload.
+        let mut bodies: Vec<Vec<StyledLine>> = Vec::new();
+        for payload in &payloads {
+            if payload.contents.is_empty() {
+                continue;
+            }
+            let lines: Vec<StyledLine> = if payload.is_markdown {
+                parse_markdown(
+                    &payload.contents,
+                    &self.theme.read().unwrap(),
+                    Some(&self.grammar_registry),
+                )
+            } else {
+                payload
+                    .contents
+                    .lines()
+                    .map(|s| {
+                        let mut sl = StyledLine::new();
+                        sl.push(
+                            s.to_string(),
+                            Style::default().fg(self.theme.read().unwrap().popup_text_fg),
+                        );
+                        sl
+                    })
+                    .collect()
+            };
+            if !lines.is_empty() {
+                bodies.push(lines);
+            }
+        }
+
+        // One-row separator between sections (diagnostics ↔ hover, and hover ↔
+        // hover when more than one server answered). Compact — no blank
+        // padding, no 40-cell dash run; popup border color so it reads as
+        // "same card, new section."
+        let make_separator = || {
             let mut sep = StyledLine::new();
             sep.push(
                 "─".repeat(12),
                 Style::default().fg(self.theme.read().unwrap().popup_border_fg),
             );
-            all_lines.push(sep);
+            sep
+        };
+
+        let has_diagnostic = !diagnostic_lines.is_empty();
+        let mut all_lines: Vec<StyledLine> = Vec::new();
+        all_lines.extend(diagnostic_lines);
+        let mut need_separator = has_diagnostic;
+        for body in bodies {
+            if need_separator {
+                all_lines.push(make_separator());
+            }
+            all_lines.extend(body);
+            need_separator = true;
         }
-        all_lines.extend(hover_lines);
 
         // Drop trailing empty lines that some markdown payloads carry.
         while all_lines

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -2449,6 +2449,220 @@ done
         dir.join("fake_lsp_server_drops_semantic_tokens.sh")
     }
 
+    /// Spawn a fake LSP server that advertises `hoverProvider` but always
+    /// returns `result: null` for `textDocument/hover` — like vtsls returning
+    /// no hover for a Tailwind class. Used to regression-test sinelaw/fresh#2635,
+    /// where a null hover from the first server suppressed a second server's
+    /// hover.
+    pub fn spawn_hover_null(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then break; fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+case "$method" in
+    "initialize")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true}}}'
+        ;;
+    "textDocument/hover")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didClose"|"initialized")
+        ;;
+    "textDocument/diagnostic")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[],"resultId":null}}'
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    *)
+        if [ -n "$msg_id" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        fi
+        ;;
+esac
+done
+"#;
+
+        let script_path = Self::hover_null_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Get the path to the null-hover fake LSP server script.
+    pub fn hover_null_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_hover_null.sh")
+    }
+
+    /// Spawn a fake LSP server that returns a distinctive hover body
+    /// ("HoverAlpha content") WITH a range. Used together with
+    /// `spawn_hover_null` / `spawn_hover_beta` to test hover merging across
+    /// multiple servers.
+    pub fn spawn_hover_alpha(dir: &std::path::Path) -> anyhow::Result<Self> {
+        Self::spawn_hover_with_body(
+            dir,
+            &Self::hover_alpha_script_path(dir),
+            "HoverAlpha content",
+        )
+    }
+
+    /// Get the path to the "HoverAlpha" fake LSP server script.
+    pub fn hover_alpha_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_hover_alpha.sh")
+    }
+
+    /// Spawn a fake LSP server that returns a distinctive hover body
+    /// ("HoverBeta content") WITH a range.
+    pub fn spawn_hover_beta(dir: &std::path::Path) -> anyhow::Result<Self> {
+        Self::spawn_hover_with_body(
+            dir,
+            &Self::hover_beta_script_path(dir),
+            "HoverBeta content",
+        )
+    }
+
+    /// Get the path to the "HoverBeta" fake LSP server script.
+    pub fn hover_beta_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_hover_beta.sh")
+    }
+
+    /// Shared helper: write and spawn a fake LSP server whose
+    /// `textDocument/hover` returns `body` (markdown) with a range spanning
+    /// 10 characters from the requested position.
+    fn spawn_hover_with_body(
+        _dir: &std::path::Path,
+        script_path: &std::path::Path,
+        body: &str,
+    ) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        // `body` is embedded via a shell variable so we don't have to escape
+        // it into the JSON template; the template itself uses no `{}` so no
+        // format!-escaping is needed.
+        let script = format!(
+            r#"#!/bin/bash
+
+HOVER_BODY="{body}"
+
+read_message() {{
+    local content_length=0
+    while IFS= read -r line; do
+        line="${{line%$'\r'}}"
+        if [ -z "$line" ]; then break; fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${{line#Content-Length:}}"
+                content_length="${{content_length// /}}"
+                ;;
+        esac
+    done
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}}
+
+send_message() {{
+    local message="$1"
+    local length=${{#message}}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+case "$method" in
+    "initialize")
+        send_message '{{"jsonrpc":"2.0","id":'$msg_id',"result":{{"capabilities":{{"textDocumentSync":1,"hoverProvider":true}}}}}}'
+        ;;
+    "textDocument/hover")
+        line=$(echo "$msg" | grep -o '"line":[0-9]*' | head -1 | cut -d':' -f2)
+        char=$(echo "$msg" | grep -o '"character":[0-9]*' | head -1 | cut -d':' -f2)
+        end_char=$((char + 10))
+        send_message '{{"jsonrpc":"2.0","id":'$msg_id',"result":{{"contents":{{"kind":"markdown","value":"'"$HOVER_BODY"'"}},"range":{{"start":{{"line":'$line',"character":'$char'}},"end":{{"line":'$line',"character":'$end_char'}}}}}}}}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didClose"|"initialized")
+        ;;
+    "textDocument/diagnostic")
+        send_message '{{"jsonrpc":"2.0","id":'$msg_id',"result":{{"items":[],"resultId":null}}}}'
+        ;;
+    "shutdown")
+        send_message '{{"jsonrpc":"2.0","id":'$msg_id',"result":null}}'
+        break
+        ;;
+    *)
+        if [ -n "$msg_id" ]; then
+            send_message '{{"jsonrpc":"2.0","id":'$msg_id',"result":null}}'
+        fi
+        ;;
+esac
+done
+"#
+        );
+
+        std::fs::write(script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
     /// Stop the server
     pub fn stop(&mut self) {
         let _ = self.stop_tx.send(());

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -2557,11 +2557,7 @@ done
     /// Spawn a fake LSP server that returns a distinctive hover body
     /// ("HoverBeta content") WITH a range.
     pub fn spawn_hover_beta(dir: &std::path::Path) -> anyhow::Result<Self> {
-        Self::spawn_hover_with_body(
-            dir,
-            &Self::hover_beta_script_path(dir),
-            "HoverBeta content",
-        )
+        Self::spawn_hover_with_body(dir, &Self::hover_beta_script_path(dir), "HoverBeta content")
     }
 
     /// Get the path to the "HoverBeta" fake LSP server script.

--- a/crates/fresh-editor/tests/e2e/lsp_unified_hover.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_unified_hover.rs
@@ -1,0 +1,172 @@
+//! E2E tests for unified LSP hover across multiple servers.
+//!
+//! Hover fans out to every capable server and merges the non-null results
+//! into a single popup. Previously hover queried only the first capable
+//! server, so a server returning `null` (e.g. vtsls on a Tailwind class)
+//! suppressed a second server's hover entirely — sinelaw/fresh#2635.
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+
+/// Build an LSP server config pointing at `command` with an optional name.
+fn server_config(command: std::path::PathBuf, name: &str) -> fresh::services::lsp::LspServerConfig {
+    fresh::services::lsp::LspServerConfig {
+        command: command.to_string_lossy().to_string(),
+        args: Some(vec![]),
+        enabled: true,
+        auto_start: true,
+        process_limits: fresh::services::process_limits::ProcessLimits::default(),
+        initialization_options: None,
+        env: Default::default(),
+        language_id_overrides: Default::default(),
+        root_markers: Default::default(),
+        name: Some(name.to_string()),
+        only_features: None,
+        except_features: None,
+    }
+}
+
+/// Create a harness wired to two hover-capable fake servers for `rust`, open a
+/// test file, and wait until both servers have finished initialization.
+fn harness_with_two_servers(
+    temp_dir: &std::path::Path,
+    server_a: std::path::PathBuf,
+    server_b: std::path::PathBuf,
+) -> anyhow::Result<EditorTestHarness> {
+    let test_file = temp_dir.join("test.rs");
+    std::fs::write(&test_file, "fn example_function() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![
+            server_config(server_a, "server-a"),
+            server_config(server_b, "server-b"),
+        ]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        24,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Both servers must finish their handshake before we fire the hover; a
+    // request sent while a server is still `Initializing` is dropped, so with
+    // two servers we'd otherwise race and lose the merge.
+    harness.wait_until(|h| {
+        h.editor()
+            .active_window()
+            .initialized_lsp_server_count("rust")
+            >= 2
+    })?;
+
+    Ok(harness)
+}
+
+/// #2635 repro: the first server returns `null`, the second returns content.
+/// The hover popup must show the second server's content rather than being
+/// suppressed by the first server's null.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_hover_null_first_server_does_not_suppress_second() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _server_a = FakeLspServer::spawn_hover_null(temp_dir.path())?;
+    let _server_b = FakeLspServer::spawn_hover_alpha(temp_dir.path())?;
+
+    let mut harness = harness_with_two_servers(
+        temp_dir.path(),
+        FakeLspServer::hover_null_script_path(temp_dir.path()),
+        FakeLspServer::hover_alpha_script_path(temp_dir.path()),
+    )?;
+
+    harness.editor_mut().request_hover()?;
+
+    // The second server's hover content must appear even though the first
+    // server returned null.
+    harness.wait_for_screen_contains("HoverAlpha content")?;
+    assert!(
+        harness.editor().active_state().popups.is_visible(),
+        "hover popup should be visible with the second server's content"
+    );
+
+    Ok(())
+}
+
+/// Both servers return non-null hovers: the popup must contain BOTH bodies,
+/// merged into a single card.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_hover_merges_bodies_from_both_servers() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _server_a = FakeLspServer::spawn_hover_alpha(temp_dir.path())?;
+    let _server_b = FakeLspServer::spawn_hover_beta(temp_dir.path())?;
+
+    let mut harness = harness_with_two_servers(
+        temp_dir.path(),
+        FakeLspServer::hover_alpha_script_path(temp_dir.path()),
+        FakeLspServer::hover_beta_script_path(temp_dir.path()),
+    )?;
+
+    harness.editor_mut().request_hover()?;
+
+    // Wait for both bodies to be merged into the popup.
+    harness.wait_for_screen_contains("HoverAlpha content")?;
+    harness.wait_for_screen_contains("HoverBeta content")?;
+
+    assert!(
+        harness.editor().active_state().popups.is_visible(),
+        "hover popup should be visible"
+    );
+    harness.assert_screen_contains("HoverAlpha content");
+    harness.assert_screen_contains("HoverBeta content");
+
+    Ok(())
+}
+
+/// All servers return `null`: exactly one "no hover" status message, and no
+/// hover popup.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_hover_all_null_reports_no_hover_and_shows_no_popup() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    // Writing the null-hover script once is enough: both config entries point
+    // at it, so the editor launches two independent null-hover processes.
+    let _server = FakeLspServer::spawn_hover_null(temp_dir.path())?;
+    let null_script = FakeLspServer::hover_null_script_path(temp_dir.path());
+
+    let mut harness =
+        harness_with_two_servers(temp_dir.path(), null_script.clone(), null_script.clone())?;
+
+    harness.editor_mut().request_hover()?;
+
+    // The "no hover" status fires only once every server has answered.
+    let no_hover = "No hover information available";
+    harness.wait_until(|h| {
+        h.editor()
+            .get_status_message()
+            .map(|m| m.contains(no_hover))
+            .unwrap_or(false)
+    })?;
+
+    assert!(
+        !harness.editor().active_state().popups.is_visible(),
+        "no hover popup should be shown when all servers return null"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -143,6 +143,7 @@ pub mod lsp_server_lifecycle_cleanup;
 pub mod lsp_stop_stale_indicator;
 pub mod lsp_toggle_desync;
 pub mod lsp_unified_code_actions;
+pub mod lsp_unified_hover;
 pub mod lsp_unresponsive_capability_does_not_block;
 pub mod macros;
 pub mod mark_mode_actions;


### PR DESCRIPTION
## Root cause

Hover dispatched through `with_lsp_for_buffer`, which queries **only the first** server that advertises `hoverProvider`. When that server returns a null hover (e.g. vtsls on a Tailwind class), the request stops there and a second capable server's hover (e.g. Tailwind LSP) is never shown. Completion and code actions already fan out to every capable server and merge; hover did not.

## Fix

Port hover to the same fan-out-and-merge pattern:

- **State** (`app/hover.rs`): `HoverState` now tracks a `HashSet<u64>` of outstanding request ids plus an accumulator of non-null `HoverPayload`s (each carrying an optional `server_name` so per-server labels can be added later). `claim_pending` removes an id and returns the batch position — kept until the last id is claimed so every response can correlate diagnostics; `pending_is_empty` reports batch completion; `record_requests` replaces the batch and clears the accumulator.
- **Requests** (`app/lsp_requests.rs`): `request_hover` / `request_hover_at_position` fan out via `with_all_lsp_for_buffer_feature`, preallocating one id per server (mirroring `request_completion`) and advancing the id counter by the number of servers. `request_hover_at_position` keeps its `Ok(bool)` contract via `!sent_ids.is_empty()`.
- **Response** (`handle_hover_response`): accumulates each non-null contribution; reports "no hover" **exactly once** (only when all servers answered, nothing accumulated, and no diagnostic overlaps); otherwise rebuilds the popup from **all** accumulated payloads, joining multiple bodies with the existing one-row separator. The symbol range/overlay is taken from the **first** payload carrying a range, so a later rangeless server's word-boundary fallback cannot clobber it.

Decision: non-null hovers are **merged** (concatenated with the one-row separator), not sequential-fallback. Null/`{}` hovers were already normalized to empty contents in `parse_hover_response`, so no changes were needed to the async dispatch/handler layers.

## Tests

- `app/hover.rs` unit tests updated to the set-based API (multi-server batch position retention, accumulator clearing/ordering).
- New e2e suite `tests/e2e/lsp_unified_hover.rs` with three fake-server variants (`spawn_hover_null` returning `result: null`, `spawn_hover_alpha` / `spawn_hover_beta` returning distinct bodies):
  1. First server null, second server content → popup shows the second server's content (the #2635 repro).
  2. Both non-null → popup contains both bodies.
  3. All null → single "no hover" status, no popup.

Closes #2635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_