### PR TITLE
fix(orchestrator): forget an in-place session's workspace on Delete/Archive

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2686,6 +2686,19 @@ pub enum PluginCommand {
     /// first. Fires `session_closed` on success.
     CloseWindow { id: WindowId },
 
+    /// Forget a directory's persisted workspace registry entry (the
+    /// `workspaces/<encoded-root>.json` file(s) the boot-time session
+    /// discovery scans). `CloseWindow` only drops the in-memory window;
+    /// without this the on-disk file survives and — because discovery
+    /// garbage-collects only entries whose directory is *gone* — an
+    /// in-place session (one that keeps its directory, unlike a worktree
+    /// the caller `git worktree remove`s) is rediscovered on the next
+    /// launch and "comes back". The orchestrator sends this when Delete
+    /// or Archive permanently forgets such a session. Removes every
+    /// co-tenant file at `root`; a still-open co-tenant window re-writes
+    /// its own file on its next checkpoint.
+    DeleteWorkspace { root: PathBuf },
+
     /// Eagerly initialise an inactive session's per-session state
     /// (file tree walk, ignore matcher, etc.) without diving. The
     /// only thing that's actually pre-warmed today is the file

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3249,6 +3249,16 @@ interface EditorAPI {
 	*/
 	closeWindow(id: number): boolean;
 	/**
+	* Forget a directory's persisted workspace so a permanently deleted
+	* or archived in-place session does not reappear on the next launch.
+	* `closeWindow` only drops the live window — this removes the on-disk
+	* registry file the session discovery would otherwise rediscover.
+	* Call it *after* `closeWindow` for a session whose directory stays
+	* on disk (a worktree-owning session is forgotten by removing its
+	* worktree instead). No-op if nothing is persisted for `root`.
+	*/
+	deleteWorkspace(root: string): boolean;
+	/**
 	* Eagerly initialise an inactive session's per-session state
 	* (file tree walk, ignore matcher, etc.) without diving.
 	* No-op for the active session or unknown id.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5330,6 +5330,10 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
       orchestratorSessions.delete(id);
       discoveredIdByPath.delete(s.root);
     }
+    // The worktree moved to the graveyard, so the original root is gone;
+    // forget its now-dangling persisted workspace explicitly rather than
+    // leaning on boot-time GC to notice the directory vanished.
+    editor.deleteWorkspace(s.root);
     return { ok: true, repoRoot };
   }
 
@@ -5349,6 +5353,11 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
   });
   saveArchiveManifest(repoRoot, manifest);
   orchestratorSessions.delete(id);
+  // In-place archive leaves the directory on disk, so its persisted
+  // workspace must be forgotten too — otherwise discovery re-adds it as a
+  // live session on the next launch, double-listed with its archive entry.
+  // Unarchive reopens from the manifest, so the dropped layout is expendable.
+  editor.deleteWorkspace(s.root);
   return { ok: true, repoRoot };
 }
 
@@ -5625,6 +5634,13 @@ async function deleteOne(id: number): Promise<LifecycleResult> {
     // could linger in the model and "come back" when the dialog reopens.
     orchestratorSessions.delete(id);
   }
+  // Permanently forget the persisted workspace so boot-time session
+  // discovery can't resurrect this row on the next launch. A worktree
+  // session already had its directory removed above (discovery GCs the
+  // now-dangling file), but an in-place / launch session keeps its
+  // directory, so its `workspaces/<root>.json` must be dropped explicitly
+  // or the row reappears after a restart.
+  editor.deleteWorkspace(s.root);
   return { ok: true, repoRoot };
 }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -978,6 +978,18 @@ impl Editor {
             PluginCommand::CloseWindow { id } => {
                 let _ = self.close_window(id);
             }
+            PluginCommand::DeleteWorkspace { root } => {
+                // Permanently forget this directory's persisted session so
+                // boot-time discovery can't rediscover it. Best-effort, like
+                // discovery's own GC: a failed unlink just leaves the file to
+                // be retried next launch rather than aborting the delete.
+                if let Err(e) = crate::workspace::Workspace::delete(&root) {
+                    tracing::warn!(
+                        "DeleteWorkspace: could not forget workspace for {:?}: {e}",
+                        root
+                    );
+                }
+            }
             PluginCommand::PrewarmWindow { id } => {
                 self.prewarm_window(id);
             }

--- a/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
+++ b/crates/fresh-editor/tests/orchestrator_eager_persistence.rs
@@ -337,3 +337,64 @@ fn tagging_a_new_session_persists_it_without_a_quit() {
     // carrying record behind.
     let _ = before;
 }
+
+/// Deleting an in-place session must forget its persisted workspace, or
+/// boot-time discovery rediscovers it and the row "comes back" after a
+/// restart. The orchestrator's Delete/Archive of a session whose directory
+/// stays on disk (a launch / in-place session, unlike a worktree it
+/// `git worktree remove`s) now follows `CloseWindow` with `DeleteWorkspace`.
+/// This pins that the explicit forget — not the window close — is what
+/// removes the registry entry the next launch would otherwise resurrect.
+/// `handle_plugin_command` (the delete's entry point) only exists with the
+/// `plugins` feature, so gate the test the same way its siblings are.
+#[cfg(feature = "plugins")]
+#[test]
+fn deleting_an_in_place_session_forgets_its_persisted_workspace() {
+    use fresh_core::api::PluginCommand;
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let proj_a = sandbox.path().join("a");
+    let proj_b = sandbox.path().join("b");
+    let data_home = sandbox.path().join("data-home");
+    std::fs::create_dir_all(&proj_a).unwrap();
+    std::fs::create_dir_all(&proj_b).unwrap();
+    std::fs::create_dir_all(&data_home).unwrap();
+    // Unique tmp roots, so the global workspace registry has no stale entry.
+    let proj_a = proj_a.canonicalize().unwrap();
+    let proj_b = proj_b.canonicalize().unwrap();
+    let file_a = proj_a.join("hello.txt");
+    std::fs::write(&file_a, "hi").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(&data_home);
+    let mut e = editor_in(&proj_a, &dir_context);
+    let win_a = e.active_window_id();
+    e.open_file(&file_a).unwrap();
+
+    // A second window, then switch to it: the switch checkpoints A into the
+    // registry (and leaves A non-active, non-last so it can be closed).
+    let win_b = e.create_window_at(proj_b.clone(), "b".into());
+    e.set_active_window(win_b);
+    assert!(
+        Workspace::load(&proj_a).unwrap().is_some(),
+        "precondition: switching away persisted A's workspace"
+    );
+
+    // Closing the window alone does NOT forget the persisted workspace —
+    // exactly why a deleted in-place row used to reappear after a restart.
+    e.handle_plugin_command(PluginCommand::CloseWindow { id: win_a })
+        .unwrap();
+    assert!(
+        Workspace::load(&proj_a).unwrap().is_some(),
+        "CloseWindow alone leaves the registry entry that discovery resurrects"
+    );
+
+    // The explicit forget is what makes the deletion stick across a restart.
+    e.handle_plugin_command(PluginCommand::DeleteWorkspace {
+        root: proj_a.clone(),
+    })
+    .unwrap();
+    assert!(
+        Workspace::load(&proj_a).unwrap().is_none(),
+        "a deleted in-place session must be forgotten so a restart can't rediscover it"
+    );
+}

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4795,6 +4795,21 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Forget a directory's persisted workspace so a permanently deleted
+    /// or archived in-place session does not reappear on the next launch.
+    /// `closeWindow` only drops the live window — this removes the on-disk
+    /// registry file the session discovery would otherwise rediscover.
+    /// Call it *after* `closeWindow` for a session whose directory stays
+    /// on disk (a worktree-owning session is forgotten by removing its
+    /// worktree instead). No-op if nothing is persisted for `root`.
+    pub fn delete_workspace(&self, root: String) -> bool {
+        self.command_sender
+            .send(PluginCommand::DeleteWorkspace {
+                root: PathBuf::from(root),
+            })
+            .is_ok()
+    }
+
     /// Eagerly initialise an inactive session's per-session state
     /// (file tree walk, ignore matcher, etc.) without diving.
     /// No-op for the active session or unknown id.


### PR DESCRIPTION
## Problem

Deleting a workspace from the Orchestrator dock (e.g. `sessions`, `session-1`) removed it from the UI but it **came back after restarting the editor**.

The dock is rebuilt on every boot by `discover_sessions`, which re-scans `<data_dir>/workspaces/*.json` (one file per directory ever opened) and its **only** GC rule is *"is the directory gone?"*. Delete/Archive for an in-place / launch session only did `orchestratorSessions.delete(id)` (in-memory) + `closeWindow` — neither of which removes the on-disk workspace file. Since the directory still exists, the entry was resurrected on the next launch.

Worktree-owned sessions masked the bug: Delete `git worktree remove`s (and Archive `git worktree move`s) their directory, so the "directory gone" GC cleans their file automatically. In-place sessions keep their directory, so nothing ever triggered cleanup.

## Fix

- New editor API `deleteWorkspace(root)` → `PluginCommand::DeleteWorkspace` → `Workspace::delete` (the existing, previously test-only, registry-forget helper).
- `deleteOne` and both branches of `archiveOne` now call it after the window closes, so the persisted registry entry is dropped and discovery can't rediscover the session.
- Deleting by root also clears any co-tenant file at that root; a still-open co-tenant re-checkpoints its own file on its next switch-away, so nothing is permanently lost.

Worktree paths are unchanged (they already work via directory removal + GC), but Archive now also forgets the now-dangling original-root file eagerly instead of waiting for the next boot's GC.

## Test

`deleting_an_in_place_session_forgets_its_persisted_workspace` (in `orchestrator_eager_persistence.rs`) pins the delta: after `CloseWindow` the registry entry still exists (the resurrection source), and only `DeleteWorkspace` removes it — so a restart can't rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)