### PR TITLE
fix(terminal): scrollback leaking between terminals, and restored terminals coming back frozen

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -284,6 +284,48 @@ impl Window {
         self.spawn_terminal_session_impl(cwd, persistent, command_override, extra_env, true)
     }
 
+    /// Pick the `fresh-terminal-…` file stem for a new persistent terminal in
+    /// `terminal_root`, avoiding any stem a *live* terminal in this window is
+    /// already writing to.
+    ///
+    /// Terminal files are named after the terminal id, and ids restart at 0
+    /// every editor run — but a restored terminal keeps the backing path it
+    /// was saved with while taking a fresh id. Restore a workspace whose
+    /// terminals were saved as `…-1` / `…-2` and the ids handed out are 0 / 1,
+    /// so the next terminal the user opens is offered `…-1` — a file another,
+    /// still-running terminal owns. Both would then stream into one file and
+    /// the new terminal's scroll-back would show the other's history
+    /// (fresh#2836). A `-<n>` disambiguator keeps them apart; the workspace
+    /// persists the resolved path, so the name never has to be re-derivable.
+    ///
+    /// A stem left behind by a terminal that is *not* live (an earlier run, a
+    /// crash) is reused as-is: the spawn opens it [`BackingMode::Fresh`] and
+    /// truncates, so no stale scrollback survives and the files don't pile up.
+    fn free_terminal_file_stem(
+        &self,
+        terminal_root: &std::path::Path,
+        terminal_id: TerminalId,
+    ) -> String {
+        let base = format!("fresh-terminal-{}", terminal_id.0);
+        let taken = |stem: &str| {
+            let backing = terminal_root.join(format!("{stem}.txt"));
+            let log = terminal_root.join(format!("{stem}.log"));
+            self.terminal_backing_files
+                .values()
+                .chain(self.terminal_log_files.values())
+                .any(|p| *p == backing || *p == log)
+        };
+        if !taken(&base) {
+            return base;
+        }
+        // Bounded scan; the loop only runs while every candidate is owned by a
+        // live terminal, and a window can't hold that many.
+        (1..u32::MAX)
+            .map(|n| format!("{base}-{n}"))
+            .find(|stem| !taken(stem))
+            .unwrap_or(base)
+    }
+
     fn spawn_terminal_session_impl(
         &mut self,
         cwd: Option<PathBuf>,
@@ -312,7 +354,7 @@ impl Window {
         // to the same path.
         let predicted_terminal_id = self.terminal_manager.next_terminal_id();
         let name_stem = if persistent {
-            format!("fresh-terminal-{}", predicted_terminal_id.0)
+            self.free_terminal_file_stem(&terminal_root, predicted_terminal_id)
         } else {
             let nanos = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -354,21 +396,22 @@ impl Window {
             rows,
             Some(working_dir),
             Some(log_path.clone()),
-            Some(backing_path),
+            Some(backing_path.clone()),
+            // A brand-new terminal: its transcripts start empty even if an
+            // earlier run left files on these paths.
+            crate::services::terminal::BackingMode::Fresh,
             wrapper,
             env_delta,
             extra_env,
         ) {
             Ok(terminal_id) => {
                 self.terminal_log_files.insert(terminal_id, log_path);
-                // If the actual terminal id differs from the predicted
-                // one, move the backing-file entry to the real id and
-                // rename to the persistent (no-eph-suffix) form. This
-                // mirrors the pre-migration behaviour exactly.
+                // If the actual terminal id differs from the predicted one,
+                // re-key the backing entry onto the real id — keeping the
+                // *same* path, which is the one the manager's reader thread
+                // is already streaming into.
                 if terminal_id != predicted_terminal_id {
                     self.terminal_backing_files.remove(&predicted_terminal_id);
-                    let backing_path =
-                        terminal_root.join(format!("fresh-terminal-{}.txt", terminal_id.0));
                     self.terminal_backing_files
                         .insert(terminal_id, backing_path);
                 }
@@ -409,7 +452,8 @@ impl Window {
                 if let Err(e) = terminal_backing_fs().create_dir_all(&root) {
                     tracing::warn!("Failed to create terminal directory: {}", e);
                 }
-                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
+                let stem = self.free_terminal_file_stem(&root, terminal_id);
+                root.join(format!("{stem}.txt"))
             });
 
         // Ensure the file exists — but DON'T truncate if it already has
@@ -921,7 +965,8 @@ impl Window {
                 if let Err(e) = terminal_backing_fs().create_dir_all(&root) {
                     tracing::warn!("Failed to create terminal directory: {}", e);
                 }
-                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
+                let stem = self.free_terminal_file_stem(&root, terminal_id);
+                root.join(format!("{stem}.txt"))
             });
 
         if !terminal_backing_fs().exists(&backing_file) {
@@ -1099,6 +1144,9 @@ impl Window {
             spec.cwd,
             spec.log_path.clone(),
             spec.backing_path.clone(),
+            // Same terminal reborn: append to its existing transcript rather
+            // than blanking the scrollback the user still has on screen.
+            crate::services::terminal::BackingMode::Continue,
             wrapper,
             env_delta,
             HashMap::new(),

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -888,6 +888,9 @@ impl crate::app::window::Window {
             terminal.cwd.clone(),
             Some(log_path.clone()),
             Some(backing_path.clone()),
+            // Restore: this terminal's own saved transcript — keep streaming
+            // into it so the restored buffer keeps its scrollback.
+            crate::services::terminal::BackingMode::Continue,
             wrapper_for_spawn,
             env_delta,
             std::collections::HashMap::new(),

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -555,6 +555,24 @@ impl Editor {
             self.windows.insert(id, built);
         }
 
+        // Active-window only: the restored active buffer never went through a
+        // focus path, so nothing has derived the terminal live/scrollback
+        // state from it. A restored terminal is created live (empty scrollback
+        // set), but `key_context` is still `Normal` and the buffer still
+        // loads editing-disabled — so without this it comes up *focused but
+        // inert*: keys don't reach the PTY and the pane shows the static
+        // backing-file view instead of the live grid. With a quiet shell that
+        // is invisible (the first keystroke, or output plus
+        // `jump_to_end_on_output`, flips it live); with a terminal that prints
+        // on its own — an agent, a `tail -f`, anything with a clock — the
+        // restored pane just sits there frozen. Deriving the flags here is the
+        // same move the remote-reconnect respawn makes for the same reason.
+        // A restored *exited* terminal is not a terminal buffer (the exit path
+        // drops the binding), so this correctly leaves it read-only.
+        if id == self.active_window {
+            self.sync_terminal_mode_to_active_buffer();
+        }
+
         // Active-window only: refresh the plugin snapshot and fire
         // buffer_activated for the restored active buffer. Background
         // (inactive) window restores must NOT fire these focus effects.

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -32,6 +32,27 @@ use std::thread;
 
 pub use fresh_core::TerminalId;
 
+/// What a spawning terminal should do with the on-disk transcripts (rendered
+/// scrollback + raw PTY log) it is handed.
+///
+/// The distinction is the difference between "this terminal *is* the one that
+/// wrote that file" and "that file just happens to sit on this path". Terminal
+/// files are named after the terminal id, and ids restart at 0 every editor
+/// run, so a brand-new terminal is regularly handed a path a *different*
+/// terminal wrote in a previous run (or, after a restore, is still writing —
+/// restored terminals keep their old paths under new ids). Inferring "append
+/// and seed the history" from "the file is non-empty" made that a scrollback
+/// leak between unrelated terminals (fresh#2836); the intent is now explicit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackingMode {
+    /// A new terminal: start its transcripts from empty, discarding whatever
+    /// an earlier terminal left on those paths.
+    Fresh,
+    /// The same terminal continuing (workspace restore, respawn after exit):
+    /// append to its transcripts and treat what's there as its own history.
+    Continue,
+}
+
 /// Messages sent to terminal I/O thread
 enum TerminalCommand {
     /// Write data to PTY
@@ -304,6 +325,8 @@ impl TerminalManager {
     /// * `cwd` - Optional working directory (defaults to current directory)
     /// * `log_path` - Optional path for raw PTY log (for session restore)
     /// * `backing_path` - Optional path for rendered scrollback (incremental streaming)
+    /// * `backing_mode` - Whether this terminal *continues* the transcript
+    ///   already in those files (restore / respawn) or starts a new one
     ///
     /// # Returns
     /// The terminal ID if successful
@@ -315,6 +338,7 @@ impl TerminalManager {
         cwd: Option<std::path::PathBuf>,
         log_path: Option<std::path::PathBuf>,
         backing_path: Option<std::path::PathBuf>,
+        backing_mode: BackingMode,
         terminal_wrapper: crate::services::authority::TerminalWrapper,
         env_delta: crate::services::env_provider::EnvDelta,
         extra_env: HashMap<String, String>,
@@ -329,6 +353,7 @@ impl TerminalManager {
             cwd,
             log_path,
             backing_path,
+            backing_mode,
             terminal_wrapper,
             env_delta,
             extra_env,
@@ -354,6 +379,7 @@ impl TerminalManager {
         cwd: Option<std::path::PathBuf>,
         log_path: Option<std::path::PathBuf>,
         backing_path: Option<std::path::PathBuf>,
+        backing_mode: BackingMode,
         terminal_wrapper: TerminalWrapper,
         env_delta: crate::services::env_provider::EnvDelta,
         extra_env: HashMap<String, String>,
@@ -381,9 +407,13 @@ impl TerminalManager {
 
         let state = Arc::new(Mutex::new(TerminalState::new(cols, rows)));
 
-        // If the backing file already exists (session restore), seed the history
-        // end so entering terminal mode doesn't truncate it to 0.
-        if let Some(p) = backing_path.as_ref() {
+        // A *continuing* terminal (workspace restore, respawn after exit) picks
+        // up the transcript already in its backing file: seed the history end
+        // so entering terminal mode doesn't truncate it to 0. A `Fresh`
+        // terminal never does — whatever is on that path belongs to some
+        // earlier terminal, and inheriting it would show one terminal's
+        // scrollback in another (fresh#2836).
+        if let (BackingMode::Continue, Some(p)) = (backing_mode, backing_path.as_ref()) {
             if let Ok(metadata) = std::fs::metadata(p) {
                 if metadata.len() > 0 {
                     if let Ok(mut s) = state.lock() {
@@ -405,8 +435,8 @@ impl TerminalManager {
             .try_clone_reader()
             .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
 
-        let log_writer = open_log_writer(log_path.as_deref());
-        let backing_writer = open_backing_writer(backing_path.as_deref());
+        let log_writer = open_log_writer(log_path.as_deref(), backing_mode);
+        let backing_writer = open_backing_writer(backing_path.as_deref(), backing_mode);
 
         // Tag output/exit with the owning window so the main loop never has to
         // guess which session a `Terminal-N` belongs to (ids collide across
@@ -651,47 +681,40 @@ fn build_shell_command(
     (cmd, shell)
 }
 
-/// Open the optional raw-PTY log file (append mode) for full-session capture.
+/// Open the optional raw-PTY log file for full-session capture. `Continue`
+/// appends to the existing capture; `Fresh` truncates (see [`BackingMode`]).
 fn open_log_writer(
     log_path: Option<&std::path::Path>,
+    mode: BackingMode,
 ) -> Option<std::io::BufWriter<std::fs::File>> {
-    log_path
-        .and_then(|p| {
-            std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(p)
-                .ok()
-        })
-        .map(std::io::BufWriter::new)
+    log_path.and_then(|p| open_transcript_file(p, mode))
 }
 
-/// Open the optional scrollback backing file. On session restore (the file
-/// already has content) we append to continue streaming; otherwise we truncate
-/// to start fresh.
+/// Open the optional scrollback backing file. `Continue` (workspace restore,
+/// respawn after exit) appends so the transcript keeps streaming where it left
+/// off; `Fresh` truncates so a new terminal never starts on top of another
+/// terminal's scrollback.
 fn open_backing_writer(
     backing_path: Option<&std::path::Path>,
+    mode: BackingMode,
 ) -> Option<std::io::BufWriter<std::fs::File>> {
-    backing_path
-        .and_then(|p| {
-            let existing_has_content =
-                p.exists() && std::fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false);
-            if existing_has_content {
-                std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(p)
-                    .ok()
-            } else {
-                std::fs::OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .open(p)
-                    .ok()
-            }
-        })
-        .map(std::io::BufWriter::new)
+    backing_path.and_then(|p| open_transcript_file(p, mode))
+}
+
+/// Shared open for the two on-disk transcripts (raw log, rendered scrollback):
+/// append when continuing an existing terminal's story, truncate when starting
+/// a new one.
+fn open_transcript_file(
+    path: &std::path::Path,
+    mode: BackingMode,
+) -> Option<std::io::BufWriter<std::fs::File>> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true);
+    match mode {
+        BackingMode::Continue => options.append(true),
+        BackingMode::Fresh => options.write(true).truncate(true),
+    };
+    options.open(path).ok().map(std::io::BufWriter::new)
 }
 
 /// Wait-thread body: block on the child's exit and fire `TerminalExited` once.

--- a/crates/fresh-editor/src/services/terminal/mod.rs
+++ b/crates/fresh-editor/src/services/terminal/mod.rs
@@ -54,7 +54,7 @@ pub mod term;
 #[cfg(windows)]
 pub mod windows_shell;
 
-pub use manager::{detect_shell, TerminalId, TerminalManager};
+pub use manager::{detect_shell, BackingMode, TerminalId, TerminalManager};
 pub use term::{PrependedHead, TerminalCell, TerminalState};
 #[cfg(windows)]
 pub use windows_shell::set_skip_app_execution_alias;

--- a/crates/fresh-editor/tests/e2e/restored_terminal_dock_activation.rs
+++ b/crates/fresh-editor/tests/e2e/restored_terminal_dock_activation.rs
@@ -117,9 +117,9 @@ fn test_switching_into_restored_terminal_window_activates_it() {
     }
 
     // ---- Session 2: restart; the session comes back with the terminal as
-    // its active buffer, restored read-only. Diving *away* to another window
-    // and back is the dock's window-switch — it must re-activate the
-    // terminal. ----
+    // its active buffer. Diving *away* to another window and back is the
+    // dock's window-switch — it must land on a live terminal, never on the
+    // stale read-only scrollback view. ----
     {
         let mut harness = EditorTestHarness::create(
             120,
@@ -143,13 +143,18 @@ fn test_switching_into_restored_terminal_window_activates_it() {
             "restored session should come back with its terminal as the \
              active buffer"
         );
-        // Precondition: the restored terminal starts read-only (scrollback),
-        // exactly the state the dive must wake. If this ever changes, the
-        // dive-back below would no longer exercise the transition.
+        // A restored terminal that is the *focused* buffer now comes back
+        // live: the restore derives the terminal flags from its active buffer
+        // rather than leaving it focused-but-inert (#2828). It used to start
+        // read-only here, which is the state this test's dive was written to
+        // wake — the dive still has to be right, because the dock's real
+        // target is a *background* window, whose lazy materialization inside
+        // `set_active_window` restores it while it is not yet the active
+        // window and so never runs that derivation. Diving in is the only
+        // thing that can activate that terminal.
         assert!(
-            !harness.editor().is_terminal_mode(),
-            "a restored terminal starts in read-only scrollback, not \
-             terminal mode"
+            harness.editor().is_terminal_mode(),
+            "a restored, focused terminal must come back live (#2828)"
         );
 
         // A second, non-terminal window to switch to — the "other session"

--- a/crates/fresh-editor/tests/terminal_restore_live.rs
+++ b/crates/fresh-editor/tests/terminal_restore_live.rs
@@ -1,0 +1,131 @@
+//! Regression: a terminal restored from the workspace must come back *live*,
+//! not focused-but-inert (fresh#2836).
+//!
+//! Restore creates the terminal buffer live (empty per-split scrollback set)
+//! and makes it the active buffer — but nothing on that path ever derives the
+//! terminal flags from it, the way every focus path does. So `key_context`
+//! stayed `Normal` and the buffer stayed editing-disabled: keys did not reach
+//! the PTY and the pane rendered the static backing-file view instead of the
+//! live grid.
+//!
+//! It hid easily. Typing flips a terminal live on the first keystroke, and
+//! with `jump_to_end_on_output` (on by default) the shell's own prompt output
+//! jumps the buffer back to live — so a quiet `bash` looks fine. Point a
+//! terminal at something that prints on its own (an agent, `tail -f`, a clock)
+//! and the restored pane just sits there frozen while its process runs.
+//!
+//! Asserted here at the state level, since "the pane stopped repainting" is
+//! what the user sees but not what the editor can be asked: after a restore,
+//! the focused terminal must be live and its buffer must accept input.
+//!
+//! Own integration binary because it sets the process-global `XDG_DATA_HOME`
+//! to isolate workspace persistence; Linux-gated for the same reason as
+//! `orchestrator_co_tenant_restore.rs`. Skips when there is no PTY.
+#![cfg(target_os = "linux")]
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::input::keybindings::KeyContext;
+use fresh::model::filesystem::StdFileSystem;
+use std::path::Path;
+use std::sync::Arc;
+
+fn isolated_dir_context(base: &Path) -> DirectoryContext {
+    let xdg_data = base.join("xdg-data");
+    std::fs::create_dir_all(&xdg_data).unwrap();
+    std::env::set_var("XDG_DATA_HOME", &xdg_data);
+    DirectoryContext {
+        data_dir: xdg_data.join("fresh"),
+        config_dir: base.join("config"),
+        home_dir: Some(base.join("home")),
+        documents_dir: None,
+        downloads_dir: None,
+    }
+}
+
+fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Editor {
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project.to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap()
+}
+
+fn pty_available() -> bool {
+    use portable_pty::{native_pty_system, PtySize};
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+#[test]
+fn a_restored_terminal_comes_back_live() {
+    if !pty_available() {
+        eprintln!("Skipping: no PTY available in this environment");
+        return;
+    }
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(sandbox.path());
+    let project = sandbox.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+
+    // Session 1: a terminal is open and focused when the editor quits.
+    {
+        let mut e1 = editor_in(&project, &dir_context);
+        e1.open_terminal();
+        assert!(
+            e1.active_window().focused_terminal_live(),
+            "sanity: a freshly opened terminal is live"
+        );
+        e1.save_workspace().unwrap();
+    }
+
+    // Session 2: cold reboot. Nothing is typed and no key is sent — exactly
+    // what the user sees on relaunch.
+    let mut e2 = editor_in(&project, &dir_context);
+    e2.restore_active_window_on_launch(false).unwrap();
+
+    let buffer_id = e2.active_buffer();
+    assert!(
+        e2.active_window().is_terminal_buffer(buffer_id),
+        "sanity: the restored workspace focuses its terminal"
+    );
+    assert!(
+        e2.active_window().focused_terminal_live(),
+        "a restored terminal must come back live, not stranded in read-only \
+         scrollback with its process running unseen"
+    );
+    assert_eq!(
+        e2.active_window().key_context,
+        KeyContext::Terminal,
+        "keys must route to the restored terminal's PTY without a wake-up \
+         keystroke first"
+    );
+    assert!(
+        !e2.active_window().is_editing_disabled(),
+        "the restored terminal's buffer must not still be editing-disabled: \
+         that is the read-only scrollback view, not the live grid"
+    );
+}

--- a/crates/fresh-editor/tests/terminal_scrollback_isolation.rs
+++ b/crates/fresh-editor/tests/terminal_scrollback_isolation.rs
@@ -1,0 +1,199 @@
+//! Regression: a brand-new terminal must never come up showing some *other*
+//! terminal's scrollback (fresh#2836).
+//!
+//! Terminal transcripts live in `fresh-terminal-<id>.{txt,log}`, named after a
+//! terminal id that restarts at 0 every editor run — while the files (and the
+//! workspace entries pointing at them) outlive the run that wrote them. The
+//! spawn path used to infer "this is a restore, append and seed the history
+//! end" from nothing more than "that file already has bytes", so two unrelated
+//! terminals could end up sharing one transcript:
+//!
+//!   * **Restore.** A restored terminal keeps the backing path it was saved
+//!     with but takes a *fresh* id. Restore a workspace whose surviving
+//!     terminal was saved as `…-1`, and it comes back as id 0 — so the next
+//!     terminal the user opens is handed id 1, i.e. the path the restored
+//!     terminal is still streaming into. Scroll up in the new terminal and the
+//!     old one's history is there.
+//!   * **Leftovers.** A run that ended without closing its terminals (a crash,
+//!     a kill) leaves `…-0.txt` on disk. The next run's first terminal is
+//!     offered that same path and inherits a dead session's scrollback.
+//!
+//! Both are covered below. The fix is two-part and both halves are asserted:
+//! a new terminal never gets a path a *live* terminal owns, and a new terminal
+//! opens its transcript `BackingMode::Fresh` (truncating) so leftovers can't
+//! survive into it.
+//!
+//! Own integration binary because it sets the process-global `XDG_DATA_HOME`
+//! to isolate workspace persistence; Linux-gated for the same reason as
+//! `orchestrator_co_tenant_restore.rs` (`dirs::data_dir()` ignores
+//! `XDG_DATA_HOME` elsewhere). Skips when the environment has no PTY.
+#![cfg(target_os = "linux")]
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::model::filesystem::StdFileSystem;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Isolate all editor persistence (workspaces, terminal transcripts) into
+/// `base`, with the returned context's `data_dir` pointing at the same tree
+/// the editor's own boot discovery will read.
+fn isolated_dir_context(base: &Path) -> DirectoryContext {
+    let xdg_data = base.join("xdg-data");
+    std::fs::create_dir_all(&xdg_data).unwrap();
+    std::env::set_var("XDG_DATA_HOME", &xdg_data);
+    DirectoryContext {
+        data_dir: xdg_data.join("fresh"),
+        config_dir: base.join("config"),
+        home_dir: Some(base.join("home")),
+        documents_dir: None,
+        downloads_dir: None,
+    }
+}
+
+fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Editor {
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project.to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap()
+}
+
+fn pty_available() -> bool {
+    use portable_pty::{native_pty_system, PtySize};
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// The backing (rendered-scrollback) file of the terminal in the editor's
+/// currently active buffer.
+fn active_terminal_backing(editor: &fresh::app::Editor) -> PathBuf {
+    let buffer_id = editor.active_buffer();
+    let window = editor.active_window();
+    let terminal_id = window
+        .get_terminal_id(buffer_id)
+        .expect("active buffer must be a terminal buffer");
+    window
+        .terminal_backing_files
+        .get(&terminal_id)
+        .cloned()
+        .expect("a spawned terminal must have a backing file")
+}
+
+fn read_to_string(path: &Path) -> String {
+    std::fs::read(path)
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_default()
+}
+
+/// Both scenarios run from one `#[test]`: each sets the process-global
+/// `XDG_DATA_HOME`, so running them as separate (concurrent) test functions
+/// would let one scenario's sandbox move out from under the other's
+/// workspace save.
+#[test]
+fn a_new_terminal_never_shows_another_terminals_scrollback() {
+    if !pty_available() {
+        eprintln!("Skipping: no PTY available in this environment");
+        return;
+    }
+    new_terminal_does_not_adopt_a_restored_terminal_transcript();
+    new_terminal_discards_a_leftover_transcript_on_its_path();
+}
+
+fn new_terminal_does_not_adopt_a_restored_terminal_transcript() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(sandbox.path());
+    let project = sandbox.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+
+    // Session 1: two terminals, then close the first. What survives to the
+    // workspace is the *second* one — the one holding `…-1`.
+    {
+        let mut e1 = editor_in(&project, &dir_context);
+        e1.open_terminal();
+        let first_terminal_buffer = e1.active_buffer();
+        e1.open_terminal();
+        e1.force_close_buffer(first_terminal_buffer).unwrap();
+        e1.save_workspace().unwrap();
+    }
+
+    // Session 2: cold reboot. The survivor restores under a *new* id while
+    // keeping its saved path. Plant a marker in that transcript standing in
+    // for the history the user still has in their scroll-back.
+    let mut e2 = editor_in(&project, &dir_context);
+    e2.restore_active_window_on_launch(false).unwrap();
+    let restored_backing = active_terminal_backing(&e2);
+    const MARKER: &str = "RESTORED_TERMINAL_HISTORY";
+    std::fs::write(&restored_backing, format!("{MARKER}\n")).unwrap();
+
+    // …and now the user opens a brand-new terminal.
+    e2.open_terminal();
+    let new_backing = active_terminal_backing(&e2);
+
+    assert_ne!(
+        new_backing, restored_backing,
+        "a new terminal must not be handed the transcript a live (restored) \
+         terminal is still writing to"
+    );
+    assert!(
+        !read_to_string(&new_backing).contains(MARKER),
+        "the new terminal's scroll-back must not contain the restored \
+         terminal's history; got: {:?}",
+        read_to_string(&new_backing)
+    );
+    // The restored terminal keeps its own history — the fix must not have
+    // moved *it* off its file either.
+    assert!(
+        read_to_string(&restored_backing).contains(MARKER),
+        "the restored terminal must keep streaming into its own transcript"
+    );
+}
+
+fn new_terminal_discards_a_leftover_transcript_on_its_path() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(sandbox.path());
+    let project = sandbox.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+
+    // A previous run died without closing its terminal, leaving a transcript
+    // on the path this run's first terminal will be offered.
+    const MARKER: &str = "DEAD_SESSION_HISTORY";
+    let terminal_root = dir_context.terminal_dir_for(&project);
+    std::fs::create_dir_all(&terminal_root).unwrap();
+    let leftover = terminal_root.join("fresh-terminal-0.txt");
+    std::fs::write(&leftover, format!("{MARKER}\n")).unwrap();
+
+    let mut editor = editor_in(&project, &dir_context);
+    editor.open_terminal();
+    let backing = active_terminal_backing(&editor);
+
+    assert!(
+        !read_to_string(&backing).contains(MARKER),
+        "a new terminal must start from an empty transcript, not inherit the \
+         one a dead session left on its path; got: {:?}",
+        read_to_string(&backing)
+    );
+}


### PR DESCRIPTION
Fixes both halves of #2828.

## 1. A brand-new terminal shows a previous terminal's history

Open a terminal, use it, quit, relaunch, open a brand-new terminal — scrolling up shows the *previous* terminal's history.

Terminal transcripts are named after the terminal id (`fresh-terminal-<id>.{txt,log}`), and ids restart at 0 every editor run, while the files outlive the run that wrote them. The spawn path inferred *"this is a restore: append, and seed the scrollback history end"* from nothing more than *"that file already has bytes"*, so two unrelated terminals could end up sharing one transcript:

- **Restore.** A restored terminal keeps the backing path it was saved with but takes a *fresh* id. Restore a workspace whose surviving terminal was saved as `…-1` and it comes back as id 0 — so the next terminal the user opens is handed id 1, i.e. the path the restored terminal is still streaming into. Both then write one file, and the new terminal's scroll-back opens on the other's history.
- **Leftovers.** A run that ended without closing its terminals (crash, kill) leaves `…-0.txt` behind; the next run's first terminal is offered that same path and inherits a dead session's scrollback.

**Fix.** `BackingMode` makes the intent explicit at the spawn boundary: `Continue` (workspace restore, respawn-after-exit) appends and seeds the history end exactly as before; `Fresh` (a new terminal) truncates, so nothing an earlier run left on the path survives into it. The raw PTY log follows the same rule. On top of that, a new persistent terminal never takes a stem a *live* terminal in the window already owns, falling back to `fresh-terminal-<id>-<n>`; the workspace persists the resolved path, so the name doesn't have to be re-derivable from the id. A stem with no live owner is still reused — `Fresh` truncates it — so stale files get recycled rather than piling up.

Also stops the id-mismatch fixup in `spawn_terminal_session_impl` from re-deriving a *different* backing path than the one the manager's reader thread was handed.

## 2. A restored terminal is focused but frozen

Relaunch with a terminal open and the restored pane is the focused tab — but frozen: it renders a static snapshot of the backing file while its process runs on unseen, and keys don't reach the PTY until something wakes it.

Restore creates the terminal buffer live (empty per-split scrollback set) and makes it the active buffer, but it gets there by writing the split's buffer directly — no focus path runs, so nothing derives the terminal flags from the new active buffer. `key_context` stays `Normal` and the buffer stays editing-disabled, which *is* the read-only scroll-back state. `complete_terminal_mode_side_effects` can't rescue it either: it is gated on `focused_terminal_live()`, i.e. on the very `key_context` nothing has set.

**Fix.** Derive the flags once at the end of the active window's restore — the same move `respawn_terminals_through_authority` already makes after a remote reconnect, for the same reason. A restored *exited* terminal is not a terminal buffer (the exit path drops the binding), so it correctly stays read-only.

This one hid behind two effects that quietly flip a terminal live: the first keystroke, and — with the default `jump_to_end_on_output` — the shell's own prompt output. A quiet `bash`, or any check that types first, looks fine.

## Reproduction

Both were reproduced interactively under tmux before any code was touched.

**#1** — two dock terminals (`AAA_MARKER` / `BBB_MARKER` + `seq 1 60`), close the first, quit, relaunch, open a brand-new terminal: `Ctrl+Space` + `Ctrl+Home` showed `BBB_MARKER` and its output, with both terminals streaming into one `fresh-terminal-1.txt`. After the fix the new terminal lands on `fresh-terminal-1-1.txt` and its scroll-back holds only its own prompt, while the restored terminal keeps its history. The crash-leftover variant (SIGKILL, relaunch) was reproduced and re-checked the same way.

**#2** — `terminal.shell` pointed at a script that prints `TICK <time>` every second, plus `jump_to_end_on_output: false` to remove the masking effect. Quit, relaunch, touch nothing: the pane stayed frozen on `TICK 4` for 12s while `fresh-terminal-0.log` kept growing. After the fix the restored pane keeps ticking with no keystroke (`TICK 6` → `TICK 12` → `TICK 18` over three 6-second samples), and a single `Ctrl+Space` probe reports *"Terminal mode disabled — read only"*, i.e. it had been live.

## Tests

- `terminal_scrollback_isolation.rs` — two terminals → close one → save → cold reboot → restore → open a new terminal: its transcript must be a different file, must not contain the restored terminal's history, and the restored terminal must keep its own. Second scenario covers the crash-leftover path.
- `terminal_restore_live.rs` — after a restore with no keystrokes: focused terminal live, key context `Terminal`, buffer not editing-disabled. Asserted at state level because "the pane stopped repainting" isn't something the editor can be asked.

Every assertion was checked to fail on the pre-fix code (by stashing the `src/` changes) and pass with it. `workspace_virtual_buffer_clobber` and `remote_terminal_backing_local` re-run green.