### PR TITLE
Keep the dock's search filter when you pick a workspace out of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Keyboard and mouse input is now parsed by our own `fresh-input-parser` crate ins
   * Codex "Auto mode" works again (it was passing a flag recent Codex CLI rejects).
   * Dock rows are fully clickable in compact (list) view, ordered by recency, and auto-name themselves from their terminal.
   * Fixed a crash when navigating to an unreachable remote workspace.
+  * Searching the dock and then opening one of the matches no longer wipes the search — the filtered list is still there when you come back for the next one. Leaving the dock (`Esc`, clicking the editor) still clears it.
+  * **Tidier workspace cards** - a card is now two rows instead of three: name with its git summary flush right, then the branch with the PR badge flush right. The branch starts at the card's left edge rather than floating mid-row, the empty third row is gone, and a branch that just repeats the workspace name gives its place to the project.
 * **Terminal**
   * Scrollback no longer loses output or gets stuck mid-scroll (#2649, reported by @dmknght).
 * **Tabs & splits**

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -820,6 +820,16 @@ function dockContentCols(dockWidth: number): number {
 // (dispatch_floating_widget_key) reads the panel focus directly to route
 // Enter/Esc/Space//'; this mirror is informational for the plugin.
 let dockFocus: "list" | "filter" = "list";
+// Set just before the dock blurs *because the user picked a workspace*
+// (a row click, Enter on the list, or attaching a discovered worktree
+// with `dive`). The `blur` handler clears the search filter so a stale
+// needle can't silently hide sessions on the next focus (F5) — but a
+// dive isn't "leaving the dock", it's acting on the very list the
+// filter produced. Wiping the needle there forces a retype for every
+// workspace picked out of a search. Consumed (and reset) by the next
+// `blur`; also reset on `focus` so an unconsumed flag can't leak into a
+// later, unrelated blur.
+let dockDiveBlur = false;
 // Full focused-widget mirror for the open dialog (both dock and
 // centered-picker modes). Updated from every `focus` widget_event.
 // Used by `toggleSelectCurrent` so a Space keypress while focus is
@@ -5051,6 +5061,9 @@ function diveDockSelectionFromClick(fromEdge: "top" | "bottom" | null): void {
     else editor.setActiveWindow(id);
   }
   // Hand keyboard focus to the activated window (mirror `dock_activate`).
+  // Picking a row is not "leaving the dock", so the search filter that
+  // produced this row survives the blur (see `dockDiveBlur`).
+  dockDiveBlur = true;
   dockBlurred = true;
   editor.floatingPanelControl(openPanel.id(), "blur", 0);
   editor.setEditorMode(null);
@@ -8978,6 +8991,8 @@ async function attachToWorktree(opts: {
     // (arrow-nav, row click) deliberately keep the dock focused, exactly
     // like switching to a live session does.
     if (opts.dive && dockMode && openPanel) {
+      // A dive out of the dock keeps the search filter (see `dockDiveBlur`).
+      dockDiveBlur = true;
       dockBlurred = true;
       editor.floatingPanelControl(openPanel.id(), "blur", 0);
       editor.setEditorMode(null);
@@ -9807,6 +9822,8 @@ editor.on("widget_event", (e) => {
       // leave, editor click, or an unhandled chord like Ctrl+P). The
       // dock stays visible; the host stops routing keys to it.
       if (dockMode) {
+        const wasDive = dockDiveBlur;
+        dockDiveBlur = false;
         dockBlurred = true;
         // Leaving the dock also closes the project dropdown so it
         // doesn't linger over the blurred dock.
@@ -9816,7 +9833,13 @@ editor.on("widget_event", (e) => {
         // "/gamma") otherwise silently hides sessions on the next
         // focus, with only the filter box as a clue — and there is no
         // one-key clear from the list. (See F5.)
-        if (openDialog.filter.value !== "") {
+        //
+        // A *dive* is the exception: clicking a row (or Enter on it) is
+        // acting on the filtered list, not abandoning it, so the needle
+        // stays put and the next workspace can be picked out of the same
+        // search without retyping it. Esc/editor-click still clear, so
+        // the one-key escape from a stale filter is unchanged.
+        if (!wasDive && openDialog.filter.value !== "") {
           openDialog.filter.value = "";
           openDialog.filter.cursor = 0;
           dockFocus = "list";
@@ -9849,6 +9872,9 @@ editor.on("widget_event", (e) => {
         pickerFocusKey = e.widget_key;
       }
       if (dockMode) {
+        // A dive that never produced a `blur` (already blurred, say)
+        // must not leave the flag armed for the next, unrelated one.
+        dockDiveBlur = false;
         const wasBlurred = dockBlurred;
         dockBlurred = false;
         dockFocus = e.widget_key === "filter" ? "filter" : "list";
@@ -9916,6 +9942,9 @@ editor.on("widget_event", (e) => {
       if (typeof id === "number" && id > 0 && id !== editor.activeWindow()) {
         editor.setActiveWindow(id);
       }
+      // Same as the row click: the filter that surfaced this row is kept
+      // across the dive (see `dockDiveBlur`).
+      dockDiveBlur = true;
       dockBlurred = true;
       editor.floatingPanelControl(openPanel.id(), "blur", 0);
       editor.setEditorMode(null);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1368,17 +1368,69 @@ function sessionNodeEntry(id: number, activeId: number): TextPropertyEntry {
 }
 
 // The dock's "card" density renders each session leaf as a fixed
-// 3-content-row card inside the tree; with `cardBorders` the host
-// wraps those rows in a rounded `╭─…─╮` border (5 screen rows total),
-// restoring the modal picker's pill look: line 1 = glyph · [facet] ·
-// NAME + project; line 2 = branch + git summary (right-aligned against
-// the card border); line 3 = PR badge (blank when none).
-const DOCK_CARD_HEIGHT = 3;
+// 2-content-row card inside the tree; with `cardBorders` the host wraps
+// those rows in a rounded `╭─…─╮` border (4 screen rows total). Two
+// rows, each one "what it is" on the left and "how it's doing" flush
+// right, so the status columns line up down the dock:
+//
+//   ╭──────────────────────────────╮
+//   │ * fresh-27            ↑2 +14 │   name              git
+//   │ ▸ fix/wrapped-nav   PR #2784 │   branch / project  PR
+//   ╰──────────────────────────────╯
+//
+// It was three rows: the third held the PR badge and stood empty on
+// every session without one, and the branch shared the middle row with
+// the git summary as a single right-aligned group — which left it
+// floating in the middle of the card instead of starting at the left
+// edge. The name-repeating branch (a worktree branch usually *is* the
+// workspace name) and the project tag beside the name were dropped for
+// the same reason: they spent a card's scarce width on what the row
+// already said.
+const DOCK_CARD_HEIGHT = 2;
+
+// A card row split into a left group and a right group flush against
+// the card's right border. Tree card rows are plain text entries (no
+// host flex spacer like the modal pill's `flexLine`), so the split
+// point rides along as a byte offset and the host's `render_tree_card`
+// — which knows the card's *actual* inner width, responsive or dragged
+// — inserts the gap. Plugin-side padding could only estimate that width
+// and drifted at every other one.
+function cardSplitRow(left: Entry[], right: Entry[]): TextPropertyEntry {
+  const row = styledRow([...left, ...right] as Parameters<typeof styledRow>[0]);
+  if (right.length === 0) return row;
+  row.properties = {
+    align: "between",
+    splitByte: left.reduce((n, e) => n + utf8Len(e.text), 0),
+  };
+  return row;
+}
+
+// Truncate to `cols` display columns, ellipsising when it doesn't fit.
+// Code-point aware (`Array.from`), so a multi-byte name can't be cut
+// mid-character.
+function capText(s: string, cols: number): string {
+  const chars = Array.from(s);
+  if (chars.length <= cols) return s;
+  return chars.slice(0, Math.max(1, cols - 1)).join("") + "…";
+}
+
+// Columns a group of entries occupies, for the left-group cap below.
+function entriesWidth(entries: Entry[]): number {
+  return entries.reduce((n, e) => n + Array.from(e.text).length, 0);
+}
+
+// Inner width of a card at the dock's default width — an estimate (the
+// dock can be dragged), used only to cap the branch so it doesn't shove
+// the right-hand group off the row. The host does the exact alignment.
+function cardInnerColsEstimate(): number {
+  return Math.max(12, dockContentCols(dockDefaultWidth()) - 2);
+}
 
 // Card line 1 (the tree node's primary text): state glyph, optional
-// remote facet, the name (highlighted when active), then a dim project
-// tag. Distinct from the compact `sessionNodeEntry`, which trails the
-// branch on the single line instead of the project.
+// remote facet, the name (highlighted when active) and — for a remote
+// session — its backend target, with the git summary flush right.
+// Distinct from the compact `sessionNodeEntry`, which trails the git
+// summary on the single line it has.
 function sessionCardPrimary(id: number, activeId: number): TextPropertyEntry {
   const s = orchestratorSessions.get(id);
   if (!s) return styledRow([{ text: editor.t("pill.unknown") }]);
@@ -1394,61 +1446,87 @@ function sessionCardPrimary(id: number, activeId: number): TextPropertyEntry {
     text: s.label,
     style: { fg: isActive ? "ui.help_key_fg" : undefined, bold: true },
   });
-  const proj = editor.pathBasename(projectKeyOf(s));
-  segs.push({ text: "  " + PROJECT_ICON + " ", style: { fg: "ui.menu_disabled_fg" } });
-  segs.push({ text: proj, style: { fg: "ui.menu_disabled_fg", italic: true } });
   // A remote session surfaces its backend target (host / ns·pod) coloured
   // by the connection state — pill parity (the pill shows it at the right
-  // end of line 1). The discovered "· on-disk" tag is NOT repeated here:
-  // the card's third line (prLineEntries) already carries it, exactly like
-  // the pill.
+  // end of line 1).
   if (s.remote) {
     segs.push({
       text: "  " + s.remote.detail,
       style: { fg: remoteStateFg(s.remote.state), italic: true },
     });
   }
-  return styledRow(segs as Parameters<typeof styledRow>[0]);
+  // Right group. A being-created placeholder has no git summary; it gets
+  // the one-key affordance instead ("↵ Retry"), so the row below is free
+  // for the whole status message.
+  if (s.pending) {
+    return cardSplitRow(
+      segs,
+      pendingActionable(s.pending)
+        ? [{
+          text: "↵ " + editor.t("dock.ctx_retry"),
+          style: { fg: "ui.menu_disabled_fg", italic: true },
+        }]
+        : [],
+    );
+  }
+  return cardSplitRow(segs, gitLineParts(s).right);
 }
 
-// Card lines 2 & 3 (continuation rows). Line 2 is the branch + a
-// compact git summary, right-aligned as one group against the card's
-// right border; line 3 is the PR badge (or a blank spacer when there's
-// no PR, keeping every card the same height). Tree card rows are plain
-// text entries (no host flex spacer), so the line carries the
-// `align: "right"` entry property and the host's `render_tree_card` —
-// which knows the card's *actual* inner width, responsive or dragged —
-// pads it flush against the right border.
+// Card line 2 (the continuation row): what this workspace *is* on the
+// left — its branch when that says something the name doesn't, else the
+// project it belongs to — and its PR badge (or the on-disk tag) flush
+// right.
 function sessionCardExtraLines(id: number): TextPropertyEntry[] {
   const s = orchestratorSessions.get(id);
   if (!s) return [];
-  // A being-created placeholder shows its status in place of the git / PR
-  // lines: line 2 is the creating/connecting/error message, line 3 is a
-  // retry/resume hint (blank while still creating).
+  // A being-created placeholder spends the row on its status message
+  // (the retry affordance sits on line 1).
   if (s.pending) {
     const p = s.pending;
-    const actionable = pendingActionable(p);
     return [
-      styledRow([{ text: p.message, style: { fg: pendingMsgFg(p), italic: actionable } }]),
-      styledRow([
-        actionable
-          ? { text: pendingHintText(p), style: { fg: "ui.menu_disabled_fg", italic: true } }
-          : { text: " " },
-      ] as Parameters<typeof styledRow>[0]),
+      styledRow([{
+        text: p.message,
+        style: { fg: pendingMsgFg(p), italic: pendingActionable(p) },
+      }]),
     ];
   }
-  const git = gitLineParts(s);
-  const gitSegs: Entry[] = [...git.left];
-  if (git.right.length) {
-    gitSegs.push({ text: "   " });
-    gitSegs.push(...git.right);
+  const dim = "ui.menu_disabled_fg";
+  const right = prLineEntries(s);
+  // The branch earns the row only when it differs from the workspace
+  // name — a worktree's branch is usually named after it, and printing
+  // it twice was pure noise. Otherwise the project takes the slot: it's
+  // the context the name doesn't carry. `(detached)` is reserved for a
+  // real repo with no branch; a plain directory just shows its project.
+  const branch = s.branch ||
+    (s.discovered
+      ? editor.t("pill.branch_worktree")
+      : s.git?.info
+      ? editor.t("pill.branch_detached")
+      : "");
+  const showBranch = branch !== "" && branch !== s.label;
+  const proj = editor.pathBasename(projectKeyOf(s));
+  const icon = showBranch ? BRANCH_ICON : PROJECT_ICON;
+  const text = showBranch ? branch : proj;
+  // Nothing to say that the name doesn't already say (a plain folder
+  // opened as its own project, whose label *is* the folder). The row
+  // stays empty rather than echoing the line above it.
+  if (text === s.label) {
+    return [cardSplitRow(right.length > 0 ? [] : [{ text: " " }], right)];
   }
-  const gitLine = styledRow(gitSegs as Parameters<typeof styledRow>[0]);
-  gitLine.properties = { align: "right" };
-  const pr = prLineEntries(s);
+  // Cap the branch/project so the badge keeps its columns: the host
+  // truncates the row's *end*, which is the badge. Budget = the card's
+  // inner width less this row's icon (2 cols), the badge, and the one
+  // column that always separates the two groups.
+  const cap = cardInnerColsEstimate() - 2 - entriesWidth(right) -
+    (right.length > 0 ? 1 : 0);
   return [
-    gitLine,
-    styledRow((pr.length ? pr : [{ text: " " }]) as Parameters<typeof styledRow>[0]),
+    cardSplitRow(
+      [
+        { text: icon + " ", style: { fg: dim } },
+        { text: capText(text, Math.max(8, cap)), style: { fg: dim, italic: !showBranch } },
+      ],
+      right,
+    ),
   ];
 }
 
@@ -2139,10 +2217,12 @@ const PROJECT_ICON = "▣";
 // already uses.
 const BRANCH_ICON = "▸";
 
-// Card line 2: branch (with icon, left) + a compact git summary
-// (right-aligned) that's useful even before any PR exists —
+// The modal pill's branch line: branch (with icon, left) + a compact
+// git summary (right-aligned) that's useful even before any PR exists —
 // ahead/behind the upstream and the uncommitted diffstat
-// (`+added −deleted`), or `clean`.
+// (`+added −deleted`), or `clean`. The dock card takes only the `right`
+// half — its name row carries the summary — so `left` (the branch) is
+// the pill's alone.
 function gitLineParts(s: AgentSession): { left: Entry[]; right: Entry[] } {
   const dim = "ui.menu_disabled_fg";
   let branch = s.branch || (s.discovered ? editor.t("pill.branch_worktree") : editor.t("pill.branch_detached"));
@@ -2272,7 +2352,10 @@ function stateGlyphEntry(s: AgentSession): Entry {
   return { text: sym.glyph + " ", style: { fg: sym.fg, bold: true } };
 }
 
-// Build one session row. Two densities, picked by `dockView`:
+// Build one session row for the modal picker's list. (The dock's own
+// tree rows are built by `sessionCardPrimary` / `sessionNodeEntry`; its
+// cards are two rows, not the three below.) Two densities, picked by
+// `dockView`:
 //
 //   card (default): a rounded `labeledSection` pill —
 //     line 1: <state> NAME (bold)              ▣ project

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -4910,18 +4910,49 @@ fn render_tree_card(node: &TreeNode, item_height: u32, panel_width: u32) -> Rend
         // The pad is ASCII spaces (1 byte == 1 char each), so shifting
         // overlay offsets by the pad length is unit-correct for both
         // byte- and char-unit overlays.
-        let align_right = src
+        let align = src
             .properties
             .get("align")
             .and_then(|v| v.as_str())
-            .map(|v| v == "right")
-            .unwrap_or(false);
-        if align_right {
+            .unwrap_or("")
+            .to_string();
+        // `align: "between"` splits the row into a left group and a
+        // right one flush against the border — the card equivalent of
+        // the flex spacer a widget `Row` gets. The split point is a byte
+        // offset into the row's own text (`splitByte`), so the plugin
+        // says *where* the groups meet and the host, which alone knows
+        // the card's real width, decides how much space goes between
+        // them. Overflowing rows get a single separating space and fall
+        // through to the usual end-truncation.
+        let split = if align == "between" {
+            src.properties
+                .get("splitByte")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize)
+                .filter(|&b| b <= src.text.len() && src.text.is_char_boundary(b))
+        } else {
+            None
+        };
+        // Where the padding goes: the row's start (right-aligned) or the
+        // group boundary (space-between).
+        let pad_at = match (align.as_str(), split) {
+            ("right", _) => Some(0),
+            ("between", Some(b)) => Some(b),
+            _ => None,
+        };
+        if let Some(at) = pad_at {
             let width = src.text.chars().count();
-            if width < inner_width {
-                let pad = " ".repeat(inner_width - width);
-                src.text.insert_str(0, &pad);
-                for o in src.inline_overlays.iter_mut() {
+            // A "between" row always keeps at least one space between
+            // the groups so they can't run together when the card is too
+            // narrow to hold both.
+            let pad_cols = inner_width.saturating_sub(width).max(usize::from(at > 0));
+            if pad_cols > 0 {
+                let pad = " ".repeat(pad_cols);
+                src.text.insert_str(at, &pad);
+                // The pad is ASCII spaces (1 byte == 1 char each), so
+                // shifting the overlays that sit after it is unit-correct
+                // for both byte- and char-unit overlays.
+                for o in src.inline_overlays.iter_mut().filter(|o| o.start >= at) {
                     o.start += pad.len();
                     o.end += pad.len();
                 }
@@ -7778,6 +7809,72 @@ mod tests {
         assert!(
             trimmed.ends_with("ab   "),
             "row should be padded after segment concat, got {trimmed:?}"
+        );
+    }
+
+    /// One `align: "between"` card row: `left` and `right` groups meet
+    /// at `splitByte`, rendered in a card `width` columns wide.
+    fn between_card_row(left: &str, right: &str, width: u32) -> String {
+        let mut node = tnode("name", 0, false);
+        let mut line = TextPropertyEntry::text(format!("{left}{right}"));
+        line.properties.insert(
+            "align".to_string(),
+            serde_json::Value::String("between".to_string()),
+        );
+        line.properties.insert(
+            "splitByte".to_string(),
+            serde_json::Value::Number((left.len() as u64).into()),
+        );
+        node.extra_lines = vec![line];
+        let spec = WidgetSpec::Tree {
+            nodes: vec![node],
+            item_keys: vec!["x".to_string()],
+            selected_index: -1,
+            visible_rows: 10,
+            expanded_keys: vec![],
+            checkable: false,
+            item_height: 2,
+            card_borders: true,
+            key: Some("T".to_string()),
+        };
+        let out = render_spec(&spec, &HashMap::new(), "", width);
+        // Top border, name row, the split row, bottom border.
+        out.entries[2].text.trim_end_matches('\n').to_string()
+    }
+
+    /// A card row (the orchestrator dock's workspace cards) can ask for
+    /// its right-hand group to sit flush against the card border while
+    /// the left group starts at the left one — `align: "between"` with
+    /// the group boundary as a byte offset. Only the host knows the
+    /// card's real width (the dock is resizable), so it owns the gap.
+    #[test]
+    fn tree_card_between_alignment_pushes_the_right_group_to_the_border() {
+        let row = between_card_row("branch", "PR #7", 30);
+        assert!(
+            row.starts_with("│branch") && row.ends_with("PR #7│"),
+            "left group hugs the left border and the right group the right one, got {row:?}"
+        );
+        // Padding only between them — not a plugin-side guess that
+        // leaves both groups floating mid-card.
+        let inner = row.trim_start_matches('│').trim_end_matches('│');
+        assert!(
+            inner["branch".len()..inner.len() - "PR #7".len()]
+                .chars()
+                .all(|c| c == ' '),
+            "the two groups are separated by padding only, got {inner:?}"
+        );
+    }
+
+    /// The groups still get a separating space when the card has no room
+    /// to spare — they must never run together into one unreadable word,
+    /// even at the exact width where they would just barely both fit.
+    #[test]
+    fn tree_card_between_alignment_keeps_a_gap_when_the_row_is_full() {
+        // Inner width 15 = exactly "abcdefghij" + "PR #7".
+        let row = between_card_row("abcdefghij", "PR #7", 17);
+        assert!(
+            !row.contains("ijPR"),
+            "a full row still separates the groups, got {row:?}"
         );
     }
 

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1767,6 +1767,88 @@ fn dock_filter_clears_when_focus_leaves_so_reentry_shows_all() {
     h.assert_screen_contains("Search Tasks");
 }
 
+/// The F5 clear-on-leave must NOT fire when the user *picks* a workspace
+/// out of the filtered list. Enter on a row (and a click on one) blurs the
+/// dock to hand the keyboard to the chosen session — a dive, not a
+/// departure — so the search that produced the row has to survive it.
+/// Wiping it there meant retyping the needle for every workspace opened
+/// out of one search, which is the common case with a long list.
+#[test]
+fn dock_filter_survives_diving_into_a_filtered_workspace() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.editor_mut()
+        .create_window_at(root.join("wt-gamma"), "gamma".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("beta") && s.contains("gamma")
+    })
+    .unwrap();
+
+    // Filter to "gamma"; "beta" drops out of the list.
+    h.send_key(KeyCode::Char('/'), KeyModifiers::NONE).unwrap();
+    h.type_text("gamma").unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("beta"))
+        .unwrap();
+
+    // Enter returns to the list, a second Enter dives into the highlighted
+    // "gamma" row — the dock blurs, handing the keyboard to that session.
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.editor().is_dock_focused()).unwrap();
+
+    // The dive must leave the filter alone: "beta" stays hidden and the
+    // box still reads "gamma" (an emptied box shows the "Search Tasks"
+    // placeholder instead).
+    let after_dive = h.screen_to_string();
+    assert!(
+        !after_dive.contains("beta"),
+        "diving into a filtered workspace must keep the filter applied, but the \
+         filtered-out 'beta' row came back:\n{after_dive}"
+    );
+    assert!(
+        !after_dive.contains("Search Tasks"),
+        "diving into a filtered workspace must keep the search text, but the box \
+         fell back to its placeholder:\n{after_dive}"
+    );
+
+    // Re-focusing the dock finds the same filtered list, so the next
+    // workspace can be picked out of the search without retyping it.
+    h.send_key(KeyCode::Char('o'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.editor().is_dock_focused()).unwrap();
+    let refocused = h.screen_to_string();
+    assert!(
+        !refocused.contains("beta"),
+        "re-entering the dock after a dive must show the still-filtered list:\n{refocused}"
+    );
+
+    // A click on a row is the same gesture as Enter, and keeps the filter
+    // for the same reason. (The row's own line, not the filter box, which
+    // also spells the needle — that one shares its row with "New Task".)
+    let gamma_row =
+        h.screen_to_string()
+            .lines()
+            .position(|l| l.contains("gamma") && !l.contains("New Task"))
+            .unwrap_or_else(|| panic!("no 'gamma' row:\n{}", h.screen_to_string())) as u16;
+    h.mouse_click(3, gamma_row).unwrap();
+    h.wait_until(|h| !h.editor().is_dock_focused()).unwrap();
+    let after_click = h.screen_to_string();
+    assert!(
+        !after_click.contains("beta"),
+        "clicking a filtered workspace must keep the filter applied:\n{after_click}"
+    );
+    assert!(
+        !after_click.contains("Search Tasks"),
+        "clicking a filtered workspace must keep the search text:\n{after_click}"
+    );
+}
+
 /// F6: the auto-generated session name is rooted in the project
 /// (`<project>-N`) rather than a bare `session-N`, so a dock row tells
 /// you which project a session belongs to.

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -478,10 +478,10 @@ fn next_window_cycles_only_dock_visible_sessions() {
     }
 }
 
-/// Rows a dock card occupies below its name row in card view: the two
-/// remaining content rows (branch, PR/spacer) plus the bottom border.
-/// Mirrors the plugin's `DOCK_CARD_HEIGHT` (3 content rows).
-const DOCK_CARD_ROWS_BELOW_NAME: u16 = 3;
+/// Rows a dock card occupies below its name row in card view: the
+/// remaining content row (branch/project + PR) plus the bottom border.
+/// Mirrors the plugin's `DOCK_CARD_HEIGHT` (2 content rows).
+const DOCK_CARD_ROWS_BELOW_NAME: u16 = 2;
 
 /// Column of the dock's right-edge divider (the "wall") on the title row.
 fn dock_wall_col(h: &EditorTestHarness) -> u16 {
@@ -2935,10 +2935,11 @@ fn dock_compact_rows_drop_branch_name() {
     .unwrap();
 }
 
-/// Card density right-aligns the whole branch + git-summary group on
-/// the card's second content line: the summary's last glyph sits flush
-/// against the card's right border instead of trailing the branch on
-/// the left.
+/// Card density right-aligns the git summary against the card's right
+/// border — it sits on the *name* row now, so the status of every
+/// workspace lines up in one column down the dock, and the branch row
+/// below starts at the card's left edge instead of being dragged along
+/// in the same right-aligned group.
 #[test]
 fn dock_card_git_line_right_aligned_to_card_border() {
     let (_tmp, root) = setup_project("alphaproj");
@@ -2965,29 +2966,24 @@ fn dock_card_git_line_right_aligned_to_card_border() {
     // inactive, fully-bordered card.
     assert_eq!(h.editor().active_window().label, "alphaproj");
 
-    // Wait for the git probe to land zzz_other's summary line ("clean" —
-    // fresh repo, nothing to diff), rendered flush against the card's
-    // right border: the summary is IMMEDIATELY followed by the rounded
-    // `│` side border, with no interior padding after the group, and the
-    // branch marker rides in the same right-aligned group before it.
-    // Waiting for the final flush state directly (instead of asserting
-    // after a stability settle) keeps the check semantic: intermediate
-    // frames where the probe result exists but a refresh is mid-flight
-    // are simply waited through.
+    // Wait for the git probe to land zzz_other's summary ("clean" —
+    // fresh repo, nothing to diff) on its name row, flush against the
+    // card's right border: the summary is IMMEDIATELY followed by the
+    // rounded `│` side border, with no interior padding after it, while
+    // the name still leads the row from the left. Waiting for the final
+    // flush state directly (instead of asserting after a stability
+    // settle) keeps the check semantic: intermediate frames where the
+    // probe result exists but a refresh is mid-flight are simply waited
+    // through.
     h.wait_until(|h| {
         let screen = h.screen_to_string();
-        let zzz_row = match screen.lines().position(|l| l.contains("zzz_other")) {
-            Some(r) => r,
-            None => return false,
-        };
-        // The git line is the card row right below the name row.
-        let Some(line) = screen.lines().nth(zzz_row + 1) else {
+        let Some(line) = screen.lines().find(|l| l.contains("zzz_other")) else {
             return false;
         };
         let Some(b) = line.find("clean") else {
             return false;
         };
-        line[b + "clean".len()..].starts_with('│') && line[..b].contains('▸')
+        line[b + "clean".len()..].starts_with('│') && line[..b].contains("zzz_other")
     })
     .unwrap();
 }
@@ -3404,4 +3400,217 @@ fn dock_git_summary_survives_transient_probe_failure() {
 
     // The target's failed re-probe must NOT have wiped its last-known summary.
     h.assert_screen_contains("+2");
+}
+
+/// The card view's two rows, each a left group and a status flush
+/// against the card's right border:
+///
+///   ╭──────────────────────────╮
+///   │ · beta              clean│
+///   │ ▸ master                 │
+///   ╰──────────────────────────╯
+///
+/// It used to be three rows, and the middle one carried the branch and
+/// the git summary as a *single right-aligned group* — so the branch
+/// floated in the middle of the card instead of starting at its left
+/// edge, and the third row stood empty on every session without a PR.
+#[test]
+fn dock_card_starts_the_branch_at_the_left_edge_and_ends_after_it() {
+    let (_tmp, root) = setup_committed_project("alphaproj");
+    // The measured workspace lives in its own repo, so its card can be
+    // read without the launch project's own status bleeding in. It stays
+    // *inactive*, keeping the right border the active card scoops away
+    // for the seamless tab.
+    let (_tmp_b, beta_root) = setup_committed_project("betaproj");
+    let branch = git_head_branch(&beta_root);
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(beta_root.clone(), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Steady state: the git probe has landed beta's summary on its name
+    // row and the branch on the row below.
+    h.wait_until(|h| {
+        let screen = h.screen_to_string();
+        let Some(r) = screen.lines().position(|l| l.contains("beta")) else {
+            return false;
+        };
+        screen.lines().nth(r).is_some_and(|l| l.contains("clean"))
+            && screen
+                .lines()
+                .nth(r + 1)
+                .is_some_and(|l| l.contains(&branch))
+    })
+    .unwrap();
+
+    let screen = h.screen_to_string();
+    let name_row = screen.lines().position(|l| l.contains("beta")).unwrap();
+    let inner = |r: usize| -> String {
+        screen
+            .lines()
+            .nth(r)
+            .unwrap_or_default()
+            .split('│')
+            .nth(1)
+            .unwrap_or_else(|| panic!("row {r} is not a bordered card row:\n{screen}"))
+            .to_string()
+    };
+
+    // Row 1: the name leads from the left border, the git summary is
+    // flush against the right one, and the project no longer rides
+    // along beside the name.
+    let row1 = inner(name_row);
+    assert!(
+        row1.trim_start().starts_with("· beta") || row1.trim_start().starts_with("* beta"),
+        "the name leads the card's first row, got {row1:?}"
+    );
+    assert!(
+        row1.ends_with("clean"),
+        "the git summary sits flush against the card's right border, got {row1:?}"
+    );
+    assert!(
+        !row1.contains('▣'),
+        "the project tag no longer doubles up beside the name, got {row1:?}"
+    );
+
+    // Row 2: the branch, starting at the card's left edge — not floating
+    // mid-card in a right-aligned group.
+    let row2 = inner(name_row + 1);
+    assert!(
+        row2.starts_with(&format!("▸ {branch}")),
+        "the branch starts at the card's left edge, got {row2:?}"
+    );
+
+    // ...and that is the last content row: the card is two rows tall, so
+    // the next line is its bottom border.
+    let after = screen.lines().nth(name_row + 2).unwrap_or_default();
+    assert!(
+        after.trim_start().starts_with('╰'),
+        "the card ends after the branch row, got {after:?}"
+    );
+}
+
+/// A worktree's branch is usually named after the workspace itself, and
+/// printing both spent one of the card's two rows saying the same thing
+/// twice. When they match, the row carries the project instead — the
+/// context the name genuinely doesn't have.
+#[test]
+fn dock_card_shows_the_project_when_the_branch_just_repeats_the_name() {
+    let (_tmp, root) = setup_committed_project("alphaproj");
+    let (_tmp_b, twin_root) = setup_committed_project("twinproj");
+    // A branch that shares nothing with the launch project's, so the
+    // card under test is the only row spelling it.
+    assert!(std::process::Command::new("git")
+        .args(["checkout", "-q", "-b", "feature-x"])
+        .current_dir(&twin_root)
+        .status()
+        .unwrap()
+        .success());
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    // The workspace is named exactly after the branch it sits on.
+    h.editor_mut()
+        .create_window_at(twin_root.clone(), "feature-x".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The row below the name is the project, not a second copy of the
+    // name. Waiting on it directly rides out the git probe: before it
+    // lands the row already reads "▣ twinproj" (no branch known yet),
+    // and it must still read that once the branch *is* known.
+    h.wait_until(|h| {
+        let screen = h.screen_to_string();
+        let Some(r) = screen.lines().position(|l| l.contains("feature-x")) else {
+            return false;
+        };
+        screen.lines().nth(r).is_some_and(|l| l.contains("clean"))
+    })
+    .unwrap();
+
+    let screen = h.screen_to_string();
+    let name_row = screen
+        .lines()
+        .position(|l| l.contains("feature-x"))
+        .unwrap();
+    let row2 = screen
+        .lines()
+        .nth(name_row + 1)
+        .unwrap_or_default()
+        .split('│')
+        .nth(1)
+        .unwrap_or_else(|| panic!("the twin card's second row is not bordered:\n{screen}"))
+        .to_string();
+    assert!(
+        row2.starts_with("▣ twinproj"),
+        "the project takes the row when the branch only repeats the name, got {row2:?}"
+    );
+    assert!(
+        !row2.contains("feature-x"),
+        "the name is not repeated as a branch on the row below it, got {row2:?}"
+    );
+}
+
+/// The branch `HEAD` points at in `root` (`master` or `main`, depending
+/// on the git that created it).
+fn git_head_branch(root: &std::path::Path) -> String {
+    String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(root)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string()
+}
+
+/// The same rule one step further: a plain folder opened as its own
+/// workspace has a project name identical to the workspace name, so the
+/// second row has nothing left to add — it stays empty instead of
+/// echoing the line above it.
+#[test]
+fn dock_card_leaves_the_second_row_empty_rather_than_echo_the_name() {
+    let (_tmp, root) = setup_committed_project("alphaproj");
+    // A plain, non-git folder outside the project: no branch, and its
+    // project *is* the folder the workspace is named after.
+    let loose = root.parent().unwrap().join("loose");
+    fs::create_dir(&loose).unwrap();
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(loose.clone(), "loose".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The card is up, and its second row is blank between the borders.
+    h.wait_until(|h| {
+        let screen = h.screen_to_string();
+        let Some(r) = screen.lines().position(|l| l.contains("loose")) else {
+            return false;
+        };
+        let Some(row2) = screen.lines().nth(r + 1) else {
+            return false;
+        };
+        row2.split('│').nth(1).is_some_and(|s| s.trim().is_empty())
+    })
+    .unwrap();
+
+    // ...and it is still a two-row card, closed by its bottom border.
+    let screen = h.screen_to_string();
+    let name_row = screen.lines().position(|l| l.contains("loose")).unwrap();
+    let after = screen.lines().nth(name_row + 2).unwrap_or_default();
+    assert!(
+        after.trim_start().starts_with('╰'),
+        "the card still ends after its second row, got {after:?}"
+    );
 }

--- a/crates/fresh-editor/tests/orchestrator_pending_recovery.rs
+++ b/crates/fresh-editor/tests/orchestrator_pending_recovery.rs
@@ -114,4 +114,13 @@ fn interrupted_local_workspace_is_restored_paused_on_launch() {
          capture-time default. Screen:\n{}",
         h.screen_to_string(),
     );
+    // The card keeps its one-key way out of the interrupted state. The
+    // two-row card has no spare line for the old sentence-long hint, so
+    // the affordance rides at the right of the name row — losing it
+    // would leave a stuck row with no visible way to resume it.
+    assert!(
+        h.screen_to_string().contains("↵ Retry"),
+        "an interrupted workspace's card must still offer its retry key. Screen:\n{}",
+        h.screen_to_string(),
+    );
 }

--- a/scripts/interactive/dock_filter_select_tmux_repro.sh
+++ b/scripts/interactive/dock_filter_select_tmux_repro.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Interactive tmux repro — Orchestrator dock: does selecting a workspace from
+# a filtered list wipe the filter?
+#
+# Lays out a project with a handful of workspaces (created from an isolated
+# init.ts so the dock has enough rows for a filter to matter), opens the dock,
+# types a search needle, then activates a matching row two ways:
+#
+#   1. Enter on the highlighted row  ("dive in")
+#   2. A real mouse click on a row    (SGR mouse report)
+#
+# After each, it re-focuses the dock and reports whether the needle survived.
+# Expected after the fix: the filter is still applied and the search box still
+# reads the needle — selecting a workspace is not "leaving the dock".
+#
+# Usage:   scripts/interactive/dock_filter_select_tmux_repro.sh
+# Requires: tmux. Run from the repo root.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SESSION="fresh-dock-filter"
+BIN="$REPO/target/debug/fresh"
+OUT="$(mktemp -d /tmp/fresh-dock-filter-out.XXXX)"
+WORK="$(mktemp -d /tmp/fresh-dock-filter-work.XXXX)"
+PASS=0
+FAIL=0
+
+cleanup() { tmux kill-session -t "$SESSION" 2>/dev/null || true; }
+trap cleanup EXIT
+
+note() { printf '\033[36m• %s\033[0m\n' "$*"; }
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+
+S() { tmux send-keys -t "$SESSION" "$@"; }
+typ() { tmux send-keys -t "$SESSION" -l "$1"; }
+cap() { tmux capture-pane -t "$SESSION" -p; }
+shot() { cap > "$OUT/$1.txt"; }
+
+wait_for() { # pattern timeout_iters
+  local pat="$1" n="${2:-30}" i=0
+  while [ "$i" -lt "$n" ]; do
+    cap | grep -qE "$pat" && return 0
+    sleep 0.5
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Click cell (1-based col,row) with an SGR mouse press+release.
+click() { # col row
+  tmux send-keys -t "$SESSION" -l $'\033[<0;'"$1"';'"$2"'M'
+  tmux send-keys -t "$SESSION" -l $'\033[<0;'"$1"';'"$2"'m'
+}
+
+# 1-based pane row of the first line matching $1 (empty if absent).
+row_of() { cap | grep -nE "$1" | head -1 | cut -d: -f1; }
+
+# --- 0. build + workspace ----------------------------------------------------
+[ -x "$BIN" ] || { note "building fresh (debug)…"; (cd "$REPO" && cargo build --bin fresh) || exit 2; }
+
+note "workspace: $WORK"
+export HOME="$WORK/home"
+mkdir -p "$HOME/.config/fresh"
+mkdir -p "$WORK/proj" && (cd "$WORK/proj" && git init -q && git config user.email t@t && git config user.name t && printf 'root\n' > README.md && git add -A && git commit -qm init)
+for w in alpha beta gamma delta epsilon zeta eta theta; do
+  mkdir -p "$WORK/proj/$w" && printf '%s\n' "$w" > "$WORK/proj/$w/notes.md"
+done
+
+# Enough workspaces that the filter has something to hide.
+cat > "$HOME/.config/fresh/init.ts" <<TS
+for (const w of ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"]) {
+  editor.createWindow("$WORK/proj/" + w, w);
+}
+TS
+
+# --- 1. launch ---------------------------------------------------------------
+cleanup
+tmux new-session -d -s "$SESSION" -x 200 -y 50
+S "cd '$WORK/proj' && HOME='$HOME' TERM=xterm-256color '$BIN' --no-restore README.md" Enter
+wait_for "Palette: Ctrl\+P" 60 || { note "editor did not start"; cap; exit 2; }
+sleep 1
+shot "00-boot"
+
+# --- 2. open + focus the dock ------------------------------------------------
+note "opening the orchestrator dock (Alt+O)"
+S M-o
+wait_for "gamma" 30 || { note "dock did not show the workspaces"; cap; exit 2; }
+sleep 0.5
+shot "01-dock-open"
+
+if cap | grep -q "epsilon" && cap | grep -q "gamma"; then
+  pass "dock lists the workspaces"
+else
+  fail "dock is missing workspaces"
+fi
+
+# --- 3. filter ---------------------------------------------------------------
+filter_to() { # needle
+  note "filtering to '$1'"
+  S "/"
+  sleep 0.4
+  typ "$1"
+  sleep 1
+}
+
+filter_to "gamma"
+shot "02-filtered"
+if cap | grep -q "gamma" && ! cap | grep -q "epsilon"; then
+  pass "filter narrows the list to 'gamma'"
+else
+  fail "filter did not narrow the list"
+fi
+
+# Enter in the filter box returns to the list (filter still applied).
+S Enter
+sleep 0.6
+shot "03-filter-enter-back-to-list"
+
+# --- 4a. select with Enter ---------------------------------------------------
+note "selecting the highlighted workspace with Enter (dive in)"
+S Enter
+sleep 1.2
+shot "04-after-enter-dive"
+note "re-focusing the dock (Alt+O)"
+S M-o
+sleep 1
+shot "05-dock-refocused-after-enter"
+if cap | grep -q "epsilon"; then
+  fail "Enter-select wiped the filter (non-matching 'epsilon' is back)"
+else
+  pass "Enter-select kept the filter (non-matching rows still hidden)"
+fi
+if cap | grep -q "Search Tasks"; then
+  fail "Enter-select cleared the search box (placeholder is showing)"
+else
+  pass "Enter-select kept the search box text"
+fi
+
+# --- 4b. select with a mouse click ------------------------------------------
+# Reset: leave the dock (Esc) so we start from a clean, unfiltered list.
+S Escape
+sleep 0.8
+S M-o
+sleep 0.8
+filter_to "delta"
+S Enter
+sleep 0.6
+shot "06-filtered-delta"
+
+DROW="$(row_of '  *delta')"
+if [ -n "$DROW" ]; then
+  note "clicking the 'delta' row at pane row $DROW"
+  click 8 "$DROW"
+  sleep 1.2
+  shot "07-after-click"
+  note "re-focusing the dock (Alt+O)"
+  S M-o
+  sleep 1
+  shot "08-dock-refocused-after-click"
+  if cap | grep -q "epsilon"; then
+    fail "click-select wiped the filter (non-matching 'epsilon' is back)"
+  else
+    pass "click-select kept the filter (non-matching rows still hidden)"
+  fi
+  if cap | grep -q "Search Tasks"; then
+    fail "click-select cleared the search box (placeholder is showing)"
+  else
+    pass "click-select kept the search box text"
+  fi
+else
+  fail "could not locate the 'delta' row to click"
+fi
+
+# --- 4c. Esc still clears ----------------------------------------------------
+note "leaving the dock with Esc must still clear the filter"
+S Escape
+sleep 0.8
+S M-o
+sleep 1
+shot "09-dock-after-esc"
+if cap | grep -q "epsilon"; then
+  pass "Esc out of the dock clears the filter (full list is back)"
+else
+  fail "Esc out of the dock did not clear the filter"
+fi
+
+# --- 5. summary --------------------------------------------------------------
+echo
+note "pane snapshots saved under: $OUT"
+printf '\033[1mRESULT: %d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Filtering the orchestrator dock to a handful of workspaces and then
clicking one wiped the search: the list sprang back to every workspace
and the box reset to its placeholder, so working through a filtered set
meant retyping the needle for every workspace opened.

The dock clears its filter on blur so a stale needle can't silently hide
sessions on the next focus (F5). But a click — or Enter — on a row blurs
the dock only to hand the keyboard to the chosen session: it is acting
on the filtered list, not leaving it. Mark those dive paths so the blur
handler keeps the filter, and leave every other blur (Esc, an editor
click) clearing it as before, which keeps the one-key escape from a
stale filter intact.

Also adds an interactive tmux reproducer covering both gestures.