### PR TITLE
git-gutter plugin: force spawned git to use built-in diff format

### DIFF
--- a/crates/fresh-editor/plugins/git_gutter.ts
+++ b/crates/fresh-editor/plugins/git_gutter.ts
@@ -207,9 +207,14 @@ async function isGitTracked(filePath: string): Promise<boolean> {
 async function getGitDiff(filePath: string): Promise<string> {
   const cwd = getFileDirectory(filePath);
 
-  // Diff against HEAD to show all changes (staged + unstaged) vs last commit
+  // Diff against HEAD to show all changes (staged + unstaged) vs last commit.
+  // Force Git's native unified format: user-configured external diff/textconv
+  // tools can emit side-by-side or ANSI output that this parser cannot consume.
   const result = await editor.spawnProcess("git", [
+    "--no-pager",
     "diff",
+    "--no-ext-diff",
+    "--no-textconv",
     "HEAD",
     "--no-color",
     "--unified=0", // No context lines for cleaner parsing

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -349,6 +349,41 @@ A sample project for testing.
         copy_plugin(&plugins_dir, "git_gutter");
     }
 
+    /// Configure local stand-ins for the `difft` external diff tool and the
+    /// `delta` pager. The fake difft intentionally emits side-by-side output
+    /// instead of a unified diff, matching the configuration from issue #2721
+    /// without requiring either tool to be installed on the test machine.
+    #[cfg(unix)]
+    pub fn setup_external_diff_and_pager(&self) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let difft = self.create_file(
+            "difft",
+            "#!/bin/sh\nprintf '%s\\n' 'src/main.rs --- Rust' '1 fn main() | 1 fn main()'\n",
+        );
+        let delta = self.create_file("delta", "#!/bin/sh\ncat\n");
+
+        for tool in [&difft, &delta] {
+            fs::set_permissions(tool, fs::Permissions::from_mode(0o755))
+                .expect("Failed to make fake diff tool executable");
+        }
+
+        for (key, value) in [
+            ("diff.external", difft.to_string_lossy()),
+            ("core.pager", delta.to_string_lossy()),
+        ] {
+            let output = git_command(&self.path)
+                .args(["config", "--local", key, value.as_ref()])
+                .output()
+                .expect("Failed to configure fake diff tool");
+            assert!(
+                output.status.success(),
+                "git config {key} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
     /// Set up live diff plugin for live-diff e2e tests
     pub fn setup_live_diff_plugin(&self) {
         let plugins_dir = self.path.join("plugins");

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -4,6 +4,7 @@ use crate::common::git_test_helper::{DirGuard, GitTestRepo};
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
+use ratatui::style::Color;
 
 // =============================================================================
 // Test Helpers
@@ -264,6 +265,26 @@ fn test_git_gutter_updates_after_save() {
 
     let screen = harness.screen_to_string();
     println!("After save screen:\n{}", screen);
+
+    let (row, added_line) = screen
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line.contains("// New comment"))
+        .expect("New comment should be visible after save");
+    assert_eq!(
+        added_line.chars().next(),
+        Some('│'),
+        "Saved Git gutter indicator should remain in its original position"
+    );
+
+    let indicator_style = harness
+        .get_cell_style(0, row as u16)
+        .expect("Git gutter indicator cell should have a style");
+    assert_eq!(
+        indicator_style.fg,
+        Some(Color::Rgb(80, 250, 123)),
+        "Saved Git gutter indicator should turn green"
+    );
 }
 
 /// Test that git gutter shows added lines indicator

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -199,6 +199,54 @@ fn start_server(config: Config) {
     println!("Git gutter screen:\n{}", screen);
 }
 
+/// Regression test for issue #2721: user-configured external diff tools may
+/// emit side-by-side output, but the gutter parser requires a unified diff.
+#[test]
+#[cfg(unix)]
+fn test_git_gutter_ignores_external_diff_and_pager() {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    repo.setup_git_gutter_plugin();
+    repo.setup_external_diff_and_pager();
+
+    repo.modify_file(
+        "src/main.rs",
+        r#"fn main() {
+    println!("Modified while difft is configured!");
+    let config = load_config();
+    start_server(config);
+}
+
+fn load_config() -> Config {
+    Config::default()
+}
+
+fn start_server(config: Config) {
+    println!("Starting server...");
+}
+"#,
+    );
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    open_file(&mut harness, &repo.path, "src/main.rs");
+    wait_for_indicator(&mut harness, "│");
+
+    assert!(
+        has_gutter_indicator(&harness.screen_to_string(), "│"),
+        "Git gutter indicator should appear even when diff.external and core.pager are configured"
+    );
+}
+
 /// Test that git gutter updates after saving a file
 // TODO: Fix git gutter tests on Windows - they fail due to git command output differences
 #[test]


### PR DESCRIPTION
fix #2721