### PR TITLE
Migrate ANSI-output test parser from vt100 to rio-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
@@ -58,7 +58,7 @@ dependencies = [
  "home",
  "libc",
  "log",
- "miow",
+ "miow 0.6.1",
  "parking_lot",
  "piper",
  "polling",
@@ -531,6 +531,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -553,7 +559,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "encoding_rs",
  "memchr",
 ]
@@ -670,7 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
- "cfg-if",
+ "cfg-if 1.0.4",
  "itoa",
  "rustversion",
  "ryu",
@@ -730,6 +736,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "corcovado"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4485657270f8214253b07f52e3a3e06affdd17fa4e06d4fc5b4f0d115f1258d"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "libc",
+ "miow 0.5.0",
+ "slab",
+ "socket2",
+ "tracing",
+ "windows 0.42.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -832,7 +857,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1198,7 +1223,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1326,7 +1351,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -1419,6 +1444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fresh-core"
 version = "0.4.5"
 dependencies = [
@@ -1479,6 +1513,7 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "regex",
+ "rio-vt",
  "rust-i18n",
  "schemars",
  "serde",
@@ -1498,7 +1533,6 @@ dependencies = [
  "unicode-width",
  "ureq",
  "uuid",
- "vt100",
  "which",
  "windows-sys 0.61.2",
  "winresource",
@@ -1614,6 +1648,22 @@ dependencies = [
  "tracing",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -1767,7 +1817,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
@@ -1778,7 +1828,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -1790,7 +1840,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
@@ -2041,7 +2091,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -2171,6 +2221,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2313,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -2300,6 +2453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,7 +2520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -2373,7 +2535,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -2441,7 +2603,7 @@ version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -2546,7 +2708,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -2556,7 +2718,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -2623,6 +2785,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2792,6 +2960,15 @@ dependencies = [
 
 [[package]]
 name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "miow"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
@@ -2829,7 +3006,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
  "half",
@@ -2883,7 +3060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.1.1",
  "libc",
 ]
@@ -2895,7 +3072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
@@ -2908,7 +3085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "libc",
 ]
@@ -3462,7 +3639,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
@@ -3838,7 +4015,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4093,7 +4270,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -4147,6 +4324,15 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -4429,7 +4615,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crossterm",
  "instability",
  "ratatui-core",
@@ -4610,11 +4796,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rio-grapheme-width"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dba44bbb5eb9f53186c804ab1a46a97ed9f0475d434767ef8c9b3ea8d24ec2"
+dependencies = [
+ "phf 0.13.1",
+ "ucd-trie",
+]
+
+[[package]]
+name = "rio-graphics"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757d408f94ad2d8cd465a005908c86c62dbab55a1b8ba21444db7c46a3b37af4"
+dependencies = [
+ "rustc-hash 2.1.2",
+ "tracing",
+]
+
+[[package]]
+name = "rio-vt"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b52c06372ac0150f6e6bcdc57113256b5e8e8cef223ca1bf6c2c3a10c50449"
+dependencies = [
+ "base64",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "corcovado",
+ "cursor-icon",
+ "flate2",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "regex",
+ "regex-automata",
+ "rio-grapheme-width",
+ "rio-graphics",
+ "rustc-hash 2.1.2",
+ "serde",
+ "simdutf",
+ "smallvec",
+ "teletypewriter",
+ "tracing",
+ "unicode-width-16",
+ "url",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5126,7 +5363,7 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "winapi",
 ]
@@ -5137,7 +5374,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
@@ -5148,7 +5385,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -5242,6 +5479,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.11.1",
+ "cc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5431,6 +5678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "syntect"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,6 +5743,23 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "teletypewriter"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ae4da081d603b942e2ed62d063e7a5cf083427caf26c7627c17a1b6a0b22b6"
+dependencies = [
+ "corcovado",
+ "dirs",
+ "iovec",
+ "libc",
+ "miow 0.6.1",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "tempfile"
@@ -5628,7 +5903,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -5670,7 +5945,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "tiny-skia-path",
 ]
@@ -5696,6 +5971,16 @@ dependencies = [
  "chunked_transfer",
  "httpdate",
  "log",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -6156,6 +6441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-width-16"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6203,6 +6494,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,6 +6516,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -6249,17 +6558,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width",
- "vte",
-]
 
 [[package]]
 name = "vte"
@@ -6333,7 +6631,7 @@ version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -6644,7 +6942,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "document-features",
  "hashbrown 0.16.1",
@@ -6737,7 +7035,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "core-graphics-types 0.2.0",
  "glow",
@@ -6833,6 +7131,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
 
 [[package]]
 name = "windows"
@@ -6986,6 +7299,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7445,6 +7773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7555,6 +7889,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7575,10 +7932,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zip"

--- a/crates/fresh-editor/Cargo.toml
+++ b/crates/fresh-editor/Cargo.toml
@@ -73,7 +73,7 @@ tree-sitter = ["fresh-languages/bundled-languages"]
 embed-plugins = ["plugins", "dep:include_dir", "dep:trash"]
 # Feature for optional development binaries (generate_schema, event_debug)
 # Includes ratatui for theme type definitions needed by schema generation
-dev-bins = ["dep:ratatui", "dep:vt100"]
+dev-bins = ["dep:ratatui", "dep:rio-vt"]
 # Runtime feature includes all heavy dependencies needed for the actual editor
 runtime = [
     "dep:crossterm",
@@ -271,7 +271,7 @@ include_dir = { version = "0.7", optional = true }
 tempfile = { version = "3.25", optional = true }
 trash = { version = "5.2.5", optional = true }
 open = { version = "5.3", optional = true }
-vt100 = { version = "0.16", optional = true }
+rio-vt = { version = "0.5.1", optional = true }
 
 # GUI mode — all windowing/GPU deps are encapsulated in fresh-gui
 fresh-gui = { workspace = true, optional = true }
@@ -280,7 +280,7 @@ fresh-gui = { workspace = true, optional = true }
 proptest = "1.9"
 tempfile = "3.25"
 insta = { version = "1.46", features = ["yaml"] }
-vt100 = "0.16"  # Virtual terminal emulator for testing real ANSI output
+rio-vt = "0.5.1"  # Terminal engine for parsing real ANSI output in tests
 ctor = "0.6.3"
 tiny_http = "0.12"  # Lightweight HTTP server for testing release checker
 unicode-segmentation = "1.12"  # For grapheme cluster testing

--- a/crates/fresh-editor/src/bin/measure_startup.rs
+++ b/crates/fresh-editor/src/bin/measure_startup.rs
@@ -3,7 +3,7 @@
 //! Spawns the editor in a real pseudo-terminal and measures time from exec
 //! until the marker string (default: "File") appears in the rendered screen.
 //!
-//! Uses the `vt100` crate as a virtual terminal emulator to process raw PTY
+//! Uses `rio-vt` as a virtual terminal emulator to process raw PTY
 //! output into actual screen contents, so we detect exactly what a user would
 //! see. A dedicated reader thread responds to crossterm's DA1 query with
 //! minimal latency.
@@ -157,7 +157,7 @@ fn run_once(
     let cols_copy = cols;
 
     let handle = std::thread::spawn(move || {
-        let mut parser = vt100::Parser::new(rows_copy, cols_copy, 0);
+        let mut parser = fresh::vt::Parser::new(rows_copy, cols_copy, 0);
         let mut raw_buf = Vec::new();
         let mut da1_replied = false;
         let mut first_output: Option<Instant> = None;

--- a/crates/fresh-editor/src/lib.rs
+++ b/crates/fresh-editor/src/lib.rs
@@ -33,6 +33,11 @@ pub mod workspace;
 pub mod model;
 pub mod primitives;
 
+// vt100-shaped terminal parser over rio-vt, for ANSI-output tests and the
+// startup-measurement binary.
+#[cfg(any(test, feature = "dev-bins"))]
+pub mod vt;
+
 // Runtime-only modules (heavy dependencies, platform-specific)
 #[cfg(feature = "runtime")]
 pub mod app;

--- a/crates/fresh-editor/src/server/tests.rs
+++ b/crates/fresh-editor/src/server/tests.rs
@@ -1040,7 +1040,7 @@ mod integration_tests {
     /// Parse accumulated ANSI output through a VT100 terminal emulator
     /// and return the visible screen text (all rows joined by newlines).
     fn vt100_screen_text(output: &[u8]) -> String {
-        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut parser = crate::vt::Parser::new(24, 80, 0);
         parser.process(output);
         let screen = parser.screen();
         let mut result = String::new();

--- a/crates/fresh-editor/src/vt.rs
+++ b/crates/fresh-editor/src/vt.rs
@@ -1,0 +1,114 @@
+//! Minimal vt100-shaped adapter over [rio-vt](https://crates.io/crates/rio-vt),
+//! used by the terminal-output tests and the startup-measurement binary: feed
+//! bytes with `process`, then read the parsed grid back through `screen()`.
+//!
+//! Only the small slice of the old `vt100` surface the tests relied on is
+//! reproduced (`process`, `screen().cell()/.contents()/.cursor_position()/
+//! .hide_cursor()`), so call sites are unchanged apart from the type path.
+
+use rio_vt::ansi::CursorShape;
+use rio_vt::crosswords::formatter::FormatOptions;
+use rio_vt::crosswords::grid::row::Row;
+use rio_vt::crosswords::pos::Column;
+use rio_vt::crosswords::square::{Square, Wide};
+use rio_vt::crosswords::{Crosswords, CrosswordsSize, Mode};
+use rio_vt::event::{VoidListener, WindowId};
+use rio_vt::performer::handler::Processor;
+
+/// A terminal parser: bytes in, grid state out.
+pub struct Parser {
+    term: Crosswords<VoidListener>,
+    processor: Processor,
+}
+
+impl Parser {
+    pub fn new(rows: u16, cols: u16, _scrollback: usize) -> Self {
+        Self {
+            term: Crosswords::new(
+                CrosswordsSize::new(cols as usize, rows as usize),
+                CursorShape::Block,
+                VoidListener,
+                WindowId::from(0),
+                0,
+                0,
+            ),
+            processor: Processor::default(),
+        }
+    }
+
+    pub fn process(&mut self, bytes: &[u8]) {
+        self.processor.advance(&mut self.term, bytes);
+    }
+
+    pub fn screen(&self) -> Screen {
+        Screen {
+            columns: self.term.columns(),
+            cursor: {
+                let pos = self.term.cursor().pos;
+                (pos.row.0 as u16, pos.col.0 as u16)
+            },
+            cursor_hidden: !self.term.mode().contains(Mode::SHOW_CURSOR),
+            plain: self.term.format(FormatOptions::plain()),
+            rows: self.term.visible_rows(),
+        }
+    }
+}
+
+/// A snapshot of the visible grid.
+pub struct Screen {
+    columns: usize,
+    cursor: (u16, u16),
+    cursor_hidden: bool,
+    plain: String,
+    rows: Vec<Row<Square>>,
+}
+
+impl Screen {
+    /// Visible screen as plain UTF-8 text.
+    pub fn contents(&self) -> String {
+        self.plain.clone()
+    }
+
+    /// The cell at `(row, col)`, or `None` when out of bounds.
+    pub fn cell(&self, row: u16, col: u16) -> Option<Cell> {
+        let grid_row = self.rows.get(row as usize)?;
+        if col as usize >= self.columns {
+            return None;
+        }
+        let square = grid_row[Column(col as usize)];
+        Some(Cell {
+            ch: square.c(),
+            spacer: matches!(square.wide(), Wide::Spacer),
+        })
+    }
+
+    /// Cursor position as `(row, col)`.
+    pub fn cursor_position(&self) -> (u16, u16) {
+        self.cursor
+    }
+
+    /// Whether the hardware cursor is hidden (`\x1b[?25l`).
+    pub fn hide_cursor(&self) -> bool {
+        self.cursor_hidden
+    }
+}
+
+/// A single grid cell.
+pub struct Cell {
+    ch: char,
+    spacer: bool,
+}
+
+impl Cell {
+    /// Cell text: empty for the continuation half of a wide glyph, a space
+    /// for an untouched cell, otherwise the glyph.
+    pub fn contents(&self) -> String {
+        if self.spacer {
+            String::new()
+        } else if self.ch == '\0' {
+            " ".to_string()
+        } else {
+            self.ch.to_string()
+        }
+    }
+}

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -522,7 +522,7 @@ pub struct EditorTestHarness {
 
     /// VT100 parser for testing real ANSI terminal output
     /// This simulates how a real terminal would interpret the escape sequences
-    vt100_parser: vt100::Parser,
+    vt100_parser: super::vt::Parser,
 
     /// Terminal dimensions for vt100
     term_width: u16,
@@ -776,7 +776,7 @@ impl EditorTestHarness {
             enable_shadow_validation: false,
             shadow_undo_stack: Vec::new(),
             shadow_redo_stack: Vec::new(),
-            vt100_parser: vt100::Parser::new(height, width, 0),
+            vt100_parser: super::vt::Parser::new(height, width, 0),
             term_width: width,
             term_height: height,
         };

--- a/crates/fresh-editor/tests/common/mod.rs
+++ b/crates/fresh-editor/tests/common/mod.rs
@@ -20,6 +20,10 @@ pub mod git_test_helper;
 pub mod harness;
 #[cfg(test)]
 #[allow(dead_code)]
+#[path = "../../src/vt.rs"]
+pub mod vt;
+#[cfg(test)]
+#[allow(dead_code)]
 pub mod locale_lock;
 #[cfg(test)]
 #[allow(dead_code)]

--- a/crates/fresh-editor/tests/common/scenario/terminal_io_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/terminal_io_scenario.rs
@@ -2,7 +2,7 @@
 //!
 //! Asserts on the [`RoundTripGrid`] produced by piping the editor's
 //! emitted ANSI through the harness's existing `render_real()` →
-//! `vt100::Parser` → typed grid pipeline. Catches escape-emission
+//! `rio-vt` parser → typed grid pipeline. Catches escape-emission
 //! bugs (redundant SGR resets, incorrect cursor positioning,
 //! incremental-redraw correctness regressions) without committing
 //! to specific byte sequences.

--- a/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
@@ -377,7 +377,7 @@ fn test_issue_1577_full_ticket_sample_renders_consistently_at_137_cols_real_term
             .unwrap();
     }
 
-    let mut parser = vt100::Parser::new(TICKET_HEIGHT, TICKET_WIDTH, 0);
+    let mut parser = crate::common::vt::Parser::new(TICKET_HEIGHT, TICKET_WIDTH, 0);
     parser.process(&captured);
     let screen = parser.screen();
     let mut vt100_text = String::new();


### PR DESCRIPTION
Swaps the terminal emulator behind the `render_real()` → ANSI → grid test pipeline from [vt100](https://crates.io/crates/vt100) to [rio-vt](https://crates.io/crates/rio-vt), Rio's terminal engine.

This PR only moves the **test** parser, but the reason to standardize on rio-vt is that it's a full terminal engine an editor can build real features on — not just a screen-scraper for tests. fresh already ships an embedded terminal (`services/terminal`), and rio-vt is exactly the core that powers, so the same dependency covers both the tests and the product surface:

the features it adds:

- **Correct Unicode width & grapheme clustering** : the same wide-glyph / combining-mark handling that `issue_1577_unicode_width` exists to protect. rio-vt packs width into the grid so cursor, wrapping and selection never desync from width-unaware apps (shells, editors).
- **Grid + scrollback, selection, and regex search** over the visible screen *and* scrollback, the primitives an in-editor terminal needs.
- **Image protocols**: sixel, Kitty, and iTerm2 graphics decoded by the core (inline images in the terminal pane).
- **Shell integration**: OSC 7 (working directory), OSC 8 (hyperlinks), OSC 133 (semantic prompt / command boundaries) jump-to-prompt, cwd-aware splits, clickable links.
- **Per-row damage tracking**, so a consumer repaints only the cells that changed, cheap redraws for a live editor loop.
- **Safe Rust, dependency-light** (no renderer, GPU, or font-shaping deps when built with no features, it's just the terminal), **fast**, and already in production at [Lovable](https://lovable.dev).

It also drops the transitive **`net2` (RUSTSEC-2020-0016, unmaintained)** the old parser pulled in.

- Benchmark against vt100 and alacritty_terminal: https://github.com/raphamorim/rio-vt-benchmark
- Background on the engine: https://rioterm.com/blog/2026/07/27/rio-vt-and-librio