### PR TITLE
fix(on-save): keep on-disk state in sync and preserve line endings (#2711, #2706)

### DIFF
--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -52,6 +52,12 @@ impl Editor {
                 return Err(format!("Failed to re-save after whitespace cleanup: {}", e));
             }
             self.active_event_log_mut().mark_saved();
+            // Refresh the recorded on-disk mtime after our own re-write (see the
+            // note on the trailing `watch_file` below). This must happen here —
+            // not only at the end of the function — because the language lookup
+            // right below can `return` early for languages with no config
+            // (e.g. plain-text files), which would otherwise skip the refresh.
+            self.watch_file(&path);
         }
 
         // Get language from buffer's stored state
@@ -73,6 +79,8 @@ impl Editor {
                             return Err(format!("Failed to re-save after format: {}", e));
                         }
                         self.active_event_log_mut().mark_saved();
+                        // Refresh the recorded on-disk mtime after our own write.
+                        self.watch_file(&path);
                         ran_any_action = true;
                     }
                     ActionResult::CommandNotFound(cmd) => {
@@ -108,6 +116,19 @@ impl Editor {
                     return Err(e);
                 }
             }
+        }
+
+        // A file-modifying on-save linter (e.g. one that rewrites `$FILE` in
+        // place) also advances the on-disk mtime past the value recorded by
+        // `finalize_save_buffer`, which ran *before* these actions. Refresh the
+        // recorded on-disk state one final time so a subsequent save's conflict
+        // check and the auto-revert poll don't mistake the editor's own on-save
+        // write for an external modification. Without keeping this state in sync
+        // the next Ctrl+S false-positives a "File changed on disk" prompt
+        // (#2706) and the poll fires a spurious "Reverted to saved file" reload
+        // (#2711).
+        if ran_any_action {
+            self.watch_file(&path);
         }
 
         Ok(ran_any_action)
@@ -557,20 +578,24 @@ impl Editor {
     /// Returns Ok(true) if any changes were made, Ok(false) if buffer unchanged.
     pub fn trim_trailing_whitespace(&mut self) -> Result<bool, String> {
         let content = self.active_state().buffer.to_string().unwrap_or_default();
+        let line_ending = self.active_state().buffer.line_ending();
+        let sep = line_ending.as_str();
 
-        // Process each line and trim trailing whitespace
+        // Split on the buffer's own line terminator and trim only trailing
+        // *horizontal* whitespace (never the CR/LF that form the ending) from
+        // each segment, then rejoin with the same terminator. Splitting on the
+        // real ending (and preserving it) keeps the line-ending mode intact —
+        // a CRLF buffer stays CRLF instead of collapsing to LF — and preserves
+        // the exact line count, whereas the old `str::lines()` + `join("\n")`
+        // approach both normalized CRLF to LF and dropped a trailing empty line
+        // (#2711).
         let trimmed: String = content
-            .lines()
-            .map(|line| line.trim_end())
+            .split(sep)
+            .map(|line| {
+                line.trim_end_matches(|c: char| c.is_whitespace() && c != '\r' && c != '\n')
+            })
             .collect::<Vec<_>>()
-            .join("\n");
-
-        // Preserve original trailing newline if present
-        let trimmed = if content.ends_with('\n') && !trimmed.ends_with('\n') {
-            format!("{}\n", trimmed)
-        } else {
-            trimmed
-        };
+            .join(sep);
 
         if trimmed == content {
             return Ok(false);
@@ -590,11 +615,15 @@ impl Editor {
             return Ok(false);
         }
 
-        if content.ends_with('\n') {
+        // Already terminated (LF, CRLF, or CR all end in one of these bytes).
+        if content.ends_with('\n') || content.ends_with('\r') {
             return Ok(false);
         }
 
-        let with_newline = format!("{}\n", content);
+        // Append the buffer's own line ending so a CRLF buffer's final newline
+        // is CRLF, not a hardcoded LF that would corrupt the line-ending mode.
+        let sep = self.active_state().buffer.line_ending().as_str();
+        let with_newline = format!("{}{}", content, sep);
         self.replace_buffer_with_output(&with_newline)?;
         Ok(true)
     }

--- a/crates/fresh-editor/tests/e2e/on_save_actions.rs
+++ b/crates/fresh-editor/tests/e2e/on_save_actions.rs
@@ -10,7 +10,7 @@
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::{Config, FormatterConfig, LanguageConfig, OnSaveAction};
+use fresh::config::{Config, FormatterConfig, LanguageConfig, LineEndingOption, OnSaveAction};
 use tempfile::TempDir;
 
 /// Test format_on_save with formatter (replaces buffer content)
@@ -664,6 +664,139 @@ fn test_whitespace_cleanup_combined() {
     // File on disk should also be cleaned up
     let disk_content = std::fs::read_to_string(&file_path).unwrap();
     assert_eq!(disk_content, "line 1\nline 2\nline 3\n");
+}
+
+/// Regression for #2706 (symptom 2) / #2711 (sub-case 3): after an on-save
+/// action rewrites and re-saves the file, the editor's recorded on-disk state
+/// (mtime) must be refreshed so a subsequent save does NOT false-positive a
+/// "File changed on disk" conflict.
+#[test]
+fn test_on_save_action_no_false_conflict_on_next_save() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file_path = project_dir.join("test.rs");
+    // Trailing whitespace guarantees the on-save trim actually rewrites and
+    // re-saves the file (advancing its mtime past the value recorded by the
+    // first write).
+    std::fs::write(&file_path, "line 1   \nline 2\t\nline 3\n").unwrap();
+
+    let mut config = Config::default();
+    config.editor.trim_trailing_whitespace_on_save = true;
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(100, 24, config, project_dir).unwrap();
+
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // First save triggers the on-save trim + re-save.
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_buffer_content("line 1\nline 2\nline 3\n");
+
+    // The editor's own on-save re-write must NOT register as an external
+    // change. Before the fix, the recorded mtime was left at the first write's
+    // value while the on-save re-save advanced the on-disk mtime, so this
+    // returned Some(..).
+    assert!(
+        harness.editor().check_save_conflict().is_none(),
+        "on-save re-write must not be mistaken for an external modification"
+    );
+
+    // Rapid successive saves must not surface the conflict prompt.
+    for _ in 0..8 {
+        harness
+            .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+            .unwrap();
+        harness.render().unwrap();
+    }
+    harness.assert_screen_not_contains("File changed on disk");
+    assert!(
+        harness.editor().check_save_conflict().is_none(),
+        "repeated on-save writes must keep the recorded on-disk state in sync"
+    );
+}
+
+/// Regression for #2711 (sub-case 2): trimming trailing whitespace on save for
+/// a CRLF buffer must preserve CRLF line endings (not collapse to LF) and must
+/// not drop a trailing empty line, and the editor's own write must not trigger
+/// a spurious "Reverted to saved file" reload.
+#[test]
+fn test_trim_on_save_preserves_crlf_and_no_revert() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file_path = project_dir.join("crlf.txt");
+    // CRLF file ending in multiple trailing empty lines, with trailing
+    // whitespace on the first two content lines so the trim does real work.
+    std::fs::write(&file_path, b"hello  \r\nworld\t\r\n\r\n\r\n").unwrap();
+
+    let mut config = Config::default();
+    config.editor.trim_trailing_whitespace_on_save = true;
+    config.editor.default_line_ending = LineEndingOption::Crlf;
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(100, 24, config, project_dir).unwrap();
+
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+    // Line-ending indicator should show CRLF for a CRLF file.
+    harness.assert_screen_contains("CRLF");
+
+    // Save once: trailing whitespace trimmed, CRLF + blank lines preserved.
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Buffer keeps CRLF endings and all four line terminators.
+    assert_eq!(
+        harness.get_buffer_content().unwrap(),
+        "hello\r\nworld\r\n\r\n\r\n"
+    );
+
+    // On disk the bytes stay CRLF (0d 0a), whitespace trimmed, no line dropped.
+    let disk = std::fs::read(&file_path).unwrap();
+    assert_eq!(
+        disk,
+        b"hello\r\nworld\r\n\r\n\r\n",
+        "on-save write must preserve CRLF and trailing empty lines; got {:?}",
+        String::from_utf8_lossy(&disk)
+    );
+
+    // The line-ending indicator must still read CRLF (not flip to LF).
+    harness.assert_screen_contains("CRLF");
+    // No spurious revert should have fired from the editor's own write.
+    harness.assert_screen_not_contains("Reverted to saved file");
+    assert!(
+        harness.editor().check_save_conflict().is_none(),
+        "editor's own on-save write must not look like an external change"
+    );
+
+    // Drive the file-change poll: with the recorded mtime kept in sync, the
+    // poll must find no change and never revert (which would re-read the file
+    // as LF). Advance past the poll interval and pump async work a few times.
+    let interval =
+        std::time::Duration::from_millis(harness.config().editor.auto_revert_poll_interval_ms + 50);
+    for _ in 0..5 {
+        harness.advance_time(interval);
+        harness.process_async_and_render().unwrap();
+        harness.sleep(std::time::Duration::from_millis(20));
+    }
+    harness.process_async_and_render().unwrap();
+
+    harness.assert_screen_not_contains("Reverted to saved file");
+    harness.assert_screen_contains("CRLF");
+    let disk_after_poll = std::fs::read(&file_path).unwrap();
+    assert_eq!(
+        disk_after_poll, b"hello\r\nworld\r\n\r\n\r\n",
+        "poll must not revert/normalize the file"
+    );
 }
 
 /// Test whitespace cleanup does nothing when file is already clean


### PR DESCRIPTION
## Summary

On-save actions (trim-trailing-whitespace, ensure-final-newline, and format-on-save) rewrite and re-save the file **after** `finalize_save_buffer` has already recorded the file's modification time. The recorded mtime was left pointing at the first write while the on-save re-write advanced the on-disk mtime, so the editor mistook **its own write** for an external modification. That single stale-state bug produced two user-visible defects, plus a line-ending bug in the trimmer itself.

## Defect A — false "File changed on disk" prompt on rapid saves (#2706 symptom 2, #2711 sub-case 3)

With an on-save action enabled (a `format_on_save` formatter, or `editor.trim_trailing_whitespace_on_save: true`), pressing Ctrl+S several times in quick succession popped `File changed on disk. (o)verwrite, (C)ancel?` even though only the editor wrote the file.

Root cause: after the on-save re-save, `file_mod_times` still held the *first* write's mtime, so on the next save `check_save_conflict()` saw `current_mtime > recorded_mtime` and treated the editor's own write as an external change (`crates/fresh-editor/src/app/file_operations.rs` `check_save_conflict` / `finalize_save_buffer`).

Fix: refresh the recorded mtime (`watch_file`) immediately after each on-save re-save in `run_on_save_actions` — after the whitespace re-save (crucially *before* the early return taken for languages with no config, e.g. plain-text files), after the format re-save, and once more after any file-modifying on-save linter.

## Defect B — spurious "Reverted to saved file" + CRLF→LF reset (#2711 sub-case 2)

With `trim_trailing_whitespace_on_save: true` and `default_line_ending: crlf`, opening a CRLF file ending in multiple trailing empty lines and pressing Ctrl+S once showed `Saved (with on-save actions)`, then ~1s later an unprompted `Reverted to saved file`, flipped the indicator CRLF→LF, and rewrote the file to LF with the last empty line dropped.

Two sub-bugs, both fixed:
1. **Self-inflicted revert** — the same stale mtime made the auto-revert poll detect a "change" and reload the file (which re-read it as LF). Fixed by the mtime sync above.
2. **Trimmer normalized line endings** — `trim_trailing_whitespace` split on `str::lines()` and rejoined with a hardcoded `"\n"`, which collapsed CRLF to LF and dropped a trailing empty line even when there was no whitespace to trim. It now splits on / rejoins with the buffer's own line ending and trims only trailing *horizontal* whitespace, preserving both the line-ending mode and blank lines. `ensure_final_newline` likewise now appends the buffer's line ending instead of a bare `"\n"`.

## Verification

Interactive (before → after), on-disk bytes via `od -A x -t x1z`:

- **#2706**: before, the 2nd of rapid Ctrl+S saves raised the false conflict prompt; after, 8 rapid saves show only `Saved`, no prompt.
- **#2711**: before, one save produced `Reverted to saved file`, indicator `LF`, and disk bytes `68 65 6c 6c 6f 0a …` (LF, one line dropped); after, one save keeps disk bytes `68 65 6c 6c 6f 0d 0a …` (CRLF, all lines intact), indicator stays `CRLF`, and no revert fires.

New e2e tests in `crates/fresh-editor/tests/e2e/on_save_actions.rs`:
- `test_on_save_action_no_false_conflict_on_next_save` — repeated on-save writes keep `check_save_conflict() == None` and never surface the conflict prompt across 8 rapid saves.
- `test_trim_on_save_preserves_crlf_and_no_revert` — trim-on-save on a CRLF buffer with multiple trailing empty lines keeps the bytes CRLF on disk, trims trailing whitespace, drops no line, and the file-change poll fires no revert.

`cargo test -p fresh-editor` (on-save + auto-revert + encoding + buffer suites) green; `cargo fmt -- --check` and `cargo clippy` clean for the changed files.

## Out of scope

The **format-on-save cursor jump** (#2706 symptom 1) is intentionally **not** addressed here — it needs diff-based cursor mapping and is tracked separately in **#2777**. No cursor/selection repositioning logic was changed by this PR.

---

Closes #2711

Partially addresses #2706 (the false on-disk-change prompt; the post-format cursor jump is a separate follow-up, tracked in #2777)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_