### PR TITLE
fix(live_diff): stop event handlers racing the recompute reference cache

### DIFF
--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -149,6 +149,22 @@ interface BufferDiffState {
   hunks: Hunk[];
   /** True while a recompute is in flight. */
   updating: boolean;
+  /**
+   * Set when a recompute is requested while one is already in flight for
+   * this buffer. The running pass re-runs once more when it finishes so the
+   * request isn't lost (a dropped post-commit refresh left a stale diff on
+   * screen forever — the #2503 `focus_gained`/reflog path).
+   */
+  rerunRequested: boolean;
+  /**
+   * Request to drop the cached git reference and re-fetch it on the next
+   * recompute pass (a HEAD move: commit, checkout, reset, merge). Consumed
+   * *inside* the recompute mutex so a concurrent pass never observes a
+   * half-cleared reference — mutating `oldText`/`oldLines` directly from an
+   * event handler raced an in-flight recompute and rendered a bogus
+   * "everything added" diff.
+   */
+  reloadRef: boolean;
   /** Token bumped on every scheduleRecompute; mismatched tokens are stale. */
   pendingToken: number;
   /**
@@ -974,10 +990,44 @@ async function recompute(bufferId: number): Promise<void> {
   const state = states.get(bufferId);
   if (!state) return;
   if (!isEnabledForBuffer(state)) return;
-  if (state.updating) return;
+  // Serialize recomputes per buffer. A recompute suspends at its `await`
+  // points (git reference load, buffer-text fetch). A second trigger that
+  // arrives meanwhile must neither start a concurrent pass (it would race on
+  // the shared `oldText`/`oldLines` reference and render a bogus "everything
+  // added" diff) nor be silently dropped (a dropped post-commit refresh left
+  // the stale diff on screen until the external test timeout — #2503's
+  // `focus_gained`/reflog path). Coalesce: mark that another pass is needed
+  // and let the in-flight one run it before it releases the mutex.
+  if (state.updating) {
+    state.rerunRequested = true;
+    return;
+  }
 
   state.updating = true;
   try {
+    do {
+      state.rerunRequested = false;
+      // Consume a reference-reload request *inside* the mutex so no other
+      // pass can observe a half-cleared reference. Event handlers that need
+      // the cached git reference re-fetched (a HEAD move) set `reloadRef`
+      // rather than mutating `oldText`/`oldLines` directly. `lastHunksKey`
+      // is intentionally kept so an unchanged diff still suppresses a no-op
+      // repaint (no flicker on every window focus).
+      if (state.reloadRef) {
+        state.reloadRef = false;
+        state.oldText = null;
+        state.oldLines = [];
+        state.lastBufferText = null;
+      }
+      await onePass();
+    } while (state.rerunRequested);
+  } finally {
+    state.updating = false;
+  }
+
+  // A single diff pass. Early `return`s end this pass only; the wrapper's
+  // `do…while` still honors any `rerunRequested` recorded meanwhile.
+  async function onePass(): Promise<void> {
     if (state.oldText === null) {
       const ref = await loadReference(state);
       if (ref === null) {
@@ -1062,8 +1112,6 @@ async function recompute(bufferId: number): Promise<void> {
     renderHunks(state, newLines);
 
     editor.setViewState(bufferId, "live_diff_hunks", hunks);
-  } finally {
-    state.updating = false;
   }
 }
 
@@ -1098,6 +1146,8 @@ function ensureState(bufferId: number): BufferDiffState | null {
     oldLines: [],
     hunks: [],
     updating: false,
+    rerunRequested: false,
+    reloadRef: false,
     pendingToken: 0,
     override: getStoredOverride(bufferId),
     lastBufferText: null,
@@ -1337,15 +1387,15 @@ function refreshGitReferences(): void {
   for (const state of states.values()) {
     if (state.mode.kind === "disk") continue;
     if (!isEnabledForBuffer(state)) continue;
-    // Re-fetch the reference (HEAD may have moved) but keep `lastHunksKey`:
-    // this path fires on every window focus, so when the diff is in fact
-    // unchanged the recompute's hunk-equality guard suppresses the repaint
-    // and there's no flicker. `lastBufferText` must still be cleared so the
-    // "same buffer text" early-return doesn't skip recomputing against the
-    // new reference.
-    state.oldText = null;
-    state.oldLines = [];
-    state.lastBufferText = null;
+    // Request a reference re-fetch (HEAD may have moved) via the flag the
+    // recompute consumes under its mutex — NOT by mutating `oldText`/
+    // `oldLines` here, which races an in-flight recompute for this buffer
+    // and made it diff the new buffer against an emptied reference (every
+    // line shown as added, and never cleared). `reloadRef` keeps
+    // `lastHunksKey`, so when the diff is in fact unchanged the recompute's
+    // hunk-equality guard still suppresses the repaint and there's no
+    // flicker on every window focus.
+    state.reloadRef = true;
     recompute(state.bufferId).catch((e) => editor.error(`live-diff: ${e}`));
   }
 }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -7097,6 +7097,21 @@ function formIsSubmittable(): boolean {
   if (!form) return false;
   switch (form.backend) {
     case "local":
+      // Mirror `captureCreateSpec`'s fallback chain EXACTLY: a local
+      // workspace can always be created against `localProjectDefault()`
+      // (the cwd) even before the async canonical-root probe
+      // (`probeProjectPathDefaults`) has filled `defaultProjectPath`.
+      // Omitting that same fallback here — while capture uses it — let a
+      // Ctrl+Enter / Create that arrived during the probe window fail this
+      // gate and be silently dropped (`if (!formIsSubmittable()) return`).
+      // The dialog then never advanced and an unbounded `wait_until` hung
+      // until the CI timeout; the probe's `git` round-trip is slow enough
+      // under load (macOS CI) to widen that window into the common case.
+      return !!(
+        form.projectPath.value.trim() ||
+        form.defaultProjectPath ||
+        localProjectDefault()
+      );
     case "devcontainer":
       return !!(form.projectPath.value.trim() || form.defaultProjectPath);
     case "ssh":

--- a/scripts/repro_plugin_hang.sh
+++ b/scripts/repro_plugin_hang.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Reproduce the intermittent e2e::plugins hang under CPU contention.
+#
+# Background: the macOS CI runners intermittently time out (180s) on a handful
+# of e2e::plugins::* tests. They HANG (they don't assertion-fail) and pass on
+# re-run. The root cause is a plugin whose synchronous UI action depends on an
+# async `git` round-trip that isn't ready yet; the async window widens under CPU
+# contention, so the bug is rare on a fast idle box and common on the slower,
+# parallel CI runners. This script recreates that pressure locally.
+#
+# It runs each target test in its OWN process (mirroring `cargo nextest`, which
+# is process-per-test), N copies in parallel, under a pile of CPU hogs, with a
+# per-test wall-clock budget well above the <2s norm. On a timeout it captures a
+# gdb backtrace of every thread and the child process tree before killing the
+# hung process, so you can see WHERE it is stuck.
+#
+# Usage:
+#   cargo test --no-run --all-features --test e2e_tests   # build first
+#   scripts/repro_plugin_hang.sh                          # defaults below
+#   TESTS="e2e::plugins::live_diff::test_live_diff_clears_after_commit" \
+#     ITERS=15 PAR=8 STRESS=8 TIMEOUT=30 scripts/repro_plugin_hang.sh
+#
+# Env knobs: BIN, TESTS (space-separated), ITERS, PAR, STRESS, TIMEOUT, OUT.
+set -u
+
+# Auto-detect the most recent e2e_tests test binary unless BIN is given.
+BIN="${BIN:-$(ls -t target/debug/deps/e2e_tests-* 2>/dev/null | grep -v '\.d$' | head -1)}"
+if [ -z "${BIN:-}" ] || [ ! -x "$BIN" ]; then
+  echo "e2e_tests binary not found; build it first:" >&2
+  echo "  cargo test --no-run --all-features --test e2e_tests" >&2
+  exit 1
+fi
+
+TIMEOUT="${TIMEOUT:-45}"   # per-test seconds; normal run is <2s, CI kill is 180s
+ITERS="${ITERS:-40}"
+PAR="${PAR:-6}"            # concurrent copies per test (oversubscribe the cores)
+STRESS="${STRESS:-8}"      # background CPU-hog workers
+OUT="${OUT:-$(mktemp -d "${TMPDIR:-/tmp}/fresh-plugin-hang.XXXXXX")}"
+mkdir -p "$OUT"
+echo "Artifacts (screens, stacks, process trees) -> $OUT"
+
+# Default to the three known offenders; override with $TESTS.
+if [ -n "${TESTS:-}" ]; then
+  read -r -a TESTS_ARR <<< "$TESTS"
+else
+  TESTS_ARR=(
+    "e2e::plugins::live_diff::test_live_diff_clears_after_commit"
+    "e2e::plugins::orchestrator_new_dialog::ctrl_enter_submits_from_a_text_field"
+    "e2e::plugins::review_diff_line_staging::test_review_visual_discard_single_added_line"
+  )
+fi
+
+echo "Starting $STRESS CPU-hog workers..."
+HOGS=()
+for _ in $(seq 1 "$STRESS"); do
+  ( while :; do : ; done ) &
+  HOGS+=($!)
+done
+cleanup() { kill "${HOGS[@]}" 2>/dev/null; }
+trap cleanup EXIT
+
+run_one() {
+  local test="$1" tag="$2"
+  local log="$OUT/${tag}.log"
+  # --nocapture so wait_until's periodic screen dump reaches the log.
+  "$BIN" --test-threads=1 --nocapture --exact "$test" >"$log" 2>&1 &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$TIMEOUT" ]; then
+      echo "!!! HANG: $test (pid $pid) after ${TIMEOUT}s -> capturing"
+      ps -o pid,ppid,stat,wchan:24,comm,args --ppid "$pid" \
+        >"$OUT/${tag}.children.txt" 2>&1
+      if command -v gdb >/dev/null 2>&1; then
+        gdb -p "$pid" -batch -ex "set pagination off" \
+          -ex "thread apply all bt" >"$OUT/${tag}.gdb.txt" 2>&1
+      fi
+      kill -9 "$pid" 2>/dev/null
+      echo "HANG:$test:$tag" >>"$OUT/hangs.txt"
+      return 99
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+  return $?
+}
+
+fail=0
+for iter in $(seq 1 "$ITERS"); do
+  pids=()
+  slot=0
+  for t in "${TESTS_ARR[@]}"; do
+    for _ in $(seq 1 "$PAR"); do
+      run_one "$t" "iter${iter}_slot${slot}" &
+      pids+=($!)
+      slot=$((slot + 1))
+    done
+  done
+  for p in "${pids[@]}"; do
+    wait "$p" || { rc=$?; [ "$rc" = 99 ] && fail=1; }
+  done
+  echo "iter $iter done (hangs so far: $( [ -f "$OUT/hangs.txt" ] && wc -l < "$OUT/hangs.txt" || echo 0 ))"
+  [ "$fail" = 1 ] && { echo "Stopping after first hang batch (see $OUT)."; break; }
+done
+
+echo "=== DONE. Hangs: ==="
+[ -f "$OUT/hangs.txt" ] && cat "$OUT/hangs.txt" || echo "(none)"


### PR DESCRIPTION
`focus_gained` / reflog `path_changed` called `refreshGitReferences()`, which
cleared `state.oldText` / `state.oldLines` directly while a concurrent
`recompute()` for the same buffer was suspended at `await editor.getBufferText`.
The resumed pass then diffed the buffer against an emptied reference and
rendered every line as added; meanwhile the refresh's own `recompute()` was
dropped by the `if (state.updating) return` guard, so nothing recomputed against
the new HEAD. The stale all-`+` diff never cleared, so the e2e wait hung until
the external CI timeout — intermittently, and mostly on the slower, parallel
macOS runners where the git round-trips that widen the race are slower.

Serialize recomputes per buffer: a request that arrives while one is in flight
sets `rerunRequested` and the running pass loops until it's clear, so the
refresh is never dropped. Reference invalidation now goes through a `reloadRef`
flag consumed inside the recompute mutex, so no concurrent pass can observe a
half-cleared reference.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MJkPcExksbzBTUu7j3GRTb