### PR TITLE
fix(terminal): capture full tall lines + grid-wrapped scroll-back with seamless live↔scrollback transition (#2649)

### DIFF
--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -651,6 +651,10 @@ impl crate::app::window::Window {
         let active_buffer = self.active_buffer();
         let state = self.buffers.get(&active_buffer)?;
         let vs = self.buffers.splits().map(|(_, vs)| vs)?.get(&split_id)?;
+        // Terminal-grid wrap (fresh#2649): rows are exactly the grid width.
+        if vs.viewport.grid_wrap {
+            return Some(vs.viewport.grid_cols());
+        }
         let gutter = vs.viewport.gutter_width(&state.buffer);
         let wrap = WrapConfig::new(
             vs.viewport.effective_width() as usize,

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -22,18 +22,35 @@ use super::Editor;
 impl crate::app::window::Window {
     /// Resolve the effective line_wrap setting for a buffer, considering language overrides.
     pub fn resolve_line_wrap_for_buffer(&self, buffer_id: BufferId) -> bool {
-        // Terminal buffers never wrap. Their content is column-formatted (ANSI,
-        // aligned output), so wrapping is wrong — and wrapping a large scrollback
-        // makes the scrollbar's visual-row index an O(all-lines) scan on every
-        // frame, freezing the UI (fresh#2608). Forced off here so no global
-        // toggle, language override, or per-buffer pin can turn it on.
+        // Terminal buffers always wrap — in *grid* mode (exact-column rows
+        // at the PTY width, `Viewport::grid_wrap`), so scroll-back lays out
+        // identically to the live grid and entering it never reflows
+        // (fresh#2649). Column alignment is preserved because rows break at
+        // exactly the grid width, and the fresh#2608/#2610 freeze doesn't
+        // return: grid row counting is allocation-free and viewport-local,
+        // and the whole-buffer visual-row index keeps its size gates.
+        // Forced on here so no global toggle, language override, or
+        // per-buffer pin can turn it off (which would reflow scroll-back
+        // into one-row logical lines).
         if self.is_terminal_buffer(buffer_id) {
-            return false;
+            return true;
         }
         match self.buffers.get(&buffer_id) {
             Some(state) => buffer_config_resolve::line_wrap(&state.language, self.config()),
             None => self.config().editor.line_wrap,
         }
+    }
+
+    /// Grid-wrap column count for a terminal buffer: the PTY's current
+    /// width. `None` for non-terminal buffers (or when the terminal state
+    /// is unavailable). Scroll-back entry (`sync_terminal_to_buffer`)
+    /// captures this at sync time; generic paths use it as the fallback.
+    pub(crate) fn terminal_grid_cols(&self, buffer_id: BufferId) -> Option<usize> {
+        let terminal_id = self.get_terminal_id(buffer_id)?;
+        let handle = self.terminal_manager.get(terminal_id)?;
+        let state = handle.state.lock().ok()?;
+        let (cols, _) = state.size();
+        Some(cols as usize)
     }
 
     /// Resolve page view settings for a buffer from its language config.
@@ -47,6 +64,12 @@ impl crate::app::window::Window {
 
     /// Resolve the effective wrap_column for a buffer, considering language overrides.
     pub(crate) fn resolve_wrap_column_for_buffer(&self, buffer_id: BufferId) -> Option<usize> {
+        // Terminal buffers wrap at the PTY grid width (fresh#2649). Best
+        // effort: paths that enter scroll-back overwrite this with the
+        // capture-time width in `sync_terminal_to_buffer`.
+        if self.is_terminal_buffer(buffer_id) {
+            return self.terminal_grid_cols(buffer_id);
+        }
         match self.buffers.get(&buffer_id) {
             Some(state) => buffer_config_resolve::wrap_column(&state.language, self.config()),
             None => self.config().editor.wrap_column,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -64,7 +64,7 @@ impl Editor {
 
         for window in self.windows.values_mut() {
             window.sync_terminal_titles();
-            window.enforce_terminal_no_wrap();
+            window.enforce_terminal_grid_wrap();
         }
 
         // Carve a full-height left column for a docked floating panel

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -249,14 +249,22 @@ impl crate::app::window::Window {
         // what the renderer uses or `max_scroll_row` ends up wrong on
         // wide terminals with `composeWidth` set (mouse-wheel /
         // scrollbar-drag stop short of the buffer's tail).
-        let (wrap_width, show_line_numbers) = self
+        let (wrap_width, show_line_numbers, grid_cols) = self
             .buffers
             .splits()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&split_id)
-            .map(|vs| (vs.viewport.effective_width() as usize, vs.show_line_numbers))
-            .unwrap_or((80, true));
+            .map(|vs| {
+                (
+                    vs.viewport.effective_width() as usize,
+                    vs.show_line_numbers,
+                    // Terminal-grid wrap (fresh#2649): scroll-back rows
+                    // break at the capture-time PTY width.
+                    vs.viewport.grid_wrap.then(|| vs.viewport.grid_cols()),
+                )
+            })
+            .unwrap_or((80, true, None));
 
         // Snapshot config values up front so the mutable borrow on `self.buffers`
         // below doesn't conflict with `self.config()`.
@@ -293,6 +301,7 @@ impl crate::app::window::Window {
                         viewport_height,
                         wrap_width,
                         show_line_numbers,
+                        grid_cols,
                         pipeline_inputs_ver,
                     )
                 } else {
@@ -456,14 +465,22 @@ impl crate::app::window::Window {
             .map(|vs| vs.viewport.line_wrap_enabled)
             .unwrap_or(false);
 
-        let (wrap_width, show_line_numbers) = self
+        let (wrap_width, show_line_numbers, grid_cols) = self
             .buffers
             .splits()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&split_id)
-            .map(|vs| (vs.viewport.effective_width() as usize, vs.show_line_numbers))
-            .unwrap_or((80, true));
+            .map(|vs| {
+                (
+                    vs.viewport.effective_width() as usize,
+                    vs.show_line_numbers,
+                    // Terminal-grid wrap (fresh#2649): scroll-back rows
+                    // break at the capture-time PTY width.
+                    vs.viewport.grid_wrap.then(|| vs.viewport.grid_cols()),
+                )
+            })
+            .unwrap_or((80, true, None));
 
         // Snapshot config up front so the mutable borrow on `self.buffers`
         // below doesn't conflict with `self.config()`.
@@ -493,6 +510,7 @@ impl crate::app::window::Window {
                         viewport_height,
                         wrap_width,
                         show_line_numbers,
+                        grid_cols,
                         pipeline_inputs_ver,
                     )
                 } else {

--- a/crates/fresh-editor/src/app/scrollbar_math.rs
+++ b/crates/fresh-editor/src/app/scrollbar_math.rs
@@ -52,8 +52,26 @@ fn ensure_index(
     state: &mut EditorState,
     wrap_width: usize,
     show_line_numbers: bool,
+    grid_cols: Option<usize>,
     pipeline_inputs_ver: u64,
 ) {
+    // Terminal-grid wrap (fresh#2649): exact-column rows at the grid
+    // width, no gutter, no hanging indent — the same row model the
+    // renderer and viewport scroll math use for terminal scroll-back.
+    if let Some(cols) = grid_cols {
+        let key = VisualRowIndexKey {
+            pipeline_inputs_version: pipeline_inputs_ver,
+            view_mode: CacheViewMode::Source,
+            effective_width: cols.max(1) as u32,
+            gutter_width: 0,
+            wrap_column: None,
+            hanging_indent: false,
+            line_wrap_enabled: true,
+            grid_wrap: true,
+        };
+        ensure_built(state, &key);
+        return;
+    }
     let gutter_width = estimated_gutter_width(&state.buffer, show_line_numbers);
     let wrap_config = WrapConfig::new(wrap_width, gutter_width, true, true);
     let effective_width = wrap_config
@@ -72,6 +90,7 @@ fn ensure_index(
         wrap_column: None,
         hanging_indent: wrap_config.hanging_indent,
         line_wrap_enabled: true,
+        grid_wrap: false,
     };
     ensure_built(state, &key);
 }
@@ -87,13 +106,20 @@ pub(crate) fn scrollbar_jump_visual(
     viewport_height: usize,
     wrap_width: usize,
     show_line_numbers: bool,
+    grid_cols: Option<usize>,
     pipeline_inputs_ver: u64,
 ) -> (usize, usize) {
     if state.buffer.is_empty() || viewport_height == 0 {
         return (0, 0);
     }
 
-    ensure_index(state, wrap_width, show_line_numbers, pipeline_inputs_ver);
+    ensure_index(
+        state,
+        wrap_width,
+        show_line_numbers,
+        grid_cols,
+        pipeline_inputs_ver,
+    );
     let total_visual_rows = state.visual_row_index.total_rows() as usize;
     if total_visual_rows == 0 {
         return (0, 0);
@@ -128,13 +154,20 @@ pub(crate) fn scrollbar_drag_relative_visual(
     viewport_height: usize,
     wrap_width: usize,
     show_line_numbers: bool,
+    grid_cols: Option<usize>,
     pipeline_inputs_ver: u64,
 ) -> (usize, usize) {
     if state.buffer.is_empty() || viewport_height == 0 || scrollbar_height <= 1 {
         return (0, 0);
     }
 
-    ensure_index(state, wrap_width, show_line_numbers, pipeline_inputs_ver);
+    ensure_index(
+        state,
+        wrap_width,
+        show_line_numbers,
+        grid_cols,
+        pipeline_inputs_ver,
+    );
     let total_visual_rows = state.visual_row_index.total_rows() as usize;
     if total_visual_rows == 0 {
         return (0, 0);

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1872,15 +1872,21 @@ impl Window {
                     let buf_state = vs.ensure_buffer_state(buffer_id);
                     buf_state.show_line_numbers = false;
                     buf_state.highlight_current_line = false;
-                    // Scrollback is stored as unwrapped logical lines, so soft-wrap
-                    // the read-only view to reflow long lines to the current width.
-                    // (Visible-screen rows are ≤ the view width and so never wrap,
-                    // keeping the exit frame aligned with the live grid.)
-                    buf_state.viewport.line_wrap_enabled = true;
+                    // Terminal scroll-back must NOT soft-wrap. The renderer,
+                    // `resolve_line_wrap_for_buffer`, and the workspace-restore
+                    // path (`install_terminal_buffer_state`) all treat terminal
+                    // buffers as non-wrapping (column-formatted output must keep
+                    // its alignment, and wrapping a huge scrollback re-walks the
+                    // whole buffer every frame — fresh#2608/#2610). Setting the
+                    // scroll-math flag to match keeps the mouse-wheel / scrollbar
+                    // scroll path (which branches on this flag) in lock-step with
+                    // the non-wrapping render, so scrolling up then back down is
+                    // stable instead of getting stuck (fresh#2649, symptom 2).
+                    buf_state.viewport.line_wrap_enabled = false;
                 }
             }
             if let Some(view_state) = view_states.get_mut(&active_split) {
-                view_state.viewport.line_wrap_enabled = true;
+                view_state.viewport.line_wrap_enabled = false;
                 view_state.viewport.set_skip_ensure_visible();
                 let buf_state = view_state.ensure_buffer_state(buffer_id);
                 buf_state.show_line_numbers = false;

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -394,9 +394,13 @@ impl Window {
         if let Some(view_states) = self.split_view_states_mut() {
             if let Some(view_state) = view_states.get_mut(&split_id) {
                 view_state.add_buffer(buffer_id);
-                // Terminal buffers should not wrap lines so escape
-                // sequences stay intact.
-                view_state.viewport.line_wrap_enabled = false;
+                // Terminal buffers grid-wrap: exact-column rows at the PTY
+                // width so scroll-back lays out like the live grid
+                // (fresh#2649). The width is filled in on scroll-back entry
+                // / by the per-frame healer once the PTY reports its size.
+                view_state.viewport.line_wrap_enabled = true;
+                view_state.viewport.grid_wrap = true;
+                view_state.viewport.wrap_indent = false;
                 // Disable line numbers + current-line highlight for the
                 // terminal buffer's per-buffer view state so exiting
                 // terminal mode doesn't suddenly add a gutter / row
@@ -408,7 +412,9 @@ impl Window {
                 let buf_state = view_state.ensure_buffer_state(buffer_id);
                 buf_state.show_line_numbers = false;
                 buf_state.highlight_current_line = false;
-                buf_state.viewport.line_wrap_enabled = false;
+                buf_state.viewport.line_wrap_enabled = true;
+                buf_state.viewport.grid_wrap = true;
+                buf_state.viewport.wrap_indent = false;
             }
         }
 
@@ -529,10 +535,11 @@ impl Window {
                                     scroll_offset: 0,
                                 },
                             );
-                            // Terminal output is ANSI-sequenced and
-                            // assumes a fixed column count; wrapping
-                            // would mangle cursor positioning.
-                            view_state.viewport.line_wrap_enabled = false;
+                            // Terminal buffers grid-wrap at the PTY
+                            // width (fresh#2649); the per-frame healer
+                            // fills in the column count.
+                            view_state.viewport.line_wrap_enabled = true;
+                            view_state.viewport.grid_wrap = true;
                             self.split_view_states_mut()
                                 .expect("active split implies populated layout")
                                 .insert(new_split_id, view_state);
@@ -555,7 +562,8 @@ impl Window {
                                 .and_then(|m| m.get_mut(&parent))
                             {
                                 view_state.add_buffer(buffer_id);
-                                view_state.viewport.line_wrap_enabled = false;
+                                view_state.viewport.line_wrap_enabled = true;
+                                view_state.viewport.grid_wrap = true;
                             }
                             self.set_active_buffer(buffer_id);
                             (buffer_id, None)
@@ -574,7 +582,8 @@ impl Window {
                         self.terminal_height,
                         buffer_id,
                     );
-                    vs.viewport.line_wrap_enabled = false;
+                    vs.viewport.line_wrap_enabled = true;
+                    vs.viewport.grid_wrap = true;
                     view_states.insert(active_leaf, vs);
                     self.buffers.set_splits((manager, view_states));
                     (buffer_id, Some(active_leaf))
@@ -602,7 +611,8 @@ impl Window {
                         self.terminal_height,
                         buffer_id,
                     );
-                    vs.viewport.line_wrap_enabled = false;
+                    vs.viewport.line_wrap_enabled = true;
+                    vs.viewport.grid_wrap = true;
                     view_states.insert(active_leaf, vs);
                     self.buffers.set_splits((manager, view_states));
                     (buffer_id, Some(active_leaf))
@@ -1131,8 +1141,10 @@ impl Editor {
             rulers: self.config.editor.rulers.clone(),
             scroll_offset: 0,
         });
-        // Terminals don't wrap — keep escape sequences intact.
-        view_state.viewport.line_wrap_enabled = false;
+        // Terminals grid-wrap at the PTY width (fresh#2649).
+        view_state.viewport.line_wrap_enabled = true;
+        view_state.viewport.grid_wrap = true;
+        view_state.viewport.wrap_indent = false;
 
         self.windows
             .get_mut(&self.active_window)
@@ -1449,7 +1461,11 @@ impl Editor {
             }
             let __active_split = self.split_manager().active_split();
             if let Some(view_state) = self.split_view_states_mut().get_mut(&__active_split) {
-                view_state.viewport.line_wrap_enabled = false;
+                // Keep the grid-wrap config (fresh#2649) — the live grid
+                // overlays the buffer view, but scroll math still reads
+                // these flags until the next scroll-back visit re-syncs.
+                view_state.viewport.line_wrap_enabled = true;
+                view_state.viewport.grid_wrap = true;
                 // A selection made in the scrollback view must not outlive
                 // the visit: the anchor would otherwise re-materialize as a
                 // phantom selection on the next scrollback entry (the sync
@@ -1753,9 +1769,20 @@ impl Window {
         // the visible screen we're about to append, which is exactly
         // where the live PTY grid drew its row 0.
         let mut history_end_byte: Option<u64> = None;
+        // In-history head of a still-in-progress line taller than the pane
+        // that `append_visible_screen` re-attaches to the first appended
+        // logical line (fresh#2649): the viewport starts `rows` visual rows
+        // into that line so the exit frame is exactly the live grid.
+        let mut prepended = crate::services::terminal::PrependedHead::default();
+        // Grid width at capture time — the scroll-back view wraps at this
+        // exact column count so it lays out identically to the live grid.
+        let mut grid_cols: Option<usize> = None;
         if let Some(handle) = self.terminal_manager.get(terminal_id) {
             if let Ok(mut state) = handle.state.lock() {
                 use std::io::BufWriter;
+
+                let (cols, _) = state.size();
+                grid_cols = Some(cols as usize);
 
                 // Flush any scrollback that has scrolled off but isn't in the
                 // file yet — in particular the lines a resize spilled from the
@@ -1779,8 +1806,14 @@ impl Window {
                 // Open backing file in append mode to add visible screen
                 if let Ok(mut file) = terminal_backing_fs().open_file_for_append(&backing_file) {
                     let mut writer = BufWriter::new(&mut *file);
-                    if let Err(e) = state.append_visible_screen(&mut writer) {
-                        tracing::error!("Failed to append visible screen to backing file: {}", e);
+                    match state.append_visible_screen(&mut writer) {
+                        Ok(head) => prepended = head,
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to append visible screen to backing file: {}",
+                                e
+                            );
+                        }
                     }
                 }
             }
@@ -1821,9 +1854,17 @@ impl Window {
             if let Some((mgr, view_states)) = self.buffers.splits_mut() {
                 let active_split = mgr.active_split();
                 if let Some(view_state) = view_states.get_mut(&active_split) {
-                    view_state.cursors.primary_mut().position = anchor_byte;
+                    // The anchor line may carry a re-attached in-history
+                    // head (a tall in-progress line, fresh#2649): the grid
+                    // view starts `prepended.rows` visual rows into it so
+                    // row 0 on screen is the live grid's row 0, with the
+                    // head reachable by scrolling up. The cursor lands on
+                    // the first visible cell (`prepended.bytes` past the
+                    // line start), not on the line start hidden above.
+                    let cursor_byte = anchor_byte.saturating_add(prepended.bytes).min(total_bytes);
+                    view_state.cursors.primary_mut().position = cursor_byte;
                     view_state.viewport.top_byte = anchor_byte;
-                    view_state.viewport.top_view_line_offset = 0;
+                    view_state.viewport.top_view_line_offset = prepended.rows;
                     view_state.viewport.left_column = 0;
                 }
             }
@@ -1872,21 +1913,32 @@ impl Window {
                     let buf_state = vs.ensure_buffer_state(buffer_id);
                     buf_state.show_line_numbers = false;
                     buf_state.highlight_current_line = false;
-                    // Terminal scroll-back must NOT soft-wrap. The renderer,
-                    // `resolve_line_wrap_for_buffer`, and the workspace-restore
-                    // path (`install_terminal_buffer_state`) all treat terminal
-                    // buffers as non-wrapping (column-formatted output must keep
-                    // its alignment, and wrapping a huge scrollback re-walks the
-                    // whole buffer every frame — fresh#2608/#2610). Setting the
-                    // scroll-math flag to match keeps the mouse-wheel / scrollbar
-                    // scroll path (which branches on this flag) in lock-step with
-                    // the non-wrapping render, so scrolling up then back down is
-                    // stable instead of getting stuck (fresh#2649, symptom 2).
-                    buf_state.viewport.line_wrap_enabled = false;
+                    // Terminal scroll-back soft-wraps in *grid* mode
+                    // (fresh#2649): exact-column rows at the capture-time
+                    // PTY width, so the view lays out identically to the
+                    // live grid and entering scroll-back never reflows.
+                    // The renderer and the mouse-wheel / scrollbar scroll
+                    // math both branch on these flags and share the grid
+                    // row model, so scrolling up then back down stays
+                    // stable (symptom 2). Grid row counting is
+                    // allocation-free and viewport-local, and the
+                    // whole-buffer visual-row index keeps its size gates,
+                    // so the fresh#2608/#2610 freeze doesn't return.
+                    buf_state.viewport.line_wrap_enabled = true;
+                    buf_state.viewport.grid_wrap = true;
+                    buf_state.viewport.wrap_indent = false;
+                    if let Some(cols) = grid_cols {
+                        buf_state.viewport.wrap_column = Some(cols);
+                    }
                 }
             }
             if let Some(view_state) = view_states.get_mut(&active_split) {
-                view_state.viewport.line_wrap_enabled = false;
+                view_state.viewport.line_wrap_enabled = true;
+                view_state.viewport.grid_wrap = true;
+                view_state.viewport.wrap_indent = false;
+                if let Some(cols) = grid_cols {
+                    view_state.viewport.wrap_column = Some(cols);
+                }
                 view_state.viewport.set_skip_ensure_visible();
                 let buf_state = view_state.ensure_buffer_state(buffer_id);
                 buf_state.show_line_numbers = false;

--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -355,10 +355,11 @@ impl super::Editor {
     /// Live terminals have no cursor/selection model of their own, so the
     /// split is dropped into read-only scrollback first — exactly the
     /// Ctrl+Space / scroll-up transition. `sync_terminal_to_buffer` pins the
-    /// scrollback viewport to the first byte of the just-appended visible
-    /// screen, making the scrollback view pixel-identical to the grid the
-    /// user aimed at: grid row r is buffer line `top_line + r` and grid
-    /// columns map 1:1 (wrap off, no gutter). That lets both the press
+    /// scrollback viewport to the just-appended visible screen, making the
+    /// scrollback view pixel-identical to the grid the user aimed at: the
+    /// view grid-wraps at the capture-time PTY width (fresh#2649), so grid
+    /// row r is visual row r of the anchored viewport and grid columns map
+    /// 1:1 within a row (no gutter). That lets both the press
     /// origin and the current drag position resolve to exact byte positions
     /// without waiting for a re-render; the standard text-selection drag
     /// machinery then takes over (Ctrl+C copies through the editor
@@ -565,6 +566,46 @@ impl super::Editor {
         // explicit scrollback view may have been scrolled right).
         let grid_col =
             col.saturating_sub(content_rect.x) as usize + vs.viewport.left_column as usize;
+
+        // Grid-wrapped scroll-back (fresh#2649): visual rows are exact-column
+        // wrap segments of the logical lines, so walk the segments from the
+        // viewport anchor to the clicked row instead of assuming one buffer
+        // line per grid row (which was only ever true for unwrapped lines —
+        // a grid row that continued a wrapped line used to resolve to the
+        // wrong buffer line entirely).
+        if vs.viewport.grid_wrap && vs.viewport.line_wrap_enabled {
+            let cols = vs.viewport.grid_cols();
+            let mut remaining = vs.viewport.top_view_line_offset + grid_row;
+            let mut line_idx = top_line;
+            loop {
+                let Some(bytes) = state.buffer.get_line(line_idx) else {
+                    // Clicked past the buffer's tail: clamp to the end.
+                    return Some(state.buffer.len());
+                };
+                let text = String::from_utf8_lossy(&bytes);
+                let trimmed = text.trim_end_matches(['\n', '\r']);
+                let rows =
+                    crate::view::line_wrap_cache::count_visual_rows_for_text_grid(trimmed, cols)
+                        as usize;
+                if remaining < rows {
+                    let line_start = state.buffer.line_col_to_position(line_idx, 0);
+                    let layout =
+                        crate::view::line_wrap_cache::layout_for_plain_text_grid(trimmed, cols, 4);
+                    let byte_in_line = layout
+                        .get(remaining)
+                        .and_then(|r| r.source_byte_at_visual_col(grid_col))
+                        .unwrap_or(trimmed.len());
+                    return Some(
+                        state
+                            .buffer
+                            .snap_to_char_boundary(line_start + byte_in_line.min(trimmed.len())),
+                    );
+                }
+                remaining -= rows;
+                line_idx += 1;
+            }
+        }
+
         let pos = state
             .buffer
             .line_col_to_position(top_line + grid_row, grid_col);

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1724,14 +1724,21 @@ impl Window {
     }
 
     /// Configure `leaf_id`'s viewport for a terminal-buffer
-    /// scrollback view: disable line wrap, clear any pending
-    /// skip-ensure-visible flag, then scroll so the buffer's primary
-    /// cursor (positioned at end-of-buffer when entering scrollback)
-    /// is visible. No-op if the buffer or split is missing.
+    /// scrollback view: enable grid wrap (exact-column rows at the PTY
+    /// width, fresh#2649), clear any pending skip-ensure-visible flag,
+    /// then scroll so the buffer's primary cursor (positioned at
+    /// end-of-buffer when entering scrollback) is visible. No-op if the
+    /// buffer or split is missing.
     pub fn enter_terminal_scrollback_view(&mut self, buffer_id: BufferId, leaf_id: LeafId) {
+        let grid_cols = self.terminal_grid_cols(buffer_id);
         self.buffers
             .with_buffer_and_split(buffer_id, leaf_id, |state, view_state| {
-                view_state.viewport.line_wrap_enabled = false;
+                view_state.viewport.line_wrap_enabled = true;
+                view_state.viewport.grid_wrap = true;
+                view_state.viewport.wrap_indent = false;
+                if let Some(cols) = grid_cols {
+                    view_state.viewport.wrap_column = Some(cols);
+                }
                 view_state.viewport.clear_skip_ensure_visible();
                 view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
             });
@@ -1767,7 +1774,13 @@ impl Window {
                         let buf_state = vs.ensure_buffer_state(buffer_id);
                         buf_state.show_line_numbers = false;
                         buf_state.highlight_current_line = false;
-                        buf_state.viewport.line_wrap_enabled = false;
+                        // Grid wrap (fresh#2649): restored scroll-back lays
+                        // out at the grid width like the live view. The
+                        // width is filled in by `enforce_terminal_grid_wrap`
+                        // once the respawned PTY reports its size.
+                        buf_state.viewport.line_wrap_enabled = true;
+                        buf_state.viewport.grid_wrap = true;
+                        buf_state.viewport.wrap_indent = false;
                     }
                 }
                 state.buffer.set_modified(false);
@@ -2449,24 +2462,43 @@ impl Window {
         self.terminal_buffer(buffer_id).is_some()
     }
 
-    /// Terminal buffers never line-wrap (see `resolve_line_wrap_for_buffer`):
-    /// their content is column-formatted, and wrapping a large scrollback turns
-    /// the scrollbar's visual-row index into an O(all-lines) scan every frame,
-    /// freezing the UI (fresh#2608). Heal any per-buffer viewport a global
-    /// line-wrap toggle (or restored state) left enabled — cheap enough to run
-    /// each frame, and a no-op when the window has no terminals.
-    pub(crate) fn enforce_terminal_no_wrap(&mut self) {
-        let terminals = &self.terminal_buffers;
-        if terminals.is_empty() {
+    /// Terminal buffers always line-wrap in *grid* mode (see
+    /// `resolve_line_wrap_for_buffer`): exact-column rows at the PTY grid
+    /// width so scroll-back lays out identically to the live grid
+    /// (fresh#2649). Heal any per-buffer viewport a global line-wrap
+    /// toggle (or restored state) left in another mode — cheap enough to
+    /// run each frame, and a no-op when the window has no terminals.
+    ///
+    /// `wrap_column` (the grid width) is only *filled in* when missing —
+    /// scroll-back entry (`sync_terminal_to_buffer`) sets the capture-time
+    /// width, which must win over the instantaneous PTY width (a split
+    /// that entered scroll-back reserves a scrollbar column, so the PTY
+    /// may be resized one column narrower afterwards while the captured
+    /// content still lays out at the width it was captured at).
+    pub(crate) fn enforce_terminal_grid_wrap(&mut self) {
+        if self.terminal_buffers.is_empty() {
             return;
         }
+        // Snapshot grid widths first — `terminal_grid_cols` borrows self
+        // immutably while the healing loop needs the view states mutably.
+        let cols_by_buffer: std::collections::HashMap<BufferId, Option<usize>> = self
+            .terminal_buffers
+            .keys()
+            .map(|&b| (b, self.terminal_grid_cols(b)))
+            .collect();
         let Some(vs_map) = self.buffers.split_view_states_mut() else {
             return;
         };
         for vs in vs_map.values_mut() {
             for (buffer_id, buffer_state) in vs.keyed_states.iter_mut() {
-                if terminals.contains_key(buffer_id) {
-                    buffer_state.viewport.line_wrap_enabled = false;
+                if let Some(cols) = cols_by_buffer.get(buffer_id) {
+                    let vp = &mut buffer_state.viewport;
+                    vp.line_wrap_enabled = true;
+                    vp.grid_wrap = true;
+                    vp.wrap_indent = false;
+                    if vp.wrap_column.is_none() {
+                        vp.wrap_column = *cols;
+                    }
                 }
             }
         }

--- a/crates/fresh-editor/src/primitives/line_wrapping.rs
+++ b/crates/fresh-editor/src/primitives/line_wrapping.rs
@@ -38,6 +38,11 @@ pub struct WrapConfig {
     /// Whether continuation lines should visually align with the
     /// first line's leading whitespace (hanging indent).
     pub hanging_indent: bool,
+    /// Terminal-grid wrap (fresh#2649): when `Some(cols)`, rows break at
+    /// exact column boundaries every `cols` columns — no word-boundary
+    /// preference, no gutter, no hanging indent — matching the live PTY
+    /// grid. The other width fields are ignored by grid-aware consumers.
+    pub grid_cols: Option<usize>,
 }
 
 impl WrapConfig {
@@ -68,6 +73,7 @@ impl WrapConfig {
             continuation_line_width: text_area_width,
             gutter_width,
             hanging_indent,
+            grid_cols: None,
         }
     }
 
@@ -78,6 +84,21 @@ impl WrapConfig {
             continuation_line_width: usize::MAX,
             gutter_width,
             hanging_indent: false,
+            grid_cols: None,
+        }
+    }
+
+    /// Terminal-grid wrap configuration: exact-column breaks every `cols`
+    /// columns, no gutter, no hanging indent (fresh#2649). The line widths
+    /// are set to `cols` so width-only consumers (e.g. "does this line
+    /// wrap?" checks) still see the correct budget.
+    pub fn grid(cols: usize) -> Self {
+        Self {
+            first_line_width: cols,
+            continuation_line_width: cols,
+            gutter_width: 0,
+            hanging_indent: false,
+            grid_cols: Some(cols),
         }
     }
 }

--- a/crates/fresh-editor/src/services/terminal/mod.rs
+++ b/crates/fresh-editor/src/services/terminal/mod.rs
@@ -55,6 +55,6 @@ pub mod term;
 pub mod windows_shell;
 
 pub use manager::{detect_shell, TerminalId, TerminalManager};
-pub use term::{TerminalCell, TerminalState};
+pub use term::{PrependedHead, TerminalCell, TerminalState};
 #[cfg(windows)]
 pub use windows_shell::set_skip_app_execution_alias;

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -774,7 +774,9 @@ impl TerminalState {
         Ok(written)
     }
 
-    /// Append the visible screen content to the writer as logical lines.
+    /// Append the visible screen content to the writer as logical lines,
+    /// returning the number of in-history rows that were *prepended* to the
+    /// first visible logical line (see below).
     ///
     /// Call this when exiting terminal mode (or saving a session) to add the
     /// current screen to the backing file. Wrapped rows are joined like
@@ -783,22 +785,66 @@ impl TerminalState {
     /// anchor to the start of this block and line up with the live PTY frame.
     /// The block is temporary — re-entering terminal mode truncates the file
     /// back to `backing_file_history_end`.
-    pub fn append_visible_screen<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+    ///
+    /// # Complete capture of an in-progress wrapped line (fresh#2649)
+    ///
+    /// When a single logical line is taller than the pane, its earlier wrapped
+    /// rows scroll into grid history while its terminator is still on screen.
+    /// `flush_new_scrollback` deliberately leaves such an *in-progress* line
+    /// uncommitted (the file must end on a logical-line boundary), so those
+    /// in-history rows are captured by NEITHER path and are lost — the leading
+    /// characters of the line become unreachable at any scroll position and
+    /// vanish on session save.
+    ///
+    /// To fix this, when the first visible row continues a logical line whose
+    /// head is in grid history (`row_wraps(Line(-1))`), we walk backward
+    /// through history to the logical-line start and *prepend* those rows to
+    /// the first emitted logical line, so the FULL line reaches the backing
+    /// file. The returned count lets the caller offset the scroll-back anchor
+    /// past the prepended rows so the exit frame still lands on the live grid's
+    /// row 0.
+    pub fn append_visible_screen<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
+        use alacritty_terminal::grid::Dimensions;
+
         let rows = self.rows as i32;
+
+        // Detect an in-progress logical line whose head is in grid history.
+        // `row_wraps(Line(-1))` means the last history row continues into
+        // visible row 0, i.e. row 0 is a continuation of a still-in-progress
+        // line. Walk upward while each further-back row also wraps into the
+        // one below it (and still exists in history) to find the line start.
+        let history = self.term.grid().history_size();
+        let mut prefix_rows = 0usize;
+        if rows > 0 && history > 0 && self.row_wraps(Line(-1)) {
+            prefix_rows = 1;
+            while prefix_rows < history && self.row_wraps(Line(-((prefix_rows + 1) as i32))) {
+                prefix_rows += 1;
+            }
+        }
+
         let mut start = 0i32;
         let mut row = 0i32;
+        let mut first_logical = true;
         while row < rows {
             if self.row_wraps(Line(row)) && row + 1 < rows {
                 row += 1;
                 continue;
             }
-            // `write_logical_line` indexes via the history convention, so pass
-            // visible rows through directly (offset 0 == oldest here is just row).
-            self.write_visible_logical_line(writer, start, row)?;
+            if first_logical && prefix_rows > 0 {
+                // The first visible logical line continues a line whose head
+                // rows are in history; prepend them so the full line is stored.
+                self.write_prefixed_visible_logical_line(writer, prefix_rows, start, row)?;
+            } else {
+                // `write_logical_line` indexes via the history convention, so
+                // pass visible rows through directly (offset 0 == oldest here
+                // is just row).
+                self.write_visible_logical_line(writer, start, row)?;
+            }
+            first_logical = false;
             row += 1;
             start = row;
         }
-        Ok(())
+        Ok(prefix_rows)
     }
 
     /// True if the last cell of `line` carries the `WRAPLINE` flag, i.e. the row
@@ -845,6 +891,32 @@ impl TerminalState {
         let mut sgr = SgrState::default();
         let mut out = String::with_capacity(self.cols as usize * 2);
         for row in line_start..=line_end {
+            self.append_row_cells(Line(row), &mut sgr, &mut out);
+        }
+        Self::finish_logical_line(&mut out, &sgr);
+        writeln!(writer, "{}", out)
+    }
+
+    /// Write one logical line made of `prefix_rows` history rows (the head of
+    /// an in-progress wrapped line, oldest first: `Line(-prefix_rows)` ..=
+    /// `Line(-1)`) joined with visible rows `vis_start..=vis_end`. Used by
+    /// `append_visible_screen` to capture a line taller than the pane in full.
+    fn write_prefixed_visible_logical_line<W: Write>(
+        &self,
+        writer: &mut W,
+        prefix_rows: usize,
+        vis_start: i32,
+        vis_end: i32,
+    ) -> io::Result<()> {
+        let mut sgr = SgrState::default();
+        let mut out = String::with_capacity(
+            (prefix_rows + (vis_end - vis_start) as usize + 1) * self.cols as usize * 2,
+        );
+        // History rows from oldest (`-prefix_rows`) to newest (`-1`).
+        for j in (1..=prefix_rows).rev() {
+            self.append_row_cells(Line(-(j as i32)), &mut sgr, &mut out);
+        }
+        for row in vis_start..=vis_end {
             self.append_row_cells(Line(row), &mut sgr, &mut out);
         }
         Self::finish_logical_line(&mut out, &sgr);
@@ -1497,6 +1569,68 @@ mod tests {
             output.contains("Line C"),
             "Visible screen should contain Line C"
         );
+    }
+
+    /// fresh#2649: a single logical line taller than the pane leaves its
+    /// leading rows in grid history while its cursor row is still on screen.
+    /// `flush_new_scrollback` won't commit an in-progress line, so those
+    /// in-history rows must be re-attached by `append_visible_screen` — the
+    /// FULL line (leading `X`s included) has to reach the sink, and the
+    /// returned prepended-row count must equal the in-history wrapped rows.
+    #[test]
+    fn test_append_visible_screen_reattaches_in_progress_line_head() {
+        // 20 cols × 5 rows. Print 8 'X' + 200 'A' = 208 chars with NO newline,
+        // so the line is still in progress (cursor mid-line). 208 / 20 = 11
+        // physical rows; 5 are visible, so 6 rows sit in grid history.
+        let mut state = TerminalState::new(20, 5);
+        state.process_output(b"XXXXXXXX");
+        state.process_output(&[b'A'; 200]);
+
+        let history_rows = state.history_size();
+        assert_eq!(history_rows, 6, "6 wrapped rows should be in history");
+
+        let mut sink: Vec<u8> = Vec::new();
+        // The line is in progress, so nothing is committed as scrollback yet.
+        assert_eq!(state.flush_new_scrollback(&mut sink).unwrap(), 0);
+        assert!(
+            sink.is_empty(),
+            "in-progress line must not be committed yet"
+        );
+
+        // Appending the visible screen must re-attach the in-history head.
+        let prepended = state.append_visible_screen(&mut sink).unwrap();
+        assert_eq!(
+            prepended, history_rows,
+            "prepended rows must equal the in-history wrapped rows"
+        );
+
+        let text = String::from_utf8_lossy(&sink);
+        let line = text
+            .lines()
+            .find(|l| l.contains("XXXXXXXX"))
+            .expect("the leading XXXXXXXX must be captured, not just the A tail");
+        assert_eq!(
+            line.chars().filter(|&c| c == 'X').count(),
+            8,
+            "all 8 leading X's must be present"
+        );
+        assert_eq!(
+            line.chars().filter(|&c| c == 'A').count(),
+            200,
+            "the full 200-char A tail must be present in the SAME logical line"
+        );
+    }
+
+    /// The re-attachment must not fire for a normal visible line whose head is
+    /// NOT in history (no data loss risk): the returned count is 0 and the
+    /// existing per-line capture is unchanged.
+    #[test]
+    fn test_append_visible_screen_no_prepend_when_head_on_screen() {
+        let mut state = TerminalState::new(80, 5);
+        state.process_output(b"Line A\r\nLine B\r\nLine C\r\n");
+        let mut sink: Vec<u8> = Vec::new();
+        let prepended = state.append_visible_screen(&mut sink).unwrap();
+        assert_eq!(prepended, 0, "no in-history head to re-attach");
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -308,6 +308,18 @@ pub struct TerminalState {
     osc7: Osc7Scanner,
 }
 
+/// What `append_visible_screen` re-attached ahead of the first visible
+/// logical line: the in-history wrapped rows (and their byte length in the
+/// emitted stream) of a line taller than the pane that is still in
+/// progress (fresh#2649). `rows` lets the scroll-back viewport start at
+/// the live grid's row 0 (`top_view_line_offset`), `bytes` locates that
+/// row's first cell in the backing file (cursor anchor).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PrependedHead {
+    pub rows: usize,
+    pub bytes: usize,
+}
+
 impl TerminalState {
     /// Create a new terminal state
     pub fn new(cols: u16, rows: u16) -> Self {
@@ -803,7 +815,7 @@ impl TerminalState {
     /// file. The returned count lets the caller offset the scroll-back anchor
     /// past the prepended rows so the exit frame still lands on the live grid's
     /// row 0.
-    pub fn append_visible_screen<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
+    pub fn append_visible_screen<W: Write>(&self, writer: &mut W) -> io::Result<PrependedHead> {
         use alacritty_terminal::grid::Dimensions;
 
         let rows = self.rows as i32;
@@ -825,6 +837,7 @@ impl TerminalState {
         let mut start = 0i32;
         let mut row = 0i32;
         let mut first_logical = true;
+        let mut prefix_bytes = 0usize;
         while row < rows {
             if self.row_wraps(Line(row)) && row + 1 < rows {
                 row += 1;
@@ -833,7 +846,8 @@ impl TerminalState {
             if first_logical && prefix_rows > 0 {
                 // The first visible logical line continues a line whose head
                 // rows are in history; prepend them so the full line is stored.
-                self.write_prefixed_visible_logical_line(writer, prefix_rows, start, row)?;
+                prefix_bytes =
+                    self.write_prefixed_visible_logical_line(writer, prefix_rows, start, row)?;
             } else {
                 // `write_logical_line` indexes via the history convention, so
                 // pass visible rows through directly (offset 0 == oldest here
@@ -844,7 +858,10 @@ impl TerminalState {
             row += 1;
             start = row;
         }
-        Ok(prefix_rows)
+        Ok(PrependedHead {
+            rows: prefix_rows,
+            bytes: prefix_bytes,
+        })
     }
 
     /// True if the last cell of `line` carries the `WRAPLINE` flag, i.e. the row
@@ -907,7 +924,7 @@ impl TerminalState {
         prefix_rows: usize,
         vis_start: i32,
         vis_end: i32,
-    ) -> io::Result<()> {
+    ) -> io::Result<usize> {
         let mut sgr = SgrState::default();
         let mut out = String::with_capacity(
             (prefix_rows + (vis_end - vis_start) as usize + 1) * self.cols as usize * 2,
@@ -916,11 +933,16 @@ impl TerminalState {
         for j in (1..=prefix_rows).rev() {
             self.append_row_cells(Line(-(j as i32)), &mut sgr, &mut out);
         }
+        // Everything before this offset is prepended in-history content;
+        // the byte at `prefix_bytes` (relative to the line start in the
+        // backing file) is the first cell of the live grid's row 0.
+        let prefix_bytes = out.len();
         for row in vis_start..=vis_end {
             self.append_row_cells(Line(row), &mut sgr, &mut out);
         }
         Self::finish_logical_line(&mut out, &sgr);
-        writeln!(writer, "{}", out)
+        writeln!(writer, "{}", out)?;
+        Ok(prefix_bytes)
     }
 
     /// Close out an in-progress logical line: emit a final SGR reset if any
@@ -1600,8 +1622,16 @@ mod tests {
         // Appending the visible screen must re-attach the in-history head.
         let prepended = state.append_visible_screen(&mut sink).unwrap();
         assert_eq!(
-            prepended, history_rows,
+            prepended.rows, history_rows,
             "prepended rows must equal the in-history wrapped rows"
+        );
+        // The prepended head is plain uncolored text here, so its byte
+        // length is exactly the prepended cell count: `rows` full-width
+        // rows of 20 columns each.
+        assert_eq!(
+            prepended.bytes,
+            history_rows * 20,
+            "prepended byte length must cover exactly the in-history rows"
         );
 
         let text = String::from_utf8_lossy(&sink);
@@ -1630,7 +1660,8 @@ mod tests {
         state.process_output(b"Line A\r\nLine B\r\nLine C\r\n");
         let mut sink: Vec<u8> = Vec::new();
         let prepended = state.append_visible_screen(&mut sink).unwrap();
-        assert_eq!(prepended, 0, "no in-history head to re-attach");
+        assert_eq!(prepended.rows, 0, "no in-history head to re-attach");
+        assert_eq!(prepended.bytes, 0, "no in-history bytes to re-attach");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -81,6 +81,13 @@ pub struct LineWrapKey {
     pub wrap_column: Option<u32>,
     pub hanging_indent: bool,
     pub line_wrap_enabled: bool,
+    /// Terminal-grid wrap mode (fresh#2649): rows break at exact column
+    /// boundaries (`effective_width` columns) with no word-boundary
+    /// preference, no hanging indent, and no gutter — matching the live
+    /// PTY grid so entering scroll-back doesn't reflow. Only terminal
+    /// buffers set this; it keys separately from word-wrap entries at the
+    /// same geometry.
+    pub grid_wrap: bool,
     /// Signature of the cursor positions inside this line (see
     /// [`cursor_sig_for_line`]). Cursor-dependent conceal/soft-break
     /// activation makes the cursor line's layout a function of where the
@@ -448,6 +455,10 @@ pub struct WrapGeometry {
     pub hanging_indent: bool,
     pub wrap_column: Option<u32>,
     pub line_wrap_enabled: bool,
+    /// Terminal-grid wrap (see [`LineWrapKey::grid_wrap`]): exact-column
+    /// breaks at `effective_width`, ignoring `gutter_width` /
+    /// `hanging_indent` / `wrap_column`.
+    pub grid_wrap: bool,
     pub view_mode: CacheViewMode,
 }
 
@@ -471,6 +482,7 @@ impl WrapGeometry {
             wrap_column: self.wrap_column,
             hanging_indent: self.hanging_indent,
             line_wrap_enabled: self.line_wrap_enabled,
+            grid_wrap: self.grid_wrap,
             cursor_sig,
         }
     }
@@ -557,12 +569,21 @@ pub fn compute_line_layout(
     // disabled, pass tokens through unchanged; ViewLineIterator will
     // still yield one ViewLine per Newline boundary.
     if geom.line_wrap_enabled {
-        tokens = apply_wrapping_transform(
-            tokens,
-            geom.effective_width,
-            geom.gutter_width,
-            geom.hanging_indent,
-        );
+        if geom.grid_wrap {
+            // Terminal-grid wrap: exact-column breaks at effective_width,
+            // matching the live PTY grid's row layout (fresh#2649).
+            tokens = crate::view::ui::split_rendering::transforms::apply_grid_wrapping_transform(
+                tokens,
+                geom.effective_width,
+            );
+        } else {
+            tokens = apply_wrapping_transform(
+                tokens,
+                geom.effective_width,
+                geom.gutter_width,
+                geom.hanging_indent,
+            );
+        }
     }
 
     // Materialise the ViewLines.  `build_base_tokens` may emit tokens
@@ -830,6 +851,124 @@ pub fn count_visual_rows_for_text(
     rows.max(1)
 }
 
+/// Walk `line_text` with the terminal-grid wrap rule and call `f` with the
+/// byte offset (within `line_text`) of every visual-row start, including 0.
+///
+/// The grid rule is the one the live PTY grid uses: rows break at **exact
+/// column boundaries** — no word-boundary preference, no hanging indent, no
+/// gutter. ANSI escape sequences are zero-width (terminal scroll-back text
+/// carries SGR color codes), tabs expand per `tab_expansion_width`, and
+/// widths are measured per grapheme cluster exactly like `ViewLineIterator`
+/// so the row split agrees with the rendered visual columns.
+///
+/// A grapheme is pushed to the next row when the current row has content
+/// (`col > 0`) and the grapheme's width no longer fits in `cols`. Zero-width
+/// graphemes (escapes) never trigger a break, so an SGR sequence at a row
+/// boundary stays attached to the row it followed — the same attachment
+/// `append_row_cells` produces when it joins grid rows into a logical line.
+///
+/// Single source of truth for terminal grid wrapping: the renderer's
+/// `apply_grid_wrapping_transform`, the row counters, and the segment-byte
+/// mapping below all reduce to this walk, so scroll math and the renderer
+/// can never disagree on row boundaries (fresh#2649).
+fn for_each_grid_row_start<F: FnMut(usize)>(line_text: &str, cols: usize, mut f: F) {
+    use crate::primitives::ansi::AnsiParser;
+    use crate::primitives::display_width::str_width;
+    use crate::primitives::visual_layout::tab_expansion_width;
+    use unicode_segmentation::UnicodeSegmentation;
+
+    f(0);
+    if cols == 0 {
+        return;
+    }
+
+    let mut parser = line_text.contains('\x1b').then(AnsiParser::new);
+    let mut col: usize = 0;
+    for (byte_offset, grapheme) in line_text.grapheme_indices(true) {
+        // Escape-sequence chars are zero width (mirrors ViewLineIterator's
+        // push_text_token: the first char decides, the rest keep the parser
+        // state machine fed).
+        if let Some(p) = parser.as_mut() {
+            let mut chars = grapheme.chars();
+            let first = chars.next().unwrap_or('\0');
+            if p.parse_char(first).is_none() {
+                for ch in chars {
+                    let _ = p.parse_char(ch);
+                }
+                continue;
+            }
+        }
+        let width = if grapheme == "\t" {
+            tab_expansion_width(col)
+        } else {
+            str_width(grapheme)
+        };
+        if col > 0 && col + width > cols {
+            f(byte_offset);
+            col = 0;
+        }
+        col += width;
+    }
+}
+
+/// Visual-row count for one logical line under terminal-grid wrapping at
+/// `cols` columns. Allocation-free — used by scroll math and the
+/// `VisualRowIndex` build for terminal scroll-back buffers, where the old
+/// word-wrap counter's per-line transform allocations were part of what made
+/// whole-buffer scans expensive (fresh#2608).
+pub fn count_visual_rows_for_text_grid(line_text: &str, cols: usize) -> u32 {
+    let mut rows: u32 = 0;
+    for_each_grid_row_start(line_text, cols, |_| rows += 1);
+    rows.max(1)
+}
+
+/// Byte offset (relative to `line_start`) of each grid-wrap visual row of
+/// `line_text` at `cols` columns. Grid-mode counterpart of
+/// `viewport::wrap_segment_source_bytes` — PageUp/PageDown use it to find
+/// the byte of the visual row at the top of the viewport.
+pub fn grid_segment_source_bytes(line_text: &str, line_start: usize, cols: usize) -> Vec<usize> {
+    let mut rows = Vec::new();
+    for_each_grid_row_start(line_text, cols, |b| rows.push(line_start + b));
+    if rows.is_empty() {
+        rows.push(line_start);
+    }
+    rows
+}
+
+/// Grid-mode counterpart of [`layout_for_plain_text`]: materialise a line's
+/// layout as `Vec<ViewLine>` under terminal-grid wrapping at `cols` columns.
+/// Matches the renderer's `apply_grid_wrapping_transform` output for the
+/// same text, so row counts and cursor mappings agree with what is drawn.
+pub fn layout_for_plain_text_grid(line_text: &str, cols: usize, tab_size: usize) -> Vec<ViewLine> {
+    use crate::view::ui::split_rendering::transforms::apply_grid_wrapping_transform;
+    use crate::view::ui::view_pipeline::LineStart;
+    use fresh_core::api::ViewTokenWire;
+    let tokens = vec![ViewTokenWire {
+        source_offset: Some(0),
+        kind: ViewTokenWireKind::Text(line_text.to_string()),
+        style: None,
+    }];
+    let wrapped = apply_grid_wrapping_transform(tokens, cols);
+    let mut lines: Vec<ViewLine> =
+        ViewLineIterator::new(&wrapped, false, true, tab_size, false).collect();
+    if lines.is_empty() {
+        lines.push(ViewLine {
+            text: String::new(),
+            source_start_byte: Some(0),
+            char_source_bytes: Vec::new(),
+            char_styles: Vec::new(),
+            char_visual_cols: Vec::new(),
+            visual_to_char: Vec::new(),
+            tab_starts: std::collections::HashSet::new(),
+            line_start: LineStart::Beginning,
+            ends_with_newline: false,
+            virtual_gutter_glyph: None,
+            virtual_line_style: None,
+        });
+    }
+    lines
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -845,6 +984,7 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            grid_wrap: false,
             cursor_sig: 0,
         }
     }
@@ -1156,6 +1296,102 @@ mod tests {
         }
     }
 
+    // -------------------------------------------------------------------
+    // Terminal-grid wrap (fresh#2649).
+    // -------------------------------------------------------------------
+
+    /// Grid counting basics: exact-column breaks, no word-boundary
+    /// preference, ANSI escapes zero-width, wide chars two cells.
+    #[test]
+    fn grid_count_basics() {
+        // Empty line is one row at any width.
+        assert_eq!(count_visual_rows_for_text_grid("", 20), 1);
+        // Exact fit stays one row; one more char wraps.
+        assert_eq!(count_visual_rows_for_text_grid(&"a".repeat(20), 20), 1);
+        assert_eq!(count_visual_rows_for_text_grid(&"a".repeat(21), 20), 2);
+        assert_eq!(count_visual_rows_for_text_grid(&"a".repeat(40), 20), 2);
+        assert_eq!(count_visual_rows_for_text_grid(&"a".repeat(41), 20), 3);
+        // Words are split mid-word at the exact column — 6 words of 5
+        // chars minus the trailing space = 29 visible cells at width 10.
+        assert_eq!(
+            count_visual_rows_for_text_grid("word1 word2 word3 word4 word5", 10),
+            3
+        );
+        // SGR color codes are zero width.
+        let colored = format!("\x1b[31m{}\x1b[0m", "x".repeat(20));
+        assert_eq!(count_visual_rows_for_text_grid(&colored, 20), 1);
+        // Wide chars take two cells: 10 CJK chars = 20 cells.
+        let cjk = "\u{4e16}".repeat(10);
+        assert_eq!(count_visual_rows_for_text_grid(&cjk, 20), 1);
+        assert_eq!(count_visual_rows_for_text_grid(&cjk, 19), 2);
+    }
+
+    /// A wide char that would straddle the boundary moves to the next row
+    /// whole (like the grid's early wrap) — the count follows the same
+    /// walk, not a `ceil(total/cols)` shortcut.
+    #[test]
+    fn grid_count_wide_char_straddles_boundary() {
+        // 19 narrow cells then a wide char at width 20: the wide char
+        // doesn't fit in the single remaining cell → next row.
+        let text = format!("{}\u{4e16}", "a".repeat(19));
+        assert_eq!(count_visual_rows_for_text_grid(&text, 20), 2);
+    }
+
+    /// The transform-backed layout (what the renderer draws), the
+    /// allocation-free count (what scroll math uses), and the segment
+    /// byte map (what PageUp/Down use) must agree row-for-row — the
+    /// single-row-model invariant that keeps terminal scroll-back
+    /// scrolling stable (fresh#2649 symptom 2).
+    #[test]
+    fn grid_layout_count_and_segments_agree() {
+        let texts: Vec<String> = vec![
+            String::new(),
+            "short".into(),
+            "a".repeat(99),
+            "a".repeat(100),
+            "a".repeat(101),
+            "word1 word2 word3 word4 word5 word6 word7 word8".into(),
+            format!("\x1b[31mred{}\x1b[0m tail", "x".repeat(50)),
+            format!("{}{}", "\u{4e16}".repeat(13), "mixed latin \u{e9}\u{5d0}"),
+            format!("prompt$ {}", "argword ".repeat(30)),
+        ];
+        for text in &texts {
+            for cols in [7usize, 10, 20, 33, 99] {
+                let count = count_visual_rows_for_text_grid(text, cols) as usize;
+                let layout = layout_for_plain_text_grid(text, cols, 4);
+                assert_eq!(
+                    layout.len(),
+                    count,
+                    "layout rows != counted rows for cols={cols} text={text:?}"
+                );
+                let segs = grid_segment_source_bytes(text, 0, cols);
+                assert_eq!(
+                    segs.len(),
+                    count,
+                    "segment starts != counted rows for cols={cols} text={text:?}"
+                );
+                // Each row's first source byte must match the segment map.
+                for (i, row) in layout.iter().enumerate() {
+                    if let Some(first) = row.char_source_bytes.iter().find_map(|b| *b) {
+                        assert_eq!(
+                            first, segs[i],
+                            "row {i} first byte mismatch for cols={cols} text={text:?}"
+                        );
+                    }
+                    // No visible row is wider than the grid... except a
+                    // trailing newline cell which ViewLine carries.
+                    let vis = row
+                        .visual_width()
+                        .saturating_sub(usize::from(row.ends_with_newline));
+                    assert!(
+                        vis <= cols,
+                        "row {i} wider than grid ({vis} > {cols}) for text={text:?}"
+                    );
+                }
+            }
+        }
+    }
+
     /// A soft-break offset that lands inside a multi-byte char must be
     /// skipped like the other malformed break positions, not panic the
     /// slice.  This happens when the break list is stale: the plugin
@@ -1347,6 +1583,7 @@ mod tests {
                 wrap_column: None,
                 hanging_indent: false,
                 line_wrap_enabled: true,
+                grid_wrap: false,
                 cursor_sig: 0,
             };
             let real_val = real.get_or_insert_with(key, || dummy_lines(shadow_rows));
@@ -1380,6 +1617,7 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            grid_wrap: false,
             cursor_sig: 0,
         };
         cache.get_or_insert_with(key_v0, || dummy_lines(5));
@@ -1423,11 +1661,12 @@ mod tests {
             wrap_column: None,
             hanging_indent: false,
             line_wrap_enabled: true,
+            grid_wrap: false,
             cursor_sig: 0,
         };
 
         // Vary each field in turn; each variation must be a distinct key.
-        let variations: [LineWrapKey; 8] = [
+        let variations: [LineWrapKey; 9] = [
             LineWrapKey {
                 pipeline_inputs_version: 2,
                 ..base
@@ -1459,6 +1698,10 @@ mod tests {
             LineWrapKey {
                 line_wrap_enabled: false,
                 cursor_sig: 0,
+                ..base
+            },
+            LineWrapKey {
+                grid_wrap: true,
                 ..base
             },
         ];

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -85,18 +85,24 @@ pub(super) fn scrollbar_visual_row_counts(
         return (1, 0);
     }
 
-    let gutter_width = viewport.gutter_width(&state.buffer);
-    let wrap_config = WrapConfig::new(
-        viewport.width as usize,
-        gutter_width,
-        true,
-        viewport.wrap_indent,
-    );
-    let effective_width = wrap_config
-        .first_line_width
-        .saturating_add(gutter_width)
-        .max(2);
-    let hanging_indent = wrap_config.hanging_indent;
+    // Terminal-grid wrap (fresh#2649): count exact-column rows at the grid
+    // width — same row model as the renderer and the viewport scroll math.
+    let (effective_width, gutter_width, hanging_indent) = if viewport.grid_wrap {
+        (viewport.grid_cols(), 0usize, false)
+    } else {
+        let gutter_width = viewport.gutter_width(&state.buffer);
+        let wrap_config = WrapConfig::new(
+            viewport.width as usize,
+            gutter_width,
+            true,
+            viewport.wrap_indent,
+        );
+        let effective_width = wrap_config
+            .first_line_width
+            .saturating_add(gutter_width)
+            .max(2);
+        (effective_width, gutter_width, wrap_config.hanging_indent)
+    };
     let pipeline_inputs_ver = pipeline_inputs_version(
         state.buffer.version(),
         state.soft_breaks.version(),
@@ -112,6 +118,7 @@ pub(super) fn scrollbar_visual_row_counts(
         wrap_column: None,
         hanging_indent,
         line_wrap_enabled: viewport.line_wrap_enabled,
+        grid_wrap: viewport.grid_wrap,
     };
     ensure_built(state, &key);
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -146,6 +146,133 @@ fn back_up_to_prior_space(
     })
 }
 
+/// Terminal-grid wrap: break the token stream at **exact column
+/// boundaries** every `cols` columns, the way the live PTY grid lays out
+/// its rows (fresh#2649).
+///
+/// Differences from [`apply_wrapping_transform`]:
+///   - no word-boundary preference — a row breaks exactly when the next
+///     visible grapheme would not fit, even mid-word;
+///   - no gutter and no hanging indent — terminal scroll-back renders
+///     without a line-number column and continuation rows start at
+///     column 0, like the grid;
+///   - ANSI-aware — terminal scroll-back text carries SGR color codes,
+///     which are zero-width and never trigger a break (they stay attached
+///     to the row they follow, matching how `append_row_cells` joins grid
+///     rows into a logical line).
+///
+/// Must agree row-for-row with `line_wrap_cache::for_each_grid_row_start`
+/// (the count/segment side used by scroll math): both walk grapheme
+/// clusters with the same width rules, so a logical line of N visible
+/// cells splits into identical rows in the renderer and in the scroll
+/// position math — the disagreement that made scroll-back stick is
+/// structurally impossible (fresh#2649 symptom 2).
+pub(crate) fn apply_grid_wrapping_transform(
+    tokens: Vec<ViewTokenWire>,
+    cols: usize,
+) -> Vec<ViewTokenWire> {
+    use crate::primitives::ansi::AnsiParser;
+    use unicode_segmentation::UnicodeSegmentation;
+
+    if cols == 0 {
+        return tokens;
+    }
+
+    let mut wrapped: Vec<ViewTokenWire> = Vec::with_capacity(tokens.len());
+    let mut col: usize = 0;
+    let mut parser = AnsiParser::new();
+
+    let emit_break = |wrapped: &mut Vec<ViewTokenWire>, col: &mut usize| {
+        wrapped.push(ViewTokenWire {
+            source_offset: None,
+            kind: ViewTokenWireKind::Break,
+            style: None,
+        });
+        *col = 0;
+    };
+
+    for token in tokens {
+        match &token.kind {
+            ViewTokenWireKind::Newline => {
+                wrapped.push(token);
+                col = 0;
+                // Escape sequences never span logical lines in captured
+                // scroll-back; start each line with a clean parser so a
+                // malformed trailing escape can't leak zero-width state.
+                parser.reset();
+            }
+            ViewTokenWireKind::Break => {
+                wrapped.push(token);
+                col = 0;
+            }
+            ViewTokenWireKind::Space => {
+                if col > 0 && col + 1 > cols {
+                    emit_break(&mut wrapped, &mut col);
+                }
+                col += 1;
+                wrapped.push(token);
+            }
+            ViewTokenWireKind::BinaryByte(_) => {
+                // Rendered as `<XX>` (width 4), same accounting as the
+                // word-wrap transform.
+                if col > 0 && col + 4 > cols {
+                    emit_break(&mut wrapped, &mut col);
+                }
+                col += 4;
+                wrapped.push(token);
+            }
+            ViewTokenWireKind::Text(text) => {
+                // Split the token at every grid row boundary. `seg_start`
+                // is the byte offset (within `text`) where the pending
+                // sub-token begins.
+                let mut seg_start = 0usize;
+                for (byte_offset, grapheme) in text.grapheme_indices(true) {
+                    // Escape-sequence chars are zero width; keep the
+                    // parser fed (mirrors ViewLineIterator).
+                    let mut chars = grapheme.chars();
+                    let first = chars.next().unwrap_or('\0');
+                    if parser.parse_char(first).is_none() {
+                        for ch in chars {
+                            let _ = parser.parse_char(ch);
+                        }
+                        continue;
+                    }
+                    let width = if grapheme == "\t" {
+                        visual_layout::tab_expansion_width(col)
+                    } else {
+                        display_width::str_width(grapheme)
+                    };
+                    if col > 0 && col + width > cols {
+                        if byte_offset > seg_start {
+                            wrapped.push(ViewTokenWire {
+                                source_offset: token.source_offset.map(|s| s + seg_start),
+                                kind: ViewTokenWireKind::Text(
+                                    text[seg_start..byte_offset].to_string(),
+                                ),
+                                style: token.style.clone(),
+                            });
+                            seg_start = byte_offset;
+                        }
+                        emit_break(&mut wrapped, &mut col);
+                    }
+                    col += width;
+                }
+                if seg_start == 0 {
+                    wrapped.push(token);
+                } else if seg_start < text.len() {
+                    wrapped.push(ViewTokenWire {
+                        source_offset: token.source_offset.map(|s| s + seg_start),
+                        kind: ViewTokenWireKind::Text(text[seg_start..].to_string()),
+                        style: token.style,
+                    });
+                }
+            }
+        }
+    }
+
+    wrapped
+}
+
 pub(crate) fn apply_wrapping_transform(
     tokens: Vec<ViewTokenWire>,
     content_width: usize,

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -9,8 +9,8 @@ use super::base_tokens::build_base_tokens;
 use super::folding::{apply_folding, fold_adjusted_visible_count, fold_skip_set};
 use super::style::fold_placeholder_style;
 use super::transforms::{
-    apply_conceal_ranges, apply_soft_breaks, apply_wrapping_transform, inject_virtual_lines,
-    splice_inline_virtual_text,
+    apply_conceal_ranges, apply_grid_wrapping_transform, apply_soft_breaks,
+    apply_wrapping_transform, inject_virtual_lines, splice_inline_virtual_text,
 };
 use super::MAX_SAFE_LINE_WIDTH;
 use crate::state::{EditorState, ViewMode};
@@ -156,16 +156,29 @@ pub(super) fn build_view_data(
     // keeps this safe at very small widths where the guard inside
     // `apply_wrapping_transform` will short-circuit anyway.
     let effective_width = if line_wrap_enabled {
-        let base = if let Some(col) = viewport.wrap_column {
-            col.min(content_width)
+        if viewport.grid_wrap {
+            // Terminal-grid wrap (fresh#2649): wrap at exactly the
+            // capture-time PTY column count. No EOL-cursor column is
+            // reserved and no clamp to the content width — the grid is one
+            // column wider than the scroll-back content area (the live view
+            // reclaims the scrollbar column), and clamping or reserving
+            // would re-wrap every full-width grid row one cell early,
+            // reflowing the whole view on entry. Full rows render with
+            // their last cell under the scrollbar, exactly like the
+            // non-wrapped exit frame always has.
+            viewport.grid_cols()
         } else {
-            content_width
-        };
-        base.saturating_sub(1).max(1)
+            let base = if let Some(col) = viewport.wrap_column {
+                col.min(content_width)
+            } else {
+                content_width
+            };
+            base.saturating_sub(1).max(1)
+        }
     } else {
         MAX_SAFE_LINE_WIDTH
     };
-    let hanging_indent = line_wrap_enabled && viewport.wrap_indent;
+    let hanging_indent = line_wrap_enabled && viewport.wrap_indent && !viewport.grid_wrap;
 
     // Splice inline virtual text (inlay hints) into the stream BEFORE
     // wrapping so its display width participates in wrap boundaries, the
@@ -194,7 +207,13 @@ pub(super) fn build_view_data(
             splice_inline_virtual_text(tokens, state, Some(theme), viewport.top_byte, viewport_end);
     }
 
-    tokens = apply_wrapping_transform(tokens, effective_width, gutter_width, hanging_indent);
+    tokens = if line_wrap_enabled && viewport.grid_wrap {
+        // Exact-column grid wrap — must stay row-for-row identical to the
+        // scroll math's `for_each_grid_row_start` (fresh#2649 symptom 2).
+        apply_grid_wrapping_transform(tokens, effective_width)
+    } else {
+        apply_wrapping_transform(tokens, effective_width, gutter_width, hanging_indent)
+    };
 
     // Convert tokens to display lines using the view pipeline.
     let is_binary = state.buffer.is_binary();
@@ -279,6 +298,7 @@ pub(super) fn build_view_data(
             wrap_column: viewport.wrap_column.map(|c| c as u32),
             hanging_indent,
             line_wrap_enabled: true,
+            grid_wrap: viewport.grid_wrap,
             cursor_sig,
         };
 

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -34,6 +34,13 @@ pub struct Viewport {
     /// When true, horizontal scrolling is disabled
     pub line_wrap_enabled: bool,
 
+    /// Terminal-grid wrap mode (fresh#2649): with `line_wrap_enabled`,
+    /// rows break at exact column boundaries every `wrap_column` columns
+    /// (no word-boundary preference, no gutter, no hanging indent),
+    /// matching the live PTY grid so entering terminal scroll-back never
+    /// reflows. Only terminal buffers set this.
+    pub grid_wrap: bool,
+
     /// Whether wrapped continuation lines should be indented to match leading whitespace
     pub wrap_indent: bool,
 
@@ -131,6 +138,7 @@ impl Viewport {
             scroll_offset: 3,
             horizontal_scroll_offset: 5,
             line_wrap_enabled: false,
+            grid_wrap: false,
             wrap_indent: true,
             wrap_column: None,
             compose_width: None,
@@ -278,6 +286,14 @@ impl Viewport {
         let v_lo = virtual_lines.partition_point(|p| *p < line_start);
         let v_hi = virtual_lines.partition_point(|p| *p < line_end);
         let extra_virtual_rows = v_hi - v_lo;
+        // Terminal-grid wrap: exact-column count, allocation-free. Soft
+        // breaks / the shared cache don't apply to terminal buffers, and
+        // the count is cheap enough to recompute per call (fresh#2649).
+        if let Some(cols) = wrap_config.grid_cols {
+            return crate::view::line_wrap_cache::count_visual_rows_for_text_grid(line_text, cols)
+                as usize
+                + extra_virtual_rows;
+        }
         let lo = soft_breaks.partition_point(|p| p.0 < line_start);
         let hi = soft_breaks.partition_point(|p| p.0 < line_end);
         let line_breaks = &soft_breaks[lo..hi];
@@ -355,6 +371,8 @@ impl Viewport {
                     wrap_column: None,
                     hanging_indent: wrap_config.hanging_indent,
                     line_wrap_enabled: true,
+                    // Grid mode returns before this cache path.
+                    grid_wrap: false,
                     // Scroll math is cursor-blind by convention (matches
                     // `VisualRowIndex` and its own cursor-free inputs).
                     cursor_sig: 0,
@@ -535,24 +553,22 @@ impl Viewport {
             return self.top_byte;
         }
 
-        let gutter_width = self.gutter_width(buffer);
-        let wrap_config = WrapConfig::new(
-            self.effective_width() as usize,
-            gutter_width,
-            true,
-            self.wrap_indent,
-        );
-        let effective_width = wrap_config
-            .first_line_width
-            .saturating_add(wrap_config.gutter_width)
-            .max(2);
-        let seg_bytes = wrap_segment_source_bytes(
-            &line_content,
-            line_start,
-            effective_width,
-            wrap_config.gutter_width,
-            wrap_config.hanging_indent,
-        );
+        let wrap_config = self.make_wrap_config(buffer);
+        let seg_bytes = if let Some(cols) = wrap_config.grid_cols {
+            crate::view::line_wrap_cache::grid_segment_source_bytes(&line_content, line_start, cols)
+        } else {
+            let effective_width = wrap_config
+                .first_line_width
+                .saturating_add(wrap_config.gutter_width)
+                .max(2);
+            wrap_segment_source_bytes(
+                &line_content,
+                line_start,
+                effective_width,
+                wrap_config.gutter_width,
+                wrap_config.hanging_indent,
+            )
+        };
         let idx = self
             .top_view_line_offset
             .min(seg_bytes.len().saturating_sub(1));
@@ -620,13 +636,7 @@ impl Viewport {
         // wrapped lines above).
         let line = buffer.get_line_number(position);
         let line_start = buffer.line_start_offset(line).unwrap_or(position);
-        let gutter_width = self.gutter_width(buffer);
-        let wrap_config = WrapConfig::new(
-            self.effective_width() as usize,
-            gutter_width,
-            true,
-            self.wrap_indent,
-        );
+        let wrap_config = self.make_wrap_config(buffer);
         let match_row_in_line = if position > line_start {
             let prefix = buffer
                 .get_text_range_mut(line_start, position - line_start)
@@ -694,13 +704,7 @@ impl Viewport {
         }
 
         let buffer_version = buffer.version();
-        let gutter_width = self.gutter_width(buffer);
-        let wrap_config = WrapConfig::new(
-            self.effective_width() as usize,
-            gutter_width,
-            true,
-            self.wrap_indent,
-        );
+        let wrap_config = self.make_wrap_config(buffer);
 
         // We need to move backwards through visual rows
         // Start from current top_byte and count backwards
@@ -782,13 +786,7 @@ impl Viewport {
         }
 
         let buffer_version = buffer.version();
-        let gutter_width = self.gutter_width(buffer);
-        let wrap_config = WrapConfig::new(
-            self.effective_width() as usize,
-            gutter_width,
-            true,
-            self.wrap_indent,
-        );
+        let wrap_config = self.make_wrap_config(buffer);
         let buffer_len = buffer.len();
 
         let mut rows_remaining = visual_rows;
@@ -1655,13 +1653,7 @@ impl Viewport {
         viewport_height: usize,
     ) {
         let buffer_version = buffer.version();
-        let gutter_width = self.gutter_width(buffer);
-        let wrap_config = WrapConfig::new(
-            self.effective_width() as usize,
-            gutter_width,
-            true,
-            self.wrap_indent,
-        );
+        let wrap_config = self.make_wrap_config(buffer);
 
         let mut iter = buffer.line_iterator(proposed_top_byte, 80);
         let mut visual_rows = 0;
@@ -2035,7 +2027,13 @@ impl Viewport {
     }
 
     /// Build the `WrapConfig` used by visibility and scroll helpers.
+    /// In terminal-grid mode (fresh#2649) this is the exact-column grid
+    /// config at `wrap_column` columns; every scroll/visibility helper
+    /// funnels through here so they all share one row model.
     fn make_wrap_config(&self, buffer: &mut Buffer) -> WrapConfig {
+        if self.grid_wrap {
+            return WrapConfig::grid(self.grid_cols());
+        }
         let gutter_width = self.gutter_width(buffer);
         WrapConfig::new(
             self.effective_width() as usize,
@@ -2045,11 +2043,20 @@ impl Viewport {
         )
     }
 
+    /// Grid-wrap column count: the capture-time terminal width stored in
+    /// `wrap_column`, falling back to the viewport width.
+    pub(crate) fn grid_cols(&self) -> usize {
+        self.wrap_column.unwrap_or(self.width as usize).max(1)
+    }
+
     /// Compute the line-wrap layout for `line_text` using `wrap_config`.
     fn compute_line_layout(
         line_text: &str,
         wrap_config: &WrapConfig,
     ) -> Vec<crate::view::ui::view_pipeline::ViewLine> {
+        if let Some(cols) = wrap_config.grid_cols {
+            return crate::view::line_wrap_cache::layout_for_plain_text_grid(line_text, cols, 4);
+        }
         let effective_width = wrap_config
             .first_line_width
             .saturating_add(wrap_config.gutter_width)
@@ -2077,15 +2084,7 @@ impl Viewport {
         effective_offset: usize,
         hidden_ranges: &[(usize, usize)],
     ) -> (bool, bool) {
-        let wrap_config = {
-            let gutter_width = self.gutter_width(buffer);
-            WrapConfig::new(
-                self.effective_width() as usize,
-                gutter_width,
-                true,
-                self.wrap_indent,
-            )
-        };
+        let wrap_config = self.make_wrap_config(buffer);
         let mut iter = buffer.line_iterator(self.top_byte, 80);
         let mut visual_rows: usize = 0;
         let mut cursor_near_top = false;
@@ -2503,13 +2502,7 @@ impl Viewport {
         // Wrap config used for both visual-row counting (lines above the
         // cursor) and the cursor's own intra-line position. Built once.
         let wrap_config = if self.line_wrap_enabled {
-            let gutter_width = self.gutter_width(buffer);
-            Some(WrapConfig::new(
-                self.effective_width() as usize,
-                gutter_width,
-                true,
-                self.wrap_indent,
-            ))
+            Some(self.make_wrap_config(buffer))
         } else {
             None
         };
@@ -2557,17 +2550,7 @@ impl Viewport {
             // Wrap the line via the renderer's word-boundary wrap so the
             // returned screen coordinates match where the renderer draws
             // the cursor.
-            let effective_width = config
-                .first_line_width
-                .saturating_add(config.gutter_width)
-                .max(2);
-            let layout = crate::view::line_wrap_cache::layout_for_plain_text(
-                &line_text,
-                effective_width,
-                config.gutter_width,
-                config.hanging_indent,
-                4,
-            );
+            let layout = Self::compute_line_layout(&line_text, config);
 
             // Find which ViewLine the cursor is in and its visual column.
             let (segment_idx, col_in_segment) =

--- a/crates/fresh-editor/src/view/visual_row_index.rs
+++ b/crates/fresh-editor/src/view/visual_row_index.rs
@@ -38,8 +38,9 @@
 
 use crate::state::EditorState;
 use crate::view::line_wrap_cache::{
-    count_visual_rows_for_text, count_visual_rows_for_text_with_soft_breaks,
-    pipeline_inputs_version, CacheViewMode, LineWrapKey, WrapGeometry,
+    count_visual_rows_for_text, count_visual_rows_for_text_grid,
+    count_visual_rows_for_text_with_soft_breaks, pipeline_inputs_version, CacheViewMode,
+    LineWrapKey, WrapGeometry,
 };
 
 /// All inputs that determine the per-line visual row counts a buffer
@@ -55,6 +56,9 @@ pub struct VisualRowIndexKey {
     pub wrap_column: Option<u32>,
     pub hanging_indent: bool,
     pub line_wrap_enabled: bool,
+    /// Terminal-grid wrap (fresh#2649): per-line counts use exact-column
+    /// breaks at `effective_width` instead of the word-boundary wrap.
+    pub grid_wrap: bool,
 }
 
 impl VisualRowIndexKey {
@@ -74,6 +78,7 @@ impl VisualRowIndexKey {
             wrap_column: self.wrap_column,
             hanging_indent: self.hanging_indent,
             line_wrap_enabled: self.line_wrap_enabled,
+            grid_wrap: self.grid_wrap,
             cursor_sig: 0,
         }
     }
@@ -302,7 +307,11 @@ pub fn ensure_built(state: &mut EditorState, key: &VisualRowIndexKey) {
             };
             let line_content = String::from_utf8_lossy(&bytes);
             let trimmed = line_content.trim_end_matches('\n').trim_end_matches('\r');
-            if line_breaks.is_empty() {
+            if key.grid_wrap {
+                // Terminal-grid wrap: exact-column, allocation-free count
+                // (soft breaks / conceals don't apply to terminal buffers).
+                count_visual_rows_for_text_grid(trimmed, effective_width)
+            } else if line_breaks.is_empty() {
                 count_visual_rows_for_text(trimmed, effective_width, gutter_width, hanging_indent)
             } else {
                 count_visual_rows_for_text_with_soft_breaks(
@@ -359,6 +368,7 @@ pub fn ensure_built_from_geom(state: &mut EditorState, geom: &WrapGeometry) {
         wrap_column: geom.wrap_column,
         hanging_indent: geom.hanging_indent,
         line_wrap_enabled: geom.line_wrap_enabled,
+        grid_wrap: geom.grid_wrap,
     };
     ensure_built(state, &key);
 }
@@ -377,6 +387,7 @@ mod tests {
                 wrap_column: None,
                 hanging_indent: false,
                 line_wrap_enabled: true,
+                grid_wrap: false,
             }),
             prefix_sums: prefix,
             line_starts: starts,

--- a/crates/fresh-editor/tests/e2e/line_wrap_cache_consistency.rs
+++ b/crates/fresh-editor/tests/e2e/line_wrap_cache_consistency.rs
@@ -104,6 +104,7 @@ fn current_keys(harness: &EditorTestHarness, line_start: usize) -> (LineWrapKey,
         wrap_column,
         hanging_indent,
         line_wrap_enabled: true,
+        grid_wrap: false,
         cursor_sig: 0,
     };
     let source = LineWrapKey {

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4627,3 +4627,89 @@ fn test_terminal_double_click_selects_word_and_copy_resumes() {
         "copying the double-click selection should resume the live terminal"
     );
 }
+
+/// fresh#2649: a single logical line taller than the terminal pane.
+///
+/// Symptom 1 (data loss): the leading `XXXXXXXX` of an in-progress wrapped
+/// line scrolls into grid history while its terminator is still on screen, so
+/// it reaches scrollback via NEITHER capture path and is unreachable at any
+/// scroll position. After the fix `append_visible_screen` re-attaches the
+/// in-history head, so scrolling to the top of scrollback reveals it.
+///
+/// Symptom 2 (scroll corruption): terminal scroll-back is non-wrapping, but
+/// the entry path used to flip the scroll-math wrap flag on — disagreeing with
+/// the non-wrapping renderer so scrolling up then back down got stuck. With
+/// the flag consistent, a scroll round-trip returns to a stable bottom frame.
+#[test]
+#[cfg(not(windows))] // Uses a Unix shell to emit the long line
+fn test_bug_2649_tall_line_scrollback_reachable_and_stable() {
+    let mut harness = harness_or_return!(100, 24);
+
+    harness.editor_mut().open_terminal();
+    // Keep the focused split parked in scroll-back instead of snapping back to
+    // the live tail when the shell prompt redraws after our command.
+    harness
+        .editor_mut()
+        .set_terminal_jump_to_end_on_output(false);
+
+    // Emit ONE logical line far taller than the ~22-row pane: 8 'X', then 3600
+    // 'A', then an 8-'Z' tail — all one line, terminated. Each run is built via
+    // `head`/`tr` (shell-portable, no python/seq) specifically so the echoed
+    // COMMAND text contains none of the literal marker strings — only the
+    // program OUTPUT does, keeping the screen assertions unambiguous. The 'Z'
+    // tail stays on the live grid (just above the returning prompt) so the line
+    // is still "in progress" when we enter scroll-back — exactly the case where
+    // the in-history head (`XXXXXXXX`) used to be lost (fresh#2649).
+    harness.editor_mut().active_window_mut().send_terminal_input(
+        b"head -c 8 /dev/zero | tr '\\0' 'X'; head -c 3600 /dev/zero | tr '\\0' 'A'; head -c 8 /dev/zero | tr '\\0' 'Z'; printf '\\n'\n",
+    );
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ZZZZZZZZ"))
+        .unwrap();
+
+    // The leading X's are above the live pane (the line is taller than it).
+    harness.assert_screen_not_contains("XXXXXXXX");
+
+    // Drop into read-only scroll-back and jump to the very top of history.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Symptom 1: the leading XXXXXXXX is now reachable in scroll-back.
+    assert!(
+        harness.screen_to_string().contains("XXXXXXXX"),
+        "leading XXXXXXXX of the tall line must be reachable at the top of \
+         scroll-back (fresh#2649 symptom 1). Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Symptom 2: scrolling to the bottom and back to the top must round-trip
+    // cleanly — terminal scroll-back is non-wrapping and the scroll math now
+    // agrees with the renderer, so this doesn't get stuck or collapse the
+    // content. After the round-trip the head is still reachable at the top.
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    for _ in 0..6 {
+        harness
+            .send_key(KeyCode::PageUp, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("XXXXXXXX"),
+        "after scrolling to the bottom and back up, the tall line's head must \
+         still be reachable — scroll-back must not get stuck or collapse \
+         (fresh#2649 symptom 2). Screen:\n{}",
+        harness.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4636,10 +4636,12 @@ fn test_terminal_double_click_selects_word_and_copy_resumes() {
 /// scroll position. After the fix `append_visible_screen` re-attaches the
 /// in-history head, so scrolling to the top of scrollback reveals it.
 ///
-/// Symptom 2 (scroll corruption): terminal scroll-back is non-wrapping, but
-/// the entry path used to flip the scroll-math wrap flag on — disagreeing with
-/// the non-wrapping renderer so scrolling up then back down got stuck. With
-/// the flag consistent, a scroll round-trip returns to a stable bottom frame.
+/// Symptom 2 (scroll corruption): the scroll math and the renderer used to
+/// disagree about how scroll-back rows lay out, so scrolling up then back
+/// down got stuck. Terminal scroll-back now *grid-wraps* — exact-column rows
+/// at the capture-time PTY width — and the renderer and every scroll path
+/// share that one row model, so a scroll round-trip returns to a stable
+/// bottom frame.
 #[test]
 #[cfg(not(windows))] // Uses a Unix shell to emit the long line
 fn test_bug_2649_tall_line_scrollback_reachable_and_stable() {
@@ -4712,4 +4714,117 @@ fn test_bug_2649_tall_line_scrollback_reachable_and_stable() {
          (fresh#2649 symptom 2). Screen:\n{}",
         harness.screen_to_string()
     );
+}
+
+/// fresh#2775 UX regression: entering scroll-back must not reflow the pane.
+///
+/// The live grid soft-wraps long lines at exact column boundaries (mid-word,
+/// at the PTY width). The scroll-back view now wraps the same way — grid
+/// wrap at the capture-time width — so the transition Ctrl+Space makes is
+/// seamless: every content row of the last live frame reads identically in
+/// the first scroll-back frame. The old behaviour (non-wrapping scroll-back)
+/// collapsed each wrapped line onto one long row with horizontal overflow;
+/// word-boundary wrapping would reshuffle rows around the spaces. Both would
+/// fail the row-for-row comparison below.
+#[test]
+#[cfg(not(windows))] // Uses a Unix shell to emit the long lines
+fn test_bug_2775_scrollback_entry_is_seamless_grid_wrap() {
+    let mut harness = harness_or_return!(100, 24);
+
+    harness.editor_mut().open_terminal();
+    harness
+        .editor_mut()
+        .set_terminal_jump_to_end_on_output(false);
+
+    // Two wrapped logical lines, built so the echoed COMMAND text contains
+    // none of the literal markers (only the OUTPUT does):
+    //  - a solid 8-'Q' + 260-'W' run (no spaces): wraps mid-run at exactly
+    //    the grid width;
+    //  - 40 space-separated words "w00xx " .. "w39xx" (~240 cells): the grid
+    //    splits these MID-WORD at the column boundary, which word-boundary
+    //    wrapping would never do — pinning the grid-wrap semantics.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(
+        b"head -c 8 /dev/zero | tr '\0' 'Q'; head -c 260 /dev/zero | tr '\0' 'W'; printf '\n'\n",
+    );
+    harness
+        .wait_until(|h| h.screen_to_string().contains("WWWWWWWW"))
+        .unwrap();
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"awk 'BEGIN{for(i=0;i<40;i++)printf \"w%02dxx \",i; print \"\"}'\n");
+    harness
+        .wait_until(|h| h.screen_to_string().contains("w39xx"))
+        .unwrap();
+
+    let live = harness.screen_to_string();
+    let live_rows: Vec<&str> = live.lines().collect();
+
+    // Rows carrying our wrapped output (not the echoed commands, which
+    // contain neither marker).
+    let marker_rows: Vec<usize> = live_rows
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains("WWWWWWWW") || l.contains("w07xx") || l.contains("w39xx"))
+        .map(|(i, _)| i)
+        .collect();
+    assert!(
+        marker_rows.len() >= 4,
+        "expected the two long lines to wrap across >= 4 rows on the live \
+         grid, got {} marker rows. Screen:\n{}",
+        marker_rows.len(),
+        live
+    );
+
+    // Enter read-only scroll-back.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(!harness.editor().is_terminal_mode());
+    harness.render().unwrap();
+    let scrollback = harness.screen_to_string();
+    let sb_rows: Vec<&str> = scrollback.lines().collect();
+
+    // Seamless transition: each content row reads the same before and
+    // after, at the same screen row. Only the far-right columns may differ
+    // (the scroll-back view draws a scrollbar over the grid's last column),
+    // so compare the first 96 of the 100 screen columns.
+    let prefix = |l: &str| {
+        l.chars()
+            .take(96)
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+    };
+    for &i in &marker_rows {
+        assert_eq!(
+            prefix(live_rows[i]),
+            prefix(sb_rows[i]),
+            "row {i} reflowed when entering scroll-back.\nLIVE:\n{live}\nSCROLLBACK:\n{scrollback}"
+        );
+    }
+
+    // And the round trip back to the bottom is stable: scroll up, return,
+    // and the same rows must still read identically.
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::PageUp, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    let after = harness.screen_to_string();
+    let after_rows: Vec<&str> = after.lines().collect();
+    for &i in &marker_rows {
+        assert_eq!(
+            prefix(sb_rows[i]),
+            prefix(after_rows[i]),
+            "row {i} unstable after PageUp x3 + Ctrl+End round trip.\nBEFORE:\n{scrollback}\nAFTER:\n{after}"
+        );
+    }
 }

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4823,8 +4823,19 @@ fn test_bug_2775_scrollback_entry_is_seamless_grid_wrap() {
         );
     }
 
-    // And the round trip back to the bottom is stable: scroll up, return,
-    // and the same rows must still read identically.
+    // And the scroll round trip is stable. Establish the bottom frame with
+    // Ctrl+End first — it moves the cursor to EOF, whose trailing empty
+    // line sits one row below the entry frame's last grid row, so the
+    // bottom frame legitimately differs from the entry frame by that one
+    // row (same as in non-wrap mode). The invariant under test is that
+    // scrolling away and returning reproduces the SAME bottom frame —
+    // grid scroll math clamping to a stable maximum instead of drifting
+    // or sticking (fresh#2649 symptom 2).
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    let bottom1 = harness.screen_to_string();
     for _ in 0..3 {
         harness
             .send_key(KeyCode::PageUp, KeyModifiers::NONE)
@@ -4834,13 +4845,18 @@ fn test_bug_2775_scrollback_entry_is_seamless_grid_wrap() {
         .send_key(KeyCode::End, KeyModifiers::CONTROL)
         .unwrap();
     harness.render().unwrap();
-    let after = harness.screen_to_string();
-    let after_rows: Vec<&str> = after.lines().collect();
-    for &i in &marker_rows {
+    let bottom2 = harness.screen_to_string();
+    let b1_rows: Vec<&str> = bottom1.lines().collect();
+    let b2_rows: Vec<&str> = bottom2.lines().collect();
+    assert_eq!(b1_rows.len(), b2_rows.len());
+    // Compare every row except the status bar (it shows the cursor
+    // position, which Ctrl+End pins to EOF both times anyway — but keep
+    // the comparison to content rows for robustness).
+    for i in 0..b1_rows.len().saturating_sub(2) {
         assert_eq!(
-            prefix(sb_rows[i]),
-            prefix(after_rows[i]),
-            "row {i} unstable after PageUp x3 + Ctrl+End round trip.\nBEFORE:\n{scrollback}\nAFTER:\n{after}"
+            prefix(b1_rows[i]),
+            prefix(b2_rows[i]),
+            "row {i} unstable after PageUp x3 + Ctrl+End round trip.\nBEFORE:\n{bottom1}\nAFTER:\n{bottom2}"
         );
     }
 }

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4313,24 +4313,40 @@ fn test_terminal_mode_hides_scrollbar_and_reclaims_width() {
     );
 }
 
-/// Terminal buffers must never line-wrap, even with global line wrap enabled.
-/// Wrapping a large terminal scrollback turns the scrollbar's visual-row index
-/// into an O(all-lines) scan on every frame, freezing the UI (fresh#2608).
+/// Terminal buffers always line-wrap in *grid* mode (fresh#2649): scroll-back
+/// lays out exactly like the live PTY grid — regardless of the global
+/// line-wrap setting — so entering scroll-back never reflows. The fresh#2608
+/// freeze does not return with it: grid row counting is allocation-free and
+/// viewport-local, and the whole-buffer visual-row index keeps its size gates.
 #[test]
-fn test_terminal_buffers_never_line_wrap() {
+fn test_terminal_buffers_always_grid_wrap() {
     let mut harness = harness_or_return!(80, 24);
     harness.editor_mut().open_terminal();
     let term_id = harness.editor().active_buffer();
 
-    // Global line wrap on: a regular buffer would wrap; a terminal must not.
-    harness.editor_mut().config_mut().editor.line_wrap = true;
+    // Regardless of the global setting, terminals resolve to (grid) wrap —
+    // no toggle or override may flip them to word wrap or to non-wrap.
+    for global in [false, true] {
+        harness.editor_mut().config_mut().editor.line_wrap = global;
+        assert!(
+            harness
+                .editor()
+                .active_window()
+                .resolve_line_wrap_for_buffer(term_id),
+            "terminal buffers must resolve to grid line-wrap (global line_wrap={global})"
+        );
+    }
 
+    // The per-frame healer pins the terminal viewport to grid-wrap mode.
+    harness.render().unwrap();
+    let win = harness.editor().active_window();
+    let (mgr, view_states) = win.buffers.splits().unwrap();
+    let vp = &view_states.get(&mgr.active_split()).unwrap().viewport;
     assert!(
-        !harness
-            .editor()
-            .active_window()
-            .resolve_line_wrap_for_buffer(term_id),
-        "terminal buffers must never resolve to line-wrap even when global line wrap is on"
+        vp.line_wrap_enabled && vp.grid_wrap,
+        "terminal viewport must be healed into grid-wrap mode (line_wrap_enabled={}, grid_wrap={})",
+        vp.line_wrap_enabled,
+        vp.grid_wrap
     );
 }
 
@@ -4747,7 +4763,7 @@ fn test_bug_2775_scrollback_entry_is_seamless_grid_wrap() {
         .editor_mut()
         .active_window_mut()
         .send_terminal_input(
-        b"head -c 8 /dev/zero | tr '\0' 'Q'; head -c 260 /dev/zero | tr '\0' 'W'; printf '\n'\n",
+        b"head -c 8 /dev/zero | tr '\\0' 'Q'; head -c 260 /dev/zero | tr '\\0' 'W'; printf '\\n'\n",
     );
     harness
         .wait_until(|h| h.screen_to_string().contains("WWWWWWWW"))


### PR DESCRIPTION
## Problem (#2649)

In the integrated terminal, printing a single logical line taller than the pane (the report used `python3 -c "print('X'*8 + 'A'*3000)"` in a short bottom split) exposed two bugs:

- **Symptom 1 — data loss.** The leading `XXXXXXXX` was unreachable at any scroll position and lost on session save ("Output has no prefix XXXX").
- **Symptom 2 — scroll corruption.** "If user scroll up, it's impossible to scroll down" — scroll-back got stuck / collapsed the output.

An earlier revision of this PR fixed symptom 2 by making scroll-back **non-wrapping** — but that traded the bug for a UX regression: the live grid soft-wraps long lines at the pane width, so entering scroll-back visibly reflowed the whole pane (every wrapped line collapsed onto one long row with horizontal overflow). This revision fixes both symptoms **and** makes the live→scroll-back transition seamless.

## Root cause

**Symptom 1.** A tall line's earlier wrapped rows scroll into the alacritty grid *history* while its terminator is still on screen. `flush_new_scrollback` deliberately never commits such an *in-progress* line (the backing file must end on a logical-line boundary), and `append_visible_screen` only emitted the *visible* rows — so those in-history rows reached scroll-back via **neither** capture path.

**Symptom 2.** The scroll math and the renderer disagreed about how scroll-back rows lay out, so scrolling up then back down got stuck. The deeper issue: the editor's only soft wrap was *word-boundary* wrap (gutter budget, hanging indent, EOL-cursor column reservation) — a layout that can never match the PTY grid's *exact-column* wrap, so no assignment of the old flags could make the view seamless **and** consistent.

## Fix

1. **Complete capture** (as before). `append_visible_screen` detects when the first visible row continues a line whose head is in grid history (`row_wraps(Line(-1))`), walks backward to the logical-line start, and *prepends* those rows so the **full** line reaches the backing file. It now returns the prepended head's row *and byte* counts (`PrependedHead`), used for anchoring (below). Session save uses the same method.

2. **Grid-wrapped scroll-back (new).** Scroll-back soft-wraps in a new *grid* mode that reproduces the live grid exactly: rows break at exact column boundaries every `cols` cells (the capture-time PTY width), mid-word, no gutter, no hanging indent, ANSI-aware (the backing file's SGR codes are zero-width). Since the backing file stores full logical lines, re-wrapping them at the grid width yields cell-for-cell the same rows the live grid showed — entering and leaving scroll-back doesn't move a single character. (This is the same model xterm.js/alacritty/kitty use internally: physical rows are exact-column re-chunks of logical lines.)

3. **One row model everywhere (keeps symptom 2 fixed).** A single grapheme walk defines grid row boundaries; the renderer (`apply_grid_wrapping_transform`), all scroll math (`count_visual_rows_for_text_grid` via `WrapConfig::grid` / `Viewport::grid_wrap`), the scrollbar (`VisualRowIndexKey.grid_wrap`), PageUp/Down byte mapping (`grid_segment_source_bytes`), and scroll-back mouse clicks (`terminal_grid_byte_at`) all reduce to it. A unit test pins the transform/count/segment three-way agreement, so renderer-vs-scroll-math drift — the original cause of stuck scrolling — is structurally impossible.

4. **Anchoring.** `sync_terminal_to_buffer` opens the view `PrependedHead::rows` visual rows into the first appended logical line, cursor on the first visible cell — the exit frame lands exactly on the live grid's row 0 and a tall in-progress line's head sits just above, reachable by scrolling up.

### Performance (#2608/#2610) — why wrapping is safe now

The old freeze came from word-wrapping the whole buffer per frame. Grid mode avoids that structurally:
- grid row counting is a single allocation-free pass (no wrap-transform allocations);
- every scroll path (wheel, PageUp/Down, Ctrl+Home/End, ensure-visible) is viewport-local — it only ever counts rows for lines at/near the viewport;
- the only whole-buffer structure, the scrollbar's `VisualRowIndex`, keeps its existing #2610 gates (exact wrapped-row scrollbar only ≤5k lines and ≤2MB; logical-line approximation beyond) and is keyed on buffer version + geometry — the scroll-back snapshot is immutable while parked, so it builds at most once per visit;
- `resolve_line_wrap_for_buffer` now hard-returns **true** (grid mode) for terminal buffers, and the per-frame healer `enforce_terminal_grid_wrap` (né `enforce_terminal_no_wrap`) keeps every terminal viewport in grid mode regardless of which generic path (global wrap toggle, restore, tab drag) touched it.

## Live verification (tmux, real PTY)

Scenario: an exact-column line (`8×Q + 260×W`), a spaced-words line (40 × `wNNxx`), and a tall line (`8×X + A-run + 8×Z`), then Ctrl+Space:

- **Before:** the scroll-back frame differed from the live frame on every content row — each wrapped line collapsed to one row (`XXXXXXXXAAAA…`).
- **After:** `diff` of live vs scroll-back content rows is **empty**; the words line stays split mid-word at the column boundary exactly like the grid; Ctrl+Home reaches `XXXXXXXX` (symptom 1); PageUp×6 → Ctrl+End returns to the identical bottom frame (symptom 2); Ctrl+Space resumes an identical live frame.

## Tests

- `term.rs` unit tests: full character count of an in-progress tall line captured; `PrependedHead` row/byte counts checked; no-op case when the head is on screen.
- `line_wrap_cache` unit tests: grid counting basics (exact fit, mid-word split, zero-width ANSI, wide chars, boundary-straddling wide char) and the transform/count/segment agreement invariant.
- `tests/e2e/terminal.rs`: the existing #2649 test (head reachable at top of scroll-back; scroll round-trip stays reachable) plus a new regression test asserting **row-for-row equality** of the live frame and the first scroll-back frame, and frame stability across a PageUp/Ctrl+End round trip.

`cargo fmt -- --check` and clippy are clean (remaining clippy warnings are pre-existing, verified against the base tree); the full unit suite (3037) passes, including the terminal (74), viewport, and line-wrap suites.

Closes #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)