### PR TITLE
fix(plugin-api): openFileInSplit returns false for a dead split id (#2769)

### DIFF
--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1429,7 +1429,12 @@ impl Editor {
         line: Option<usize>,
         column: Option<usize>,
     ) -> AnyhowResult<()> {
-        // Switch to the target split
+        // Validate the target split BEFORE touching any buffer state so a
+        // dead/unknown split id cannot leave an orphan buffer loaded with
+        // nothing on screen. `set_active_split` returns false when the id
+        // doesn't resolve to a live leaf (the split was closed, or its last
+        // tab collapsed it away). Surface that as an error so the failure is
+        // reported instead of masquerading as success (#2769).
         let target_split_id = LeafId(SplitId(split_id));
         if !self
             .windows
@@ -1439,13 +1444,13 @@ impl Editor {
             .set_active_split(target_split_id)
         {
             tracing::error!("Failed to switch to split {}", split_id);
-            return Ok(());
+            anyhow::bail!("openFileInSplit: split {} does not exist", split_id);
         }
 
         // Open the file in the now-active split
         if let Err(e) = self.open_file(&path) {
             tracing::error!("Failed to open file from plugin: {}", e);
-            return Ok(());
+            return Err(e);
         }
 
         // Jump to the specified location (or default to start)

--- a/crates/fresh-editor/tests/e2e/plugins/buffer_info_splits.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/buffer_info_splits.rs
@@ -39,6 +39,36 @@ fn snapshot_active_split(harness: &EditorTestHarness) -> Option<usize> {
     Some(snapshot.active_split_id)
 }
 
+/// Number of buffers the plugin state snapshot knows about. Used to
+/// detect an orphan buffer leaked by a failed open.
+fn snapshot_buffer_count(harness: &EditorTestHarness) -> usize {
+    let snapshot_handle = harness
+        .editor()
+        .plugin_manager()
+        .state_snapshot_handle()
+        .expect("snapshot handle present");
+    let snapshot = snapshot_handle.read().expect("snapshot readable");
+    snapshot.buffers.len()
+}
+
+/// Whether any buffer in the snapshot corresponds to `path`. Matches on
+/// the file name to sidestep the symlink canonicalisation that the file
+/// open path applies (see the note on `snapshot_splits_for_buffer`).
+fn snapshot_has_buffer_for_path(harness: &EditorTestHarness, path: &std::path::Path) -> bool {
+    let want = path.file_name();
+    let snapshot_handle = harness
+        .editor()
+        .plugin_manager()
+        .state_snapshot_handle()
+        .expect("snapshot handle present");
+    let snapshot = snapshot_handle.read().expect("snapshot readable");
+    snapshot
+        .buffers
+        .values()
+        .filter_map(|b| b.path.as_ref())
+        .any(|p| p.file_name() == want)
+}
+
 /// A buffer open in a single split should report exactly that
 /// split id in `BufferInfo.splits`.
 #[test]
@@ -151,5 +181,87 @@ fn buffer_info_splits_drives_refocus_pattern() {
         active_after, hello_split,
         "focusSplit(hello_split) must make that split active. was {} now {}",
         active, active_after
+    );
+}
+
+/// Regression for #2769: `openFileInSplit` against a split id that no
+/// longer resolves to a live split must report failure (an `Err` from
+/// the command dispatcher) instead of masquerading as success — and it
+/// must NOT leak an invisible orphan buffer for the file it failed to
+/// place.
+#[test]
+fn open_file_in_split_fails_for_dead_split_id() {
+    use fresh::services::plugins::api::PluginCommand;
+    use fresh_core::SplitId;
+
+    let temp = tempfile::tempdir().unwrap();
+    let hello = temp.path().join("hello.txt");
+    let world = temp.path().join("world.txt");
+    fs::write(&hello, "hello\n").unwrap();
+    fs::write(&world, "world\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.editor_mut().open_file(&hello).unwrap();
+    harness.tick_and_render().unwrap();
+
+    // Split horizontally: the new (now-active) split is the one we will
+    // kill, so its id becomes a dangling reference.
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(fresh::input::keybindings::Action::SplitHorizontal);
+    harness.tick_and_render().unwrap();
+    let dead_split = snapshot_active_split(&harness).expect("active split id after split");
+
+    // Close that split — collapses the layout back to a single pane and
+    // leaves `dead_split` pointing at nothing.
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::CloseSplit {
+            split_id: SplitId(dead_split),
+        })
+        .unwrap();
+    harness.tick_and_render().unwrap();
+
+    let live_split = snapshot_active_split(&harness).expect("active split id after close");
+    assert_ne!(
+        live_split, dead_split,
+        "sanity: the surviving split must differ from the closed one"
+    );
+
+    // Baseline buffer count before the doomed open. world.txt has not
+    // been opened, so it must not appear.
+    let buffers_before = snapshot_buffer_count(&harness);
+
+    // The plugin targets the dead split. This must FAIL (Err), not
+    // silently return success.
+    let result = harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::OpenFileInSplit {
+            split_id: dead_split,
+            path: world.clone(),
+            line: Some(0),
+            column: Some(0),
+        });
+    assert!(
+        result.is_err(),
+        "openFileInSplit against a dead split id must report failure, got {:?}",
+        result
+    );
+    harness.tick_and_render().unwrap();
+
+    // No orphan buffer: the failed open must not have loaded world.txt
+    // into a hidden buffer that no split displays.
+    let buffers_after = snapshot_buffer_count(&harness);
+    assert_eq!(
+        buffers_after, buffers_before,
+        "failed openFileInSplit must not leak a buffer (before={buffers_before}, after={buffers_after})"
+    );
+
+    // And no split displays world.txt: every buffer known to the
+    // snapshot is displayed in at least the original pane, none of them
+    // is the file we tried (and failed) to place.
+    assert!(
+        !snapshot_has_buffer_for_path(&harness, &world),
+        "world.txt must not be present in any buffer after the failed open"
     );
 }


### PR DESCRIPTION
## Root cause

`editor.openFileInSplit(splitId, path, line, col)` reported success even when the target split no longer existed — closed by the user, or collapsed when its last tab went away — leaving the file displayed in no split.

The culprit is `handle_open_file_in_split` in `crates/fresh-editor/src/app/plugin_commands.rs`. When `set_active_split(target_split_id)` returned `false` (the id doesn't resolve to a live leaf), the handler only `tracing::error!`d and then `return Ok(())`. `Ok(())` is the dispatcher's non-failure result, so the failure was swallowed. The handler also fell through to `open_file(...)` and, on error, returned `Ok(())` again — a path that could load a buffer visible in no split.

## Fix

- When `set_active_split` fails, `anyhow::bail!` so `handle_plugin_command` returns `Err` (the failure signal) instead of masquerading as success.
- The split is validated **before** any buffer is opened, so no orphan buffer is created on the dead-split path.
- The `open_file` error branch now propagates its error (`return Err(e)`) instead of reporting success.

## Test

`open_file_in_split_fails_for_dead_split_id` (in `tests/e2e/plugins/buffer_info_splits.rs`) mirrors the report: open a buffer, split horizontally, close the new split to make its id dangle, then dispatch `OpenFileInSplit` against that dead id. It asserts the dispatch returns `Err`, that the snapshot buffer count is unchanged (no orphan buffer leaked), and that the target file appears in no buffer.

Verified: `cargo build`, the new regression test, `cargo fmt -- --check`, and `cargo clippy` are all clean. Also reproduced end-to-end in the running editor via an `init.ts` plugin (create split → close it → `openFileInSplit` on the dead id): the editor stays intact showing the surviving split, the target file never appears, and the log records `Failed to switch to split 3` from the new failure path.

Closes #2769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_