### PR TITLE
feat(whitespace): add newline and carriage-return indicators

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -95,6 +95,8 @@
         "whitespace_tabs_leading": true,
         "whitespace_tabs_inner": true,
         "whitespace_tabs_trailing": true,
+        "whitespace_newlines": false,
+        "whitespace_carriage_returns": false,
         "use_tabs": false,
         "tab_size": 4,
         "auto_indent": true,
@@ -649,6 +651,18 @@
           "description": "Show tab indicators (→) for trailing tabs.\nCan be overridden per-language via `show_whitespace_tabs` in language config.\nDefault: true",
           "type": "boolean",
           "default": true,
+          "x-section": "Whitespace"
+        },
+        "whitespace_newlines": {
+          "description": "Show newline indicators (↵) at the end of every line.\nDefault: false",
+          "type": "boolean",
+          "default": false,
+          "x-section": "Whitespace"
+        },
+        "whitespace_carriage_returns": {
+          "description": "Show carriage-return indicators (␍) for the CR half of CRLF line\nendings, next to the newline position. Stray CR bytes that are not\npart of the buffer's line ending always render as `<0D>` escapes.\nDefault: false",
+          "type": "boolean",
+          "default": false,
           "x-section": "Whitespace"
         },
         "use_tabs": {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -680,11 +680,13 @@ pub struct WhitespaceVisibility {
     pub tabs_leading: bool,
     pub tabs_inner: bool,
     pub tabs_trailing: bool,
+    pub newlines: bool,
+    pub carriage_returns: bool,
 }
 
 impl Default for WhitespaceVisibility {
     fn default() -> Self {
-        // Match EditorConfig defaults: tabs all on, spaces all off
+        // Match EditorConfig defaults: tabs all on, spaces and line endings all off
         Self {
             spaces_leading: false,
             spaces_inner: false,
@@ -692,6 +694,8 @@ impl Default for WhitespaceVisibility {
             tabs_leading: true,
             tabs_inner: true,
             tabs_trailing: true,
+            newlines: false,
+            carriage_returns: false,
         }
     }
 }
@@ -700,14 +704,7 @@ impl WhitespaceVisibility {
     /// Resolve from EditorConfig flat fields (applying master toggle)
     pub fn from_editor_config(editor: &EditorConfig) -> Self {
         if !editor.whitespace_show {
-            return Self {
-                spaces_leading: false,
-                spaces_inner: false,
-                spaces_trailing: false,
-                tabs_leading: false,
-                tabs_inner: false,
-                tabs_trailing: false,
-            };
+            return Self::hidden();
         }
         Self {
             spaces_leading: editor.whitespace_spaces_leading,
@@ -716,6 +713,8 @@ impl WhitespaceVisibility {
             tabs_leading: editor.whitespace_tabs_leading,
             tabs_inner: editor.whitespace_tabs_inner,
             tabs_trailing: editor.whitespace_tabs_trailing,
+            newlines: editor.whitespace_newlines,
+            carriage_returns: editor.whitespace_carriage_returns,
         }
     }
 
@@ -740,9 +739,14 @@ impl WhitespaceVisibility {
         self.tabs_leading || self.tabs_inner || self.tabs_trailing
     }
 
-    /// Returns true if any indicator (space or tab) is enabled
+    /// Returns true if any line-ending indicator (newline or CR) is enabled
+    pub fn any_line_endings(&self) -> bool {
+        self.newlines || self.carriage_returns
+    }
+
+    /// Returns true if any indicator (space, tab, or line ending) is enabled
     pub fn any_visible(&self) -> bool {
-        self.any_spaces() || self.any_tabs()
+        self.any_spaces() || self.any_tabs() || self.any_line_endings()
     }
 
     /// All indicators disabled — the "hidden" state of the master toggle.
@@ -754,6 +758,8 @@ impl WhitespaceVisibility {
             tabs_leading: false,
             tabs_inner: false,
             tabs_trailing: false,
+            newlines: false,
+            carriage_returns: false,
         }
     }
 
@@ -1361,6 +1367,20 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Whitespace"))]
     pub whitespace_tabs_trailing: bool,
 
+    /// Show newline indicators (↵) at the end of every line.
+    /// Default: false
+    #[serde(default = "default_false")]
+    #[schemars(extend("x-section" = "Whitespace"))]
+    pub whitespace_newlines: bool,
+
+    /// Show carriage-return indicators (␍) for the CR half of CRLF line
+    /// endings, next to the newline position. Stray CR bytes that are not
+    /// part of the buffer's line ending always render as `<0D>` escapes.
+    /// Default: false
+    #[serde(default = "default_false")]
+    #[schemars(extend("x-section" = "Whitespace"))]
+    pub whitespace_carriage_returns: bool,
+
     // ===== Editing =====
     /// Whether pressing Tab inserts a tab character instead of spaces.
     /// This is the global default; individual languages can override it
@@ -1917,6 +1937,8 @@ impl Default for EditorConfig {
             whitespace_tabs_leading: true,
             whitespace_tabs_inner: true,
             whitespace_tabs_trailing: true,
+            whitespace_newlines: false,
+            whitespace_carriage_returns: false,
         }
     }
 }

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -232,6 +232,8 @@ pub struct PartialEditorConfig {
     pub whitespace_tabs_leading: Option<bool>,
     pub whitespace_tabs_inner: Option<bool>,
     pub whitespace_tabs_trailing: Option<bool>,
+    pub whitespace_newlines: Option<bool>,
+    pub whitespace_carriage_returns: Option<bool>,
 }
 
 impl Merge for PartialEditorConfig {
@@ -363,6 +365,10 @@ impl Merge for PartialEditorConfig {
             .merge_from(&other.whitespace_tabs_inner);
         self.whitespace_tabs_trailing
             .merge_from(&other.whitespace_tabs_trailing);
+        self.whitespace_newlines
+            .merge_from(&other.whitespace_newlines);
+        self.whitespace_carriage_returns
+            .merge_from(&other.whitespace_carriage_returns);
     }
 }
 
@@ -683,6 +689,8 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             whitespace_tabs_leading: Some(cfg.whitespace_tabs_leading),
             whitespace_tabs_inner: Some(cfg.whitespace_tabs_inner),
             whitespace_tabs_trailing: Some(cfg.whitespace_tabs_trailing),
+            whitespace_newlines: Some(cfg.whitespace_newlines),
+            whitespace_carriage_returns: Some(cfg.whitespace_carriage_returns),
         }
     }
 }
@@ -876,6 +884,12 @@ impl PartialEditorConfig {
             whitespace_tabs_trailing: self
                 .whitespace_tabs_trailing
                 .unwrap_or(defaults.whitespace_tabs_trailing),
+            whitespace_newlines: self
+                .whitespace_newlines
+                .unwrap_or(defaults.whitespace_newlines),
+            whitespace_carriage_returns: self
+                .whitespace_carriage_returns
+                .unwrap_or(defaults.whitespace_carriage_returns),
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -22,6 +22,7 @@ use super::super::selection_sweep::SelectionActiveSet;
 use super::{cursor_indicator_style, CursorTracker, SpanCursors};
 use crate::app::types::CellThemeInfo;
 use crate::config::IndentationGuideMode;
+use crate::model::buffer::LineEnding;
 use crate::primitives::ansi::AnsiParser;
 use crate::primitives::display_width::char_width;
 use crate::state::EditorState;
@@ -84,6 +85,10 @@ pub(super) struct CellPassOutput {
     /// Changed). Picked up by the tail-fill pass so the bg wash
     /// continues past the scoped text to the viewport's right edge.
     pub syntax_extend_bg: Option<Color>,
+    /// Screen cells the newline's line-ending indicator occupied (0 when
+    /// none rendered). The cursor-on-newline placement subtracts these so
+    /// the cursor lands on the indicator, not past it.
+    pub newline_indicator_cols: usize,
 }
 
 /// Render one line's characters into `line_spans` / `line_view_map`.
@@ -150,6 +155,7 @@ pub(super) fn render_line_cells<'a, 'c>(
         first_line_byte_pos: None,
         last_line_byte_pos: None,
         syntax_extend_bg: None,
+        newline_indicator_cols: 0,
     };
 
     for ch in line_content.chars() {
@@ -195,6 +201,11 @@ struct CellPass<'a, 'b, 'c> {
     first_line_byte_pos: Option<usize>,
     last_line_byte_pos: Option<usize>,
     syntax_extend_bg: Option<Color>,
+    /// Screen cells emitted for the newline's line-ending indicator (0 when
+    /// none rendered). The view pipeline gives `\n` visual width 1 but the
+    /// indicator may occupy one or two cells (`↵` / `␍↵`), so the rendered
+    /// column count is tracked separately from the pipeline width.
+    newline_indicator_cols: usize,
 }
 
 /// Resolved style and theme-inspector metadata for one cell.
@@ -286,7 +297,16 @@ impl CellPass<'_, '_, '_> {
         let is_selected =
             !exclude_from_selection && self.selection_sweep.contains(byte_pos, self.byte_index);
 
-        let resolved = self.resolve_cell_style(byte_pos, ansi_style, is_cursor, is_selected);
+        // A virtual-space cursor "at" the newline byte sits visually past the
+        // content end — its indicator is drawn at the virtual column by
+        // `place_cell_cursor`, so the newline cell itself (which may render a
+        // line-ending indicator) must not be styled as the cursor.
+        let newline_virtual_cursor = is_cursor
+            && ch == '\n'
+            && byte_pos.is_some_and(|bp| self.input.selection.virtual_cols_at.contains_key(&bp));
+        let style_as_cursor = is_cursor && !newline_virtual_cursor;
+
+        let resolved = self.resolve_cell_style(byte_pos, ansi_style, style_as_cursor, is_selected);
         self.record_cell_theme(&resolved);
 
         // `indicator_buf` holds the UTF-8 bytes of a single fallback indicator
@@ -309,8 +329,15 @@ impl CellPass<'_, '_, '_> {
             };
             (guide_glyph, false)
         } else {
-            self.display_cell_text(ch, is_cursor, is_tab_start, &mut indicator_buf)
+            self.display_cell_text(ch, byte_pos, is_cursor, is_tab_start, &mut indicator_buf)
         };
+        // A newline cell normally renders as nothing; when it renders a
+        // line-ending indicator instead, remember how many cells landed so
+        // position bookkeeping (rendered_cols, the cursor-on-newline
+        // indicator) accounts for them.
+        if ch == '\n' && is_whitespace_indicator {
+            self.newline_indicator_cols = display_char.chars().count();
+        }
 
         // Apply subdued indicator colors from theme. Cursor styling keeps
         // precedence (so guides do not obscure the caret), but selection does
@@ -322,7 +349,7 @@ impl CellPass<'_, '_, '_> {
         let mut style = resolved.style;
         if is_indentation_guide && !is_cursor {
             style = style.fg(self.indentation_guide_color());
-        } else if is_whitespace_indicator && !is_cursor && !is_selected {
+        } else if is_whitespace_indicator && !style_as_cursor && !is_selected {
             style = style.fg(self.input.theme.whitespace_indicator_fg);
         }
 
@@ -330,7 +357,13 @@ impl CellPass<'_, '_, '_> {
             self.emit_cell(display_char, style, byte_pos, ch);
         }
 
-        self.place_cell_cursor(ch, byte_pos, is_cursor, resolved.is_secondary_cursor);
+        // Recover the secondary-cursor flag for virtual-space cursors whose
+        // styling was suppressed above — the indicator span they rely on is
+        // still placed by `place_cell_cursor`.
+        let is_secondary_cursor = resolved.is_secondary_cursor
+            || (newline_virtual_cursor
+                && byte_pos != Some(self.input.selection.primary_cursor_position));
+        self.place_cell_cursor(ch, byte_pos, is_cursor, is_secondary_cursor);
     }
 
     /// Whether the current leading-whitespace cell should render as an
@@ -553,11 +586,13 @@ impl CellPass<'_, '_, '_> {
     }
 
     /// What to draw for this character: the char itself, a whitespace
-    /// indicator (→ / ·), an LSP-waiting marker, a debug escape, or
-    /// nothing (newline). Tabs are already expanded by ViewLineIterator.
+    /// indicator (→ / · / ↵ / ␍), an LSP-waiting marker, a debug escape,
+    /// or nothing (newline with line-ending indicators disabled). Tabs are
+    /// already expanded by ViewLineIterator.
     fn display_cell_text<'buf>(
         &self,
         ch: char,
+        byte_pos: Option<usize>,
         is_cursor: bool,
         is_tab_start: bool,
         indicator_buf: &'buf mut [u8; 4],
@@ -590,7 +625,8 @@ impl CellPass<'_, '_, '_> {
             // Debug mode: show LF explicitly
             ("\\n", false)
         } else if ch == '\n' {
-            ("", false)
+            let indicator = self.newline_indicator(byte_pos);
+            (indicator, !indicator.is_empty())
         } else if ws_show_tab {
             // Visual indicator for tab: show → at the first position
             ('→'.encode_utf8(indicator_buf), true)
@@ -599,6 +635,41 @@ impl CellPass<'_, '_, '_> {
             ('·'.encode_utf8(indicator_buf), true)
         } else {
             (ch.encode_utf8(indicator_buf), false)
+        }
+    }
+
+    /// Line-ending indicator glyphs for the newline cell ("" when disabled).
+    ///
+    /// The buffer's newline token covers the whole line break — in a CRLF
+    /// buffer it spans the `\r\n` pair (the `\n` half is skipped by the view
+    /// pipeline) — so this one cell carries both the CR and newline
+    /// indicators. Classic-Mac CR buffers store their breaks as `\n` in
+    /// memory but save them as `\r`, so their indicator reflects the on-disk
+    /// ending. Only source newlines qualify: plugin-injected line breaks
+    /// (`byte_pos == None`) are not part of the file's content.
+    fn newline_indicator(&self, byte_pos: Option<usize>) -> &'static str {
+        if byte_pos.is_none() {
+            return "";
+        }
+        let ws = &self.input.state.buffer_settings.whitespace;
+        if !ws.newlines && !ws.carriage_returns {
+            return "";
+        }
+        match self.input.state.buffer.line_ending() {
+            LineEnding::CRLF => match (ws.carriage_returns, ws.newlines) {
+                (true, true) => "␍↵",
+                (true, false) => "␍",
+                (false, true) => "↵",
+                (false, false) => "",
+            },
+            LineEnding::CR if ws.carriage_returns => "␍",
+            LineEnding::CR | LineEnding::LF => {
+                if ws.newlines {
+                    "↵"
+                } else {
+                    ""
+                }
+            }
         }
     }
 
@@ -663,16 +734,21 @@ impl CellPass<'_, '_, '_> {
             } else {
                 true
             };
-            if should_add_indicator {
+            // A virtual-space cursor sits past the content end: pad the
+            // indicator out to its on-screen column. Cells already emitted
+            // for a line-ending indicator occupy the start of that gap.
+            let virtual_pad = byte_pos
+                .and_then(|bp| self.input.selection.virtual_cols_at.get(&bp))
+                .copied()
+                .unwrap_or(0)
+                .saturating_sub(self.newline_indicator_cols);
+            // When the newline rendered a line-ending indicator, that cell
+            // already carries the cursor styling from resolve_cell_style —
+            // an extra indicator cell would land one column too far right.
+            if should_add_indicator && (self.newline_indicator_cols == 0 || virtual_pad > 0) {
                 // Flush accumulated text before adding the cursor indicator
                 // so the indicator appears after the line content, not before
                 self.span_acc.flush(self.line_spans, self.line_view_map);
-                // A virtual-space cursor sits past the content end: pad the
-                // indicator out to its on-screen column.
-                let virtual_pad = byte_pos
-                    .and_then(|bp| self.input.selection.virtual_cols_at.get(&bp))
-                    .copied()
-                    .unwrap_or(0);
                 if virtual_pad > 0 {
                     push_span_with_map(
                         self.line_spans,
@@ -715,12 +791,16 @@ impl CellPass<'_, '_, '_> {
             .unwrap_or(self.line_total_visual_width);
         let ch_width = next_col_for_char.saturating_sub(self.col_offset);
         // `\n` gets visual width 1 from the view pipeline but renders as
-        // empty — don't count it as an on-screen cell.
+        // empty — don't count it as an on-screen cell. When it rendered a
+        // line-ending indicator instead, count the indicator's actual cells
+        // (which may exceed the pipeline width: `␍↵` is two cells).
         let was_rendered = self.col_offset >= self.input.left_col && ch != '\n';
         self.col_offset = next_col_for_char;
         self.visible_char_count += ch_width;
         if was_rendered {
             self.rendered_cols += ch_width;
+        } else if ch == '\n' {
+            self.rendered_cols += self.newline_indicator_cols;
         }
     }
 
@@ -747,6 +827,7 @@ impl CellPass<'_, '_, '_> {
             first_line_byte_pos: self.first_line_byte_pos,
             last_line_byte_pos: self.last_line_byte_pos,
             syntax_extend_bg: self.syntax_extend_bg,
+            newline_indicator_cols: self.newline_indicator_cols,
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -1035,7 +1035,12 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         let end_x = if line_was_empty {
             gutter_width as u16
         } else {
-            last_visible_x.saturating_add(1)
+            // A rendered line-ending indicator adds view-map cells for the
+            // newline byte itself; step back over them so the end-of-line
+            // cursor lands on the indicator, not past it.
+            last_visible_x
+                .saturating_add(1)
+                .saturating_sub(cells.newline_indicator_cols as u16)
         };
         let line_len_chars = line_content.chars().count();
 

--- a/crates/fresh-editor/tests/e2e/buffer_settings_commands.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_settings_commands.rs
@@ -564,3 +564,162 @@ fn test_toggle_line_numbers_persists_across_file_changes() {
     // Verify the edited content is still visible
     harness.assert_screen_contains("Edited line 5");
 }
+
+// ===========================================================================
+// Line-ending indicator tests
+// (`whitespace_newlines` / `whitespace_carriage_returns`)
+// ===========================================================================
+
+/// Newline indicators (↵) render at the end of every line of an LF file when
+/// `whitespace_newlines` is enabled, and the master toggle hides and restores
+/// them like any other whitespace indicator.
+#[test]
+fn test_newline_indicators_lf_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one\ntwo\n").unwrap();
+
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_newlines = true;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("one↵") && screen.contains("two↵"),
+        "Newline indicators should render at each line end. Screen:\n{}",
+        screen
+    );
+
+    // Master toggle hides the newline indicators.
+    run_command(&mut harness, "Toggle Whitespace Indicators");
+    let screen_off = harness.screen_to_string();
+    assert!(
+        !screen_off.contains('↵'),
+        "Master toggle off should hide newline indicators. Screen:\n{}",
+        screen_off
+    );
+
+    // Toggling back on restores the configured newline indicators.
+    run_command(&mut harness, "Toggle Whitespace Indicators");
+    let screen_on = harness.screen_to_string();
+    assert!(
+        screen_on.contains("one↵"),
+        "Master toggle on should restore newline indicators. Screen:\n{}",
+        screen_on
+    );
+}
+
+/// A CRLF buffer's line break carries both halves: with carriage returns and
+/// newlines enabled each line ends with `␍↵`.
+#[test]
+fn test_crlf_line_ending_indicators() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one\r\ntwo\r\n").unwrap();
+
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_newlines = true;
+    config.editor.whitespace_carriage_returns = true;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("one␍↵") && screen.contains("two␍↵"),
+        "CRLF line endings should render both CR and newline indicators. Screen:\n{}",
+        screen
+    );
+}
+
+/// With only `whitespace_newlines` enabled, a CRLF buffer shows just the
+/// newline half; with only `whitespace_carriage_returns`, just the CR half.
+#[test]
+fn test_crlf_indicator_halves_are_independent() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one\r\ntwo\r\n").unwrap();
+
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_newlines = true;
+    config.editor.whitespace_carriage_returns = false;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("one↵") && !screen.contains('␍'),
+        "Newlines-only should render ↵ without ␍ on CRLF files. Screen:\n{}",
+        screen
+    );
+
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_newlines = false;
+    config.editor.whitespace_carriage_returns = true;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("one␍") && !screen.contains('↵'),
+        "CR-only should render ␍ without ↵ on CRLF files. Screen:\n{}",
+        screen
+    );
+}
+
+/// A Classic-Mac (CR) buffer saves its line breaks as `\r`; with carriage
+/// returns enabled its line ends show the CR indicator.
+#[test]
+fn test_cr_buffer_line_ending_indicator() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one\rtwo\rthree\r").unwrap();
+
+    let mut config = Config::default();
+    config.editor.whitespace_show = true;
+    config.editor.whitespace_carriage_returns = true;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("one␍") && screen.contains("two␍"),
+        "CR buffers should render the CR indicator at line ends. Screen:\n{}",
+        screen
+    );
+}
+
+/// Line-ending indicators are off by default — a default config must not
+/// suddenly decorate every line end.
+#[test]
+fn test_line_ending_indicators_off_by_default() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one\r\ntwo\r\n").unwrap();
+
+    let config = Config::default();
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains('↵') && !screen.contains('␍'),
+        "No line-ending indicators should render by default. Screen:\n{}",
+        screen
+    );
+}

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -68,6 +68,8 @@ Files without write permission and known library paths (rustup toolchains, `/usr
 
 Control visibility of space (`·`) and tab (`→`) characters. Configure independently for leading, inner, and trailing positions via the Settings UI or `whitespace_indicators` in config. A master toggle and per-language overrides are supported. Theme color: `whitespace_indicator_fg`.
 
+Line endings can be shown too: `whitespace_newlines` renders `↵` at the end of every line, and `whitespace_carriage_returns` renders `␍` for the CR half of CRLF (and Classic-Mac CR) line endings — so a CRLF file shows `␍↵` where an LF file shows `↵`. Both are off by default and follow the same master toggle.
+
 ## Inline Diagnostics
 
 Diagnostic messages can be displayed at the end of each line, right-aligned, with version-aware staleness dimming. Disabled by default — enable "diagnostics inline text" in the Settings UI or set `diagnostics_inline_text` in config.


### PR DESCRIPTION
## Motivation

The whitespace indicator feature can reveal spaces (`·`) and tabs (`→`) — leading, inner, and trailing — but gives no way to see line endings: an LF file and a CRLF file render identically, and nothing marks where lines end.

Implements the proposal in #2798.

## What's added

Two new options in the **Whitespace** settings section, both **off by default** (opt-in, as #2798 requests) and governed by the existing `whitespace_show` master toggle and the *Toggle Whitespace Indicators* command:

- **`whitespace_newlines`** — render `↵` at the end of every line.
- **`whitespace_carriage_returns`** — render `␍` for the CR half of the line break, so a CRLF file shows `␍↵` where an LF file shows `↵`, and a Classic-Mac CR buffer shows `␍`. (Stray CR bytes that are not part of the buffer's line ending already render as `<0D>` escapes.)

**Screenshots:** see the [before/after terminal captures posted on the issue](https://github.com/sinelaw/fresh/issues/2798#issuecomment-5082939274).

## Rendering details

The newline's view cell previously always rendered as empty. It now:

- renders the indicator glyph(s) with the standard `whitespace_indicator_fg` theme color, and participates in selection highlighting like other indicators;
- counts the emitted cells toward the row's rendered columns (`␍↵` is two cells while the view pipeline gives `\n` width 1) so tail fills and blank-line indentation guides stay aligned;
- keeps the end-of-line cursor on the indicator cell rather than one past it, and keeps a virtual-space cursor's indicator at its virtual column instead of lighting up the glyph.

## Testing

- Five new e2e tests (rendered-output assertions only) covering LF, CRLF, each flag independently, Classic-Mac CR buffers, off-by-default, and master-toggle hide/restore. They fail with the rendering change reverted (reproduce-before-claiming).
- Manually validated in tmux: LF/CRLF/CR/mixed files, empty lines, wrapped long lines, cursor-at-EOL placement, typing at EOL, selection across the newline, master toggle, and Settings UI exposure.
- `cargo fmt`, `clippy --all-targets`, `check --all-targets --features gui`, lib tests, and the e2e suite are green (the only full-suite failures are locale/terminal tests that fail in different sets on each run and pass in isolation — parallel-load flakiness unrelated to this change).

`config-schema.json` was regenerated (`./scripts/gen_schema.sh`) so the options appear in the Settings UI; the whitespace section of `docs/features/editing.md` documents the new options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rBfqYynfutZdebh9hbZHG