### PR TITLE
fix(trust,widgets): stop clipping modal dialogs, re-asking worktree trust, and accepting trust on click

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4931,6 +4931,13 @@ function dockMenuEnterConfirm(action: "archive" | "delete"): void {
   editor.floatingPanelControl(dockMenuPanel.id(), "center", 0);
   editor.floatingPanelControl(dockMenuPanel.id(), "fullscreen", 1);
   renderDockMenu();
+  // Pin Cancel, exactly as the modal picker's `enterConfirm` does. Today the
+  // host would land here anyway (the outgoing `ctx-delete` focus key isn't
+  // tabbable in the confirm spec, so it falls back to the first one), but
+  // relying on that makes the safe default a property of the button *order* —
+  // swap the pair and a destructive action becomes one Enter away. State the
+  // intent instead of inheriting it.
+  dockMenuPanel.setFocusKey("confirm-cancel");
 }
 
 function closeDockContextMenu(): void {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -508,10 +508,18 @@ fn build_persisted_window_shells(
         // This shell's own local authority, gated by its own per-session trust
         // + env (scoped to its root + project store) — never a clone of the
         // active session's handles.
+        // `shell_resources.fs_manager` is the local host filesystem these
+        // shells read through, so it's also what resolves a linked worktree
+        // to the repo whose trust decision governs it.
+        let trust_owner = crate::services::workspace_trust::trust_owner_root(
+            shell_resources.fs_manager.filesystem().as_ref(),
+            &ps.root,
+        );
         let shell_authority = crate::services::authority::Authority::local_scoped(
             crate::services::authority::SessionScope::for_root(
                 &ps.root,
                 &dir_context.project_state_dir(&ps.root),
+                &dir_context.project_state_dir(&trust_owner),
             ),
         );
         let mut shell = crate::app::window::Window::new(

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2060,7 +2060,17 @@ impl Editor {
                             self.should_quit = true;
                         }
                     } else if let Some(i) = layout.radios.iter().position(|r| hit(*r)) {
-                        self.confirm_workspace_trust(i);
+                        // Selecting a radio is NOT consent. A click moves the
+                        // selection and leaves the dialog up; [ OK ] commits
+                        // it — the same two-step the keyboard already used
+                        // (`T`/`K`/`B` select, Enter/`O` confirm). Accepting
+                        // on click made "Trust folder & Allow Tooling" a
+                        // one-click grant of full execution rights on a
+                        // security prompt, with no chance to reconsider and
+                        // no way to read the option before committing to it.
+                        // The web UI forwards its radio clicks to this same
+                        // hit-test, so both frontends inherit the fix.
+                        self.set_workspace_trust_selection(i);
                     }
                     // else: click on the dialog body or dimmed backdrop — absorb.
                 }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -1356,12 +1356,24 @@ impl Editor {
         // editor fires when the level changes (see env-manager.ts). One
         // decision, one prompt, one place it is recorded.
         //
-        // A decision the user explicitly recorded is always honored — this
-        // branch only fires for undecided projects.
-        let store = crate::services::workspace_trust::TrustStore::for_project_dir(
-            &self.dir_context.project_state_dir(self.working_dir()),
+        // Anchor persistence before consulting it, so the gate and the live
+        // handle can never disagree about *which* file records this
+        // workspace's decision. `store_for_workspace` resolves a linked git
+        // worktree to the repo that owns it, so every checkout of one
+        // repository shares a single decision — and `set_store` adopts that
+        // level, which is what makes a worktree open already-trusted instead
+        // of re-asking. Idempotent: re-anchoring the same store is a no-op.
+        //
+        // A decision the user explicitly recorded is always honored — the rest
+        // of this function only runs for undecided projects.
+        let store = crate::services::workspace_trust::store_for_workspace(
+            &self.dir_context,
+            self.authority().filesystem.as_ref(),
+            self.working_dir(),
         );
-        if store.is_decided() {
+        let decided = store.is_decided();
+        self.authority().workspace_trust.set_store(Some(store));
+        if decided {
             return; // respect a decision the user already recorded
         }
 
@@ -1562,8 +1574,9 @@ impl Editor {
     }
 
     /// Set the radio selection to an absolute index (0=Trust, 1=Restricted,
-    /// 2=Block) without confirming.
-    fn set_workspace_trust_selection(&mut self, index: usize) {
+    /// 2=Block) without confirming. Shared by the keyboard mnemonics and the
+    /// mouse hit-test — both select, only [ OK ] / Enter commits.
+    pub(crate) fn set_workspace_trust_selection(&mut self, index: usize) {
         if let Some(popup) = self.global_popups.top_mut() {
             if let crate::view::popup::PopupContent::List { selected, .. } = &mut popup.content {
                 *selected = index.min(2);

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4451,7 +4451,18 @@ impl Editor {
             super::PanelPlacement::Centered => {
                 let requested = Self::centered_overlay_rect(area, width_pct, height_pct);
                 let needed_h = (entries.len() as u16).saturating_add(2);
-                let effective_h = needed_h.min(requested.height).max(3);
+                // Fit the content in BOTH directions: the requested height is
+                // a hint, never a guillotine. Shorter content shrinks the box
+                // (the original Bug 7 fix); content taller than the requested
+                // percentage GROWS it, up to the frame. Capping at the request
+                // silently amputated the tail of the spec — on a 24-row
+                // terminal the dock's delete confirmation (mounted at 44%,
+                // i.e. 10 rows) lost its `[ Cancel ] [ Confirm Delete ]` row
+                // entirely, so the modal read as "up but not focused" while
+                // the (invisible) focused button still answered Enter.
+                // Clipping is only acceptable when the frame itself is too
+                // small, which `area.height` already expresses.
+                let effective_h = needed_h.clamp(3, area.height.max(3));
                 ratatui::layout::Rect {
                     x: requested.x,
                     y: area.y + (area.height.saturating_sub(effective_h)) / 2,

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -262,13 +262,24 @@ impl crate::app::Editor {
     /// blessed factory. Each call mints handles owned by exactly one session,
     /// so a trust decision or env activation in one window can never leak into
     /// another. Every per-session window construction goes through this.
+    ///
+    /// Trust is keyed on the *repo* rather than on `root`: a session opened on
+    /// a linked git worktree is born under the main worktree's recorded
+    /// decision, so forking a worktree per agent doesn't re-ask the trust
+    /// question for code the user already vouched for. Env stays keyed on
+    /// `root` (a worktree can carry its own `.venv`).
     pub(crate) fn session_scope_for(
         &self,
         root: &std::path::Path,
     ) -> crate::services::authority::SessionScope {
+        let trust_owner = crate::services::workspace_trust::trust_owner_root(
+            self.authority().filesystem.as_ref(),
+            root,
+        );
         crate::services::authority::SessionScope::for_root(
             root,
             &self.dir_context.project_state_dir(root),
+            &self.dir_context.project_state_dir(&trust_owner),
         )
     }
 
@@ -1567,13 +1578,9 @@ impl crate::app::Editor {
         let root = descriptor.root.clone();
         // Same per-session local scope a boot-discovered local shell gets:
         // its own trust + env handles, never a clone of the previous
-        // window's.
-        let authority = crate::services::authority::Authority::local_scoped(
-            crate::services::authority::SessionScope::for_root(
-                &root,
-                &self.dir_context.project_state_dir(&root),
-            ),
-        );
+        // window's. Routed through the blessed factory so this shell inherits
+        // the worktree→repo trust keying too.
+        let authority = self.local_session_authority(&root);
         let mut window = Window::new(
             id,
             descriptor.label.clone(),

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1712,12 +1712,14 @@ fn initialize_app(args: &Args) -> AnyhowResult<SetupState> {
     let dir_context = fresh::config_io::DirectoryContext::from_system()?;
 
     // Re-anchor trust to this project now that the working dir is known.
+    // `store_for_workspace` keys a linked git worktree on the repo that owns
+    // it, so every checkout of one repository shares a single decision.
     workspace_trust.set_root(Some(effective_working_dir.clone()));
-    workspace_trust.set_store(Some(
-        fresh::services::workspace_trust::TrustStore::for_project_dir(
-            &dir_context.project_state_dir(&effective_working_dir),
-        ),
-    ));
+    workspace_trust.set_store(Some(fresh::services::workspace_trust::store_for_workspace(
+        &dir_context,
+        authority.filesystem.as_ref(),
+        &effective_working_dir,
+    )));
     // Attach the project's env recipe store and, when trusted, re-enter the
     // env the user previously activated — so the editor boots already in it
     // and the env-manager plugin's auto-activation finds nothing to do
@@ -2833,13 +2835,15 @@ fn run_server_command(args: &Args) -> AnyhowResult<()> {
     let dir_context = fresh::config_io::DirectoryContext::from_system()?;
 
     // Re-anchor trust to this project: its persisted level (if any) is
-    // adopted, else the safe Restricted default.
+    // adopted, else the safe Restricted default. `store_for_workspace` keys a
+    // linked git worktree on the repo that owns it, so every checkout shares
+    // one decision.
     workspace_trust.set_root(Some(working_dir.clone()));
-    workspace_trust.set_store(Some(
-        fresh::services::workspace_trust::TrustStore::for_project_dir(
-            &dir_context.project_state_dir(&working_dir),
-        ),
-    ));
+    workspace_trust.set_store(Some(fresh::services::workspace_trust::store_for_workspace(
+        &dir_context,
+        authority.filesystem.as_ref(),
+        &working_dir,
+    )));
     // Attach the project's env recipe store and, when trusted, re-enter the
     // previously-activated env so the editor boots already in it (no
     // auto-activation restart flicker on a re-open, issue #2280).
@@ -4331,10 +4335,18 @@ fn real_main() -> AnyhowResult<()> {
                 .clone()
                 .or_else(|| std::env::current_dir().ok())
                 .unwrap_or_default();
+            // The placeholder is local by construction, so its own filesystem
+            // is what resolves a linked worktree to the repo that owns its
+            // trust decision.
+            let trust_owner = fresh::services::workspace_trust::trust_owner_root(
+                current_authority.filesystem.as_ref(),
+                &placeholder_root,
+            );
             let placeholder = fresh::services::authority::Authority::local_scoped(
                 fresh::services::authority::SessionScope::for_root(
                     &placeholder_root,
                     &dir_context.project_state_dir(&placeholder_root),
+                    &dir_context.project_state_dir(&trust_owner),
                 ),
             );
             std::mem::replace(&mut current_authority, placeholder)

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -750,11 +750,10 @@ impl EditorServer {
             self.workspace_trust
                 .set_root(Some(self.config.working_dir.clone()));
             self.workspace_trust.set_store(Some(
-                crate::services::workspace_trust::TrustStore::for_project_dir(
-                    &self
-                        .config
-                        .dir_context
-                        .project_state_dir(&self.config.working_dir),
+                crate::services::workspace_trust::store_for_workspace(
+                    &self.config.dir_context,
+                    self.current_authority.filesystem.as_ref(),
+                    &self.config.working_dir,
                 ),
             ));
             // New project ⇒ the old env recipe no longer applies; deactivate

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -374,8 +374,14 @@ impl SessionScope {
     /// is trusted, a previously-activated recipe is restored so the session
     /// boots already in its env (no auto-activation restart); otherwise it
     /// starts inactive. Each call yields handles owned by exactly one session.
-    pub fn for_root(root: &Path, project_state_dir: &Path) -> Self {
-        let trust = WorkspaceTrust::for_session(root, project_state_dir);
+    ///
+    /// The two state dirs differ for a linked git worktree: `project_state_dir`
+    /// is the worktree's own (its env recipe, its `.venv`), while
+    /// `trust_state_dir` is the *repo's* — every checkout of one repository
+    /// shares a single trust decision. See
+    /// [`trust_owner_root`](crate::services::workspace_trust::trust_owner_root).
+    pub fn for_root(root: &Path, project_state_dir: &Path, trust_state_dir: &Path) -> Self {
+        let trust = WorkspaceTrust::for_session(root, trust_state_dir);
         let trusted = trust.level() == crate::services::workspace_trust::TrustLevel::Trusted;
         Self {
             trust,

--- a/crates/fresh-editor/src/services/workspace_trust.rs
+++ b/crates/fresh-editor/src/services/workspace_trust.rs
@@ -140,19 +140,19 @@ impl WorkspaceTrust {
         Self::new(None, TrustLevel::Trusted)
     }
 
-    /// Build a **per-session** trust handle for `root`, backed by that
-    /// project's on-disk store at `project_state_dir`, adopting whatever level
-    /// the user previously recorded for it (Restricted by default). Each
-    /// session owns one of these, so trusting one project never raises the
-    /// live trust level another open session's spawns are gated against —
-    /// they read distinct handles. The shared "remember this folder" registry
-    /// is the per-project store itself. See
-    /// `docs/internal/PER_SESSION_BACKENDS_DESIGN.md`.
-    pub fn for_session(root: &Path, project_state_dir: &Path) -> Arc<Self> {
+    /// Build a **per-session** trust handle for `root`, backed by the on-disk
+    /// store at `trust_state_dir` (the *owning repo's* state dir — see
+    /// [`trust_owner_root`]), adopting whatever level the user previously
+    /// recorded for it (Restricted by default). Each session owns one of
+    /// these, so trusting one project never raises the live trust level
+    /// another open session's spawns are gated against — they read distinct
+    /// handles. The shared "remember this folder" registry is the per-project
+    /// store itself. See `docs/internal/PER_SESSION_BACKENDS_DESIGN.md`.
+    pub fn for_session(root: &Path, trust_state_dir: &Path) -> Arc<Self> {
         let trust = Self::new(Some(root.to_path_buf()), TrustLevel::Restricted);
         // `set_store` adopts the project's persisted level (or the safe
         // Restricted default for an undecided project).
-        let store = TrustStore::for_project_dir(project_state_dir);
+        let store = TrustStore::for_project_dir(trust_state_dir);
         let decided = store.is_decided();
         trust.set_store(Some(store));
         // For an *undecided* project, match the boot session's
@@ -410,6 +410,83 @@ impl TrustStore {
         std::fs::write(&tmp, json.as_bytes())?;
         std::fs::rename(&tmp, &self.path)?;
         Ok(())
+    }
+}
+
+/// The folder whose recorded decision governs `root`.
+///
+/// For a **linked git worktree** that is the repo's *main* worktree, not the
+/// checkout: `git worktree add` produces a second working copy of the same
+/// repository, with the same manifests, the same build scripts and the same
+/// language servers. Asking the trust question again per worktree asks the
+/// user the same question about the same code, and an agent-per-worktree
+/// workflow (the Orchestrator's whole point) turns that into a prompt on every
+/// new session. One repo, one decision.
+///
+/// Everything else — the main worktree, a plain directory, a submodule —
+/// answers with `root` itself, so the mapping is identity for every workspace
+/// that isn't a linked worktree.
+///
+/// Detection is the same one git uses and needs no subprocess: a linked
+/// worktree's `.git` is a *file* holding `gitdir: <per-worktree git dir>`, and
+/// that dir holds a `commondir` file pointing at the shared `.git`. The main
+/// worktree's root is that shared dir's parent. A submodule also has a `.git`
+/// file but its git dir has **no** `commondir`, so it falls through to
+/// identity rather than being wrongly folded into the superproject (guideline
+/// 9: recover on the specific shape, not on any `.git` file).
+///
+/// Reads route through `fs` so an SSH/container workspace resolves against the
+/// host that actually holds the repo.
+pub fn trust_owner_root(fs: &dyn crate::model::filesystem::FileSystem, root: &Path) -> PathBuf {
+    linked_worktree_main_root(fs, root).unwrap_or_else(|| root.to_path_buf())
+}
+
+/// The per-project trust store that governs `root`, resolved through
+/// [`trust_owner_root`]. The single place a workspace root becomes a
+/// `trust.json` path — every caller that anchors trust persistence goes
+/// through here so worktree inheritance can't be forgotten at one of them.
+///
+/// Note this deliberately does *not* apply to the project's **env** store:
+/// a worktree is a separate checkout that may carry its own `.venv`, so env
+/// recipes stay keyed on the workspace's own directory.
+pub fn store_for_workspace(
+    dir_context: &crate::config_io::DirectoryContext,
+    fs: &dyn crate::model::filesystem::FileSystem,
+    root: &Path,
+) -> TrustStore {
+    TrustStore::for_project_dir(&dir_context.project_state_dir(&trust_owner_root(fs, root)))
+}
+
+/// Resolve `root` to the main worktree of the repository it belongs to, or
+/// `None` when `root` is not a linked worktree. See [`trust_owner_root`].
+fn linked_worktree_main_root(
+    fs: &dyn crate::model::filesystem::FileSystem,
+    root: &Path,
+) -> Option<PathBuf> {
+    // `.git` as a regular file (rather than a directory) is the marker of a
+    // worktree or submodule checkout. `read_file` on a directory errors, so
+    // this doubles as the file/dir test without a second round-trip.
+    let text = String::from_utf8(fs.read_file(&root.join(".git")).ok()?).ok()?;
+    let git_dir = resolve_git_pointer(root, text.trim().strip_prefix("gitdir:")?.trim());
+    // Only a *linked worktree* git dir carries `commondir`; a submodule's does
+    // not, and the main worktree never reaches here (its `.git` is a dir).
+    let common = String::from_utf8(fs.read_file(&git_dir.join("commondir")).ok()?).ok()?;
+    let common_dir = resolve_git_pointer(&git_dir, common.trim());
+    // The shared git dir is `<main worktree>/.git`; its parent is the root.
+    let main_root = lexical_normalize(common_dir.parent()?);
+    // A degenerate pointer that resolves back to this checkout is identity —
+    // report `None` so the caller keeps `root` untouched.
+    (main_root != lexical_normalize(root)).then_some(main_root)
+}
+
+/// Resolve a git pointer path (the target of a `.git` file or of a
+/// `commondir`), which git writes either absolute or relative to `base`.
+fn resolve_git_pointer(base: &Path, target: &str) -> PathBuf {
+    let target = Path::new(target);
+    if target.is_absolute() {
+        lexical_normalize(target)
+    } else {
+        lexical_normalize(&base.join(target))
     }
 }
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -168,6 +168,7 @@ pub mod multicursor;
 pub mod occurrence_highlight;
 pub mod on_save_actions;
 pub mod open_folder;
+pub mod orchestrator_dialog_trust_repro;
 pub mod orchestrator_dock;
 pub mod orchestrator_window_lsp;
 pub mod overlay_extend_to_line_end;

--- a/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
@@ -111,13 +111,22 @@ fn open_delete_confirmation(height: u16) -> (tempfile::TempDir, EditorTestHarnes
     h.render().unwrap();
     open_dock(&mut h);
 
+    // Guard the wait below against passing vacuously: the confirmation's
+    // heading must not already be on screen before we ask for it.
+    assert!(
+        !h.screen_to_string().contains("Confirm Delete"),
+        "the dock must not already be showing a delete confirmation"
+    );
+
     let card_row = row_of(&h, "alphaproj") as u16;
     h.mouse_right_click(4, card_row).unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("Delete"))
+    // Match the rendered button, not the bare word — "Delete" alone could pick
+    // up any other row that happens to mention it.
+    h.wait_until(|h| h.screen_to_string().contains("[ Delete ]"))
         .unwrap();
 
-    let (dcol, drow) = pos_of(&h, "Delete");
-    h.mouse_click(dcol, drow).unwrap();
+    let (dcol, drow) = pos_of(&h, "[ Delete ]");
+    h.mouse_click(dcol + 2, drow).unwrap();
     h.wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
         .unwrap();
     (tmp, h)
@@ -285,6 +294,20 @@ fn trust_dialog_radio_click_selects_without_accepting() {
     h.wait_until(|h| h.screen_to_string().contains("SECURITY WARNING"))
         .unwrap();
 
+    // The prompt opens on the safe default, so the "(*)" assertion below is a
+    // real state change rather than a value that was already there.
+    let trust_row = row_of(&h, "Trust folder & Allow Tooling");
+    let before = h
+        .screen_to_string()
+        .lines()
+        .nth(trust_row)
+        .unwrap()
+        .to_string();
+    assert!(
+        before.contains("( )"),
+        "the Trust option should start unselected.\nRow: {before}"
+    );
+
     // Click "Trust folder & Allow Tooling (T)".
     let (col, row) = pos_of(&h, "Trust folder & Allow Tooling");
     h.mouse_click(col + 2, row).unwrap();
@@ -304,7 +327,6 @@ fn trust_dialog_radio_click_selects_without_accepting() {
     );
 
     // The click did move the selection: the Trust row is now the marked radio.
-    let trust_row = row_of(&h, "Trust folder & Allow Tooling");
     let line = h
         .screen_to_string()
         .lines()
@@ -316,9 +338,10 @@ fn trust_dialog_radio_click_selects_without_accepting() {
         "the clicked row should become the selected radio.\nRow: {line}"
     );
 
-    // [ OK ] commits it.
-    let (ok_col, ok_row) = pos_of(&h, "OK");
-    h.mouse_click(ok_col + 1, ok_row).unwrap();
+    // [ OK ] commits it. Match the rendered button so the hit can't land on a
+    // stray "OK" elsewhere on screen.
+    let (ok_col, ok_row) = pos_of(&h, "[ OK ]");
+    h.mouse_click(ok_col + 2, ok_row).unwrap();
     h.wait_until(|h| !h.screen_to_string().contains("SECURITY WARNING"))
         .unwrap();
     let status = status_bar(&h);

--- a/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
@@ -1,27 +1,24 @@
-//! Reproductions for three reported UX defects around the Orchestrator dock's
-//! destructive-action confirmation and the workspace-trust modal.
+//! Orchestrator dock destructive-action confirmation + workspace-trust modal.
 //!
-//! 1. **Dock context-menu confirm keyboard focus.** Right-click a dock session
-//!    row → Delete must raise a centered confirmation whose Cancel button holds
-//!    the keyboard. This one currently *passes*: focus lands on Cancel via the
-//!    renderer's "first tabbable" fallback (`render_spec_inner`'s
-//!    `auto_focus_first`), because the outgoing focus key (`ctx-delete`) is not
-//!    tabbable in the confirm spec. It is guarded here because it holds only by
-//!    accident — `dockMenuEnterConfirm` never pins `confirm-cancel` the way the
-//!    modal picker's `enterConfirm` does, so reordering the button pair would
-//!    silently move default focus onto **Confirm Delete**.
+//! Three reported defects, each guarded here by driving only keyboard/mouse and
+//! asserting on rendered output (CONTRIBUTING §2):
 //!
-//! 2. **A worktree re-asks the trust question.** Creating a workspace as a
-//!    git worktree of an already-decided repo raises the trust modal again —
-//!    trust is keyed purely on the worktree's own path, so the base repo's
-//!    recorded decision is not inherited.
+//! 1. The dock's right-click → Delete confirmation was **clipped** on a short
+//!    terminal: it mounts at `heightPct: 44`, the centered placement treated
+//!    that as a hard cap, and the tail of the spec — including the
+//!    `[ Cancel ] [ Confirm Delete ]` row — was cut off. The modal read as
+//!    "up but the keyboard isn't on it" while the (invisible) focused Cancel
+//!    still answered Enter.
 //!
-//! 3. **Clicking a trust level accepts it immediately.** In the trust modal a
-//!    click on a radio row calls `confirm_workspace_trust` — it records the
-//!    decision and dismisses the dialog, instead of just moving the radio and
-//!    waiting for OK (which is what the keyboard mnemonics `T`/`K`/`B` do).
-//!    Shared by the TUI and the web UI (the web frontend forwards the click to
-//!    the same `handle_workspace_trust_mouse`).
+//! 2. A workspace opened on a linked git worktree re-asked the trust question
+//!    even though the user had already answered it for the repo, because trust
+//!    was keyed purely on the workspace's own path.
+//!
+//! 3. Clicking a radio row in the trust modal recorded the decision and
+//!    dismissed the dialog, rather than moving the selection and waiting for
+//!    [ OK ] — so "Trust folder & Allow Tooling" was a one-click grant of full
+//!    execution rights. The web UI forwards its radio clicks to the same
+//!    hit-test, so both frontends are covered by the same fix.
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -30,6 +27,10 @@ use std::path::{Path, PathBuf};
 
 const WIDTH: u16 = 120;
 const HEIGHT: u16 = 40;
+/// Tall enough for the dock and a session card, short enough that a 44%-high
+/// centered modal cannot hold the confirmation's ~13 content rows — the shape
+/// that clipped the button row.
+const SHORT_HEIGHT: u16 = 24;
 
 /// 0-based screen (col, row) of the first occurrence of `needle`. Dock rows
 /// carry multibyte box-drawing glyphs, so the byte offset `str::find` returns
@@ -54,8 +55,19 @@ fn row_of(h: &EditorTestHarness, needle: &str) -> usize {
         .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
 }
 
+/// The status bar — the last painted row. Carries the `{trust}` pill, which is
+/// how the trust level is *observable* rather than inspected.
+fn status_bar(h: &EditorTestHarness) -> String {
+    h.screen_to_string()
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or_default()
+        .to_string()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue 1 — dock context-menu confirmation keyboard focus
+// Issue 1 — the dock's delete confirmation must show its buttons
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// A git project with the orchestrator plugin (+ shared lib) installed.
@@ -89,14 +101,13 @@ fn open_dock(h: &mut EditorTestHarness) {
         .unwrap();
 }
 
-/// Right-click a dock session card → Delete → the confirmation pane must open
-/// with the **Cancel** button holding keyboard focus, so a stray Enter is a
-/// no-op (it returns to the menu) rather than nothing at all.
-#[test]
-fn dock_context_menu_delete_confirm_focuses_cancel() {
-    let (_tmp, root) = setup_project("alphaproj");
-    let mut h = EditorTestHarness::with_config_and_working_dir(WIDTH, 32, Default::default(), root)
-        .unwrap();
+/// Open the dock, right-click the session card, and choose Delete. Leaves the
+/// harness showing the confirmation.
+fn open_delete_confirmation(height: u16) -> (tempfile::TempDir, EditorTestHarness) {
+    let (tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(WIDTH, height, Default::default(), root)
+            .unwrap();
     h.render().unwrap();
     open_dock(&mut h);
 
@@ -109,28 +120,51 @@ fn dock_context_menu_delete_confirm_focuses_cancel() {
     h.mouse_click(dcol, drow).unwrap();
     h.wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
         .unwrap();
+    (tmp, h)
+}
 
-    // Enter must activate the focused button. With Cancel focused (the safe
-    // default for a destructive prompt) that returns to the three-action menu.
-    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("Visit"))
-        .unwrap_or_else(|_| {
-            let screen = h.screen_to_string();
-            panic!(
-                "Enter on the delete confirmation did nothing — no button holds \
-                 keyboard focus. Expected Cancel to be focused and return to the \
-                 context menu.\nScreen:\n{screen}"
-            )
-        });
+/// A destructive confirmation is useless if the user can't see how to answer
+/// it. On a short terminal the centered panel must grow to fit its content
+/// instead of clipping the tail: both the warning and the Cancel / Confirm
+/// pair have to be on screen.
+#[test]
+fn dock_delete_confirmation_shows_its_buttons_on_a_short_terminal() {
+    let (_tmp, h) = open_delete_confirmation(SHORT_HEIGHT);
+
     let screen = h.screen_to_string();
     assert!(
-        !screen.contains("Confirm Delete"),
-        "Enter should have dismissed the confirmation via Cancel.\nScreen:\n{screen}"
+        screen.contains("Uncommitted changes will be lost"),
+        "the delete warning was clipped off the confirmation.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("[ Cancel ]"),
+        "the confirmation must show its Cancel button — a modal whose buttons \
+         are clipped reads as 'the keyboard isn't on it'.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("[ Confirm Delete ]"),
+        "the confirmation must show its Confirm button.\nScreen:\n{screen}"
     );
 }
 
+/// Cancel holds the keyboard by default, so a stray Enter on a destructive
+/// prompt is recoverable: it returns to the context menu rather than wiping a
+/// worktree.
+#[test]
+fn dock_delete_confirmation_focuses_cancel() {
+    let (_tmp, mut h) = open_delete_confirmation(HEIGHT);
+
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("Visit") && !s.contains("Confirm Delete")
+    })
+    .unwrap();
+    h.assert_screen_contains("Archive");
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue 2 — a git worktree must inherit its base repo's trust decision
+// Issue 2 — a git worktree inherits its repo's trust decision
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn git(args: &[&str], cwd: &Path) {
@@ -175,51 +209,27 @@ fn repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
     (temp, base, wt)
 }
 
-/// Record `level` for `root` in the harness's per-project trust store — the
-/// same on-disk decision the trust modal writes when the user picks a row.
-fn record_trust(
-    h: &EditorTestHarness,
-    root: &Path,
-    level: fresh::services::workspace_trust::TrustLevel,
-) {
+/// Write the on-disk decision the trust modal records for `root`. Spelled out
+/// as literal JSON so the test's *setup* doesn't ride the same resolution the
+/// assertion is checking.
+fn record_trusted_on_disk(h: &EditorTestHarness, root: &Path) {
     let dir = h.editor().dir_context().project_state_dir(root);
     fs::create_dir_all(&dir).unwrap();
-    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&dir);
-    let trust =
-        fresh::services::workspace_trust::WorkspaceTrust::new_persistent(None, level, store);
-    trust.set_level(level);
+    fs::write(dir.join("trust.json"), r#"{"level":"trusted"}"#).unwrap();
 }
 
-/// Point the harness's live trust handle at the working dir's own (undecided)
-/// project store, so the prompt gate sees a real per-project store.
-fn arm_project_store(h: &mut EditorTestHarness) {
-    let dir = h.editor().working_dir().to_path_buf();
-    let store_path = h.editor().dir_context().project_state_dir(&dir);
-    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
-    h.editor()
-        .authority()
-        .workspace_trust
-        .set_store(Some(store));
-}
-
-/// A workspace opened on a linked worktree of an already-trusted repo must NOT
-/// re-ask the trust question — the decision belongs to the repo, not to each
-/// checkout of it.
+/// Opening a linked worktree of an already-trusted repo must not re-ask the
+/// trust question: `git worktree add` makes a second checkout of the *same*
+/// code, and an agent-per-worktree workflow would otherwise prompt on every
+/// new session. The worktree opens under the repo's recorded level.
 #[test]
-#[ignore = "reproduces an open bug: trust is keyed on the worktree's own path, \
-            so the base repo's recorded decision is never inherited"]
 fn worktree_inherits_base_repo_trust_decision() {
     let (_tmp, base, wt) = repo_with_worktree();
     let mut h =
         EditorTestHarness::with_config_and_working_dir(WIDTH, HEIGHT, Default::default(), wt)
             .unwrap();
-    // The user already answered the trust prompt for the base repo.
-    record_trust(
-        &h,
-        &base,
-        fresh::services::workspace_trust::TrustLevel::Trusted,
-    );
-    arm_project_store(&mut h);
+    // The user already answered the prompt for the base repo.
+    record_trusted_on_disk(&h, &base);
 
     // Activating the worktree workspace runs the same gate the Orchestrator's
     // new-session path runs.
@@ -232,33 +242,43 @@ fn worktree_inherits_base_repo_trust_decision() {
         "a worktree of an already-trusted repo must not re-prompt for \
          trust.\nScreen:\n{screen}"
     );
-    assert_eq!(
-        h.editor().authority().workspace_trust.level(),
-        fresh::services::workspace_trust::TrustLevel::Trusted,
-        "the worktree must adopt the base repo's recorded trust level"
+    let status = status_bar(&h);
+    assert!(
+        status.contains("Trusted"),
+        "the worktree must open under the repo's recorded level.\nStatus bar: {status}"
     );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Issue 3 — clicking a trust radio must select, not accept
-// ─────────────────────────────────────────────────────────────────────────────
+/// The counterpart: an *undecided* repo still prompts through its worktree —
+/// inheritance shares a real decision, it never invents one.
+#[test]
+fn worktree_of_undecided_repo_still_prompts() {
+    let (_tmp, _base, wt) = repo_with_worktree();
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(WIDTH, HEIGHT, Default::default(), wt)
+            .unwrap();
 
-fn arm_undecided_project_with_markers(h: &mut EditorTestHarness) {
-    let dir = h.editor().working_dir().to_path_buf();
-    fs::write(dir.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
-    arm_project_store(h);
+    h.editor_mut().maybe_prompt_workspace_trust(true);
+    h.render().unwrap();
+
+    h.wait_until(|h| h.screen_to_string().contains("SECURITY WARNING"))
+        .unwrap();
+    h.assert_screen_contains("Cargo.toml");
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 3 — clicking a trust radio selects, it does not accept
+// ─────────────────────────────────────────────────────────────────────────────
 
 /// Clicking a radio row in the workspace-trust modal must only move the
 /// selection — the decision is committed by [ OK ], exactly as the keyboard
 /// mnemonics (`T`/`K`/`B` select, Enter/`O` confirm) already behave. The web
 /// UI forwards its clicks to this same hit-test, so the two share the fix.
 #[test]
-#[ignore = "reproduces an open bug: a radio click calls confirm_workspace_trust, \
-            recording the decision and dismissing the dialog immediately"]
 fn trust_dialog_radio_click_selects_without_accepting() {
     let mut h = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
-    arm_undecided_project_with_markers(&mut h);
+    let dir = h.editor().working_dir().to_path_buf();
+    fs::write(dir.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
 
     h.editor_mut().maybe_prompt_workspace_trust(true);
     h.render().unwrap();
@@ -276,15 +296,11 @@ fn trust_dialog_radio_click_selects_without_accepting() {
         "clicking a trust option must only move the radio — the dialog stays up \
          until [ OK ].\nScreen:\n{screen}"
     );
-
-    let store_path = {
-        let dir = h.editor().working_dir().to_path_buf();
-        h.editor().dir_context().project_state_dir(&dir)
-    };
-    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
+    let status = status_bar(&h);
     assert!(
-        !store.is_decided(),
-        "clicking a trust option must not record the decision — only [ OK ] does"
+        status.contains("Restricted"),
+        "an un-committed selection must not change the live trust \
+         level.\nStatus bar: {status}"
     );
 
     // The click did move the selection: the Trust row is now the marked radio.
@@ -303,12 +319,11 @@ fn trust_dialog_radio_click_selects_without_accepting() {
     // [ OK ] commits it.
     let (ok_col, ok_row) = pos_of(&h, "OK");
     h.mouse_click(ok_col + 1, ok_row).unwrap();
-    h.render().unwrap();
     h.wait_until(|h| !h.screen_to_string().contains("SECURITY WARNING"))
         .unwrap();
-    assert_eq!(
-        h.editor().authority().workspace_trust.level(),
-        fresh::services::workspace_trust::TrustLevel::Trusted,
-        "[ OK ] must commit the highlighted option"
+    let status = status_bar(&h);
+    assert!(
+        status.contains("Trusted"),
+        "[ OK ] must commit the highlighted option.\nStatus bar: {status}"
     );
 }

--- a/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs
@@ -1,0 +1,314 @@
+//! Reproductions for three reported UX defects around the Orchestrator dock's
+//! destructive-action confirmation and the workspace-trust modal.
+//!
+//! 1. **Dock context-menu confirm keyboard focus.** Right-click a dock session
+//!    row → Delete must raise a centered confirmation whose Cancel button holds
+//!    the keyboard. This one currently *passes*: focus lands on Cancel via the
+//!    renderer's "first tabbable" fallback (`render_spec_inner`'s
+//!    `auto_focus_first`), because the outgoing focus key (`ctx-delete`) is not
+//!    tabbable in the confirm spec. It is guarded here because it holds only by
+//!    accident — `dockMenuEnterConfirm` never pins `confirm-cancel` the way the
+//!    modal picker's `enterConfirm` does, so reordering the button pair would
+//!    silently move default focus onto **Confirm Delete**.
+//!
+//! 2. **A worktree re-asks the trust question.** Creating a workspace as a
+//!    git worktree of an already-decided repo raises the trust modal again —
+//!    trust is keyed purely on the worktree's own path, so the base repo's
+//!    recorded decision is not inherited.
+//!
+//! 3. **Clicking a trust level accepts it immediately.** In the trust modal a
+//!    click on a radio row calls `confirm_workspace_trust` — it records the
+//!    decision and dismisses the dialog, instead of just moving the radio and
+//!    waiting for OK (which is what the keyboard mnemonics `T`/`K`/`B` do).
+//!    Shared by the TUI and the web UI (the web frontend forwards the click to
+//!    the same `handle_workspace_trust_mouse`).
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 40;
+
+/// 0-based screen (col, row) of the first occurrence of `needle`. Dock rows
+/// carry multibyte box-drawing glyphs, so the byte offset `str::find` returns
+/// is converted to a character column (= screen column for width-1 glyphs).
+fn pos_of(h: &EditorTestHarness, needle: &str) -> (u16, u16) {
+    let screen = h.screen_to_string();
+    screen
+        .lines()
+        .enumerate()
+        .find_map(|(r, l)| {
+            l.find(needle)
+                .map(|b| (l[..b].chars().count() as u16, r as u16))
+        })
+        .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
+}
+
+fn row_of(h: &EditorTestHarness, needle: &str) -> usize {
+    let screen = h.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 1 — dock context-menu confirmation keyboard focus
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A git project with the orchestrator plugin (+ shared lib) installed.
+fn setup_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let root = temp_dir.path().join(name);
+    fs::create_dir(&root).unwrap();
+    let plugins_dir = root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+    fs::write(root.join("readme.txt"), "hello\n").unwrap();
+    assert!(std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&root)
+        .status()
+        .unwrap()
+        .success());
+    (temp_dir, root)
+}
+
+fn open_dock(h: &mut EditorTestHarness) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator") && h.editor().is_dock_focused())
+        .unwrap();
+}
+
+/// Right-click a dock session card → Delete → the confirmation pane must open
+/// with the **Cancel** button holding keyboard focus, so a stray Enter is a
+/// no-op (it returns to the menu) rather than nothing at all.
+#[test]
+fn dock_context_menu_delete_confirm_focuses_cancel() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h = EditorTestHarness::with_config_and_working_dir(WIDTH, 32, Default::default(), root)
+        .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    let card_row = row_of(&h, "alphaproj") as u16;
+    h.mouse_right_click(4, card_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Delete"))
+        .unwrap();
+
+    let (dcol, drow) = pos_of(&h, "Delete");
+    h.mouse_click(dcol, drow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
+        .unwrap();
+
+    // Enter must activate the focused button. With Cancel focused (the safe
+    // default for a destructive prompt) that returns to the three-action menu.
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Visit"))
+        .unwrap_or_else(|_| {
+            let screen = h.screen_to_string();
+            panic!(
+                "Enter on the delete confirmation did nothing — no button holds \
+                 keyboard focus. Expected Cancel to be focused and return to the \
+                 context menu.\nScreen:\n{screen}"
+            )
+        });
+    let screen = h.screen_to_string();
+    assert!(
+        !screen.contains("Confirm Delete"),
+        "Enter should have dismissed the confirmation via Cancel.\nScreen:\n{screen}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 2 — a git worktree must inherit its base repo's trust decision
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn git(args: &[&str], cwd: &Path) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Build a git repo with a manifest (so the folder has executable-content
+/// markers and therefore trips the trust gate) plus one linked worktree.
+/// Returns (tempdir guard, base repo root, worktree root).
+fn repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let base = temp.path().join("base");
+    fs::create_dir(&base).unwrap();
+    git(&["init", "-q", "-b", "main"], &base);
+    git(&["config", "user.email", "t@example.com"], &base);
+    git(&["config", "user.name", "T"], &base);
+    fs::write(base.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    git(&["add", "-A"], &base);
+    git(&["commit", "-qm", "init"], &base);
+
+    let wt = temp.path().join("wt-feature");
+    git(
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature",
+            wt.to_str().unwrap(),
+        ],
+        &base,
+    );
+    (temp, base, wt)
+}
+
+/// Record `level` for `root` in the harness's per-project trust store — the
+/// same on-disk decision the trust modal writes when the user picks a row.
+fn record_trust(
+    h: &EditorTestHarness,
+    root: &Path,
+    level: fresh::services::workspace_trust::TrustLevel,
+) {
+    let dir = h.editor().dir_context().project_state_dir(root);
+    fs::create_dir_all(&dir).unwrap();
+    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&dir);
+    let trust =
+        fresh::services::workspace_trust::WorkspaceTrust::new_persistent(None, level, store);
+    trust.set_level(level);
+}
+
+/// Point the harness's live trust handle at the working dir's own (undecided)
+/// project store, so the prompt gate sees a real per-project store.
+fn arm_project_store(h: &mut EditorTestHarness) {
+    let dir = h.editor().working_dir().to_path_buf();
+    let store_path = h.editor().dir_context().project_state_dir(&dir);
+    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
+    h.editor()
+        .authority()
+        .workspace_trust
+        .set_store(Some(store));
+}
+
+/// A workspace opened on a linked worktree of an already-trusted repo must NOT
+/// re-ask the trust question — the decision belongs to the repo, not to each
+/// checkout of it.
+#[test]
+#[ignore = "reproduces an open bug: trust is keyed on the worktree's own path, \
+            so the base repo's recorded decision is never inherited"]
+fn worktree_inherits_base_repo_trust_decision() {
+    let (_tmp, base, wt) = repo_with_worktree();
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(WIDTH, HEIGHT, Default::default(), wt)
+            .unwrap();
+    // The user already answered the trust prompt for the base repo.
+    record_trust(
+        &h,
+        &base,
+        fresh::services::workspace_trust::TrustLevel::Trusted,
+    );
+    arm_project_store(&mut h);
+
+    // Activating the worktree workspace runs the same gate the Orchestrator's
+    // new-session path runs.
+    h.editor_mut().maybe_prompt_workspace_trust(true);
+    h.render().unwrap();
+
+    let screen = h.screen_to_string();
+    assert!(
+        !screen.contains("SECURITY WARNING"),
+        "a worktree of an already-trusted repo must not re-prompt for \
+         trust.\nScreen:\n{screen}"
+    );
+    assert_eq!(
+        h.editor().authority().workspace_trust.level(),
+        fresh::services::workspace_trust::TrustLevel::Trusted,
+        "the worktree must adopt the base repo's recorded trust level"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 3 — clicking a trust radio must select, not accept
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn arm_undecided_project_with_markers(h: &mut EditorTestHarness) {
+    let dir = h.editor().working_dir().to_path_buf();
+    fs::write(dir.join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    arm_project_store(h);
+}
+
+/// Clicking a radio row in the workspace-trust modal must only move the
+/// selection — the decision is committed by [ OK ], exactly as the keyboard
+/// mnemonics (`T`/`K`/`B` select, Enter/`O` confirm) already behave. The web
+/// UI forwards its clicks to this same hit-test, so the two share the fix.
+#[test]
+#[ignore = "reproduces an open bug: a radio click calls confirm_workspace_trust, \
+            recording the decision and dismissing the dialog immediately"]
+fn trust_dialog_radio_click_selects_without_accepting() {
+    let mut h = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    arm_undecided_project_with_markers(&mut h);
+
+    h.editor_mut().maybe_prompt_workspace_trust(true);
+    h.render().unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("SECURITY WARNING"))
+        .unwrap();
+
+    // Click "Trust folder & Allow Tooling (T)".
+    let (col, row) = pos_of(&h, "Trust folder & Allow Tooling");
+    h.mouse_click(col + 2, row).unwrap();
+    h.render().unwrap();
+
+    let screen = h.screen_to_string();
+    assert!(
+        screen.contains("SECURITY WARNING"),
+        "clicking a trust option must only move the radio — the dialog stays up \
+         until [ OK ].\nScreen:\n{screen}"
+    );
+
+    let store_path = {
+        let dir = h.editor().working_dir().to_path_buf();
+        h.editor().dir_context().project_state_dir(&dir)
+    };
+    let store = fresh::services::workspace_trust::TrustStore::for_project_dir(&store_path);
+    assert!(
+        !store.is_decided(),
+        "clicking a trust option must not record the decision — only [ OK ] does"
+    );
+
+    // The click did move the selection: the Trust row is now the marked radio.
+    let trust_row = row_of(&h, "Trust folder & Allow Tooling");
+    let line = h
+        .screen_to_string()
+        .lines()
+        .nth(trust_row)
+        .unwrap()
+        .to_string();
+    assert!(
+        line.contains("(*)"),
+        "the clicked row should become the selected radio.\nRow: {line}"
+    );
+
+    // [ OK ] commits it.
+    let (ok_col, ok_row) = pos_of(&h, "OK");
+    h.mouse_click(ok_col + 1, ok_row).unwrap();
+    h.render().unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("SECURITY WARNING"))
+        .unwrap();
+    assert_eq!(
+        h.editor().authority().workspace_trust.level(),
+        fresh::services::workspace_trust::TrustLevel::Trusted,
+        "[ OK ] must commit the highlighted option"
+    );
+}


### PR DESCRIPTION
Three defects reported against the Orchestrator dock's destructive-action confirmation and the workspace-trust modal.

## 1. A centered modal clipped its own buttons

A centered floating panel treated the plugin's `heightPct` as a hard cap, so content taller than the requested percentage was silently truncated. That is the wrong end to cut: plugins pass a percentage precisely because they don't know their content height up front, so the request is a hint about how much room to *want*, not permission to amputate the spec.

The dock's right-click → Delete confirmation mounts at 44%, which on a 24-row terminal is 10 rows against ~13 rows of content. The "Uncommitted changes will be lost." warning and the whole `[ Cancel ] [ Confirm Delete ]` row fell off the bottom, so the modal appeared to have no controls and no focus — while the invisible focused Cancel was still quietly answering Enter. A destructive prompt the user cannot see how to answer is worse than no prompt.

Height now fits the content in both directions: shorter content still shrinks the box (the existing behaviour), taller content grows it, and clipping only happens when the frame itself is too small — which `area.height` already expresses. This is a host-level fix, so every plugin dialog inherits it.

The dock's confirm stage also pins `confirm-cancel` explicitly now, mirroring the modal picker's `enterConfirm`. Focus already landed there via the renderer's first-tabbable fallback, but only because `ctx-delete` happens not to be tabbable in the confirm spec — that made the safe default a property of button *order* rather than of intent.

Reproduced in a 24-row terminal:

```
                             ┌──────────────────────────────────────────┐
                             │╭─ Confirm Delete ───────────────────────╮│
                             ││ Delete workspace base?                 ││
                             ││ This will:                             ││
                             ││   • stop all workspace processes       ││
                             ││   • run `git worktree remove`          ││
                             ││   • drop the workspace record          ││
                             └──────────────────────────────────────────┘   ← buttons gone
```

## 2. A git worktree re-asked the trust question

Workspace Trust was keyed purely on the workspace's own path, so every `git worktree add` produced a folder the user had never "decided" and the security modal came up again. But a linked worktree is a second checkout of the *same* repository — same manifests, same build scripts, same language servers. Re-asking there asks the same question about the same code, and the Orchestrator's whole premise is one worktree per agent, which turned an occasional prompt into a prompt on every new workspace. Users learn to dismiss a security prompt they see constantly, which is the real cost.

A worktree now opens under the level recorded for its main worktree. `trust_owner_root` resolves it the way git does and without a subprocess: a linked worktree's `.git` is a file holding `gitdir: <dir>`, that dir holds `commondir` pointing at the shared `.git`, and its parent is the main worktree. A submodule also has a `.git` file but **no** `commondir`, so it stays keyed on itself rather than being folded into the superproject. Reads route through the `FileSystem` trait, so an SSH/container workspace resolves on the host that actually holds the repo.

`store_for_workspace` is now the single place a workspace root becomes a `trust.json` path, and every anchor site goes through it — boot, the daemon's working-dir rebuild, per-session scopes, restored shells — so the mapping can't be forgotten at one of them. Env recipes deliberately stay keyed on the workspace's own directory: a worktree can carry its own `.venv`.

The prompt gate also anchors persistence before consulting it, so the gate and the live handle can no longer disagree about which file records the decision — that is what makes the inherited level take effect rather than merely suppressing the prompt.

## 3. Clicking a trust option accepted it

In the workspace-trust modal a click on a radio row called `confirm_workspace_trust`: it recorded the decision and dismissed the dialog in one gesture. A single click on "Trust folder & Allow Tooling" granted the folder full execution rights — language servers, build scripts, env activation — with no chance to read the option first and no chance to reconsider. The keyboard had it right all along: `T`/`K`/`B` move the selection, Enter or `O` commits.

A click now only moves the radio; the dialog stays up until `[ OK ]`. The web UI forwards its radio clicks to this same hit-test, so both frontends are fixed by the one change.

## Testing

Five e2e tests in `crates/fresh-editor/tests/e2e/orchestrator_dialog_trust_repro.rs`, driving only keyboard/mouse and asserting on rendered output (CONTRIBUTING §2):

| Test | Guards |
|---|---|
| `dock_delete_confirmation_shows_its_buttons_on_a_short_terminal` | #1 — warning + both buttons on screen at 24 rows |
| `dock_delete_confirmation_focuses_cancel` | Enter on the confirmation returns to the menu |
| `worktree_inherits_base_repo_trust_decision` | #2 — no prompt, status bar reads `Trusted` |
| `worktree_of_undecided_repo_still_prompts` | #2 counterpart — inheritance shares a real decision, never invents one |
| `trust_dialog_radio_click_selects_without_accepting` | #3 — dialog stays up, level unchanged until `[ OK ]` |

Each of the three fixes was reverted in turn and the corresponding test confirmed to fail. Assertions pin the "before" state as well as the "after" so none can pass vacuously, and button hits match the rendered `[ Delete ]` / `[ OK ]` rather than a bare word. Verified stable across repeated parallel runs.

Also reproduced manually in both frontends before fixing — tmux for the TUI, headless Chromium against `webui_server` for the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UhcWWiiLz3uEQfxVp5aYk