### PR TITLE
fix(input): decode SGR horizontal wheel reports

### DIFF
--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -893,11 +893,11 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
     );
 
     let kind = if cb & 64 != 0 {
-        // Wheel: low bit selects up/down.
-        if cb & 1 != 0 {
-            MouseEventKind::ScrollDown
-        } else {
-            MouseEventKind::ScrollUp
+        match button_bits {
+            0 => MouseEventKind::ScrollUp,
+            1 => MouseEventKind::ScrollDown,
+            2 => MouseEventKind::ScrollLeft,
+            _ => MouseEventKind::ScrollRight,
         }
     } else if button_bits == 3 {
         // No button pressed. This is always motion, never a button event —

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -446,6 +446,26 @@ fn sgr_mouse_is_zero_indexed() {
 }
 
 #[test]
+fn sgr_mouse_decodes_wheel_buttons_across_a_split_boundary() {
+    // SGR wheel buttons 64–67 are respectively up, down, left, and right.
+    for (button, kind) in [
+        (64, MouseEventKind::ScrollUp),
+        (65, MouseEventKind::ScrollDown),
+        (66, MouseEventKind::ScrollLeft),
+        (67, MouseEventKind::ScrollRight),
+    ] {
+        let mut parser = InputParser::new();
+        let sequence = format!("\x1b[<{button};10;5M");
+        let split = sequence.len() - 1;
+        assert!(parser.parse(&sequence.as_bytes()[..split]).is_empty());
+        assert!(matches!(
+            parser.parse(&sequence.as_bytes()[split..]).as_slice(),
+            [Event::Mouse(MouseEvent { kind: actual, .. })] if *actual == kind
+        ));
+    }
+}
+
+#[test]
 fn sgr_mouse_motion_without_button() {
     let mut p = InputParser::new();
     let ev = p.parse(b"\x1b[<35;10;5M");


### PR DESCRIPTION
## Summary

xterm SGR mouse wheel button codes 66 and 67 denote horizontal wheel left/right. Fresh currently aliases them to up/down by inspecting only the low bit.

Decode wheel values 64–67 by their low two button bits:

- 64: `ScrollUp`
- 65: `ScrollDown`
- 66: `ScrollLeft`
- 67: `ScrollRight`

Legacy X10 and malformed-input behavior are unchanged.

## Regression coverage

The public `InputParser` API parses all four SGR reports across split input boundaries and asserts the exact emitted event. The test fails on the parent for 66/67.

## Validation

- `cargo test -p fresh-input-parser` — 89 passed
- `cargo test -p fresh-input-parser --release` — 89 passed
- `cargo clippy -p fresh-input-parser --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`