### PR TITLE
fix(scroll): prevent blank frame at horizontal scroll bound

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -476,6 +476,21 @@ pub(crate) fn render_content(
                 .unwrap_or(&mut empty_folds);
 
             let _render_buf_span = tracing::trace_span!("render_buffer_in_split").entered();
+
+            // Use a previously discovered bound so an extra wheel step cannot
+            // paint a blank frame before the post-render scan refreshes it.
+            if show_horizontal_scrollbar
+                && !viewport.line_wrap_enabled
+                && viewport.max_line_length_seen > 0
+            {
+                let visible_width = viewport.width as usize;
+                let max_scroll = viewport
+                    .max_line_length_seen
+                    .max(visible_width)
+                    .saturating_sub(visible_width);
+                viewport.left_column = viewport.left_column.min(max_scroll);
+            }
+
             let split_view_mappings = render_buffer_in_split(
                 buf,
                 state,

--- a/crates/fresh-editor/tests/e2e/scrolling.rs
+++ b/crates/fresh-editor/tests/e2e/scrolling.rs
@@ -179,6 +179,45 @@ fn test_cursor_advances_beyond_viewport_width() {
     assert_eq!(harness.cursor_position(), 100);
 }
 
+/// An extra horizontal wheel step at the right bound must not paint a blank frame.
+#[test]
+fn test_extra_horizontal_scroll_at_right_bound_does_not_paint_blank_frame() {
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+    use fresh::config::Config;
+
+    let mut config = Config::default();
+    config.editor.line_wrap = false;
+    config.editor.show_horizontal_scrollbar = true;
+    let line: String = (0..160)
+        .map(|i| char::from(b'a' + (i % 26) as u8))
+        .collect();
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&line).unwrap();
+
+    let scroll_right = || MouseEvent {
+        kind: MouseEventKind::ScrollRight,
+        column: 10,
+        row: 2,
+        modifiers: KeyModifiers::NONE,
+    };
+
+    // More wheel steps than source cells guarantees that the existing
+    // viewport-local bound has been discovered and exceeded.
+    for _ in 0..line.len() {
+        harness.send_mouse(scroll_right()).unwrap();
+        harness.render().unwrap();
+    }
+
+    // Settle the frame after the final overshoot, then observe only rendered
+    // output when one more wheel event arrives at the same bound.
+    harness.render().unwrap();
+    let settled_frame = harness.screen_to_string();
+    harness.send_mouse(scroll_right()).unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(harness.screen_to_string(), settled_frame);
+}
+
 /// Test horizontal scrolling when cursor moves beyond visible width
 /// The viewport should scroll horizontally to keep the cursor visible
 #[test]


### PR DESCRIPTION
## Summary

After horizontal wheel input reaches the no-wrap right bound, one additional `ScrollRight` can paint a transient blank/shifted frame.

The existing viewport-local bound is refreshed and clamped only after buffer rendering. This change also clamps against the previously discovered `max_line_length_seen` immediately before rendering, preventing an overshot wheel position from being painted first.

This is intentionally an ordering fix:

- uses the existing cached bound
- adds only constant-time arithmetic and `min`
- leaves the post-render scan and clamp unchanged
- does not change width accounting, cache lifetime, scrollbar geometry, wrapping, or mouse routing

The existing monotonic cache behavior after buffer edits is outside this PR’s scope.

## Regression coverage

The screen-only E2E:

1. disables wrapping and enables the horizontal scrollbar
2. sends enough horizontal wheel events to pass the discovered right bound
3. captures the settled rendered frame
4. sends one additional `ScrollRight`
5. asserts that the immediate rendered frame is identical

Verified red/green against parent `44ae19473`:

- parent: fails with a three-column transient frame shift
- this branch: passes

## Validation

- focused blank-frame E2E
- full scrolling E2E suite
- scrollbar-marker E2Es
- `cargo check --all-targets`
- `cargo check --no-default-features --features runtime --all-targets`
- `cargo clippy --all-features --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Only pre-existing workspace warnings remain. No performance benchmark is included because the production change adds no scan, allocation, or algorithmic work.