### PR TITLE
fix(splits): constrain splits by absolute minimum pane size instead of a fixed ratio percentage

### DIFF
--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -856,7 +856,10 @@ impl crate::app::window::Window {
         use crate::view::split::SplitNode;
         for node in self.grouped_subtrees.values_mut() {
             if let Some(SplitNode::Split { ratio, .. }) = node.find_mut(container.into()) {
-                *ratio = new_ratio.clamp(0.1, 0.9);
+                // Raw-storage clamp only: the sibling is kept usable by the
+                // layout-time min-pane-size guard (see `clamp_first_to_min`),
+                // matching `SplitManager::set_ratio` — not a fixed percentage floor.
+                *ratio = new_ratio.clamp(0.0, 1.0);
                 return true;
             }
         }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3286,7 +3286,11 @@ impl Editor {
         // The ratio represents the fraction of space the first split gets
         if total_size > 0 {
             let ratio_delta = delta as f32 / total_size as f32;
-            let new_ratio = (start_ratio + ratio_delta).clamp(0.1, 0.9);
+            // Store the raw fraction; the absolute minimum-pane-size guard is
+            // enforced at layout time, so dragging the separator toward the
+            // edge stops when the sibling would drop below the minimum size
+            // rather than at a fixed 10%/90%.
+            let new_ratio = (start_ratio + ratio_delta).clamp(0.0, 1.0);
 
             // Update the split ratio. The container may live in the main
             // split tree or inside a stashed Grouped subtree (buffer group

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1062,8 +1062,10 @@ impl Editor {
     /// second child). A plugin asking to resize "its" leaf resizes that
     /// parent split; whether the leaf is the first or second child, adjusting
     /// the parent ratio is the single, well-defined knob for that divider, and
-    /// the value is clamped to `[0.1, 0.9]`. Callers wanting a specific pane to
-    /// grow should account for which side it sits on.
+    /// the stored value is clamped only to the raw `[0.0, 1.0]` range; a sibling
+    /// pane is kept usable by the layout-time min-pane-size guard rather than a
+    /// fixed percentage floor. Callers wanting a specific pane to grow should
+    /// account for which side it sits on.
     ///
     /// Returns `true` if the ratio was applied:
     /// - a leaf id with a resizable parent `Split` → set the parent's ratio;

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -670,7 +670,10 @@ impl SplitNode {
             direction,
             first: Box::new(first),
             second: Box::new(second),
-            ratio: ratio.clamp(0.1, 0.9), // Prevent extreme ratios
+            // Keep the stored ratio a valid fraction; the absolute
+            // minimum-pane-size guard is applied at layout time
+            // (see `clamp_first_to_min`), not as a fixed percentage floor.
+            ratio: ratio.clamp(0.0, 1.0),
             split_id: ContainerId(split_id),
             fixed_first: None,
             fixed_second: None,
@@ -1007,6 +1010,45 @@ impl SplitNode {
     }
 }
 
+/// Minimum usable pane width, in columns.
+///
+/// A vertical split's separator eats one column; each child then needs enough
+/// room to show a (truncated) tab label plus a little content. Ten columns
+/// keeps a short filename tab and a handful of content cells legible, which is
+/// about the floor for a pane to be worth showing at all.
+pub const MIN_PANE_WIDTH: u16 = 10;
+
+/// Minimum usable pane height, in rows.
+///
+/// A pane spends one row on its tab bar; three rows leaves the tab bar plus two
+/// content rows, the smallest height where a pane is still usable rather than
+/// just a header.
+pub const MIN_PANE_HEIGHT: u16 = 3;
+
+/// Clamp the first child's cell size so neither child of a split renders below
+/// `min` cells.
+///
+/// `total` is the space shared by both children (the separator has already been
+/// subtracted). Normally the first child is clamped to `[min, total - min]`, so
+/// whatever the first child takes, the sibling keeps at least `min`. This is the
+/// real guard on split sizing: the stored ratio is free to be anything in
+/// `[0, 1]` (a plugin may ask for `0.99`), but at layout time the effective size
+/// is pinned so the sibling never drops below the minimum.
+///
+/// Small-container fallback: when the container cannot give *both* children the
+/// minimum (`total < 2 * min`), there is no size that satisfies the constraint.
+/// Rather than collapse or hide a pane, we split the available space evenly
+/// (`total / 2`) as a best effort so both panes stay as usable as the cramped
+/// container allows. This never panics (e.g. `total == 0` yields `0`).
+fn clamp_first_to_min(first: u16, total: u16, min: u16) -> u16 {
+    if total < min.saturating_mul(2) {
+        // Not enough room for both minimums — degrade to an even split.
+        total / 2
+    } else {
+        first.clamp(min, total - min)
+    }
+}
+
 /// Split a rectangle into two parts based on direction and ratio
 /// Leaves 1 character space for the separator line between splits
 #[cfg(test)]
@@ -1030,7 +1072,11 @@ fn split_rect_ext(
             } else if let Some(s) = fixed_second {
                 total_height.saturating_sub(s.min(total_height))
             } else {
-                (total_height as f32 * ratio).round() as u16
+                // Convert the ratio to cells, then pin it so neither child
+                // renders below the absolute minimum height (the sibling
+                // always keeps at least MIN_PANE_HEIGHT rows).
+                let raw = (total_height as f32 * ratio).round() as u16;
+                clamp_first_to_min(raw, total_height, MIN_PANE_HEIGHT)
             };
             let second_height = total_height.saturating_sub(first_height);
 
@@ -1058,7 +1104,11 @@ fn split_rect_ext(
             } else if let Some(s) = fixed_second {
                 total_width.saturating_sub(s.min(total_width))
             } else {
-                (total_width as f32 * ratio).round() as u16
+                // Convert the ratio to cells, then pin it so neither child
+                // renders below the absolute minimum width (the sibling
+                // always keeps at least MIN_PANE_WIDTH columns).
+                let raw = (total_width as f32 * ratio).round() as u16;
+                clamp_first_to_min(raw, total_width, MIN_PANE_WIDTH)
             };
             let second_width = total_width.saturating_sub(first_width);
 
@@ -1465,7 +1515,10 @@ impl SplitManager {
     pub fn adjust_ratio(&mut self, container_id: ContainerId, delta: f32) {
         match self.root.find_mut(container_id.into()) {
             Some(SplitNode::Split { ratio, .. }) => {
-                *ratio = (*ratio + delta).clamp(0.1, 0.9);
+                // Store the raw fraction; layout enforces the absolute
+                // minimum pane size, so resizing can approach the edge and
+                // simply stops when the sibling would drop below the minimum.
+                *ratio = (*ratio + delta).clamp(0.0, 1.0);
             }
             Some(SplitNode::Leaf { .. }) => {
                 unreachable!("ContainerId {:?} points to a leaf", container_id)
@@ -1543,7 +1596,11 @@ impl SplitManager {
     #[must_use]
     pub fn set_ratio(&mut self, container_id: ContainerId, new_ratio: f32) -> bool {
         if let Some(SplitNode::Split { ratio, .. }) = self.root.find_mut(container_id.into()) {
-            *ratio = new_ratio.clamp(0.1, 0.9);
+            // Store the plugin-supplied fraction as-is (within [0, 1]).
+            // A request like 0.99 is honored as a ratio, but layout pins the
+            // effective size so the sibling keeps at least the minimum pane
+            // size instead of being clamped to a fixed 90%.
+            *ratio = new_ratio.clamp(0.0, 1.0);
             true
         } else {
             false
@@ -1592,8 +1649,10 @@ impl SplitManager {
                 let total_leaves = first_leaves + second_leaves;
 
                 // Set ratio so each leaf gets equal space
-                // ratio = proportion for first pane
-                *ratio = (first_leaves as f32 / total_leaves as f32).clamp(0.1, 0.9);
+                // ratio = proportion for first pane. The absolute
+                // minimum-pane-size guard is applied at layout time, so we
+                // store the exact proportion here (clamped only to [0, 1]).
+                *ratio = (first_leaves as f32 / total_leaves as f32).clamp(0.0, 1.0);
 
                 total_leaves
             }
@@ -1946,9 +2005,17 @@ mod tests {
         );
         assert_eq!(manager.get_ratio(container_id), Some(0.7));
 
-        // Ratios are clamped to [0.1, 0.9].
+        // The stored ratio is now the raw fraction (only clamped to [0, 1]);
+        // the absolute minimum-pane-size guard lives at layout time, not as a
+        // fixed percentage floor. A plugin asking for 0.99 keeps 0.99.
         assert!(manager.set_ratio(ContainerId(container_id), 0.99));
-        assert_eq!(manager.get_ratio(container_id), Some(0.9));
+        assert_eq!(manager.get_ratio(container_id), Some(0.99));
+
+        // Out-of-range values are still pinned to a valid fraction.
+        assert!(manager.set_ratio(ContainerId(container_id), 1.5));
+        assert_eq!(manager.get_ratio(container_id), Some(1.0));
+        assert!(manager.set_ratio(ContainerId(container_id), -0.5));
+        assert_eq!(manager.get_ratio(container_id), Some(0.0));
     }
 
     #[test]
@@ -1975,11 +2042,15 @@ mod tests {
             .parent_container_of(LeafId(new_leaf_id))
             .expect("a split leaf must have a parent container");
 
-        // ...and setting the parent's ratio applies and clamps.
+        // ...and setting the parent's ratio applies. The stored ratio is the
+        // raw fraction (only clamped to [0, 1]); the absolute minimum-pane-size
+        // guard is applied at layout time, so a plugin's 0.99 is preserved and
+        // the sibling is kept >= min when the split is actually rendered
+        // (see the `split_rect` layout tests), not pinned to a fixed 90%.
         assert!(manager.set_ratio(parent, 0.75));
         assert_eq!(manager.get_ratio(parent.into()), Some(0.75));
         assert!(manager.set_ratio(parent, 0.99));
-        assert_eq!(manager.get_ratio(parent.into()), Some(0.9));
+        assert_eq!(manager.get_ratio(parent.into()), Some(0.99));
     }
 
     #[test]
@@ -2030,6 +2101,91 @@ mod tests {
         assert_eq!(second.height, 100);
         assert_eq!(first.x, 0);
         assert_eq!(second.x, 51); // first.x + first.width + 1 (separator)
+    }
+
+    // === Absolute minimum pane-size clamp tests ===
+
+    #[test]
+    fn test_clamp_first_to_min_pins_both_children() {
+        // Normal case: first child is clamped into [min, total - min].
+        assert_eq!(clamp_first_to_min(0, 100, 10), 10); // floor
+        assert_eq!(clamp_first_to_min(100, 100, 10), 90); // ceiling (sibling keeps min)
+        assert_eq!(clamp_first_to_min(50, 100, 10), 50); // unaffected in-range value
+        assert_eq!(clamp_first_to_min(5, 100, 10), 10);
+        assert_eq!(clamp_first_to_min(95, 100, 10), 90);
+    }
+
+    #[test]
+    fn test_clamp_first_to_min_small_container_fallback() {
+        // total < 2*min: cannot satisfy both minimums, degrade to even split.
+        assert_eq!(clamp_first_to_min(0, 15, 10), 7); // 15/2
+        assert_eq!(clamp_first_to_min(15, 15, 10), 7); // request ignored, even split
+        assert_eq!(clamp_first_to_min(3, 5, 10), 2); // 5/2
+        assert_eq!(clamp_first_to_min(0, 0, 10), 0); // never panics
+        assert_eq!(clamp_first_to_min(1, 1, 10), 0);
+    }
+
+    #[test]
+    fn test_layout_never_renders_child_below_min_width() {
+        // An extreme ratio (plugin asks for 0.99) must not starve the sibling:
+        // the second child keeps at least MIN_PANE_WIDTH columns.
+        let rect = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 40,
+        };
+        let (first, second) = split_rect(rect, SplitDirection::Vertical, 0.99);
+        assert!(
+            second.width >= MIN_PANE_WIDTH,
+            "sibling width {} must be >= {}",
+            second.width,
+            MIN_PANE_WIDTH
+        );
+        assert!(first.width >= MIN_PANE_WIDTH);
+        // total = 99; first pinned to 99 - MIN_PANE_WIDTH = 89, second = 10.
+        assert_eq!(first.width, 100 - 1 - MIN_PANE_WIDTH);
+        assert_eq!(second.width, MIN_PANE_WIDTH);
+
+        // The symmetric case: ratio 0.0 must leave the first child >= min.
+        let (first, second) = split_rect(rect, SplitDirection::Vertical, 0.0);
+        assert_eq!(first.width, MIN_PANE_WIDTH);
+        assert!(second.width >= MIN_PANE_WIDTH);
+    }
+
+    #[test]
+    fn test_layout_never_renders_child_below_min_height() {
+        let rect = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 40,
+        };
+        let (first, second) = split_rect(rect, SplitDirection::Horizontal, 0.99);
+        assert!(second.height >= MIN_PANE_HEIGHT);
+        assert!(first.height >= MIN_PANE_HEIGHT);
+        assert_eq!(second.height, MIN_PANE_HEIGHT);
+
+        let (first, second) = split_rect(rect, SplitDirection::Horizontal, 0.0);
+        assert_eq!(first.height, MIN_PANE_HEIGHT);
+        assert!(second.height >= MIN_PANE_HEIGHT);
+    }
+
+    #[test]
+    fn test_layout_small_container_degrades_evenly() {
+        // A vertical container too narrow for two MIN_PANE_WIDTH panes
+        // (available < 2*min) splits its space evenly instead of hiding one.
+        let rect = Rect {
+            x: 0,
+            y: 0,
+            width: 15, // total = 14 after separator, < 2*MIN_PANE_WIDTH (20)
+            height: 40,
+        };
+        let (first, second) = split_rect(rect, SplitDirection::Vertical, 0.99);
+        // total = 14 -> first = 7, second = 7. Neither collapses to zero.
+        assert_eq!(first.width, 7);
+        assert_eq!(second.width, 7);
+        assert!(first.width > 0 && second.width > 0);
     }
 
     // === Split label tests ===

--- a/crates/fresh-editor/tests/e2e/mouse.rs
+++ b/crates/fresh-editor/tests/e2e/mouse.rs
@@ -944,9 +944,15 @@ fn test_vertical_split_separator_drag_resize() {
     );
 }
 
-/// Test that separator drag respects minimum and maximum ratios
+/// Test that separator drag keeps both panes at least the absolute minimum
+/// pane size. The stored ratio is now free to reach the extremes (it is only
+/// clamped to `[0, 1]`); the real guard is applied at layout time, so an
+/// extreme drag pins the *rendered* sibling pane to `MIN_PANE_HEIGHT` rather
+/// than stopping the ratio at a fixed 0.1/0.9.
 #[test]
 fn test_split_separator_drag_respects_limits() {
+    use fresh::view::split::MIN_PANE_HEIGHT;
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Delay to avoid double-click detection (use config value * 2 for safety margin)
@@ -964,46 +970,47 @@ fn test_split_separator_drag_respects_limits() {
         .unwrap();
     harness.render().unwrap();
 
+    let (content_first, content_last) = harness.content_area_rows();
+    // `content_first` is where buffer *text* begins; a pane's split rectangle
+    // starts one row higher, at its tab bar. The bottom pane has no tab bar
+    // below it, so `content_last` already aligns with the split-area bottom.
+    let split_area_top = content_first.saturating_sub(1);
     let separators = harness.editor().get_separator_areas().to_vec();
-    let (split_id, _, sep_x, sep_y, sep_length) = separators[0];
+    let (_split_id, _, sep_x, sep_y, sep_length) = separators[0];
 
     // Try to drag separator way beyond reasonable limits
     let start_col = sep_x + sep_length / 2;
 
-    // Drag extremely far down (should clamp to max 0.9)
+    // Drag extremely far down: the first pane grows, but the second pane must
+    // still render at least MIN_PANE_HEIGHT rows (the separator cannot reach
+    // the bottom of the content area).
     harness
         .mouse_drag(start_col, sep_y, start_col, sep_y + 100)
         .unwrap();
+    harness.render().unwrap();
 
-    let max_ratio = harness.editor().get_split_ratio(split_id.into()).unwrap();
+    let sep_y_down = harness.editor().get_separator_areas()[0].3 as usize;
+    let second_pane_height = content_last.saturating_sub(sep_y_down);
     assert!(
-        max_ratio <= 0.9,
-        "Ratio should not exceed 0.9, got {max_ratio}"
-    );
-    assert!(
-        max_ratio >= 0.8,
-        "Ratio should be close to maximum after extreme drag down, got {max_ratio}"
+        second_pane_height >= MIN_PANE_HEIGHT as usize,
+        "After extreme drag down the sibling pane must keep at least {MIN_PANE_HEIGHT} rows, got {second_pane_height}"
     );
 
     // Wait to avoid double-click detection
     std::thread::sleep(double_click_delay);
 
-    // Drag extremely far up (should clamp to min 0.1)
-    let separators_after = harness.editor().get_separator_areas().to_vec();
-    let (_, _, _, sep_y_after, _) = separators_after[0];
-
+    // Drag extremely far up: now the first pane is pinned to the minimum.
+    let sep_y_after = harness.editor().get_separator_areas()[0].3;
     harness
         .mouse_drag(start_col, sep_y_after, start_col, 0)
         .unwrap();
+    harness.render().unwrap();
 
-    let min_ratio = harness.editor().get_split_ratio(split_id.into()).unwrap();
+    let sep_y_up = harness.editor().get_separator_areas()[0].3 as usize;
+    let first_pane_height = sep_y_up.saturating_sub(split_area_top);
     assert!(
-        min_ratio >= 0.1,
-        "Ratio should not be less than 0.1, got {min_ratio}"
-    );
-    assert!(
-        min_ratio <= 0.2,
-        "Ratio should be close to minimum after extreme drag up, got {min_ratio}"
+        first_pane_height >= MIN_PANE_HEIGHT as usize,
+        "After extreme drag up the first pane must keep at least {MIN_PANE_HEIGHT} rows, got {first_pane_height}"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/set_split_ratio_leaf.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/set_split_ratio_leaf.rs
@@ -130,10 +130,18 @@ fn set_split_ratio_on_leaf_resizes_parent_container() {
     );
 }
 
-/// Clamping still applies when resolving through a leaf: an out-of-range
-/// ratio is pinned to [0.1, 0.9] on the parent container.
+/// An out-of-range ratio resolved through a leaf is handled safely under the
+/// min-pane-size model.
+///
+/// The stored ratio is no longer pinned to a fixed `0.1/0.9` percentage window;
+/// it is only clamped to the raw `[0.0, 1.0]` range (so `5.0` stores as `1.0`).
+/// The real guarantee — a sibling pane never collapsing — moved to layout time,
+/// where `clamp_first_to_min` keeps every rendered pane at least `MIN_PANE_*`.
+/// This test asserts both facets: the raw ratio clamp *and* the rendered floor.
 #[test]
 fn set_split_ratio_on_leaf_clamps_parent_ratio() {
+    use fresh::view::split::MIN_PANE_HEIGHT;
+
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("hello.txt");
     fs::write(&path, "hi\n").unwrap();
@@ -163,12 +171,34 @@ fn set_split_ratio_on_leaf_clamps_parent_ratio() {
         .expect("setSplitRatio on a leaf resolves to its parent container");
     harness.tick_and_render().unwrap();
 
+    // (a) Raw-storage clamp: an out-of-range 5.0 is pinned to the [0.0, 1.0]
+    // range, i.e. stored as 1.0 (no longer to the old 0.9 percentage floor).
     assert_eq!(
         harness
             .editor()
             .split_manager_for_tests()
             .get_ratio(parent.into()),
-        Some(0.9),
-        "an out-of-range ratio must clamp to 0.9 on the parent container"
+        Some(1.0),
+        "an out-of-range ratio must clamp to the raw [0.0, 1.0] range (5.0 -> 1.0)"
+    );
+
+    // (b) The real guarantee: even with the parent ratio pushed to the extreme,
+    // the layout-time min-size clamp keeps *both* rendered panes at least
+    // MIN_PANE_HEIGHT rows tall — the sibling never collapses.
+    let (content_first, content_last) = harness.content_area_rows();
+    // A pane's split rectangle starts one row above where its text begins (the
+    // tab bar); the bottom pane has no tab bar below it, so `content_last`
+    // already aligns with the split-area bottom.
+    let split_area_top = content_first.saturating_sub(1);
+    let sep_y = harness.editor().get_separator_areas()[0].3 as usize;
+    let first_pane_height = sep_y.saturating_sub(split_area_top);
+    let second_pane_height = content_last.saturating_sub(sep_y);
+    assert!(
+        first_pane_height >= MIN_PANE_HEIGHT as usize,
+        "first pane must stay at least {MIN_PANE_HEIGHT} rows, got {first_pane_height}"
+    );
+    assert!(
+        second_pane_height >= MIN_PANE_HEIGHT as usize,
+        "sibling pane must stay at least {MIN_PANE_HEIGHT} rows after an extreme ratio, got {second_pane_height}"
     );
 }


### PR DESCRIPTION
## Problem

Split container ratios were clamped to a fixed `[0.1, 0.9]` percentage everywhere — split creation, separator drag, keyboard resize, plugin `setSplitRatio`, and distribute-evenly. A percentage floor is the wrong constraint:

- 10% of a huge pane is plenty of space, while 10% of a narrow terminal is only a few columns — too few to render a tab bar or any content.
- It arbitrarily blocks legitimately-small panes even when there is plenty of room to make one.

A plugin asking for `0.99` didn't get "leave the sibling a minimum usable size"; it got a fixed 90%, which on a narrow terminal is still an unusable sliver.

## What changed

Replace the percentage clamp with an **absolute minimum pane size enforced at layout time**.

- Added `MIN_PANE_WIDTH = 10` columns and `MIN_PANE_HEIGHT = 3` rows. A vertical split's separator eats one column and each child needs room for a truncated tab label plus a little content (≈10 cols); a horizontal pane spends one row on its tab bar, so three rows leaves the tab bar plus two content rows — the floor for a pane to be usable rather than just a header.
- `split_rect_ext` now converts the ratio to cells and then pins the split via a new `clamp_first_to_min` helper so that **neither child renders below the minimum** — whatever the first child takes, the sibling always keeps at least the minimum. This is the real guard now.
- **Small-container fallback:** when the container is too small to give both children the minimum (`available < 2 * min`), there is no size that satisfies the constraint, so it degrades to an **even split** rather than collapsing or hiding a pane. Never panics (`total == 0` yields `0`).
- Relaxed the stored-ratio clamps to `[0.0, 1.0]` at all five sites (split creation, `adjust_ratio`, `set_ratio`, `distribute_splits_evenly`, and the mouse-drag path). A plugin asking for `0.99` now **keeps `0.99`**, and the layout leaves the sibling `≥ min` instead of pinning it to a fixed 90%. This applies through the `setSplitRatio` leaf→parent-container resolution added in #2779 as well.

`set_ratio` keeps its `bool` return contract; `get_ratio` round-trips the raw stored ratio.

## Verification

Same action on a 44-column terminal — create a vertical split, then keyboard-resize the divider to the extreme:

- **Before** (`[0.1, 0.9]` clamp): the right pane is pinned to ~4 columns — the `s.txt` tab label and all content are gone, only the close icons remain. Unusable.
- **After** (min-size clamp): the right pane stops at `MIN_PANE_WIDTH` (~10 columns) — the `s.txt` tab, gutter, and (wrapped) content stay visible. Usable.

Tests:
- Unit: `clamp_first_to_min` pins both children; small-container fallback splits evenly; layout never renders a child below min width/height even at ratio `0.99`/`0.0`.
- Updated `test_set_ratio_on_container_applies_and_clamps` and `test_leaf_resolves_to_parent_container_for_ratio` to the new raw-storage semantics (`0.99` stays `0.99`, out-of-range pinned to `[0,1]`).
- Rewrote the `test_split_separator_drag_respects_limits` e2e test: after an extreme drag, the rendered sibling pane keeps at least `MIN_PANE_HEIGHT` rows (rather than asserting the old 0.1/0.9 ratio bounds).
- `cargo test -p fresh-editor` (split/layout focus), `cargo fmt --check`, and `cargo clippy` are clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P64ZBvEmKCHGdueUT2D5vt)_