### PR TITLE
fix(cli): `fresh --cmd cmd …` hung in embedded terminals of the daemon and GUI

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -137,8 +137,21 @@ pub(crate) fn agent_command_env(
         }
     }
     if let Some(allowlist) = command_allowlist {
-        if let Ok(session_id) = crate::server::local_control::start() {
-            env.insert("FRESH_SESSION".to_string(), session_id.to_string());
+        match crate::server::local_control::start() {
+            Ok(session_id) => {
+                env.insert("FRESH_SESSION".to_string(), session_id.to_string());
+            }
+            // The token still ships (it is what authorizes the agent), but with
+            // no socket to present it to every `fresh --cmd …` the agent runs
+            // fails with "not inside a Fresh session". Silently swallowing that
+            // made it look like the CLI itself was broken, so say what happened
+            // — the cause is environmental (e.g. a socket path over the
+            // platform's `sun_path` limit), not something the agent can fix.
+            Err(e) => tracing::warn!(
+                "Local control socket unavailable ({}); the agent terminal gets a \
+                 command token but no FRESH_SESSION to use it with",
+                e
+            ),
         }
         let token = crate::server::command_access::mint(crate::server::command_access::Grant::new(
             Some(window.0),

--- a/crates/fresh-editor/src/gui/mod.rs
+++ b/crates/fresh-editor/src/gui/mod.rs
@@ -100,6 +100,17 @@ pub fn run_gui(
         cfg
     };
 
+    // Bind this process's in-process control socket so a `fresh` run inside an
+    // embedded terminal forwards opens *and* drives the command channel
+    // (`ListCommands` / `RunCommand`) back to this editor — same as the TUI
+    // path (main.rs) and the web path (webui::run). GUI mode used to bind it
+    // only lazily, when an agent terminal minted a `FRESH_CMD_TOKEN`; a plain
+    // terminal therefore never advertised `FRESH_SESSION` at all. Best-effort:
+    // on failure the editor still runs and nested launches open inline.
+    if let Err(e) = crate::server::local_control::start() {
+        tracing::warn!("Local control socket unavailable: {}", e);
+    }
+
     // Move all captured state into the closure that creates the editor app.
     fresh_gui::run(gui_config, move |cols, rows| {
         // For GUI, we always have true color.
@@ -211,7 +222,17 @@ impl GuiApplication for EditorApp {
     }
 
     fn tick(&mut self) -> AnyhowResult<bool> {
-        crate::app::editor_tick(&mut self.editor, || Ok(()))
+        // Drain nested-forward requests (file/dir opens from a `fresh` run in an
+        // embedded terminal, and the `fresh --cmd` command channel) before the
+        // tick, exactly like the TUI loop (main.rs) and the web loop
+        // (webui::run), so queued work is applied on this same pass. Without
+        // this, a request reaches the editor thread's queue and is never drained:
+        // the handler thread parks on its reply forever and `fresh --cmd cmd
+        // list` hangs in the agent's terminal. Cheap no-op until `start()` has
+        // bound the socket; never blocks.
+        let control_changed = crate::server::local_control::pump(&mut self.editor);
+        let ticked = crate::app::editor_tick(&mut self.editor, || Ok(()))?;
+        Ok(control_changed || ticked)
     }
 
     fn should_quit(&self) -> bool {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3162,6 +3162,19 @@ fn run_open_files_command(
 /// caller should abort quietly — a message has already been printed), and
 /// `Err` on a protocol-level error.
 fn client_handshake(conn: &fresh::server::ipc::ClientConnection) -> AnyhowResult<bool> {
+    client_handshake_reading(conn, || Ok(conn.read_control()?))
+}
+
+/// [`client_handshake`], but with the reply read through a caller-supplied
+/// reader. The command-channel client passes a deadline-bounded one so a server
+/// that accepts the connection and then goes quiet is an error, not a hang.
+fn client_handshake_reading<F>(
+    conn: &fresh::server::ipc::ClientConnection,
+    mut read_reply: F,
+) -> AnyhowResult<bool>
+where
+    F: FnMut() -> AnyhowResult<Option<String>>,
+{
     use fresh::server::protocol::{
         ClientControl, ClientHello, ServerControl, TermSize, PROTOCOL_VERSION,
     };
@@ -3170,8 +3183,7 @@ fn client_handshake(conn: &fresh::server::ipc::ClientConnection) -> AnyhowResult
     let hello = ClientHello::new(TermSize::new(80, 24));
     conn.write_control(&serde_json::to_string(&ClientControl::Hello(hello))?)?;
 
-    let response = conn
-        .read_control()?
+    let response = read_reply()?
         .ok_or_else(|| anyhow::anyhow!("Server closed connection during handshake"))?;
 
     match serde_json::from_str::<ServerControl>(&response)? {
@@ -3381,48 +3393,112 @@ fn resolve_cmd_socket(session_override: Option<&str>) -> AnyhowResult<SocketPath
     Ok(socket_paths)
 }
 
-/// Connect to the resolved socket and complete the client handshake.
-fn connect_cmd(socket_paths: &SocketPaths) -> AnyhowResult<fresh::server::ipc::ClientConnection> {
+/// How long a command-channel client waits for the editor to answer before
+/// giving up. Replies are computed on the editor thread and sent within a frame,
+/// so this only ever trips when the editor cannot answer at all — in which case
+/// an agent must get an error it can report, not an indefinite hang. Override
+/// with `FRESH_CMD_TIMEOUT_MS` for an editor deliberately parked (e.g. under a
+/// debugger).
+fn cmd_reply_timeout() -> std::time::Duration {
+    const DEFAULT_MS: u64 = 10_000;
+    let ms = std::env::var("FRESH_CMD_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .unwrap_or(DEFAULT_MS);
+    std::time::Duration::from_millis(ms)
+}
+
+/// Turn a bounded-read failure into an actionable message. A timeout here means
+/// the editor accepted the connection but never answered — the signature of a
+/// build whose event loop doesn't drain the control socket.
+fn cmd_read_error(e: std::io::Error) -> anyhow::Error {
+    if e.kind() == std::io::ErrorKind::TimedOut {
+        anyhow::anyhow!(
+            "the Fresh editor accepted the connection but did not answer within {:?}. \
+             It may be busy, or running a build without command-channel support; \
+             raise the wait with FRESH_CMD_TIMEOUT_MS if it is merely slow.",
+            cmd_reply_timeout()
+        )
+    } else {
+        anyhow::Error::from(e)
+    }
+}
+
+/// A live command-channel connection: the socket plus the reader that carries
+/// bytes buffered between replies. One reader for the whole exchange — a fresh
+/// one per read would drop anything that arrived in the same chunk as the
+/// previous message.
+struct CmdConnection {
+    conn: fresh::server::ipc::ClientConnection,
+    reader: fresh::server::ipc::ControlReader,
+}
+
+impl CmdConnection {
+    fn send(&self, msg: &fresh::server::protocol::ClientControl) -> AnyhowResult<()> {
+        self.conn.write_control(&serde_json::to_string(msg)?)?;
+        Ok(())
+    }
+
+    /// Read one reply, bounded by [`cmd_reply_timeout`].
+    fn recv(&mut self) -> AnyhowResult<Option<fresh::server::protocol::ServerControl>> {
+        let line = self
+            .reader
+            .read_line_timeout(cmd_reply_timeout())
+            .map_err(cmd_read_error)?;
+        match line {
+            Some(line) => Ok(Some(serde_json::from_str(&line)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Connect to the resolved socket and complete the client handshake. Reads are
+/// deadline-bounded, so the client can never hang on an editor that accepts the
+/// connection and then never answers.
+fn connect_cmd(socket_paths: &SocketPaths) -> AnyhowResult<CmdConnection> {
     let conn = fresh::server::ipc::ClientConnection::connect(socket_paths)?;
-    if !client_handshake(&conn)? {
+    let mut reader = conn.control_reader();
+    let accepted = client_handshake_reading(&conn, || {
+        reader
+            .read_line_timeout(cmd_reply_timeout())
+            .map_err(cmd_read_error)
+    })?;
+    if !accepted {
         // client_handshake already printed the mismatch reason.
         anyhow::bail!("handshake with the Fresh editor failed");
     }
-    Ok(conn)
+    Ok(CmdConnection { conn, reader })
 }
 
-/// Read control replies until a `CommandList` arrives (or an error/EOF).
+/// Read control replies until a `CommandList` arrives (or an error/EOF/timeout).
 fn read_command_list(
-    conn: &fresh::server::ipc::ClientConnection,
+    conn: &mut CmdConnection,
 ) -> AnyhowResult<Vec<fresh::server::protocol::CommandInfo>> {
     use fresh::server::protocol::ServerControl;
     loop {
-        match conn.read_control()? {
-            Some(line) => match serde_json::from_str::<ServerControl>(&line)? {
-                ServerControl::CommandList { commands } => return Ok(commands),
-                ServerControl::Error { message } => anyhow::bail!("server error: {}", message),
-                _ => continue,
-            },
+        match conn.recv()? {
+            Some(ServerControl::CommandList { commands }) => return Ok(commands),
+            Some(ServerControl::Error { message }) => anyhow::bail!("server error: {}", message),
+            Some(_) => continue,
             None => anyhow::bail!("server closed the connection before answering"),
         }
     }
 }
 
-/// Read control replies until a `CommandResult` arrives (or an error/EOF).
+/// Read control replies until a `CommandResult` arrives (or an error/EOF/timeout).
 /// Returns `(ok, error, output)`.
 fn read_command_result(
-    conn: &fresh::server::ipc::ClientConnection,
+    conn: &mut CmdConnection,
 ) -> AnyhowResult<(bool, Option<String>, Option<String>)> {
     use fresh::server::protocol::ServerControl;
     loop {
-        match conn.read_control()? {
-            Some(line) => match serde_json::from_str::<ServerControl>(&line)? {
-                ServerControl::CommandResult { ok, error, output } => {
-                    return Ok((ok, error, output))
-                }
-                ServerControl::Error { message } => anyhow::bail!("server error: {}", message),
-                _ => continue,
-            },
+        match conn.recv()? {
+            Some(ServerControl::CommandResult { ok, error, output }) => {
+                return Ok((ok, error, output))
+            }
+            Some(ServerControl::Error { message }) => anyhow::bail!("server error: {}", message),
+            Some(_) => continue,
             None => anyhow::bail!("server closed the connection before answering"),
         }
     }
@@ -3480,11 +3556,11 @@ fn cmd_list(session: Option<&str>, flags: &[&str]) -> AnyhowResult<()> {
     let json = flags.contains(&"--json");
 
     let socket = resolve_cmd_socket(session)?;
-    let conn = connect_cmd(&socket)?;
-    conn.write_control(&serde_json::to_string(&ClientControl::ListCommands {
+    let mut conn = connect_cmd(&socket)?;
+    conn.send(&ClientControl::ListCommands {
         include_args: false,
-    })?)?;
-    let mut commands = read_command_list(&conn)?;
+    })?;
+    let mut commands = read_command_list(&mut conn)?;
     commands.sort_by(|a, b| a.id.cmp(&b.id));
 
     if json {
@@ -3504,11 +3580,9 @@ fn cmd_describe(session: Option<&str>, id: &str, flags: &[&str]) -> AnyhowResult
     let json = flags.contains(&"--json");
 
     let socket = resolve_cmd_socket(session)?;
-    let conn = connect_cmd(&socket)?;
-    conn.write_control(&serde_json::to_string(&ClientControl::ListCommands {
-        include_args: true,
-    })?)?;
-    let commands = read_command_list(&conn)?;
+    let mut conn = connect_cmd(&socket)?;
+    conn.send(&ClientControl::ListCommands { include_args: true })?;
+    let commands = read_command_list(&mut conn)?;
 
     let info = match commands.iter().find(|c| c.id == id) {
         Some(info) => info,
@@ -3570,13 +3644,13 @@ fn run_command_id(
     use fresh::server::protocol::ClientControl;
 
     let socket = resolve_cmd_socket(session)?;
-    let conn = connect_cmd(&socket)?;
-    conn.write_control(&serde_json::to_string(&ClientControl::RunCommand {
+    let mut conn = connect_cmd(&socket)?;
+    conn.send(&ClientControl::RunCommand {
         id: id.to_string(),
         args,
-    })?)?;
+    })?;
 
-    let (ok, error, output) = read_command_result(&conn)?;
+    let (ok, error, output) = read_command_result(&mut conn)?;
     if let Some(out) = output {
         if !out.is_empty() {
             println!("{}", out);
@@ -3608,9 +3682,9 @@ fn workspace_new(session: Option<&str>, dir: &str) -> AnyhowResult<()> {
 
     let socket = resolve_cmd_socket(session)?;
     let conn = connect_cmd(&socket)?;
-    conn.write_control(&serde_json::to_string(&ClientControl::OpenWindow {
+    conn.send(&ClientControl::OpenWindow {
         path: abs.to_string_lossy().into_owned(),
-    })?)?;
+    })?;
     // OpenWindow is fire-and-forget (the server sends no reply), matching
     // `forward_to_session`.
     Ok(())

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -323,6 +323,24 @@ impl EditorServer {
                 }
             }
 
+            // Drain nested-forward requests (file/dir opens from a `fresh` run
+            // in an embedded terminal, and the `fresh --cmd` command channel)
+            // before anything else, exactly like the TUI loop (main.rs), the
+            // GUI tick (gui::EditorApp::tick) and the standalone web loop
+            // (webui::run). The daemon hosts terminals of its own — `fresh
+            // --web` runs here — so an agent workspace spawned in one gets a
+            // `FRESH_SESSION` / `FRESH_CMD_TOKEN` pointing at the in-process
+            // control socket. Without this drain the request reached the
+            // editor thread's queue and stayed there: the handler thread parked
+            // on a reply that never came and `fresh --cmd cmd list` hung in the
+            // agent's terminal. Cheap no-op until the socket is bound; never
+            // blocks.
+            if let Some(ref mut editor) = self.editor {
+                if crate::server::local_control::pump(editor) {
+                    needs_render = true;
+                }
+            }
+
             // Accept new connections
             tracing::debug!("[server] main loop: calling accept()");
             match self.listener.accept() {

--- a/crates/fresh-editor/src/server/ipc/mod.rs
+++ b/crates/fresh-editor/src/server/ipc/mod.rs
@@ -9,6 +9,7 @@
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use interprocess::local_socket::{
     prelude::*, Listener, ListenerNonblockingMode, ListenerOptions, Stream,
@@ -314,6 +315,100 @@ impl StreamWrapper {
     }
 }
 
+/// A deadline-bounded, buffered line reader over a control stream.
+///
+/// [`ClientConnection::read_control`] blocks until a newline arrives, which is
+/// right for a client that has attached to an editor and follows it for the
+/// rest of its life. It is wrong for the one-shot `fresh --cmd cmd …` clients
+/// an agent runs: if the editor never answers — an old build, or one whose
+/// event loop doesn't drain the control socket — the agent hangs forever with
+/// nothing to report. Reads here fail with [`io::ErrorKind::TimedOut`] instead,
+/// so a stuck editor surfaces as a diagnosable error.
+///
+/// Bytes read past the first newline stay in this reader's own buffer, so
+/// consecutive reads on one connection never lose a message that arrived in the
+/// same chunk as its predecessor — the hazard of building a fresh [`BufReader`]
+/// per call.
+pub struct ControlReader {
+    stream: StreamWrapper,
+    buf: Vec<u8>,
+}
+
+impl ControlReader {
+    /// How long to sleep between polls while waiting for the next chunk. Small
+    /// enough to be invisible on a live editor (replies come back in one frame),
+    /// large enough not to spin a core while waiting.
+    const POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+    /// Wrap a control stream. Cheap: shares the underlying stream (no I/O until
+    /// the first read), so the reader can outlive the borrow it was made from
+    /// and carry its buffered bytes across a whole exchange.
+    pub fn new(stream: &StreamWrapper) -> Self {
+        Self {
+            stream: stream.clone(),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Read one newline-terminated control message, waiting at most `timeout`.
+    ///
+    /// Returns `Ok(Some(line))` for a complete message (newline included, as
+    /// [`ClientConnection::read_control`] does), `Ok(None)` when the peer closed
+    /// the connection with nothing buffered, and `Err` with kind `TimedOut` when
+    /// the deadline passes first.
+    pub fn read_line_timeout(&mut self, timeout: Duration) -> io::Result<Option<String>> {
+        let deadline = Instant::now() + timeout;
+        let mut chunk = [0u8; 4096];
+
+        loop {
+            if let Some(line) = self.take_line() {
+                return Ok(Some(line));
+            }
+
+            match self.stream.try_read(&mut chunk) {
+                // EOF. A newline-less tail is handed back rather than dropped so
+                // a truncated message fails to parse loudly instead of looking
+                // like a clean close.
+                Ok(0) => return Ok(self.take_rest()),
+                Ok(n) => {
+                    self.buf.extend_from_slice(&chunk[..n]);
+                    continue;
+                }
+                Err(e)
+                    if e.kind() == io::ErrorKind::WouldBlock
+                        || e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for a control message",
+                ));
+            }
+            std::thread::sleep(Self::POLL_INTERVAL.min(deadline - now));
+        }
+    }
+
+    /// Split off the first complete line in the buffer, if there is one.
+    fn take_line(&mut self) -> Option<String> {
+        let end = self.buf.iter().position(|b| *b == b'\n')? + 1;
+        let rest = self.buf.split_off(end);
+        let line = std::mem::replace(&mut self.buf, rest);
+        Some(String::from_utf8_lossy(&line).into_owned())
+    }
+
+    /// Take whatever is buffered, `None` when empty.
+    fn take_rest(&mut self) -> Option<String> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        let line = std::mem::take(&mut self.buf);
+        Some(String::from_utf8_lossy(&line).into_owned())
+    }
+}
+
 /// Helper to map Windows pipe errors to WouldBlock
 #[inline]
 fn map_windows_pipe_error(result: io::Result<usize>) -> io::Result<usize> {
@@ -478,6 +573,14 @@ impl ClientConnection {
         }
     }
 
+    /// A deadline-bounded reader over this connection's control stream, for
+    /// clients that must not hang when the editor never answers (see
+    /// [`ControlReader`]). Hold on to one reader for the whole exchange: it
+    /// carries the bytes buffered between reads.
+    pub fn control_reader(&self) -> ControlReader {
+        ControlReader::new(&self.control)
+    }
+
     /// Write a control message
     pub fn write_control(&self, msg: &str) -> io::Result<()> {
         self.control.write_all(msg.as_bytes())?;
@@ -608,6 +711,85 @@ mod tests {
 
         // No sockets exist, should return false (nothing to clean)
         assert!(!paths.cleanup_if_stale());
+    }
+
+    /// Connect a client to a freshly bound listener and return both ends.
+    #[cfg(unix)]
+    fn connected_pair(paths: &SocketPaths) -> (ServerConnection, ClientConnection) {
+        use std::thread;
+
+        let mut listener = ServerListener::bind(paths.clone()).unwrap();
+        let client_paths = paths.clone();
+        let client = thread::spawn(move || ClientConnection::connect(&client_paths).unwrap());
+        let server_conn = loop {
+            if let Some(c) = listener.accept().unwrap() {
+                break c;
+            }
+        };
+        // The listener owns the socket files; keep it alive for the caller's
+        // lifetime by leaking it (the temp dir cleans up).
+        std::mem::forget(listener);
+        (server_conn, client.join().unwrap())
+    }
+
+    /// Two messages written back-to-back arrive in one chunk. A reader that
+    /// rebuilt its buffer per call (what `read_control` does with a fresh
+    /// `BufReader`) would drop the second; `ControlReader` keeps it.
+    #[cfg(unix)]
+    #[test]
+    fn control_reader_keeps_a_second_message_from_the_same_chunk() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("ctrl-reader-chunk", temp_dir.path());
+        let (server_conn, client_conn) = connected_pair(&paths);
+
+        server_conn.write_control("{\"first\":1}").unwrap();
+        server_conn.write_control("{\"second\":2}").unwrap();
+
+        let mut reader = client_conn.control_reader();
+        let first = reader
+            .read_line_timeout(Duration::from_secs(30))
+            .unwrap()
+            .expect("first message");
+        let second = reader
+            .read_line_timeout(Duration::from_secs(30))
+            .unwrap()
+            .expect("second message");
+        assert_eq!(first.trim(), "{\"first\":1}");
+        assert_eq!(second.trim(), "{\"second\":2}");
+    }
+
+    /// A peer that accepts the connection and then goes quiet must not park the
+    /// reader forever — this is the `fresh --cmd cmd list` hang, bounded. The
+    /// deadline is the unit under test: nothing is ever written, so there is no
+    /// race between "reply arrives" and "deadline passes".
+    #[cfg(unix)]
+    #[test]
+    fn control_reader_times_out_when_nothing_is_written() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("ctrl-reader-timeout", temp_dir.path());
+        let (_server_conn, client_conn) = connected_pair(&paths);
+
+        let err = client_conn
+            .control_reader()
+            .read_line_timeout(Duration::from_millis(50))
+            .expect_err("a silent peer must not block the reader forever");
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+
+    /// A closed connection reports EOF rather than waiting out the deadline.
+    #[cfg(unix)]
+    #[test]
+    fn control_reader_reports_eof_when_the_peer_closes() {
+        let temp_dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("ctrl-reader-eof", temp_dir.path());
+        let (server_conn, client_conn) = connected_pair(&paths);
+        drop(server_conn);
+
+        let msg = client_conn
+            .control_reader()
+            .read_line_timeout(Duration::from_secs(30))
+            .expect("EOF is not an error");
+        assert!(msg.is_none(), "expected EOF, got {:?}", msg);
     }
 
     /// Regression test for the embedded-terminal copy hang.

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -185,7 +185,13 @@ pub fn pump(editor: &mut Editor) -> bool {
     let Some(shared) = GLOBAL.get() else {
         return false;
     };
+    pump_shared(shared, editor)
+}
 
+/// The body of [`pump`], against an explicit [`Shared`] rather than the
+/// process-global one — so a test can drive a socket bound by
+/// [`bind_and_spawn`] without touching (or racing on) the global.
+fn pump_shared(shared: &Shared, editor: &mut Editor) -> bool {
     let mut changed = false;
 
     // Drain decoded requests. The lock is only contended for the brief
@@ -530,12 +536,23 @@ fn read_msg(
 
 /// A unique-per-process session id: `local-<pid>-<nanos>`. The nanosecond
 /// component guards against pid reuse across quick successive runs.
+///
+/// The clock component is truncated to its low 40 bits and printed in hex (10
+/// chars instead of 19). The id becomes a socket *filename* under the runtime
+/// dir, and a Unix `sockaddr_un` path is capped at ~108 bytes — a shorter name
+/// leaves that much more headroom for the runtime dir itself before `bind`
+/// fails outright. 40 bits of nanoseconds still spans ~18 minutes, far longer
+/// than the window in which a pid could plausibly be recycled.
 fn generate_session_id() -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    format!("local-{}-{}", std::process::id(), nanos)
+    format!(
+        "local-{}-{:x}",
+        std::process::id(),
+        (nanos as u64) & 0xFF_FFFF_FFFF
+    )
 }
 
 #[cfg(test)]
@@ -827,6 +844,137 @@ mod tests {
             }
             other => panic!("expected RunCommand, got {}", req_kind(&other)),
         }
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// Build a `Shared` over an already-bound control socket, so a test can run
+    /// the editor-thread half (`pump_shared`) exactly as a host loop does.
+    fn shared_for(bound: BoundControl) -> Shared {
+        Shared {
+            req_rx: Mutex::new(bound.req_rx),
+            waiters: bound.waiters,
+        }
+    }
+
+    /// An editor for the pump half of the round trip. Plugins stay off: the
+    /// commands under test are built-ins, and a plugin runtime would only add
+    /// startup cost.
+    fn pump_test_editor() -> (Editor, TempDir) {
+        let temp = TempDir::new().unwrap();
+        let dir_context = crate::config_io::DirectoryContext::for_testing(temp.path());
+        let editor = Editor::new(
+            crate::config::Config::default(),
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            std::sync::Arc::new(crate::model::filesystem::StdFileSystem),
+        )
+        .expect("editor");
+        (editor, temp)
+    }
+
+    /// The full `fresh --cmd cmd list` round trip against a host that drains the
+    /// channel: the request reaches the editor thread, `pump` answers it from
+    /// the command registry scoped to the caller's token, and the client reads a
+    /// `CommandList`.
+    ///
+    /// Regression: only the TUI loop and the standalone web bridge pumped. The
+    /// GUI tick and the session daemon (what `fresh --web` and every attached
+    /// terminal run) did not, so the request sat in the queue, the handler
+    /// thread parked on a reply that was never produced, and `fresh --cmd cmd
+    /// list` hung forever in the agent's terminal.
+    #[test]
+    fn list_commands_is_answered_when_the_host_pumps() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("list-cmd-pump-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+        let shutdown = bound.shutdown.clone();
+        let shared = shared_for(bound);
+
+        let token = command_access::mint(command_access::Grant::new(
+            None,
+            ["split_vertical".to_string()],
+        ));
+
+        // The client runs on its own thread with a blocking read, exactly like
+        // the real CLI; this thread plays the host loop below.
+        let (done_tx, done_rx) = mpsc::channel::<Vec<String>>();
+        let client_paths = paths.clone();
+        let client_token = token.clone();
+        let client = std::thread::spawn(move || {
+            let conn = connect_client_with_token(&client_paths, &client_token);
+            conn.write_control(
+                &serde_json::to_string(&ClientControl::ListCommands {
+                    include_args: false,
+                })
+                .unwrap(),
+            )
+            .unwrap();
+            let line = conn
+                .read_control()
+                .expect("read reply")
+                .expect("reply present");
+            let ids = match serde_json::from_str::<ServerControl>(&line).expect("parse reply") {
+                ServerControl::CommandList { commands } => {
+                    commands.into_iter().map(|c| c.id).collect()
+                }
+                other => panic!("expected CommandList, got {:?}", other),
+            };
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = done_tx.send(ids);
+        });
+
+        // Host loop: pump until the client reports. Unbounded on purpose — with
+        // the regression the reply never comes and the external runner times the
+        // test out, which is the signal we want.
+        let (mut editor, _temp) = pump_test_editor();
+        let ids = loop {
+            pump_shared(&shared, &mut editor);
+            if let Ok(ids) = done_rx.try_recv() {
+                break ids;
+            }
+        };
+
+        assert_eq!(
+            ids,
+            vec!["split_vertical".to_string()],
+            "the reply must carry exactly the commands the token allows"
+        );
+
+        client.join().unwrap();
+        command_access::revoke(&token);
+        shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// A host that accepts the connection but never drains the channel (the
+    /// regression above, and any older editor build an agent may be talking to)
+    /// must not park the client forever: the CLI's deadline-bounded read gives
+    /// up with `TimedOut` so the agent gets a diagnosable error instead of a
+    /// hang. The short deadline here *is* the unit under test — no reply can
+    /// ever arrive, so there is nothing to race with.
+    #[test]
+    fn client_read_times_out_when_the_host_never_pumps() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("list-cmd-nopump-test", dir.path());
+        // Note: no `pump` — `bound` holds the receiving end and never drains it.
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        conn.write_control(
+            &serde_json::to_string(&ClientControl::ListCommands {
+                include_args: false,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let err = conn
+            .control_reader()
+            .read_line_timeout(Duration::from_millis(100))
+            .expect_err("a host that never answers must not block the client forever");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
 
         bound.shutdown.store(true, Ordering::SeqCst);
     }


### PR DESCRIPTION
An agent launched into a workspace gets `FRESH_SESSION` + `FRESH_CMD_TOKEN` and drives the editor by shelling out to `fresh --cmd cmd list` / `cmd run`. Reported symptom: those commands just hang, in the web UI.

## Cause

Command-channel requests arrive on the in-process control socket, are handed to the editor thread, and are answered by `local_control::pump()` — which **only the TUI loop (`main.rs`) and the standalone web bridge (`webui::run`) ever called**. The session daemon (what `fresh --web` and every attached terminal run) and the GUI tick did not, so a request sat in the queue forever: the connection handler parked on `reply_rx.recv()` and the client blocked on a reply that was never written. `fresh <file>` from those terminals hung the same way.

## Changes

- **`server/editor_server.rs`** — drain the channel in the daemon's main loop (the reported `--web` case).
- **`gui/mod.rs`** — same drain in the GUI tick, and bind the control socket at startup as the TUI does. GUI bound it only lazily, when an agent workspace minted a token, so a plain terminal there never advertised `FRESH_SESSION` at all.
- **`server/ipc/mod.rs` + `main.rs`** — the command-channel client's reads are now deadline-bounded (`ControlReader`, 10s default, `FRESH_CMD_TIMEOUT_MS` to override). A host that accepts the connection and then goes quiet — an older build, a wedged loop — now gives an agent a diagnosable error instead of parking it indefinitely. The reader also keeps bytes buffered between replies, which the previous fresh-`BufReader`-per-read discarded.
- **`app/terminal.rs`, `server/local_control.rs`** — a secondary defect found while reproducing: when the control socket cannot bind, the terminal shipped `FRESH_CMD_TOKEN` with no `FRESH_SESSION` and no log line, so every `fresh --cmd` failed with "not inside a Fresh session". It now logs the reason, and the local session id is shortened (hex, low 40 bits of the clock) to leave headroom under the `sockaddr_un` path limit that made the bind fail.

## Verification

Reproduced end-to-end against a real `fresh --web` daemon with an agent-style terminal (`createTerminal` with a `commandAllowlist`, so it gets a token and a session):

- With the fix: `cmd list --json`, `cmd describe split_vertical` and `cmd run split_vertical` all return (exit 0); a non-allowlisted id is still refused (exit 1).
- Reverting only the daemon drain: the same terminal gets no answer — confirming that hunk is the fix.

Tests: new coverage for the pump round trip and for a host that never drains, plus `ControlReader` unit tests in `ipc`. Full `fresh-editor` lib suite passes (3125 tests), `cargo fmt` clean, `cargo clippy --features gui,web --all-targets` error-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FboHXXHsxVMuuNywWjULMi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FboHXXHsxVMuuNywWjULMi)_