### PR TITLE
feat(api): let a script leave behind a view that still works after it exits

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -612,6 +612,11 @@ pub struct SplitSnapshot {
     pub split_id: usize,
     /// Buffer currently shown in this split.
     pub buffer_id: BufferId,
+    /// Label set by `setSplitLabel`, when this pane has one. Reported here so
+    /// a later script can re-find a pane it named earlier — the ids change
+    /// across restarts, the label is what the caller chose.
+    #[serde(default)]
+    pub label: Option<String>,
     /// Column of this pane's left edge, in terminal cells, measured from
     /// the left edge of the editor area. This is what answers "which pane
     /// is on the left" — compare `x` between panes rather than guessing
@@ -643,6 +648,10 @@ pub struct PaneDescription {
     /// `"terminal"` (a PTY), `"file"` (backed by a path), or `"virtual"`
     /// (a plugin-owned scratch buffer).
     pub kind: String,
+    /// Label set by `setSplitLabel`, when this pane has one — how a script
+    /// finds a pane it named in an earlier run.
+    #[serde(default)]
+    pub label: Option<String>,
     /// Absolute path when this pane shows a file, else `None`.
     pub path: Option<PathBuf>,
     /// Short label — the file name, or the buffer's name for the rest.
@@ -680,6 +689,29 @@ pub struct WorkspaceDescription {
     pub panes: Vec<PaneDescription>,
     /// Which pane has focus; also flagged on the pane itself.
     pub active_split_id: usize,
+}
+
+/// One clickable line in a buffer: press Enter on it, or click it, and the
+/// editor opens what it points at.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub struct LineTarget {
+    /// Row in the source buffer, 0-indexed, that carries this target.
+    pub line: usize,
+    /// File to open. Relative paths resolve against the window's root.
+    pub path: String,
+    /// Line to land on in that file, 0-indexed. Defaults to the top.
+    #[serde(default)]
+    #[ts(optional)]
+    pub target: Option<usize>,
+    /// Label of the pane to open into (`setSplitLabel`). When the label
+    /// names no live pane — or is omitted — the editor opens beside the
+    /// buffer holding the targets rather than replacing it, so an index
+    /// never eats its own pane.
+    #[serde(default)]
+    #[ts(optional)]
+    pub into: Option<String>,
 }
 
 /// Where a new pane goes relative to the one being split.
@@ -974,6 +1006,17 @@ pub struct ScrollbarMarker {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub priority: Option<i32>,
+}
+
+#[cfg(feature = "plugins")]
+impl<'js> rquickjs::FromJs<'js> for LineTarget {
+    fn from_js(_ctx: &rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
+        rquickjs_serde::from_value(value).map_err(|e| rquickjs::Error::FromJs {
+            from: "object",
+            to: "LineTarget",
+            message: Some(e.to_string()),
+        })
+    }
 }
 
 #[cfg(feature = "plugins")]
@@ -3970,6 +4013,22 @@ pub enum PluginCommand {
     MoveBufferToSplit {
         buffer_id: BufferId,
         split_id: SplitId,
+    },
+
+    /// Make lines of `buffer_id` clickable: a click or Enter on a listed
+    /// line opens what it points at.
+    ///
+    /// Declarative on purpose. The alternative is an `editor.on("mouse_click")`
+    /// handler, which means the author has to still be running when the user
+    /// clicks — fine for a resident plugin, useless for a one-shot script that
+    /// builds an index and exits. Here the editor owns the behaviour, so the
+    /// view keeps working after its author is gone.
+    ///
+    /// Replaces any previous targets for the buffer; an empty list clears
+    /// them.
+    SetLineTargets {
+        buffer_id: BufferId,
+        targets: Vec<LineTarget>,
     },
 
     /// Split the active pane and answer with the new pane's id and

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -298,6 +298,12 @@ type SplitSnapshot = {
 	*/
 	bufferId: BufferId;
 	/**
+	* Label set by `setSplitLabel`, when this pane has one. Reported here so
+	* a later script can re-find a pane it named earlier — the ids change
+	* across restarts, the label is what the caller chose.
+	*/
+	label: string | null;
+	/**
 	* Column of this pane's left edge, in terminal cells, measured from
 	* the left edge of the editor area. This is what answers "which pane
 	* is on the left" — compare `x` between panes rather than guessing
@@ -323,6 +329,150 @@ type SplitSnapshot = {
 	* gutter, so it is smaller than the pane rect above.
 	*/
 	viewport: ViewportInfo;
+};
+type SplitCreated = {
+	/**
+	* The new pane's id — pass to `openFileInSplit`, `focusSplit`, ...
+	*/
+	splitId: number;
+	/**
+	* The pane the split was created from, still live and now smaller.
+	*/
+	sourceSplitId: number;
+	/**
+	* Buffer shown in the new pane.
+	*/
+	bufferId: BufferId;
+	/**
+	* Geometry of the new pane (see `SplitSnapshot`).
+	*/
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+type SplitWindowOptions = {
+	/**
+	* Divider orientation. Default `"vertical"` — panes side by side.
+	*/
+	direction?: SplitAxis;
+	/**
+	* Which side the new pane lands on. Default `"after"`.
+	*/
+	place?: SplitPlacement;
+	/**
+	* First child's share of the space, 0.0–1.0. Default 0.5.
+	* "First" is the left/top pane regardless of `place`.
+	*/
+	ratio?: number;
+	/**
+	* Open this file in the new pane. Relative paths resolve against the
+	* window's root. When omitted the new pane shows the same buffer as
+	* the pane it was split from, which is what the keyboard split does.
+	*/
+	file?: string;
+	/**
+	* Leave focus where it was instead of moving it into the new pane.
+	* Default false (the new pane takes focus, matching the keyboard
+	* split).
+	*/
+	keepFocus?: boolean;
+};
+type SplitAxis = "vertical" | "horizontal";
+type SplitPlacement = "before" | "after";
+type LineTarget = {
+	/**
+	* Row in the source buffer, 0-indexed, that carries this target.
+	*/
+	line: number;
+	/**
+	* File to open. Relative paths resolve against the window's root.
+	*/
+	path: string;
+	/**
+	* Line to land on in that file, 0-indexed. Defaults to the top.
+	*/
+	target?: number;
+	/**
+	* Label of the pane to open into (`setSplitLabel`). When the label
+	* names no live pane — or is omitted — the editor opens beside the
+	* buffer holding the targets rather than replacing it, so an index
+	* never eats its own pane.
+	*/
+	into?: string;
+};
+type PaneDescription = {
+	/**
+	* Pass to `openFileInSplit`, `focusSplit`, `setSplitRatio`, ...
+	*/
+	splitId: number;
+	/**
+	* Buffer shown in this pane.
+	*/
+	bufferId: BufferId;
+	/**
+	* `"terminal"` (a PTY), `"file"` (backed by a path), or `"virtual"`
+	* (a plugin-owned scratch buffer).
+	*/
+	kind: string;
+	/**
+	* Label set by `setSplitLabel`, when this pane has one — how a script
+	* finds a pane it named in an earlier run.
+	*/
+	label: string | null;
+	/**
+	* Absolute path when this pane shows a file, else `None`.
+	*/
+	path: string | null;
+	/**
+	* Short label — the file name, or the buffer's name for the rest.
+	*/
+	name: string;
+	/**
+	* Whether this pane has focus.
+	*/
+	active: boolean;
+	/**
+	* Unsaved changes.
+	*/
+	modified: boolean;
+	/**
+	* On-screen geometry, in editor-area cells. Panes are listed left to
+	* right, top to bottom, so `panes[0]` is the leftmost/topmost; `x`
+	* and `y` say so precisely.
+	*/
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+type WorkspaceDescription = {
+	/**
+	* Working directory of the active window.
+	*/
+	cwd: string;
+	/**
+	* The window this script is pointed at.
+	*/
+	windowId: bigint;
+	/**
+	* Durable id of that window — the one still valid after a restart.
+	*/
+	stableId: string;
+	/**
+	* Every open workspace, so a script can tell whether the thing it
+	* wants is in another window.
+	*/
+	windows: Array<WindowInfo>;
+	/**
+	* The active window's panes, in visual order (left to right, top to
+	* bottom).
+	*/
+	panes: Array<PaneDescription>;
+	/**
+	* Which pane has focus; also flagged on the pane itself.
+	*/
+	activeSplitId: number;
 };
 type LayoutHints = {
 	/**
@@ -3005,6 +3155,30 @@ interface EditorAPI {
 	*/
 	moveBufferToSplit(bufferId: number, splitId: number): boolean;
 	/**
+	* Make lines of a buffer clickable: a click or Enter on a listed line
+	* opens what it points at.
+	* 
+	* ```js
+	* editor.setLineTargets(bufferId, [
+	* { line: 0, path: "src/main.rs", target: 41, into: "code" },
+	* { line: 1, path: "src/lib.rs",  target: 12, into: "code" },
+	* ]);
+	* ```
+	* 
+	* `line` is the row *in this buffer*; `target` is the line to land on in
+	* the file, both 0-indexed. `into` names a pane by its `setSplitLabel`
+	* label; when it names no live pane the target opens beside this one, so
+	* an index never replaces itself with what you clicked.
+	* 
+	* The editor owns the behaviour, which is the point: a script that builds
+	* an index — a search result list, an error list, a review map — exits
+	* immediately, and a `mouse_click` handler would die with it. These
+	* targets keep working.
+	* 
+	* Replaces any previous targets for the buffer; pass `[]` to clear.
+	*/
+	setLineTargets(bufferId: number, targets: LineTarget[]): boolean;
+	/**
 	* Describe the editor as it is right now: the panes of the active
 	* window in visual order with their geometry and contents, which one
 	* has focus, the working directory, and every open workspace.
@@ -4333,6 +4507,14 @@ interface HookEventMap {
 	post_command: {
 		action: string | Record<string, unknown>;
 	};
+	/**
+	* NOT EMITTED. Declared here historically, but nothing in the editor ever
+	* fires it: `editor.on("idle", ...)` registers successfully and the handler
+	* is never called. Listed so that its absence is documented rather than
+	* discovered — do not build on it. For "run something later", drive it from
+	* an event that does fire (`cursor_moved`, `buffer_changed`) or from your
+	* own `spawnProcess` timer.
+	*/
 	idle: {
 		milliseconds: number;
 	};

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -237,6 +237,7 @@ impl Editor {
         // target on click. Checked before the plugin hook so a declarative
         // index behaves the same whether or not anything is listening — its
         // author is typically a script that has already exited.
+        #[cfg(feature = "plugins")]
         if let Some(brow) = mc_buffer_row {
             if let Some(target) = self.line_target_at(buffer_id, brow as usize) {
                 self.follow_line_target(target);

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -240,7 +240,7 @@ impl Editor {
         #[cfg(feature = "plugins")]
         if let Some(brow) = mc_buffer_row {
             if let Some(target) = self.line_target_at(buffer_id, brow as usize) {
-                self.follow_line_target(target);
+                self.follow_line_target(target, split_id);
                 return Ok(());
             }
         }

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -233,6 +233,17 @@ impl Editor {
             }
         }
 
+        // A line that points somewhere (`editor.setLineTargets`) opens its
+        // target on click. Checked before the plugin hook so a declarative
+        // index behaves the same whether or not anything is listening — its
+        // author is typically a script that has already exited.
+        if let Some(brow) = mc_buffer_row {
+            if let Some(target) = self.line_target_at(buffer_id, brow as usize) {
+                self.follow_line_target(target);
+                return Ok(());
+            }
+        }
+
         // Dispatch MouseClick hook to plugins
         // Plugins can handle clicks on their virtual buffers
         if self

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -643,6 +643,7 @@ impl Editor {
             status_bar_token_registry: Mutex::new(HashMap::new()),
             plugin_schemas: std::sync::Arc::new(std::sync::RwLock::new(parts.plugin_schemas)),
             event_broadcaster: parts.event_broadcaster,
+            #[cfg(feature = "plugins")]
             line_targets: std::collections::HashMap::new(),
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -643,8 +643,8 @@ impl Editor {
             status_bar_token_registry: Mutex::new(HashMap::new()),
             plugin_schemas: std::sync::Arc::new(std::sync::RwLock::new(parts.plugin_schemas)),
             event_broadcaster: parts.event_broadcaster,
-            #[cfg(feature = "plugins")]
             line_targets: std::collections::HashMap::new(),
+            #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),
             #[cfg(feature = "plugins")]
             plugin_render_requested: false,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -644,6 +644,7 @@ impl Editor {
             plugin_schemas: std::sync::Arc::new(std::sync::RwLock::new(parts.plugin_schemas)),
             event_broadcaster: parts.event_broadcaster,
             #[cfg(feature = "plugins")]
+            line_targets: std::collections::HashMap::new(),
             pending_plugin_actions: Vec::new(),
             #[cfg(feature = "plugins")]
             plugin_render_requested: false,

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1074,7 +1074,8 @@ impl Editor {
             let buffer_id = self.active_buffer();
             if let Some(line) = self.cursor_line_in_active_buffer() {
                 if let Some(target) = self.line_target_at(buffer_id, line) {
-                    self.follow_line_target(target);
+                    let source = self.active_split_id();
+                    self.follow_line_target(target, source);
                     return Ok(());
                 }
             }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1063,6 +1063,22 @@ impl Editor {
             self.reset_dabbrev_state();
         }
 
+        // Enter on a line that points somewhere (`editor.setLineTargets`)
+        // follows it, the same as clicking it. Intercepted here rather than
+        // inside the newline handler so the behaviour is identical whether
+        // the buffer is editable or not — an index built by a script is
+        // usually a plain file, and typing a newline into it is never what
+        // pressing Enter on an entry meant.
+        if matches!(action, Action::InsertNewline) {
+            let buffer_id = self.active_buffer();
+            if let Some(line) = self.cursor_line_in_active_buffer() {
+                if let Some(target) = self.line_target_at(buffer_id, line) {
+                    self.follow_line_target(target);
+                    return Ok(());
+                }
+            }
+        }
+
         match action {
             Action::Quit => self.quit(),
             Action::ForceQuit => {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1069,6 +1069,7 @@ impl Editor {
         // the buffer is editable or not — an index built by a script is
         // usually a plain file, and typing a newline into it is never what
         // pressing Enter on an entry meant.
+        #[cfg(feature = "plugins")]
         if matches!(action, Action::InsertNewline) {
             let buffer_id = self.active_buffer();
             if let Some(line) = self.cursor_line_in_active_buffer() {

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -886,6 +886,7 @@ pub struct Editor {
     /// Editor-owned rather than plugin-owned so a view outlives the script
     /// that built it: a one-shot agent can leave behind an index whose lines
     /// still open their targets long after it has exited.
+    #[cfg(feature = "plugins")]
     line_targets: std::collections::HashMap<fresh_core::BufferId, Vec<fresh_core::api::LineTarget>>,
 
     /// Pending plugin action receivers (for async action execution)

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -881,6 +881,13 @@ pub struct Editor {
     /// `last_register`, and the `playing` guard flag).
     // `macros` moved onto `Window`.
 
+    /// Clickable lines per buffer, from `editor.setLineTargets`.
+    ///
+    /// Editor-owned rather than plugin-owned so a view outlives the script
+    /// that built it: a one-shot agent can leave behind an index whose lines
+    /// still open their targets long after it has exited.
+    line_targets: std::collections::HashMap<fresh_core::BufferId, Vec<fresh_core::api::LineTarget>>,
+
     /// Pending plugin action receivers (for async action execution)
     #[cfg(feature = "plugins")]
     pending_plugin_actions: Vec<(

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1549,6 +1549,9 @@ impl Editor {
             PluginCommand::FlushLayout => {
                 self.flush_layout();
             }
+            PluginCommand::SetLineTargets { buffer_id, targets } => {
+                self.set_line_targets(buffer_id, targets);
+            }
             PluginCommand::SplitWindow {
                 options,
                 request_id,
@@ -6192,6 +6195,7 @@ impl Window {
                     snapshot.splits.push(fresh_core::api::SplitSnapshot {
                         split_id: leaf_id.0 .0,
                         buffer_id: buf_id,
+                        label: mgr.get_label(leaf_id.0).map(|l| l.to_string()),
                         x: rect.x,
                         y: rect.y,
                         width: rect.width,

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -862,11 +862,87 @@ impl Editor {
         buffer_id: fresh_core::BufferId,
         targets: Vec<fresh_core::api::LineTarget>,
     ) {
+        self.clear_line_target_decorations(buffer_id);
         if targets.is_empty() {
             self.line_targets.remove(&buffer_id);
         } else {
+            self.decorate_line_targets(buffer_id, &targets);
             self.line_targets.insert(buffer_id, targets);
         }
+    }
+
+    /// Namespace the link decorations live under, so replacing a buffer's
+    /// targets can drop exactly its own styling and nothing else's.
+    #[cfg(feature = "plugins")]
+    const LINE_TARGET_NS: &'static str = "fresh.line-targets";
+
+    /// Underline the lines that point somewhere.
+    ///
+    /// Without this a link is indistinguishable from ordinary text: the user
+    /// has no way to know a line is clickable except by clicking it, which is
+    /// no way to discover anything.
+    ///
+    /// Underline only, deliberately. There is no link colour in the theme
+    /// today, and referencing a key that doesn't exist would resolve to
+    /// nothing and leave the styling silently absent again. Underline is the
+    /// convention terminals and browsers already trained users on, and it
+    /// works against every theme.
+    #[cfg(feature = "plugins")]
+    fn decorate_line_targets(
+        &mut self,
+        buffer_id: fresh_core::BufferId,
+        targets: &[fresh_core::api::LineTarget],
+    ) {
+        let ranges: Vec<std::ops::Range<usize>> = {
+            let Some(state) = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.get(&buffer_id))
+            else {
+                return;
+            };
+            targets
+                .iter()
+                .filter_map(|t| {
+                    let start = state.buffer.line_start_offset(t.line)?;
+                    let end = state
+                        .buffer
+                        .line_start_offset(t.line + 1)
+                        .unwrap_or_else(|| state.buffer.len());
+                    // Trim the newline so the underline stops at the text.
+                    let end = end.saturating_sub(1).max(start);
+                    (end > start).then_some(start..end)
+                })
+                .collect()
+        };
+
+        let namespace = Some(crate::view::overlay::OverlayNamespace::from_string(
+            Self::LINE_TARGET_NS.to_string(),
+        ));
+        for range in ranges {
+            let options = fresh_core::api::OverlayOptions {
+                underline: true,
+                ..Default::default()
+            };
+            self.handle_add_overlay(buffer_id, namespace.clone(), range, options);
+        }
+    }
+
+    /// Drop the link styling this buffer's previous targets installed.
+    #[cfg(feature = "plugins")]
+    fn clear_line_target_decorations(&mut self, buffer_id: fresh_core::BufferId) {
+        let len = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.get(&buffer_id))
+            .map(|state| state.buffer.len())
+            .unwrap_or(0);
+        if len == 0 {
+            return;
+        }
+        let namespace =
+            crate::view::overlay::OverlayNamespace::from_string(Self::LINE_TARGET_NS.to_string());
+        self.handle_clear_overlays_in_range_for_namespace(buffer_id, namespace, 0, len);
     }
 
     /// The 0-indexed line the primary cursor is on, in the active buffer.
@@ -898,8 +974,17 @@ impl Editor {
     /// Falling back to *beside* the index — rather than into it — is
     /// deliberate: an index that replaced itself with the first thing you
     /// clicked would destroy the view you were navigating.
-    pub(crate) fn follow_line_target(&mut self, target: fresh_core::api::LineTarget) {
-        let source_split = self.active_split_id();
+    pub(crate) fn follow_line_target(
+        &mut self,
+        target: fresh_core::api::LineTarget,
+        source_split: crate::model::event::LeafId,
+    ) {
+        // `source_split` is the pane the index itself lives in — passed in by
+        // the caller rather than read from the active split, because a click
+        // is dispatched *before* it moves focus. Reading the active split here
+        // meant "beside" was computed relative to whichever pane the user
+        // happened to be in last, so the same link opened somewhere different
+        // each time.
         let destination = target
             .into
             .as_deref()
@@ -979,29 +1064,39 @@ impl Editor {
             .filter(|leaf| self.split_rect(*leaf).is_some())
     }
 
-    /// Any visible pane that isn't `this_one`, preferring the one to its right
-    /// or below — where a reader would expect the destination to appear.
+    /// The pane to open a target in when no label named one: the nearest
+    /// neighbour of `this_one` that is safe to write into.
+    ///
+    /// "Safe" excludes terminals — replacing a running shell with a source
+    /// file loses the user's session, and the first version of this did
+    /// exactly that when the index was the rightmost pane. Preference is for
+    /// the pane immediately after (right/below), then the nearest before, so
+    /// the destination is where a reader would look for it and does not depend
+    /// on where focus happened to be.
     #[cfg(feature = "plugins")]
     fn pane_beside(
         &self,
         this_one: crate::model::event::LeafId,
     ) -> Option<crate::model::event::LeafId> {
-        let area = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| w.editor_content_area())?;
-        let (mgr, _) = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.buffers.splits())?;
+        let window = self.windows.get(&self.active_window)?;
+        let area = window.editor_content_area();
+        let (mgr, _) = window.buffers.splits()?;
         let panes = mgr.get_visible_buffers(area);
         let here = panes.iter().find(|(id, _, _)| *id == this_one)?.2;
-        panes
+
+        let usable: Vec<_> = panes
             .iter()
-            .filter(|(id, _, _)| *id != this_one)
-            .min_by_key(|(_, _, rect)| {
-                let after = rect.x > here.x || rect.y > here.y;
-                (!after as u32, rect.x as u32, rect.y as u32)
+            .filter(|(id, buf, _)| *id != this_one && !window.is_terminal_buffer(*buf))
+            .collect();
+        // Nearest to the right / below first.
+        usable
+            .iter()
+            .filter(|(_, _, rect)| rect.x > here.x || rect.y > here.y)
+            .min_by_key(|(_, _, rect)| (rect.x as u32, rect.y as u32))
+            .or_else(|| {
+                usable
+                    .iter()
+                    .max_by_key(|(_, _, rect)| (rect.x as u32, rect.y as u32))
             })
             .map(|(id, _, _)| *id)
     }

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -857,6 +857,7 @@ impl Editor {
 impl Editor {
     /// Record which lines of a buffer point somewhere, replacing any previous
     /// set. An empty list clears them.
+    #[cfg(feature = "plugins")]
     pub(crate) fn set_line_targets(
         &mut self,
         buffer_id: fresh_core::BufferId,
@@ -946,12 +947,14 @@ impl Editor {
     }
 
     /// The 0-indexed line the primary cursor is on, in the active buffer.
+    #[cfg(feature = "plugins")]
     pub(crate) fn cursor_line_in_active_buffer(&self) -> Option<usize> {
         let position = self.active_window().active_cursors().primary().position;
         Some(self.active_state().buffer.get_line_number(position))
     }
 
     /// The target on `line` of `buffer_id`, if that line has one.
+    #[cfg(feature = "plugins")]
     pub(crate) fn line_target_at(
         &self,
         buffer_id: fresh_core::BufferId,

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -772,6 +772,7 @@ impl Editor {
 
     /// Resolve a caller-supplied path against the window's root, so a script
     /// can say `"README.md"` and mean the obvious thing.
+    #[cfg(feature = "plugins")]
     fn resolve_workspace_path(&self, path: &str) -> std::path::PathBuf {
         let p = std::path::Path::new(path);
         if p.is_absolute() {
@@ -809,16 +810,29 @@ impl Editor {
             return;
         }
 
-        // Every pane that currently holds it, except the destination.
+        // Every pane whose *tab strip* carries it, except the destination.
+        //
+        // Read from the view states rather than `splits_for_buffer`, which
+        // reports the narrower "is displaying it" relation: a pane can hold a
+        // buffer as a background tab without showing it, and those are exactly
+        // the copies a move is supposed to clean up.
         let sources: Vec<LeafId> = self
             .windows
             .get(&self.active_window)
             .and_then(|w| w.buffers.splits())
-            .map(|(mgr, _)| mgr.splits_for_buffer(buffer_id))
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|leaf| *leaf != target)
-            .collect();
+            .map(|(_, vs)| {
+                vs.iter()
+                    .filter(|(leaf, state)| {
+                        **leaf != target
+                            && state
+                                .open_buffers
+                                .iter()
+                                .any(|tab| tab.as_buffer() == Some(buffer_id))
+                    })
+                    .map(|(leaf, _)| *leaf)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
 
         // Show it in the destination first: dropping the last tab from a pane
         // can collapse that pane, and doing it in this order means the buffer
@@ -873,7 +887,12 @@ impl Editor {
             .cloned()
     }
 
+    #[cfg(feature = "plugins")]
     /// Open what a line points at.
+    ///
+    /// Gated with the rest of the plugin surface: targets can only be set
+    /// through `editor.setLineTargets`, so without plugins there is never one
+    /// to follow.
     ///
     /// The destination pane is resolved by label when the target names one.
     /// Falling back to *beside* the index — rather than into it — is
@@ -924,11 +943,30 @@ impl Editor {
             tracing::warn!("line target: could not open {}: {e}", target.path);
             return;
         }
+
+        // Opening leaves a tab for the file in the pane that was active as
+        // well as the destination, so following a few entries would silently
+        // fill the index's own tab strip with the things you visited. Move it
+        // instead: the destination keeps it, everyone else drops it.
+        #[cfg(feature = "plugins")]
+        {
+            let opened = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.splits())
+                .and_then(|(_, vs)| vs.get(&leaf))
+                .map(|vs| vs.active_buffer);
+            if let Some(buffer_id) = opened {
+                self.handle_move_buffer_to_split(buffer_id, leaf.0);
+            }
+        }
+
         // Focus follows the jump — the user asked to go there.
         self.split_manager_mut().set_active_split(leaf);
     }
 
     /// The leaf a label names, when it still exists.
+    #[cfg(feature = "plugins")]
     fn split_by_label(&self, label: &str) -> Option<crate::model::event::LeafId> {
         let (mgr, _) = self
             .windows
@@ -943,6 +981,7 @@ impl Editor {
 
     /// Any visible pane that isn't `this_one`, preferring the one to its right
     /// or below — where a reader would expect the destination to appear.
+    #[cfg(feature = "plugins")]
     fn pane_beside(
         &self,
         this_one: crate::model::event::LeafId,

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -839,3 +839,131 @@ impl Editor {
         self.relayout();
     }
 }
+
+impl Editor {
+    /// Record which lines of a buffer point somewhere, replacing any previous
+    /// set. An empty list clears them.
+    pub(crate) fn set_line_targets(
+        &mut self,
+        buffer_id: fresh_core::BufferId,
+        targets: Vec<fresh_core::api::LineTarget>,
+    ) {
+        if targets.is_empty() {
+            self.line_targets.remove(&buffer_id);
+        } else {
+            self.line_targets.insert(buffer_id, targets);
+        }
+    }
+
+    /// The 0-indexed line the primary cursor is on, in the active buffer.
+    pub(crate) fn cursor_line_in_active_buffer(&self) -> Option<usize> {
+        let position = self.active_window().active_cursors().primary().position;
+        Some(self.active_state().buffer.get_line_number(position))
+    }
+
+    /// The target on `line` of `buffer_id`, if that line has one.
+    pub(crate) fn line_target_at(
+        &self,
+        buffer_id: fresh_core::BufferId,
+        line: usize,
+    ) -> Option<fresh_core::api::LineTarget> {
+        self.line_targets
+            .get(&buffer_id)
+            .and_then(|targets| targets.iter().find(|t| t.line == line))
+            .cloned()
+    }
+
+    /// Open what a line points at.
+    ///
+    /// The destination pane is resolved by label when the target names one.
+    /// Falling back to *beside* the index — rather than into it — is
+    /// deliberate: an index that replaced itself with the first thing you
+    /// clicked would destroy the view you were navigating.
+    pub(crate) fn follow_line_target(&mut self, target: fresh_core::api::LineTarget) {
+        let source_split = self.active_split_id();
+        let destination = target
+            .into
+            .as_deref()
+            .and_then(|label| self.split_by_label(label))
+            .filter(|leaf| *leaf != source_split);
+
+        let path = {
+            let p = std::path::Path::new(&target.path);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                self.active_window().root.join(p)
+            }
+        };
+        let line = target.target;
+
+        let leaf = match destination {
+            Some(leaf) => leaf,
+            None => {
+                // No usable label: put it in the pane next door, making one if
+                // this is the only pane.
+                match self.pane_beside(source_split) {
+                    Some(leaf) => leaf,
+                    None => match self.split_pane_impl(
+                        crate::model::event::SplitDirection::Vertical,
+                        false,
+                        0.5,
+                    ) {
+                        Ok(leaf) => leaf,
+                        Err(e) => {
+                            tracing::warn!("line target: could not open a pane: {e}");
+                            return;
+                        }
+                    },
+                }
+            }
+        };
+
+        #[cfg(feature = "plugins")]
+        if let Err(e) = self.handle_open_file_in_split(leaf.0 .0, path, line, None) {
+            tracing::warn!("line target: could not open {}: {e}", target.path);
+            return;
+        }
+        // Focus follows the jump — the user asked to go there.
+        self.split_manager_mut().set_active_split(leaf);
+    }
+
+    /// The leaf a label names, when it still exists.
+    fn split_by_label(&self, label: &str) -> Option<crate::model::event::LeafId> {
+        let (mgr, _) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())?;
+        mgr.labels()
+            .iter()
+            .find(|(_, l)| l.as_str() == label)
+            .map(|(id, _)| crate::model::event::LeafId(*id))
+            .filter(|leaf| self.split_rect(*leaf).is_some())
+    }
+
+    /// Any visible pane that isn't `this_one`, preferring the one to its right
+    /// or below — where a reader would expect the destination to appear.
+    fn pane_beside(
+        &self,
+        this_one: crate::model::event::LeafId,
+    ) -> Option<crate::model::event::LeafId> {
+        let area = self
+            .windows
+            .get(&self.active_window)
+            .map(|w| w.editor_content_area())?;
+        let (mgr, _) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())?;
+        let panes = mgr.get_visible_buffers(area);
+        let here = panes.iter().find(|(id, _, _)| *id == this_one)?.2;
+        panes
+            .iter()
+            .filter(|(id, _, _)| *id != this_one)
+            .min_by_key(|(_, _, rect)| {
+                let after = rect.x > here.x || rect.y > here.y;
+                (!after as u32, rect.x as u32, rect.y as u32)
+            })
+            .map(|(id, _, _)| *id)
+    }
+}

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3462,6 +3462,41 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Make lines of a buffer clickable: a click or Enter on a listed line
+    /// opens what it points at.
+    ///
+    /// ```js
+    /// editor.setLineTargets(bufferId, [
+    ///   { line: 0, path: "src/main.rs", target: 41, into: "code" },
+    ///   { line: 1, path: "src/lib.rs",  target: 12, into: "code" },
+    /// ]);
+    /// ```
+    ///
+    /// `line` is the row *in this buffer*; `target` is the line to land on in
+    /// the file, both 0-indexed. `into` names a pane by its `setSplitLabel`
+    /// label; when it names no live pane the target opens beside this one, so
+    /// an index never replaces itself with what you clicked.
+    ///
+    /// The editor owns the behaviour, which is the point: a script that builds
+    /// an index — a search result list, an error list, a review map — exits
+    /// immediately, and a `mouse_click` handler would die with it. These
+    /// targets keep working.
+    ///
+    /// Replaces any previous targets for the buffer; pass `[]` to clear.
+    #[plugin_api(js_name = "setLineTargets", ts_return = "boolean")]
+    pub fn set_line_targets(
+        &self,
+        buffer_id: u32,
+        targets: Vec<fresh_core::api::LineTarget>,
+    ) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetLineTargets {
+                buffer_id: BufferId(buffer_id as usize),
+                targets,
+            })
+            .is_ok()
+    }
+
     // === Orientation ===
 
     /// Describe the editor as it is right now: the panes of the active
@@ -3524,6 +3559,7 @@ impl JsEditorApi {
                     split_id: split.split_id,
                     buffer_id: split.buffer_id,
                     kind: kind.to_string(),
+                    label: split.label.clone(),
                     path,
                     name,
                     active: split.split_id == active_split_id,

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -61,6 +61,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         "SplitWindowOptions" => Some(fresh_core::api::SplitWindowOptions::decl(&cfg)),
         "SplitAxis" => Some(fresh_core::api::SplitAxis::decl(&cfg)),
         "SplitPlacement" => Some(fresh_core::api::SplitPlacement::decl(&cfg)),
+        "LineTarget" => Some(fresh_core::api::LineTarget::decl(&cfg)),
         "PaneDescription" => Some(fresh_core::api::PaneDescription::decl(&cfg)),
         "WorkspaceDescription" => Some(fresh_core::api::WorkspaceDescription::decl(&cfg)),
         "ActionSpec" => Some(ActionSpec::decl(&cfg)),
@@ -343,6 +344,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "SplitWindowOptions",              // Options for editor.splitWindow()
     "SplitAxis",                       // SplitWindowOptions.direction
     "SplitPlacement",                  // SplitWindowOptions.place
+    "LineTarget",                      // Used by editor.setLineTargets()
     "PaneDescription",                 // Part of WorkspaceDescription
     "WorkspaceDescription",            // Returned by editor.describeWorkspace()
     "LayoutHints",                     // Used by plugins for view transforms
@@ -656,6 +658,14 @@ interface HookEventMap {
   // ── commands ─────────────────────────────────────────────────────────────
   pre_command: { action: string | Record<string, unknown> };
   post_command: { action: string | Record<string, unknown> };
+  /**
+   * NOT EMITTED. Declared here historically, but nothing in the editor ever
+   * fires it: `editor.on("idle", ...)` registers successfully and the handler
+   * is never called. Listed so that its absence is documented rather than
+   * discovered — do not build on it. For "run something later", drive it from
+   * an event that does fire (`cursor_moved`, `buffer_changed`) or from your
+   * own `spawnProcess` timer.
+   */
   idle: { milliseconds: number };
   resize: { width: number; height: number };
 


### PR DESCRIPTION
Stacked on #2839 — review that one first; this branch is based on it, not on master.

An agent script is one-shot: it builds something and settles. Anything callback-shaped dies with it, so an index a script produces is inert — a `mouse_click` handler needs its author to still be running. That makes the highest-value APIs for one-shot authors **declarative**: state the editor owns and acts on, rather than callbacks someone must stay alive to service.

```js
// Build an index, point its lines at real locations, and exit.
const idx = await editor.splitWindow({ direction: "vertical", place: "before", file: "index.txt" });
editor.setSplitLabel(idx.sourceSplitId, "code");
editor.setLineTargets(idx.bufferId, [
  { line: 1, path: "src/server/command_access.rs", target: 118, into: "code" },
  { line: 2, path: "src/server/editor_server.rs",  target: 207, into: "code" },
]);
```

A click or Enter on a listed line opens its target — after the script is gone. `into` names a destination pane by its `setSplitLabel` label; when no such pane is live the target opens *beside* the index rather than replacing it, so an index never eats the view you were navigating.

## Also here

**Pane labels are reported.** `setSplitLabel` / `getSplitByLabel` already existed, but `describeWorkspace()` and `listSplits()` dropped the label, so a later script couldn't re-find a pane it had named. That's what makes multi-step layout work composable — and it's why labels were useless as an observation instrument.

**The `idle` hook is documented as never emitted.** It's declared in the hook map with a `milliseconds` payload, and no `run_hook("idle")` exists anywhere in the editor: registering succeeds and the handler can never fire.

## A premise worth correcting

The motivating report concluded that `editor.on()` from a script is a silent no-op after settle. Measured, it isn't. A `cursor_moved` handler registered by a script that had long since exited fired for both `executeAction` moves and real keystrokes — the counter went 2 → 4 when I pressed arrow keys by hand. Script contexts outlive their script (they are deliberately never unloaded), so events do reach them.

The probe's negative result came from choosing `idle`, the one event that never arrives — plausibly compounded by using split labels as the observable, which the snapshot wasn't reporting.

That changes the priority order: **a script-lifetime mechanism is not a prerequisite for interactive behaviour**. `editor.on("mouse_click")` from a resident script works today. `setLineTargets` is still the better answer for an index — no callback, Enter works too, and the editor keeps the behaviour — but the two are independent, and Tier 2 is no longer blocking anything.

## Deferred, with reasons

- **Diff → source mapping** (`getDiffLocation`, `openDiff`). The most valuable remaining item: with it, targets for a diff view could be populated by the editor rather than the caller. Needs a real diff-buffer representation, not a `git diff` dump.
- **`openScratch`** — a file-buffer with no file. Worth having; the current honest answer is a temp file, which is what the API now steers agents toward, since a file buffer gets highlighting, search, save, and renders ANSI colour.
- **`collapseAll(bufferId, depth)`** — small, and clearly useful for opening a 5000-line diff folded to file headers.
- **`retainScript` / `defineView`** — deliberately not built, given the measurement above. The **leak it would also fix is real**: agent-script contexts accumulate for the session, one per submission. That deserves fixing on its own terms.
- **Exporting audit_mode's review session** — the best workflow idea in the report (agent seeds findings as review comments, human walks them in the native UI) and the one needing the most design outside this change.

## Verification

Driven by hand against a real TUI. A script built the index, labelled the neighbouring pane, set targets, and exited; `describeWorkspace()` then reported `[{"x":0,"name":"index.txt","label":null},{"x":86,"name":"terminal","label":"code"}]` — labels now visible, which was the second gap.

The event-behaviour claims above were measured the same way, with a handler writing to a file so the observation survived across script invocations.

`cargo fmt`, `cargo check --workspace --all-targets`, and `cargo clippy --workspace --all-targets --features web,gui` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FboHXXHsxVMuuNywWjULMi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FboHXXHsxVMuuNywWjULMi)_