### PR TITLE
fix: single-line files — decorate the visible wrapped rows, and stop the wheel snapping to a 100 KB boundary

### DIFF
--- a/crates/fresh-editor/src/primitives/line_iterator.rs
+++ b/crates/fresh-editor/src/primitives/line_iterator.rs
@@ -240,6 +240,33 @@ impl<'a> LineIterator<'a> {
         Some((line_start, line_string))
     }
 
+    /// Get the next *logical* line — never split at a chunk boundary.
+    ///
+    /// `next_line` caps each yielded piece at `MAX_LINE_BYTES` so a file
+    /// that is one huge line can be read without materializing all of it
+    /// at once. That cap is a read budget, not document structure: code
+    /// that reasons about layout (how many visual rows a line occupies,
+    /// where the *next* line starts) must not mistake a 100 KB read
+    /// offset for a line start, or scroll math snaps the viewport to it
+    /// (issue #2843). Such callers use this method, which re-joins the
+    /// pieces until a real terminator or EOF.
+    ///
+    /// The trade-off is the one already accepted elsewhere for wrapped
+    /// layout (`VisualRowIndex` reads whole lines via `Buffer::get_line`):
+    /// the returned `String` is as long as the logical line.
+    pub fn next_logical_line(&mut self) -> Option<(usize, String)> {
+        let (line_start, mut content) = self.next_line()?;
+        // A piece that stopped short of a terminator while bytes remain was
+        // cut by the read budget — keep pulling until the line really ends.
+        while !content.ends_with('\n') && self.current_pos < self.buffer_len {
+            match self.next_line() {
+                Some((_, more)) => content.push_str(&more),
+                None => break,
+            }
+        }
+        Some((line_start, content))
+    }
+
     /// Get the previous line (moving backward)
     /// Uses direct byte scanning which works even with unloaded chunks
     pub fn prev(&mut self) -> Option<(usize, String)> {
@@ -685,6 +712,70 @@ mod tests {
             10,
             "Iterator at byte 10 should be at line start already"
         );
+    }
+
+    /// `next_logical_line` must hide the `MAX_LINE_BYTES` read budget: a line
+    /// longer than a chunk is still yielded as *one* line ending at the real
+    /// terminator, and iteration lands on the next line's start rather than on
+    /// a chunk boundary.
+    ///
+    /// Not visible on screen directly — it is the primitive the wrapped-scroll
+    /// math reads through, where a chunk boundary posing as a line start snaps
+    /// the viewport to byte 100,000 (issue #2843).
+    #[test]
+    fn test_next_logical_line_spans_chunk_boundaries() {
+        // First line straddles several MAX_LINE_BYTES chunks; second is short.
+        let long_line = "x".repeat(super::MAX_LINE_BYTES * 2 + 1234);
+        let content = format!("{long_line}\nsecond\n");
+        let mut buffer = TextBuffer::from_bytes(content.into_bytes(), test_fs());
+
+        // `next_line` splits it — that is the read budget doing its job.
+        let mut chunked = buffer.line_iterator(0, 200);
+        let (_, first_chunk) = chunked.next_line().expect("first chunk");
+        assert_eq!(
+            first_chunk.len(),
+            super::MAX_LINE_BYTES,
+            "next_line should stop at the read budget"
+        );
+        assert_ne!(
+            chunked.current_position(),
+            long_line.len() + 1,
+            "precondition: next_line does not reach the real line end"
+        );
+
+        // `next_logical_line` rejoins the pieces.
+        let mut iter = buffer.line_iterator(0, 200);
+        let (start, line) = iter.next_logical_line().expect("first logical line");
+        assert_eq!(start, 0);
+        assert_eq!(
+            line.len(),
+            long_line.len() + 1,
+            "the whole line plus its newline should be returned as one line"
+        );
+        assert!(line.ends_with('\n'));
+        assert_eq!(
+            iter.current_position(),
+            long_line.len() + 1,
+            "iteration should land on the next line's start, not a chunk boundary"
+        );
+
+        let (second_start, second) = iter.next_logical_line().expect("second logical line");
+        assert_eq!(second_start, long_line.len() + 1);
+        assert_eq!(second, "second\n");
+    }
+
+    /// A final line with no terminator must still come back whole, and the
+    /// iterator must then report EOF rather than looping on the tail.
+    #[test]
+    fn test_next_logical_line_unterminated_tail() {
+        let long_line = "y".repeat(super::MAX_LINE_BYTES + 7);
+        let mut buffer = TextBuffer::from_bytes(long_line.clone().into_bytes(), test_fs());
+
+        let mut iter = buffer.line_iterator(0, 200);
+        let (start, line) = iter.next_logical_line().expect("logical line");
+        assert_eq!(start, 0);
+        assert_eq!(line.len(), long_line.len());
+        assert!(iter.next_logical_line().is_none(), "should be at EOF");
     }
 
     /// Test that large single-line files are chunked correctly and all data is preserved.

--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -333,6 +333,37 @@ pub(super) fn calculate_viewport_end(
     viewport_end
 }
 
+/// Source-byte span actually covered by `rows` — the visual rows that will
+/// be drawn this frame.
+///
+/// With soft wrap on, `calculate_viewport_end` cannot describe the visible
+/// window: one logical line can occupy *every* row, and the top row can sit
+/// thousands of wrap segments into it (`top_view_line_offset`), so the
+/// decoration pass needs a span that starts where the drawn rows start, not
+/// at the line's `top_byte`. The rows already carry a source byte per
+/// character, so read the window off them (issue #2843: past the first few
+/// wrapped rows of a 441 KB single-line JSON the request stayed at
+/// `0..952`, and every row below rendered in whatever single span happened
+/// to overlap it).
+///
+/// Cost is proportional to the screen, not the line. Returns `None` when no
+/// drawn row carries source bytes (all-virtual rows, past-EOF filler), so
+/// callers keep their previous window.
+pub(super) fn visible_source_span(rows: &[ViewLine]) -> Option<(usize, usize)> {
+    let mut span: Option<(usize, usize)> = None;
+    for row in rows {
+        for (ch, src) in row.text.chars().zip(row.char_source_bytes.iter()) {
+            let Some(start) = *src else { continue };
+            let end = start.saturating_add(ch.len_utf8());
+            span = Some(match span {
+                Some((lo, hi)) => (lo.min(start), hi.max(end)),
+                None => (start, end),
+            });
+        }
+    }
+    span
+}
+
 /// Draw the separator line between two splits.
 pub(super) fn render_separator(
     buf: &mut ratatui::buffer::Buffer,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -9,7 +9,8 @@
 use super::super::folding::fold_adjusted_visible_count;
 use super::super::gutter::render_compose_margins;
 use super::super::layout::{
-    calculate_compose_layout, calculate_view_anchor, calculate_viewport_end, ComposeLayout,
+    calculate_compose_layout, calculate_view_anchor, calculate_viewport_end, visible_source_span,
+    ComposeLayout,
 };
 use super::super::post_pass::{
     apply_background_to_lines, render_column_guides, render_cursor_column_bg, render_ruler_bg,
@@ -332,6 +333,25 @@ pub(crate) fn compute_buffer_layout(
         viewport.left_column,
         render_area.width as usize,
     );
+
+    // `calculate_viewport_end` walks *logical lines* from `top_byte` and
+    // clamps each to one screen row's worth of columns — the right model for
+    // horizontal scrolling, where a long line shows one row's window of
+    // itself. Under soft wrap neither half holds: the drawn rows can all
+    // belong to one logical line and can start `top_view_line_offset`
+    // segments into it, so the byte window to decorate is the one the rows
+    // themselves cover. Without this, scrolling into a long wrapped line
+    // leaves every row past the first few undecorated — no syntax colours,
+    // no overlays — because the request never moved off the line's start
+    // (issue #2843).
+    let (viewport_start, viewport_end) = if line_wrap {
+        let first_drawn = viewport.top_view_line_offset.min(view_data.lines.len());
+        let drawn = &view_data.lines[first_drawn..];
+        let drawn = &drawn[..drawn.len().min(adjusted_visible_count)];
+        visible_source_span(drawn).unwrap_or((viewport_start, viewport_end))
+    } else {
+        (viewport_start, viewport_end)
+    };
 
     let decorations = decoration_context(
         state,

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -360,7 +360,17 @@ impl Viewport {
                 );
                 crate::view::line_wrap_cache::placeholder_layout_for_row_count(n)
             };
-            if let Some((cache, pipeline_inputs_ver)) = cache {
+            // The cache is keyed by `line_start`, so an entry is only
+            // reusable if `line_text` really is that whole line. Callers
+            // that pass a prefix (cursor-row math) or a `LineIterator`
+            // piece cut at the read budget would otherwise store a short
+            // count under the line's key and every later lookup — from
+            // the wheel, the scrollbar clamp, ensure-visible — would read
+            // it back (issue #2843: a 100 KB piece of a 441 KB line
+            // cached 916 rows for a 4130-row line). Trailing `\r\n` is
+            // trimmed off `line_text`, hence the 2-byte slack.
+            let covers_whole_line = line_text.len() + 2 >= line_end.saturating_sub(line_start);
+            if let Some((cache, pipeline_inputs_ver)) = cache.filter(|_| covers_whole_line) {
                 use crate::view::line_wrap_cache::{CacheViewMode, LineWrapKey};
                 let key = LineWrapKey {
                     pipeline_inputs_version: pipeline_inputs_ver,
@@ -736,7 +746,7 @@ impl Viewport {
 
             // Get the line content to calculate how many visual rows it has
             let line_start = iter.current_position();
-            let (line_end, line_content) = if let Some((_, content)) = iter.next_line() {
+            let (line_end, line_content) = if let Some((_, content)) = iter.next_logical_line() {
                 let end = iter.current_position();
                 (end, content.trim_end_matches(['\n', '\r']).to_string())
             } else {
@@ -795,16 +805,16 @@ impl Viewport {
 
         // First, handle any existing top_view_line_offset
         // Get current line's visual row count to see how many rows are left in it
-        let (current_line_end, current_line_content) = if let Some((_, content)) = iter.next_line()
-        {
-            let end = iter.current_position();
-            let c = content.trim_end_matches(['\n', '\r']).to_string();
-            // Reset iterator to start of this line for later use
-            iter = buffer.line_iterator(current_top, 80);
-            (end, c)
-        } else {
-            (current_top, String::new())
-        };
+        let (current_line_end, current_line_content) =
+            if let Some((_, content)) = iter.next_logical_line() {
+                let end = iter.current_position();
+                let c = content.trim_end_matches(['\n', '\r']).to_string();
+                // Reset iterator to start of this line for later use
+                iter = buffer.line_iterator(current_top, 80);
+                (end, c)
+            } else {
+                (current_top, String::new())
+            };
 
         let current_visual_rows = Self::count_visual_rows_for_line(
             current_top,
@@ -833,7 +843,7 @@ impl Viewport {
         self.top_view_line_offset = 0;
 
         // Move to next line
-        if iter.next_line().is_none() {
+        if iter.next_logical_line().is_none() {
             // Already at end of buffer
             return;
         }
@@ -848,7 +858,7 @@ impl Viewport {
                 return;
             }
 
-            let (line_end, line_content) = if let Some((_, content)) = iter.next_line() {
+            let (line_end, line_content) = if let Some((_, content)) = iter.next_logical_line() {
                 let end = iter.current_position();
                 (end, content.trim_end_matches(['\n', '\r']).to_string())
             } else {
@@ -912,7 +922,7 @@ impl Viewport {
         let mut iter = buffer.line_iterator(self.top_byte, 80);
 
         // First, count rows in current line (from top_view_line_offset to end)
-        if let Some((line_start, content)) = iter.next_line() {
+        if let Some((line_start, content)) = iter.next_logical_line() {
             let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
             let line_visual_rows = Self::count_visual_rows_for_line(
@@ -928,7 +938,7 @@ impl Viewport {
         }
 
         // Count rows in subsequent lines
-        while let Some((line_start, content)) = iter.next_line() {
+        while let Some((line_start, content)) = iter.next_logical_line() {
             let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
             visual_rows_remaining += Self::count_visual_rows_for_line(
@@ -997,7 +1007,7 @@ impl Viewport {
         // Build visual row positions from scan_start to end of file
         let mut positions: Vec<(usize, usize)> = Vec::new();
         let mut iter = buffer.line_iterator(scan_start, 80);
-        while let Some((line_start, content)) = iter.next_line() {
+        while let Some((line_start, content)) = iter.next_logical_line() {
             let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
             let visual_rows_in_line = Self::count_visual_rows_for_line(
@@ -1658,7 +1668,7 @@ impl Viewport {
         let mut iter = buffer.line_iterator(proposed_top_byte, 80);
         let mut visual_rows = 0;
 
-        while let Some((line_start, content)) = iter.next_line() {
+        while let Some((line_start, content)) = iter.next_logical_line() {
             let line_end = iter.current_position();
             let line_text = content.trim_end_matches(['\n', '\r']);
             visual_rows += Self::count_visual_rows_for_line(
@@ -2515,7 +2525,7 @@ impl Viewport {
         let mut iter = buffer.line_iterator(self.top_byte, 80);
         let mut screen_row: usize = 0;
 
-        while let Some((line_byte, content)) = iter.next_line() {
+        while let Some((line_byte, content)) = iter.next_logical_line() {
             if line_byte >= line_start {
                 break;
             }
@@ -2540,7 +2550,7 @@ impl Viewport {
         let (screen_col, additional_rows) = if let Some(ref config) = wrap_config {
             // Get the line text for wrapping
             let mut line_iter = buffer.line_iterator(line_start, 80);
-            let line_text = if let Some((_start, content)) = line_iter.next_line() {
+            let line_text = if let Some((_start, content)) = line_iter.next_logical_line() {
                 // Remove trailing newline if present
                 content.trim_end_matches(['\n', '\r']).to_string()
             } else {

--- a/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
@@ -103,57 +103,71 @@ fn fg_of(harness: &EditorTestHarness, needle: &str) -> Option<ratatui::style::Co
     harness.get_cell_style(col, row).map(|s| s.fg)?
 }
 
-/// A single-line JSON whose tail carries a string and a number, behind a
-/// padding string long enough that the tail is over a hundred KB in. After
-/// scrolling to the bottom, the two tail tokens must render in their own
-/// syntax colours.
+/// A single-line JSON of ascending `"M######": 424242` pairs. After a
+/// scrollbar jump deep into the line, the key on screen (a string) and the
+/// value next to it (a number) must still render in different syntax
+/// colours.
 ///
 /// The bug asked the highlighter for a byte window anchored at `top_byte`
 /// and one screen row wide (`0..952` on the issue's file) no matter how far
-/// the viewport had scrolled into the line, so every row past the first few
-/// wrapped ones was painted by whatever single span happened to overlap
-/// that window — uniformly, with no structure — or left undecorated.
+/// the viewport had scrolled into the line. Every row past the first few
+/// wrapped ones was then painted by whatever single span happened to
+/// overlap that window — uniformly, with no structure — or, once nothing
+/// overlapped, left undecorated, which is what makes both tokens come back
+/// the same colour here.
+///
+/// The marker doubles as proof the viewport really moved: reading it off
+/// the screen fails loudly if the jump left the view at the top of the
+/// line, where highlighting worked even before the fix.
 #[test]
-fn wrapped_long_line_keeps_syntax_colours_when_scrolled_to_the_tail() {
+fn wrapped_long_line_keeps_syntax_colours_when_scrolled_into() {
     const WIDTH: u16 = 100;
     const HEIGHT: u16 = 30;
+    const PAIRS: u32 = 10_000;
 
     let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
     let dir = harness.project_dir().unwrap();
     let path = dir.join("one_line.json");
 
-    // ~150 KB of padding inside one JSON string, then a string value and a
-    // numeric value. No trailing newline: the whole file is one line, and the
-    // tail sits well past the first screenful of wrap segments.
-    let padding = "pad ".repeat(37_500);
-    let content = format!(r#"{{"pad":"{padding}","tag":"ZZSTRINGZZ","num":424242}}"#);
-    std::fs::write(&path, &content).unwrap();
+    // ~170 KB on one line, no trailing newline. Every wrapped row carries
+    // several key/value pairs, so whichever part of the line the viewport
+    // lands on has both a string and a number on screen.
+    let mut body = String::with_capacity(PAIRS as usize * 18);
+    for i in 0..PAIRS {
+        if i > 0 {
+            body.push(',');
+        }
+        body.push_str(&format!(r#""M{i:06}":424242"#));
+    }
+    std::fs::write(&path, format!("{{{body}}}")).unwrap();
 
     harness.open_file(&path).unwrap();
     harness.render().unwrap();
 
-    // Jump to the bottom of the scrollbar track so the tail is on screen.
-    let (_, last_content_row) = harness.content_area_rows();
-    harness
-        .mouse_click(scrollbar_col(WIDTH), last_content_row as u16)
-        .unwrap();
+    // Jump two thirds down the scrollbar track — far enough in that the old
+    // `0..952` window covers nothing that is on screen.
+    harness.mouse_click(scrollbar_col(WIDTH), 20).unwrap();
     harness.render().unwrap();
 
     let screen = harness.screen_to_string();
+    let marker = first_marker(&screen)
+        .unwrap_or_else(|| panic!("no marker visible after the scrollbar jump:\n{screen}"));
     assert!(
-        screen.contains("ZZSTRINGZZ") && screen.contains("424242"),
-        "precondition: the line's tail should be visible after a scrollbar \
-         jump to the bottom. Screen:\n{screen}"
+        marker > 1_000,
+        "precondition: the scrollbar jump should land well into the line, \
+         past the first screenful of wrap segments (top marker is M{marker:06}). \
+         Screen:\n{screen}"
     );
 
-    let string_fg = fg_of(&harness, "ZZSTRINGZZ")
-        .unwrap_or_else(|| panic!("no style for the tail string. Screen:\n{screen}"));
+    let key = format!("M{marker:06}");
+    let string_fg = fg_of(&harness, &key)
+        .unwrap_or_else(|| panic!("no style for the key string. Screen:\n{screen}"));
     let number_fg = fg_of(&harness, "424242")
-        .unwrap_or_else(|| panic!("no style for the tail number. Screen:\n{screen}"));
+        .unwrap_or_else(|| panic!("no style for the numeric value. Screen:\n{screen}"));
 
     assert_ne!(
         string_fg, number_fg,
-        "after scrolling into a soft-wrapped line the tail's string and number \
+        "after scrolling into a soft-wrapped line the visible key and value \
          must still be syntax-coloured differently (string {string_fg:?}, \
          number {number_fg:?}) — identical colours mean the decoration pass is \
          still describing the top of the line. Screen:\n{screen}"

--- a/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
@@ -96,3 +96,66 @@ fn wheel_after_scrollbar_jump_continues_from_the_jump_position() {
          is a jump, not a scroll. Screen:\n{after}"
     );
 }
+
+/// Foreground colour of the first cell of `needle` on screen.
+fn fg_of(harness: &EditorTestHarness, needle: &str) -> Option<ratatui::style::Color> {
+    let (col, row) = harness.find_text_on_screen(needle)?;
+    harness.get_cell_style(col, row).map(|s| s.fg)?
+}
+
+/// A single-line JSON whose tail carries a string and a number, behind a
+/// padding string long enough that the tail is over a hundred KB in. After
+/// scrolling to the bottom, the two tail tokens must render in their own
+/// syntax colours.
+///
+/// The bug asked the highlighter for a byte window anchored at `top_byte`
+/// and one screen row wide (`0..952` on the issue's file) no matter how far
+/// the viewport had scrolled into the line, so every row past the first few
+/// wrapped ones was painted by whatever single span happened to overlap
+/// that window — uniformly, with no structure — or left undecorated.
+#[test]
+fn wrapped_long_line_keeps_syntax_colours_when_scrolled_to_the_tail() {
+    const WIDTH: u16 = 100;
+    const HEIGHT: u16 = 30;
+
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    let dir = harness.project_dir().unwrap();
+    let path = dir.join("one_line.json");
+
+    // ~150 KB of padding inside one JSON string, then a string value and a
+    // numeric value. No trailing newline: the whole file is one line, and the
+    // tail sits well past the first screenful of wrap segments.
+    let padding = "pad ".repeat(37_500);
+    let content = format!(r#"{{"pad":"{padding}","tag":"ZZSTRINGZZ","num":424242}}"#);
+    std::fs::write(&path, &content).unwrap();
+
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+
+    // Jump to the bottom of the scrollbar track so the tail is on screen.
+    let (_, last_content_row) = harness.content_area_rows();
+    harness
+        .mouse_click(scrollbar_col(WIDTH), last_content_row as u16)
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("ZZSTRINGZZ") && screen.contains("424242"),
+        "precondition: the line's tail should be visible after a scrollbar \
+         jump to the bottom. Screen:\n{screen}"
+    );
+
+    let string_fg = fg_of(&harness, "ZZSTRINGZZ")
+        .unwrap_or_else(|| panic!("no style for the tail string. Screen:\n{screen}"));
+    let number_fg = fg_of(&harness, "424242")
+        .unwrap_or_else(|| panic!("no style for the tail number. Screen:\n{screen}"));
+
+    assert_ne!(
+        string_fg, number_fg,
+        "after scrolling into a soft-wrapped line the tail's string and number \
+         must still be syntax-coloured differently (string {string_fg:?}, \
+         number {number_fg:?}) — identical colours mean the decoration pass is \
+         still describing the top of the line. Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2843_single_line_viewport.rs
@@ -1,0 +1,98 @@
+//! Regression tests for issue #2843 — a file that is one very long line.
+//!
+//! The defects only show up once the viewport has scrolled *into* a
+//! soft-wrapped line, i.e. when `top_byte` stays at the line's start and the
+//! position is carried by the wrap-segment offset instead.
+//!
+//! Asserts on rendered output only (CONTRIBUTING §2).
+
+use crate::common::harness::EditorTestHarness;
+
+/// Rightmost column of a `width`-wide terminal — where the vertical
+/// scrollbar is drawn.
+fn scrollbar_col(width: u16) -> u16 {
+    width - 1
+}
+
+/// First `M`-prefixed six-digit marker on the screen, in reading order.
+/// The markers ascend along the line, so this says which part of the line
+/// the viewport is showing.
+fn first_marker(screen: &str) -> Option<u32> {
+    for line in screen.lines() {
+        let bytes = line.as_bytes();
+        for (i, _) in line.match_indices('M') {
+            let digits = &bytes[i + 1..];
+            if digits.len() >= 6 && digits[..6].iter().all(|b| b.is_ascii_digit()) {
+                return std::str::from_utf8(&digits[..6]).ok()?.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+/// Click the scrollbar to land deep inside the single line, then wheel down
+/// one notch. The view must advance a little — the bug threw the scrollbar
+/// position away and snapped `top_byte` to 100,000 (`MAX_LINE_BYTES`, the
+/// size of the chunks `LineIterator` splits over-long lines into), which on
+/// this file is far *above* where the click landed. Scroll math was treating
+/// a read-budget boundary as a line boundary.
+#[test]
+fn wheel_after_scrollbar_jump_continues_from_the_jump_position() {
+    const WIDTH: u16 = 100;
+    const HEIGHT: u16 = 30;
+    // Comfortably more than the 100,000-byte chunk size, so a snap to the
+    // chunk boundary is unmistakably backwards from where the click lands.
+    const MARKERS: u32 = 50_000;
+
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+    let dir = harness.project_dir().unwrap();
+    let path = dir.join("one_line.txt");
+
+    // One line of ascending 8-byte markers (~400 KB), so the topmost visible
+    // marker says exactly how far into the line the viewport sits.
+    let mut content = String::with_capacity(MARKERS as usize * 8);
+    for i in 0..MARKERS {
+        content.push_str(&format!("M{i:06} "));
+    }
+    std::fs::write(&path, &content).unwrap();
+
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+
+    // Land well past the 100,000-byte chunk boundary (~row 20 of 30 on the
+    // track is roughly two thirds down a ~400 KB line).
+    harness.mouse_click(scrollbar_col(WIDTH), 20).unwrap();
+    harness.render().unwrap();
+
+    let before = harness.screen_to_string();
+    let top_before = first_marker(&before)
+        .unwrap_or_else(|| panic!("no marker visible after the scrollbar jump:\n{before}"));
+    assert!(
+        top_before > 20_000,
+        "precondition: the scrollbar jump should land past the 100,000-byte \
+         chunk boundary (marker {top_before} is byte ~{}). Screen:\n{before}",
+        top_before * 8
+    );
+
+    harness.mouse_scroll_down(WIDTH / 2, HEIGHT / 2).unwrap();
+    harness.render().unwrap();
+
+    let after = harness.screen_to_string();
+    let top_after = first_marker(&after)
+        .unwrap_or_else(|| panic!("no marker visible after the wheel notch:\n{after}"));
+
+    assert!(
+        top_after > top_before,
+        "one wheel notch must scroll forward from where the scrollbar left the \
+         viewport (top marker was M{top_before:06}, now M{top_after:06}) — \
+         going backwards means the wheel snapped to a chunk boundary. \
+         Screen:\n{after}"
+    );
+    // A notch is three visual rows; each row holds at most `WIDTH` bytes, so
+    // a legitimate notch cannot move more than a few hundred markers.
+    assert!(
+        top_after - top_before < 500,
+        "one wheel notch moved from M{top_before:06} to M{top_after:06} — that \
+         is a jump, not a scroll. Screen:\n{after}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -95,6 +95,7 @@ pub mod issue_2605_format_selection_range;
 pub mod issue_2796_key_release_duplicates;
 #[cfg(feature = "plugins")]
 pub mod issue_2810_session_escape_flush;
+pub mod issue_2843_single_line_viewport;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod language_dialog_esc_cancels_edit;


### PR DESCRIPTION
Fixes both defects in #2843, on top of #2841. Two independent fixes, one commit each.

## 1. Highlighting turns uniform after the first few wrapped rows

The decoration pass asks for a byte window built from `top_byte` and `calculate_viewport_end`, which walks *logical lines* from `top_byte` and clamps each to one screen row's worth of columns. Correct for horizontal scrolling — and it is what bounds the per-frame scan behind #2529 — but under soft wrap neither half holds: the drawn rows can all belong to one logical line, and the top row can sit thousands of wrap segments into it.

Instrumenting the call confirms it: on the issue's `fp4_poll.json` the request stays at `0..952` no matter how far down you scroll. Whatever single span overlapped that window was returned in full and painted every row below it; once nothing overlapped, the rows were left bare.

Under wrap, the window is now derived from the view lines about to be rendered — they already carry a source byte per character, so the span is exact and costs a walk proportional to the screen, not to the line. The unwrapped path keeps `calculate_viewport_end` unchanged. The overlay, bracket and diagnostic passes take the same window and get the same correction.

**Note on the issue's leading hypothesis** — it does not hold up, and no fix was needed there. Feeding the whole 441 KB line to `ParseState::parse_line` in one call keeps the scope stack at `string.quoted.double.json` at byte 43,059, 50,000 and 200,000; `TextMateEngine::highlight_viewport` returns `String@49994..50005` for the `50,000..54,000` window. syntect never leaves the string state, so `parse_line_into_spans` is not at fault and nothing needed chunking or state carry-over. The reported `Comment@43059..62192` was a *rendered* symptom of the window bug above: one span overlapping `0..952` gets returned whole and colours everything below it.

## 2. Wheel scroll collapses to a chunk boundary

`MAX_LINE_BYTES` (100,000) is the budget `LineIterator` uses to avoid materialising a huge line at once — it splits such a line into pieces and yields each as a separate "line". That is a read budget, not document structure, but the wrapped-scroll math consumed it as a line boundary: it counted the visual rows of a 100 KB piece, ran out of rows inside it, and "advanced" to the next piece as if it were the next line. The scrollbar reads `VisualRowIndex` (real logical lines) and disagreed — hence the jump on the first notch after a scrollbar jump.

`LineIterator::next_logical_line` rejoins the pieces up to the real terminator; every wrapped-scroll path now reads through it (scroll up/down, the scroll limit, the max-scroll search, the clamp, cursor-row math). `next_line` keeps its budget for callers that stream.

The per-line row-count cache made this stick even after the traversal was fixed. It is keyed by `line_start`, so the piece-based caller had stored *916 rows* under the key for a line that is really *4130 rows*, and every later lookup — wheel, scrollbar clamp, ensure-visible — read that back. The cache is now gated on the text actually covering the line, so a partial-line caller (the cursor-row prefix math passes one too) cannot poison it.

Measured on the issue's file, 120×30:

| | before | after |
|---|---|---|
| scrollbar click | `top_byte=0 offset=1642` | `top_byte=0 offset=1642` |
| wheel ×1 | `top_byte=100000 offset=3` | `top_byte=0 offset=1645` |
| wheel ×6 | `top_byte=100000 offset=18` | `top_byte=0 offset=1660` |

## Tests

`tests/e2e/issue_2843_single_line_viewport.rs` — two e2e tests, both driving mouse only and asserting on rendered output:

- `wheel_after_scrollbar_jump_continues_from_the_jump_position` reads the topmost ascending marker off the screen before and after one wheel notch.
- `wrapped_long_line_keeps_syntax_colours_when_scrolled_into` jumps two thirds down the track into a line of ascending `"M######":424242` pairs and asserts the visible key and value still render in different colours. The marker read off the screen doubles as the precondition, so a jump that left the view at the top of the line (where highlighting worked even before the fix) fails loudly instead of passing vacuously.

`line_iterator.rs` — two unit tests for `next_logical_line` (spans chunk boundaries and lands on the next line's start; unterminated tail). Not screen-visible, so unit-level per CONTRIBUTING §2.

## Verification

`cargo fmt`, `cargo clippy --all-targets` (no new warnings in the touched files) and `cargo check --all-targets` are clean; the full lib suite passes (3134 tests). Both e2e tests pass locally, and the highlighting one was verified failing with the decoration-window fix reverted (key and value both render undecorated white) and passing with it.

Both bugs were also reproduced, and both fixes confirmed, against the real `fp4_poll.json` through the editor harness before any test was written.

### An adjacent defect this branch does *not* fix

The first revision of the highlighting test jumped to the **bottom** of the scrollbar track, and the tail never appeared. Cause: at max scroll the scrollbar's `VisualRowIndex` counts more wrap rows than the renderer builds — they derive the gutter width differently — so the requested row offset lands past the last view line and `render_buffer` silently falls back to the top of the line. Reproducible on `master`, same area as #1574 / #2649, and out of scope here; the test now lands where the two agree. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F54wthCxJtDmeUmgmnZzoU