### PR TITLE
test(review-diff): de-flake line-staging cursor navigation

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -83,40 +83,68 @@ fn status_line_number(harness: &EditorTestHarness) -> Option<usize> {
     None
 }
 
-/// Find the diff-buffer line number whose rendered center-panel row contains
-/// `needle`. The center diff panel starts at a fixed screen row, so the
-/// buffer line is `screen_row - CENTER_FIRST_ROW + 1`.
+/// The diff-buffer line whose rendered center-panel row contains `needle`, or
+/// `None` if no visible center-panel row does. The center diff panel starts at
+/// a fixed screen row, so the buffer line is `screen_row - CENTER_FIRST_ROW + 1`
+/// (both this and `status_line_number` are read in the same buffer-line space,
+/// which is what lets `move_cursor_onto` converge the caret onto the needle).
 const CENTER_FIRST_ROW: usize = 7;
-fn diff_line_of(harness: &mut EditorTestHarness, needle: &str) -> usize {
-    harness.render().unwrap();
-    let screen = harness.screen_to_string();
-    for (row, line) in screen.lines().enumerate() {
+fn screen_row_of(harness: &EditorTestHarness, needle: &str) -> Option<usize> {
+    for (row, line) in harness.screen_to_string().lines().enumerate() {
         if row >= CENTER_FIRST_ROW && line.contains(needle) {
-            return row - CENTER_FIRST_ROW + 1;
+            return Some(row - CENTER_FIRST_ROW + 1);
+        }
+    }
+    None
+}
+
+/// Move the diff cursor onto the row that renders `needle`.
+///
+/// Self-correcting and bounded. Each iteration re-reads the caret's line
+/// (`status_line_number`) and the needle's current line (`screen_row_of`) from
+/// the *same* frame and takes a single step toward it — in *either* direction.
+/// Re-deriving the target every step is what makes this robust to the async,
+/// multi-phase hunk-jump/focus repaint: a mid-reflow frame can at worst cost
+/// one corrective step, never strand the cursor. `send_key` moves the caret
+/// synchronously and renders, so no per-step `wait_until` is needed.
+///
+/// The loop is bounded so a needle that never lines up (e.g. a genuine mapping
+/// regression) fails fast with the screen for triage, instead of hanging an
+/// indefinite wait until nextest's external 180s timeout (CONTRIBUTING.md §3
+/// semantic waiting, §16 don't hide a wrong state behind an unbounded wait).
+///
+/// Replaces the old down-only `move_cursor_to_line`, which pressed Down forever
+/// — hanging to the external timeout — whenever the target was mis-derived
+/// above the cursor or the caret was already past it.
+fn move_cursor_onto(harness: &mut EditorTestHarness, needle: &str) {
+    // These diff buffers are a handful of lines; the cap is generous and only
+    // reached on genuine failure. Each step is one synchronous key + render.
+    const MAX_STEPS: usize = 300;
+    for _ in 0..MAX_STEPS {
+        match (status_line_number(harness), screen_row_of(harness, needle)) {
+            (Some(current), Some(target)) if current == target => return,
+            (Some(current), Some(target)) => {
+                let key = if current < target {
+                    KeyCode::Down
+                } else {
+                    KeyCode::Up
+                };
+                harness.send_key(key, KeyModifiers::NONE).unwrap();
+            }
+            // Needle not visible yet, or no `Ln` indicator this frame (the focus
+            // repaint is still settling). Pump one tick and re-read without
+            // moving, so we don't chase a target that hasn't rendered.
+            _ => harness.tick_and_render().unwrap(),
         }
     }
     panic!(
-        "no center-panel row renders {:?}. Screen:\n{}",
-        needle, screen
+        "could not land the diff cursor on a row rendering {:?} within {} steps \
+         (caret at {:?}); screen:\n{}",
+        needle,
+        MAX_STEPS,
+        status_line_number(harness),
+        harness.screen_to_string()
     );
-}
-
-/// Step the diff cursor down one row at a time until the status bar reports
-/// `target`. Each Down is followed by a semantic wait for the reported line to
-/// change, rather than spinning on a fixed render budget (CONTRIBUTING.md:
-/// "use semantic waiting, not timers"). The cursor only moves downward here,
-/// so `target` must be at or below the current line.
-fn move_cursor_to_line(harness: &mut EditorTestHarness, target: usize) {
-    loop {
-        let current = status_line_number(harness);
-        if current == Some(target) {
-            return;
-        }
-        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-        harness
-            .wait_until(|h| status_line_number(h) != current)
-            .unwrap();
-    }
 }
 
 fn cached_diff(repo: &GitTestRepo) -> String {
@@ -135,19 +163,14 @@ fn test_review_visual_stage_single_added_line() {
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
 
-    // Jump to the hunk, then walk down onto the green "+extra line" row.
+    // Jump to the hunk, then walk onto the green "+extra line" row. Wait for the
+    // async focus repaint to first render the line; `move_cursor_onto` then
+    // self-corrects onto it even if the panel is still settling.
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Read the row→line mapping only from a converged frame — the async,
-    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
-    // cursor lands off "+extra line" and the wait below hangs until the
-    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
-    // state behind an unbounded wait).
     harness.wait_for_screen_contains("+extra line").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "+extra line");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "+extra line");
 
     // Start a visual selection and stage it.
     harness
@@ -191,13 +214,10 @@ fn test_review_visual_stage_modified_line_pair() {
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
     // Land on the removed "-beta" row, then visual-extend down over "+BETA".
-    // Read the row→line mapping only from a converged frame — the async,
-    // multi-phase hunk-jump repaint can otherwise mis-map the target and hang
-    // the wait below until the external timeout (CONTRIBUTING.md §3/§16).
+    // Wait for the async focus repaint to first render the line; the caret walk
+    // then self-corrects onto it even if the panel is still settling.
     harness.wait_for_screen_contains("-beta").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "-beta");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "-beta");
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
         .unwrap();
@@ -230,15 +250,10 @@ fn test_review_visual_discard_single_added_line() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Read the row→line mapping only from a converged frame — the async,
-    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
-    // cursor lands off "+extra line" and the wait below hangs until the
-    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
-    // state behind an unbounded wait).
+    // Wait for the async focus repaint to first render the line; the caret walk
+    // then self-corrects onto it even if the panel is still settling.
     harness.wait_for_screen_contains("+extra line").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "+extra line");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "+extra line");
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
         .unwrap();
@@ -273,15 +288,10 @@ fn test_review_visual_discard_status_is_localized() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Read the row→line mapping only from a converged frame — the async,
-    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
-    // cursor lands off "+extra line" and the wait below hangs until the
-    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
-    // state behind an unbounded wait).
+    // Wait for the async focus repaint to first render the line; the caret walk
+    // then self-corrects onto it even if the panel is still settling.
     harness.wait_for_screen_contains("+extra line").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "+extra line");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "+extra line");
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
         .unwrap();
@@ -365,19 +375,11 @@ fn test_review_visual_stage_only_selected_line_of_hunk() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // The hunk-jump repaint is async + multi-phase (focus mode paints the
-    // focused file's body, then the panel can still reflow). `diff_line_of`
-    // maps a *screen* row to a diff-buffer line against a fixed panel offset,
-    // so sampling a mid-reflow frame yields a wrong target: the cursor lands
-    // off `+ADD1`, `s` stages nothing, and the wait below hangs until the
-    // external timeout. Wait for the body to appear *and* for the async plugin
-    // pipeline to go quiet, so the row→line mapping is read from a converged
-    // frame (CONTRIBUTING.md §3 semantic waiting, §16 no wrong state behind an
-    // unbounded wait).
+    // Wait for the async focus repaint to first render the line; `move_cursor_onto`
+    // then self-corrects onto it even while the panel is still reflowing, so a
+    // mid-reflow frame can't strand the caret off `+ADD1`.
     harness.wait_for_screen_contains("+ADD1").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "+ADD1");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "+ADD1");
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
         .unwrap();
@@ -439,30 +441,14 @@ fn test_review_visual_stage_line_in_second_file() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Hunk navigation + focus-mode repaint are async *and multi-phase*: focus
-    // mode only paints the focused file's body, and after `+ADDED_B` first
-    // appears the plugin can still reflow the panel. `diff_line_of` maps a
-    // *screen* row to a diff-buffer line against a fixed panel offset
-    // (`CENTER_FIRST_ROW`), so sampling a mid-reflow frame yields a wrong target:
-    // the cursor lands off `+ADDED_B`, `s` stages nothing, and the wait below
-    // hangs until the external timeout. Wait for the body to appear *and* for the
-    // async plugin pipeline to go quiet, so the row→line mapping is read from a
-    // converged frame.
+    // Focus mode only paints the focused (second) file's body, and after
+    // `+ADDED_B` first appears the plugin can still reflow the panel. Wait for
+    // the line to render, then `move_cursor_onto` self-corrects the caret onto
+    // it across any remaining reflow — and panics with the screen if it can't,
+    // so a mapping regression is a clear diagnostic rather than the opaque 180s
+    // timeout this test used to hit (CONTRIBUTING.md §3/§16).
     harness.wait_for_screen_contains("+ADDED_B").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let bravo_added = diff_line_of(&mut harness, "+ADDED_B");
-    move_cursor_to_line(&mut harness, bravo_added);
-
-    // Fail fast if the cursor didn't land on the `+ADDED_B` row. Without this a
-    // mis-mapped target degrades into an opaque 180s timeout on the indefinite
-    // wait below instead of a clear diagnostic (CONTRIBUTING.md §16: don't let a
-    // wrong state hide behind an unbounded wait).
-    assert_eq!(
-        diff_line_of(&mut harness, "+ADDED_B"),
-        bravo_added,
-        "cursor line {bravo_added} must still map to the +ADDED_B row before staging; screen:\n{}",
-        harness.screen_to_string()
-    );
+    move_cursor_onto(&mut harness, "+ADDED_B");
 
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
@@ -507,15 +493,10 @@ fn test_review_visual_unstage_single_added_line() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    // Read the row→line mapping only from a converged frame — the async,
-    // multi-phase hunk-jump repaint can otherwise mis-map the target so the
-    // cursor lands off "+extra line" and the wait below hangs until the
-    // external timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong
-    // state behind an unbounded wait).
+    // Wait for the async focus repaint to first render the line; the caret walk
+    // then self-corrects onto it even if the panel is still settling.
     harness.wait_for_screen_contains("+extra line").unwrap();
-    harness.wait_for_async_quiescence(6).unwrap();
-    let target = diff_line_of(&mut harness, "+extra line");
-    move_cursor_to_line(&mut harness, target);
+    move_cursor_onto(&mut harness, "+extra line");
     harness
         .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
         .unwrap();


### PR DESCRIPTION
## Problem

The Review Diff line-staging e2e tests intermittently timed out at the external 180s slow-timeout under full-suite parallel load — most visibly `test_review_visual_stage_line_in_second_file`.

Two issues compounded:

1. **Target read from an unconverged frame.** The cursor target was computed from a single screen sample (`diff_line_of`, using a fixed `CENTER_FIRST_ROW` panel offset). The focus-mode hunk-jump repaint is async and multi-phase, so a mid-reflow sample yields a wrong target — especially for a *second* file, whose body is only painted after a focus switch.
2. **Down-only cursor walk that could never converge.** `move_cursor_to_line` only pressed `Down`. When the mis-derived target sat above the caret (or the caret was already past it), it pressed Down forever and its inner `wait_until(line changed)` never resolved once the caret reached the buffer end — hanging until nextest killed it at 180s.

## Fix

Replace both helpers with `move_cursor_onto(needle)`:

- **Self-correcting** — re-reads the caret line and the needle's line from the *same* frame every step, so a mid-reflow frame costs at most one corrective step instead of stranding the cursor.
- **Bidirectional** — moves `Up` or `Down` toward the target (the old one-way walk was the core hang).
- **Bounded** — caps the walk and panics *with the screen* on genuine failure, turning a mapping regression into a clear diagnostic rather than an opaque timeout (CONTRIBUTING.md §3 semantic waiting, §16 no wrong state behind an unbounded wait).

`send_key` moves the caret synchronously and renders, so no per-step wait is needed.

This is a **centralized** fix: all seven tests in the file shared the broken pattern and now route through the robust helper. Also drops the now-redundant `wait_for_async_quiescence` calls and the second file's `assert_eq!` re-mapping guard (the helper guarantees landing-or-panic).

## Verification

- `cargo check --test e2e_tests` — clean (the 2 warnings are pre-existing, in unrelated source files).
- Full module run — **7/7 pass** in 3.43s, no hangs.
- `test_review_visual_stage_line_in_second_file` stressed **15/15** consecutive runs — 0 failures.

## Not in scope

The sibling `test_review_visual_discard_status_is_localized` still uses a fixed-timer `for _ in 0..120 { sleep(20ms) }` loop — a separate CONTRIBUTING §3 concern, not the timeout addressed here. Left untouched to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2CxsrsS4J8Gzg9oLz3dJS)_