### PR TITLE
Open Settings over the whole screen, dimming the dock with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Keyboard and mouse input is now parsed by our own `fresh-input-parser` crate ins
   * Dock rows are fully clickable in compact (list) view, ordered by recency, and auto-name themselves from their terminal.
   * Fixed a crash when navigating to an unreachable remote workspace.
   * Searching the dock and then opening one of the matches no longer wipes the search — the filtered list is still there when you come back for the next one. Leaving the dock (`Esc`, clicking the editor) still clears it.
+  * **Settings opens over the dock**, not beside it - the Settings dialog (and the keybinding editor) now centres on the whole screen and dims the dock along with everything else, instead of being squeezed into the columns right of the dock and leaving it bright, as if it were still live.
   * **Tidier workspace cards** - a card is now two rows instead of three: name with its git summary flush right, then the branch with the PR badge flush right. The branch starts at the card's left edge rather than floating mid-row, the empty third row is gone, and a branch that just repeats the workspace name gives its place to the project.
 * **Terminal**
   * Scrollback no longer loses output or gets stuck mid-scroll (#2649, reported by @dmknght).

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -915,17 +915,13 @@ impl Editor {
         // Update menu context with current editor state
         self.update_menu_context();
 
-        // Settings / calibration-wizard / keybinding-editor / event-debug
-        // modals, dimming the chrome behind each. Rendered before the menu
-        // bar so open menus overlay them.
-        self.render_modal_overlays(frame, chrome_area);
-
-        // The workspace-trust prompt is a blocking, top-most security modal.
-        // It dims the *entire* frame (the dock included) and centres in the
-        // full window, so it is rendered at the very end of this method —
-        // after the dock and floating panels — rather than here, where the
-        // dock's later pass would overpaint its left edge. See the bottom of
-        // `render`.
+        // The full-screen modals (settings, calibration wizard, keybinding
+        // editor, event-debug dialog) and the blocking workspace-trust prompt
+        // each dim the *entire* frame — the dock included — and centre in the
+        // full window, so they are rendered at the very end of this method,
+        // after the dock and floating panels, rather than here, where the
+        // dock's later pass would overpaint their left edge. See the bottom of
+        // `render` and `render_panels_and_modals`.
 
         // Menu bar, drawn last so its dropdowns sit above all other content.
         self.render_menu_bar(frame, menu_bar_area);
@@ -964,19 +960,15 @@ impl Editor {
             }
         }
 
-        // Convert all colors for terminal capability (256/16 color fallback)
-        crate::view::color_support::convert_buffer_colors(
-            frame.buffer_mut(),
-            self.color_capability,
-        );
-
-        // Frame-buffer animations run last so they mutate the final paint.
+        // Frame-buffer animations run after the main draw so they mutate the
+        // final paint.
         self.active_window_mut()
             .animations
             .apply_all(frame.buffer_mut());
 
-        // Dock, floating panel, theme-info popup, and the workspace-trust
-        // modal — the topmost layers, drawn above prompts/popups/animations.
+        // Dock, full-screen modals, floating panel, theme-info popup, and the
+        // workspace-trust modal — the topmost layers, drawn above
+        // prompts/popups/animations.
         self.render_panels_and_modals(
             frame,
             size,
@@ -984,6 +976,15 @@ impl Editor {
             dock_area,
             top_is_trust_modal,
             &theme_clone,
+        );
+
+        // Convert all colors for terminal capability (256/16 color fallback).
+        // Dead last, so the layers painted above — dock, full-screen modals,
+        // animations — go through the fallback too instead of emitting
+        // truecolor SGR on a terminal that cannot render it.
+        crate::view::color_support::convert_buffer_colors(
+            frame.buffer_mut(),
+            self.color_capability,
         );
     }
 
@@ -1318,8 +1319,9 @@ impl Editor {
     }
 
     /// Render the topmost layers: the dock and floating widget panel (each in
-    /// its own slot), the theme-info popup, and the blocking workspace-trust
-    /// modal. Drawn after every other layer so they sit on top.
+    /// its own slot), the full-screen modals (settings, keybinding editor,
+    /// …), the theme-info popup, and the blocking workspace-trust modal.
+    /// Drawn after every other layer so they sit on top.
     fn render_panels_and_modals(
         &mut self,
         frame: &mut Frame,
@@ -1339,6 +1341,14 @@ impl Editor {
                 self.render_floating_widget_panel(frame, dock, super::PanelSlot::Dock);
             }
         }
+
+        // Settings / calibration-wizard / keybinding-editor / event-debug —
+        // full-screen modals. They get the whole frame (`size`), not the
+        // chrome region right of the dock: each dims everything behind it,
+        // the dock included, and centres in the full window. Drawn here,
+        // after the dock's own pass, so the dock cannot overpaint the
+        // modal's left edge.
+        self.render_modal_overlays(frame, size);
 
         // The theme-info popup (Ctrl+Right-Click) anchors to an absolute
         // screen cell that may sit over the dock column, so draw it after
@@ -1953,12 +1963,16 @@ impl Editor {
         }
     }
 
-    /// Render the modal overlays that dim the chrome behind them: settings,
+    /// Render the modal overlays that dim everything behind them: settings,
     /// calibration wizard, keybinding editor, and event-debug dialog. Each is
     /// drawn only for the TUI (`!suppress_chrome_cells`); the web projects
-    /// them natively. Rendered before the menu bar so open menus overlay them.
-    fn render_modal_overlays(&mut self, frame: &mut Frame, chrome_area: ratatui::layout::Rect) {
-        // Render settings modal (before menu bar so menus can overlay)
+    /// them natively.
+    ///
+    /// `area` is the whole frame — these are full-screen modals, so the dim
+    /// pass covers the dock column too and each dialog centres in the full
+    /// window. They are called from `render_panels_and_modals` (after the
+    /// dock paints) so the dock cannot overpaint them.
+    fn render_modal_overlays(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
         // Check visibility first to avoid borrow conflict with dimming
         // The web renders Settings natively from `settings_view`; paint cells
         // only for the TUI.
@@ -1970,10 +1984,12 @@ impl Editor {
                 .map(|s| s.visible)
                 .unwrap_or(false);
         if settings_visible {
-            // Dim the editor content behind the settings modal. Use the
-            // chrome area (right of a left dock) so the modal sits beside
-            // the persistent dock instead of being overlapped by it.
-            crate::view::dimming::apply_dimming(frame, chrome_area);
+            // Dim everything behind the settings modal — the editor chrome
+            // *and* the dock. The dock is input-inaccessible while the modal
+            // is up (`dispatch_modal_mouse` routes every click to settings),
+            // so leaving it at full brightness read as if it were still live
+            // beside a dialog that had already swallowed its input.
+            crate::view::dimming::apply_dimming(frame, area);
         }
         if let Some(ref mut settings_state) = self.settings_state {
             if !draw_settings {
@@ -1988,7 +2004,7 @@ impl Editor {
                 settings_state.update_focus_states();
                 let settings_layout = crate::view::settings::render_settings(
                     frame,
-                    chrome_area,
+                    area,
                     settings_state,
                     &self.theme.read().unwrap(),
                 );
@@ -2001,10 +2017,10 @@ impl Editor {
         if !self.suppress_chrome_cells {
             if let Some(ref wizard) = self.calibration_wizard {
                 // Dim the editor content behind the wizard modal
-                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::dimming::apply_dimming(frame, area);
                 crate::view::calibration_wizard::render_calibration_wizard(
                     frame,
-                    chrome_area,
+                    area,
                     wizard,
                     &self.theme.read().unwrap(),
                 );
@@ -2019,10 +2035,10 @@ impl Editor {
         // paint cells only for the TUI.
         if draw_aux {
             if let Some(ref mut kb_editor) = self.keybinding_editor {
-                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::dimming::apply_dimming(frame, area);
                 crate::view::keybinding_editor::render_keybinding_editor(
                     frame,
-                    chrome_area,
+                    area,
                     kb_editor,
                     &self.theme.read().unwrap(),
                 );
@@ -2033,10 +2049,10 @@ impl Editor {
         if draw_aux {
             if let Some(ref debug) = self.active_window().event_debug {
                 // Dim the editor content behind the dialog modal
-                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::dimming::apply_dimming(frame, area);
                 crate::view::event_debug::render_event_debug(
                     frame,
-                    chrome_area,
+                    area,
                     debug,
                     &self.theme.read().unwrap(),
                 );

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -89,11 +89,11 @@ pub fn render_settings(
     // Calculate modal size (90% of screen width, 90% height to fill most of available space)
     let modal_width = (area.width * 90 / 100).min(160);
     let modal_height = area.height * 90 / 100;
-    // Offsets must be ABSOLUTE — `area.x` / `area.y` are nonzero when
-    // `area` is the chrome region right of the dock (or a bottom-anchored
-    // split). Centring with bare `area.width / 2` placed the modal at the
-    // FRAME origin, where the dock then over-drew its left edge — hiding
-    // the title bar and clipping the rounded top-left corner.
+    // Offsets must be ABSOLUTE — `area.x` / `area.y` are not assumed to be
+    // zero (this is the full frame today, but the modal must centre in
+    // whatever rect it is handed). Centring with bare `area.width / 2` placed
+    // the modal at the FRAME origin, where the dock then over-drew its left
+    // edge — hiding the title bar and clipping the rounded top-left corner.
     let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
     let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
 

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -3614,3 +3614,62 @@ fn dock_card_leaves_the_second_row_empty_rather_than_echo_the_name() {
         "the card still ends after its second row, got {after:?}"
     );
 }
+
+/// The Settings modal is a *full-screen* modal: with the dock open it must
+/// centre in the whole window — painting over the dock column — and dim the
+/// dock along with the rest of the frame.
+///
+/// It used to be laid into the chrome region right of the dock (the dock's
+/// later paint pass would otherwise overpaint the modal's left edge), which
+/// squeezed the dialog into the remaining columns and left the dock at full
+/// brightness beside it, reading as live even though the modal had already
+/// swallowed every key and click bound for it.
+#[test]
+fn settings_modal_covers_the_full_screen_and_dims_the_dock() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The dock's right border on the toolbar row (row 0) marks the width of
+    // its column; row 0 sits above the modal, so it survives it.
+    let cols = h.screen_row_text(0).chars().count() as u16;
+    let dock_border_col = (0..cols)
+        .find(|&c| h.get_cell(c, 0).as_deref() == Some("│"))
+        .expect("dock right border (│) should be present on the toolbar row");
+
+    // Sample a dock cell before the modal opens: its title, which the
+    // modal does not cover.
+    let (title_col, title_row) = h
+        .find_text_on_screen("Orchestrator")
+        .expect("dock title should be on screen");
+    let undimmed_fg = h.get_cell_style(title_col, title_row).unwrap().fg;
+
+    h.open_settings().unwrap();
+
+    // The modal's top-left corner lands *inside* the dock column, i.e. it
+    // is centred on the full frame rather than on the chrome beside the
+    // dock.
+    let (modal_left, modal_row) = h
+        .find_text_on_screen("Settings [")
+        .expect("settings modal title should be on screen");
+    let corner_col = (0..modal_left)
+        .rev()
+        .find(|&c| h.get_cell(c, modal_row).as_deref() == Some("╭"))
+        .expect("settings modal should draw its rounded top-left corner");
+    assert!(
+        corner_col < dock_border_col,
+        "the settings modal must start inside the dock column (corner at {corner_col}, \
+         dock border at {dock_border_col}):\n{}",
+        h.screen_to_string()
+    );
+
+    // ...and the dock is dimmed behind it rather than left looking live.
+    let dimmed_fg = h.get_cell_style(title_col, title_row).unwrap().fg;
+    assert_ne!(
+        undimmed_fg, dimmed_fg,
+        "the dock must dim while the settings modal is up"
+    );
+}

--- a/docs/internal/rendering-and-layout.md
+++ b/docs/internal/rendering-and-layout.md
@@ -19,7 +19,9 @@ Fresh is an **immediate-mode** TUI: there is no retained widget tree and no dirt
 6. Carve the file-explorer sidebar out of the main content area and paint it.
 7. Fire `lines_changed` plugin hooks for newly-visible lines (lets plugins add overlays *before* the content render).
 8. **Render split content**: a single split-borrow of the active window yields the buffers, the split manager, and the view states, and the split renderer paints every visible leaf into the frame buffer. It returns per-leaf layout caches (split areas, tab layouts, view-line mappings, scrollbar areas, …) stored on the window for the next frame's hit-testing.
-9. Post-content passes: cursor-jump animation, viewport-change hooks, popups, modals, menu bar, status bar, context menus, software cursor, dock/overlay painting, then dimming behind modals.
+9. Post-content passes: cursor-jump animation, viewport-change hooks, popups, menu bar, status bar, context menus, software cursor, frame-buffer animations.
+10. Topmost layers, painted after everything above: the dock into its carved column; then the full-screen modals (settings, keybinding editor, event-debug dialog, calibration wizard), each dimming the *whole* frame behind it — the dock included — and centring in the full window rather than in the chrome beside the dock; then the floating widget panel, the theme-info popup, and the blocking workspace-trust prompt. Modals paint *after* the dock so the dock's own pass cannot overpaint their left edge.
+11. Terminal colour-capability conversion (256/16 fallback) over the finished buffer, so every layer — including the dock, the modals, and animation output — goes through it.
 
 ### `RenderStyle`, `EditorRenderConfig`, and rendering into an arbitrary buffer
 


### PR DESCRIPTION
## Motivation

Opening Settings while the orchestrator dock is up laid the dialog into the chrome region right of the dock and dimmed only that region. Two problems:

* the modal was squeezed into the remaining columns instead of using the screen;
* the dock stayed at full brightness beside it, reading as live — even though the modal had already swallowed every key and click bound for it (`dispatch_modal_mouse` routes the whole mouse channel to Settings while it is open).

That confinement existed only because the dock painted *after* the modals, so a full-frame modal would have had its left edge overpainted.

## What changed

* `crates/fresh-editor/src/app/render.rs` — the full-screen modals (settings, keybinding editor, event-debug dialog, calibration wizard) move into `render_panels_and_modals`, drawn right after the dock and handed the whole frame. That is the same treatment the workspace-trust prompt already got. They now centre in the full window and their dim pass covers the dock, the menu bar and the status bar.
* Painting the modals that late would have left them out of the terminal colour-capability conversion, so `convert_buffer_colors` moves to the very end of `render`, after every layer. That also fixes the dock itself, which has been emitting truecolor SGR on 256/16-colour terminals.
* `crates/fresh-editor/src/view/settings/render.rs` — refreshed the stale comment about `area` being the chrome region right of the dock.
* Docs (`docs/internal/rendering-and-layout.md`) and CHANGELOG updated.

Mouse routing needed no change: Settings already captured the entire mouse channel, so clicks on the part of the modal that now sits over the dock column hit-test correctly.

## Testing

New e2e test `orchestrator_dock::settings_modal_covers_the_full_screen_and_dims_the_dock` asserts only on rendered output (the modal's top-left corner column vs the dock's border column, plus the dock title cell's fg before/after opening the modal). It fails on the pre-change code and passes with it.

Full e2e suite: 3211 passed, 5 failed — all 5 (`e2e::locale` ×3, one LSP inlay-hint, one terminal-title) reproduce on a clean tree or pass in isolation, i.e. pre-existing / parallelism flakes. `cargo fmt`, `cargo check --all-targets` and `cargo clippy --all-targets` are clean.

Verified interactively in tmux (200×50) per CONTRIBUTING's tip:

* before: modal started at the dock's right edge, dock title fg `255,255,255` while Settings was up;
* after: the modal's corner lands inside the dock column, the dock dims to fg `85,85,85` and returns to full brightness on Escape;
* also checked with no dock (unchanged), the keybinding editor, the settings help overlay, `FRESH_COLOR_MODE=256` (dock and modal now emit `38;5;N`), 60×20 (narrow mode renders instead of the old "terminal too small", since the modal no longer loses the dock's columns) and 38×9 (small-size guard still trips).

## Scope notes

Two things go slightly beyond the literal report, easy to narrow if you'd rather not:

* the keybinding editor / event-debug / calibration modals share the code path and get the same treatment;
* the menu bar and status bar are now dimmed too — they previously repainted at full brightness over the dim pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DBUFp8RTbs6WymC47YN4c

---
_Generated by [Claude Code](https://claude.ai/code/session_011DBUFp8RTbs6WymC47YN4c)_