### PR TITLE
fix(daemon): one workspace set for every invocation, and keep detached daemons alive

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -629,6 +629,7 @@ impl Editor {
             session_mode: false,
             software_cursor_only: false,
             session_name: None,
+            session_display_name: None,
             pending_escape_sequences: Vec::new(),
             restart_with_dir: None,
             last_window_title: None,

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -47,11 +47,22 @@ impl Editor {
         self.software_cursor_only = enabled;
     }
 
-    /// Set the session name for display in status bar.
+    /// Set the daemon name that scopes this editor's persistence.
     ///
-    /// When a session name is set, the recovery service is reinitialized
-    /// to use a session-scoped recovery directory so each named session's
-    /// recovery data is isolated.
+    /// `Some` means a *named* daemon (`fresh --cmd daemon new NAME`), which owns
+    /// its own workspace collection and recovery directory: two named daemons
+    /// over one project must not share a layout. It must stay `None` for an
+    /// unnamed working-directory daemon (`fresh -a`), which is the same editor
+    /// state a direct-mode `fresh` in that directory sees and therefore shares
+    /// its per-directory workspaces and recovery. Passing a directory *label*
+    /// here is what made `fresh -a` come up with empty workspaces.
+    ///
+    /// For the status-bar label — which every daemon has, named or not — see
+    /// [`Self::set_session_display_name`].
+    ///
+    /// When a name is set, the recovery service is reinitialized to use a
+    /// session-scoped recovery directory so each named daemon's recovery data is
+    /// isolated.
     pub fn set_session_name(&mut self, name: Option<String>) {
         if let Some(ref session_name) = name {
             let base_recovery_dir = self.dir_context.recovery_dir();
@@ -71,9 +82,28 @@ impl Editor {
         self.session_name = name;
     }
 
-    /// Get the session name (for status bar display)
+    /// Get the daemon name that scopes persistence (`None` for a
+    /// working-directory daemon and for direct mode).
     pub fn session_name(&self) -> Option<&str> {
         self.session_name.as_deref()
+    }
+
+    /// Set the label shown in the status bar for a daemon-backed editor.
+    ///
+    /// Purely cosmetic, and set for *every* daemon: a named one shows its name,
+    /// an unnamed working-directory one shows the directory. Deliberately
+    /// separate from [`Self::set_session_name`], which decides where workspaces
+    /// and recovery data live.
+    pub fn set_session_display_name(&mut self, name: Option<String>) {
+        self.session_display_name = name;
+    }
+
+    /// The status-bar label for a daemon-backed editor, falling back to the
+    /// persistence-scoping name when no distinct label was set.
+    pub fn session_display_name(&self) -> Option<&str> {
+        self.session_display_name
+            .as_deref()
+            .or_else(|| self.session_name.as_deref())
     }
 
     /// Queue escape sequences to be sent to the client (session mode only)

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -503,8 +503,16 @@ pub struct Editor {
     /// Backend does not render a hardware cursor — always use software cursor indicators.
     software_cursor_only: bool,
 
-    /// Session name for display in status bar (session mode only)
+    /// Name of the *named* daemon whose persistence scope this editor uses
+    /// (`fresh --cmd daemon new NAME`). `None` in direct mode and for an
+    /// unnamed working-directory daemon, which shares the directory's
+    /// workspaces and recovery with a direct-mode run. Not a display field —
+    /// see `session_display_name`.
     session_name: Option<String>,
+
+    /// Status-bar label for a daemon-backed editor: the daemon's name, or the
+    /// working directory for an unnamed one. Cosmetic only.
+    session_display_name: Option<String>,
 
     /// Pending escape sequences to send to client (session mode only)
     /// These get prepended to the next render output

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -164,6 +164,9 @@ pub(crate) fn read_persisted_windows_env(
         migrate_legacy_windows(filesystem, data_dir);
     }
     migrate_windows_json_into_workspaces(filesystem, data_dir);
+    // Daemon-scoped workspaces predate the one-set model; fold them in before
+    // discovery so they show up in the dock like any other workspace.
+    migrate_session_workspaces_into_store(filesystem, data_dir);
 
     // The workspace cache is the session registry now: sessions discovered
     // from disk, keyed by durable identity. A directory may host several
@@ -440,6 +443,103 @@ fn migrate_windows_json_into_workspaces(
         // Best-effort: if delete also fails the file stays and migration reruns (idempotent).
         let _ = filesystem.remove_file(&global_p).ok();
     }
+}
+
+/// Fold pre-migration daemon-scoped workspaces into the one workspace store.
+///
+/// A named daemon used to persist *all* of its windows into a single
+/// `session-workspaces/<daemon>.json`, keyed on the daemon's name. That store
+/// could not represent more than one window (each overwrote the last) and
+/// nothing here ever scanned it, so those layouts were invisible to the dock
+/// and unreachable from any other invocation. Workspaces are now one set,
+/// shared by direct mode and every daemon, so each surviving legacy snapshot is
+/// re-keyed as an ordinary workspace: its recorded `working_dir` plus a minted
+/// `stable_id` if it predates durable identities.
+///
+/// Two named daemons that each held a layout over the same root migrate into
+/// two co-tenant workspaces over that root — which the per-window store already
+/// supports — so neither user's layout is dropped.
+///
+/// Idempotent and best-effort: the legacy directory is renamed aside once every
+/// file in it has been converted, and anything that fails to convert is left
+/// alone for the next boot to retry rather than deleted.
+fn migrate_session_workspaces_into_store(
+    filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
+) {
+    let legacy_dir = data_dir.join("session-workspaces");
+    let Ok(entries) = filesystem.read_dir(&legacy_dir) else {
+        return;
+    };
+    let mut all_converted = true;
+    for entry in entries {
+        if !entry.name.ends_with(".json") {
+            continue;
+        }
+        let Ok(bytes) = filesystem.read_file(&entry.path) else {
+            all_converted = false;
+            continue;
+        };
+        let Ok(mut val) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            // Unparseable: leave it rather than silently lose a layout.
+            all_converted = false;
+            continue;
+        };
+        let Some(root) = val
+            .get("working_dir")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from)
+        else {
+            all_converted = false;
+            continue;
+        };
+        // Mint an identity for snapshots written before durable ids, so the
+        // file lands under the id-keyed name the per-window store uses.
+        let stable_id = match val.get("stable_id").and_then(|v| v.as_str()) {
+            Some(id) if !id.is_empty() => id.to_string(),
+            _ => {
+                let id = crate::workspace::generate_stable_id();
+                if let Some(obj) = val.as_object_mut() {
+                    obj.insert("stable_id".into(), serde_json::Value::String(id.clone()));
+                }
+                id
+            }
+        };
+        let dest = workspaces_dir(data_dir).join(format!(
+            "{}.{}.json",
+            crate::workspace::encode_path_for_filename(&canonical_key(&root)),
+            stable_id
+        ));
+        // Never clobber a live workspace: the per-window store is authoritative
+        // wherever both describe the same identity.
+        if filesystem.exists(&dest) {
+            continue;
+        }
+        let Ok(out) = serde_json::to_vec_pretty(&val) else {
+            all_converted = false;
+            continue;
+        };
+        if filesystem.write_file(&dest, &out).is_err() {
+            all_converted = false;
+            continue;
+        }
+        tracing::info!(
+            "Migrated daemon-scoped workspace {:?} into the shared store as {:?}",
+            entry.path,
+            dest
+        );
+    }
+    if !all_converted {
+        return;
+    }
+    // Retire the legacy directory (keep it as a .bak so a downgrade isn't
+    // one-way). A failure just leaves it for the next boot — the conversion
+    // above skips anything already present, so rerunning is harmless.
+    let bak = legacy_dir.with_extension("retired.bak");
+    if filesystem.exists(&bak) {
+        return;
+    }
+    let _ = filesystem.rename(&legacy_dir, &bak).ok();
 }
 
 /// Pick which persisted session to bring up at boot, scoped to the

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1842,8 +1842,10 @@ impl Editor {
                 .contains(&(u64::MAX - self.active_window_id().0))
                 && self.active_window().authority_spec.is_remote();
 
-            // Get session name for display (only in session mode)
-            let session_name = self.session_name().map(|s| s.to_string());
+            // Get session label for display (only in session mode). The display
+            // name, not `session_name`: an unnamed working-directory daemon has
+            // no daemon name but is still labelled with its directory.
+            let session_name = self.session_display_name().map(|s| s.to_string());
 
             let active_split = self.effective_active_split();
             let active_buf = self.active_buffer();

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -1350,7 +1350,6 @@ impl crate::app::Editor {
         if self.session_keepalives.remove(&id).is_some() {
             tracing::info!("close_window: dropped remote session keepalive for window {id}");
         }
-
         self.plugin_manager
             .read()
             .unwrap()
@@ -1489,13 +1488,8 @@ impl crate::app::Editor {
         // terminals spawn over SSH/kube), or seed an empty layout when there is
         // no saved workspace. Either constructor takes the authority by value —
         // the window is born owning its real backend.
-        let workspace = if let Some(name) = self.session_name.clone() {
-            crate::workspace::Workspace::load_session(&name, &root)
-                .ok()
-                .flatten()
-        } else {
-            crate::workspace::Workspace::load(&root).ok().flatten()
-        };
+        // One store, whatever launched this editor — see `save_workspace_for`.
+        let workspace = crate::workspace::Workspace::load(&root).ok().flatten();
         let mut window = match workspace {
             Some(ws) => crate::app::window::Window::from_workspace(
                 id,

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -439,11 +439,7 @@ impl Editor {
         // a terminal-only on-disk workspace must NOT block this save.
         if workspace.has_no_real_content() && win.has_any_virtual_buffer() {
             let root = win.root.clone();
-            let on_disk = if let Some(ref session_name) = self.session_name {
-                Workspace::load_session(session_name, &root).ok().flatten()
-            } else {
-                Workspace::load(&root).ok().flatten()
-            };
+            let on_disk = Workspace::load(&root).ok().flatten();
             if let Some(existing) = on_disk {
                 if !existing.has_no_preservable_content() {
                     tracing::info!(
@@ -455,12 +451,11 @@ impl Editor {
             }
         }
 
-        // For a named daemon, save to the daemon-scoped workspace file
-        if let Some(ref session_name) = self.session_name {
-            workspace.save_session(session_name)
-        } else {
-            workspace.save()
-        }
+        // One store, whatever launched this editor. A daemon — named or not —
+        // is a host for workspaces, not an owner of a private set of them, so
+        // its windows persist exactly where a direct-mode run's do and boot
+        // discovery (which only ever scans this store) can see them all.
+        workspace.save()
     }
 
     /// Restore a specific window's workspace from disk into
@@ -486,9 +481,8 @@ impl Editor {
             return Ok(false);
         };
 
-        let workspace = if let Some(ref session_name) = self.session_name {
-            Workspace::load_session(session_name, &root)?
-        } else if stable_id.is_empty() {
+        // One store, whatever launched this editor — see `save_workspace_for`.
+        let workspace = if stable_id.is_empty() {
             // No durable id yet (a brand-new window): fall back to the
             // freshest file for the root.
             Workspace::load(&root)?
@@ -501,6 +495,7 @@ impl Editor {
             tracing::debug!("No workspace found for {:?}", root);
             return Ok(false);
         };
+
         tracing::info!("Found workspace for {:?}, applying...", root);
 
         // Editor-global config overrides (the shared `Config`).

--- a/crates/fresh-editor/src/server/daemon/unix.rs
+++ b/crates/fresh-editor/src/server/daemon/unix.rs
@@ -63,6 +63,18 @@ pub fn daemonize() -> io::Result<()> {
 /// spawned daemon boots into an SSH authority instead of the default
 /// `Authority::local()` (see `EditorServerConfig.startup_authority`).
 /// Returns the PID of the spawned server (intermediate, not final daemon PID).
+///
+/// The child calls `setsid()` before exec so the daemon leads its own session
+/// with no controlling terminal — the Unix counterpart of the Windows
+/// `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`. Without it the daemon stayed
+/// in the launching terminal's session and process group: closing that terminal
+/// SIGHUP'd the daemon even though the user had already detached, and killing
+/// the terminal's process group took the daemon down with it — along with any
+/// client attached from another terminal.
+///
+/// `setsid()` rather than [`daemonize`] because the daemon must keep the
+/// inherited working directory (it serves that project); `daemonize` chdirs
+/// to `/`.
 pub fn spawn_server_detached(session_name: Option<&str>, ssh_url: Option<&str>) -> io::Result<u32> {
     let exe = std::env::current_exe()?;
 
@@ -79,18 +91,119 @@ pub fn spawn_server_detached(session_name: Option<&str>, ssh_url: Option<&str>) 
     }
 
     // Use Command to spawn, which properly handles the process
-    let child = std::process::Command::new(&exe)
-        .args(&args)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.args(&args);
+    detach_from_terminal(&mut cmd);
+
+    let child = cmd.spawn()?;
 
     Ok(child.id())
+}
+
+/// Configure `cmd` so the spawned child outlives this process's terminal:
+/// stdio at `/dev/null`, and its own session with no controlling terminal.
+///
+/// The session is the part that matters. A child spawned normally stays in the
+/// caller's session and process group, so closing the launching terminal
+/// SIGHUPs it and a signal aimed at that process group reaches it — which is
+/// how a detached daemon died along with the terminal it was started from.
+fn detach_from_terminal(cmd: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    // SAFETY: runs in the forked child between fork and exec, where only
+    // async-signal-safe calls are allowed. `setsid` is one such call, and it
+    // touches no allocator or lock this process holds. It fails with EPERM only
+    // when the caller is already a session leader — harmless here, since that
+    // means the child is already free of a controlling terminal, so the error is
+    // deliberately not propagated (returning would abort an otherwise usable
+    // daemon).
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
 }
 
 /// Check if a process with the given PID is still running
 pub fn is_process_running(pid: u32) -> bool {
     // Send signal 0 to check if process exists
     unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_of(pid: u32) -> i32 {
+        let sid = unsafe { libc::getsid(pid as i32) };
+        assert_ne!(sid, -1, "could not read session of pid {pid}");
+        sid
+    }
+
+    fn group_of(pid: u32) -> i32 {
+        let pgid = unsafe { libc::getpgid(pid as i32) };
+        assert_ne!(pgid, -1, "could not read process group of pid {pgid}");
+        pgid
+    }
+
+    /// A child left in our session and process group is reachable by the
+    /// terminal teardown that closing a terminal performs; `detach_from_terminal`
+    /// is what moves the daemon out of range.
+    ///
+    /// The plain spawn is the control: it proves the assertion below can fail,
+    /// so a change that silently stopped detaching would be caught rather than
+    /// passing vacuously. `/bin/sh` stands in for the daemon — the property
+    /// under test belongs to the spawn, not to the editor, so nothing here has
+    /// to boot one.
+    #[test]
+    fn detach_from_terminal_puts_the_child_in_its_own_session() {
+        let ours = session_of(std::process::id());
+
+        // Control: a normally spawned child inherits our session and group.
+        let mut attached = std::process::Command::new("/bin/sh")
+            .args(["-c", "read _ 2>/dev/null || sleep 300"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn control child");
+        assert_eq!(
+            session_of(attached.id()),
+            ours,
+            "control child should have inherited our session"
+        );
+
+        // Detached: its own session, and therefore its own process group, so
+        // neither a terminal hangup nor a signal to our group can reach it.
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.args(["-c", "sleep 300"]);
+        detach_from_terminal(&mut cmd);
+        let mut detached = cmd.spawn().expect("spawn detached child");
+
+        let detached_sid = session_of(detached.id());
+        assert_ne!(
+            detached_sid, ours,
+            "detached child must not share our session"
+        );
+        assert_eq!(
+            detached_sid,
+            detached.id() as i32,
+            "detached child must lead its own session"
+        );
+        assert_ne!(
+            group_of(detached.id()),
+            group_of(std::process::id()),
+            "detached child must not share our process group"
+        );
+
+        let _ = attached.kill();
+        let _ = attached.wait();
+        let _ = detached.kill();
+        let _ = detached.wait();
+    }
 }

--- a/crates/fresh-editor/src/server/daemon/unix.rs
+++ b/crates/fresh-editor/src/server/daemon/unix.rs
@@ -201,9 +201,12 @@ mod tests {
             "detached child must not share our process group"
         );
 
-        let _ = attached.kill();
-        let _ = attached.wait();
-        let _ = detached.kill();
-        let _ = detached.wait();
+        // Reap both stubs rather than ignoring the results: a `sleep` that
+        // outlives the test would linger for five minutes, and the detached one
+        // is — by construction — in a session this process no longer controls.
+        attached.kill().expect("kill the control child");
+        attached.wait().expect("reap the control child");
+        detached.kill().expect("kill the detached child");
+        detached.wait().expect("reap the detached child");
     }
 }

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -798,7 +798,17 @@ impl EditorServer {
         // Enable session mode - use hardware cursor only, no REVERSED software cursor
         editor.set_session_mode(true);
 
-        // Set session name for status bar display
+        // Only a *named* daemon scopes persistence to itself. An unnamed
+        // working-directory daemon is the same editor state a direct-mode
+        // `fresh` in that directory sees, so it must keep the per-directory
+        // workspaces and recovery — handing the directory's basename over as if
+        // it were a daemon name is what made `fresh -a` restore nothing: the
+        // per-directory workspaces boot discovery had enumerated were then
+        // looked up in a daemon-scoped store that nothing had ever written.
+        editor.set_session_name(self.config.session_name.clone());
+
+        // The status bar labels every daemon, named or not: its name, else the
+        // directory it serves.
         let session_display_name = self.config.session_name.clone().unwrap_or_else(|| {
             // Use the directory name as a short display name for unnamed daemons
             self.config
@@ -808,7 +818,7 @@ impl EditorServer {
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "session".to_string())
         });
-        editor.set_session_name(Some(session_display_name));
+        editor.set_session_display_name(Some(session_display_name));
 
         Ok((editor, terminal))
     }

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -912,27 +912,14 @@ pub fn find_workspace_file_by_root(working_dir: &Path) -> io::Result<Option<Path
     Ok(best.map(|b| b.path))
 }
 
-/// Get the session-workspaces directory
+/// The retired daemon-scoped workspace directory.
+///
+/// Workspaces are one set now, shared by direct mode and every daemon, so
+/// nothing writes here any more. The path survives only so boot migration can
+/// find pre-existing snapshots and fold them into the real store — see
+/// `orchestrator_persistence::migrate_session_workspaces_into_store`.
 pub fn get_session_workspaces_dir() -> io::Result<PathBuf> {
     Ok(get_data_dir()?.join("session-workspaces"))
-}
-
-/// Get the workspace file path for a named session
-pub fn get_session_workspace_path(session_name: &str) -> io::Result<PathBuf> {
-    let dir = get_session_workspaces_dir()?;
-    std::fs::create_dir_all(&dir)?;
-    // Sanitize session name for filesystem safety
-    let safe_name: String = session_name
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    Ok(dir.join(format!("{}.json", safe_name)))
 }
 
 /// Workspace error types
@@ -1185,71 +1172,6 @@ impl Workspace {
             }
         }
 
-        Ok(())
-    }
-
-    /// Load workspace for a named session (if exists)
-    pub fn load_session(
-        session_name: &str,
-        working_dir: &Path,
-    ) -> Result<Option<Workspace>, WorkspaceError> {
-        let path = get_session_workspace_path(session_name)?;
-        tracing::debug!("Looking for session workspace at {:?}", path);
-
-        if !path.exists() {
-            return Ok(None);
-        }
-
-        let content = std::fs::read_to_string(&path)?;
-        let workspace: Workspace = serde_json::from_str(&content)?;
-
-        // For session workspaces, skip working_dir validation — the session
-        // always restores its own workspace regardless of CWD.
-        if workspace.version > WORKSPACE_VERSION {
-            return Err(WorkspaceError::VersionTooNew {
-                version: workspace.version,
-                max_supported: WORKSPACE_VERSION,
-            });
-        }
-
-        // If working_dir changed, log but still load (session owns its layout)
-        let found = workspace
-            .working_dir
-            .canonicalize()
-            .unwrap_or_else(|_| workspace.working_dir.clone());
-        let expected = working_dir
-            .canonicalize()
-            .unwrap_or_else(|_| working_dir.to_path_buf());
-        if expected != found {
-            tracing::info!(
-                "Session '{}' workspace was saved from {:?}, now loading from {:?}",
-                session_name,
-                found,
-                expected
-            );
-        }
-
-        Ok(Some(workspace))
-    }
-
-    /// Save workspace for a named session using atomic write
-    pub fn save_session(&self, session_name: &str) -> Result<(), WorkspaceError> {
-        let path = get_session_workspace_path(session_name)?;
-        tracing::debug!("Saving session workspace to {:?}", path);
-
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let content = serde_json::to_string_pretty(self)?;
-        let temp_path = path.with_extension("json.tmp");
-        {
-            let mut file = std::fs::File::create(&temp_path)?;
-            file.write_all(content.as_bytes())?;
-            file.sync_all()?;
-        }
-        std::fs::rename(&temp_path, &path)?;
-        tracing::info!("Session workspace saved to {:?}", path);
         Ok(())
     }
 

--- a/crates/fresh-editor/tests/daemon_workspace_restore_parity.rs
+++ b/crates/fresh-editor/tests/daemon_workspace_restore_parity.rs
@@ -1,0 +1,162 @@
+//! An unnamed working-directory daemon shares the directory's workspaces with a
+//! direct-mode run (issue #2808).
+//!
+//! Reported symptom: build a set of Orchestrator workspaces in a direct-mode
+//! run (`fresh`), quit, then come back through `fresh -a`. The dock listed every
+//! workspace — boot discovery scans the per-directory store in both modes — but
+//! each came up holding a single empty `[No Name]` buffer, and switching between
+//! them never changed the buffer view.
+//!
+//! The daemon handed the working directory's *basename* to `set_session_name`,
+//! which is the identity of a **named** daemon (`daemon new NAME`) and scopes
+//! workspaces and recovery to that daemon alone. So an unnamed `fresh -a` looked
+//! its layout up in a daemon-scoped store nothing had ever written, while the
+//! workspaces discovery had just enumerated sat in the per-directory store.
+//!
+//! Everything is asserted on rendered output, driving the dock with the same
+//! keys a user presses (CONTRIBUTING: "E2E Tests Observe, Not Inspect").
+//!
+//! Lives in its own integration binary because it sets the process-global
+//! `XDG_DATA_HOME` to isolate persistence: workspace save/load key off
+//! `$XDG_DATA_HOME/fresh` while boot discovery reads
+//! `DirectoryContext::data_dir`, so both must name one isolated tree. That
+//! global is also why this is a single `#[test]` — two tests in this binary
+//! would race each other's `set_var`. See `orchestrator_co_tenant_restore.rs`
+//! for the same pattern. Linux-gated: `dirs::data_dir()` ignores
+//! `XDG_DATA_HOME` elsewhere.
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use std::path::{Path, PathBuf};
+
+/// Isolate ALL editor persistence into `base`: `$XDG_DATA_HOME/fresh` is where
+/// `Workspace::save`/`load` live, and the returned `DirectoryContext`'s
+/// `data_dir` is the SAME path — so the direct-mode run's saves and the
+/// daemon-mode run's boot discovery agree, inside the test's temp tree.
+fn isolated_dir_context(base: &Path) -> DirectoryContext {
+    let xdg_data = base.join("xdg-data");
+    std::fs::create_dir_all(&xdg_data).unwrap();
+    std::env::set_var("XDG_DATA_HOME", &xdg_data);
+    DirectoryContext {
+        data_dir: xdg_data.join("fresh"),
+        config_dir: base.join("config"),
+        home_dir: Some(base.join("home")),
+        documents_dir: None,
+        downloads_dir: None,
+    }
+}
+
+fn harness_in(project: &Path, dir_context: &DirectoryContext) -> EditorTestHarness {
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new()
+            .with_working_dir(project.to_path_buf())
+            .with_shared_dir_context(dir_context.clone())
+            .with_config(config)
+            .with_empty_plugins_dir(),
+    )
+    .unwrap()
+}
+
+fn json_files_in(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn unnamed_daemon_restores_the_workspaces_direct_mode_saved() {
+    fresh::i18n::set_locale("en");
+    let sandbox = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(sandbox.path());
+    let workspaces_dir = dir_context.data_dir.join("workspaces");
+
+    let mk = |n: &str| {
+        let p = sandbox.path().join(n);
+        std::fs::create_dir_all(&p).unwrap();
+        p.canonicalize().unwrap()
+    };
+    let alpha_root = mk("alpha");
+    let beta_root = mk("beta");
+    let alpha_file = alpha_root.join("alpha_one.rs");
+    let beta_file = beta_root.join("beta_one.md");
+    std::fs::write(&alpha_file, "ALPHA_MARKER\n").unwrap();
+    std::fs::write(&beta_file, "BETA_MARKER\n").unwrap();
+
+    // Direct mode: one workspace per project root, each with its own file open.
+    // This is the state `fresh` persists on quit.
+    {
+        let mut h = harness_in(&alpha_root, &dir_context);
+        h.startup(true, &[]).unwrap();
+        h.open_file(&alpha_file).unwrap();
+
+        let beta_win = h
+            .editor_mut()
+            .create_window_at(beta_root.clone(), "beta".to_string());
+        h.editor_mut().set_active_window(beta_win);
+        h.open_file(&beta_file).unwrap();
+
+        h.editor_mut().save_all_windows_workspaces().unwrap();
+    }
+
+    // Two workspaces are in the per-directory store — the only store boot
+    // discovery enumerates.
+    assert_eq!(
+        json_files_in(&workspaces_dir).len(),
+        2,
+        "direct mode must persist one workspace file per window, got: {:?}",
+        json_files_in(&workspaces_dir)
+    );
+
+    // Now attach as an unnamed working-directory daemon at the same root.
+    let mut h = harness_in(&alpha_root, &dir_context);
+    h.editor_mut().set_session_mode(true);
+    // What a `fresh -a` daemon has: a status-bar label, but no daemon name —
+    // it is not its own persistence scope.
+    h.editor_mut()
+        .set_session_display_name(Some("alpha".into()));
+    h.startup(true, &[]).unwrap();
+    h.render().unwrap();
+
+    // The active workspace came back: its file's content is on screen, not the
+    // empty unnamed buffer the daemon used to show.
+    h.assert_screen_contains("ALPHA_MARKER");
+    h.assert_screen_not_contains("[No Name]");
+
+    // Switch workspaces the way a user does — run "Next Window" from the
+    // command palette — and the buffer view must follow to the other
+    // workspace's own file. This is the part that never changed before: every
+    // workspace rendered the same empty buffer. (The Orchestrator dock drives
+    // the same window switch; it lives in a plugin, and this binary runs
+    // without plugins to keep the core restore path isolated.)
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Next Window").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Next Window"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("BETA_MARKER"))
+        .unwrap();
+
+    // The other workspace restored its OWN file, not a second copy of the
+    // active one.
+    h.assert_screen_not_contains("ALPHA_MARKER");
+}

--- a/crates/fresh-editor/tests/daemon_workspace_restore_parity.rs
+++ b/crates/fresh-editor/tests/daemon_workspace_restore_parity.rs
@@ -1,5 +1,8 @@
-//! An unnamed working-directory daemon shares the directory's workspaces with a
-//! direct-mode run (issue #2808).
+//! Every invocation sees and opens the same workspaces (issues #2808, #2811).
+//!
+//! Direct mode, an unnamed working-directory daemon (`fresh -a`) and a named
+//! daemon (`fresh -a NAME`) are all hosts for one shared set of workspaces —
+//! none of them owns a private copy.
 //!
 //! Reported symptom: build a set of Orchestrator workspaces in a direct-mode
 //! run (`fresh`), quit, then come back through `fresh -a`. The dock listed every
@@ -7,11 +10,11 @@
 //! each came up holding a single empty `[No Name]` buffer, and switching between
 //! them never changed the buffer view.
 //!
-//! The daemon handed the working directory's *basename* to `set_session_name`,
-//! which is the identity of a **named** daemon (`daemon new NAME`) and scopes
-//! workspaces and recovery to that daemon alone. So an unnamed `fresh -a` looked
-//! its layout up in a daemon-scoped store nothing had ever written, while the
-//! workspaces discovery had just enumerated sat in the per-directory store.
+//! Daemons used to persist into `session-workspaces/<name>.json`, a store keyed
+//! on the daemon's name that could hold only one window and that discovery never
+//! scanned. An unnamed daemon was pushed into it by a basename fallback (#2808);
+//! a named one lived there by design (#2811). Either way the workspaces
+//! discovery had just enumerated were looked up somewhere nothing had written.
 //!
 //! Everything is asserted on rendered output, driving the dock with the same
 //! keys a user presses (CONTRIBUTING: "E2E Tests Observe, Not Inspect").
@@ -82,7 +85,7 @@ fn json_files_in(dir: &Path) -> Vec<PathBuf> {
 }
 
 #[test]
-fn unnamed_daemon_restores_the_workspaces_direct_mode_saved() {
+fn every_invocation_sees_and_opens_the_same_workspaces() {
     fresh::i18n::set_locale("en");
     let sandbox = tempfile::tempdir().unwrap();
     let dir_context = isolated_dir_context(sandbox.path());
@@ -125,38 +128,120 @@ fn unnamed_daemon_restores_the_workspaces_direct_mode_saved() {
         json_files_in(&workspaces_dir)
     );
 
-    // Now attach as an unnamed working-directory daemon at the same root.
-    let mut h = harness_in(&alpha_root, &dir_context);
-    h.editor_mut().set_session_mode(true);
-    // What a `fresh -a` daemon has: a status-bar label, but no daemon name —
-    // it is not its own persistence scope.
-    h.editor_mut()
-        .set_session_display_name(Some("alpha".into()));
+    // Every way of launching must now see and open that same set: a
+    // direct-mode run, an unnamed working-directory daemon, and a *named*
+    // daemon, which used to keep a private store of its own.
+    for daemon in [
+        DaemonKind::Direct,
+        DaemonKind::WorkingDirectory,
+        DaemonKind::Named("build-01"),
+    ] {
+        let mut h = harness_in(&alpha_root, &dir_context);
+        daemon.apply(&mut h);
+
+        let restored = h.startup(true, &[]).unwrap();
+        assert!(
+            restored,
+            "{daemon:?} must restore the workspace saved for this root"
+        );
+        h.render().unwrap();
+
+        // The active workspace came back: its file's content is on screen, not
+        // the empty unnamed buffer a daemon used to show.
+        h.assert_screen_contains("ALPHA_MARKER");
+        h.assert_screen_not_contains("[No Name]");
+
+        // Switch workspaces the way a user does — run "Next Window" from the
+        // command palette — and the buffer view must follow to the other
+        // workspace's own file. This is the part that never changed before:
+        // every workspace rendered the same empty buffer. (The Orchestrator
+        // dock drives the same window switch; it lives in a plugin, and this
+        // binary runs without plugins to keep the core restore path isolated.)
+        h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+            .unwrap();
+        h.wait_for_prompt().unwrap();
+        h.type_text("Next Window").unwrap();
+        h.wait_until(|h| h.screen_to_string().contains("Next Window"))
+            .unwrap();
+        h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+        h.wait_until(|h| h.screen_to_string().contains("BETA_MARKER"))
+            .unwrap();
+
+        // The other workspace opened its OWN file, not a second copy of the
+        // active one.
+        h.assert_screen_not_contains("ALPHA_MARKER");
+    }
+
+    // A layout a named daemon wrote *before* the stores were unified must not
+    // be orphaned by the change: boot migration folds it into the shared set,
+    // where it opens like any other workspace.
+    let legacy_root = mk("legacy");
+    let legacy_file = legacy_root.join("legacy_one.txt");
+    std::fs::write(&legacy_file, "LEGACY_MARKER\n").unwrap();
+    {
+        // Build a real snapshot of that project, then move it into the retired
+        // daemon-scoped store the way a pre-unification daemon would have left
+        // it behind.
+        let before: Vec<PathBuf> = json_files_in(&workspaces_dir);
+        let mut h = harness_in(&legacy_root, &dir_context);
+        h.startup(true, &[]).unwrap();
+        h.open_file(&legacy_file).unwrap();
+        h.editor_mut().save_all_windows_workspaces().unwrap();
+
+        let written: Vec<PathBuf> = json_files_in(&workspaces_dir)
+            .into_iter()
+            .filter(|p| !before.contains(p))
+            .collect();
+        assert_eq!(
+            written.len(),
+            1,
+            "expected one new workspace file to convert"
+        );
+        let legacy_dir = dir_context.data_dir.join("session-workspaces");
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::copy(&written[0], legacy_dir.join("build-01.json")).unwrap();
+        std::fs::remove_file(&written[0]).unwrap();
+    }
+
+    // Any invocation now finds it — here the plainest one, direct mode.
+    let mut h = harness_in(&legacy_root, &dir_context);
     h.startup(true, &[]).unwrap();
     h.render().unwrap();
+    h.assert_screen_contains("LEGACY_MARKER");
 
-    // The active workspace came back: its file's content is on screen, not the
-    // empty unnamed buffer the daemon used to show.
-    h.assert_screen_contains("ALPHA_MARKER");
-    h.assert_screen_not_contains("[No Name]");
+    assert!(
+        json_files_in(&dir_context.data_dir.join("session-workspaces")).is_empty(),
+        "the daemon-scoped store should be retired once its contents are folded in"
+    );
+}
 
-    // Switch workspaces the way a user does — run "Next Window" from the
-    // command palette — and the buffer view must follow to the other
-    // workspace's own file. This is the part that never changed before: every
-    // workspace rendered the same empty buffer. (The Orchestrator dock drives
-    // the same window switch; it lives in a plugin, and this binary runs
-    // without plugins to keep the core restore path isolated.)
-    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    h.wait_for_prompt().unwrap();
-    h.type_text("Next Window").unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("Next Window"))
-        .unwrap();
-    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("BETA_MARKER"))
-        .unwrap();
+/// How the editor under test was launched. Only the daemon *name* ever scoped
+/// persistence; the rest is display and cursor rendering.
+#[derive(Debug, Clone, Copy)]
+enum DaemonKind {
+    /// `fresh` — no daemon at all.
+    Direct,
+    /// `fresh -a` — a daemon addressed by its working directory, so it has a
+    /// status-bar label but no name.
+    WorkingDirectory,
+    /// `fresh -a NAME` / `daemon new NAME` — addressed by name.
+    Named(&'static str),
+}
 
-    // The other workspace restored its OWN file, not a second copy of the
-    // active one.
-    h.assert_screen_not_contains("ALPHA_MARKER");
+impl DaemonKind {
+    fn apply(self, h: &mut EditorTestHarness) {
+        match self {
+            DaemonKind::Direct => {}
+            DaemonKind::WorkingDirectory => {
+                h.editor_mut().set_session_mode(true);
+                h.editor_mut()
+                    .set_session_display_name(Some("alpha".into()));
+            }
+            DaemonKind::Named(name) => {
+                h.editor_mut().set_session_mode(true);
+                h.editor_mut().set_session_name(Some(name.into()));
+                h.editor_mut().set_session_display_name(Some(name.into()));
+            }
+        }
+    }
 }

--- a/crates/fresh-editor/tests/e2e/hot_exit_flows.rs
+++ b/crates/fresh-editor/tests/e2e/hot_exit_flows.rs
@@ -375,6 +375,15 @@ fn test_flow_b_hot_exit_recovery_with_cli_files() {
 ///
 /// Currently fails because recovery storage is global, not session-scoped (#1233).
 /// Will pass after implementing session-scoped recovery (Phase 2 of the plan).
+///
+/// Both sessions run with `editor.restore_previous_session = false` so this
+/// isolates *recovery*, which is what it is about. Workspaces are one shared set
+/// — a daemon is a host for them, not the owner of a private copy — so two
+/// daemons over one project directory legitimately restore the same layout, and
+/// asserting recovery isolation through the workspace layout would just be
+/// re-testing the old partitioned store. Hot-exit content is still restored with
+/// session restore off (the documented `--no-restore` behaviour), which is
+/// exactly the state under test.
 #[test]
 fn test_flow_c_session_scoped_recovery_isolation() {
     let temp_dir = TempDir::new().unwrap();
@@ -470,8 +479,7 @@ fn test_flow_c_session_scoped_recovery_isolation() {
         harness
             .editor_mut()
             .set_session_name(Some("session_a".into()));
-        let restored = harness.startup(true, &[]).unwrap();
-        assert!(restored, "Session A workspace should be restored");
+        harness.startup(false, &[]).unwrap();
         harness.render().unwrap();
 
         harness.assert_screen_contains("MODIFIED_A");
@@ -499,8 +507,7 @@ fn test_flow_c_session_scoped_recovery_isolation() {
         harness
             .editor_mut()
             .set_session_name(Some("session_b".into()));
-        let restored = harness.startup(true, &[]).unwrap();
-        assert!(restored, "Session B workspace should be restored");
+        harness.startup(false, &[]).unwrap();
         harness.render().unwrap();
 
         harness.assert_screen_contains("MODIFIED_B");


### PR DESCRIPTION
Fixes the daemon-mode defects in #2808.

## Design

**Workspaces are one set. A daemon is a host for them, not the owner of a private copy.**

Boot discovery has always enumerated exactly one store — the per-directory
`workspaces/<root>.<stable_id>.json` — in every mode. Persistence disagreed: with a
session name set it wrote to `session-workspaces/<name>.json` instead, a single file
keyed on the daemon's name. Nothing reconciled the two, so a daemon listed workspaces
it could not open.

Persistence now uses the store discovery scans, unconditionally. Direct mode,
`fresh -a`, `fresh -a NAME` and `--web` all see the same workspaces and can open any
of them.

**Detached daemons leave the launching terminal's session.** `spawn_server_detached`
spawned an ordinary child, so the daemon inherited the client's session and process
group and died when that terminal closed — taking down any client attached elsewhere.
It now calls `setsid()` from `pre_exec`.

## Choices

**One set rather than a namespace per daemon.** The alternative — give a named daemon
a *correct* private store, per-window and discoverable — preserves isolation but makes
"which workspaces exist" depend on how you started the editor. A daemon name is an
address (which socket to connect to); making it a data namespace is what produced the
bug. So the name addresses a process and nothing else.

**`session_name` keeps its other jobs.** It still scopes recovery, which is genuinely
per-daemon (`RecoveryScope::Session` is documented as such). Only workspace storage
stops branching on it. The working directory's basename was also doing duty as the
status-bar label for unnamed daemons; that splits into a display-only
`session_display_name`, so a cosmetic string can no longer decide where data lives.

**Migrate rather than orphan.** Layouts already in the daemon-scoped store are folded
into the shared one at boot, keyed by their recorded `working_dir` plus a minted
`stable_id`, and the directory is retired to `.retired.bak`. Two named daemons holding
layouts over one root become two co-tenants over that root — a shape the per-window
store already supports — so neither is dropped. Migration skips any destination that
already exists, so the live store always wins and reruns are harmless.

**`setsid` rather than the existing `daemonize()`.** `daemonize` chdirs to `/`; the
daemon must keep the inherited working directory because it serves that project.

**No lease in this PR.** Nothing stops two live editors opening one workspace and
clobbering each other on save. That predates this change — two `fresh` processes in a
directory have always done it, and `session.lock` only records a pid for crash
detection — but unification does expose named daemons to a hazard they were
accidentally shielded from. Fixing it properly means an `flock`-based lease plus a way
to reach a workspace someone else holds, which is a design of its own: #2811.

## Tests

- `tests/daemon_workspace_restore_parity.rs` — direct mode saves two workspaces over
  two roots; direct mode, an unnamed daemon and a named daemon must each restore them
  and switch between them, plus legacy-store migration. Rendered output only, driving
  the window switch from the command palette (CONTRIBUTING: "E2E Tests Observe, Not
  Inspect"). Fails without the fix on `Named("build-01") must restore the workspace
  saved for this root`.
- `detach_from_terminal_puts_the_child_in_its_own_session` — a unit test on the spawn,
  not the editor, so it runs against a stub child with a plain spawn alongside as a
  control that keeps it from passing vacuously. Fails without the fix on `detached
  child must not share our session`.
- `test_flow_c_session_scoped_recovery_isolation` asserted recovery isolation *through*
  the workspace layout, which only held while the stores were partitioned. It now opts
  out of session restore (`--no-restore` behaviour, which still restores hot-exit
  content) so it tests the isolation it is named for.

## Known limitations

- Two live editors can still clobber one workspace (above; #2811).
- Discovery runs only at boot, so a workspace created in one editor does not appear in
  another that is *already running* until it restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjzTLqa27FEwYb7E2djB3B