### PR TITLE
fix(input): decode the rest of the mouse Cb byte, and forward the horizontal wheel

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1993,6 +1993,16 @@ impl Window {
                     }
                     return;
                 }
+                // Alternate scroll is vertical-only, in xterm as here: there is
+                // no horizontal counterpart to synthesize (Left/Right arrows
+                // would walk the shell's cursor through the command line, not
+                // pan anything). Reaching this arm also means the program never
+                // enabled mouse reporting — `uses_alt_scroll` requires
+                // `!wants_mouse` — so falling through to a real mouse report
+                // would inject bytes it never asked for. Drop it instead.
+                TerminalMouseEventKind::ScrollLeft | TerminalMouseEventKind::ScrollRight => {
+                    return;
+                }
                 _ => {}
             }
         }
@@ -2683,8 +2693,11 @@ fn encode_sgr_mouse(
             (code, false)
         }
         TerminalMouseEventKind::Moved => (35, false), // 3 + 32 (no button + motion)
+        // Wheel: buttons 4-7 are up, down, left and right.
         TerminalMouseEventKind::ScrollUp => (64, false),
         TerminalMouseEventKind::ScrollDown => (65, false),
+        TerminalMouseEventKind::ScrollLeft => (66, false),
+        TerminalMouseEventKind::ScrollRight => (67, false),
     };
 
     // Add modifier flags
@@ -2728,8 +2741,11 @@ fn encode_x10_mouse(
         },
         TerminalMouseEventKind::Up(_) => 3, // Release is button 3 in X10
         TerminalMouseEventKind::Moved => 3 + 32,
+        // Wheel: buttons 4-7 are up, down, left and right.
         TerminalMouseEventKind::ScrollUp => 64,
         TerminalMouseEventKind::ScrollDown => 65,
+        TerminalMouseEventKind::ScrollLeft => 66,
+        TerminalMouseEventKind::ScrollRight => 67,
     };
 
     // Add modifier flags and motion flag for drag
@@ -2789,5 +2805,51 @@ mod title_tests {
     #[test]
     fn none_when_neither_present() {
         assert_eq!(combine_terminal_title(None, None), None);
+    }
+}
+
+#[cfg(test)]
+mod mouse_encoding_tests {
+    use super::{encode_sgr_mouse, encode_x10_mouse};
+    use crate::input::handler::TerminalMouseEventKind;
+    use crossterm::event::KeyModifiers;
+
+    /// Encode at 0-based cell (9, 4), which both protocols report as 10;5.
+    fn sgr(kind: TerminalMouseEventKind) -> String {
+        String::from_utf8(encode_sgr_mouse(9, 4, kind, KeyModifiers::empty()).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn sgr_encodes_the_wheel_as_buttons_4_through_7() {
+        // xterm's wheel buttons are 64 up, 65 down, 66 left, 67 right. The
+        // horizontal pair had no encoding, so a horizontal wheel over a
+        // mouse-tracking program was dropped before it reached the PTY.
+        assert_eq!(sgr(TerminalMouseEventKind::ScrollUp), "\x1b[<64;10;5M");
+        assert_eq!(sgr(TerminalMouseEventKind::ScrollDown), "\x1b[<65;10;5M");
+        assert_eq!(sgr(TerminalMouseEventKind::ScrollLeft), "\x1b[<66;10;5M");
+        assert_eq!(sgr(TerminalMouseEventKind::ScrollRight), "\x1b[<67;10;5M");
+    }
+
+    #[test]
+    fn sgr_horizontal_wheel_carries_modifiers() {
+        let bytes = encode_sgr_mouse(
+            9,
+            4,
+            TerminalMouseEventKind::ScrollLeft,
+            KeyModifiers::SHIFT | KeyModifiers::CONTROL,
+        )
+        .unwrap();
+        // 66 + 4 (shift) + 16 (ctrl)
+        assert_eq!(String::from_utf8(bytes).unwrap(), "\x1b[<86;10;5M");
+    }
+
+    #[test]
+    fn x10_encodes_the_wheel_as_buttons_4_through_7() {
+        // Same button numbers, biased by 32 like every other X10 field.
+        let cb = |kind| encode_x10_mouse(9, 4, kind, KeyModifiers::empty()).unwrap()[3];
+        assert_eq!(cb(TerminalMouseEventKind::ScrollUp), 64 + 32);
+        assert_eq!(cb(TerminalMouseEventKind::ScrollDown), 65 + 32);
+        assert_eq!(cb(TerminalMouseEventKind::ScrollLeft), 66 + 32);
+        assert_eq!(cb(TerminalMouseEventKind::ScrollRight), 67 + 32);
     }
 }

--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -316,21 +316,8 @@ impl Window {
         let term_col = col.saturating_sub(content_rect.x);
         let term_row = row.saturating_sub(content_rect.y);
 
-        // Convert crossterm MouseEventKind to our TerminalMouseEventKind.
-        let kind = match mouse_event.kind {
-            MouseEventKind::Down(btn) => TerminalMouseEventKind::Down(convert_button(btn)),
-            MouseEventKind::Up(btn) => TerminalMouseEventKind::Up(convert_button(btn)),
-            MouseEventKind::Drag(btn) => TerminalMouseEventKind::Drag(convert_button(btn)),
-            MouseEventKind::Moved => TerminalMouseEventKind::Moved,
-            MouseEventKind::ScrollUp => TerminalMouseEventKind::ScrollUp,
-            MouseEventKind::ScrollDown => TerminalMouseEventKind::ScrollDown,
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
-                // Horizontal scroll not typically supported in terminal mouse protocols.
-                return Ok(false);
-            }
-        };
-
         // Send to terminal.
+        let kind = convert_kind(mouse_event.kind);
         self.send_terminal_mouse(term_col, term_row, kind, mouse_event.modifiers);
 
         // Terminal renders itself, so we need to trigger a render.
@@ -344,6 +331,67 @@ fn convert_button(btn: MouseButton) -> TerminalMouseButton {
         MouseButton::Left => TerminalMouseButton::Left,
         MouseButton::Right => TerminalMouseButton::Right,
         MouseButton::Middle => TerminalMouseButton::Middle,
+    }
+}
+
+/// Convert a crossterm `MouseEventKind` to the kind the PTY encoders speak.
+///
+/// Total: every kind the input parser can produce has a wire representation,
+/// horizontal wheel included (xterm buttons 6 and 7). This used to drop
+/// `ScrollLeft`/`ScrollRight` on the floor — and because the caller reports
+/// "handled" either way, a horizontal wheel over a mouse-tracking terminal
+/// was swallowed rather than falling through to Fresh's own panning.
+fn convert_kind(kind: MouseEventKind) -> TerminalMouseEventKind {
+    match kind {
+        MouseEventKind::Down(btn) => TerminalMouseEventKind::Down(convert_button(btn)),
+        MouseEventKind::Up(btn) => TerminalMouseEventKind::Up(convert_button(btn)),
+        MouseEventKind::Drag(btn) => TerminalMouseEventKind::Drag(convert_button(btn)),
+        MouseEventKind::Moved => TerminalMouseEventKind::Moved,
+        MouseEventKind::ScrollUp => TerminalMouseEventKind::ScrollUp,
+        MouseEventKind::ScrollDown => TerminalMouseEventKind::ScrollDown,
+        MouseEventKind::ScrollLeft => TerminalMouseEventKind::ScrollLeft,
+        MouseEventKind::ScrollRight => TerminalMouseEventKind::ScrollRight,
+    }
+}
+
+#[cfg(test)]
+mod convert_kind_tests {
+    use super::*;
+
+    #[test]
+    fn horizontal_wheel_has_a_wire_representation() {
+        assert_eq!(
+            convert_kind(MouseEventKind::ScrollLeft),
+            TerminalMouseEventKind::ScrollLeft
+        );
+        assert_eq!(
+            convert_kind(MouseEventKind::ScrollRight),
+            TerminalMouseEventKind::ScrollRight
+        );
+    }
+
+    #[test]
+    fn other_kinds_are_unchanged() {
+        assert_eq!(
+            convert_kind(MouseEventKind::Down(MouseButton::Left)),
+            TerminalMouseEventKind::Down(TerminalMouseButton::Left)
+        );
+        assert_eq!(
+            convert_kind(MouseEventKind::Drag(MouseButton::Middle)),
+            TerminalMouseEventKind::Drag(TerminalMouseButton::Middle)
+        );
+        assert_eq!(
+            convert_kind(MouseEventKind::Moved),
+            TerminalMouseEventKind::Moved
+        );
+        assert_eq!(
+            convert_kind(MouseEventKind::ScrollUp),
+            TerminalMouseEventKind::ScrollUp
+        );
+        assert_eq!(
+            convert_kind(MouseEventKind::ScrollDown),
+            TerminalMouseEventKind::ScrollDown
+        );
     }
 }
 

--- a/crates/fresh-editor/src/input/handler.rs
+++ b/crates/fresh-editor/src/input/handler.rs
@@ -55,6 +55,10 @@ pub enum TerminalMouseEventKind {
     ScrollUp,
     /// Scroll down
     ScrollDown,
+    /// Horizontal scroll left (xterm button 6)
+    ScrollLeft,
+    /// Horizontal scroll right (xterm button 7)
+    ScrollRight,
 }
 
 /// Mouse buttons for terminal forwarding.

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -410,7 +410,12 @@ impl InputParser {
         buf[have as usize] = byte;
         have += 1;
         if have == 3 {
-            out.push(x10_mouse_event(buf));
+            // A report we can't represent yields no event, but its bytes are
+            // still consumed here — they must never fall through to ground and
+            // print as literal text (sinelaw/fresh#2745).
+            if let Some(ev) = x10_mouse_event(buf) {
+                out.push(ev);
+            }
             self.state = State::Ground;
         } else {
             self.state = State::X10 { buf, have };
@@ -864,9 +869,22 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
     if parts.len() < 3 {
         return None;
     }
-    let cb: u16 = parts[0].parse().unwrap_or(0);
+    // `Cb` is a single byte in every mouse protocol, so anything non-numeric or
+    // out of range is malformed. Defaulting it to 0 (as this used to) turns
+    // garbage into a synthetic left-click at the reported cell.
+    let cb: u8 = parts[0].parse().ok()?;
     let cx: u16 = parts[1].parse().unwrap_or(1);
     let cy: u16 = parts[2].parse().unwrap_or(1);
+
+    // Bit 7 is xterm's high-button extension: the button number is
+    // `(cb & 3) | (cb & 0xC0) >> 4`, so bit 7 marks buttons 8-15. `MouseButton`
+    // has no representation for those, and their low bits alias onto
+    // Left/Middle/Right — and, when bit 6 is set too (buttons 12-15), onto the
+    // wheel. Decoding them would manufacture clicks and scrolls the user never
+    // made, so drop them, as crossterm does.
+    if cb & 0b1000_0000 != 0 {
+        return None;
+    }
 
     let button_bits = cb & 0b11;
     let button = match button_bits {
@@ -876,21 +894,7 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
         _ => MouseButton::Left, // 3 = no button; never used as a real button
     };
 
-    let modifiers = KeyModifiers::from_bits_truncate(
-        if cb & 4 != 0 {
-            KeyModifiers::SHIFT.bits()
-        } else {
-            0
-        } | if cb & 8 != 0 {
-            KeyModifiers::ALT.bits()
-        } else {
-            0
-        } | if cb & 16 != 0 {
-            KeyModifiers::CONTROL.bits()
-        } else {
-            0
-        },
-    );
+    let modifiers = mouse_modifiers(cb);
 
     let kind = if cb & 64 != 0 {
         match button_bits {
@@ -922,23 +926,85 @@ fn sgr_mouse_event(params: &[u8], pressed: bool) -> Option<Event> {
     }))
 }
 
+/// Decode the Shift/Alt/Ctrl bits of a mouse report's `Cb` byte. The bit
+/// layout is shared by the SGR and X10 encodings — only the transport differs.
+fn mouse_modifiers(cb: u8) -> KeyModifiers {
+    let mut modifiers = KeyModifiers::empty();
+    if cb & 4 != 0 {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+    if cb & 8 != 0 {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if cb & 16 != 0 {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+    modifiers
+}
+
 /// Decode a legacy X10 mouse report from its three raw coordinate bytes.
-fn x10_mouse_event(buf: [u8; 3]) -> Event {
+///
+/// The button byte carries the same `Cb` layout as an SGR report (button in
+/// bits 0-1, Shift/Alt/Ctrl in bits 2-4, motion in bit 5, wheel in bit 6, high
+/// buttons in bit 7); only the transport differs. Each field is a single byte
+/// biased by 32, and there is no `m` release terminator — a release is
+/// reported as button 3, so which button came up is simply not encoded.
+///
+/// Returns `None` for reports that have no `MouseEventKind` counterpart.
+fn x10_mouse_event(buf: [u8; 3]) -> Option<Event> {
     let cb = buf[0].wrapping_sub(32);
     let cx = buf[1].wrapping_sub(32);
     let cy = buf[2].wrapping_sub(32);
-    let kind = match cb & 0b11 {
-        0 => MouseEventKind::Down(MouseButton::Left),
-        1 => MouseEventKind::Down(MouseButton::Middle),
-        2 => MouseEventKind::Down(MouseButton::Right),
-        _ => MouseEventKind::Up(MouseButton::Left), // 3 = release
+
+    // Buttons 8-15 are unrepresentable — see `sgr_mouse_event`.
+    if cb & 0b1000_0000 != 0 {
+        return None;
+    }
+
+    let button_bits = cb & 0b11;
+    let button = match button_bits {
+        0 => MouseButton::Left,
+        1 => MouseButton::Middle,
+        2 => MouseButton::Right,
+        _ => MouseButton::Left, // 3 = no button / release
     };
-    Event::Mouse(MouseEvent {
+
+    let kind = if cb & 64 != 0 {
+        // Wheel: buttons 4-7 are up, down, left and right.
+        match button_bits {
+            0 => MouseEventKind::ScrollUp,
+            1 => MouseEventKind::ScrollDown,
+            2 => MouseEventKind::ScrollLeft,
+            _ => MouseEventKind::ScrollRight,
+        }
+    } else if cb & 32 != 0 {
+        // Motion. With a button held this is a drag; button 3 means no button
+        // is down, i.e. bare pointer movement under DECSET 1003. Reading the
+        // whole class as a press produced a click flood on every mouse move —
+        // the X10 half of the same bug `sgr_mouse_event` documents.
+        if button_bits == 3 {
+            MouseEventKind::Moved
+        } else {
+            MouseEventKind::Drag(button)
+        }
+    } else if button_bits == 3 {
+        MouseEventKind::Up(MouseButton::Left)
+    } else {
+        MouseEventKind::Down(button)
+    };
+
+    Some(Event::Mouse(MouseEvent {
         kind,
-        column: cx as u16,
-        row: cy as u16,
-        modifiers: KeyModifiers::empty(),
-    })
+        // X10 coordinates are 1-based, exactly like SGR's: the byte is
+        // `coordinate + 32` with the top-left cell at 1,1. Dropping the `- 1`
+        // (as this used to) placed every legacy-protocol click one cell down
+        // and to the right of the cell the user aimed at. `saturating_sub`
+        // rather than `- 1` for the same reason as in `sgr_mouse_event`: an
+        // out-of-spec 0 coordinate must not underflow (sinelaw/fresh#2732).
+        column: u16::from(cx).saturating_sub(1),
+        row: u16::from(cy).saturating_sub(1),
+        modifiers: mouse_modifiers(cb),
+    }))
 }
 
 /// Convert buffered bracketed-paste bytes to text, dropping stray C0/C1 control

--- a/crates/fresh-input-parser/src/proptests.rs
+++ b/crates/fresh-input-parser/src/proptests.rs
@@ -72,9 +72,13 @@ proptest! {
 
     /// A well-formed **SGR mouse** report parses to exactly one mouse event with
     /// the right 0-indexed coordinates, at every split point, with no leak.
+    ///
+    /// `Cb` stops at 127: bit 7 selects xterm's buttons 8-15, which have no
+    /// `MouseEventKind` counterpart and are deliberately dropped. That range is
+    /// covered by `high_button_reports_are_dropped_without_leaking`.
     #[test]
     fn wellformed_sgr_mouse_parses_at_any_split(
-        cb in 0u16..=255, cx in 1u16..=4000, cy in 1u16..=4000,
+        cb in 0u16..=127, cx in 1u16..=4000, cy in 1u16..=4000,
         press in any::<bool>(), cut in 0usize..64,
     ) {
         let final_byte = if press { 'M' } else { 'm' };
@@ -94,9 +98,12 @@ proptest! {
     /// A well-formed **X10 mouse** report (three coordinate bytes, each a valid
     /// `value + 32` byte `>= 0x20`) parses to exactly one mouse event at every
     /// split point, with no structural leak.
+    ///
+    /// The button byte stops at 0x9f for the same reason `Cb` stops at 127 in
+    /// the SGR property above: `0xa0` is where bit 7 — buttons 8-15 — starts.
     #[test]
     fn wellformed_x10_mouse_parses_at_any_split(
-        b0 in 0x20u8..=0xff, b1 in 0x20u8..=0xff, b2 in 0x20u8..=0xff,
+        b0 in 0x20u8..=0x9f, b1 in 0x20u8..=0xff, b2 in 0x20u8..=0xff,
         cut in 0usize..8,
     ) {
         let seq = [0x1b, b'[', b'M', b0, b1, b2];
@@ -107,6 +114,31 @@ proptest! {
 
         prop_assert_eq!(structural_char_leaks(&ev), 0, "leak: {:?}", ev);
         prop_assert_eq!(mouse_events(&ev).len(), 1, "expected 1 mouse event, got {:?}", ev);
+    }
+
+    /// **Unrepresentable buttons are dropped, never leaked.** Bit 7 of `Cb`
+    /// selects xterm's buttons 8-15, which `MouseEventKind` cannot express, so
+    /// both encodings must swallow the report whole rather than alias it onto
+    /// Left/Middle/Right (or, with bit 6 also set, onto the wheel). Emitting no
+    /// event must not weaken the #2745 invariant, which holds for *every* `Cb`:
+    /// the report's bytes are still consumed, at every split point.
+    #[test]
+    fn high_button_reports_are_dropped_without_leaking(
+        cb in 128u16..=255, cx in 1u16..=4000, cy in 1u16..=4000,
+        b0 in 0xa0u8..=0xff, b1 in 0x20u8..=0xff, b2 in 0x20u8..=0xff,
+        cut in 0usize..64,
+    ) {
+        let sgr = format!("\x1b[<{cb};{cx};{cy}M").into_bytes();
+        let x10 = vec![0x1b, b'[', b'M', b0, b1, b2];
+        for seq in [sgr, x10] {
+            let cut = cut % (seq.len() + 1);
+            let mut p = InputParser::new();
+            let mut ev = p.parse(&seq[..cut]);
+            ev.extend(p.parse(&seq[cut..]));
+
+            prop_assert_eq!(structural_char_leaks(&ev), 0, "leak: {:?} (seq {:02x?})", ev, seq);
+            prop_assert_eq!(mouse_events(&ev).len(), 0, "expected no mouse event, got {:?}", ev);
+        }
     }
 
     /// Ground-state **printable ASCII text** (no `ESC`) passes through 1:1 — one
@@ -133,7 +165,7 @@ proptest! {
     #[test]
     fn truncated_x10_then_sgr_resyncs(
         prefix_coords in proptest::collection::vec(0x20u8..=0xff, 0..3),
-        cb in 0u16..=255, cx in 1u16..=4000, cy in 1u16..=4000, cut in 0usize..64,
+        cb in 0u16..=127, cx in 1u16..=4000, cy in 1u16..=4000, cut in 0usize..64,
     ) {
         let mut seq = vec![0x1b, b'[', b'M'];
         seq.extend_from_slice(&prefix_coords); // 0..=2 coord bytes: truncated
@@ -164,7 +196,7 @@ proptest! {
     fn sgr_mouse_amid_esc_free_noise(
         pre in proptest::collection::vec(0x20u8..=0x7e, 0..64),
         post in proptest::collection::vec(0x20u8..=0x7e, 0..64),
-        cb in 0u16..=255, cx in 1u16..=4000, cy in 1u16..=4000,
+        cb in 0u16..=127, cx in 1u16..=4000, cy in 1u16..=4000,
     ) {
         let mut seq = pre.clone();
         seq.extend_from_slice(format!("\x1b[<{cb};{cx};{cy}M").as_bytes());

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -513,22 +513,209 @@ fn partial_csi_mouse_not_flushed() {
     }
 }
 
+#[test]
+fn sgr_mouse_high_buttons_are_dropped_without_leaking() {
+    // Bit 7 is xterm's high-button extension (buttons 8-15). `MouseButton` has
+    // no counterpart, and the low bits alias onto Left/Middle/Right — and, with
+    // bit 6 set too, onto the wheel — so 128-131 used to arrive as clicks and
+    // 192-195 as scrolls. Dropping them must not leak the report as text.
+    for seq in [
+        &b"\x1b[<128;10;5M"[..], // button 8
+        &b"\x1b[<129;10;5M"[..], // button 9
+        &b"\x1b[<131;10;5M"[..], // button 11
+        &b"\x1b[<192;10;5M"[..], // button 12 — bit 6 set, but not the wheel
+        &b"\x1b[<195;10;5M"[..], // button 15
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(seq);
+        assert!(
+            !ev.iter().any(|e| matches!(e, Event::Mouse(_))),
+            "{:?} produced a mouse event: {:?}",
+            std::str::from_utf8(seq),
+            ev
+        );
+        assert!(!has_char_key(&ev), "{:?} leaked: {:?}", seq, ev);
+    }
+}
+
+#[test]
+fn sgr_mouse_wheel_still_decodes_below_the_high_button_range() {
+    // The guard above keys on bit 7 alone, so ordinary wheel reports (buttons
+    // 4-7, bit 6) must be untouched by it.
+    let mut p = InputParser::new();
+    for seq in [&b"\x1b[<64;10;5M"[..], &b"\x1b[<67;10;5M"[..]] {
+        assert!(
+            matches!(p.parse(seq).first(), Some(Event::Mouse(_))),
+            "{:?} produced no mouse event",
+            std::str::from_utf8(seq)
+        );
+    }
+}
+
+#[test]
+fn sgr_mouse_unparseable_button_is_rejected() {
+    // `Cb` is a byte. A non-numeric or out-of-range field used to default to 0
+    // — a synthetic left-click at the reported cell, conjured out of garbage.
+    // Each stays inside the CSI parameter range (0x30-0x3f) so the sequence is
+    // still framed as one mouse report — it is the decoder that must reject it.
+    for seq in [
+        &b"\x1b[<?;10;5M"[..],   // not a number
+        &b"\x1b[<;10;5M"[..],    // empty
+        &b"\x1b[<300;10;5M"[..], // wider than a byte
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(seq);
+        assert!(
+            !ev.iter().any(|e| matches!(e, Event::Mouse(_))),
+            "{:?} produced a mouse event: {:?}",
+            std::str::from_utf8(seq),
+            ev
+        );
+        assert!(!has_char_key(&ev), "{:?} leaked: {:?}", seq, ev);
+    }
+}
+
 // ---- X10 mouse ----
 
 #[test]
 fn x10_mouse_press() {
     let mut p = InputParser::new();
-    // ESC [ M  btn=0(+32=' ')  x=41(+32=')')  y=21(+32='5')  => col 9, row 21? decode:
-    // cx = 0x29 - 32 = 9, cy = 0x35 - 32 = 21
+    // ESC [ M  btn=0(+32=' ')  x=41(+32=')')  y=21(+32='5'). Each byte is the
+    // 1-based coordinate plus 32, so 0x29 is column 9 and 0x35 is row 21, which
+    // are columns 8 and 20 once converted to the 0-based coordinates the rest
+    // of the editor uses.
     let ev = p.parse(b"\x1b[M \x29\x35");
     match &ev[0] {
         Event::Mouse(me) => {
             assert!(matches!(me.kind, MouseEventKind::Down(MouseButton::Left)));
-            assert_eq!((me.column, me.row), (9, 21));
+            assert_eq!((me.column, me.row), (8, 20));
         }
         other => panic!("expected x10 mouse, got {:?}", other),
     }
     assert!(!has_char_key(&ev));
+}
+
+#[test]
+fn x10_and_sgr_agree_on_the_same_cell() {
+    // Both protocols report the top-left cell as 1,1; the editor works in
+    // 0-based cells, so a press on it must decode to 0,0 either way. X10 used
+    // to keep the 1-based value, placing every legacy-protocol click one cell
+    // down and to the right of its SGR equivalent.
+    let mut p = InputParser::new();
+    let x10 = p.parse(b"\x1b[M\x20\x21\x21"); // btn 0, x 1, y 1
+    let sgr = p.parse(b"\x1b[<0;1;1M");
+    let coords = |ev: &[Event]| match &ev[0] {
+        Event::Mouse(me) => (me.column, me.row),
+        other => panic!("expected mouse, got {:?}", other),
+    };
+    assert_eq!(coords(&x10), (0, 0));
+    assert_eq!(coords(&sgr), (0, 0));
+}
+
+#[test]
+fn x10_mouse_zero_coordinate_does_not_panic() {
+    // An out-of-spec 0 coordinate (byte 0x20, the bias itself) must saturate
+    // rather than underflow the 1-based conversion — the X10 counterpart of
+    // `sgr_mouse_zero_coordinate_does_not_panic` (#2732).
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[M\x20\x20\x20");
+    match &ev[0] {
+        Event::Mouse(me) => assert_eq!((me.column, me.row), (0, 0)),
+        other => panic!("expected x10 mouse, got {:?}", other),
+    }
+}
+
+#[test]
+fn x10_mouse_decodes_wheel_buttons() {
+    // X10 encodes the wheel the same way SGR does — buttons 4-7 in bit 6 plus
+    // the low two bits — so 96-99 are up, down, left and right. They used to
+    // fall through to the button match and arrive as clicks.
+    for (cb, kind) in [
+        (0x60, MouseEventKind::ScrollUp),
+        (0x61, MouseEventKind::ScrollDown),
+        (0x62, MouseEventKind::ScrollLeft),
+        (0x63, MouseEventKind::ScrollRight),
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(&[0x1b, b'[', b'M', cb, 0x2a, 0x26]);
+        match &ev[0] {
+            Event::Mouse(me) => assert_eq!(me.kind, kind, "cb {cb:#04x}"),
+            other => panic!("expected x10 mouse, got {:?}", other),
+        }
+        assert!(!has_char_key(&ev));
+    }
+}
+
+#[test]
+fn x10_mouse_decodes_motion_and_drag() {
+    // Bit 5 is the motion bit: held with a button it is a drag, and with
+    // button 3 (no button down) it is bare pointer movement. Both used to
+    // decode as presses, flooding clicks on every mouse move.
+    for (cb, kind) in [
+        (0x40, MouseEventKind::Drag(MouseButton::Left)),
+        (0x41, MouseEventKind::Drag(MouseButton::Middle)),
+        (0x42, MouseEventKind::Drag(MouseButton::Right)),
+        (0x43, MouseEventKind::Moved),
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(&[0x1b, b'[', b'M', cb, 0x2a, 0x26]);
+        match &ev[0] {
+            Event::Mouse(me) => assert_eq!(me.kind, kind, "cb {cb:#04x}"),
+            other => panic!("expected x10 mouse, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn x10_mouse_decodes_modifiers() {
+    // Bits 2-4 are Shift/Alt/Ctrl. X10 reported every event as unmodified, so
+    // Ctrl+click was indistinguishable from a plain click.
+    for (cb, expected) in [
+        (0x20, KeyModifiers::empty()),
+        (0x24, KeyModifiers::SHIFT),
+        (0x28, KeyModifiers::ALT),
+        (0x30, KeyModifiers::CONTROL),
+        (0x34, KeyModifiers::SHIFT | KeyModifiers::CONTROL),
+    ] {
+        let mut p = InputParser::new();
+        let ev = p.parse(&[0x1b, b'[', b'M', cb, 0x2a, 0x26]);
+        match &ev[0] {
+            Event::Mouse(me) => assert_eq!(me.modifiers, expected, "cb {cb:#04x}"),
+            other => panic!("expected x10 mouse, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn x10_mouse_release_is_still_button_agnostic() {
+    // X10 has no `m` terminator: a release is button 3 with the motion bit
+    // clear, and which button came up simply isn't encoded. Unlike SGR — where
+    // button 3 is always motion — this must stay a release.
+    let mut p = InputParser::new();
+    let ev = p.parse(b"\x1b[M\x23\x2a\x26");
+    match &ev[0] {
+        Event::Mouse(me) => assert_eq!(me.kind, MouseEventKind::Up(MouseButton::Left)),
+        other => panic!("expected x10 mouse, got {:?}", other),
+    }
+}
+
+#[test]
+fn x10_mouse_high_buttons_are_dropped_without_leaking() {
+    // Bit 7 marks buttons 8-15, which have no `MouseButton` counterpart. They
+    // used to alias onto Left/Middle/Right; dropping them must not let the
+    // report's bytes escape as literal text (#2745).
+    for cb in [0xa0u8, 0xa1, 0xa2, 0xa3, 0xe0, 0xe3] {
+        let mut p = InputParser::new();
+        let ev = p.parse(&[0x1b, b'[', b'M', cb, 0x2a, 0x26]);
+        assert!(
+            !ev.iter().any(|e| matches!(e, Event::Mouse(_))),
+            "cb {cb:#04x} produced a mouse event: {:?}",
+            ev
+        );
+        assert!(!has_char_key(&ev), "cb {cb:#04x} leaked: {:?}", ev);
+        // The parser is back in ground state and still usable.
+        assert!(matches!(p.parse(b"\x1b[<0;1;1M")[0], Event::Mouse(_)));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two commits, both about mouse reports Fresh mis-handles — one on the way in, one on the way out.

Rebased onto master after #2823 merged; the two didn't conflict, as expected — neither touches the SGR wheel arm in `sgr_mouse_event`.

---

## 1. `fix(input): decode the rest of the mouse Cb byte`

`Cb` packs a button, three modifier bits, a motion bit, a wheel bit and a high-button bit, in the same layout for the SGR and X10 encodings. The X10 decoder read only the low two bits of it, and neither decoder handled bit 7.

### X10 (`ESC [ M`)

The fallback encoding whenever a terminal doesn't take SGR 1006.

| | before | after |
|---|---|---|
| coordinates | 1-based (off by one vs SGR) | 0-based, like SGR |
| wheel (Cb 64–67) | left/middle/right **clicks** | `ScrollUp/Down/Left/Right` |
| Shift/Alt/Ctrl | dropped | decoded |
| motion bit | ignored — a drag arrived as a **press per report** | `Drag(button)` / `Moved` |

The coordinate fix has the widest blast radius: the byte is `coordinate + 32` with the top-left cell at 1,1, so every legacy-protocol click landed one cell below and to the right of the cell the user aimed at. `saturating_sub(1)` rather than `- 1`, keeping the #2732 underflow hardening.

The motion-bit fix is the X10 half of the click flood already fixed for SGR — the JediTerm comment in `sgr_mouse_event` describes the same failure. The wheel fix is the X10 counterpart of #2823, which fixed the same four button codes on the SGR side.

Release stays button-agnostic: X10 has no `m` terminator, so button 3 with the motion bit clear is a release and *which* button came up isn't encoded. That's why this decoder can't simply defer to the SGR one, where button 3 is always motion.

### Both encodings

- **Buttons 8–15 are dropped.** Bit 7 is xterm's high-button extension — the button number is `(cb & 3) | (cb & 0xC0) >> 4`. `MouseButton` has no counterpart and the low bits alias onto Left/Middle/Right, so 128–131 arrived as clicks; with bit 6 also set (192–195) they aliased onto the wheel and arrived as scrolls. crossterm rejects this range; now so do we. The bytes are still consumed, so nothing leaks as literal text (#2745).
- **An unparseable `Cb` is rejected.** It used to default to `0`, conjuring a left-click at the reported cell out of garbage. Coordinates keep their lenient defaults — a bad coordinate misplaces an otherwise-real event, whereas a bad button synthesizes input.

### Deliberately unchanged

A wheel report with the motion bit set (Cb 96/97) still decodes as a scroll; crossterm calls it `Moved`. xterm doesn't emit it, and treating a stray motion bit as "not a scroll" risks breaking emulators that set it spuriously.

---

## 2. `feat(terminal): forward the horizontal wheel to the PTY`

A horizontal wheel over a terminal split that tracks the mouse did nothing at all. `convert_kind` had no case for `ScrollLeft`/`ScrollRight` and bailed out of `forward_mouse_to_terminal`, while the caller still reported the event handled — so it was neither sent to the child nor allowed to fall through to Fresh's own panning. The comment blamed the protocol ("horizontal scroll not typically supported"), but SGR and X10 have encoded it since xterm added buttons 6 and 7, and that's what kitty, WezTerm, foot and iTerm2 send us.

Both encoders now emit the horizontal pair (SGR `66`/`67`, X10 the same biased by 32) alongside the vertical one, so a mouse-aware child pans the way it would under any other terminal emulator.

`convert_kind` becomes total, which is the point: the dropped arm was only reachable because the conversion was allowed to fail. A future `MouseEventKind` variant is now a compile error rather than a silently swallowed event.

Alternate scroll stays vertical-only, as in xterm. There's no horizontal counterpart to synthesize — Left/Right arrows would walk the shell's cursor through the command line rather than pan anything — and reaching that branch means the child never enabled mouse reporting, so falling through to a real report would inject bytes it never asked for.

With #2823 merged and the X10 half fixed in commit 1, encode and decode now agree in both protocols — which nested Fresh exercises directly: an outer Fresh forwards `66`/`67` to an inner Fresh, which reads them back as horizontal scroll.

---

## Regression coverage

**Commit 1** — nine example-based tests through the public `InputParser` API, covering each row of the table above plus the dropped ranges, and `x10_and_sgr_agree_on_the_same_cell` pinning both encodings to the same 0-based cell. Verified red-then-green: with `lib.rs` reverted, 9 of them fail. Three more (`x10_mouse_release_is_still_button_agnostic`, `x10_mouse_zero_coordinate_does_not_panic`, `sgr_mouse_wheel_still_decodes_below_the_high_button_range`) pass either way by design — they pin behavior the change deliberately preserves, including that the new bit-7 guard doesn't over-reach into the wheel range.

The two `wellformed_*_parses_at_any_split` properties now stop below the high-button range, since "every well-formed report yields exactly one mouse event" is no longer the contract there. `high_button_reports_are_dropped_without_leaking` covers what they gave up — no event, no leak, at every split point, for both encodings. The no-leak invariant still holds for every `Cb`.

`x10_mouse_press` changes expectations from `(9, 21)` to `(8, 20)`: it asserted the off-by-one, and its comment (`=> col 9, row 21?`) suggests the value was recorded from the code rather than derived from the spec.

**Commit 2** — unit tests on the components rather than an e2e test, per CONTRIBUTING's rule for invariants that aren't visible on screen: what changes is the byte sequence written to the PTY, which never reaches the screen. `mouse_encoding_tests` pins the exact wire output of both encoders for all four wheel directions (plus modifier composition on the horizontal pair); `convert_kind_tests` pins the mapping that used to drop them. Being new enum variants, these fail to *compile* against the parent rather than failing an assertion.

## Validation

Re-run on the rebased commits:

- `cargo test -p fresh-input-parser` — 100 passed
- `cargo test -p fresh-editor --lib mouse_` / `convert_kind_tests` — 14 passed
- `cargo test -p fresh-editor --test e2e_tests terminal` — 137 passed
- `cargo test -p fresh-editor --test e2e_tests mouse_session_input` — 3 passed
- `cargo clippy -p fresh-input-parser --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Run before the rebase, on identical trees for the crates involved:

- `cargo test -p fresh-input-parser --release` — 99 passed (pre-rebase count, without #2823's test)
- `cargo test -p fresh-editor --test mouse_capture_default` — 2 passed
- `cargo check --all-targets` — clean (the three warnings are pre-existing, in files this branch doesn't touch)
- `cargo check --no-default-features --features runtime --all-targets` — clean
- `cargo clippy --all-features --all-targets` — no errors (CI parity; also covers the `gui` feature build)