### PR TITLE
fix(terminal): resize terminals when a split, maximize or tab drop changes the pane

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2625,6 +2625,12 @@ impl Editor {
                 }
                 Err(e) => self.set_status_message(e),
             }
+            // Maximize/restore changed every pane's geometry: reflow through
+            // the single layout funnel, exactly as the keyboard/command
+            // `toggle_maximize_split` does. Without this the mouse path left
+            // every visible terminal at its pre-toggle PTY size and scroll-back
+            // wrap column.
+            self.relayout();
             return Some(Ok(()));
         }
 
@@ -3653,6 +3659,11 @@ impl Editor {
         {
             self.set_active_buffer(buffer_id);
         }
+        // Closing a split gives its space back to the surviving panes — the
+        // same reflow `close_active_split` runs. `set_active_buffer` above only
+        // resizes terminals when the *newly focused* buffer is one, so the
+        // other surviving panes need the funnel.
+        self.relayout();
         self.set_status_message(t!("split.closed").to_string());
     }
 

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1092,6 +1092,10 @@ impl Editor {
         };
 
         if applied {
+            // The two panes either side of the container changed width /
+            // height — reflow through the layout funnel so their terminals
+            // follow, same as the separator drag and `adjust_split_size`.
+            self.relayout();
             tracing::debug!("Set split {:?} ratio to {}", split_id, ratio);
         } else {
             tracing::debug!(
@@ -1111,6 +1115,8 @@ impl Editor {
             .and_then(|w| w.split_manager_mut())
             .expect("active window must have a populated split layout")
             .distribute_splits_evenly();
+        // Every pane just changed size — reflow through the layout funnel.
+        self.relayout();
         tracing::debug!("Distributed splits evenly");
     }
 

--- a/crates/fresh-editor/src/app/tab_drag.rs
+++ b/crates/fresh-editor/src/app/tab_drag.rs
@@ -210,6 +210,15 @@ impl Editor {
                 self.move_tab_to_split(buffer_id, source_split_id, target_split_id, None);
             }
         }
+
+        // Every drop outcome above can change pane geometry: the four
+        // `Split*` zones create a split, and a move can empty (and close)
+        // the source one. Reflow through the single layout funnel here —
+        // the one fork all of them pass through — so a dropped terminal's
+        // PTY is SIGWINCHed to its new pane instead of keeping the size it
+        // had before the drag. Redundant for a same-split reorder, which
+        // `relayout` is explicitly cheap enough to absorb.
+        self.relayout();
     }
 
     /// Reorder a tab within the same split

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -2133,7 +2133,8 @@ impl Window {
     }
 
     /// Resize all this window's visible terminal PTYs to match their
-    /// current split dimensions. Reads the window's cached
+    /// current split dimensions, and re-pin the scroll-back view's grid
+    /// wrap column to the same pane width. Reads the window's cached
     /// `terminal_width` / `terminal_height` for the screen size.
     pub fn resize_visible_terminals(&mut self) {
         let editor_area = self.editor_content_area();
@@ -2143,6 +2144,10 @@ impl Window {
         };
         let visible_buffers = mgr.get_visible_buffers(editor_area);
 
+        // (split, terminal buffer, pty cols, pty rows, grid cols). Collected
+        // first because applying it needs `&mut self` for both the terminal
+        // manager and the split view states.
+        let mut plan: Vec<(crate::model::event::LeafId, BufferId, u16, u16, u16)> = Vec::new();
         for (split_id, buffer_id, split_area) in visible_buffers {
             if self.terminal_buffers.contains_key(&buffer_id) {
                 // A split hides its scrollbar (grid reclaims the column)
@@ -2152,13 +2157,51 @@ impl Window {
                 // matches the rendered `content_rect`.
                 let showing_live_grid = !self.split_terminal_scrollback(split_id, buffer_id);
                 let scrollbar_cols = if showing_live_grid { 0 } else { 1 };
+                // The column count this pane lays terminal content out at,
+                // whichever view it shows: the live grid is drawn at exactly
+                // this width, and a split in scroll-back reserves the scrollbar
+                // column out of it, which puts the text `content_rect` at the
+                // same width. That shared value is what the scroll-back view
+                // must wrap at.
+                let grid_cols = split_area.width.saturating_sub(1);
                 // Tab bar takes 1 row; reserve 1 row for chrome and the
                 // scrollbar column (when shown) on the right.
                 let content_height = split_area.height.saturating_sub(2);
-                let content_width = split_area.width.saturating_sub(1 + scrollbar_cols);
+                let content_width = grid_cols.saturating_sub(scrollbar_cols);
 
-                if content_width > 0 && content_height > 0 {
-                    self.resize_terminal(buffer_id, content_width, content_height);
+                plan.push((
+                    split_id,
+                    buffer_id,
+                    content_width,
+                    content_height,
+                    grid_cols,
+                ));
+            }
+        }
+
+        for (split_id, buffer_id, content_width, content_height, grid_cols) in plan {
+            if content_width > 0 && content_height > 0 {
+                self.resize_terminal(buffer_id, content_width, content_height);
+            }
+
+            // Re-pin the grid wrap column of this split's scroll-back view.
+            // `sync_terminal_to_buffer` pins the capture-time width on entry,
+            // but nothing revisited it when the *pane* later changed width
+            // (a sibling split created or closed, a maximize toggled, a
+            // dock/explorer drag). The captured backing file holds unwrapped
+            // logical lines, so a stale, wider column simply clipped every
+            // line at the pane edge and lost the rest (fresh#2649 follow-up).
+            // Pushing it here keeps it on the same one-directional funnel as
+            // the PTY size, for every split showing the terminal.
+            if grid_cols > 0 {
+                if let Some(vs) = self
+                    .buffers
+                    .split_view_states_mut()
+                    .and_then(|vs_map| vs_map.get_mut(&split_id))
+                {
+                    if let Some(buf_state) = vs.buffer_state_mut(buffer_id) {
+                        buf_state.viewport.wrap_column = Some(grid_cols as usize);
+                    }
                 }
             }
         }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -3465,6 +3465,10 @@ impl Editor {
                 // Drop the closed split from every terminal's scrollback set.
                 self.active_window_mut()
                     .forget_split_terminal_modes(leaf_id);
+                // The surviving panes just grew into the closed split's
+                // space — reflow through the layout funnel so their
+                // terminals are resized, same as `close_active_split`.
+                self.relayout();
                 tracing::info!("Closed split {:?}", split_id);
             }
             Err(e) => {

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2616,6 +2616,9 @@ impl Window {
     /// that entered scroll-back reserves a scrollbar column, so the PTY
     /// may be resized one column narrower afterwards while the captured
     /// content still lays out at the width it was captured at).
+    /// When the *pane* changes width the authority is
+    /// `resize_visible_terminals`, which re-pins it to the new pane width
+    /// on the same funnel that pushes the PTY size.
     pub(crate) fn enforce_terminal_grid_wrap(&mut self) {
         if self.terminal_buffers.is_empty() {
             return;

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -60,6 +60,22 @@ fn tab_row_col_of_str(screen: &str, needle: &str) -> Option<u16> {
     Some(line[..byte_idx].chars().count() as u16)
 }
 
+/// Column of the last character of the *terminal* tab's name on the tab row,
+/// for a window holding `[No Name]` plus one terminal. Walks left from that
+/// tab's close button (the row's second "×") past the padding, so the caller
+/// never has to know what the spawned shell is called — the title is the
+/// foreground process name and differs per platform and per CI runner.
+fn terminal_tab_name_col(screen: &str) -> Option<u16> {
+    let row: Vec<char> = screen.lines().nth(1)?.chars().collect();
+    let mut closes = row.iter().enumerate().filter(|(_, c)| **c == '×');
+    closes.next()?; // the [No Name] tab's close button
+    let close_col = closes.next()?.0; // the terminal tab's
+    row[..close_col]
+        .iter()
+        .rposition(|c| !c.is_whitespace() && *c != '×')
+        .map(|p| p as u16)
+}
+
 /// The rendered text of the LEFT pane of a two-pane vertical split: every
 /// screen row truncated at the vertical separator. Lets an assertion say
 /// "this appeared in *that* pane" when both panes show the same terminal.
@@ -5021,17 +5037,7 @@ fn test_mouse_maximize_button_resizes_terminal() {
 #[test]
 #[cfg(not(windows))] // Uses Unix shell
 fn test_tab_drag_split_resizes_terminal() {
-    let mut config = Config::default();
-    // Pin the shell so the tab's title (and therefore the drag origin) is
-    // deterministic.
-    config.terminal.shell = Some(TerminalShellConfig {
-        command: "/bin/sh".to_string(),
-        args: Vec::new(),
-    });
-    let mut harness = match EditorTestHarness::with_config(120, 30, config) {
-        Ok(h) => h,
-        Err(_) => return,
-    };
+    let mut harness = harness_or_return!(120, 30);
 
     harness.editor_mut().open_terminal();
     harness.render().unwrap();
@@ -5054,9 +5060,11 @@ fn test_tab_drag_split_resizes_terminal() {
     );
 
     // Drag the terminal's tab onto the right edge of the content area, which
-    // is the "split right" drop zone (the rightmost 25% of the pane).
+    // is the "split right" drop zone (the rightmost 25% of the pane). Only a
+    // press on the tab's *name* starts a drag, so aim at the title rather than
+    // its close button.
     let screen = harness.screen_to_string();
-    let tab_col = tab_row_col_of_str(&screen, "sh")
+    let tab_col = terminal_tab_name_col(&screen)
         .unwrap_or_else(|| panic!("expected the terminal's tab on the tab row:\n{screen}"));
     harness.mouse_drag(tab_col, 1, 115, 15).unwrap();
     harness.render().unwrap();

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -60,6 +60,23 @@ fn tab_row_col_of_str(screen: &str, needle: &str) -> Option<u16> {
     Some(line[..byte_idx].chars().count() as u16)
 }
 
+/// The rendered text of the LEFT pane of a two-pane vertical split: every
+/// screen row truncated at the vertical separator. Lets an assertion say
+/// "this appeared in *that* pane" when both panes show the same terminal.
+fn left_pane_text(screen: &str) -> String {
+    screen
+        .lines()
+        .map(|line| line.split('│').next().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Shell command emitting one line of `X` * 100 followed by the marker
+/// `ZEND`. The `Z` is written as `\x5a` so the marker never appears
+/// literally in the echoed command line — finding "ZEND" on screen can only
+/// mean the *output* row's tail was actually rendered.
+const WIDE_LINE_CMD: &[u8] = b"printf 'X%.0s' $(seq 1 100); printf '\\x5aEND\\n'\n";
+
 /// Regression: with the keyboard focused on an *active terminal* buffer
 /// (terminal mode owns the keyboard), opening the tab bar's "+" popup must
 /// still hand the keyboard to the popup. Its navigation keys drive the menu
@@ -4888,4 +4905,169 @@ fn test_bug_2775_scrollback_entry_is_seamless_grid_wrap() {
             "row {i} unstable after PageUp x3 + Ctrl+End round trip.\nBEFORE:\n{bottom1}\nAFTER:\n{bottom2}"
         );
     }
+}
+
+/// fresh#2844: a terminal's scroll-back view keeps the wrap column it was
+/// captured at, so when a *new split* halves its pane the exact-column grid
+/// rows are laid out too wide and every line is clipped at the pane edge —
+/// the tail of each line simply disappears.
+///
+/// Drives: print a line wider than half the screen, drop the split into
+/// read-only scroll-back, then split vertically. The pre-existing (left) pane
+/// must re-wrap at its new width, so the line's tail is still on screen
+/// *inside that pane*.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_terminal_scrollback_rewraps_when_split_shrinks_pane() {
+    let mut harness = harness_or_return!(120, 30);
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(WIDE_LINE_CMD);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ZEND"))
+        .unwrap();
+
+    // Ctrl+Space drops the focused split into read-only scroll-back, which
+    // captures the buffer at the current (full-width) grid width.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Split vertically: the pre-existing split's pane halves in width. The new
+    // split streams the live grid, so only the LEFT pane exercises scroll-back.
+    harness.editor_mut().split_pane_vertical();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        left_pane_text(&screen).contains("ZEND"),
+        "The pre-existing split's scroll-back must re-wrap to its new pane \
+         width and keep the tail of the line on screen. Screen:\n{}",
+        screen
+    );
+}
+
+/// fresh#2844: the tab bar's maximize button toggles the split tree directly
+/// and never reflows, so every visible terminal keeps the PTY size (and
+/// scroll-back wrap column) it had before the click — the grid stays wrapped
+/// at the old half-pane width inside a now full-width pane.
+///
+/// Drives: split a terminal in two, then click the maximize button on the
+/// left split's tab bar. Its pane is now full width, so the whole 104-column
+/// line must fit on a single rendered row.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_mouse_maximize_button_resizes_terminal() {
+    let mut harness = harness_or_return!(120, 30);
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(WIDE_LINE_CMD);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ZEND"))
+        .unwrap();
+
+    // Two splits, both showing the same terminal at roughly half width. The
+    // 100-X run no longer fits on one row.
+    harness.editor_mut().split_pane_vertical();
+    harness.render().unwrap();
+    let run = "X".repeat(100);
+    assert!(
+        !harness.screen_to_string().lines().any(|l| l.contains(&run)),
+        "Precondition: at half width no row should hold 100 columns of output. \
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // The maximize glyph is "□" while not maximized; the first one on the tab
+    // row belongs to the left split.
+    let screen = harness.screen_to_string();
+    let btn_col = tab_row_col_of(&screen, '□')
+        .unwrap_or_else(|| panic!("expected a '□' maximize button on the tab row:\n{screen}"));
+    harness.mouse_click(btn_col, 1).unwrap();
+    harness.render().unwrap();
+
+    // The grid reflow happens synchronously with the resize, so the very next
+    // frame already shows it — no waiting on the PTY child.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.lines().any(|l| l.contains(&run)),
+        "Maximizing via the tab bar button must resize the terminal to the \
+         full-width pane, fitting the whole line on one row. Screen:\n{}",
+        screen
+    );
+}
+
+/// fresh#2844: dropping a tab onto a pane edge builds a new split without
+/// going through the layout funnel, so the dragged terminal's PTY child never
+/// gets the resize — an alternate-screen app (or anything that only redraws on
+/// SIGWINCH) keeps painting at the old width and is clipped at the new,
+/// narrower pane edge.
+///
+/// Drives: drag the terminal's tab to the right edge of its own pane to create
+/// a vertical split. The terminal now lives in a half-width pane, so its grid
+/// must re-wrap — the line's tail stays on screen instead of being clipped
+/// away.
+#[test]
+#[cfg(not(windows))] // Uses Unix shell
+fn test_tab_drag_split_resizes_terminal() {
+    let mut config = Config::default();
+    // Pin the shell so the tab's title (and therefore the drag origin) is
+    // deterministic.
+    config.terminal.shell = Some(TerminalShellConfig {
+        command: "/bin/sh".to_string(),
+        args: Vec::new(),
+    });
+    let mut harness = match EditorTestHarness::with_config(120, 30, config) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(WIDE_LINE_CMD);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ZEND"))
+        .unwrap();
+
+    // Full width: the whole line sits on one row.
+    let run = "X".repeat(100);
+    assert!(
+        harness.screen_to_string().lines().any(|l| l.contains(&run)),
+        "Precondition: at full width the whole line should fit on one row. \
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Drag the terminal's tab onto the right edge of the content area, which
+    // is the "split right" drop zone (the rightmost 25% of the pane).
+    let screen = harness.screen_to_string();
+    let tab_col = tab_row_col_of_str(&screen, "sh")
+        .unwrap_or_else(|| panic!("expected the terminal's tab on the tab row:\n{screen}"));
+    harness.mouse_drag(tab_col, 1, 115, 15).unwrap();
+    harness.render().unwrap();
+
+    // The terminal is now in a half-width pane. Its grid must have re-wrapped,
+    // so the tail marker is still rendered (rather than clipped off the pane).
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("ZEND"),
+        "A terminal dropped into a new split must be resized to its new pane, \
+         re-wrapping so the tail of the line stays on screen. Screen:\n{}",
+        screen
+    );
 }


### PR DESCRIPTION
Fixes #2844.

Two independent causes, both of which leave a pre-existing terminal laid out at its old pane width and clipped at the new pane edge.

## 1. Scroll-back kept a stale wrap column

A terminal's scroll-back view pins its exact-column grid wrap at the width the buffer was captured at, and nothing revisited that value when the *pane* later changed size. The backing file holds unwrapped logical lines, so the content was recoverable all along — only the display width was stale, and every line lost its tail past the pane edge.

The wrap column now goes down the same one-directional funnel that already pushes the PTY size, so pane width has a single authority. The capture-time value still wins at the moment of capture: the pushed value is the pane's grid width, which is exactly what the live grid draws at and what the scroll-back text `content_rect` is (the scrollbar column comes out of the PTY width, not the text width), so entering scroll-back still lays out identically to the last live frame.

## 2. Several pane-geometry changes bypassed `relayout`

`relayout` is the single funnel that pushes new geometry to split viewports and terminal PTYs. The keyboard/command paths all call it; these did not:

- the tab bar's maximize button (mouse) and the close-split menu
- dropping a dragged tab on a pane edge, which builds a whole new split
- the plugin commands that close a split, set a split ratio, or distribute splits evenly

A live terminal in one of those panes never got the resize, so its PTY child was never SIGWINCHed — an alternate-screen app (or anything that only redraws on resize) kept painting at its old size. For the tab drop the call goes on `execute_tab_drop`, the one fork all six drop zones pass through.

## Testing

Reproduced interactively in tmux against a debug build, before and after, for both causes — including an alternate-screen app that prints its own SIGWINCH-reported size, which still read `SIZE=119x36` in a 59-column pane after a tab-drag split.

Three e2e reproducers added:

- splitting a pane whose terminal is in scroll-back must re-wrap that pane — asserted inside the left pane's columns so the new split's live grid can't satisfy it
- clicking the tab bar's maximize button must resize the terminal — asserted by the 100-column run fitting on one row only at full width
- dropping the terminal's tab on a pane edge must resize it into the new split — asserted by the line's tail surviving the narrower pane

`cargo fmt --all --check` and `cargo check --all-targets` are clean locally; the e2e suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgUZHyy9XoXzoqmGUNcuCZ