### PR TITLE
fix(flatpak): copy write-install-receipt.sh into the source tree

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -51,6 +51,14 @@ jobs:
           mkdir -p crates/fresh-editor/docs/icons/linux
           cp -r docs/icons/linux/hicolor crates/fresh-editor/docs/icons/linux/
 
+      - name: Copy install-receipt script into Flatpak source tree
+        run: |
+          # The manifest runs scripts/write-install-receipt.sh relative to the
+          # source root (crates/fresh-editor, via `path: ..`), but the script
+          # lives at the repo root. Copy it in like the icons above.
+          mkdir -p crates/fresh-editor/scripts
+          cp scripts/write-install-receipt.sh crates/fresh-editor/scripts/
+
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:


### PR DESCRIPTION
## Problem

The Flatpak build [failed](https://github.com/sinelaw/fresh/actions/runs/30101454600/job/89514875693) with exit code 127:

```
Running: sh scripts/write-install-receipt.sh flatpak ${FLATPAK_DEST}/share/fresh/install-receipt.toml flatpak_ref=io.github.sinelaw.fresh
sh: scripts/write-install-receipt.sh: No such file or directory
Error: module fresh: Child process exited with code 127
```

The manifest's `sources` use `type: dir, path: ..`, so the Flatpak build source root is `crates/fresh-editor/`. The install-receipt provenance step (recently added) invokes `scripts/write-install-receipt.sh`, which resolves to `crates/fresh-editor/scripts/…` — but the script actually lives at the repo root (`scripts/write-install-receipt.sh`). The workflow stages the binary and icons into the source tree but never copied this script.

## Fix

Add a workflow step that copies `scripts/write-install-receipt.sh` into `crates/fresh-editor/scripts/`, mirroring the existing "Copy icons into Flatpak source tree" step. The script is self-contained POSIX `sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)