### PR TITLE
fix(plugin-api): resolve leaf split id to parent container in setSplitRatio (#2770)

### DIFF
--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1050,26 +1050,50 @@ impl Editor {
 
     /// Handle SetSplitRatio command.
     ///
-    /// Returns `true` if `split_id` resolved to a resizable split
-    /// container and the ratio was applied, `false` if it pointed at a
-    /// leaf, grouped, or unknown node. Every plugin-visible split id is
-    /// a leaf, so a plugin calling `setSplitRatio` on one must be a
-    /// graceful no-op that reports failure — never a panic that aborts
-    /// the editor (issue #2770).
+    /// Every split id a plugin can obtain is a *leaf* id (`getActiveSplitId`,
+    /// `listSplits`, `BufferInfo.splits`, `createTerminal` all return leaf
+    /// ids), but only a `SplitNode::Split` *container* carries a resizable
+    /// `ratio`. So we resolve the leaf to its parent container and set the
+    /// parent's ratio — that is exactly "resize the pane the plugin is
+    /// pointing at" (it moves the divider between that leaf and its sibling).
+    ///
+    /// Ratio orientation: a parent `Split`'s `ratio` is the fraction of space
+    /// given to its FIRST child (larger ratio => bigger first child, smaller
+    /// second child). A plugin asking to resize "its" leaf resizes that
+    /// parent split; whether the leaf is the first or second child, adjusting
+    /// the parent ratio is the single, well-defined knob for that divider, and
+    /// the value is clamped to `[0.1, 0.9]`. Callers wanting a specific pane to
+    /// grow should account for which side it sits on.
+    ///
+    /// Returns `true` if the ratio was applied:
+    /// - a leaf id with a resizable parent `Split` → set the parent's ratio;
+    /// - a container id (rare for plugins) → set it directly (legacy behavior);
+    /// - a lone top-level leaf (no parent container) or unknown id → no-op,
+    ///   `false`. Never panics (issue #2770, follow-up to #2774).
     pub(super) fn handle_set_split_ratio(&mut self, split_id: SplitId, ratio: f32) -> bool {
-        // Plugin sends arbitrary SplitId — convert to ContainerId at the boundary
-        let container_id = ContainerId(split_id);
-        let applied = self
+        let manager = self
             .windows
             .get_mut(&self.active_window)
             .and_then(|w| w.split_manager_mut())
-            .expect("active window must have a populated split layout")
-            .set_ratio(container_id, ratio);
+            .expect("active window must have a populated split layout");
+
+        // Try the id as a container directly first (preserves behavior for a
+        // real container id); `set_ratio` is a no-op returning `false` on a
+        // leaf/grouped/unknown node. If that fails, resolve the (leaf) id to
+        // its parent container and set that.
+        let applied = if manager.set_ratio(ContainerId(split_id), ratio) {
+            true
+        } else if let Some(parent) = manager.parent_container_of(LeafId(split_id)) {
+            manager.set_ratio(parent, ratio)
+        } else {
+            false
+        };
+
         if applied {
             tracing::debug!("Set split {:?} ratio to {}", split_id, ratio);
         } else {
             tracing::debug!(
-                "setSplitRatio: split {:?} is not a resizable container; ignoring",
+                "setSplitRatio: split {:?} has no resizable parent container; ignoring",
                 split_id
             );
         }

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1952,6 +1952,47 @@ mod tests {
     }
 
     #[test]
+    fn test_leaf_resolves_to_parent_container_for_ratio() {
+        // Follow-up to #2774 (#2770): plugins only ever hold *leaf* split
+        // ids, so `setSplitRatio` must resolve a leaf to its parent
+        // container. Here we exercise the building blocks
+        // (`parent_container_of` + `set_ratio`) that `handle_set_split_ratio`
+        // composes.
+        let mut manager = SplitManager::new(BufferId(0));
+        let new_leaf = manager
+            .split_active(SplitDirection::Horizontal, BufferId(1), 0.5)
+            .unwrap();
+        let new_leaf_id: SplitId = new_leaf.into();
+
+        // The leaf itself is not a container: setting its ratio directly fails.
+        assert!(
+            !manager.set_ratio(ContainerId(new_leaf_id), 0.75),
+            "a leaf split id is not a resizable container"
+        );
+
+        // But it resolves to the parent Split container...
+        let parent = manager
+            .parent_container_of(LeafId(new_leaf_id))
+            .expect("a split leaf must have a parent container");
+
+        // ...and setting the parent's ratio applies and clamps.
+        assert!(manager.set_ratio(parent, 0.75));
+        assert_eq!(manager.get_ratio(parent.into()), Some(0.75));
+        assert!(manager.set_ratio(parent, 0.99));
+        assert_eq!(manager.get_ratio(parent.into()), Some(0.9));
+    }
+
+    #[test]
+    fn test_lone_top_level_leaf_has_no_parent_container() {
+        // A single un-split pane has no parent container, so there is no
+        // resizable divider — resolution must yield `None` (a graceful
+        // `false` no-op in `handle_set_split_ratio`), never a panic.
+        let manager = SplitManager::new(BufferId(0));
+        let lone_leaf: SplitId = manager.active_split().into();
+        assert_eq!(manager.parent_container_of(LeafId(lone_leaf)), None);
+    }
+
+    #[test]
     fn test_split_rect_horizontal() {
         let rect = Rect {
             x: 0,

--- a/crates/fresh-editor/tests/e2e/plugins/set_split_ratio_leaf.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/set_split_ratio_leaf.rs
@@ -1,18 +1,23 @@
-//! Regression for #2770: `editor.setSplitRatio(leafSplitId, ratio)` used
-//! to hit `unreachable!` inside `SplitManager::set_ratio` and abort the
-//! whole editor. Every plugin-visible split id is a *leaf*, while
-//! `set_ratio` only accepts resizable *container* ids, so any plugin
-//! calling `setSplitRatio` crashed the editor.
+//! Regression for #2770 and follow-up to #2774.
 //!
-//! After the fix the plugin path is a graceful no-op: no panic, and a
-//! leaf id leaves the layout untouched (the internal handler reports
-//! `false` — see the `set_ratio` unit tests in `view::split`).
+//! History: `editor.setSplitRatio(leafSplitId, ratio)` first hit
+//! `unreachable!` inside `SplitManager::set_ratio` and aborted the whole
+//! editor (#2770). PR #2774 made that a graceful no-op. But every
+//! plugin-visible split id is a *leaf* (`getActiveSplitId`, `listSplits`,
+//! `BufferInfo.splits`, `createTerminal` all return leaf ids), while
+//! `set_ratio` only mutates a resizable *container*, so `setSplitRatio`
+//! could never actually resize anything — it always no-op'd.
+//!
+//! This follow-up makes it work: `handle_set_split_ratio` resolves a leaf
+//! id to its parent split container and sets that container's ratio. These
+//! tests assert (a) a lone top-level leaf with no parent is still a graceful
+//! no-op (no panic), and (b) a leaf inside a split now resizes its parent.
 
 #![cfg(feature = "plugins")]
 
 use crate::common::harness::EditorTestHarness;
 use fresh::services::plugins::api::PluginCommand;
-use fresh_core::SplitId;
+use fresh_core::{LeafId, SplitId};
 use std::fs;
 
 fn snapshot_active_split(harness: &EditorTestHarness) -> Option<usize> {
@@ -21,11 +26,11 @@ fn snapshot_active_split(harness: &EditorTestHarness) -> Option<usize> {
     Some(snapshot.active_split_id)
 }
 
-/// Driving `SetSplitRatio` with a leaf split id (the only kind a plugin
-/// ever holds) must not panic/abort the editor, and must leave the
-/// layout unchanged.
+/// Driving `SetSplitRatio` with a *lone* top-level leaf (no parent
+/// container to resize) must not panic/abort the editor, and must leave
+/// the layout unchanged.
 #[test]
-fn set_split_ratio_on_leaf_does_not_panic() {
+fn set_split_ratio_on_lone_leaf_does_not_panic() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("hello.txt");
     fs::write(&path, "hi\n").unwrap();
@@ -57,11 +62,12 @@ fn set_split_ratio_on_leaf_does_not_panic() {
     );
 }
 
-/// Even when a real resizable container exists in the tree, targeting a
-/// *leaf* id is still a no-op (the container's ratio is untouched) — the
-/// handler does not accidentally resolve a leaf to its parent.
+/// When a leaf sits inside a split, `setSplitRatio` on that *leaf* id
+/// resolves to the parent container and actually resizes it — the whole
+/// point of the follow-up fix. Every id a plugin holds is a leaf, so this
+/// is the real plugin path.
 #[test]
-fn set_split_ratio_on_leaf_leaves_container_untouched() {
+fn set_split_ratio_on_leaf_resizes_parent_container() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("hello.txt");
     fs::write(&path, "hi\n").unwrap();
@@ -78,21 +84,91 @@ fn set_split_ratio_on_leaf_leaves_container_untouched() {
 
     let leaf = snapshot_active_split(&harness).expect("active split is a leaf after splitting");
 
+    // The parent container of the active leaf, and its ratio before.
+    let parent = harness
+        .editor()
+        .split_manager_for_tests()
+        .parent_container_of(LeafId(SplitId(leaf)))
+        .expect("a split leaf must have a parent container");
+    let ratio_before = harness
+        .editor()
+        .split_manager_for_tests()
+        .get_ratio(parent.into())
+        .expect("parent container has a ratio");
+    assert_ne!(
+        ratio_before, 0.8,
+        "precondition: parent ratio differs from the value we will set"
+    );
+
+    // Drive the real plugin command with the LEAF id.
     harness
         .editor_mut()
         .handle_plugin_command(PluginCommand::SetSplitRatio {
             split_id: SplitId(leaf),
             ratio: 0.8,
         })
-        .expect("setSplitRatio on a leaf must be a graceful no-op, not an error");
+        .expect("setSplitRatio on a leaf resolves to its parent container");
 
     harness.tick_and_render().unwrap();
 
-    // Both splits are still present — the editor did not crash and the
-    // leaf id did not resize its parent.
+    // The parent container's ratio was actually updated (clamped range).
+    let ratio_after = harness
+        .editor()
+        .split_manager_for_tests()
+        .get_ratio(parent.into())
+        .expect("parent container still has a ratio");
+    assert_eq!(
+        ratio_after, 0.8,
+        "setSplitRatio on a leaf must resize its parent container"
+    );
+
+    // Editor is still alive and the active split id is unchanged.
     assert_eq!(
         snapshot_active_split(&harness),
         Some(leaf),
-        "editor must survive setSplitRatio on a leaf even with a container present"
+        "editor must survive setSplitRatio and keep the same active leaf"
+    );
+}
+
+/// Clamping still applies when resolving through a leaf: an out-of-range
+/// ratio is pinned to [0.1, 0.9] on the parent container.
+#[test]
+fn set_split_ratio_on_leaf_clamps_parent_ratio() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("hello.txt");
+    fs::write(&path, "hi\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.editor_mut().open_file(&path).unwrap();
+    harness.tick_and_render().unwrap();
+
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(fresh::input::keybindings::Action::SplitHorizontal);
+    harness.tick_and_render().unwrap();
+
+    let leaf = snapshot_active_split(&harness).expect("active split is a leaf after splitting");
+    let parent = harness
+        .editor()
+        .split_manager_for_tests()
+        .parent_container_of(LeafId(SplitId(leaf)))
+        .expect("a split leaf must have a parent container");
+
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::SetSplitRatio {
+            split_id: SplitId(leaf),
+            ratio: 5.0,
+        })
+        .expect("setSplitRatio on a leaf resolves to its parent container");
+    harness.tick_and_render().unwrap();
+
+    assert_eq!(
+        harness
+            .editor()
+            .split_manager_for_tests()
+            .get_ratio(parent.into()),
+        Some(0.9),
+        "an out-of-range ratio must clamp to 0.9 on the parent container"
     );
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4907,7 +4907,18 @@ impl JsEditorApi {
             .is_ok()
     }
 
-    /// Set the ratio of a split (0.0 to 1.0, 0.5 = equal)
+    /// Resize the split that `split_id` lives in.
+    ///
+    /// `split_id` is a leaf id (as returned by `getActiveSplitId`,
+    /// `listSplits`, `BufferInfo.splits`, `createTerminal`); the editor
+    /// resolves it to its parent split container and sets that container's
+    /// ratio, moving the divider between this pane and its sibling. `ratio`
+    /// is the fraction of space given to the container's FIRST child
+    /// (0.0–1.0, 0.5 = equal), clamped to [0.1, 0.9]. A leaf with no parent
+    /// container (the only pane) is a no-op.
+    ///
+    /// Note: this is fire-and-forget — the returned bool only reports that
+    /// the command was queued, not whether the resize succeeded.
     pub fn set_split_ratio(&self, split_id: u32, ratio: f32) -> bool {
         self.command_sender
             .send(PluginCommand::SetSplitRatio {


### PR DESCRIPTION
## The gap

PR #2774 (merged) made `editor.setSplitRatio(splitId, ratio)` crash-safe by turning `SplitManager::set_ratio` into a no-op that returns `false` for any non-container id. That stopped the panic — but it left `setSplitRatio` doing nothing useful:

- Every split id a plugin can obtain is a **leaf** id. `getActiveSplitId`, `listSplits`, `BufferInfo.splits`, and `createTerminal` all return leaf ids.
- `set_ratio` only mutates a `SplitNode::Split` **container**.

So a plugin's `setSplitRatio` call always landed on a leaf and always no-op'd — **plugins could never resize a split.** #2774's own body flagged this by deferring the "resolve-to-parent" step. This is that follow-up.

## The fix

`handle_set_split_ratio` (`crates/fresh-editor/src/app/plugin_commands.rs`) now resolves the plugin's leaf id to its parent container via the existing `SplitManager::parent_container_of`, and sets that container's ratio:

- **leaf id with a resizable parent `Split`** → set the parent's ratio (clamped to `[0.1, 0.9]`), report `true`;
- **container id** (rare for plugins) → set directly (legacy behavior preserved by trying the id as a container first);
- **lone top-level leaf** (no parent) or **unknown id** → no-op, `false`. Never panics.

### Ratio orientation
A parent `Split`'s `ratio` is the fraction of space given to its **first** child (larger ratio ⇒ bigger first child, smaller second child). A plugin asking to resize "its" leaf resizes that parent split; whichever side the leaf sits on, adjusting the parent ratio is the single, well-defined knob for that divider. This is documented in the handler and in the plugin-facing `setSplitRatio` doc comment (`quickjs_backend.rs`).

The fire-and-forget JS return contract is **unchanged** — `setSplitRatio` still returns whether the command was *queued*, not the resize result.

## Verification

**Tests** (`cargo test -p fresh-editor --features plugins`, all green):
- Unit tests in `view::split`: a leaf id resolves to its parent + applies + clamps; a lone top-level leaf resolves to `None`; container ids still work.
- E2E tests driving `PluginCommand::SetSplitRatio` with a real **leaf** id: the parent container's ratio actually changes (`0.5` → `0.8`), an out-of-range value clamps to `0.9`, and a lone leaf is a graceful no-op (no panic).

`cargo fmt -- --check` clean; clippy clean for the changed lines.

**Interactive:** an `init.ts` calling `createTerminal({ direction: "vertical", ratio: 0.5 })` then `setSplitRatio(activeLeafId, 0.75)`:
- **before** (origin/master): divider stays at 50/50 — the no-op.
- **after** (this branch): the divider moves to 75/25 — the leaf resolved to its parent and the ratio applied.

Follow-up to #2774 (#2770).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_