### PR TITLE
Scale long-line rendering and input with the viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ bun.lockb
 dist
 .amp/
 .worktrees/
+
+# Generated single-line perf fixture (scripts/gen-single-line-bench.py)
+bench-single-line-*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Keyboard and mouse input is now parsed by our own `fresh-input-parser` crate ins
 
 ### Bug Fixes
 
+* **Editing a file that is one very long line is much faster** - a file with no line breaks (minified JS, a one-line JSON blob, a long log record) made every frame tokenize and wrap ~540 KB of text to fill a screen that holds a few thousand characters, and every keystroke walk back to the line start one byte at a time — so typing got slower the further right the cursor was. Both now scale with the viewport instead of the line.
 * **Orchestrator & dock**
   * Codex "Auto mode" works again (it was passing a flag recent Codex CLI rejects).
   * Dock rows are fully clickable in compact (list) view, ordered by recency, and auto-name themselves from their terminal.

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -952,6 +952,39 @@ struct InsertCursorData {
     virtual_gap: String,
 }
 
+/// Find the start of the line containing `pos`, and report whether everything
+/// between it and `pos` is a space or a tab (the auto-dedent precondition).
+///
+/// Reads in blocks rather than a byte at a time. Each `slice_bytes` call is a
+/// piece-tree range query plus a heap allocation, so walking back one byte per
+/// iteration costs one of each per column — the dominant cost of a keystroke
+/// on a long line, and one that grows the further right the cursor sits.
+/// Materialising the whole prefix to test it for whitespace has the same
+/// problem: on a single-line file that prefix can be megabytes.
+fn line_start_and_blank_prefix(state: &EditorState, pos: usize) -> (usize, bool) {
+    const CHUNK: usize = 4096;
+    let mut end = pos;
+    let mut only_spaces = true;
+    while end > 0 {
+        let start = end.saturating_sub(CHUNK);
+        let bytes = state.buffer.slice_bytes(start..end);
+        if let Some(i) = bytes.iter().rposition(|&b| b == b'\n') {
+            if only_spaces {
+                only_spaces = bytes[i + 1..].iter().all(|&b| b == b' ' || b == b'\t');
+            }
+            return (start + i + 1, only_spaces);
+        }
+        // Once a non-blank byte is seen the answer is settled, but the scan
+        // still has to reach the line start — `line_start` is returned either
+        // way.
+        if only_spaces {
+            only_spaces = bytes.iter().all(|&b| b == b' ' || b == b'\t');
+        }
+        end = start;
+    }
+    (0, only_spaces)
+}
+
 /// Collect cursor data needed for character insertion.
 fn collect_insert_cursor_data(state: &mut EditorState, cursors: &Cursors) -> Vec<InsertCursorData> {
     // Collect cursors and sort by the effective insert position (reverse order)
@@ -989,17 +1022,7 @@ fn collect_insert_cursor_data(state: &mut EditorState, cursors: &Cursors) -> Vec
         .into_iter()
         .map(|(cursor_id, selection, insert_position, virtual_gap)| {
             // Calculate line start for auto-dedent
-            let mut line_start = insert_position;
-            while line_start > 0 {
-                let prev = line_start - 1;
-                if state.buffer.slice_bytes(prev..prev + 1).first() == Some(&b'\n') {
-                    break;
-                }
-                line_start = prev;
-            }
-
-            let line_before_cursor = state.buffer.slice_bytes(line_start..insert_position);
-            let only_spaces = line_before_cursor.iter().all(|&b| b == b' ' || b == b'\t');
+            let (line_start, only_spaces) = line_start_and_blank_prefix(state, insert_position);
 
             let check_pos = selection.as_ref().map(|r| r.end).unwrap_or(insert_position);
             let char_after = if check_pos < state.buffer.len() {
@@ -6234,6 +6257,75 @@ mod tests {
         }
 
         assert_eq!(state.buffer.to_string().unwrap(), "(bc)");
+    }
+
+    fn state_with(text: &str) -> EditorState {
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: text.to_string(),
+                cursor_id: CursorId(0),
+            },
+        );
+        state
+    }
+
+    #[test]
+    fn blank_prefix_finds_line_start_after_newline() {
+        let state = state_with("abc\n    ");
+        assert_eq!(line_start_and_blank_prefix(&state, 8), (4, true));
+    }
+
+    #[test]
+    fn blank_prefix_is_false_with_text_before_cursor() {
+        let state = state_with("abc\nfoo ");
+        assert_eq!(line_start_and_blank_prefix(&state, 8), (4, false));
+    }
+
+    #[test]
+    fn blank_prefix_at_buffer_start() {
+        let state = state_with("hello");
+        assert_eq!(line_start_and_blank_prefix(&state, 0), (0, true));
+        assert_eq!(line_start_and_blank_prefix(&state, 5), (0, false));
+    }
+
+    /// The scan reads in blocks, so a line longer than one block has to keep
+    /// walking back — and has to carry the "blank so far" answer across the
+    /// block boundary rather than resetting it.
+    #[test]
+    fn blank_prefix_spans_multiple_scan_blocks() {
+        let indent = " ".repeat(10_000);
+        let state = state_with(&format!("first\n{indent}"));
+        assert_eq!(
+            line_start_and_blank_prefix(&state, 6 + indent.len()),
+            (6, true)
+        );
+
+        let mut long_line = " ".repeat(10_000);
+        long_line.push('x');
+        long_line.push_str(&" ".repeat(10_000));
+        let state = state_with(&format!("first\n{long_line}"));
+        assert_eq!(
+            line_start_and_blank_prefix(&state, 6 + long_line.len()),
+            (6, false)
+        );
+    }
+
+    /// A file that is one enormous line: the line start is byte 0 no matter
+    /// how far right the cursor sits.
+    #[test]
+    fn blank_prefix_on_single_line_file() {
+        let text = "x".repeat(200_000);
+        let state = state_with(&text);
+        assert_eq!(line_start_and_blank_prefix(&state, text.len()), (0, false));
     }
 }
 

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -1318,7 +1318,10 @@ impl TextBuffer {
     /// NOTE: Currently loads entire buffers on-demand. Future optimization would split
     /// large pieces and load only LOAD_CHUNK_SIZE chunks at a time.
     pub fn get_text_range_mut(&mut self, offset: usize, bytes: usize) -> Result<Vec<u8>> {
-        let _span = tracing::info_span!("get_text_range_mut", offset, bytes).entered();
+        // `trace`, not `info`: this fires once per chunk of every line read, so
+        // on a long-line file an enabled span formats its fields thousands of
+        // times per frame — enough to show up as several percent of total CPU.
+        let _span = tracing::trace_span!("get_text_range_mut", offset, bytes).entered();
         if bytes == 0 {
             return Ok(Vec::new());
         }

--- a/crates/fresh-editor/src/primitives/line_iterator.rs
+++ b/crates/fresh-editor/src/primitives/line_iterator.rs
@@ -38,6 +38,9 @@ pub struct LineIterator<'a> {
     /// (set when starting at EOF after a trailing newline or when a newline-ending
     /// line exhausts the buffer during forward iteration)
     pending_trailing_empty_line: bool,
+    /// Cap on the bytes `next_line` will return for one line. Defaults to
+    /// [`MAX_LINE_BYTES`]; see [`LineIterator::with_max_line_bytes`].
+    max_line_bytes: usize,
 }
 
 impl<'a> LineIterator<'a> {
@@ -129,7 +132,22 @@ impl<'a> LineIterator<'a> {
             buffer_len,
             estimated_line_length,
             pending_trailing_empty_line,
+            max_line_bytes: MAX_LINE_BYTES,
         }
+    }
+
+    /// Lower the per-line read cap below the default [`MAX_LINE_BYTES`].
+    ///
+    /// A line longer than the cap is yielded as several consecutive pieces, so
+    /// a caller that will discard everything past the first few thousand bytes
+    /// of a line — the renderer, which only fills a viewport — can avoid
+    /// reading and decoding 100 KB of it. Callers that need whole logical
+    /// lines (row counts, column math) must leave the default in place.
+    ///
+    /// Clamped to `1..=MAX_LINE_BYTES`; the cap can only ever tighten.
+    pub fn with_max_line_bytes(mut self, max_line_bytes: usize) -> Self {
+        self.max_line_bytes = max_line_bytes.clamp(1, MAX_LINE_BYTES);
+        self
     }
 
     /// Get the next line (moving forward)
@@ -182,23 +200,29 @@ impl<'a> LineIterator<'a> {
 
         // If we didn't find a newline and didn't reach EOF, the line is longer than our estimate
         // Load more data iteratively (rare case for very long lines)
-        // BUT: limit to MAX_LINE_BYTES to prevent memory exhaustion from huge lines
+        // BUT: limit to `max_line_bytes` to prevent memory exhaustion from huge lines
         if !found_newline && self.current_pos + line_len < self.buffer_len {
             // Line is longer than expected, keep loading until we find newline, EOF, or hit limit
             let mut extended_chunk = chunk;
             while !found_newline
                 && self.current_pos + extended_chunk.len() < self.buffer_len
-                && extended_chunk.len() < MAX_LINE_BYTES
+                && extended_chunk.len() < self.max_line_bytes
             {
+                // Grow geometrically. Extending by a fixed `estimated_max_line_length`
+                // each round takes ~415 read-and-append round trips (each a
+                // piece-tree range query plus a realloc) to reach the 100 KB cap
+                // on a single-line file; doubling takes ~9.
                 let additional_bytes = estimated_max_line_length
+                    .max(extended_chunk.len())
                     .min(self.buffer_len - self.current_pos - extended_chunk.len())
-                    .min(MAX_LINE_BYTES - extended_chunk.len()); // Don't exceed limit
+                    .min(self.max_line_bytes - extended_chunk.len()); // Don't exceed limit
                 match self
                     .buffer
                     .get_text_range_mut(self.current_pos + extended_chunk.len(), additional_bytes)
                 {
                     Ok(mut more_data) => {
                         let start_len = extended_chunk.len();
+                        extended_chunk.reserve(more_data.len());
                         extended_chunk.append(&mut more_data);
 
                         // Scan the newly added portion
@@ -209,7 +233,7 @@ impl<'a> LineIterator<'a> {
                                 break;
                             }
                             // Also stop if we've hit the limit
-                            if line_len >= MAX_LINE_BYTES {
+                            if line_len >= self.max_line_bytes {
                                 break;
                             }
                         }
@@ -221,8 +245,8 @@ impl<'a> LineIterator<'a> {
                 }
             }
 
-            // Clamp line_len to MAX_LINE_BYTES (safety limit for huge single-line files)
-            line_len = line_len.min(MAX_LINE_BYTES).min(extended_chunk.len());
+            // Clamp line_len to the per-line read cap (safety limit for huge single-line files)
+            line_len = line_len.min(self.max_line_bytes).min(extended_chunk.len());
 
             // Use the extended chunk
             let line_bytes = &extended_chunk[..line_len];

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -531,6 +531,9 @@ pub fn compute_line_layout(
         is_binary,
         line_ending,
         &[], // no fold skip ranges — folds affect what's rendered, not per-line wrap count
+        // No character budget: callers ask this for the line's *total* visual
+        // row count, so a viewport-sized read would under-report it.
+        None,
     );
 
     let is_compose = matches!(geom.view_mode, CacheViewMode::Compose);

--- a/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
@@ -11,6 +11,16 @@ use fresh_core::api::{ViewTokenWire, ViewTokenWireKind};
 /// Build tokens from a text buffer starting at `top_byte`, stopping roughly
 /// after `visible_count` visual lines. Honors CRLF / LF line endings and
 /// renders unsafe control characters as `BinaryByte` tokens.
+///
+/// `char_budget` is a second, independent stop condition: tokenising ends once
+/// this many characters have been emitted, whatever `lines_seen` says. The
+/// line budget alone is not enough on a file whose logical lines are far wider
+/// than the screen — `lines_seen` only advances once per
+/// [`MAX_SAFE_LINE_WIDTH`] characters inside a single line, so a 50-row
+/// viewport would ask for 54 "lines" and tokenise 540,000 characters to fill
+/// rows that hold a few thousand. Callers that know the width a row wraps at
+/// pass roughly `rows × width`; pass `None` to bound by source lines only.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_base_tokens(
     buffer: &mut Buffer,
     top_byte: usize,
@@ -19,6 +29,7 @@ pub(crate) fn build_base_tokens(
     is_binary: bool,
     line_ending: LineEnding,
     fold_skip: &[std::ops::Range<usize>],
+    char_budget: Option<usize>,
 ) -> Vec<ViewTokenWire> {
     let mut tokens = Vec::new();
 
@@ -29,6 +40,10 @@ pub(crate) fn build_base_tokens(
     }
 
     let max_lines = visible_count.saturating_add(4);
+    // Never stop before a single row's worth of text exists, however small the
+    // caller's estimate turns out to be.
+    let char_budget = char_budget.map(|b| b.max(MAX_SAFE_LINE_WIDTH.min(1024)));
+    let mut chars_seen = 0usize;
     let mut lines_seen = 0usize;
     let buffer_len = buffer.len();
     // Don't clamp `cursor` to buffer_len: `LineIterator::new` clamps
@@ -71,6 +86,14 @@ pub(crate) fn build_base_tokens(
         }
 
         let mut iter = buffer.line_iterator(cursor, estimated_line_length);
+        if let Some(budget) = char_budget {
+            // Bytes, not characters — UTF-8 runs to 4 bytes per character — so
+            // the first piece the iterator yields always covers the whole
+            // budget and the loop below never asks for a second one. Without
+            // this the iterator reads and UTF-8-decodes 100 KB of a long line
+            // to hand back text we stop consuming after a few thousand chars.
+            iter = iter.with_max_line_bytes(budget.saturating_mul(4).saturating_add(1024));
+        }
         while lines_seen < max_lines {
             let Some((line_start, line_content)) = iter.next_line() else {
                 break 'segments;
@@ -87,6 +110,13 @@ pub(crate) fn build_base_tokens(
             let mut skip_next_lf = false; // Track if we should skip \n after \r in CRLF
             let mut chars_this_line = 0usize; // Track chars to enforce MAX_SAFE_LINE_WIDTH
             for ch in line_content.chars() {
+                // Stop once the viewport's rows are covered. Unlike the
+                // `lines_seen` bound this fires inside a single long line,
+                // which is the only place it can fire at all.
+                if char_budget.is_some_and(|budget| chars_seen >= budget) {
+                    break 'segments;
+                }
+                chars_seen += 1;
                 // Limit characters per line to prevent memory exhaustion from huge lines.
                 // Insert a Break token to force wrapping at safe intervals.
                 if chars_this_line >= MAX_SAFE_LINE_WIDTH {
@@ -339,4 +369,138 @@ fn is_control_char(ch: char) -> bool {
         return false;
     }
     b < 0x20 || b == 0x7F
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::filesystem::{FileSystem, StdFileSystem};
+    use std::sync::Arc;
+
+    fn test_fs() -> Arc<dyn FileSystem + Send + Sync> {
+        Arc::new(StdFileSystem)
+    }
+
+    /// Number of source characters the token stream covers.
+    fn char_count(tokens: &[ViewTokenWire]) -> usize {
+        tokens
+            .iter()
+            .map(|t| match &t.kind {
+                ViewTokenWireKind::Text(s) => s.chars().count(),
+                ViewTokenWireKind::Break => 0,
+                _ => 1,
+            })
+            .sum()
+    }
+
+    /// The line budget alone cannot bound a file that is one enormous line:
+    /// `lines_seen` advances once per `MAX_SAFE_LINE_WIDTH` characters, so a
+    /// 50-row viewport pulls in 540,000 characters. The character budget is
+    /// what actually stops the read.
+    #[test]
+    fn char_budget_bounds_a_single_enormous_line() {
+        let content = "x".repeat(500_000);
+        let mut buffer = Buffer::from_bytes(content.into_bytes(), test_fs());
+
+        let unbudgeted =
+            build_base_tokens(&mut buffer, 0, 80, 50, false, LineEnding::LF, &[], None);
+        assert!(
+            char_count(&unbudgeted) > 100_000,
+            "expected the unbudgeted read to run away, got {} chars",
+            char_count(&unbudgeted)
+        );
+
+        // 50 rows at a 200-column terminal.
+        let budgeted = build_base_tokens(
+            &mut buffer,
+            0,
+            80,
+            50,
+            false,
+            LineEnding::LF,
+            &[],
+            Some(50 * 200),
+        );
+        let budgeted_chars = char_count(&budgeted);
+        assert!(
+            budgeted_chars >= 50 * 200,
+            "budget must still cover every visible row, got {budgeted_chars} chars"
+        );
+        assert!(
+            budgeted_chars < 20_000,
+            "budget should stop near its bound, got {budgeted_chars} chars"
+        );
+    }
+
+    /// On ordinary content the character budget never binds — the line bound
+    /// is reached first — so the token stream is byte-for-byte what it was.
+    #[test]
+    fn char_budget_leaves_ordinary_lines_untouched() {
+        let content = (0..200)
+            .map(|i| format!("line {i} with some text"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut buffer = Buffer::from_bytes(content.into_bytes(), test_fs());
+
+        let unbudgeted =
+            build_base_tokens(&mut buffer, 0, 80, 30, false, LineEnding::LF, &[], None);
+        let budgeted = build_base_tokens(
+            &mut buffer,
+            0,
+            80,
+            30,
+            false,
+            LineEnding::LF,
+            &[],
+            Some(30 * 200),
+        );
+
+        assert_eq!(char_count(&unbudgeted), char_count(&budgeted));
+        assert_eq!(unbudgeted.len(), budgeted.len());
+    }
+
+    /// A budget far smaller than one row still yields something to render —
+    /// the floor keeps a degenerate viewport from producing an empty frame.
+    #[test]
+    fn char_budget_has_a_floor() {
+        let content = "y".repeat(10_000);
+        let mut buffer = Buffer::from_bytes(content.into_bytes(), test_fs());
+
+        let tokens = build_base_tokens(&mut buffer, 0, 80, 1, false, LineEnding::LF, &[], Some(0));
+        assert!(
+            char_count(&tokens) >= 1024,
+            "floor should apply to tiny budgets"
+        );
+    }
+
+    /// Tokens must be identical whether the budget is reached or absent, up to
+    /// the point where the budgeted stream stops — a budget may truncate, but
+    /// it must never change what it does emit.
+    #[test]
+    fn char_budget_truncates_without_reshaping() {
+        let content = format!("{}\nsecond line\nthird line\n", "z".repeat(50_000));
+        let mut buffer = Buffer::from_bytes(content.into_bytes(), test_fs());
+
+        let unbudgeted =
+            build_base_tokens(&mut buffer, 0, 80, 40, false, LineEnding::LF, &[], None);
+        let budgeted = build_base_tokens(
+            &mut buffer,
+            0,
+            80,
+            40,
+            false,
+            LineEnding::LF,
+            &[],
+            Some(4_000),
+        );
+
+        assert!(budgeted.len() <= unbudgeted.len());
+        // Every token but the last (which the budget may cut mid-run) matches.
+        for (i, tok) in budgeted.iter().take(budgeted.len() - 1).enumerate() {
+            assert_eq!(
+                tok.source_offset, unbudgeted[i].source_offset,
+                "token {i} moved"
+            );
+        }
+    }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -1267,6 +1267,9 @@ pub(crate) fn build_base_tokens_for_hook(
         is_binary,
         line_ending,
         &[],
+        // The hook hands this stream to a plugin, which may wrap it at a width
+        // of its own choosing; budget by source lines only.
+        None,
     )
 }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -34,6 +34,110 @@ pub(super) struct ViewData {
     pub lines: Vec<ViewLine>,
 }
 
+/// Width at which one visual row wraps.
+///
+/// Wrapping is always applied for safety, but with different thresholds. When
+/// line_wrap is on: wrap at viewport width (or `wrap_column` if set). When
+/// line_wrap is off: wrap at `MAX_SAFE_LINE_WIDTH` to prevent memory
+/// exhaustion from extremely long lines.
+///
+/// When wrapping is on, reserve the last content column so the end-of-line
+/// cursor never lands on top of the vertical scrollbar. The cursor sits one
+/// column past the last rendered character, so a row that fills
+/// `content_width` exactly would place the EOL cursor on the scrollbar track
+/// (which is drawn in the column immediately to the right of the content
+/// area). `saturating_sub` keeps this safe at very small widths where the
+/// guard inside `apply_wrapping_transform` will short-circuit anyway.
+fn effective_wrap_width(
+    viewport: &Viewport,
+    line_wrap_enabled: bool,
+    content_width: usize,
+) -> usize {
+    if !line_wrap_enabled {
+        return MAX_SAFE_LINE_WIDTH;
+    }
+    if viewport.grid_wrap {
+        // Terminal-grid wrap (fresh#2649): wrap at exactly the capture-time
+        // PTY column count. No EOL-cursor column is reserved and no clamp to
+        // the content width — the grid is one column wider than the
+        // scroll-back content area (the live view reclaims the scrollbar
+        // column), and clamping or reserving would re-wrap every full-width
+        // grid row one cell early, reflowing the whole view on entry. Full
+        // rows render with their last cell under the scrollbar, exactly like
+        // the non-wrapped exit frame always has.
+        return viewport.grid_cols();
+    }
+    let base = if let Some(col) = viewport.wrap_column {
+        col.min(content_width)
+    } else {
+        content_width
+    };
+    base.saturating_sub(1).max(1)
+}
+
+/// Character budget for [`build_base_tokens`], or `None` to bound the read by
+/// source lines alone.
+///
+/// Only meaningful under soft wrap. There, a logical line occupies
+/// `ceil(width / effective_width)` rows, so the rows the renderer can possibly
+/// draw are covered by about `rows × effective_width` characters — a few
+/// thousand, against the ~540,000 an unbudgeted read pulls in on a
+/// single-line file (`lines_seen` advances only once per `MAX_SAFE_LINE_WIDTH`
+/// characters, so the line bound never fires inside one long line).
+///
+/// With wrapping off there is no budget to give: a long line is chopped into
+/// rows of `MAX_SAFE_LINE_WIDTH` columns each, so covering the viewport's rows
+/// genuinely costs `rows × MAX_SAFE_LINE_WIDTH` characters.
+fn base_char_budget(
+    viewport: &Viewport,
+    line_wrap_enabled: bool,
+    effective_width: usize,
+    adjusted_visible_count: usize,
+    cursor_positions: &[usize],
+) -> Option<usize> {
+    if !line_wrap_enabled {
+        return None;
+    }
+
+    // Rows the caller may draw: the renderer skips `top_view_line_offset` rows
+    // of the first logical line before the visible window starts, and those
+    // skipped rows still have to be built.
+    let rows = viewport
+        .top_view_line_offset
+        .saturating_add(adjusted_visible_count)
+        .saturating_add(4);
+
+    // Characters per row and columns per row are not the same number: a
+    // double-width glyph fills two columns, a combining mark or ZWJ fills
+    // none, and a tab fills up to `tab_size`. Only the zero-width direction
+    // can make a row consume *more* characters than columns, so pad
+    // generously rather than trying to be exact — over-reading a little is
+    // free next to the 50× the budget saves.
+    let mut budget = rows
+        .saturating_mul(effective_width.max(1))
+        .saturating_mul(2)
+        .saturating_add(1024);
+
+    // The scroll math (`ensure_visible_in_layout`) locates the cursor by
+    // searching the rows this build produces, so the build must reach the
+    // cursor even when it sits past the budgeted window — otherwise a cursor
+    // moved far down a long wrapped line would never scroll into view.
+    if let Some(furthest) = cursor_positions
+        .iter()
+        .copied()
+        .filter(|&pos| pos >= viewport.top_byte)
+        .max()
+    {
+        budget = budget.max(
+            (furthest - viewport.top_byte)
+                .saturating_add(effective_width.saturating_mul(2))
+                .saturating_add(1024),
+        );
+    }
+
+    Some(budget)
+}
+
 /// Run the entire view pipeline for the current viewport:
 /// base tokens → (optional plugin transform) → soft breaks → conceal →
 /// wrapping → [`ViewLine`] conversion → virtual lines → folding.
@@ -74,6 +178,11 @@ pub(super) fn build_view_data(
     // depth for any tokens produced by plugin view transforms).
     let fold_skip = fold_skip_set(&state.buffer, &state.marker_list, folds);
 
+    // Width one visual row wraps at. Computed here — before the token build
+    // rather than just before `apply_wrapping_transform` — because it also
+    // sizes the token build's character budget (see `base_char_budget`).
+    let effective_width = effective_wrap_width(viewport, line_wrap_enabled, content_width);
+
     // Build base token stream from source, skipping any source-byte range
     // that falls inside a collapsed fold.
     let base_tokens = build_base_tokens(
@@ -84,6 +193,13 @@ pub(super) fn build_view_data(
         is_binary,
         line_ending,
         &fold_skip,
+        base_char_budget(
+            viewport,
+            line_wrap_enabled,
+            effective_width,
+            adjusted_visible_count,
+            cursor_positions,
+        ),
     );
 
     // Use plugin transform if available, otherwise use base tokens
@@ -141,43 +257,8 @@ pub(super) fn build_view_data(
         }
     }
 
-    // Apply wrapping transform - always enabled for safety, but with
-    // different thresholds. When line_wrap is on: wrap at viewport width (or
-    // wrap_column if set). When line_wrap is off: wrap at
-    // MAX_SAFE_LINE_WIDTH to prevent memory exhaustion from extremely long
-    // lines.
-    //
-    // When wrapping is on, reserve the last content column so the
-    // end-of-line cursor never lands on top of the vertical scrollbar.
-    // The cursor sits one column past the last rendered character, so
-    // a row that fills `content_width` exactly would place the EOL
-    // cursor on the scrollbar track (which is drawn in the column
-    // immediately to the right of the content area).  `saturating_sub`
-    // keeps this safe at very small widths where the guard inside
-    // `apply_wrapping_transform` will short-circuit anyway.
-    let effective_width = if line_wrap_enabled {
-        if viewport.grid_wrap {
-            // Terminal-grid wrap (fresh#2649): wrap at exactly the
-            // capture-time PTY column count. No EOL-cursor column is
-            // reserved and no clamp to the content width — the grid is one
-            // column wider than the scroll-back content area (the live view
-            // reclaims the scrollbar column), and clamping or reserving
-            // would re-wrap every full-width grid row one cell early,
-            // reflowing the whole view on entry. Full rows render with
-            // their last cell under the scrollbar, exactly like the
-            // non-wrapped exit frame always has.
-            viewport.grid_cols()
-        } else {
-            let base = if let Some(col) = viewport.wrap_column {
-                col.min(content_width)
-            } else {
-                content_width
-            };
-            base.saturating_sub(1).max(1)
-        }
-    } else {
-        MAX_SAFE_LINE_WIDTH
-    };
+    // Wrapping is applied below at `effective_width` (computed before the
+    // token build, above).
     let hanging_indent = line_wrap_enabled && viewport.wrap_indent && !viewport.grid_wrap;
 
     // Splice inline virtual text (inlay hints) into the stream BEFORE
@@ -346,7 +427,17 @@ pub(super) fn build_view_data(
                     }
                 }
             }
-            if !has_injected {
+            // `j == source_lines.len()` means nothing after this group proves
+            // where it ends: the window may have stopped mid-line, either at
+            // the row budget (`base_char_budget`) or at the `visible_count`
+            // line bound. Caching a partial run would tell every later reader
+            // the logical line is shorter than it is, so publish only groups a
+            // following row closes off. On a file that is one enormous line
+            // this skips the writeback entirely — which is what we want there
+            // anyway: the entry would be a deep copy of every row of that line,
+            // stored once and evicted before any reader could use it.
+            let group_is_complete = j < source_lines.len();
+            if !has_injected && group_is_complete {
                 // Slice `source_lines[i..j]` corresponds to one logical
                 // line with no plugin-injected reshaping.  Store it.
                 //

--- a/scripts/gen-single-line-bench.py
+++ b/scripts/gen-single-line-bench.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Generate a single-line text file for editor performance testing.
+
+The default output is 500 KB of space-separated words on one line with no
+newline at all, which exercises the long-line paths in the renderer (base
+token budgeting, wrapping, grapheme segmentation) and in the input path
+(backward scan to line start on every keystroke).
+
+Usage:
+    scripts/gen-single-line-bench.py [--bytes 500000] [--out PATH]
+"""
+
+import argparse
+import random
+
+WORDS = [
+    "fresh", "buffer", "token", "render", "viewport", "cursor", "piece", "tree",
+    "wrap", "grapheme", "layout", "segment", "offset", "column", "insert",
+    "delete", "scroll", "frame", "cache", "line", "width", "measure", "iterate",
+    "span", "trace", "alloc", "vector", "slice", "range", "index",
+]
+
+
+def build_line(size: int, seed: int) -> str:
+    rng = random.Random(seed)
+    parts = []
+    length = 0
+    while length < size:
+        word = rng.choice(WORDS)
+        parts.append(word)
+        length += len(word) + 1
+    line = " ".join(parts)[:size]
+    # The slice can land mid-word and come up short; pad to an exact size.
+    return line + "x" * (size - len(line))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bytes", type=int, default=500_000, help="file size in bytes")
+    parser.add_argument("--seed", type=int, default=1337, help="RNG seed")
+    parser.add_argument(
+        "--out", default="bench-single-line-500k.txt", help="output path"
+    )
+    args = parser.parse_args()
+
+    line = build_line(args.bytes, args.seed)
+    with open(args.out, "w", encoding="utf-8") as handle:
+        handle.write(line)
+    print(f"{args.out}: {len(line)} bytes, 1 line, no trailing newline")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## TL;DR

Six changes, all aimed at files that are one very long line:

1. **`build_base_tokens` takes a character budget** (`Option<usize>`) that stops tokenizing once the viewport's rows are covered, independent of the existing source-line bound. `build_view_data` sizes it from `(top_view_line_offset + visible_count + 4) × effective_width`; every other caller passes `None`.
2. **`effective_width` moved above the token build** in `build_view_data` (extracted to `effective_wrap_width`) so it can size that budget. Same value, same inputs — just computed earlier.
3. **New `LineIterator::with_max_line_bytes`** lowers the per-line read cap below `MAX_LINE_BYTES`; the budgeted token build sets it so a long line isn't read and decoded 100 KB at a time.
4. **The line-wrap cache writeback publishes only complete row runs** — a group is written only when a following row proves where it ends.
5. **`collect_insert_cursor_data` scans back to the line start in 4 KB blocks** instead of one byte at a time, and decides `only_spaces` during that scan instead of materializing the prefix.
6. **Two small ones**: `get_text_range_mut`'s span drops `info` → `trace`, and the line iterator's long-line extension grows geometrically instead of by a fixed 240 bytes.

No behavior change intended for files with ordinary line lengths — on those the character budget never binds. Details and the profile that motivated each below.

---

Editing a file that is one enormous line (minified JS, a one-line JSON blob, a long log record) was slow, and got slower the further right the cursor sat. Two paths dominated a profile of typing into a 500 KB single-line file.

## Renderer: ~540 KB tokenized per frame

`build_base_tokens` budgets its read by *source lines* — `visible_count + 4` of them — but inside a single line `lines_seen` only advances once per `MAX_SAFE_LINE_WIDTH` (10,000) characters. A 50-row viewport therefore asked for 54 "lines" and tokenized 540,000 characters every frame to fill rows that hold a few thousand. Everything downstream was unbounded and paid for all of it: `apply_wrapping_transform` wrapped the lot, `ViewLineIterator` grapheme-segmented and width-measured every character, and thousands of `ViewLine`s were built and dropped so ~50 could be drawn.

The budget is doubled and padded before use, since a zero-width glyph makes a row consume more characters than columns. At width 200 it works out to ~11 K characters instead of 540 K.

Two details:

- The budget also lowers the line iterator's per-line read cap, so a long line is no longer read and UTF-8-decoded 100 KB at a time to hand back text the tokenizer stops consuming after a few thousand characters.
- It never stops short of the furthest cursor in the split. `ensure_visible_in_layout` finds the cursor by searching the rows this build produces, so a budget that stopped before it would leave the cursor un-scrolled-to.

Callers that need *whole* logical lines pass no budget and are unaffected: the line-wrap cache's miss handler (`compute_line_layout`, which reports a line's total row count) and the plugin view-transform hook (the plugin may wrap at a width of its own).

Because a budgeted window can stop mid-line, the line-wrap cache writeback now publishes only runs that a following row proves complete — a partial run would tell every later reader the logical line is shorter than it is. That also drops the writeback entirely on a single-line file, where the entry was a deep copy of every row of that line, stored once and evicted before any reader could use it.

With wrapping **off** there is no budget to give, and none is passed: a long line is chopped into rows of `MAX_SAFE_LINE_WIDTH` columns each, so covering the viewport's rows genuinely costs `rows × 10,000` characters.

## Input: a byte-at-a-time scan on every keystroke

`collect_insert_cursor_data` walked back to the line start one byte at a time, each byte a `slice_bytes` → piece-tree range query → `Vec::with_capacity(1)`. Typing at column N cost N range queries and N allocations. It then materialized the entire prefix — potentially megabytes — to test whether it was all spaces or tabs. Both existed only to compute an auto-dedent flag.

Replaced with a single chunked backward scan (4 KB blocks, `rposition` for `\n`) that settles the whitespace question during the same pass.

## Smaller items

- `get_text_range_mut`'s `info_span!` → `trace_span!`. It fires once per chunk of every line read, so on a long-line file an enabled span formats its fields thousands of times per frame.
- The line iterator's long-line extension grew by a fixed 240 bytes per round trip — ~415 read-and-append cycles (each a range query plus a realloc) to reach the 100 KB cap. Now geometric: ~9.

## Testing

`cargo test -p fresh-editor --lib` — 3151 passed, 0 failed. `cargo clippy --workspace --all-targets` clean. New unit tests cover the budget (bounds an enormous line, leaves ordinary lines byte-for-byte identical, honors a floor, truncates without reshaping what it does emit) and the backward scan (line start after a newline, across scan-block boundaries, on a single-line file). Not profiled here — @sinelaw is measuring locally; `scripts/gen-single-line-bench.py` writes the 500 KB single-line fixture.

Remaining from the same profile, not addressed here: `compute_buffer_layout` still calls `build_view_data` up to three times per frame, the status bar re-derives the cursor column from scratch each frame, and scroll math re-runs the wrap pipeline over the cursor's whole logical line.