### PR TITLE
fix(terminal): include the last character when a drag overshoots the text

### DIFF
--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -591,10 +591,23 @@ impl super::Editor {
                     let line_start = state.buffer.line_col_to_position(line_idx, 0);
                     let layout =
                         crate::view::line_wrap_cache::layout_for_plain_text_grid(trimmed, cols, 4);
-                    let byte_in_line = layout
-                        .get(remaining)
-                        .and_then(|r| r.source_byte_at_visual_col(grid_col))
-                        .unwrap_or(trimmed.len());
+                    // A column past the row's rendered content resolves to
+                    // the row segment's END (the next segment's start, or the
+                    // line end on the last row) — same as click_geometry's
+                    // past-content clamp for ordinary buffer views. It must
+                    // NOT go through `source_byte_at_visual_col`, whose
+                    // out-of-range fallback clamps to the LAST character's
+                    // start byte and would drop the final character from any
+                    // selection whose drag overshoots the text.
+                    let byte_in_line = match layout.get(remaining) {
+                        Some(seg) if grid_col < seg.visual_width() => seg
+                            .source_byte_at_visual_col(grid_col)
+                            .unwrap_or(trimmed.len()),
+                        _ => layout
+                            .get(remaining + 1)
+                            .and_then(|next| next.source_start_byte)
+                            .unwrap_or(trimmed.len()),
+                    };
                     return Some(
                         state
                             .buffer

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -4468,6 +4468,38 @@ fn test_terminal_drag_select_copy_resumes_live() {
     );
 }
 
+/// A drag that overshoots the end of the echoed text must still select the
+/// WHOLE text, last character included. Regression: the grid-wrap byte
+/// resolver (`terminal_grid_byte_at`) resolved a past-end column through
+/// `source_byte_at_visual_col`, whose out-of-range fallback clamps to the
+/// last character's *start* byte — so every selection whose drag ended past
+/// the text silently lost the final character (fresh web-ui suite caught it
+/// as a copied "…MARKER-4" for an on-screen "…MARKER-42").
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_drag_select_past_line_end_includes_last_char() {
+    let mut harness = harness_or_return!(120, 30);
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    let marker = "XSELECT_PAST_EOL_9";
+    let (col, row) = terminal_with_marker(&mut harness, marker);
+
+    // Overshoot the 18-char marker by several columns.
+    drag_select_row(&mut harness, col, col + marker.len() as u16 + 7, row).unwrap();
+    assert!(
+        primary_selection_active(&harness),
+        "drag should build a real selection over the terminal text"
+    );
+
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    let clip = harness.editor_mut().clipboard_content_for_test();
+    assert!(
+        clip.contains(marker),
+        "a drag past the end of the text must copy it whole (last char included), got {clip:?}"
+    );
+}
+
 /// A bare click on a drag-parked scrollback pane abandons the selection and
 /// resumes the live grid immediately — no new output required.
 #[test]


### PR DESCRIPTION
Dragging a selection across terminal scrollback text and releasing past
the end of the line silently dropped the final character: the grid-wrap
byte resolver (terminal_grid_byte_at) mapped past-end columns through
ViewLine::source_byte_at_visual_col, whose out-of-range fallback clamps
to the LAST character's start byte — one short of the line end. A drag
over "web-sel-MARKER-42" that ended a couple of cells past the text
copied "web-sel-MARKER-4".

Regression from the grid-wrap scroll-back rework (5fb490f, fresh#2649):
the previous non-wrap path clamped via line_col_to_position, which
resolves past-end columns to the line END. None of that commit's files
are in the web-ui workflow's path filter, so the suite that catches
this (drive.mjs terminal-selection block) never re-ran on master.

Resolve columns at or past a row segment's rendered width to the
segment's end (the next segment's start byte, or the line end on the
last row), matching click_geometry's past-content clamp for ordinary
buffer views. Affects both frontends — the TUI drag path shares
terminal_grid_byte_at.

Reproducer: test_terminal_drag_select_past_line_end_includes_last_char
drags past the end of an echoed marker and asserts the copy contains
the whole marker; it fails without this fix (copy missing the final
character) and passes with it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012LVXW6NYuyfbLxyNQUdbEo