### PR TITLE
fix(nix): include web-ui assets in the filtered build source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,12 @@
               (lib.fileset.fileFilter (file: file.hasExt "ttf") unfilteredRoot)
               # Icon files (used by include_bytes! in fresh-gui)
               (lib.fileset.fileFilter (file: file.hasExt "png") unfilteredRoot)
+              # Web UI assets assembled by crates/fresh-editor/build.rs
+              # (shell.html + css/*.css + js/*.js concatenated into the
+              # embedded webui-index.html). The .js filter above already
+              # catches web-ui/js, but shell.html and the css/ parts are
+              # not covered by any extension filter, so include the tree.
+              ./web-ui
               # Runtime assets in crates/fresh-editor
               ./crates/fresh-editor/docs
               ./crates/fresh-editor/keymaps


### PR DESCRIPTION
## Problem

The `test-nix-build` CI job [failed](https://github.com/sinelaw/fresh/actions/runs/30100067026/job/89503722412):

```
thread 'main' panicked at crates/fresh-editor/build.rs:461:61:
web-ui/shell.html: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

`crates/fresh-editor/build.rs` (`assemble_webui`) reads `web-ui/shell.html` and `web-ui/css/*.css` to assemble the embedded `webui-index.html`. The flake's source filter kept `.js` files by extension — so `web-ui/js` slipped through — but nothing covered `.html` or `.css`, so `shell.html` was absent from the sandboxed source tree and the build script panicked.

This surfaced now because the web-UI assembly landed recently and the flake's `fileset` was never updated to match.

## Fix

Add `./web-ui` to the `lib.fileset.unions` in `flake.nix`, bringing in `shell.html`, `css/`, and `js/` wholesale — matching how the other runtime asset directories (`docs`, `keymaps`, `themes`, …) are already enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)