### PR TITLE
fix(input): keypresses acted twice, and reached embedded terminals with modifiers missing

### DIFF
--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -304,10 +304,11 @@ impl Editor {
     ///
     /// Returns whether the editor wants the next frame redrawn.
     pub fn handle_input_event(&mut self, event: crossterm::event::Event) -> anyhow::Result<bool> {
-        use crossterm::event::{Event as Ev, KeyEventKind};
+        use crate::input::is_keystroke;
+        use crossterm::event::Event as Ev;
 
         match event {
-            Ev::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+            Ev::Key(key_event) if is_keystroke(key_event.kind) => {
                 let key_code = format!("{:?}", key_event.code);
                 let modifiers = format!("{:?}", key_event.modifiers);
                 self.active_window_mut()

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -241,11 +241,12 @@ impl Editor {
     /// every event loop (the local terminal loop in `main.rs` and the daemon
     /// server loop) shares one dismissal path rather than duplicating it.
     pub fn maybe_dismiss_wave_animation(&mut self, event: &crossterm::event::Event) -> bool {
-        use crossterm::event::{Event, KeyEventKind};
+        use crate::input::is_keystroke;
+        use crossterm::event::Event;
         if !self.wave_animation_active() {
             return false;
         }
-        let dismiss = matches!(event, Event::Key(k) if k.kind == KeyEventKind::Press)
+        let dismiss = matches!(event, Event::Key(k) if is_keystroke(k.kind))
             || matches!(event, Event::Mouse(_));
         if dismiss {
             self.cancel_wave_animation();

--- a/crates/fresh-editor/src/input/mod.rs
+++ b/crates/fresh-editor/src/input/mod.rs
@@ -2,6 +2,24 @@
 //!
 //! This module handles the input-to-action-to-event translation.
 
+/// Whether a key event is a keystroke the editor should act on.
+///
+/// A terminal that is not reporting event types only ever sends presses, so
+/// this is normally trivially true. With the kitty keyboard protocol's
+/// event-type reporting on (`keyboard_report_event_types`), one physical
+/// keystroke instead produces a press, a repeat per auto-repeat tick while the
+/// key is held, and a release. Presses and repeats are keystrokes; a release is
+/// not — acting on it runs every key twice (sinelaw/fresh#2796), and ignoring
+/// repeats would stop held keys from repeating.
+///
+/// This is the single gate for that distinction: every raw-event entry point
+/// (the local event loop, the session server, the editor's own dispatch) must
+/// go through it rather than comparing against `Press` directly.
+pub fn is_keystroke(kind: crossterm::event::KeyEventKind) -> bool {
+    use crossterm::event::KeyEventKind;
+    matches!(kind, KeyEventKind::Press | KeyEventKind::Repeat)
+}
+
 pub mod actions;
 pub mod buffer_mode;
 pub mod command_registry;

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -7,9 +7,7 @@ use windows_sys::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
 
 use anyhow::{Context, Result as AnyhowResult};
 use clap::{CommandFactory, FromArgMatches, Parser};
-use crossterm::event::{
-    poll as event_poll, read as event_read, Event as CrosstermEvent, KeyEventKind,
-};
+use crossterm::event::{poll as event_poll, read as event_read, Event as CrosstermEvent};
 use fresh::input::key_translator::KeyTranslator;
 #[cfg(target_os = "linux")]
 use fresh::services::gpm::{gpm_to_crossterm, GpmClient};
@@ -5088,7 +5086,7 @@ where
         // This is essential for diagnosing terminal keybinding issues
         if editor.active_window().is_event_debug_active() {
             if let CrosstermEvent::Key(key_event) = event {
-                if key_event.kind == KeyEventKind::Press {
+                if fresh::input::is_keystroke(key_event.kind) {
                     editor
                         .active_window_mut()
                         .handle_event_debug_input(&key_event);
@@ -5105,7 +5103,7 @@ where
         // tracing spans + key-translation that depend on
         // event-loop-local state.
         let _span = match &event {
-            CrosstermEvent::Key(key_event) if key_event.kind == KeyEventKind::Press => Some(
+            CrosstermEvent::Key(key_event) if fresh::input::is_keystroke(key_event.kind) => Some(
                 tracing::trace_span!(
                     "handle_key",
                     code = ?key_event.code,

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crossterm::event::{Event, KeyEventKind};
+use crossterm::event::Event;
 use ratatui::Terminal;
 
 use crate::app::Editor;
@@ -1498,7 +1498,7 @@ impl EditorServer {
 
         match event {
             Event::Key(key_event) => {
-                if key_event.kind == KeyEventKind::Press {
+                if crate::input::is_keystroke(key_event.kind) {
                     editor
                         .handle_key(key_event.code, key_event.modifiers)
                         .map_err(|e| io::Error::other(e.to_string()))?;

--- a/crates/fresh-editor/src/services/terminal/pty.rs
+++ b/crates/fresh-editor/src/services/terminal/pty.rs
@@ -9,6 +9,11 @@ use crossterm::event::{KeyCode, KeyModifiers};
 /// This handles special keys and modifier combinations that need
 /// to be sent as escape sequences or control characters.
 ///
+/// The encoding is the legacy xterm one: fresh's terminal emulator does not
+/// speak the kitty keyboard protocol to the child, so a modified key is
+/// expressed by the `1 + bits` modifier parameter of its escape sequence
+/// ([`xterm_modifier_param`]) rather than a CSI-u form.
+///
 /// When `app_cursor` is true (DECCKM mode), unmodified arrow keys use SS3
 /// sequences (`\x1bOA`) instead of CSI (`\x1b[A`). Programs like less and
 /// git log enable this mode.
@@ -21,35 +26,30 @@ pub fn key_to_pty_bytes(
     let alt = modifiers.contains(KeyModifiers::ALT);
     let shift = modifiers.contains(KeyModifiers::SHIFT);
 
-    // Handle Ctrl+key combinations (send as control characters)
-    if ctrl && !alt {
+    // Ctrl+key combinations (send as control characters). Alt on top of them
+    // adds the `ESC` prefix below (xterm's metaSendsEscape), so Ctrl+Alt+C is
+    // `ESC 0x03` rather than a bare `c` — which is what it used to send, since
+    // neither the Ctrl nor the Alt branch accepted the combination.
+    //
+    // Windows is the exception: crossterm reports AltGr as Ctrl+Alt, and that
+    // is a plain character key, not a control sequence.
+    if ctrl && !(alt && cfg!(windows)) {
         if let KeyCode::Char(c) = code {
-            let c = c.to_ascii_lowercase();
-            if c.is_ascii_lowercase() {
-                // Ctrl+A = 0x01, Ctrl+B = 0x02, etc.
-                let ctrl_char = (c as u8) - b'a' + 1;
-                return Some(vec![ctrl_char]);
-            }
-            // Special Ctrl combinations
-            match c {
-                '[' | '3' => return Some(vec![0x1b]), // Escape
-                '\\' | '4' => return Some(vec![0x1c]),
-                ']' | '5' => return Some(vec![0x1d]),
-                '^' | '6' => return Some(vec![0x1e]),
-                '_' | '7' => return Some(vec![0x1f]),
-                '@' | '2' => return Some(vec![0x00]), // NUL
-                ' ' => return Some(vec![0x00]),       // Ctrl+Space = NUL
-                '?' => return Some(vec![0x7f]),       // DEL
-                _ => {}
+            if let Some(ctrl_byte) = control_byte(c) {
+                return Some(if alt {
+                    vec![0x1b, ctrl_byte]
+                } else {
+                    vec![ctrl_byte]
+                });
             }
         }
     }
 
-    // Handle Alt+key (send as ESC + key)
+    // Alt+key (send as ESC + key).
     if alt && !ctrl {
         if let KeyCode::Char(c) = code {
             let c = if shift { c.to_ascii_uppercase() } else { c };
-            return Some(vec![0x1b, c as u8]);
+            return Some(esc_prefixed(&encode_char(c)));
         }
     }
 
@@ -57,18 +57,20 @@ pub fn key_to_pty_bytes(
     match code {
         KeyCode::Char(c) => {
             let c = if shift { c.to_ascii_uppercase() } else { c };
-            let mut bytes = vec![0u8; 4];
-            let len = c.encode_utf8(&mut bytes).len();
-            bytes.truncate(len);
-            Some(bytes)
+            Some(encode_char(c))
         }
-        KeyCode::Enter => Some(vec![b'\r']),
+        // The keys below have no parameterised escape sequence to carry a
+        // modifier, so Alt is expressed the only way legacy encoding can: an
+        // `ESC` prefix (metaSendsEscape). Alt+Backspace as `ESC DEL` is
+        // readline's delete-previous-word; before this, Alt was simply dropped
+        // and the child saw a bare Backspace.
+        KeyCode::Enter => Some(maybe_esc(alt, vec![b'\r'])),
         KeyCode::Tab => {
             if shift {
                 // Shift+Tab (backtab)
                 Some(vec![0x1b, b'[', b'Z'])
             } else {
-                Some(vec![b'\t'])
+                Some(maybe_esc(alt, vec![b'\t']))
             }
         }
         // Crossterm reports Shift+Tab as `KeyCode::BackTab` (with the
@@ -81,123 +83,168 @@ pub fn key_to_pty_bytes(
         KeyCode::Backspace => {
             if ctrl {
                 // Ctrl+Backspace - delete word
-                Some(vec![0x17]) // Ctrl+W
+                Some(maybe_esc(alt, vec![0x17])) // Ctrl+W
             } else {
-                Some(vec![0x7f]) // DEL
+                Some(maybe_esc(alt, vec![0x7f])) // DEL
             }
         }
-        KeyCode::Delete => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'3', b';', b'5', b'~']) // Ctrl+Delete
-            } else if shift {
-                Some(vec![0x1b, b'[', b'3', b';', b'2', b'~']) // Shift+Delete
-            } else {
-                Some(vec![0x1b, b'[', b'3', b'~'])
-            }
+        KeyCode::Esc => Some(maybe_esc(alt, vec![0x1b])),
+        KeyCode::Up => Some(cursor_key(b'A', modifiers, app_cursor)),
+        KeyCode::Down => Some(cursor_key(b'B', modifiers, app_cursor)),
+        KeyCode::Right => Some(cursor_key(b'C', modifiers, app_cursor)),
+        KeyCode::Left => Some(cursor_key(b'D', modifiers, app_cursor)),
+        // Home and End take the same modifier parameter as the arrows but keep
+        // the CSI form when unmodified: DECCKM's SS3 variant is deliberately
+        // not applied to them here, to leave the long-standing unmodified
+        // output byte-for-byte unchanged.
+        KeyCode::Home => Some(cursor_key(b'H', modifiers, false)),
+        KeyCode::End => Some(cursor_key(b'F', modifiers, false)),
+        KeyCode::Insert => Some(tilde_key(2, modifiers)),
+        KeyCode::Delete => Some(tilde_key(3, modifiers)),
+        KeyCode::PageUp => Some(tilde_key(5, modifiers)),
+        KeyCode::PageDown => Some(tilde_key(6, modifiers)),
+        // F1-F4 are SS3 when unmodified and take the cursor-key CSI form once
+        // a modifier is involved; F5 and up are `CSI <n> ~` throughout. Every
+        // one of these used to ignore its modifiers entirely, so Shift+F3
+        // reached the child as a bare F3 — the same class of bug as #699, on
+        // the outgoing side.
+        KeyCode::F(n @ 1..=4) => {
+            let final_byte = b'P' + (n - 1);
+            Some(match xterm_modifier_param(modifiers) {
+                Some(param) => csi(&format!("1;{param}"), final_byte),
+                None => vec![0x1b, b'O', final_byte],
+            })
         }
-        KeyCode::Esc => Some(vec![0x1b]),
-        KeyCode::Up => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'A'])
-            } else if shift {
-                Some(vec![0x1b, b'[', b'1', b';', b'2', b'A'])
-            } else if alt {
-                Some(vec![0x1b, b'[', b'1', b';', b'3', b'A'])
-            } else if app_cursor {
-                Some(vec![0x1b, b'O', b'A'])
-            } else {
-                Some(vec![0x1b, b'[', b'A'])
-            }
-        }
-        KeyCode::Down => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'B'])
-            } else if shift {
-                Some(vec![0x1b, b'[', b'1', b';', b'2', b'B'])
-            } else if alt {
-                Some(vec![0x1b, b'[', b'1', b';', b'3', b'B'])
-            } else if app_cursor {
-                Some(vec![0x1b, b'O', b'B'])
-            } else {
-                Some(vec![0x1b, b'[', b'B'])
-            }
-        }
-        KeyCode::Right => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'C'])
-            } else if shift {
-                Some(vec![0x1b, b'[', b'1', b';', b'2', b'C'])
-            } else if alt {
-                Some(vec![0x1b, b'[', b'1', b';', b'3', b'C'])
-            } else if app_cursor {
-                Some(vec![0x1b, b'O', b'C'])
-            } else {
-                Some(vec![0x1b, b'[', b'C'])
-            }
-        }
-        KeyCode::Left => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'D'])
-            } else if shift {
-                Some(vec![0x1b, b'[', b'1', b';', b'2', b'D'])
-            } else if alt {
-                Some(vec![0x1b, b'[', b'1', b';', b'3', b'D'])
-            } else if app_cursor {
-                Some(vec![0x1b, b'O', b'D'])
-            } else {
-                Some(vec![0x1b, b'[', b'D'])
-            }
-        }
-        KeyCode::Home => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'H'])
-            } else {
-                Some(vec![0x1b, b'[', b'H'])
-            }
-        }
-        KeyCode::End => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'1', b';', b'5', b'F'])
-            } else {
-                Some(vec![0x1b, b'[', b'F'])
-            }
-        }
-        KeyCode::PageUp => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'5', b';', b'5', b'~'])
-            } else {
-                Some(vec![0x1b, b'[', b'5', b'~'])
-            }
-        }
-        KeyCode::PageDown => {
-            if ctrl {
-                Some(vec![0x1b, b'[', b'6', b';', b'5', b'~'])
-            } else {
-                Some(vec![0x1b, b'[', b'6', b'~'])
-            }
-        }
-        KeyCode::Insert => Some(vec![0x1b, b'[', b'2', b'~']),
-        KeyCode::F(n) => {
-            // F1-F12 escape sequences
-            let base = match n {
-                1 => vec![0x1b, b'O', b'P'],
-                2 => vec![0x1b, b'O', b'Q'],
-                3 => vec![0x1b, b'O', b'R'],
-                4 => vec![0x1b, b'O', b'S'],
-                5 => vec![0x1b, b'[', b'1', b'5', b'~'],
-                6 => vec![0x1b, b'[', b'1', b'7', b'~'],
-                7 => vec![0x1b, b'[', b'1', b'8', b'~'],
-                8 => vec![0x1b, b'[', b'1', b'9', b'~'],
-                9 => vec![0x1b, b'[', b'2', b'0', b'~'],
-                10 => vec![0x1b, b'[', b'2', b'1', b'~'],
-                11 => vec![0x1b, b'[', b'2', b'3', b'~'],
-                12 => vec![0x1b, b'[', b'2', b'4', b'~'],
-                _ => return None,
-            };
-            Some(base)
-        }
+        KeyCode::F(n) => function_key_number(n).map(|num| tilde_key(num, modifiers)),
         _ => None,
     }
+}
+
+/// The control byte for Ctrl + this character, or `None` when the combination
+/// has no control-character equivalent (the key is then sent as itself).
+fn control_byte(c: char) -> Option<u8> {
+    let c = c.to_ascii_lowercase();
+    if c.is_ascii_lowercase() {
+        // Ctrl+A = 0x01, Ctrl+B = 0x02, etc.
+        return Some((c as u8) - b'a' + 1);
+    }
+    Some(match c {
+        '[' | '3' => 0x1b, // Escape
+        '\\' | '4' => 0x1c,
+        ']' | '5' => 0x1d,
+        '^' | '6' => 0x1e,
+        '_' | '7' => 0x1f,
+        '@' | '2' => 0x00, // NUL
+        ' ' => 0x00,       // Ctrl+Space = NUL
+        '?' => 0x7f,       // DEL
+        _ => return None,
+    })
+}
+
+/// UTF-8 bytes for a character. Multi-byte characters must go out whole — an
+/// `as u8` truncation would send a mangled byte for anything non-ASCII.
+fn encode_char(c: char) -> Vec<u8> {
+    let mut bytes = [0u8; 4];
+    c.encode_utf8(&mut bytes).as_bytes().to_vec()
+}
+
+/// Prefix `bytes` with `ESC` (xterm's metaSendsEscape encoding of Alt).
+fn esc_prefixed(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len() + 1);
+    out.push(0x1b);
+    out.extend_from_slice(bytes);
+    out
+}
+
+/// [`esc_prefixed`] when `alt` is set, otherwise `bytes` unchanged.
+fn maybe_esc(alt: bool, bytes: Vec<u8>) -> Vec<u8> {
+    if alt {
+        esc_prefixed(&bytes)
+    } else {
+        bytes
+    }
+}
+
+/// `CSI <params> <final_byte>`.
+fn csi(params: &str, final_byte: u8) -> Vec<u8> {
+    let mut out = vec![0x1b, b'['];
+    out.extend_from_slice(params.as_bytes());
+    out.push(final_byte);
+    out
+}
+
+/// The xterm modifier parameter for a legacy escape sequence: `1 + bits`, with
+/// shift = 1, alt = 2, ctrl = 4, meta = 8. `None` means no modifier the legacy
+/// encoding can express, which selects the short unparameterised form of a
+/// sequence.
+///
+/// The bits are additive, which is the whole point: Ctrl+Shift+Right is
+/// `1 + 4 + 1` = 6, not "whichever modifier was tested first". Each key used to
+/// run its own if/else-if chain over the individual modifiers, so every
+/// combination collapsed onto its first matching branch and reached the child
+/// as a lesser chord.
+///
+/// Super and Hyper have no legacy xterm encoding and are dropped — the kitty
+/// protocol is where they would survive, and fresh's emulator does not speak it
+/// to the child.
+fn xterm_modifier_param(modifiers: KeyModifiers) -> Option<u8> {
+    let mut bits = 0u8;
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        bits |= 1;
+    }
+    if modifiers.contains(KeyModifiers::ALT) {
+        bits |= 2;
+    }
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        bits |= 4;
+    }
+    if modifiers.contains(KeyModifiers::META) {
+        bits |= 8;
+    }
+    (bits != 0).then_some(1 + bits)
+}
+
+/// A cursor-style key: `CSI 1 ; <mods> <final>` when modified, and
+/// `CSI <final>` — or `SS3 <final>` under DECCKM — when not.
+fn cursor_key(final_byte: u8, modifiers: KeyModifiers, app_cursor: bool) -> Vec<u8> {
+    match xterm_modifier_param(modifiers) {
+        Some(param) => csi(&format!("1;{param}"), final_byte),
+        None if app_cursor => vec![0x1b, b'O', final_byte],
+        None => vec![0x1b, b'[', final_byte],
+    }
+}
+
+/// An editing/function key: `CSI <num> ; <mods> ~`, or `CSI <num> ~` unmodified.
+fn tilde_key(num: u8, modifiers: KeyModifiers) -> Vec<u8> {
+    match xterm_modifier_param(modifiers) {
+        Some(param) => csi(&format!("{num};{param}"), b'~'),
+        None => csi(&num.to_string(), b'~'),
+    }
+}
+
+/// The `CSI <n> ~` number for F5 and up. F13-F20 continue the xterm sequence
+/// (they used to be dropped outright); beyond F20 there is no legacy encoding,
+/// so those keys are still dropped rather than mis-encoded as some other key.
+fn function_key_number(n: u8) -> Option<u8> {
+    Some(match n {
+        5 => 15,
+        6 => 17,
+        7 => 18,
+        8 => 19,
+        9 => 20,
+        10 => 21,
+        11 => 23,
+        12 => 24,
+        13 => 25,
+        14 => 26,
+        15 => 28,
+        16 => 29,
+        17 => 31,
+        18 => 32,
+        19 => 33,
+        20 => 34,
+        _ => return None,
+    })
 }
 
 #[cfg(test)]
@@ -296,5 +343,139 @@ mod tests {
     fn test_alt_key() {
         let bytes = key_to_pty_bytes(KeyCode::Char('x'), KeyModifiers::ALT, false);
         assert_eq!(bytes, Some(vec![0x1b, b'x']));
+    }
+
+    /// Bytes as a printable string, so a failure reads as `ESC[1;6C` rather
+    /// than a list of integers.
+    fn seq(code: KeyCode, modifiers: KeyModifiers) -> String {
+        String::from_utf8(key_to_pty_bytes(code, modifiers, false).expect("key was dropped"))
+            .expect("not utf-8")
+    }
+
+    /// Modifiers are additive: each key used to run its own if/else-if chain
+    /// over the individual modifiers, so a combination collapsed onto its
+    /// first matching branch and the child received a lesser chord —
+    /// Ctrl+Shift+Right arrived as Ctrl+Right.
+    #[test]
+    fn combined_modifiers_are_encoded_additively() {
+        let shift = KeyModifiers::SHIFT;
+        let alt = KeyModifiers::ALT;
+        let ctrl = KeyModifiers::CONTROL;
+
+        assert_eq!(seq(KeyCode::Right, ctrl | shift), "\x1b[1;6C");
+        assert_eq!(seq(KeyCode::Up, alt | shift), "\x1b[1;4A");
+        assert_eq!(seq(KeyCode::Left, ctrl | alt), "\x1b[1;7D");
+        assert_eq!(seq(KeyCode::Down, ctrl | alt | shift), "\x1b[1;8B");
+
+        // Single modifiers keep their established encodings.
+        assert_eq!(seq(KeyCode::Up, ctrl), "\x1b[1;5A");
+        assert_eq!(seq(KeyCode::Up, shift), "\x1b[1;2A");
+        assert_eq!(seq(KeyCode::Up, alt), "\x1b[1;3A");
+    }
+
+    /// Home/End/PageUp/PageDown/Insert accepted only Ctrl (or nothing at all),
+    /// so every other modifier on them was silently dropped.
+    #[test]
+    fn editing_keys_carry_every_modifier() {
+        assert_eq!(seq(KeyCode::Home, KeyModifiers::SHIFT), "\x1b[1;2H");
+        assert_eq!(seq(KeyCode::End, KeyModifiers::ALT), "\x1b[1;3F");
+        assert_eq!(seq(KeyCode::PageUp, KeyModifiers::SHIFT), "\x1b[5;2~");
+        assert_eq!(
+            seq(
+                KeyCode::PageDown,
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            ),
+            "\x1b[6;6~"
+        );
+        assert_eq!(seq(KeyCode::Insert, KeyModifiers::SHIFT), "\x1b[2;2~");
+
+        // Unmodified and previously-handled forms are unchanged.
+        assert_eq!(seq(KeyCode::Home, KeyModifiers::NONE), "\x1b[H");
+        assert_eq!(seq(KeyCode::End, KeyModifiers::NONE), "\x1b[F");
+        assert_eq!(seq(KeyCode::Insert, KeyModifiers::NONE), "\x1b[2~");
+        assert_eq!(seq(KeyCode::Delete, KeyModifiers::NONE), "\x1b[3~");
+        assert_eq!(seq(KeyCode::Delete, KeyModifiers::CONTROL), "\x1b[3;5~");
+        assert_eq!(seq(KeyCode::Delete, KeyModifiers::SHIFT), "\x1b[3;2~");
+        assert_eq!(seq(KeyCode::PageUp, KeyModifiers::CONTROL), "\x1b[5;5~");
+    }
+
+    /// `KeyCode::F(n)` ignored its modifiers entirely, so Shift+F3 reached the
+    /// child as a bare F3 — the outgoing-side twin of #699.
+    #[test]
+    fn function_keys_carry_their_modifiers() {
+        // F1-F4: SS3 unmodified, cursor-key CSI form once modified.
+        assert_eq!(seq(KeyCode::F(1), KeyModifiers::NONE), "\x1bOP");
+        assert_eq!(seq(KeyCode::F(3), KeyModifiers::NONE), "\x1bOR");
+        assert_eq!(seq(KeyCode::F(3), KeyModifiers::SHIFT), "\x1b[1;2R");
+        assert_eq!(seq(KeyCode::F(4), KeyModifiers::CONTROL), "\x1b[1;5S");
+
+        // F5 and up: `CSI <n> ~` throughout.
+        assert_eq!(seq(KeyCode::F(5), KeyModifiers::NONE), "\x1b[15~");
+        assert_eq!(seq(KeyCode::F(5), KeyModifiers::CONTROL), "\x1b[15;5~");
+        assert_eq!(seq(KeyCode::F(12), KeyModifiers::NONE), "\x1b[24~");
+        assert_eq!(
+            seq(KeyCode::F(12), KeyModifiers::ALT | KeyModifiers::SHIFT),
+            "\x1b[24;4~"
+        );
+
+        // F13-F20 were dropped outright; they continue the xterm numbering.
+        assert_eq!(seq(KeyCode::F(13), KeyModifiers::NONE), "\x1b[25~");
+        assert_eq!(seq(KeyCode::F(20), KeyModifiers::NONE), "\x1b[34~");
+
+        // Past F20 there is no legacy encoding — still dropped, rather than
+        // mis-encoded as some other key.
+        assert_eq!(
+            key_to_pty_bytes(KeyCode::F(21), KeyModifiers::NONE, false),
+            None
+        );
+    }
+
+    /// Keys with no parameterised sequence express Alt as an `ESC` prefix
+    /// (metaSendsEscape). Alt used to be dropped for all of them.
+    #[test]
+    fn alt_prefixes_keys_that_have_no_modifier_parameter() {
+        assert_eq!(seq(KeyCode::Enter, KeyModifiers::ALT), "\x1b\r");
+        assert_eq!(seq(KeyCode::Tab, KeyModifiers::ALT), "\x1b\t");
+        assert_eq!(seq(KeyCode::Esc, KeyModifiers::ALT), "\x1b\x1b");
+        // readline's delete-previous-word.
+        assert_eq!(
+            key_to_pty_bytes(KeyCode::Backspace, KeyModifiers::ALT, false),
+            Some(vec![0x1b, 0x7f])
+        );
+
+        // Without Alt these are unchanged.
+        assert_eq!(seq(KeyCode::Enter, KeyModifiers::NONE), "\r");
+        assert_eq!(seq(KeyCode::Tab, KeyModifiers::NONE), "\t");
+        assert_eq!(seq(KeyCode::Esc, KeyModifiers::NONE), "\x1b");
+        assert_eq!(
+            key_to_pty_bytes(KeyCode::Backspace, KeyModifiers::NONE, false),
+            Some(vec![0x7f])
+        );
+    }
+
+    /// Ctrl+Alt+key matched neither the Ctrl branch nor the Alt branch and fell
+    /// through to the plain-character arm, so the child got a bare letter.
+    #[cfg(not(windows))]
+    #[test]
+    fn ctrl_alt_char_is_escape_prefixed_control_byte() {
+        assert_eq!(
+            key_to_pty_bytes(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+                false
+            ),
+            Some(vec![0x1b, 0x03])
+        );
+    }
+
+    /// A non-ASCII character behind Alt was truncated by an `as u8` cast.
+    #[test]
+    fn alt_non_ascii_char_keeps_its_utf8_bytes() {
+        let mut expected = vec![0x1b];
+        expected.extend_from_slice("é".as_bytes());
+        assert_eq!(
+            key_to_pty_bytes(KeyCode::Char('é'), KeyModifiers::ALT, false),
+            Some(expected)
+        );
     }
 }

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1398,6 +1398,22 @@ impl EditorTestHarness {
     /// per-key `type_text` path and from `Ctrl+V`). Routes through the
     /// editor's real `handle_input_event` so floating-panel / dock
     /// paste routing is exercised.
+    /// Deliver a raw key event through the editor's real
+    /// `handle_input_event`, preserving its [`KeyEventKind`].
+    ///
+    /// Unlike [`Self::send_key`], which calls `handle_key` directly, this goes
+    /// through the same dispatch the event loops use — so it exercises the
+    /// press/repeat/release gate that decides whether a key event is a
+    /// keystroke at all. Tests that feed terminal bytes through `InputParser`
+    /// must use this; `send_key` cannot express a release.
+    pub fn send_key_event(&mut self, key_event: crossterm::event::KeyEvent) -> anyhow::Result<()> {
+        self.editor
+            .handle_input_event(crossterm::event::Event::Key(key_event))?;
+        self.drain_async_work();
+        self.render()?;
+        Ok(())
+    }
+
     pub fn send_paste(&mut self, text: &str) -> anyhow::Result<()> {
         self.editor
             .handle_input_event(crossterm::event::Event::Paste(text.to_string()))?;

--- a/crates/fresh-editor/tests/e2e/issue_2796_key_release_duplicates.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2796_key_release_duplicates.rs
@@ -1,0 +1,110 @@
+//! Regression test for issue #2796: cursor movement duplicates when
+//! `keyboard_report_event_types` is enabled.
+//!
+//! With the kitty keyboard protocol's event-type reporting on, one physical
+//! keypress produces a press, a repeat per auto-repeat tick while held, and a
+//! release. The arrows and the `CSI <n> ~` editing keys keep their *legacy*
+//! escape-code form under that flag and carry the event type as a
+//! sub-parameter of the modifier field, so a parser that reads only the
+//! modifiers reports the release as a second press — and the cursor moves
+//! twice for one keypress.
+//!
+//! These drive the editor with the exact byte stream such a terminal sends and
+//! assert only on what the status bar shows.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::Event;
+use fresh::server::input_parser::InputParser;
+
+/// Feed raw terminal bytes through the same parser the event loops use, and
+/// dispatch whatever events they produce into the editor.
+fn feed(harness: &mut EditorTestHarness, parser: &mut InputParser, bytes: &[u8]) {
+    for event in parser.parse(bytes) {
+        if let Event::Key(key_event) = event {
+            harness.send_key_event(key_event).unwrap();
+        }
+    }
+}
+
+/// The "Ln <n>, Col <n>" readout from the status bar, as rendered.
+fn line_col(harness: &EditorTestHarness) -> String {
+    let status = harness.get_status_bar();
+    let start = status
+        .find("Ln ")
+        .unwrap_or_else(|| panic!("no line/column readout in status bar: {status:?}"));
+    let rest = &status[start..];
+    let end = rest.find("  ").unwrap_or(rest.len());
+    rest[..end].trim().to_string()
+}
+
+/// One Down keypress — press then release, as the terminal sends it — must
+/// move the cursor exactly one line.
+#[test]
+fn arrow_key_release_does_not_move_the_cursor_again() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness
+        .load_buffer_from_text("aaaa\nbbbb\ncccc\ndddd\neeee\n")
+        .unwrap();
+    harness.render().unwrap();
+    let mut parser = InputParser::new();
+
+    assert_eq!(line_col(&harness), "Ln 1, Col 1");
+
+    // Down: press (legacy form, unchanged by the flag) then release.
+    feed(&mut harness, &mut parser, b"\x1b[B");
+    assert_eq!(line_col(&harness), "Ln 2, Col 1", "press should move once");
+    feed(&mut harness, &mut parser, b"\x1b[1;1:3B");
+    assert_eq!(
+        line_col(&harness),
+        "Ln 2, Col 1",
+        "release must not move the cursor a second time"
+    );
+
+    // Right, in the same shape.
+    feed(&mut harness, &mut parser, b"\x1b[C");
+    feed(&mut harness, &mut parser, b"\x1b[1;1:3C");
+    assert_eq!(line_col(&harness), "Ln 2, Col 2");
+}
+
+/// Auto-repeat while a key is held is a keystroke and must still move the
+/// cursor — the fix for the release must not silence repeats.
+#[test]
+fn arrow_key_repeat_still_moves_the_cursor() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness
+        .load_buffer_from_text("aaaa\nbbbb\ncccc\ndddd\neeee\n")
+        .unwrap();
+    harness.render().unwrap();
+    let mut parser = InputParser::new();
+
+    // Press, two auto-repeat ticks, then release: three lines down in total.
+    feed(&mut harness, &mut parser, b"\x1b[B");
+    feed(&mut harness, &mut parser, b"\x1b[1;1:2B");
+    feed(&mut harness, &mut parser, b"\x1b[1;1:2B");
+    feed(&mut harness, &mut parser, b"\x1b[1;1:3B");
+
+    assert_eq!(line_col(&harness), "Ln 4, Col 1");
+}
+
+/// The same duplication hit the `CSI <n> ~` editing keys, where it destroyed
+/// text rather than just moving the cursor: one Delete removed two characters.
+#[test]
+fn delete_key_release_does_not_delete_again() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.load_buffer_from_text("abcdef\n").unwrap();
+    harness.render().unwrap();
+    let mut parser = InputParser::new();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let text_row = |h: &EditorTestHarness| h.get_screen_row(content_first_row);
+    assert!(text_row(&harness).contains("abcdef"));
+
+    feed(&mut harness, &mut parser, b"\x1b[3~");
+    feed(&mut harness, &mut parser, b"\x1b[3;1:3~");
+
+    let row = text_row(&harness);
+    assert!(
+        row.contains("bcdef"),
+        "one Delete keypress must remove exactly one character, got {row:?}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -88,6 +88,7 @@ pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_2566_env_detector_labels;
 pub mod issue_2572_hover_through_panel;
 pub mod issue_2605_format_selection_range;
+pub mod issue_2796_key_release_duplicates;
 #[cfg(feature = "plugins")]
 pub mod issue_2810_session_escape_flush;
 pub mod issue_779_after_eof_shade;

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -556,14 +556,14 @@ impl InputParser {
         }
 
         match final_byte {
-            b'A' => out.push(key(KeyCode::Up, modifiers_of(&params))),
-            b'B' => out.push(key(KeyCode::Down, modifiers_of(&params))),
-            b'C' => out.push(key(KeyCode::Right, modifiers_of(&params))),
-            b'D' => out.push(key(KeyCode::Left, modifiers_of(&params))),
-            b'H' => out.push(key(KeyCode::Home, modifiers_of(&params))),
-            b'F' => out.push(key(KeyCode::End, modifiers_of(&params))),
+            b'A' => out.push(csi_key(KeyCode::Up, &params)),
+            b'B' => out.push(csi_key(KeyCode::Down, &params)),
+            b'C' => out.push(csi_key(KeyCode::Right, &params)),
+            b'D' => out.push(csi_key(KeyCode::Left, &params)),
+            b'H' => out.push(csi_key(KeyCode::Home, &params)),
+            b'F' => out.push(csi_key(KeyCode::End, &params)),
             // Keypad Begin (the center "5" key), `CSI E` / `CSI 1;<mod> E`.
-            b'E' => out.push(key(KeyCode::KeypadBegin, modifiers_of(&params))),
+            b'E' => out.push(csi_key(KeyCode::KeypadBegin, &params)),
             // Modified F1–F4: xterm's SS3-derived form `CSI 1 ; <mod> {P,Q,R,S}`
             // (e.g. Shift+F3 = `ESC [ 1 ; 2 R`). *Unmodified* F1–F4 arrive as
             // SS3 (`ESC O P/Q/R/S`) and are decoded in `feed_ss3`; adding a
@@ -585,7 +585,7 @@ impl InputParser {
                     b'R' => KeyCode::F(3),
                     _ => KeyCode::F(4), // b'S'
                 };
-                out.push(key(code, modifiers_of(&params)));
+                out.push(csi_key(code, &params));
             }
             b'~' => self.dispatch_tilde(&params, out),
             b'M' | b'm' => {
@@ -605,7 +605,14 @@ impl InputParser {
                     tracing::trace!("InputParser: unrecognised CSI {:?} M/m, dropping", params);
                 }
             }
-            b'Z' => out.push(key(KeyCode::BackTab, KeyModifiers::SHIFT)),
+            // Shift+Tab. The event type still rides in the modifier field for
+            // emulators that send one here, so decode it the same way; the
+            // modifiers are fixed because the key *is* the shifted Tab.
+            b'Z' => out.push(Event::Key(KeyEvent::new_with_kind(
+                KeyCode::BackTab,
+                KeyModifiers::SHIFT,
+                kind_of(&params),
+            ))),
             b'I' => out.push(Event::FocusGained),
             b'O' => out.push(Event::FocusLost),
             b'u' => self.dispatch_csi_u(&params, out),
@@ -632,11 +639,12 @@ impl InputParser {
         }
 
         let num: u8 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
-        let mods = parts
-            .get(1)
-            .and_then(|s| first_subparam(s).parse().ok())
-            .unwrap_or(1);
+        let mods_field = parts.get(1).copied().unwrap_or("");
+        let mods = first_subparam(mods_field).parse().unwrap_or(1);
         let modifiers = modifiers_from_param(mods);
+        // As in `dispatch_csi_u`, the modifier field carries the kitty event
+        // type as a sub-parameter (`CSI <num> ; <mods>:<event-type> ~`).
+        let kind = event_kind_of(mods_field);
 
         // Bracketed paste start.
         if num == 200 {
@@ -679,7 +687,9 @@ impl InputParser {
                 return;
             }
         };
-        out.push(Event::Key(KeyEvent::new(keycode, modifiers)));
+        out.push(Event::Key(KeyEvent::new_with_kind(
+            keycode, modifiers, kind,
+        )));
     }
 
     /// Dispatch `CSI codepoint ; modifiers u` (fixterms / kitty keyboard).
@@ -718,9 +728,21 @@ fn event_kind_of(mods_field: &str) -> KeyEventKind {
     }
 }
 
-/// Build a `Key` event.
-fn key(code: KeyCode, modifiers: KeyModifiers) -> Event {
-    Event::Key(KeyEvent::new(code, modifiers))
+/// Build a `Key` event for a key that arrived in the *legacy* CSI form
+/// (`CSI 1 ; <mods>:<event-type> {A,B,C,D,E,F,H,P,Q,R,S}`), decoding both the
+/// modifiers and the event type from the modifier field.
+///
+/// Enabling the kitty protocol's event-type reporting does not move these keys
+/// to the CSI-u form — they keep their legacy final byte and gain a
+/// `:<event-type>` sub-parameter. Decoding only the modifiers here (and so
+/// reporting every release as a press) is what made one arrow keypress move the
+/// cursor twice (sinelaw/fresh#2796).
+fn csi_key(code: KeyCode, params: &[u8]) -> Event {
+    Event::Key(KeyEvent::new_with_kind(
+        code,
+        modifiers_of(params),
+        kind_of(params),
+    ))
 }
 
 /// The primary value of a CSI parameter field, discarding any kitty
@@ -843,6 +865,17 @@ fn is_modified_f1_f4(params: &[u8]) -> bool {
             .and_then(|f| first_subparam(f).parse::<u16>().ok()),
         Some(2..=64)
     )
+}
+
+/// Parse the event type out of the modifier field (`…;mods:event-type`) of a
+/// standard CSI parameter list. Absent field or absent sub-parameter — every
+/// sequence from a terminal that is not reporting event types — is a press.
+fn kind_of(params: &[u8]) -> KeyEventKind {
+    let params_str = std::str::from_utf8(params).unwrap_or("");
+    match params_str.find(';') {
+        Some(idx) => event_kind_of(&params_str[idx + 1..]),
+        None => KeyEventKind::Press,
+    }
 }
 
 /// Parse the modifier field (`…;mods`) of a standard CSI parameter list.

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -1189,6 +1189,91 @@ fn kitty_event_type_release_is_not_a_press() {
 }
 
 #[test]
+fn kitty_event_type_on_legacy_form_keys() {
+    // Turning on event-type reporting does *not* move keys to the CSI-u form:
+    // the arrows, Home/End, keypad Begin and the `CSI <n> ~` editing keys keep
+    // their legacy final byte and gain a `:<event-type>` sub-parameter on the
+    // modifier field (`CSI 1 ; <mods>:<event-type> {ABCDEFHPQS}`,
+    // `CSI <n> ; <mods>:<event-type> ~`).
+    //
+    // Decoding only the modifiers there reported every release as a press, so a
+    // single arrow keypress moved the cursor twice and a single Delete removed
+    // two characters (sinelaw/fresh#2796).
+    let releases: &[(&[u8], KeyCode)] = &[
+        (b"\x1b[1;1:3A", KeyCode::Up),
+        (b"\x1b[1;1:3B", KeyCode::Down),
+        (b"\x1b[1;1:3C", KeyCode::Right),
+        (b"\x1b[1;1:3D", KeyCode::Left),
+        (b"\x1b[1;1:3H", KeyCode::Home),
+        (b"\x1b[1;1:3F", KeyCode::End),
+        (b"\x1b[1;1:3E", KeyCode::KeypadBegin),
+        (b"\x1b[2;1:3~", KeyCode::Insert),
+        (b"\x1b[3;1:3~", KeyCode::Delete),
+        (b"\x1b[5;1:3~", KeyCode::PageUp),
+        (b"\x1b[6;1:3~", KeyCode::PageDown),
+        (b"\x1b[24;1:3~", KeyCode::F(12)),
+        (b"\x1b[1;2:3P", KeyCode::F(1)),
+        (b"\x1b[1;2:3Z", KeyCode::BackTab),
+    ];
+    for (bytes, code) in releases {
+        let mut p = InputParser::new();
+        let ev = p.parse(bytes);
+        match &ev[..] {
+            [Event::Key(ke)] => {
+                assert_eq!(ke.code, *code, "wrong key for {:?}", bytes);
+                assert_eq!(
+                    ke.kind,
+                    KeyEventKind::Release,
+                    "{:?} is a release, not a press",
+                    bytes
+                );
+            }
+            other => panic!("expected one key event for {:?}, got {:?}", bytes, other),
+        }
+    }
+
+    // Repeat (auto-repeat while the key is held) is its own kind — it is a
+    // keystroke, so it must not be dropped, but it is not a press either.
+    let mut p = InputParser::new();
+    assert!(matches!(
+        &p.parse(b"\x1b[1;1:2B")[0],
+        Event::Key(ke) if ke.code == KeyCode::Down && ke.kind == KeyEventKind::Repeat
+    ));
+    assert!(matches!(
+        &p.parse(b"\x1b[3;1:2~")[0],
+        Event::Key(ke) if ke.code == KeyCode::Delete && ke.kind == KeyEventKind::Repeat
+    ));
+
+    // An explicit press, and the plain legacy forms a terminal without
+    // event-type reporting sends, all stay presses.
+    for bytes in [
+        b"\x1b[1;1:1B".as_slice(),
+        b"\x1b[B".as_slice(),
+        b"\x1b[3~".as_slice(),
+        b"\x1b[1;5C".as_slice(),
+    ] {
+        let mut p = InputParser::new();
+        assert!(
+            matches!(&p.parse(bytes)[0], Event::Key(ke) if ke.kind == KeyEventKind::Press),
+            "{:?} should be a press",
+            bytes
+        );
+    }
+
+    // Modifiers still decode alongside an event type: the sub-parameter must
+    // not swallow the modifier value it is attached to.
+    let mut p = InputParser::new();
+    match &p.parse(b"\x1b[1;2:3D")[0] {
+        Event::Key(ke) => {
+            assert_eq!(ke.code, KeyCode::Left);
+            assert_eq!(ke.modifiers, KeyModifiers::SHIFT);
+            assert_eq!(ke.kind, KeyEventKind::Release);
+        }
+        other => panic!("expected key, got {:?}", other),
+    }
+}
+
+#[test]
 fn ss3_application_keypad_forms() {
     // The numeric keypad in application mode (DECPAM) went silent for these.
     let mut p = InputParser::new();

--- a/docs/internal/input-keybindings-actions.md
+++ b/docs/internal/input-keybindings-actions.md
@@ -14,6 +14,7 @@ A keystroke flows through these stages:
 
 ```
 Terminal (crossterm KeyEvent)
+  → input::is_keystroke(kind)      — press/repeat act, release is dropped
   → KeyTranslator.translate()      — calibration fixups
   → Editor::handle_key()           — modal priority + chord state
       → KeybindingResolver.resolve() — key → Action
@@ -24,6 +25,14 @@ Terminal (crossterm KeyEvent)
 
 The stage before this one — raw terminal bytes to a `KeyEvent`/`MouseEvent` — is
 [terminal-input-parsing.md](terminal-input-parsing.md).
+
+`input::is_keystroke` is the single gate on the event *kind*, and every raw-event
+entry point (the local event loop, the session server, `handle_input_event`) goes
+through it rather than comparing against `Press`. It only does anything when the
+terminal reports event types (`keyboard_report_event_types`): then one physical
+keypress yields a press, a repeat per auto-repeat tick, and a release. Presses
+and repeats are keystrokes; a release is not. Acting on releases doubled every
+key (#2796); dropping repeats would stop held keys from repeating.
 
 Three distinct vocabularies live here and the separation is deliberate (§4):
 

--- a/docs/internal/terminal-input-parsing.md
+++ b/docs/internal/terminal-input-parsing.md
@@ -174,9 +174,16 @@ parser exists to prevent — each is covered by a test that fails without the fi
   The old decoder mapped it to a left button-down, flooding clicks on every move.
 - **SGR reports tolerate a trailing separator** before the terminator; the
   decoder now reads the first three fields instead of requiring exactly three.
-- **Kitty event types are honoured.** The modifier field's press/repeat/release
-  sub-parameter becomes the key event's kind, so a release is no longer reported
-  as a fresh press (which would double every keystroke with event reporting on).
+- **Kitty event types are honoured, in every form a key can arrive in.** The
+  modifier field's press/repeat/release sub-parameter becomes the key event's
+  kind, so a release is no longer reported as a fresh press (which would double
+  every keystroke with event reporting on). This covers the CSI-u form *and* the
+  legacy forms, which the flag does not migrate to CSI-u: the arrows and
+  Home/End/keypad-Begin (`CSI 1;<mods>:<event-type> {ABCDEFHPQS}`) and the
+  editing/function keys (`CSI <n>;<mods>:<event-type> ~`) keep their legacy final
+  byte and merely gain the sub-parameter. Decoding it for CSI-u alone left every
+  arrow keypress moving the cursor twice and every Delete removing two characters
+  (#2796) while typing was unaffected — the asymmetry that hid the gap.
 - **Modifier decoding is complete.** Shift/Alt/Ctrl/Super/Hyper/Meta are all
   mapped, and the modifier field is parsed as `u16` so its maximum legal value
   (256) no longer overflows and fails closed. Caps Lock / Num Lock have no


### PR DESCRIPTION
Two commits, both about key events losing fidelity. The first fixes #2796; the second fixes bugs found while probing the embedded-terminal path for the same class of problem.

# 1. `fix(input-parser)`: one keypress acted twice — fixes #2796

## Symptom

With `keyboard_report_event_types` enabled, one arrow keypress moves the cursor two positions, in all four directions. One Delete keypress removes two characters. Typing is unaffected. Keys forwarded into an embedded terminal arrived twice as well.

## Cause

The flag does not migrate keys to the CSI-u form. Per the [spec](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), arrows, Home/End and keypad Begin keep `CSI 1 ; <mods>:<event-type> {ABCDEFHPQS}`, and the editing/function keys keep `CSI <n> ; <mods>:<event-type> ~`; they only gain the sub-parameter.

The parser read that sub-parameter in `dispatch_csi_u` only. Legacy forms ran their modifier field through `first_subparam`, which discards everything after the `:`, and emitted `KeyEventKind::Press`. Consumers act on presses, so each release ran as a second keystroke. Text keys stay legacy bytes and get no release at all, which is why typing looked fine and only cursor movement appeared broken.

## Change

- `fresh-input-parser`: decode the event type wherever a modifier field can carry one — arrows, `H`/`F`/`E`, the modified F1–F4 CSI form, `Z`, and the `CSI <n> ~` family — via `kind_of` alongside the existing `modifiers_of`.
- `fresh-editor`: gate raw key events on press *or repeat* through one new `input::is_keystroke`, replacing four `kind == Press` comparisons (local event loop, session server, `handle_input_event`, wave dismissal). Kitty reports auto-repeat as event type 2, so a press-only gate would trade doubled arrows for held arrows that stop moving.
- `docs/internal/terminal-input-parsing.md` claimed event types were honoured — true for CSI-u only. Corrected; the kind gate is added to the input-pipeline diagram.

## Tests

- `kitty_event_type_on_legacy_form_keys` — release, repeat and press across every affected final byte, plus modifiers decoding alongside an event type.
- e2e `issue_2796_key_release_duplicates.rs` — feeds the byte stream through `InputParser` into the editor, asserting only on rendered output (status-bar `Ln`/`Col`, buffer text): release-does-not-move, repeat-still-moves, one-Delete-deletes-one. Adds a harness `send_key_event` routing through the real `handle_input_event`; the existing `send_key` calls `handle_key` directly and cannot express a release.

# 2. `fix(terminal)`: modified keys reached the child pty as lesser chords

Pre-existing, unrelated to #2796, found while checking whether the duplication extended into embedded terminals.

## Symptom

A program running in an embedded terminal cannot distinguish several distinct keys. Confirmed against `cat -v` in an embedded shell:

| key | child received | should be |
| --- | --- | --- |
| Shift+F3 | `^[OR` (plain F3) | `^[[1;2R` |
| Ctrl+Shift+Right | `^[[1;5C` (Ctrl+Right) | `^[[1;6C` |
| Shift+Home | `^[[H` (plain Home) | `^[[1;2H` |

## Cause

`key_to_pty_bytes` tested modifiers one at a time in an if/else-if chain per key, so every combination collapsed onto its first matching branch. Home/End/PageUp/PageDown accepted only Ctrl. `KeyCode::F(n)` ignored modifiers outright and dropped F13 and up. Alt was lost on every key with no parameterised sequence to carry it (Alt+Backspace, readline's delete-previous-word, arrived as a bare Backspace). Ctrl+Alt+key matched neither the Ctrl nor the Alt branch and fell through to the plain-character arm. Alt + a non-ASCII character was truncated by an `as u8` cast.

## Change

Encode modifiers additively in one place — xterm's `1 + shift|alt<<1|ctrl<<2|meta<<3` parameter — and build each sequence from shared helpers, so a key cannot grow its own divergent chain again. Super and Hyper are dropped (no legacy encoding; the kitty protocol is where they would survive, and the emulator does not speak it to the child).

Established encodings are unchanged: the 9 pre-existing tests pass untouched. 6 new tests cover the combinations, the function keys, the Alt-prefixed keys, Ctrl+Alt, and the multi-byte character; all 6 fail against the old encoder.

# Checks

`cargo fmt`, `cargo clippy --all-targets` (265 warnings before and after), `cargo check --all-targets --features gui` clean. `cargo test -p fresh-editor --lib`: 3126 passed. Terminal e2e: 137 passed. Full `e2e_tests`: 5 failures under parallel load (locale, auto-indent, plugin-LSP, terminal-title); all 5 pass in isolation and one also fails on unmodified `master`.

# Manual verification

Against a debug build in tmux: press moves once, release does not move, repeat moves, one Delete removes one character; in an embedded terminal running `cat -v`, press+release yields one `^[[B` where two presses yield two, and the three chords in the table above now arrive intact.

Caveat: the byte sequences were injected with `tmux send-keys -H` using the encoding the spec documents, not captured from a real Kitty session, and tmux does not advertise kitty-protocol support, so the flag was likely never negotiated in those runs. The parse path does not depend on that negotiation, but the reporter's terminal was not observed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZMNk9LhVNKL8wAxy5ug2x