### PR TITLE
fix(dock): load remote session buffers off the editor loop, not on it

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -97,6 +97,12 @@ impl Editor {
         // reconnect notification and posts `RemoteReconnected`.
         self.ensure_remote_reconnect_forwarders();
 
+        // Kick off off-loop content loads for any freshly-restored remote
+        // placeholder buffers (idempotent; drains each window's queue). This is
+        // what makes a dived-into remote session's files fill in without ever
+        // reading them on the editor loop.
+        self.drive_pending_content_loads();
+
         let Some(bridge) = &self.async_bridge else {
             return false;
         };
@@ -411,6 +417,13 @@ impl Editor {
                 }
                 AsyncMessage::RemoteReconnected { connection_id } => {
                     self.handle_remote_reconnected(connection_id);
+                }
+                AsyncMessage::RemoteBufferContentLoaded {
+                    window_id,
+                    buffer_id,
+                    content,
+                } => {
+                    self.handle_remote_buffer_content_loaded(window_id, buffer_id, content);
                 }
                 AsyncMessage::RemoteAttachFailed {
                     error,
@@ -920,6 +933,97 @@ impl Editor {
     /// channel id and a fresh forwarder; the old forwarder parks forever on a
     /// notify that can no longer fire (its channel is dropped) — a single idle
     /// task per rebuild, which is rare. Cleaning those up is a future refinement.
+    /// Start off-loop content reads for any window's freshly-restored remote
+    /// placeholder buffers, delivering each via `RemoteBufferContentLoaded`.
+    /// Idempotent: it drains each window's `pending_content_load`, so a buffer
+    /// is scheduled exactly once. Runs the blocking `read_file` on a plain
+    /// thread (never a runtime worker — the remote read uses `block_on`), so a
+    /// slow link never touches the editor loop.
+    fn drive_pending_content_loads(&mut self) {
+        if self.async_bridge.is_none() {
+            return;
+        }
+        type Job = (
+            fresh_core::WindowId,
+            fresh_core::BufferId,
+            std::path::PathBuf,
+            std::sync::Arc<dyn crate::model::filesystem::FileSystem + Send + Sync>,
+        );
+        let mut jobs: Vec<Job> = Vec::new();
+        for (wid, window) in self.windows.iter_mut() {
+            if window.pending_content_load.is_empty() {
+                continue;
+            }
+            let fs = std::sync::Arc::clone(&window.authority().filesystem);
+            for (bid, path) in window.pending_content_load.drain(..) {
+                jobs.push((*wid, bid, path, std::sync::Arc::clone(&fs)));
+            }
+        }
+        if jobs.is_empty() {
+            return;
+        }
+        let sender = self.async_bridge.as_ref().unwrap().sender();
+        for (window_id, buffer_id, path, fs) in jobs {
+            let sender = sender.clone();
+            std::thread::Builder::new()
+                .name("remote-buffer-load".to_string())
+                .spawn(move || {
+                    let content = fs.read_file(&path).map_err(|e| e.to_string());
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = sender.send(AsyncMessage::RemoteBufferContentLoaded {
+                        window_id,
+                        buffer_id,
+                        content,
+                    });
+                })
+                .ok();
+        }
+    }
+
+    /// Install content read off-loop into a remote session's placeholder buffer
+    /// (see `drive_pending_content_loads`). Skips a buffer that has since closed
+    /// or that the user already edited, so a late load never clobbers input.
+    fn handle_remote_buffer_content_loaded(
+        &mut self,
+        window_id: fresh_core::WindowId,
+        buffer_id: fresh_core::BufferId,
+        content: Result<Vec<u8>, String>,
+    ) {
+        let content = match content {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("remote buffer {buffer_id:?} content load failed: {e}");
+                return;
+            }
+        };
+        let Some(window) = self.windows.get_mut(&window_id) else {
+            return;
+        };
+        let (modified, path) = {
+            let Some(state) = window.buffers.get(&buffer_id) else {
+                return;
+            };
+            (
+                state.buffer.is_modified(),
+                state.buffer.file_path().map(|p| p.to_path_buf()),
+            )
+        };
+        if modified {
+            return;
+        }
+        let Some(path) = path else {
+            return;
+        };
+        // Build the buffer from the off-loop content, then run the *same*
+        // finalize the synchronous open path runs — so an async-filled remote
+        // buffer is identical to a normally-opened one (LSP didOpen, read-only,
+        // editorconfig, metadata). The only difference is the content arrived
+        // from a background read. For a remote session the path is already the
+        // canonical remote path, so it doubles as display / canonical here.
+        let state = window.build_workspace_file_state(&path, Some(content));
+        window.finalize_file_buffer(buffer_id, state, &path, &path, &path, true);
+    }
+
     fn ensure_remote_reconnect_forwarders(&mut self) {
         let (Some(runtime), Some(bridge)) =
             (self.tokio_runtime.as_ref(), self.async_bridge.as_ref())

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -921,6 +921,116 @@ impl crate::app::window::Window {
         path.starts_with(&canonical_data) && !path.starts_with(&canonical_root)
     }
 
+    /// Install a freshly-built file buffer into this window and apply every
+    /// open-time side effect: binary detection + read-only, `.editorconfig` /
+    /// per-language settings, file metadata, and the LSP `didOpen`.
+    ///
+    /// Shared by the synchronous open path ([`Self::open_file_no_focus_inner`])
+    /// and the asynchronous remote-content fill
+    /// ([`crate::app::Editor::handle_remote_buffer_content_loaded`]) so a buffer
+    /// opened either way is byte-for-byte the same — same LSP registration,
+    /// read-only handling, editorconfig and metadata. The only difference is
+    /// *where the content was read* (inline vs. a background thread); everything
+    /// after that is this one routine. The caller owns split placement.
+    pub(crate) fn finalize_file_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        mut state: EditorState,
+        path: &Path,
+        display_path: &Path,
+        canonical_path: &Path,
+        file_exists: bool,
+    ) {
+        // Check if the buffer contains binary content
+        let is_binary = state.buffer.is_binary();
+        if is_binary {
+            // Make binary buffers read-only
+            state.editing_disabled = true;
+            tracing::info!("Detected binary file: {}", path.display());
+        }
+
+        // Internal app artifacts under the data dir (e.g. terminal scrollback
+        // backing files surfaced by Universal Search) are things the user is
+        // inspecting, not editing — open them read-only so an accidental
+        // keystroke can't corrupt persisted state. Files inside the window's
+        // own root are excluded so session working trees that live under the
+        // data dir stay editable.
+        if self.is_internal_data_artifact(canonical_path) {
+            state.editing_disabled = true;
+        }
+
+        // Apply the global + per-language buffer settings (whitespace
+        // visibility, tabs, auto-close/surround, guides, …).
+        state.apply_buffer_config(&self.resources.config);
+
+        // Apply `.editorconfig` overrides. Project-level indentation settings
+        // take precedence over the language/global defaults resolved above.
+        // Resolved through the FileSystem abstraction so it also works on
+        // remote hosts; matched against the canonical on-disk path.
+        let editorconfig = crate::services::editorconfig::resolve_for_file(
+            self.authority().filesystem.as_ref(),
+            canonical_path,
+        );
+        if let Some(use_tabs) = editorconfig.use_tabs {
+            state.buffer_settings.use_tabs = use_tabs;
+        }
+        if let Some(tab_size) = editorconfig.tab_size {
+            state.buffer_settings.tab_size = tab_size;
+        }
+
+        // Apply line_numbers default from config
+        state
+            .margins
+            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
+        state.reference_highlight_overlay.enabled =
+            self.resources.config.editor.highlight_occurrences;
+
+        self.buffers.insert(buffer_id, state);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+
+        // Create metadata for this buffer
+        let mut metadata = crate::app::types::BufferMetadata::with_file(
+            path.to_path_buf(),
+            display_path,
+            &self.root,
+            self.authority().path_translation.as_ref(),
+            self.resources.config.editor.auto_read_only,
+        );
+
+        // Mark binary files in metadata and disable LSP
+        if is_binary {
+            metadata.binary = true;
+            metadata.read_only = true;
+            metadata.disable_lsp(t!("buffer.binary_file").to_string());
+        }
+
+        // Check if the file is read-only on disk (filesystem permissions),
+        // unless the user opted out of automatic read-only via config
+        if file_exists
+            && !metadata.read_only
+            && self.resources.config.editor.auto_read_only
+            && !self.authority().filesystem.is_writable(path)
+        {
+            metadata.read_only = true;
+        }
+
+        // Mark read-only files (library, binary, or filesystem-readonly) as editing-disabled
+        if metadata.read_only {
+            if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                state.editing_disabled = true;
+            }
+        }
+
+        // Notify LSP about the newly opened file (skip for binary files)
+        if !is_binary {
+            self.notify_lsp_file_opened(path, buffer_id, &mut metadata);
+        }
+
+        // Store metadata for this buffer
+        self.buffer_metadata.insert(buffer_id, metadata);
+    }
+
     fn open_file_no_focus_inner(
         &mut self,
         path: &Path,
@@ -1047,7 +1157,7 @@ impl crate::app::window::Window {
             path.extension(),
             self.resources.grammar_registry.catalog().len(),
         );
-        let mut state = if file_exists {
+        let state = if file_exists {
             // Load from canonical path (for I/O and dedup), detect language from
             // display path (for glob pattern matching against user-visible names).
             let buffer = crate::model::buffer::Buffer::load_from_file_for_editing(
@@ -1087,96 +1197,17 @@ impl crate::app::window::Window {
         };
         // Note: line_wrap_enabled is set on SplitViewState.viewport when the split is created
 
-        // Check if the buffer contains binary content
-        let is_binary = state.buffer.is_binary();
-        if is_binary {
-            // Make binary buffers read-only
-            state.editing_disabled = true;
-            tracing::info!("Detected binary file: {}", path.display());
-        }
-
-        // Internal app artifacts under the data dir (e.g. terminal scrollback
-        // backing files surfaced by Universal Search) are things the user is
-        // inspecting, not editing — open them read-only so an accidental
-        // keystroke can't corrupt persisted state. Files inside the window's
-        // own root are excluded so session working trees that live under the
-        // data dir stay editable.
-        if self.is_internal_data_artifact(&canonical_path) {
-            state.editing_disabled = true;
-        }
-
-        // Apply the global + per-language buffer settings (whitespace
-        // visibility, tabs, auto-close/surround, guides, …).
-        // Uses the buffer's stored language (already set by
-        // from_file_with_languages).
-        state.apply_buffer_config(&self.resources.config);
-
-        // Apply `.editorconfig` overrides. Project-level indentation settings
-        // take precedence over the language/global defaults resolved above.
-        // Resolved through the FileSystem abstraction so it also works on
-        // remote hosts; matched against the canonical on-disk path.
-        let editorconfig = crate::services::editorconfig::resolve_for_file(
-            self.authority().filesystem.as_ref(),
-            &canonical_path,
-        );
-        if let Some(use_tabs) = editorconfig.use_tabs {
-            state.buffer_settings.use_tabs = use_tabs;
-        }
-        if let Some(tab_size) = editorconfig.tab_size {
-            state.buffer_settings.tab_size = tab_size;
-        }
-
-        // Apply line_numbers default from config
-        state
-            .margins
-            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
-        state.reference_highlight_overlay.enabled =
-            self.resources.config.editor.highlight_occurrences;
-
-        self.buffers.insert(buffer_id, state);
-        self.event_logs
-            .insert(buffer_id, crate::model::event::EventLog::new());
-
-        // Create metadata for this buffer
-        let mut metadata = crate::app::types::BufferMetadata::with_file(
-            path.to_path_buf(),
+        // Install the built buffer + all its side effects (binary/read-only,
+        // per-language + editorconfig settings, metadata, LSP didOpen). Shared
+        // with the async remote-content fill so both open paths are identical.
+        self.finalize_file_buffer(
+            buffer_id,
+            state,
+            path,
             &display_path,
-            &self.root,
-            self.authority().path_translation.as_ref(),
-            self.resources.config.editor.auto_read_only,
+            &canonical_path,
+            file_exists,
         );
-
-        // Mark binary files in metadata and disable LSP
-        if is_binary {
-            metadata.binary = true;
-            metadata.read_only = true;
-            metadata.disable_lsp(t!("buffer.binary_file").to_string());
-        }
-
-        // Check if the file is read-only on disk (filesystem permissions),
-        // unless the user opted out of automatic read-only via config
-        if file_exists
-            && !metadata.read_only
-            && self.resources.config.editor.auto_read_only
-            && !self.authority().filesystem.is_writable(path)
-        {
-            metadata.read_only = true;
-        }
-
-        // Mark read-only files (library, binary, or filesystem-readonly) as editing-disabled
-        if metadata.read_only {
-            if let Some(state) = self.buffers.get_mut(&buffer_id) {
-                state.editing_disabled = true;
-            }
-        }
-
-        // Notify LSP about the newly opened file (skip for binary files)
-        if !is_binary {
-            self.notify_lsp_file_opened(path, buffer_id, &mut metadata);
-        }
-
-        // Store metadata for this buffer
-        self.buffer_metadata.insert(buffer_id, metadata);
 
         // Add buffer to the preferred split's tabs (but don't switch to it)
         // Uses preferred_split_for_file() to avoid opening in labeled splits (e.g., sidebars)

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -261,6 +261,13 @@ pub struct Window {
     /// drops the buffer and its log together.
     pub event_logs: HashMap<BufferId, crate::model::event::EventLog>,
 
+    /// File buffers restored as **empty placeholders** because this window's
+    /// authority is remote: reading their content synchronously during restore
+    /// would freeze the single-threaded editor loop over a slow link. The editor
+    /// drains this each tick, reads each file off-loop, and fills the buffer via
+    /// `AsyncMessage::RemoteBufferContentLoaded`. Always empty for local windows.
+    pub(crate) pending_content_load: Vec<(BufferId, PathBuf)>,
+
     /// Status message (shown in this window's status bar). Per-window
     /// because each window has its own context — a save in window A
     /// shouldn't flash a status message into window B's UI. Only the
@@ -2020,6 +2027,7 @@ impl Window {
             panel_ids: HashMap::new(),
             buffers: WindowBuffers::new(),
             buffer_metadata: HashMap::new(),
+            pending_content_load: Vec::new(),
             terminal_manager: crate::services::terminal::TerminalManager::new(id),
             terminal_buffers: HashMap::new(),
             terminal_backing_files: HashMap::new(),

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1598,12 +1598,88 @@ impl crate::app::window::Window {
         }
     }
 
+    /// Build the `EditorState` for a restored workspace file. `content` is the
+    /// file's bytes when known (a fill), or `None` for an empty placeholder (a
+    /// remote restore, before its content streams in off-loop). Language and
+    /// buffer config are applied either way, so a placeholder already carries
+    /// the right gutter / title / language and the later fill just swaps in the
+    /// text.
+    pub(crate) fn build_workspace_file_state(
+        &self,
+        path: &Path,
+        content: Option<Vec<u8>>,
+    ) -> EditorState {
+        let fs = std::sync::Arc::clone(&self.authority().filesystem);
+        let threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
+        let buffer = match content {
+            Some(bytes) => {
+                let mut b = crate::model::buffer::Buffer::from_bytes(bytes, fs);
+                b.set_file_path(path.to_path_buf());
+                b
+            }
+            None => crate::model::buffer::Buffer::new_with_path(threshold, fs, path.to_path_buf()),
+        };
+        let first_line = buffer.first_line_lossy();
+        let detected =
+            crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
+                path,
+                first_line.as_deref(),
+                &self.resources.grammar_registry,
+                &self.resources.config.languages,
+                self.resources.config.default_language.as_deref(),
+            );
+        let mut state = EditorState::from_buffer_with_language(buffer, detected);
+        state
+            .margins
+            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
+        state.apply_buffer_config(&self.resources.config);
+        state
+    }
+
+    /// Install an empty placeholder buffer for `abs_path` and queue its content
+    /// to be read off-loop (see [`crate::app::window::Window::pending_content_load`]).
+    /// Returns the new buffer id so the split layout can reference it at once.
+    fn install_remote_placeholder(&mut self, abs_path: &Path) -> BufferId {
+        let buffer_id = self.alloc_buffer_id();
+        let state = self.build_workspace_file_state(abs_path, None);
+        self.buffers.insert(buffer_id, state);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+        self.buffer_metadata
+            .insert(buffer_id, crate::app::types::BufferMetadata::new());
+        self.pending_content_load
+            .push((buffer_id, abs_path.to_path_buf()));
+        buffer_id
+    }
+
     /// Open every file referenced by the saved split states, returning a map
     /// from relative (or absolute) path to the new `BufferId`.
     fn open_workspace_files(
         &mut self,
         split_states: &HashMap<usize, SerializedSplitViewState>,
     ) -> HashMap<PathBuf, BufferId> {
+        // Remote sessions: never *read* persisted file buffers here. These reads
+        // run synchronously on the single-threaded editor loop, so over a slow /
+        // high-latency link they freeze the whole editor while a dived-into
+        // session materializes — the orchestrator-dock freeze. Instead restore
+        // each file as an empty placeholder (no I/O) so the layout, tabs and
+        // titles come up instantly; the editor then loads their content off-loop
+        // and fills them in (see `Editor::drive_pending_content_loads`).
+        // Terminals restore separately, unaffected.
+        if self
+            .authority()
+            .filesystem
+            .remote_connection_info()
+            .is_some()
+        {
+            let mut path_to_buffer: HashMap<PathBuf, BufferId> = HashMap::new();
+            for rel_path in collect_file_paths_from_states(split_states) {
+                let abs_path = self.root.join(&rel_path);
+                let buffer_id = self.install_remote_placeholder(&abs_path);
+                path_to_buffer.insert(rel_path, buffer_id);
+            }
+            return path_to_buffer;
+        }
         let file_paths = collect_file_paths_from_states(split_states);
         tracing::debug!(
             "Workspace has {} files to restore: {:?}",
@@ -1641,6 +1717,21 @@ impl crate::app::window::Window {
         path_to_buffer: &mut HashMap<PathBuf, BufferId>,
     ) {
         if external_files.is_empty() {
+            return;
+        }
+        // Same rationale as `open_workspace_files`: don't read remote files on
+        // the editor loop during restore. Restore each as an empty placeholder
+        // and let the content load off-loop.
+        if self
+            .authority()
+            .filesystem
+            .remote_connection_info()
+            .is_some()
+        {
+            for abs_path in external_files {
+                let buffer_id = self.install_remote_placeholder(abs_path);
+                path_to_buffer.insert(abs_path.clone(), buffer_id);
+            }
             return;
         }
         tracing::debug!(

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -272,6 +272,13 @@ impl TextBuffer {
         buffer
     }
 
+    /// Associate this buffer with `path` (title, dedup, save target). Used when
+    /// building a buffer from in-memory bytes that logically belongs to a file
+    /// — e.g. filling a restored remote placeholder with content read off-loop.
+    pub fn set_file_path(&mut self, path: PathBuf) {
+        self.persistence.set_file_path(path);
+    }
+
     /// Current buffer version (monotonic, wraps on overflow)
     pub fn version(&self) -> u64 {
         self.version

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -98,6 +98,17 @@ pub enum AsyncMessage {
     /// the app-level `RemoteAttachMode::Reconnect` rebuild path.
     RemoteReconnected { connection_id: u64 },
 
+    /// Content for a remote session's placeholder buffer, read off the editor
+    /// loop (see `Window::pending_content_load`). The main loop installs it into
+    /// `window_id`'s `buffer_id`, replacing the empty placeholder — or logs and
+    /// drops it on read error. Keeps remote workspace restore from freezing the
+    /// UI: the buffers appear instantly (empty) and fill in as this arrives.
+    RemoteBufferContentLoaded {
+        window_id: fresh_core::WindowId,
+        buffer_id: fresh_core::BufferId,
+        content: Result<Vec<u8>, String>,
+    },
+
     /// An async `attachRemoteAgent` connect failed — reject the plugin's
     /// promise with `error` (the plugin shows it and creates no window); the
     /// editor stays on its current authority. `reconnect_window` is `Some(id)`

--- a/crates/fresh-editor/tests/common/dormant_ssh.rs
+++ b/crates/fresh-editor/tests/common/dormant_ssh.rs
@@ -39,6 +39,20 @@ pub fn ensure_hanging_fake_ssh_on_path() {
     HANG_PATH_INIT.call_once(|| prepend_shim_dir("tests/fixtures/fake-ssh-hang"));
 }
 
+static SLOW_PATH_INIT: Once = Once::new();
+
+/// Like [`ensure_fake_ssh_on_path`], but the shim **completes the connection
+/// slowly** (`tests/fixtures/fake-ssh-slow`): it bootstraps the real agent
+/// locally so file ops actually work, but throttles selected responses so the
+/// channel becomes "connected but slow" — the bandwidth-throttled remote shape
+/// (cf. `ProxyCommand ... | pv -qL 20k`). This is the state that stalls a
+/// *synchronous* filesystem call, unlike the hang shim (which never
+/// establishes the channel at all). Behaviour is tuned per-test through the
+/// `FAKE_SSH_SLOW_*` env vars the shim reads.
+pub fn ensure_slow_fake_ssh_on_path() {
+    SLOW_PATH_INIT.call_once(|| prepend_shim_dir("tests/fixtures/fake-ssh-slow"));
+}
+
 fn prepend_shim_dir(rel: &str) {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
     assert!(

--- a/crates/fresh-editor/tests/fixtures/fake-ssh-slow/ssh
+++ b/crates/fresh-editor/tests/fixtures/fake-ssh-slow/ssh
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Fake `ssh` for tests: models a host that COMPLETES the connection but is
+# SLOW — the "bandwidth-throttled remote" shape (cf. the user's
+# `ProxyCommand ... | pv -qL 20k`). Unlike `fake-ssh-hang` (never establishes
+# the channel) and `fake-ssh` (fails fast), this one bootstraps the *real*
+# agent locally so file ops actually work, then throttles selected responses so
+# the channel becomes "connected but slow". That is the state that stalls a
+# synchronous plugin filesystem call on the single plugin thread.
+#
+# The remote command ssh would run is passed as the last argument
+# (`python3 -u -c "import sys;exec(sys.stdin.read(N))"`); we run it locally via
+# `sh -c` so the agent reads its bootstrap + protocol requests from our stdin,
+# exactly as over a real carrier. We forward stdin verbatim (byte-preserving,
+# so python's `read(N)` still lands on a program boundary) while snooping each
+# JSON request line to learn its id -> method mapping, and we delay the agent's
+# responses for the methods named in FAKE_SSH_SLOW_METHODS.
+#
+# Env knobs:
+#   FAKE_SSH_SLOW_METHODS      comma list of methods to slow (default: ls,stat)
+#   FAKE_SSH_SLOW_RESP_DELAY   seconds to delay each slow-method response line
+#   FAKE_SSH_SLOW_READY_DELAY  seconds to delay the agent's initial ready line
+#   FAKE_SSH_SLOW_BLOCK_FILE   if set, slow-method responses block until this
+#                              path is DELETED (deterministic, no wall clock)
+import os
+import sys
+import json
+import time
+import signal
+import threading
+import subprocess
+
+SLOW_METHODS = set(
+    m for m in (os.environ.get("FAKE_SSH_SLOW_METHODS") or "ls,stat").split(",") if m
+)
+RESP_DELAY = float(os.environ.get("FAKE_SSH_SLOW_RESP_DELAY") or "0")
+READY_DELAY = float(os.environ.get("FAKE_SSH_SLOW_READY_DELAY") or "0")
+BLOCK_FILE = os.environ.get("FAKE_SSH_SLOW_BLOCK_FILE") or ""
+LOG_FILE = os.environ.get("FAKE_SSH_SLOW_LOG") or ""
+_t0 = time.time()
+
+
+def _log(msg):
+    if LOG_FILE:
+        try:
+            with open(LOG_FILE, "a") as f:
+                f.write("%.3f %s\n" % (time.time() - _t0, msg))
+        except Exception:
+            pass
+
+remote_cmd = sys.argv[-1]
+proc = subprocess.Popen(
+    ["sh", "-c", remote_cmd],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    preexec_fn=os.setsid,
+)
+
+id_to_method = {}
+lock = threading.Lock()
+
+
+def _cleanup(*_):
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except Exception:
+        pass
+    os._exit(0)
+
+
+for _sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(_sig, _cleanup)
+
+
+def pump_stdin():
+    # Forward our stdin -> agent, line by line (byte-preserving), snooping the
+    # id -> method map so the stdout side knows which responses to slow.
+    try:
+        for line in sys.stdin.buffer:
+            try:
+                obj = json.loads(line)
+                mid, m = obj.get("id"), obj.get("m")
+                if mid is not None and m is not None:
+                    with lock:
+                        id_to_method[mid] = m
+                    _log("REQ id=%s m=%s" % (mid, m))
+            except Exception:
+                pass
+            proc.stdin.write(line)
+            proc.stdin.flush()
+    except Exception:
+        pass
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+
+
+def _write_line(line):
+    sys.stdout.buffer.write(line if isinstance(line, bytes) else line.encode())
+    sys.stdout.buffer.flush()
+
+
+def _hold_read_open(rid):
+    # Hold a `read`'s final result indefinitely while the gate exists,
+    # dribbling empty keepalive data chunks so the editor's idle-timeout never
+    # fires. This models a bandwidth-throttled transfer that makes (trivial)
+    # progress forever: the read blocks whichever thread issued it without the
+    # request timing out — an UNBOUNDED stall, so a test that stays frozen on it
+    # is caught by nextest's external cap rather than silently recovering.
+    keepalive = json.dumps({"id": rid, "d": {"data": ""}}) + "\n"
+    while os.path.exists(BLOCK_FILE):
+        _write_line(keepalive)
+        time.sleep(1.0)
+
+
+first = True
+threading.Thread(target=pump_stdin, daemon=True).start()
+for line in proc.stdout:
+    if first:
+        if READY_DELAY:
+            time.sleep(READY_DELAY)
+        first = False
+        _write_line(line)
+        continue
+    try:
+        obj = json.loads(line)
+        rid = obj.get("id")
+    except Exception:
+        obj, rid = None, None
+    with lock:
+        method = id_to_method.get(rid)
+    is_result = isinstance(obj, dict) and "r" in obj
+    if method in SLOW_METHODS:
+        if BLOCK_FILE and is_result:
+            # Only the final result is withheld; any real data chunk already
+            # streamed through, so the client has the content but never the
+            # completion — it waits forever.
+            _log("HOLD id=%s m=%s" % (rid, method))
+            _hold_read_open(rid)
+            _log("RELEASE id=%s m=%s" % (rid, method))
+        elif RESP_DELAY:
+            _log("SLOW resp id=%s m=%s (delaying)" % (rid, method))
+            time.sleep(RESP_DELAY)
+    _log("RESP id=%s m=%s" % (rid, method))
+    _write_line(line)
+
+proc.wait()

--- a/crates/fresh-editor/tests/orchestrator_dock_ssh_navigation_slow_nonblocking.rs
+++ b/crates/fresh-editor/tests/orchestrator_dock_ssh_navigation_slow_nonblocking.rs
@@ -1,0 +1,138 @@
+//! Behaviour: arrow-navigating the orchestrator dock onto a **slow / high-
+//! latency** SSH workspace keeps the whole editor responsive while the session
+//! connects and materializes in the background.
+//!
+//! This is the companion to `orchestrator_dock_ssh_navigation_nonblocking.rs`.
+//! That test uses a host that never establishes the channel (`fake-ssh-hang`),
+//! so `is_connected()` stays false and every remote request fails fast — the
+//! switch is trivially non-blocking. The bug this test pins is the *opposite*
+//! shape: a host that **does** connect but is bandwidth-throttled
+//! (`fake-ssh-slow`, cf. `ProxyCommand … | pv -qL 20k`). There the channel
+//! comes up and the agent answers, so promoting the dived-into session
+//! re-reads its persisted buffers over the slow link. Done on the editor loop,
+//! those reads froze the whole UI for seconds — the user could not arrow to
+//! another window until the reads returned.
+//!
+//! The fix restores the session's persisted *file* buffers as empty
+//! placeholders (no I/O on the editor loop) and loads their content off-loop,
+//! filling each in via `AsyncMessage::RemoteBufferContentLoaded`. So the layout
+//! and tabs come up instantly, the loop never blocks on a slow read, and the
+//! content still appears once it arrives.
+//!
+//! Reproducer shape: the slow shim holds the file `read` open indefinitely (it
+//! dribbles keepalive chunks so the request never times out). While it's held,
+//! the editor stays responsive — driving frames all complete (loading on the
+//! loop would freeze here and nextest's per-test cap would fail the test) and
+//! the placeholder shows no content. Releasing the read then fills the buffer,
+//! so the file's real content appears.
+//!
+//! Single test in this binary: the fake-ssh PATH shim and `isolated_dir_context`'s
+//! process-global `XDG_DATA_HOME` / `FAKE_SSH_SLOW_*` env must not leak.
+#![cfg(all(target_os = "linux", feature = "plugins"))]
+
+mod common;
+
+use common::dormant_ssh::{
+    canonical_mkdir, ensure_slow_fake_ssh_on_path, isolated_dir_context, persist_previous_session,
+};
+use common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+#[test]
+fn arrow_nav_onto_slow_remote_keeps_editor_responsive() {
+    common::tracing::init_tracing_from_env();
+    ensure_slow_fake_ssh_on_path();
+    fresh::i18n::set_locale("en");
+
+    let base = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(base.path());
+    let project = canonical_mkdir(base.path(), "project");
+    let remote_root = canonical_mkdir(base.path(), "remote-root");
+
+    // Throttle the shim: hold every `read` open until this gate file is removed,
+    // modelling a transfer that makes only trivial progress (the shim keeps the
+    // request alive so it never times out). The gate lives under the per-test
+    // temp tree, so it's cleaned up with everything else on teardown — which
+    // also releases the held read on the connect worker.
+    let gate = base.path().join("read.gate");
+    std::fs::write(&gate, "hold").unwrap();
+    std::env::set_var("FAKE_SSH_SLOW_METHODS", "read");
+    std::env::set_var("FAKE_SSH_SLOW_BLOCK_FILE", &gate);
+
+    let plugins_dir = project.join("plugins");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    // Leaves behind a local project workspace + a dormant SSH session
+    // (`ssh-dead`) with a real persisted buffer (`remote_notes.txt`) that
+    // promoting the session will reopen over the (slow) link.
+    persist_previous_session(&dir_context, &project, &remote_root, true);
+
+    let mut cfg = fresh::config::Config::default();
+    cfg.editor.animations = false;
+    cfg.editor.cursor_jump_animation = false;
+    let mut h = EditorTestHarness::create(
+        140,
+        40,
+        HarnessOptions::new()
+            .with_config(cfg)
+            .with_working_dir(project.clone())
+            .with_shared_dir_context(dir_context.clone()),
+    )
+    .unwrap();
+    h.wait_until(|h| {
+        let reg = h.editor().command_registry().read().unwrap();
+        reg.get_all()
+            .iter()
+            .any(|c| c.get_localized_name() == "Orchestrator: Toggle Dock")
+    })
+    .unwrap();
+    h.open_file(&project.join("local_marker.txt")).unwrap();
+    h.wait_for_screen_contains("local_marker.txt").unwrap();
+
+    // Open the dock.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| {
+        let scr = h.screen_to_string();
+        scr.contains("ssh-dead") && scr.contains("⇅")
+    })
+    .unwrap();
+
+    // Arrow onto the SSH row: the switch commits into the session and the
+    // connect resolves in the background. Promote restores the layout + tabs
+    // immediately with the file buffer as an empty placeholder — no read on the
+    // editor loop — so the tab for `remote_notes.txt` is up right away even
+    // though its content read is still held open by the gate.
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.editor().active_window().root == remote_root)
+        .unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("remote_notes"))
+        .unwrap();
+
+    // The content read is held open by the gate, yet the editor loop keeps
+    // turning — drive frames that must all complete. Loading content on the loop
+    // would freeze here (the held read never returns) and nextest's per-test cap
+    // would fail the test. Meanwhile the placeholder shows no content yet.
+    for _ in 0..20 {
+        h.tick_and_render().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        !h.screen_to_string().contains("REMOTE NOTES"),
+        "file content must not appear while its read is still held"
+    );
+
+    // Release the read: the off-loop load completes and fills the placeholder,
+    // so the file's real content appears. Proves the buffers do load — just
+    // never on the editor loop.
+    std::fs::remove_file(&gate).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("REMOTE NOTES"))
+        .unwrap();
+}


### PR DESCRIPTION
## Problem

Navigating the orchestrator dock onto a dormant SSH session over a slow / high-latency link (e.g. a bandwidth-throttled `ProxyCommand … | pv -qL 20k`) froze the whole editor: the user saw "Connecting…" but could not arrow to another window until the connection resolved.

The root cause is **synchronous filesystem work on the single-threaded editor loop**. Promoting a dived-into remote session restores its persisted workspace, which reopened every file buffer — and those reads run over the link on the editor loop, so a throttled host stalled the UI for the full round-trip.

(The "never connects" variant was already non-blocking — `is_connected()` stays false and requests fail fast. The regression was the opposite: a host that *does* connect but is slow.)

## Fix

When the session's authority is remote, restore each persisted file buffer as an **empty placeholder** (`Buffer::new_with_path`, no I/O on the loop), so the split layout, tabs and titles come up instantly. The editor then reads each file **off the loop** on a background thread and fills the buffer in via a new `AsyncMessage::RemoteBufferContentLoaded`. **The large content read never runs on the editor loop.**

Crucially, an async-filled buffer is **identical to a normally-opened one**. The synchronous open path and the async fill both run one shared `Window::finalize_file_buffer`:

- binary detection → read-only,
- per-language + `.editorconfig` settings,
- file metadata (`with_file`: URI, path translation, auto-read-only),
- LSP `didOpen`.

So the *only* difference between the two is where the bytes were read — inline vs. a background thread — not a second, feature-poorer open path. `mtime` for auto-revert is established lazily by the file poll for all buffers alike, so it needs no special wiring.

Other properties:

- **No cache** — each buffer holds its own content, delivered once via the async message; nothing is a snapshot of a live source that could go stale.
- A late fill **skips a buffer the user already started editing**, so it can't clobber input.
- Terminals and the split layout restore as before. Transport-agnostic — kube sessions benefit too.

## Testing

- **e2e** (`orchestrator_dock_ssh_navigation_slow_nonblocking`): a new `fake-ssh-slow` shim completes the connection but holds a file `read` open indefinitely (dribbling keepalive chunks so it never times out). While it's held, the placeholder tab is up and driving frames all complete — loading on the loop would freeze here and nextest's per-test cap would fail the test; releasing the read fills the buffer and the content appears. Verified to **hang without the off-loop loader** (self-reverting bypass).
- **Regression**: `editorconfig_tests` (18) and the full lib suite (3102) pass — the shared `finalize_file_buffer` is a behaviour-preserving extraction of the normal open path.
- **Manual** (tmux, against the slow shim, since there's no real `ssh` in the sandbox): diving onto the remote is instant with an empty placeholder tab; navigating to and *editing in* other workspaces stays fully responsive while it loads; the content streams in once the read completes.
- `cargo fmt`, `cargo clippy`, and `cargo check --all-targets` are clean.

## Key changes

- `app/file_open_orchestrators.rs` — extract `Window::finalize_file_buffer` from the sync open path; both open paths now call it.
- `app/workspace.rs` — remote branch of `open_workspace_files` / `restore_external_files` installs placeholders and queues loads; `build_workspace_file_state` builds the buffer for placeholder or fill.
- `app/window/mod.rs` — `pending_content_load` queue on `Window`.
- `app/async_dispatch.rs` — `drive_pending_content_loads` (per-tick, off-loop spawn) + `handle_remote_buffer_content_loaded` (builds the buffer, then runs the shared finalize).
- `services/async_bridge.rs` — `RemoteBufferContentLoaded` message.
- `model/buffer/mod.rs` — public `Buffer::set_file_path`.
- `tests/fixtures/fake-ssh-slow` shim + e2e test.

## Follow-ups (out of scope)

- The shared finalize still issues its small metadata / editorconfig / LSP-size stats on the loop when content lands (same as a normal open); a bounded interactive time-box would be a good structural backstop, and those small reads could also be prefetched by the off-loop job.
- Other loop-blocking remote paths (file-explorer `read_dir`, save) would benefit from the same off-loop treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbgTabpTLFgYR5WJTcG95i