### PR TITLE
(feature) Pin ancestor directory names in file explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Keyboard and mouse input is now parsed by our own `fresh-input-parser` crate ins
 * **Classic Mac (CR) line endings** are now fully supported (#2736, requested by @720720).
 * **`.editorconfig` support** - `indent_style`/`indent_size`/`tab_width` are picked up automatically (#959, requested by @nyurik).
 * **Save All** - save every modified buffer at once from the File menu (#2289, requested by @alspaughb).
+* **File Explorer sticky parents** - scrolling inside a nested folder now keeps its expanded ancestor folders stacked at the top of the sidebar, matching VS Code (#2705).
 
 ### Bug Fixes
 

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -616,13 +616,9 @@ impl Editor {
         let relative_row = row.saturating_sub(explorer_area.y + 1); // +1 for top border
 
         if let Some(explorer) = self.file_explorer_mut().as_mut() {
-            let display_nodes = explorer.get_display_nodes();
-            let scroll_offset = explorer.get_scroll_offset();
-            let clicked_index = (relative_row as usize) + scroll_offset;
-
-            if clicked_index < display_nodes.len() {
-                let (node_id, _indent) = display_nodes[clicked_index];
-
+            if let Some((node_id, _indent)) =
+                explorer.get_display_node_at_viewport_row(relative_row as usize)
+            {
                 // Select this node
                 explorer.set_selected(Some(node_id));
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1113,12 +1113,9 @@ impl Editor {
                 // Determine which item is at this row
                 if let Some(explorer) = self.file_explorer().as_ref() {
                     let relative_row = row.saturating_sub(content_start_y) as usize;
-                    let scroll_offset = explorer.get_scroll_offset();
-                    let item_index = relative_row + scroll_offset;
-                    let display_nodes = explorer.get_display_nodes();
-
-                    if item_index < display_nodes.len() {
-                        let (node_id, indent) = display_nodes[item_index];
+                    if let Some((node_id, indent)) =
+                        explorer.get_display_node_at_viewport_row(relative_row)
+                    {
                         if let Some(node) = explorer.tree().get_node(node_id) {
                             let theme = self.theme.read().unwrap();
                             let neutral_fg = if node
@@ -3369,12 +3366,10 @@ impl Editor {
                 let relative_row = row.saturating_sub(explorer_area.y + 1);
                 let (is_multi, is_root_selected) =
                     if let Some(explorer) = self.file_explorer_mut().as_mut() {
-                        let display_nodes = explorer.get_display_nodes();
-                        let scroll_offset = explorer.get_scroll_offset();
-                        let clicked_index = (relative_row as usize) + scroll_offset;
                         let mut clicked_is_root = false;
-                        if clicked_index < display_nodes.len() {
-                            let (node_id, _) = display_nodes[clicked_index];
+                        if let Some((node_id, _)) =
+                            explorer.get_display_node_at_viewport_row(relative_row as usize)
+                        {
                             explorer.set_selected(Some(node_id));
                             clicked_is_root = node_id == explorer.tree().root_id();
                         }

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -46,8 +46,7 @@ impl crate::app::window::Window {
                         return Ok(());
                     }
 
-                    let viewport = explorer.viewport_height.max(1);
-                    let max_scroll = count.saturating_sub(viewport);
+                    let max_scroll = explorer.max_scroll_offset();
                     let current_offset = explorer.get_scroll_offset();
                     let new_offset = if delta < 0 {
                         current_offset.saturating_sub(delta.unsigned_abs() as usize)

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -7,6 +7,10 @@ use crate::model::filesystem::DirEntry;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+/// Match VS Code's default upper bound for explorer sticky-scroll rows while
+/// always leaving at least one row for the scrolled contents.
+const MAX_STICKY_ANCESTORS: usize = 7;
+
 /// View state for file tree navigation and filtering
 #[derive(Debug)]
 pub struct FileTreeView {
@@ -189,6 +193,10 @@ impl FileTreeView {
         if let Some(sel) = self.selected_node {
             self.selected_node = Some(self.promote_to_anchor(sel));
         }
+        // A sticky ancestor can be toggled directly with the mouse. Collapsing
+        // it removes the scrolled descendants, so reconcile the old offset
+        // immediately or the selected parent could disappear from the screen.
+        self.update_scroll_for_selection();
         Ok(())
     }
 
@@ -282,6 +290,108 @@ impl FileTreeView {
                 (id, depth.saturating_sub(absorbed))
             })
             .collect()
+    }
+
+    /// Indices into [`Self::get_display_nodes`] in the order they should be
+    /// painted in the viewport.
+    ///
+    /// Once the tree is scrolled, expanded ancestors of the first ordinary
+    /// row are prepended as sticky context. The ancestor cap is also bounded
+    /// by the viewport so scrolling can never hide every ordinary row.
+    pub fn viewport_display_indices(&self) -> Vec<usize> {
+        let visible = self.filtered_visible_nodes();
+        self.viewport_display_indices_with_nodes(&visible, self.scroll_offset, self.viewport_height)
+    }
+
+    /// Resolve a screen row in the explorer body to the displayed tree node.
+    /// Sticky ancestor rows and ordinary scrolled rows deliberately share this
+    /// mapping so render, click, hover, and context-menu targeting cannot drift.
+    pub fn get_display_node_at_viewport_row(&self, row: usize) -> Option<(NodeId, usize)> {
+        let display = self.get_display_nodes();
+        let display_index = self.viewport_display_indices().get(row).copied()?;
+        display.get(display_index).copied()
+    }
+
+    fn viewport_display_indices_with_nodes(
+        &self,
+        visible: &[NodeId],
+        scroll_offset: usize,
+        viewport_height: usize,
+    ) -> Vec<usize> {
+        if visible.is_empty() || viewport_height == 0 {
+            return Vec::new();
+        }
+
+        let scroll_offset = scroll_offset.min(visible.len() - 1);
+        let sticky = self.sticky_indices(visible, scroll_offset, viewport_height);
+        let ordinary_rows = viewport_height.saturating_sub(sticky.len());
+        let ordinary_end = (scroll_offset + ordinary_rows).min(visible.len());
+
+        let mut indices = Vec::with_capacity(viewport_height);
+        indices.extend(sticky);
+        indices.extend(scroll_offset..ordinary_end);
+        indices
+    }
+
+    fn sticky_indices(
+        &self,
+        visible: &[NodeId],
+        scroll_offset: usize,
+        viewport_height: usize,
+    ) -> Vec<usize> {
+        if scroll_offset == 0 || scroll_offset >= visible.len() || viewport_height < 2 {
+            return Vec::new();
+        }
+
+        let max_sticky = MAX_STICKY_ANCESTORS.min(viewport_height - 1);
+        let mut ancestors = Vec::new();
+        let mut current = self
+            .tree
+            .get_node(visible[scroll_offset])
+            .and_then(|node| node.parent);
+
+        while let Some(ancestor) = current {
+            // Absorbed compact-directory nodes do not own a display row, so
+            // only pin ancestors found in the flattened visible list.
+            if let Some(index) = visible[..scroll_offset]
+                .iter()
+                .position(|&id| id == ancestor)
+            {
+                ancestors.push(index);
+            }
+            current = self.tree.get_node(ancestor).and_then(|node| node.parent);
+        }
+
+        ancestors.reverse();
+        if ancestors.len() > max_sticky {
+            // In a path deeper than the cap, the immediate parents carry
+            // more useful context than the outermost workspace levels.
+            ancestors.drain(..ancestors.len() - max_sticky);
+        }
+        ancestors
+    }
+
+    /// Largest scroll offset that still fills the viewport as far as the
+    /// sticky ancestor rows allow. Deep trees may need a slightly larger
+    /// offset than `visible_count - viewport_height`, because pinned parents
+    /// consume part of the viewport.
+    pub fn max_scroll_offset(&self) -> usize {
+        let visible = self.filtered_visible_nodes();
+        if visible.is_empty() || self.viewport_height == 0 {
+            return 0;
+        }
+
+        let first_candidate = visible.len().saturating_sub(self.viewport_height);
+        for offset in first_candidate..visible.len() {
+            let sticky = self
+                .sticky_indices(&visible, offset, self.viewport_height)
+                .len();
+            let ordinary_rows = self.viewport_height.saturating_sub(sticky);
+            if offset + ordinary_rows >= visible.len() {
+                return offset;
+            }
+        }
+        visible.len() - 1
     }
 
     /// Count ancestors of `id` whose row is folded into a deeper anchor's
@@ -431,8 +541,22 @@ impl FileTreeView {
             if let Some(pos) = visible.iter().position(|&id| id == selected) {
                 if pos < self.scroll_offset {
                     self.scroll_offset = pos;
-                } else if pos >= self.scroll_offset + self.viewport_height {
-                    self.scroll_offset = pos - self.viewport_height + 1;
+                } else {
+                    // Sticky ancestors reduce the number of ordinary rows in
+                    // the viewport. Advance only far enough to expose the
+                    // selection under the current ancestor stack, then repeat
+                    // if crossing a tree boundary changes that stack.
+                    loop {
+                        let sticky = self
+                            .sticky_indices(visible, self.scroll_offset, self.viewport_height)
+                            .len();
+                        let ordinary_rows = self.viewport_height.saturating_sub(sticky).max(1);
+                        let ordinary_end = self.scroll_offset + ordinary_rows;
+                        if pos < ordinary_end {
+                            break;
+                        }
+                        self.scroll_offset += pos - ordinary_end + 1;
+                    }
                 }
             }
         }
@@ -631,8 +755,18 @@ impl FileTreeView {
                     self.scroll_offset = pos;
                 }
                 // If selection is below viewport, scroll down
-                else if pos >= self.scroll_offset + viewport_height {
-                    self.scroll_offset = pos - viewport_height + 1;
+                else {
+                    loop {
+                        let sticky = self
+                            .sticky_indices(&visible, self.scroll_offset, viewport_height)
+                            .len();
+                        let ordinary_rows = viewport_height.saturating_sub(sticky).max(1);
+                        let ordinary_end = self.scroll_offset + ordinary_rows;
+                        if pos < ordinary_end {
+                            break;
+                        }
+                        self.scroll_offset += pos - ordinary_end + 1;
+                    }
                 }
             }
         }
@@ -949,6 +1083,35 @@ mod tests {
         (temp_dir, view)
     }
 
+    async fn create_sticky_scroll_view() -> (TempDir, FileTreeView) {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+        let leaf_dir = root.join("a/b/c");
+        std_fs::create_dir_all(&leaf_dir).unwrap();
+        for i in 0..6 {
+            std_fs::write(leaf_dir.join(format!("file{i}.txt")), "content").unwrap();
+        }
+
+        let manager = Arc::new(FsManager::new(Arc::new(StdFileSystem)));
+        let mut tree = FileTree::new(root.to_path_buf(), manager).await.unwrap();
+        for path in [
+            root.to_path_buf(),
+            root.join("a"),
+            root.join("a/b"),
+            leaf_dir,
+        ] {
+            let id = tree.get_node_by_path(&path).unwrap().id;
+            tree.expand_node(id).await.unwrap();
+        }
+
+        let mut view = FileTreeView::new(tree);
+        // Keep every ancestor on its own row so this fixture exercises the
+        // sticky stack rather than compact-directory folding.
+        view.set_compact_directories(false);
+        view.set_viewport_height(5);
+        (temp_dir, view)
+    }
+
     #[tokio::test]
     async fn test_view_creation() {
         let (_temp_dir, view) = create_test_view().await;
@@ -1050,6 +1213,57 @@ mod tests {
 
         // Scroll offset should be 0
         assert_eq!(view.get_scroll_offset(), 0);
+    }
+
+    #[tokio::test]
+    async fn sticky_ancestors_share_the_viewport_and_hit_mapping() {
+        let (_temp_dir, mut view) = create_sticky_scroll_view().await;
+        let display = view.get_display_nodes();
+        let ids: Vec<NodeId> = display.iter().map(|&(id, _)| id).collect();
+        assert_eq!(ids.len(), 10); // root + a/b/c + six files
+
+        view.set_scroll_offset(4);
+        assert_eq!(view.viewport_display_indices(), vec![0, 1, 2, 3, 4]);
+        for (row, &display_index) in [0usize, 1, 2, 3, 4].iter().enumerate() {
+            assert_eq!(
+                view.get_display_node_at_viewport_row(row).map(|(id, _)| id),
+                Some(ids[display_index])
+            );
+        }
+
+        // Four pinned parents leave one ordinary row, so reaching the last
+        // child requires a larger maximum than `count - viewport_height`.
+        assert_eq!(view.max_scroll_offset(), 9);
+        view.set_scroll_offset(view.max_scroll_offset());
+        assert_eq!(view.viewport_display_indices(), vec![0, 1, 2, 3, 9]);
+    }
+
+    #[tokio::test]
+    async fn selection_auto_scroll_accounts_for_sticky_ancestors() {
+        let (_temp_dir, mut view) = create_sticky_scroll_view().await;
+        view.select_last();
+        view.update_scroll_for_selection();
+
+        let selected = view.get_selected_index().unwrap();
+        assert_eq!(selected, 9);
+        assert_eq!(view.get_scroll_offset(), view.max_scroll_offset());
+        assert!(view.viewport_display_indices().contains(&selected));
+    }
+
+    #[tokio::test]
+    async fn collapsing_a_sticky_ancestor_keeps_it_selected_and_visible() {
+        let (_temp_dir, mut view) = create_sticky_scroll_view().await;
+        let display = view.get_display_nodes();
+        let sticky_parent = display[1].0;
+        view.set_scroll_offset(6);
+        view.set_selected(Some(sticky_parent));
+
+        view.toggle_with_chain(sticky_parent).await.unwrap();
+
+        assert_eq!(view.get_selected(), Some(sticky_parent));
+        assert_eq!(view.get_scroll_offset(), 1);
+        let selected = view.get_selected_index().unwrap();
+        assert!(view.viewport_display_indices().contains(&selected));
     }
 
     #[tokio::test]

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -720,6 +720,8 @@ pub struct FileExplorerView {
     pub scroll_offset: usize,
     pub viewport_height: usize,
     pub selected: Option<usize>,
+    /// Flattened-row indices in screen order, including sticky ancestors.
+    pub viewport_rows: Vec<usize>,
     pub rows: Vec<FileRow>,
 }
 
@@ -755,6 +757,7 @@ impl Editor {
             scroll_offset: view.get_scroll_offset(),
             viewport_height: view.viewport_height,
             selected: view.get_selected_index(),
+            viewport_rows: view.viewport_display_indices(),
             rows,
         })
     }

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -237,34 +237,24 @@ impl FileExplorerRenderer {
             );
         }
 
-        // Viewport height already applied above (before the `draw` early-out).
-        let viewport_height = viewport_height_pre;
-
         let display_nodes = view.get_display_nodes();
-        let scroll_offset = view.get_scroll_offset();
+        let viewport_indices = view.viewport_display_indices();
         let selected_index = view.get_selected_index();
-
-        // Clamp scroll_offset to valid range to prevent panic after tree mutations
-        // (e.g., when deleting a folder with many children while scrolled down)
-        // Issue #562: scroll_offset can become larger than display_nodes.len()
-        let scroll_offset = scroll_offset.min(display_nodes.len());
-
-        // Only render the visible subset of items (for manual scroll control)
-        // This prevents ratatui's List widget from auto-scrolling
-        let visible_end = (scroll_offset + viewport_height).min(display_nodes.len());
-        let visible_items = &display_nodes[scroll_offset..visible_end];
+        let selected_viewport_index = selected_index
+            .and_then(|selected| viewport_indices.iter().position(|&i| i == selected));
 
         // Available width for content (subtract borders and cursor indicator)
         let content_width = area.width.saturating_sub(3) as usize;
 
         let multi_selection = view.multi_selection();
 
-        // Create list items for visible nodes only
-        let items: Vec<ListItem> = visible_items
+        // Create list items for the viewport only. `viewport_indices` starts
+        // with any sticky ancestor rows, followed by the ordinary scrolled
+        // rows, and is also used by mouse hit-testing.
+        let items: Vec<ListItem> = viewport_indices
             .iter()
-            .enumerate()
-            .map(|(viewport_idx, &(node_id, indent))| {
-                let actual_idx = scroll_offset + viewport_idx;
+            .filter_map(|&actual_idx| {
+                let &(node_id, indent) = display_nodes.get(actual_idx)?;
                 let is_selected = selected_index == Some(actual_idx);
                 let is_multi_selected = multi_selection.contains(&node_id);
                 let fuzzy_match = if search_active {
@@ -272,7 +262,7 @@ impl FileExplorerRenderer {
                 } else {
                     None
                 };
-                Self::render_node(
+                Some(Self::render_node(
                     view,
                     deco,
                     node_id,
@@ -287,7 +277,7 @@ impl FileExplorerRenderer {
                     cut_paths,
                     tree_indicator_collapsed,
                     tree_indicator_expanded,
-                )
+                ))
             })
             .collect();
 
@@ -326,39 +316,34 @@ impl FileExplorerRenderer {
                 Style::default().bg(theme.current_line_bg)
             });
 
-        // Create list state for scrolling
-        // Since we're only passing visible items, the selection is relative to viewport
+        // Since we're only passing viewport items, selection is a screen-row
+        // index rather than an offset into the full flattened tree.
         let mut list_state = ListState::default();
-        if let Some(selected) = selected_index {
-            if selected >= scroll_offset && selected < scroll_offset + viewport_height {
-                // Selected item is in the visible range
-                list_state.select(Some(selected - scroll_offset));
-            }
+        if let Some(selected) = selected_viewport_index {
+            list_state.select(Some(selected));
         }
 
         frame.render_stateful_widget(list, area, &mut list_state);
 
         // Refine the selected row with its highlight keys (focused → selection
         // background, blurred → current-line background).
-        if let Some(selected) = selected_index {
-            if selected >= scroll_offset && selected < scroll_offset + viewport_height {
-                let row = area.y + 1 + (selected - scroll_offset) as u16;
-                let inner_x = area.x + 1;
-                let inner_w = area.width.saturating_sub(2);
-                let bg_key = if is_focused {
-                    "editor.selection_bg"
-                } else {
-                    "editor.current_line_bg"
-                };
-                rec.run(
-                    inner_x,
-                    row,
-                    inner_w,
-                    Some("editor.fg"),
-                    Some(bg_key),
-                    "File Explorer",
-                );
-            }
+        if let Some(selected) = selected_viewport_index {
+            let row = area.y + 1 + selected as u16;
+            let inner_x = area.x + 1;
+            let inner_w = area.width.saturating_sub(2);
+            let bg_key = if is_focused {
+                "editor.selection_bg"
+            } else {
+                "editor.current_line_bg"
+            };
+            rec.run(
+                inner_x,
+                row,
+                inner_w,
+                Some("editor.fg"),
+                Some(bg_key),
+                "File Explorer",
+            );
         }
 
         // Render close button "×" at the right side of the title bar
@@ -368,21 +353,19 @@ impl FileExplorerRenderer {
         // We render a cursor indicator character and position the hardware cursor there
         // The hardware cursor provides efficient terminal-native blinking
         if is_focused {
-            if let Some(selected) = selected_index {
-                if selected >= scroll_offset && selected < scroll_offset + viewport_height {
-                    // Position at the left edge of the selected row (after border)
-                    let cursor_x = area.x + 1;
-                    let cursor_y = area.y + 1 + (selected - scroll_offset) as u16;
+            if let Some(selected) = selected_viewport_index {
+                // Position at the left edge of the selected row (after border)
+                let cursor_x = area.x + 1;
+                let cursor_y = area.y + 1 + selected as u16;
 
-                    // Render a cursor indicator character that the hardware cursor will blink over
-                    let cursor_indicator = ratatui::widgets::Paragraph::new("▌")
-                        .style(Style::default().fg(theme.cursor));
-                    let cursor_area = ratatui::layout::Rect::new(cursor_x, cursor_y, 1, 1);
-                    frame.render_widget(cursor_indicator, cursor_area);
+                // Render a cursor indicator character that the hardware cursor will blink over
+                let cursor_indicator =
+                    ratatui::widgets::Paragraph::new("▌").style(Style::default().fg(theme.cursor));
+                let cursor_area = ratatui::layout::Rect::new(cursor_x, cursor_y, 1, 1);
+                frame.render_widget(cursor_indicator, cursor_area);
 
-                    // Position hardware cursor here for blinking effect
-                    frame.set_cursor_position((cursor_x, cursor_y));
-                }
+                // Position hardware cursor here for blinking effect
+                frame.set_cursor_position((cursor_x, cursor_y));
             }
         }
     }

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -1136,11 +1136,6 @@ fn test_scroll_allows_cursor_to_top() {
     let initial_screen = harness.screen_to_string();
     println!("Initial screen:\n{}", initial_screen);
 
-    // Get the viewport height (number of visible rows in file explorer)
-    // Terminal height is 10, minus menu bar (1), status bar (1), prompt line (1), tab bar (1) = 6 main area
-    // File explorer has borders (1 top) and may share space, so content area is ~5 rows
-    let viewport_height = 5;
-
     // Navigate down to the bottom of the list
     // This will cause the explorer to scroll down
     for _ in 0..25 {
@@ -1152,10 +1147,18 @@ fn test_scroll_allows_cursor_to_top() {
 
     let screen_at_bottom = harness.screen_to_string();
     println!("Screen at bottom (scrolled down):\n{}", screen_at_bottom);
+    assert!(
+        screen_at_bottom
+            .lines()
+            .any(|line| line.starts_with('│') && line.contains("project_root")),
+        "the project root should remain pinned while its children scroll"
+    );
 
     // Now we're at the bottom and the view has scrolled down.
     // The test: when we press Up, the cursor should move WITHIN the viewport
-    // for (viewport_height - 1) times before the view scrolls.
+    // for (visible ordinary rows - 1) times before the view scrolls. Sticky
+    // ancestor rows (the project root here) intentionally consume part of
+    // the viewport and are not included in `get_visible_files`.
 
     // Track which files are visible to detect scrolling. Only scan rows
     // that start with the explorer's left border so the tab bar and
@@ -1179,9 +1182,9 @@ fn test_scroll_allows_cursor_to_top() {
     let initial_visible = get_visible_files(&screen_at_bottom);
     println!("Initially visible files: {:?}", initial_visible);
 
-    // Press Up multiple times (less than viewport_height times)
+    // Press Up while there are still earlier ordinary rows in the viewport.
     // The visible files should stay the same (no scrolling yet)
-    for i in 0..(viewport_height - 1) {
+    for i in 0..initial_visible.len().saturating_sub(1) {
         harness
             .send_key(KeyCode::Up, KeyModifiers::empty())
             .unwrap();

--- a/docs/features/file-explorer.md
+++ b/docs/features/file-explorer.md
@@ -5,6 +5,7 @@ Fresh includes a built-in file explorer.
 *   **Toggle Sidebar:** Use `Ctrl+B` to show/hide the file explorer sidebar. When a nested file is active, toggling on expands the tree and reveals the file.
 *   **Focus:** Use `Ctrl+E` to switch focus between the file explorer and editor.
 *   **Navigation:** Use the arrow keys to move up and down the file tree.
+*   **Sticky parents:** When you scroll through a nested folder, its expanded ancestor folders remain visible at the top of the sidebar.
 
 ## Opening Files
 

--- a/docs/internal/web-ui.md
+++ b/docs/internal/web-ui.md
@@ -38,7 +38,7 @@ Strengths to preserve through any of the work below:
 6. **Accessibility**: screen-reader access to buffer and chrome, focus visibility, keyboard-only completeness.
 7. **Deployment**: survives being more than one localhost tab — authentication, TLS, reconnect, more than one concurrent client.
 
-Two things VS Code has that are **editor-core feature gaps, not web-frontend gaps**, and therefore out of scope here: the minimap and sticky scroll (neither exists in the TUI; the web renders what the pipeline renders). Pixel-smooth *sub-cell* scrolling is likewise bounded by the cell model itself — the web can only scroll in whole visual rows for as long as the pipeline thinks in cells. These belong to core rendering discussions, not this doc.
+The minimap remains an **editor-core feature gap, not a web-frontend gap**, and therefore is out of scope here. Explorer sticky scroll is derived by the core and projected to both renderers. Pixel-smooth *sub-cell* scrolling is likewise bounded by the cell model itself — the web can only scroll in whole visual rows for as long as the pipeline thinks in cells. These belong to core rendering discussions, not this doc.
 
 ## 3. Design gaps — PLANNED, decisions needed before code
 

--- a/web-ui/js/70-panels.js
+++ b/web-ui/js/70-panels.js
@@ -41,8 +41,12 @@ function fileExplorerEl(fe){
   const title=div("fx-title"); title.textContent=fe.title||"Explorer"; el.appendChild(title);
   const list=div("fx-list");
   const n=Math.max(0,(fe.viewportHeight||fe.rect.h)), start=fe.scrollOffset||0;
+  // Newer cores provide the exact screen-row mapping, including sticky
+  // ancestors. Keep the contiguous fallback for compatibility with an older
+  // core while the web assets are being refreshed.
+  const viewportRows=fe.viewportRows||Array.from({length:n},(_,j)=>start+j);
   for(let j=0;j<n;j++){
-    const idx=start+j, r=fe.rows[idx]; if(!r) break;
+    const idx=viewportRows[j], r=fe.rows[idx]; if(!r) break;
     const row=div("fx-row"+(idx===fe.selected?" sel":""));
     row.style.paddingLeft=(6 + r.depth*10)+"px";
     const chev=document.createElement("span"); chev.className="fx-chev";
@@ -87,4 +91,3 @@ function borderDragHandle(bx, by, h){
   };
   return grip;
 }
-


### PR DESCRIPTION
fix #2705