### PR TITLE
fix(session): Escape does nothing in `fresh -a` and swallows the next keypress

### DIFF
--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -24,7 +24,7 @@ use crate::server::capture_backend::{
     terminal_setup_sequences, terminal_teardown_sequences, CaptureBackend,
 };
 use crate::server::command_access;
-use crate::server::input_parser::InputParser;
+use crate::server::input_parser::ClientInputParser;
 use crate::server::ipc::{ServerConnection, ServerListener, SocketPaths, StreamWrapper};
 use crate::server::protocol::{
     ClientControl, ServerControl, ServerHello, TermSize, VersionMismatch, PROTOCOL_VERSION,
@@ -194,7 +194,7 @@ struct ConnectedClient {
     term_size: TermSize,
     env: std::collections::HashMap<String, Option<String>>,
     id: u64,
-    input_parser: InputParser,
+    input_parser: ClientInputParser,
     /// Whether this client needs a full screen render on next frame
     needs_full_render: bool,
     /// If set, this client is waiting for a --wait completion signal
@@ -1124,7 +1124,7 @@ impl EditorServer {
             term_size: hello.term_size,
             env: hello.env,
             id: client_id,
-            input_parser: InputParser::new(),
+            input_parser: ClientInputParser::new(),
             needs_full_render: true,
             wait_id: None,
             cmd_token: hello.cmd_token,
@@ -1183,6 +1183,18 @@ impl EditorServer {
                 }
             }
             let _ = data_eof; // Suppress unused warning
+
+            // A lone trailing `ESC` is ambiguous until the next byte says
+            // whether it was the Escape key or the head of a sequence. The
+            // socket read above is non-blocking, so nothing else in this loop
+            // ever decides that — resolve it here once the grace window has
+            // passed with no continuation, or Escape never registers at all
+            // (sinelaw/fresh#2810).
+            let flushed = client.input_parser.flush_idle(Instant::now());
+            if !flushed.is_empty() {
+                input_source_client = Some(idx);
+                input_events.extend(flushed);
+            }
 
             // Check control socket
             // On Windows, don't toggle nonblocking mode - it fails on named pipes

--- a/crates/fresh-editor/src/server/input_parser.rs
+++ b/crates/fresh-editor/src/server/input_parser.rs
@@ -4,6 +4,90 @@
 //! a DEC/ANSI state machine that converts the raw client byte stream into
 //! crossterm events without ever leaking control-sequence bytes as literal
 //! input (see sinelaw/fresh#2745). This module re-exports it so existing call
-//! sites (`crate::server::input_parser::InputParser`) keep working.
+//! sites (`crate::server::input_parser::InputParser`) keep working, and adds
+//! [`ClientInputParser`], which owns the "a lone `ESC` is the Escape key once
+//! the stream goes idle" rule for session (daemon) clients.
+
+use std::time::{Duration, Instant};
+
+use crossterm::event::Event;
 
 pub use fresh_input_parser::InputParser;
+
+/// How long a lone `ESC` stays buffered before it is resolved as the Escape
+/// key. Mirrors the tty reader's grace window: long enough that a control
+/// sequence split across two socket reads still arrives as one sequence, short
+/// enough that Escape feels immediate. Two keystrokes can never land this close
+/// together, so nothing a user types is coalesced by it.
+const ESC_GRACE: Duration = Duration::from_millis(15);
+
+/// [`InputParser`] plus the idle-flush rule the session path needs.
+///
+/// The direct (tty) reader resolves a buffered lone `ESC` when a blocking poll
+/// on stdin times out with no further bytes. A session client's bytes arrive
+/// over a socket that the server drains with a non-blocking read on every loop
+/// tick, so there is no poll timeout to hang the decision on: without this
+/// wrapper the `ESC` sat in the parser *indefinitely*, so in `fresh -a` the
+/// Escape key did nothing until the next keypress — which was then swallowed
+/// into an Alt chord with it (sinelaw/fresh#2810).
+///
+/// Call [`parse`](Self::parse) for every chunk read from the client and
+/// [`flush_idle`](Self::flush_idle) on every tick; the latter emits the Escape
+/// once the grace window has elapsed with no continuation.
+pub struct ClientInputParser {
+    parser: InputParser,
+    /// When the currently-buffered lone `ESC` was first observed. `None`
+    /// whenever the parser is not sitting on one.
+    escape_pending_since: Option<Instant>,
+}
+
+impl ClientInputParser {
+    pub fn new() -> Self {
+        Self {
+            parser: InputParser::new(),
+            escape_pending_since: None,
+        }
+    }
+
+    /// Parse a chunk of client bytes, arming (or disarming) the escape timer
+    /// according to what the chunk left the parser holding.
+    pub fn parse(&mut self, bytes: &[u8]) -> Vec<Event> {
+        let events = self.parser.parse(bytes);
+        self.sync_escape_timer(Instant::now());
+        events
+    }
+
+    /// Resolve a buffered lone `ESC` as the Escape key once it has been pending
+    /// for [`ESC_GRACE`] without a continuation. Returns the events to inject
+    /// (empty when nothing is pending or the grace window has not elapsed).
+    ///
+    /// `now` is a parameter so tests can drive the window without sleeping.
+    pub fn flush_idle(&mut self, now: Instant) -> Vec<Event> {
+        let Some(since) = self.escape_pending_since else {
+            return Vec::new();
+        };
+        if now.duration_since(since) < ESC_GRACE {
+            return Vec::new();
+        }
+        let events = self.parser.flush();
+        self.escape_pending_since = None;
+        events
+    }
+
+    /// Start the timer when an `ESC` becomes pending, and clear it as soon as
+    /// the parser has moved on (the continuation arrived, or the escape was
+    /// already flushed).
+    fn sync_escape_timer(&mut self, now: Instant) {
+        if self.parser.escape_pending() {
+            self.escape_pending_since.get_or_insert(now);
+        } else {
+            self.escape_pending_since = None;
+        }
+    }
+}
+
+impl Default for ClientInputParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/fresh-editor/src/server/runner.rs
+++ b/crates/fresh-editor/src/server/runner.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::server::capture_backend::{terminal_setup_sequences, terminal_teardown_sequences};
-use crate::server::input_parser::InputParser;
+use crate::server::input_parser::ClientInputParser;
 use crate::server::ipc::{ServerConnection, ServerListener, SocketPaths};
 use crate::server::protocol::{
     ClientControl, ServerControl, ServerHello, TermSize, VersionMismatch, PROTOCOL_VERSION,
@@ -56,7 +56,7 @@ pub struct ConnectedClient {
     /// Client ID for logging
     id: u64,
     /// Input parser for converting raw bytes to events
-    input_parser: InputParser,
+    input_parser: ClientInputParser,
 }
 
 impl Server {
@@ -231,7 +231,7 @@ impl Server {
             term_size: hello.term_size,
             env: hello.env,
             id: client_id,
-            input_parser: InputParser::new(),
+            input_parser: ClientInputParser::new(),
         })
     }
 
@@ -278,6 +278,15 @@ impl Server {
                     disconnected.push(idx);
                     continue;
                 }
+            }
+
+            // Resolve a buffered lone `ESC` as the Escape key once the socket
+            // has gone quiet: the read above is non-blocking, so without this
+            // the escape waits for the next keypress and is swallowed into an
+            // Alt chord with it (sinelaw/fresh#2810).
+            let flushed = client.input_parser.flush_idle(Instant::now());
+            if !flushed.is_empty() {
+                input_events.push((client.id, flushed));
             }
 
             // Try to read a control message (non-blocking)

--- a/crates/fresh-editor/tests/e2e/issue_2810_session_escape_flush.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2810_session_escape_flush.rs
@@ -1,0 +1,175 @@
+//! Regression test for #2810: in session (daemon, `fresh -a`) mode the Escape
+//! key did nothing until the *next* keypress, which was then swallowed along
+//! with it.
+//!
+//! ## The wedge the user reported
+//! `Alt+A` opens the project Search/Replace panel. `Esc` — advertised by the
+//! panel's own hint line as "Esc close" — leaves it open and focused. The
+//! following `Ctrl+P` never opens the command palette, and the characters typed
+//! for the palette are inserted into the open file instead, marking it dirty.
+//!
+//! ## Root cause
+//! A session client sends raw terminal bytes; the server decodes them with
+//! `InputParser`. A lone trailing `ESC` is ambiguous — the Escape key, or the
+//! head of an escape sequence — so the parser buffers it until the next byte
+//! decides. The direct (tty) reader resolves that with a poll timeout; the
+//! server's socket read is non-blocking and nothing ever resolved it, so the
+//! `ESC` waited indefinitely. The next keypress then completed it as an Alt
+//! chord: `ESC` + `Ctrl+P` (`0x10`) became one Alt+Ctrl+P event, consuming both
+//! keys. (`InputParser` compounded it by dropping the Control bit, so that
+//! chord matched the bound `Alt+P` and ran "find previous match".)
+//!
+//! ## What this test does
+//! It drives the real session decode path — raw bytes through
+//! `ClientInputParser`, its events into the editor — and asserts only on
+//! rendered output: the panel closes on Escape, `Ctrl+P` opens the palette, and
+//! the keystrokes meant for the palette never reach the file.
+//!
+//! Without the fix `flush_idle` yields nothing, the panel stays on screen and
+//! the test fails at the first wait.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::Event;
+use fresh::server::input_parser::ClientInputParser;
+use std::fs;
+use std::time::{Duration, Instant};
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 30;
+
+/// Longer than the parser's escape grace window, so `flush_idle` resolves a
+/// buffered `ESC` the way an idle socket does on the server. Passed as an
+/// explicit `Instant` rather than slept, so the test stays time-insensitive.
+const PAST_ESC_GRACE: Duration = Duration::from_millis(50);
+
+/// Raw bytes for the keys the report uses. A session client forwards exactly
+/// these; `Alt+A` is `ESC a`, Escape is a lone `ESC`, `Ctrl+P` is `0x10`.
+const ALT_A: &[u8] = b"\x1ba";
+const ESCAPE: &[u8] = b"\x1b";
+const CTRL_P: &[u8] = b"\x10";
+
+/// Project with the search_replace plugin and one file to search in.
+fn setup() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "search_replace");
+
+    fs::write(
+        project_root.join("alpha_one.rs"),
+        "fn main() {\n    println!(\"alpha one\");\n}\n",
+    )
+    .unwrap();
+
+    (temp_dir, project_root)
+}
+
+/// Feed one chunk of client bytes through the session decode path and dispatch
+/// whatever it produces into the editor, then let the socket go idle so a
+/// buffered lone `ESC` resolves — exactly what the server loop does per tick.
+fn send_bytes(harness: &mut EditorTestHarness, parser: &mut ClientInputParser, bytes: &[u8]) {
+    let mut events = parser.parse(bytes);
+    events.extend(parser.flush_idle(Instant::now() + PAST_ESC_GRACE));
+    for event in events {
+        if let Event::Key(ke) = event {
+            harness.send_key(ke.code, ke.modifiers).unwrap();
+        }
+    }
+    harness.render().unwrap();
+}
+
+/// Esc closes the Search/Replace panel and the next Ctrl+P opens the palette,
+/// so the characters typed for it never land in the file.
+#[test]
+fn session_escape_closes_search_replace_and_frees_the_palette() {
+    let (_temp_dir, project_root) = setup();
+    let start_file = project_root.join("alpha_one.rs");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        WIDTH,
+        HEIGHT,
+        Default::default(),
+        project_root,
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    let mut parser = ClientInputParser::new();
+
+    // Alt+A → the project Search/Replace panel.
+    send_bytes(&mut harness, &mut parser, ALT_A);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Escape must close it — the panel's own hint line says "Esc close".
+    send_bytes(&mut harness, &mut parser, ESCAPE);
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+
+    // Ctrl+P must reach the palette rather than being absorbed into the
+    // still-pending escape.
+    send_bytes(&mut harness, &mut parser, CTRL_P);
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(">command"),
+        "Ctrl+P after Escape should open the command palette. Screen:\n{}",
+        screen
+    );
+
+    // …so the characters typed for the palette go to the palette, not the file.
+    send_bytes(&mut harness, &mut parser, b"Open Terminal");
+    let content = harness.get_buffer_content().unwrap_or_default();
+    assert!(
+        !content.contains("Open Terminal"),
+        "palette keystrokes were inserted into the buffer: {:?}",
+        content
+    );
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("alpha_one.rs*"),
+        "the buffer must not be marked dirty by palette keystrokes. Screen:\n{}",
+        screen
+    );
+}
+
+/// The plain-editor half of the same wedge: Escape then Ctrl+P must not
+/// collapse into one Alt chord that runs an unrelated command and drops both
+/// keypresses.
+#[test]
+fn session_escape_then_ctrl_p_is_two_keys_not_an_alt_chord() {
+    let (_temp_dir, project_root) = setup();
+    let start_file = project_root.join("alpha_one.rs");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        WIDTH,
+        HEIGHT,
+        Default::default(),
+        project_root,
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    let mut parser = ClientInputParser::new();
+    send_bytes(&mut harness, &mut parser, ESCAPE);
+    send_bytes(&mut harness, &mut parser, CTRL_P);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(">command"),
+        "Escape followed by Ctrl+P should still open the palette. Screen:\n{}",
+        screen
+    );
+    // The mis-decoded chord used to resolve to Alt+P (find previous match),
+    // which reports its own status message.
+    assert!(
+        !screen.contains("Match 1 of"),
+        "Escape + Ctrl+P must not run the Alt+P binding. Screen:\n{}",
+        screen
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -88,6 +88,8 @@ pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_2566_env_detector_labels;
 pub mod issue_2572_hover_through_panel;
 pub mod issue_2605_format_selection_range;
+#[cfg(feature = "plugins")]
+pub mod issue_2810_session_escape_flush;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod language_dialog_esc_cancels_edit;

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -285,10 +285,15 @@ impl InputParser {
                 };
             }
             other => {
-                // Alt + key.
+                // Alt + key. The byte keeps whatever modifier it would carry
+                // on its own, with Alt added: a C0 control byte after `ESC` is
+                // Alt+Ctrl+<letter> (`ESC 0x10` = Alt+Ctrl+P), not Alt+<letter>.
+                // Dropping the Control bit made the two indistinguishable, so
+                // Alt+Ctrl+P silently ran the (bound) Alt+P command instead of
+                // resolving to an unbound chord — sinelaw/fresh#2810.
                 out.push(Event::Key(KeyEvent::new(
                     byte_to_keycode(other),
-                    KeyModifiers::ALT,
+                    c0_control_modifier(other) | KeyModifiers::ALT,
                 )));
                 self.state = State::Ground;
             }
@@ -965,17 +970,27 @@ fn utf8_char_width(first_byte: u8) -> usize {
     }
 }
 
+/// CONTROL for C0 control characters — except Tab, LF, CR and Esc, which are
+/// their own keys and carry no modifier.
+///
+/// Shared by the ground-state mapping and the `ESC <byte>` (Alt+key) mapping so
+/// both agree that `0x10` is Ctrl+P.
+fn c0_control_modifier(byte: u8) -> KeyModifiers {
+    if byte < 32 && byte != 9 && byte != 10 && byte != 13 && byte != 27 {
+        KeyModifiers::CONTROL
+    } else {
+        KeyModifiers::empty()
+    }
+}
+
 /// Convert a single ground-state byte to a key event, attaching CONTROL for
 /// C0 control characters (except Tab, LF, CR and Esc, which are their own
 /// keys).
 fn byte_to_event(byte: u8) -> Event {
-    let keycode = byte_to_keycode(byte);
-    let modifiers = if byte < 32 && byte != 9 && byte != 10 && byte != 13 && byte != 27 {
-        KeyModifiers::CONTROL
-    } else {
-        KeyModifiers::empty()
-    };
-    Event::Key(KeyEvent::new(keycode, modifiers))
+    Event::Key(KeyEvent::new(
+        byte_to_keycode(byte),
+        c0_control_modifier(byte),
+    ))
 }
 
 /// Convert a byte to a `KeyCode`.

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -111,6 +111,44 @@ fn alt_key_via_esc_prefix() {
 }
 
 #[test]
+fn alt_ctrl_key_via_esc_prefix_keeps_the_control_modifier() {
+    // `ESC` + a C0 control byte is Alt+Ctrl+<letter> — the same encoding an
+    // Escape keypress followed closely by a Ctrl chord produces. Reporting it
+    // as a plain Alt+<letter> made it run whichever command Alt+<letter> is
+    // bound to (Alt+P = find previous, Alt+A = open Search/Replace), silently
+    // eating both keypresses. See sinelaw/fresh#2810.
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b\x10")),
+        vec![(
+            KeyCode::Char('p'),
+            KeyModifiers::ALT | KeyModifiers::CONTROL
+        )]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b\x01")),
+        vec![(
+            KeyCode::Char('a'),
+            KeyModifiers::ALT | KeyModifiers::CONTROL
+        )]
+    );
+    // Tab / Enter / Backspace are keys in their own right, so they stay
+    // Alt-only rather than picking up a spurious Control.
+    assert_eq!(
+        keys(&p.parse(b"\x1b\x09")),
+        vec![(KeyCode::Tab, KeyModifiers::ALT)]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b\x0d")),
+        vec![(KeyCode::Enter, KeyModifiers::ALT)]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b\x7f")),
+        vec![(KeyCode::Backspace, KeyModifiers::ALT)]
+    );
+}
+
+#[test]
 fn csi_modifiers_parsed() {
     let mut p = InputParser::new();
     // Shift+Up: ESC [ 1 ; 2 A


### PR DESCRIPTION
Fixes #2810.

The reported symptom: `Alt+A` opens the project Search/Replace panel, `Esc` leaves it open and focused despite the panel's own hint line advertising "Esc close", and the following `Ctrl+P` never opens the command palette — the characters typed for the palette land in the open file instead, marking it dirty.

Two independent bugs on the session (daemon) input path combine to produce it.

## 1. Escape never registered in daemon mode

A session client forwards raw terminal bytes and the server decodes them with `InputParser`. A lone trailing `ESC` is ambiguous — the Escape key, or the head of an escape sequence — so the parser buffers it until the next byte decides.

The direct (tty) reader resolves that when a blocking poll on stdin times out with no further bytes. The server's socket read is non-blocking and nothing else in the loop ever made the call, so under `fresh -a` the `ESC` sat in the parser *indefinitely* — Escape did nothing at all until the user pressed another key.

`ClientInputParser` now wraps the parser, times a pending escape, and resolves it as the Escape key once the same grace window the tty reader uses has passed with no continuation. Both server loops call it on every tick. The window is short enough that Escape stays responsive and long enough that a control sequence split across two socket reads still arrives whole.

## 2. The buffered `ESC` then ate the next keypress

`ESC` + a C0 control byte is how a terminal encodes Alt+Ctrl+&lt;letter&gt; — and it is also exactly what a stuck `ESC` followed by a Ctrl chord looks like. The Alt+key arm of the escape state attached only `ALT`, so `ESC 0x10` decoded as a plain Alt+P rather than Alt+Ctrl+P. Alt+P is bound to "find previous match", so instead of resolving to an unbound chord the two keypresses vanished into an unrelated command. (Alt+A, bound to "open Search and Replace", is the same trap.)

The C0 → `CONTROL` rule is now shared between the ground-state mapping and the escape-prefix mapping, so both agree that `0x10` is Ctrl+P.

## Changes

- `crates/fresh-input-parser/src/lib.rs` — factor out `c0_control_modifier`, apply it in the `ESC <byte>` arm.
- `crates/fresh-editor/src/server/input_parser.rs` — new `ClientInputParser` owning the idle-flush rule.
- `crates/fresh-editor/src/server/editor_server.rs`, `runner.rs` — call `flush_idle` per tick.

## Tests

- `issue_2810_session_escape_flush.rs` drives the real session decode path (raw bytes → `ClientInputParser` → editor) and asserts only on rendered output. Without the fix the first test hangs waiting for the panel to close; the second (Esc → Ctrl+P outside the panel) fails outright.
- `alt_ctrl_key_via_esc_prefix_keeps_the_control_modifier` pins the modifier, and pins Tab/Enter/Backspace as Alt-only so they don't pick up a spurious Control.

Both were verified to fail with the fix reverted.

## Verification

- `cargo nextest run --no-fail-fast --locked` — 8323 passed, 155 skipped.
- `cargo fmt`, `cargo clippy --all-targets`, `cargo check --all-targets --features gui` all clean.
- Confirmed live in tmux against a rebuilt binary under `fresh -a`: Esc reports "Search/Replace closed", and Ctrl+P then opens the palette.

One caveat: a `--all-features` test run exhausted the dev container's disk allowance at link time and could not be completed locally, so the GUI-feature test targets were not exercised here — `cargo check --all-targets --features gui` is the strongest local evidence for that configuration. CI covers the rest.