### PR TITLE
Settings: make the status-bar element picker's cursor and keys visible

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2083,6 +2083,27 @@ pub enum WidgetSpec {
         /// the host owns focus.
         #[serde(default)]
         focused: bool,
+        /// Which column the cursor sits in: `true` = Included,
+        /// `false` = Available. Seed only, like `included` — host
+        /// instance state takes over after first render. Hosts that
+        /// drive the control themselves (Settings) keep re-supplying
+        /// it so the rendered cursor tracks their own state.
+        #[serde(default)]
+        active_included: bool,
+        /// Cursor row within the Available column. Seed only (see
+        /// `active_included`).
+        #[serde(default)]
+        available_cursor: u32,
+        /// Cursor row within the Included column. Seed only (see
+        /// `active_included`).
+        #[serde(default)]
+        included_cursor: u32,
+        /// Optional one-line key hint rendered under the columns
+        /// (e.g. `↑↓:Move  Shift+←→:Add/Remove`). Empty = omitted.
+        /// The control's keys are not guessable from its shape, so
+        /// hosts are expected to supply their own localized copy.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        hint: String,
         /// Number of body rows the columns occupy. Plugin computes
         /// from its viewport.
         #[serde(default = "default_dual_visible_rows")]

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Šířka psaní nastavena na %{value}",
   "settings.dual_list_enter_hint": "Enter pro úpravu",
   "settings.dual_list_shift_hint": "Shift+←→ přesun  Shift+↑↓ pořadí",
+  "settings.dual_list_keys_hint": "↑↓ Vybrat  ←→ Přepnout sloupec  Shift+←→ Přesunout položku  Shift+↑↓ Pořadí  Esc Hotovo",
+  "settings.help_duallist": "↑↓:Vybrat  ←→:Sloupec  Shift+←→:Přesunout  Shift+↑↓:Pořadí  Esc:Hotovo",
   "settings.editing_config": "Úprava konfigurace %{layer}: %{path}",
   "settings.failed_to_apply": "Použití nastavení selhalo: %{error}",
   "settings.failed_to_open": "Otevření nastavení selhalo: %{error}",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Schreibbreite auf %{value} gesetzt",
   "settings.dual_list_enter_hint": "Enter zum Bearbeiten",
   "settings.dual_list_shift_hint": "Shift+←→ verschieben  Shift+↑↓ umsortieren",
+  "settings.dual_list_keys_hint": "↑↓ Auswählen  ←→ Spalte wechseln  Shift+←→ Eintrag verschieben  Shift+↑↓ Umsortieren  Esc Fertig",
+  "settings.help_duallist": "↑↓:Auswählen  ←→:Spalte  Shift+←→:Verschieben  Shift+↑↓:Umsortieren  Esc:Fertig",
   "settings.editing_config": "%{layer}-Konfiguration bearbeiten: %{path}",
   "settings.failed_to_apply": "Einstellungen konnten nicht angewendet werden: %{error}",
   "settings.failed_to_open": "Einstellungen konnten nicht geöffnet werden: %{error}",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1426,6 +1426,8 @@
   "settings.help_default": "↑↓:Navigate  Tab:Next  Enter:Edit  /:Search  Esc:Close",
   "settings.dual_list_enter_hint": "Enter to edit",
   "settings.dual_list_shift_hint": "Shift+←→ move  Shift+↑↓ reorder",
+  "settings.dual_list_keys_hint": "↑↓ Select  ←→ Switch column  Shift+←→ Move item  Shift+↑↓ Reorder  Esc Done",
+  "settings.help_duallist": "↑↓:Select  ←→:Column  Shift+←→:Move  Shift+↑↓:Reorder  Esc:Done",
   "settings.field.editor.whitespace_show": "Show Whitespace",
   "settings.field.editor.whitespace_spaces_leading": "Leading Spaces",
   "settings.field.editor.whitespace_spaces_inner": "Inner Spaces",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Ancho de composición establecido a %{value}",
   "settings.dual_list_enter_hint": "Enter para editar",
   "settings.dual_list_shift_hint": "Shift+←→ mover  Shift+↑↓ reordenar",
+  "settings.dual_list_keys_hint": "↑↓ Seleccionar  ←→ Cambiar columna  Shift+←→ Mover elemento  Shift+↑↓ Reordenar  Esc Listo",
+  "settings.help_duallist": "↑↓:Seleccionar  ←→:Columna  Shift+←→:Mover  Shift+↑↓:Reordenar  Esc:Listo",
   "settings.editing_config": "Editando configuración de %{layer}: %{path}",
   "settings.failed_to_apply": "Error al aplicar configuración: %{error}",
   "settings.failed_to_open": "Error al abrir configuración: %{error}",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Largeur de composition définie à %{value}",
   "settings.dual_list_enter_hint": "Entrée pour modifier",
   "settings.dual_list_shift_hint": "Shift+←→ déplacer  Shift+↑↓ réordonner",
+  "settings.dual_list_keys_hint": "↑↓ Sélectionner  ←→ Changer de colonne  Shift+←→ Déplacer l'élément  Shift+↑↓ Réordonner  Échap Terminé",
+  "settings.help_duallist": "↑↓:Sélectionner  ←→:Colonne  Shift+←→:Déplacer  Shift+↑↓:Réordonner  Échap:Terminé",
   "settings.editing_config": "Édition de la configuration %{layer} : %{path}",
   "settings.failed_to_apply": "Échec de l'application des paramètres : %{error}",
   "settings.failed_to_open": "Échec de l'ouverture des paramètres : %{error}",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Larghezza composizione impostata a %{value}",
   "settings.dual_list_enter_hint": "Invio per modificare",
   "settings.dual_list_shift_hint": "Shift+←→ sposta  Shift+↑↓ riordina",
+  "settings.dual_list_keys_hint": "↑↓ Seleziona  ←→ Cambia colonna  Shift+←→ Sposta elemento  Shift+↑↓ Riordina  Esc Fatto",
+  "settings.help_duallist": "↑↓:Seleziona  ←→:Colonna  Shift+←→:Sposta  Shift+↑↓:Riordina  Esc:Fatto",
   "settings.editing_config": "Modifica configurazione %{layer}: %{path}",
   "settings.failed_to_apply": "Impossibile applicare le impostazioni: %{error}",
   "settings.failed_to_open": "Impossibile aprire le impostazioni: %{error}",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "作成幅を %{value} に設定",
   "settings.dual_list_enter_hint": "Enterで編集",
   "settings.dual_list_shift_hint": "Shift+←→ 移動  Shift+↑↓ 並べ替え",
+  "settings.dual_list_keys_hint": "↑↓ 選択  ←→ 列を切り替え  Shift+←→ 項目を移動  Shift+↑↓ 並べ替え  Esc 完了",
+  "settings.help_duallist": "↑↓:選択  ←→:列  Shift+←→:移動  Shift+↑↓:並べ替え  Esc:完了",
   "settings.editing_config": "%{layer} 設定を編集中: %{path}",
   "settings.failed_to_apply": "設定の適用に失敗: %{error}",
   "settings.failed_to_open": "設定を開くのに失敗: %{error}",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "작성 너비가 %{value}(으)로 설정됨",
   "settings.dual_list_enter_hint": "Enter로 편집",
   "settings.dual_list_shift_hint": "Shift+←→ 이동  Shift+↑↓ 순서변경",
+  "settings.dual_list_keys_hint": "↑↓ 선택  ←→ 열 전환  Shift+←→ 항목 이동  Shift+↑↓ 순서변경  Esc 완료",
+  "settings.help_duallist": "↑↓:선택  ←→:열  Shift+←→:이동  Shift+↑↓:순서변경  Esc:완료",
   "settings.editing_config": "%{layer} 설정 편집 중: %{path}",
   "settings.failed_to_apply": "설정 적용 실패: %{error}",
   "settings.failed_to_open": "설정 열기 실패: %{error}",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Largura de composição definida para %{value}",
   "settings.dual_list_enter_hint": "Enter para editar",
   "settings.dual_list_shift_hint": "Shift+←→ mover  Shift+↑↓ reordenar",
+  "settings.dual_list_keys_hint": "↑↓ Selecionar  ←→ Trocar coluna  Shift+←→ Mover item  Shift+↑↓ Reordenar  Esc Concluir",
+  "settings.help_duallist": "↑↓:Selecionar  ←→:Coluna  Shift+←→:Mover  Shift+↑↓:Reordenar  Esc:Concluir",
   "settings.editing_config": "Editando configuração %{layer}: %{path}",
   "settings.failed_to_apply": "Falha ao aplicar configurações: %{error}",
   "settings.failed_to_open": "Falha ao abrir configurações: %{error}",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Ширина композиции установлена на %{value}",
   "settings.dual_list_enter_hint": "Enter для редактирования",
   "settings.dual_list_shift_hint": "Shift+←→ переместить  Shift+↑↓ порядок",
+  "settings.dual_list_keys_hint": "↑↓ Выбор  ←→ Сменить столбец  Shift+←→ Переместить элемент  Shift+↑↓ Порядок  Esc Готово",
+  "settings.help_duallist": "↑↓:Выбор  ←→:Столбец  Shift+←→:Переместить  Shift+↑↓:Порядок  Esc:Готово",
   "settings.editing_config": "Редактирование конфигурации %{layer}: %{path}",
   "settings.failed_to_apply": "Не удалось применить настройки: %{error}",
   "settings.failed_to_open": "Не удалось открыть настройки: %{error}",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "ตั้งค่าความกว้างในการเขียนเป็น %{value}",
   "settings.dual_list_enter_hint": "Enter เพื่อแก้ไข",
   "settings.dual_list_shift_hint": "Shift+←→ ย้าย  Shift+↑↓ เรียงลำดับ",
+  "settings.dual_list_keys_hint": "↑↓ เลือก  ←→ สลับคอลัมน์  Shift+←→ ย้ายรายการ  Shift+↑↓ เรียงลำดับ  Esc เสร็จ",
+  "settings.help_duallist": "↑↓:เลือก  ←→:คอลัมน์  Shift+←→:ย้าย  Shift+↑↓:เรียงลำดับ  Esc:เสร็จ",
   "settings.editing_config": "กำลังแก้ไขคอนфิก %{layer}: %{path}",
   "settings.failed_to_apply": "ใช้การตั้งค่าไม่สำเร็จ: %{error}",
   "settings.failed_to_open": "เปิดการตั้งค่าไม่สำเร็จ: %{error}",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Ширину композиції встановлено на %{value}",
   "settings.dual_list_enter_hint": "Enter для редагування",
   "settings.dual_list_shift_hint": "Shift+←→ перемістити  Shift+↑↓ порядок",
+  "settings.dual_list_keys_hint": "↑↓ Вибір  ←→ Змінити стовпець  Shift+←→ Перемістити елемент  Shift+↑↓ Порядок  Esc Готово",
+  "settings.help_duallist": "↑↓:Вибір  ←→:Стовпець  Shift+←→:Перемістити  Shift+↑↓:Порядок  Esc:Готово",
   "settings.editing_config": "Редагування конфігурації %{layer}: %{path}",
   "settings.failed_to_apply": "Не вдалося застосувати налаштування: %{error}",
   "settings.failed_to_open": "Не вдалося відкрити налаштування: %{error}",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "Đã đặt độ rộng soạn thảo thành %{value}",
   "settings.dual_list_enter_hint": "Enter để chỉnh sửa",
   "settings.dual_list_shift_hint": "Shift+←→ di chuyển  Shift+↑↓ sắp xếp",
+  "settings.dual_list_keys_hint": "↑↓ Chọn  ←→ Đổi cột  Shift+←→ Di chuyển mục  Shift+↑↓ Sắp xếp  Esc Xong",
+  "settings.help_duallist": "↑↓:Chọn  ←→:Cột  Shift+←→:Di chuyển  Shift+↑↓:Sắp xếp  Esc:Xong",
   "settings.editing_config": "Đang chỉnh sửa cấu hình %{layer}: %{path}",
   "settings.failed_to_apply": "Áp dụng cài đặt thất bại: %{error}",
   "settings.failed_to_open": "Mở cài đặt thất bại: %{error}",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1361,6 +1361,8 @@
   "settings.compose_width_set": "编辑宽度设置为 %{value}",
   "settings.dual_list_enter_hint": "Enter编辑",
   "settings.dual_list_shift_hint": "Shift+←→ 移动  Shift+↑↓ 排序",
+  "settings.dual_list_keys_hint": "↑↓ 选择  ←→ 切换列  Shift+←→ 移动条目  Shift+↑↓ 排序  Esc 完成",
+  "settings.help_duallist": "↑↓:选择  ←→:列  Shift+←→:移动  Shift+↑↓:排序  Esc:完成",
   "settings.editing_config": "正在编辑 %{layer} 配置：%{path}",
   "settings.failed_to_apply": "应用设置失败：%{error}",
   "settings.failed_to_open": "打开设置失败：%{error}",

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1505,6 +1505,31 @@ type WidgetSpec = {
 	*/
 	focused: boolean;
 	/**
+	* Which column the cursor sits in: `true` = Included,
+	* `false` = Available. Seed only, like `included` — host
+	* instance state takes over after first render. Hosts that
+	* drive the control themselves (Settings) keep re-supplying
+	* it so the rendered cursor tracks their own state.
+	*/
+	activeIncluded: boolean;
+	/**
+	* Cursor row within the Available column. Seed only (see
+	* `active_included`).
+	*/
+	availableCursor: number;
+	/**
+	* Cursor row within the Included column. Seed only (see
+	* `active_included`).
+	*/
+	includedCursor: number;
+	/**
+	* Optional one-line key hint rendered under the columns
+	* (e.g. `↑↓:Move  Shift+←→:Add/Remove`). Empty = omitted.
+	* The control's keys are not guessable from its shape, so
+	* hosts are expected to supply their own localized copy.
+	*/
+	hint?: string;
+	/**
 	* Number of body rows the columns occupy. Plugin computes
 	* from its viewport.
 	*/

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -243,7 +243,14 @@ export function dropdown(
  * `WidgetPanel.setDualIncluded(key, values)`.
  *
  * `excluded` names option values owned by a sibling list, kept out of
- * this list's Available column (cross-exclusion). */
+ * this list's Available column (cross-exclusion).
+ *
+ * The focused column's cursor row is marked `▸`, the other column's
+ * parked cursor `▹`, and the active column's header `▾`, so the state
+ * reads without relying on color. `activeIncluded` / `availableCursor`
+ * / `includedCursor` seed that cursor (host instance state takes over
+ * after the first render); `hint` adds a one-line key legend under the
+ * columns. */
 export function dualList(
   options: { value: string; label: string }[],
   opts?: {
@@ -251,6 +258,10 @@ export function dualList(
     excluded?: string[];
     label?: string;
     focused?: boolean;
+    activeIncluded?: boolean;
+    availableCursor?: number;
+    includedCursor?: number;
+    hint?: string;
     visibleRows?: number;
     key?: string;
   },
@@ -262,6 +273,10 @@ export function dualList(
     excluded: opts?.excluded ?? [],
     label: opts?.label ?? "",
     focused: opts?.focused ?? false,
+    activeIncluded: opts?.activeIncluded ?? false,
+    availableCursor: opts?.availableCursor ?? 0,
+    includedCursor: opts?.includedCursor ?? 0,
+    hint: opts?.hint ?? "",
     visibleRows: opts?.visibleRows ?? 6,
     key: opts?.key,
   };

--- a/crates/fresh-editor/src/view/controls/mod.rs
+++ b/crates/fresh-editor/src/view/controls/mod.rs
@@ -30,7 +30,9 @@ pub mod toggle;
 
 pub use button::{ButtonEvent, ButtonState};
 pub use dropdown::{DropdownEvent, DropdownState};
-pub use dual_list::{DualListColumn, DualListHit, DualListLayout, DualListState};
+pub use dual_list::{
+    DualListColumn, DualListHit, DualListLayout, DualListRowArea, DualListState,
+};
 pub use keybinding_list::{KeybindingListEvent, KeybindingListState};
 pub use map_input::{MapEvent, MapState};
 pub use number_input::{NumberInputEvent, NumberInputState};

--- a/crates/fresh-editor/src/view/controls/mod.rs
+++ b/crates/fresh-editor/src/view/controls/mod.rs
@@ -30,9 +30,7 @@ pub mod toggle;
 
 pub use button::{ButtonEvent, ButtonState};
 pub use dropdown::{DropdownEvent, DropdownState};
-pub use dual_list::{
-    DualListColumn, DualListHit, DualListLayout, DualListRowArea, DualListState,
-};
+pub use dual_list::{DualListColumn, DualListHit, DualListLayout, DualListRowArea, DualListState};
 pub use keybinding_list::{KeybindingListEvent, KeybindingListState};
 pub use map_input::{MapEvent, MapState};
 pub use number_input::{NumberInputEvent, NumberInputState};

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -369,8 +369,15 @@ impl SettingControl {
                 // 1 for label + items count + 1 for add-new row
                 (state.items.len() + 2) as u16
             }
-            // DualList needs: 1 label + 1 header + body rows
-            Self::DualList(state) => 2 + state.body_rows() as u16,
+            // DualList needs: 1 label + 1 header + body rows, plus the
+            // key-hint row the control grows once it is reachable
+            // (selected or being edited).
+            Self::DualList(state) => {
+                let hint_row = u16::from(
+                    state.editing || state.focus == crate::view::controls::FocusState::Focused,
+                );
+                2 + state.body_rows() as u16 + hint_row
+            }
             // Map needs: 1 label + 1 header (if display_field) + entries + expanded content + 1 add-new row (if allowed)
             Self::Map(state) => {
                 let header_row = if state.display_field.is_some() { 1 } else { 0 };

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -1411,6 +1411,66 @@ fn hit_rect(
     Rect::default()
 }
 
+/// Build the click geometry for a `DualList` from the cells the widget
+/// renderer just painted.
+///
+/// The widget emits one `dual_focus` hit per occupied cell, carrying
+/// the column name and the row index the settings state indexes by.
+/// Converting each hit's byte range against its own row text (the same
+/// conversion [`hit_rect`] does) keeps the rects correct no matter how
+/// the columns were laid out or how far the panel is scrolled.
+fn dual_list_layout(
+    out: &crate::widgets::RenderOutput,
+    area: Rect,
+    skip_rows: u16,
+) -> crate::view::controls::DualListLayout {
+    use crate::primitives::display_width::str_width;
+    use crate::view::controls::{DualListLayout, DualListRowArea};
+
+    let mut layout = DualListLayout {
+        full_area: area,
+        ..Default::default()
+    };
+    for h in &out.hits {
+        if h.widget_kind != "dual_list" || h.event_type != "dual_focus" {
+            continue;
+        }
+        let (Some(column), Some(index)) = (
+            h.payload.get("column").and_then(|v| v.as_str()),
+            h.payload.get("index").and_then(|v| v.as_u64()),
+        ) else {
+            continue;
+        };
+        let Some(dst) = (h.buffer_row as u16).checked_sub(skip_rows) else {
+            continue;
+        };
+        if dst >= area.height {
+            continue;
+        }
+        let Some(entry) = out.entries.get(h.buffer_row as usize) else {
+            continue;
+        };
+        let text = entry.text.trim_end_matches('\n');
+        let s = h.byte_start.min(text.len());
+        let e = h.byte_end.min(text.len());
+        let x = str_width(&text[..s]) as u16;
+        if x >= area.width {
+            continue;
+        }
+        let w = (str_width(&text[s..e]).max(1) as u16).min(area.width - x);
+        let row = DualListRowArea {
+            area: Rect::new(area.x + x, area.y + dst, w, 1),
+            index: index as usize,
+        };
+        match column {
+            "available" => layout.available_rows.push(row),
+            "included" => layout.included_rows.push(row),
+            _ => {}
+        }
+    }
+    layout
+}
+
 /// Render the appropriate control for a setting
 ///
 /// # Arguments
@@ -1652,23 +1712,31 @@ fn render_control(
             ControlLayoutInfo::TextList { rows }
         }
 
-        SettingControl::DualList(_) => {
+        SettingControl::DualList(state) => {
+            // A keyed widget takes its focus from `focus_key`, not from
+            // the spec's `focused` flag, so the picker only paints its
+            // cursor once we name it as the focused widget. Gate that on
+            // *editing*, not mere selection: outside edit mode ↑↓ walks
+            // the settings list, and a cursor drawn inside the columns
+            // would promise a movement the arrows don't make.
+            let focus_key = if state.editing { name } else { "" };
             // View migrated to the widget `DualList` kind (two-column
             // Available/Included picker); editing still runs through the
-            // settings input path. Mouse hit geometry is approximate for
-            // now (keyboard nav is the primary path).
-            render_control_via_widget(
+            // settings input path. The click geometry is read back from
+            // the cells the widget actually painted, so a click lands on
+            // the row under the pointer instead of nowhere.
+            let out = render_control_via_widget(
                 frame,
                 area,
                 control,
                 name,
                 theme,
                 skip_rows,
-                "",
+                focus_key,
                 label_width,
                 prev,
             );
-            ControlLayoutInfo::DualList(Default::default())
+            ControlLayoutInfo::DualList(dual_list_layout(&out, area, skip_rows))
         }
 
         SettingControl::Map(state) => {
@@ -2113,6 +2181,12 @@ fn render_footer(
         t!("settings.help_search").to_string()
     } else if footer_focused {
         t!("settings.help_footer").to_string()
+    } else if state.is_editing_dual_list() {
+        // The generic "Enter:Edit" line is actively wrong once the
+        // two-column picker has the keyboard — Enter no longer starts
+        // an edit, and none of the keys that do move items appear in
+        // it.
+        t!("settings.help_duallist").to_string()
     } else {
         t!("settings.help_default").to_string()
     };

--- a/crates/fresh-editor/src/view/settings/widget_map.rs
+++ b/crates/fresh-editor/src/view/settings/widget_map.rs
@@ -38,7 +38,7 @@
 
 use super::items::{SettingControl, SettingItem};
 use crate::view::controls::keybinding_list::format_key_combo;
-use crate::view::controls::FocusState;
+use crate::view::controls::{DualListColumn, DualListState, FocusState};
 use fresh_core::api::{DualListOption, OverlayColorSpec, OverlayOptions, WidgetSpec};
 use fresh_core::text_property::{InlineOverlay, OffsetUnit, StyledSegment, TextPropertyEntry};
 
@@ -187,6 +187,13 @@ pub fn setting_control_to_widget_aligned(
                 key,
             }
         }
+        // Settings owns this control's state (cursor, active column,
+        // edit mode) in its own `DualListState`, so every frame
+        // re-seeds the widget from it rather than letting the widget
+        // framework's instance state drift out of sync. Without this
+        // the picker rendered a cursor that never moved: arrows walked
+        // an invisible selection and Enter moved whichever item it
+        // happened to be on.
         SettingControl::DualList(s) => WidgetSpec::DualList {
             options: s
                 .all_options
@@ -199,8 +206,18 @@ pub fn setting_control_to_widget_aligned(
             included: s.included.clone(),
             excluded: s.excluded.clone(),
             label: s.label.clone(),
-            focused: false,
-            visible_rows: 6,
+            // Only edit mode gets the in-column cursor; while the row is
+            // merely selected the arrows still navigate the settings
+            // list (see the `focus_key` gate in `render.rs`).
+            focused: s.editing,
+            active_included: s.active_column == DualListColumn::Included,
+            available_cursor: s.available_cursor as u32,
+            included_cursor: s.included_cursor as u32,
+            hint: dual_list_hint(s),
+            // Match the row count the Settings layout reserves for
+            // this control (`SettingControl::height`), so the columns
+            // are never clipped or padded past their box.
+            visible_rows: s.body_rows() as u32,
             key,
         },
         // String-list editor: label, one bracketed cell + `[x]` delete
@@ -390,6 +407,23 @@ const TEXTLIST_CELL_WIDTH: usize = 28;
 
 /// Dim hint / disabled-text color.
 const DIM_HINT: &str = "ui.menu_disabled_fg";
+
+/// One-line key hint carried under a `DualList`'s columns.
+///
+/// Which keys move an item between the columns, and which reorder the
+/// Included side, cannot be inferred from the control's appearance, so
+/// the hint is always rendered once the row is reachable: "press Enter
+/// to start" while merely selected, the full key list while editing.
+fn dual_list_hint(s: &DualListState) -> String {
+    use rust_i18n::t;
+    if s.editing {
+        t!("settings.dual_list_keys_hint").to_string()
+    } else if s.focus == FocusState::Focused {
+        t!("settings.dual_list_enter_hint").to_string()
+    } else {
+        String::new()
+    }
+}
 
 /// The TextList's trailing add row, in its three historical states:
 /// a live input box (with placeholder, block caret and `Enter:add

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -661,13 +661,23 @@ fn render_collected(
             excluded,
             label,
             focused,
+            active_included,
+            available_cursor,
+            included_cursor,
+            hint,
             visible_rows,
             key,
         } => collect_dual_list(
             options,
-            included,
-            excluded,
+            DualListSeed {
+                included,
+                excluded,
+                active_included: *active_included,
+                available_cursor: *available_cursor as usize,
+                included_cursor: *included_cursor as usize,
+            },
             label,
+            hint,
             *focused,
             *visible_rows,
             key.as_deref(),
@@ -4329,21 +4339,50 @@ fn cell(s: &str, width: usize) -> String {
 fn dual_col_width(panel_width: u32) -> usize {
     // `u32::MAX` means flex is disabled (tests / unbounded) — fall
     // back to a readable fixed width. Otherwise split the panel in
-    // two with a two-column gap, clamped to a sane range.
+    // two, reserving each column's cursor gutter plus the gap
+    // between them, and clamp to a sane range.
     let width = if panel_width == u32::MAX {
         40
     } else {
         panel_width
     };
-    ((width.saturating_sub(4)) / 2).clamp(8, 40) as usize
+    let chrome = (2 * DUAL_GUTTER_W + 2) as u32;
+    ((width.saturating_sub(chrome)) / 2).clamp(8, 40) as usize
+}
+
+/// Display width of the per-column cursor gutter: one marker glyph
+/// plus a separating space.
+const DUAL_GUTTER_W: usize = 2;
+/// Cursor marker for the column the keyboard is currently driving.
+/// Filled triangle, matching [`FOCUS_MARKER`].
+const DUAL_CURSOR_ACTIVE: &str = "▸ ";
+/// Cursor marker for the *other* column — where the cursor will land
+/// if the user switches columns. Hollow so the two are distinguishable
+/// in a monochrome capture, not only by color.
+const DUAL_CURSOR_IDLE: &str = "▹ ";
+/// Marker under the active column's header, pointing down into it.
+const DUAL_COLUMN_ACTIVE: &str = "▾ ";
+/// Blank gutter — the same width as the markers, so rows and headers
+/// never reflow as the cursor or the active column moves.
+const DUAL_GUTTER_BLANK: &str = "  ";
+
+/// Spec-supplied starting state for a `DualList`, used when the host
+/// has no instance state for the widget yet — or, for hosts that own
+/// the control's state themselves (Settings), on every frame.
+struct DualListSeed<'a> {
+    included: &'a [String],
+    excluded: &'a [String],
+    active_included: bool,
+    available_cursor: usize,
+    included_cursor: usize,
 }
 
 #[allow(clippy::too_many_arguments)]
 fn collect_dual_list(
     options: &[DualListOption],
-    spec_included: &[String],
-    excluded: &[String],
+    seed: DualListSeed<'_>,
     label: &str,
+    hint: &str,
     focused: bool,
     visible_rows: u32,
     key: Option<&str>,
@@ -4353,9 +4392,18 @@ fn collect_dual_list(
     panel_width: u32,
 ) -> CollectedOutput {
     let mut out = CollectedOutput::default();
+    let excluded = seed.excluded;
     let is_focused = match key {
         Some(k) if !k.is_empty() => k == focus_key,
         _ => focused,
+    };
+    let seed_state = || {
+        (
+            seed.included.to_vec(),
+            seed.active_included,
+            seed.available_cursor,
+            seed.included_cursor,
+        )
     };
     // Instance state is authoritative after first render.
     let (included, active_included, mut avail_cur, mut incl_cur) = match key {
@@ -4371,9 +4419,9 @@ fn collect_dual_list(
                 *available_cursor as usize,
                 *included_cursor as usize,
             ),
-            _ => (spec_included.to_vec(), false, 0, 0),
+            _ => seed_state(),
         },
-        _ => (spec_included.to_vec(), false, 0, 0),
+        _ => seed_state(),
     };
     let included = dual_sanitize_included(options, &included);
     let available = dual_available_values(options, &included, excluded);
@@ -4411,19 +4459,51 @@ fn collect_dual_list(
         ensure_trailing_newline(&mut e);
         out.entries.push(e);
     }
-    // Header row.
-    let header = format!("{}  {}", cell("Available", col_w), cell("Included", col_w));
-    let mut header_entry = TextPropertyEntry::text(&header);
-    header_entry.inline_overlays.push(InlineOverlay {
-        start: 0,
-        end: header.len(),
-        style: OverlayOptions {
-            fg: Some(OverlayColorSpec::theme_key(KEY_SECTION_LABEL_FG)),
-            ..Default::default()
+    // Header row. Each title carries the same two-column gutter its
+    // cells do, and the column the keyboard is driving is marked with
+    // `▾ ` plus the accent fg — so "which side am I on?" survives both
+    // a monochrome terminal and a color-only reading.
+    let avail_active = is_focused && !active_included;
+    let incl_active = is_focused && active_included;
+    let avail_head = format!(
+        "{}{}",
+        if avail_active {
+            DUAL_COLUMN_ACTIVE
+        } else {
+            DUAL_GUTTER_BLANK
         },
-        properties: Default::default(),
-        unit: OffsetUnit::Byte,
-    });
+        cell("Available", col_w)
+    );
+    let incl_head = format!(
+        "{}{}",
+        if incl_active {
+            DUAL_COLUMN_ACTIVE
+        } else {
+            DUAL_GUTTER_BLANK
+        },
+        cell("Included", col_w)
+    );
+    let header = format!("{avail_head}  {incl_head}");
+    let head_left = 0..avail_head.len();
+    let head_right = (avail_head.len() + 2)..header.len();
+    let mut header_entry = TextPropertyEntry::text(&header);
+    for (range, active) in [(head_left, avail_active), (head_right, incl_active)] {
+        header_entry.inline_overlays.push(InlineOverlay {
+            start: range.start,
+            end: range.end,
+            style: OverlayOptions {
+                fg: Some(OverlayColorSpec::theme_key(if active {
+                    KEY_SECTION_LABEL_FG
+                } else {
+                    KEY_COMPLETION_DIM_FG
+                })),
+                bold: active,
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        });
+    }
     ensure_trailing_newline(&mut header_entry);
     let header_row = out.entries.len() as u32;
     out.entries.push(header_entry);
@@ -4439,8 +4519,22 @@ fn collect_dual_list(
         let right_val = included.get(i);
         let left = left_val.map(|v| dual_label(options, v)).unwrap_or("");
         let right = right_val.map(|v| dual_label(options, v)).unwrap_or("");
-        let left_cell = cell(left, col_w);
-        let right_cell = cell(right, col_w);
+        // Per-column cursor gutter. The active column's cursor row
+        // gets the filled `▸ `, the idle column's the hollow `▹ ` so
+        // both cursors are readable at once — the idle marker is what
+        // tells you where Left/Right will drop you. Rows that hold no
+        // cursor still reserve the two columns, so nothing shifts as
+        // the cursor moves.
+        let left_gutter = dual_cursor_marker(
+            is_focused && left_val.is_some() && i == avail_cur,
+            !active_included,
+        );
+        let right_gutter = dual_cursor_marker(
+            is_focused && right_val.is_some() && i == incl_cur,
+            active_included,
+        );
+        let left_cell = format!("{left_gutter}{}", cell(left, col_w));
+        let right_cell = format!("{right_gutter}{}", cell(right, col_w));
         let text = format!("{}  {}", left_cell, right_cell);
         let left_start = 0usize;
         let left_end = left_cell.len();
@@ -4448,8 +4542,10 @@ fn collect_dual_list(
         let right_end = right_start + right_cell.len();
 
         let mut entry = TextPropertyEntry::text(&text);
-        // Cursor highlight on the active column's cursor row (only
-        // when the widget is focused).
+        // Cursor highlight, spanning the marker *and* the label so the
+        // whole cell reads as one selected row. The active column gets
+        // the full fg/bg flip; the idle column gets a dimmed marker
+        // only (below) so the two never compete for attention.
         if is_focused {
             let (hs, he) = if active_included {
                 if right_val.is_some() && i == incl_cur {
@@ -4470,6 +4566,25 @@ fn collect_dual_list(
                         fg: Some(OverlayColorSpec::theme_key(KEY_FOCUSED_FG)),
                         bg: Some(OverlayColorSpec::theme_key(KEY_FOCUSED_BG)),
                         bold: true,
+                        ..Default::default()
+                    },
+                    properties: Default::default(),
+                    unit: OffsetUnit::Byte,
+                });
+            }
+            // Idle-column marker: dimmed, no background, so it reads
+            // as "the other cursor is parked here".
+            let idle = if active_included {
+                (left_val.is_some() && i == avail_cur).then_some(left_start)
+            } else {
+                (right_val.is_some() && i == incl_cur).then_some(right_start)
+            };
+            if let Some(start) = idle {
+                entry.inline_overlays.push(InlineOverlay {
+                    start,
+                    end: start + DUAL_CURSOR_IDLE.len(),
+                    style: OverlayOptions {
+                        fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
                         ..Default::default()
                     },
                     properties: Default::default(),
@@ -4507,7 +4622,39 @@ fn collect_dual_list(
         }
         out.entries.push(entry);
     }
+
+    // Key hint under the columns. The control's bindings (Shift+←→ to
+    // move an item across, Shift+↑↓ to reorder) aren't guessable from
+    // its shape, so the host supplies a localized one-liner and it
+    // rides with the control instead of only in a panel footer.
+    if !hint.is_empty() {
+        let text = format!("{DUAL_GUTTER_BLANK}{hint}");
+        let mut e = TextPropertyEntry::text(&text);
+        e.inline_overlays.push(InlineOverlay {
+            start: 0,
+            end: text.len(),
+            style: OverlayOptions {
+                fg: Some(OverlayColorSpec::theme_key(KEY_PLACEHOLDER_FG)),
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        });
+        ensure_trailing_newline(&mut e);
+        out.entries.push(e);
+    }
     out
+}
+
+/// The two-column gutter a `DualList` cell leads with: `▸ ` when the
+/// cursor is on this cell and its column is the active one, `▹ ` when
+/// the cursor is parked here in the idle column, two spaces otherwise.
+fn dual_cursor_marker(on_cursor: bool, column_active: bool) -> &'static str {
+    match (on_cursor, column_active) {
+        (true, true) => DUAL_CURSOR_ACTIVE,
+        (true, false) => DUAL_CURSOR_IDLE,
+        _ => DUAL_GUTTER_BLANK,
+    }
 }
 
 /// Render a `Button` to a single `TextPropertyEntry`.
@@ -9057,9 +9204,130 @@ mod tests {
             excluded: Vec::new(),
             label: "Elements".into(),
             focused: false,
+            active_included: false,
+            available_cursor: 0,
+            included_cursor: 0,
+            hint: String::new(),
             visible_rows: 3,
             key: key.map(|k| k.to_string()),
         }
+    }
+
+    /// Focused dual list seeded straight from the spec — the shape
+    /// Settings renders, where the host owns cursor + active column and
+    /// re-supplies them every frame.
+    fn make_dual_focused(
+        options: &[(&str, &str)],
+        included: &[&str],
+        active_included: bool,
+        available_cursor: u32,
+        included_cursor: u32,
+        hint: &str,
+    ) -> WidgetSpec {
+        WidgetSpec::DualList {
+            options: opts(options),
+            included: included.iter().map(|s| s.to_string()).collect(),
+            excluded: Vec::new(),
+            label: "Elements".into(),
+            focused: true,
+            active_included,
+            available_cursor,
+            included_cursor,
+            hint: hint.to_string(),
+            visible_rows: 3,
+            key: None,
+        }
+    }
+
+    /// Rows the picker paints for a spec-seeded, focused dual list.
+    fn dual_rows(spec: &WidgetSpec) -> Vec<String> {
+        let (out, _hits, _state) = render_no_focus(spec, &HashMap::new());
+        out.iter()
+            .map(|e| e.text.trim_end_matches('\n').to_string())
+            .collect()
+    }
+
+    #[test]
+    fn dual_list_marks_cursor_and_active_column_with_glyphs() {
+        // Cursor on "Beta" in Available; Included holds "Gamma".
+        let spec = make_dual_focused(
+            &[("a", "Alpha"), ("b", "Beta"), ("g", "Gamma")],
+            &["g"],
+            false,
+            1,
+            0,
+            "",
+        );
+        let rows = dual_rows(&spec);
+        // Header marks the Available column, not Included.
+        let header = &rows[1];
+        assert!(
+            header.contains("▾ Available"),
+            "active column unmarked: {header:?}"
+        );
+        assert!(
+            !header.contains("▾ Included"),
+            "idle column marked active: {header:?}"
+        );
+        // Body: filled marker on the Available cursor row, hollow one
+        // on the idle Included cursor.
+        assert!(rows[2].contains("  Alpha"), "row 0: {:?}", rows[2]);
+        assert!(rows[2].contains("▹ Gamma"), "idle cursor: {:?}", rows[2]);
+        assert!(rows[3].contains("▸ Beta"), "active cursor: {:?}", rows[3]);
+    }
+
+    #[test]
+    fn dual_list_cursor_glyphs_follow_the_active_column() {
+        let spec = make_dual_focused(
+            &[("a", "Alpha"), ("b", "Beta"), ("g", "Gamma")],
+            &["g"],
+            true,
+            1,
+            0,
+            "",
+        );
+        let rows = dual_rows(&spec);
+        assert!(rows[1].contains("▾ Included"), "header: {:?}", rows[1]);
+        // Filled marker moved to Included; Available keeps the hollow one.
+        assert!(rows[2].contains("▸ Gamma"), "active cursor: {:?}", rows[2]);
+        assert!(rows[3].contains("▹ Beta"), "idle cursor: {:?}", rows[3]);
+    }
+
+    #[test]
+    fn dual_list_unfocused_renders_no_cursor_glyphs() {
+        let spec = make_dual(&[("a", "Alpha")], &[], None);
+        let joined = dual_rows(&spec).join("\n");
+        assert!(!joined.contains('▸'), "{joined:?}");
+        assert!(!joined.contains('▹'), "{joined:?}");
+        assert!(!joined.contains('▾'), "{joined:?}");
+    }
+
+    #[test]
+    fn dual_list_appends_hint_row_when_supplied() {
+        let hint = "↑↓ Select  Shift+←→ Move item";
+        let spec = make_dual_focused(&[("a", "Alpha")], &[], false, 0, 0, hint);
+        let rows = dual_rows(&spec);
+        assert_eq!(rows.last().map(|r| r.trim()), Some(hint));
+        // ...and nothing extra when the host supplies no hint.
+        let bare = make_dual_focused(&[("a", "Alpha")], &[], false, 0, 0, "");
+        assert_eq!(dual_rows(&bare).len(), rows.len() - 1);
+    }
+
+    #[test]
+    fn dual_list_cell_hits_cover_the_cursor_gutter() {
+        // The gutter is part of the cell, so clicking the marker (or
+        // the blank column reserved for it) selects that row.
+        let spec = make_dual(&[("a", "Alpha"), ("b", "Beta")], &["b"], None);
+        let (out, hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let h = hits
+            .iter()
+            .find(|h| h.payload["column"] == "available")
+            .expect("available cell hit");
+        let row = &out[h.buffer_row as usize].text;
+        let cell = &row[h.byte_start..h.byte_end];
+        assert_eq!(h.byte_start, 0, "cell should start at the gutter");
+        assert!(cell.starts_with("  "), "gutter not in the hit: {cell:?}");
+        assert!(cell.contains("Alpha"), "label not in the hit: {cell:?}");
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -243,6 +243,7 @@ pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
 pub mod settings_save_error_popup;
 pub mod settings_scrolled_list_click;
+pub mod settings_status_bar_dual_list;
 pub mod settings_text_click_position;
 pub mod settings_text_field_esc_cancels;
 pub mod settings_text_input_focus;

--- a/crates/fresh-editor/tests/e2e/settings_status_bar_dual_list.rs
+++ b/crates/fresh-editor/tests/e2e/settings_status_bar_dual_list.rs
@@ -1,0 +1,269 @@
+//! E2E coverage for the status-bar element picker in Settings
+//! (Editor › Status Bar › Left / Right) — the two-column
+//! Available/Included `DualList`.
+//!
+//! Before the fix the control rendered no cursor at all: every row in
+//! both columns painted identically, nothing marked which column had
+//! the keyboard, and nothing said how to move an item. Arrow keys
+//! walked an invisible selection and Enter moved whichever entry it
+//! happened to be sitting on. These tests drive keyboard and mouse
+//! events and assert only on rendered output (per CONTRIBUTING.md,
+//! "E2E Tests Observe, Not Inspect").
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Cursor glyph on the column the keyboard is driving.
+const ACTIVE: char = '▸';
+/// Cursor glyph parked in the other column.
+const IDLE: char = '▹';
+/// Marker under the active column's header.
+const COLUMN: char = '▾';
+
+/// Open Settings, walk the sidebar to Editor › Status Bar, then Tab
+/// into the content pane so the `Left` picker is the selected control.
+fn focus_status_bar_left(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+    // Expand the Editor category, then step down to its Status Bar
+    // subsection. Stop as soon as the picker's columns are on screen.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    for _ in 0..40 {
+        let screen = harness.screen_to_string();
+        if screen.contains("Available") && screen.contains("Included") {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Available") && screen.contains("Included"),
+        "should reach the Status Bar element picker; screen:\n{screen}"
+    );
+    // Move focus from the category sidebar into the content pane.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+}
+
+/// The label carried by the row holding `marker`, with the marker and
+/// surrounding padding stripped — e.g. `▸ Filename` → `Filename`.
+/// Multiple cells can sit on one screen row (the two columns), so the
+/// text is cut at the run of spaces that separates them.
+fn cell_at_marker(harness: &EditorTestHarness, marker: char) -> Option<String> {
+    let screen = harness.screen_to_string();
+    let (pos, line) = screen.lines().find_map(|line| {
+        line.char_indices()
+            .find(|&(_, c)| c == marker)
+            .map(|(i, _)| (i, line))
+    })?;
+    let after = &line[pos + marker.len_utf8()..];
+    let label = after.trim_start().split("  ").next()?.trim();
+    (!label.is_empty()).then(|| label.to_string())
+}
+
+/// Screen column (not byte offset) where `needle` starts on a rendered
+/// row. Rows are full of box-drawing glyphs, so the two differ.
+fn char_index_of(line: &[char], needle: &str) -> Option<usize> {
+    let needle: Vec<char> = needle.chars().collect();
+    line.windows(needle.len())
+        .position(|w| w == needle.as_slice())
+}
+
+/// Enter starts editing the picker: the cursor appears in the Available
+/// column, the other column's parked cursor is marked distinctly, and
+/// the header points at the column that has the keyboard.
+///
+/// Without the fix the control painted no markers in any state — the
+/// spec it projected carried neither focus nor cursor — so every one of
+/// these assertions fails.
+#[test]
+fn dual_list_shows_cursor_and_active_column_once_editing() {
+    let mut harness = EditorTestHarness::new(140, 44).unwrap();
+    harness.render().unwrap();
+    focus_status_bar_left(&mut harness);
+
+    // Selected but not editing: arrows still walk the settings list, so
+    // no in-column cursor is drawn — just the invitation to edit.
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains(ACTIVE) && !screen.contains(COLUMN),
+        "no cursor should be painted before editing; screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("Enter to edit"),
+        "selected picker should say how to start; screen:\n{screen}"
+    );
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&format!("{COLUMN} Available")),
+        "the active column's header should be marked; screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains(&format!("{COLUMN} Included")),
+        "only one column may read as active; screen:\n{screen}"
+    );
+    assert!(
+        cell_at_marker(&harness, ACTIVE).is_some(),
+        "the active column should show a cursor; screen:\n{screen}"
+    );
+    assert!(
+        cell_at_marker(&harness, IDLE).is_some(),
+        "the idle column's parked cursor should be shown too; screen:\n{screen}"
+    );
+    // The keys that move items are not guessable from the control's
+    // shape, so they are spelled out while editing.
+    assert!(
+        screen.contains("Shift+←→") && screen.contains("Shift+↑↓"),
+        "editing should list the move/reorder keys; screen:\n{screen}"
+    );
+}
+
+/// Down moves the cursor to a visibly different entry, and Right hands
+/// the keyboard to the Included column — both observable on screen.
+///
+/// Without the fix these keys mutated an invisible cursor: the rendered
+/// output was byte-identical before and after.
+#[test]
+fn dual_list_cursor_moves_and_switches_columns_visibly() {
+    let mut harness = EditorTestHarness::new(140, 44).unwrap();
+    harness.render().unwrap();
+    focus_status_bar_left(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let first = cell_at_marker(&harness, ACTIVE).expect("cursor on entry");
+
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let second = cell_at_marker(&harness, ACTIVE).expect("cursor after Down");
+    assert_ne!(
+        first,
+        second,
+        "Down should visibly move the cursor; screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Right hands the keyboard to the Included column: its header takes
+    // the marker and the filled cursor crosses over.
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&format!("{COLUMN} Included")),
+        "Right should mark the Included column active; screen:\n{screen}"
+    );
+    // The Available cursor stays put, now drawn as the parked one.
+    assert_eq!(
+        cell_at_marker(&harness, IDLE).as_deref(),
+        Some(second.as_str()),
+        "the Available cursor should be parked where it was; screen:\n{screen}"
+    );
+}
+
+/// Shift+Right moves the cursor's entry into the Included column, and
+/// the cursor follows it — the whole point of the control, and until
+/// now impossible to aim because the cursor was invisible.
+#[test]
+fn dual_list_shift_right_moves_the_entry_under_the_cursor() {
+    let mut harness = EditorTestHarness::new(140, 44).unwrap();
+    harness.render().unwrap();
+    focus_status_bar_left(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let picked = cell_at_marker(&harness, ACTIVE).expect("cursor on entry");
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&format!("{COLUMN} Included")),
+        "focus should follow the moved entry into Included; screen:\n{screen}"
+    );
+    assert_eq!(
+        cell_at_marker(&harness, ACTIVE).as_deref(),
+        Some(picked.as_str()),
+        "the cursor should land on the entry it moved; screen:\n{screen}"
+    );
+}
+
+/// Clicking a cell selects that row. The picker previously published no
+/// click geometry at all, so clicks inside the columns did nothing.
+#[test]
+fn dual_list_click_selects_the_clicked_entry() {
+    let mut harness = EditorTestHarness::new(140, 44).unwrap();
+    harness.render().unwrap();
+    focus_status_bar_left(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let before = cell_at_marker(&harness, ACTIVE).expect("cursor on entry");
+
+    // Aim at the Available column by its header's screen column, so the
+    // click can't land in the category sidebar that shares these rows.
+    // Screen rows carry box-drawing glyphs, so index by chars, not bytes.
+    let screen = harness.screen_to_string();
+    let header_row = screen
+        .lines()
+        .position(|l| l.contains("Available") && l.contains("Included"))
+        .expect("column header on screen");
+    let header: Vec<char> = screen.lines().nth(header_row).unwrap().chars().collect();
+    let avail_col = char_index_of(&header, "Available").expect("Available header");
+    // Three rows below the header, well clear of the entry the cursor
+    // entered on.
+    let target_row = header_row + 3;
+    let line: Vec<char> = screen
+        .lines()
+        .nth(target_row)
+        .expect("target row on screen")
+        .chars()
+        .collect();
+    let target: String = line[avail_col..]
+        .iter()
+        .collect::<String>()
+        .split("  ")
+        .next()
+        .unwrap()
+        .trim()
+        .to_string();
+    assert!(
+        !target.is_empty(),
+        "precondition: an entry sits at the click target; screen:\n{screen}"
+    );
+    assert_ne!(target, before, "precondition: clicking a different entry");
+
+    harness
+        .mouse_click(avail_col as u16, target_row as u16)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        cell_at_marker(&harness, ACTIVE).as_deref(),
+        Some(target.as_str()),
+        "clicking a cell should move the cursor to it; screen:\n{}",
+        harness.screen_to_string()
+    );
+}


### PR DESCRIPTION
## The problem

Settings › Editor › Status Bar › **Left** / **Right** is a two-column
Available/Included picker. Driving it in a real terminal, it was
effectively unusable:

- **No cursor.** Every row in both columns painted identically — same fg,
  no background, no marker. Capturing the pane with escape sequences
  confirmed it: not even a subtle attribute-only highlight.
- **No column indicator.** Nothing said which of the two columns had the
  keyboard, and `↑`/`↓` walk a single cursor that crosses between them —
  so pressing Up past the top of Included silently drops you into
  Available.
- **No hint.** The panel footer stayed on the generic
  `↑↓ Navigate  Tab Next  Enter Edit …`, which is actively wrong once the
  picker has the keyboard.
- **Clicks did nothing.** Clicking a cell was a no-op (mouse works
  elsewhere in the dialog — clicking a sidebar entry navigates fine).

The keys were all there, just invisible: `Enter` enters edit mode with
zero feedback, then `↑↓` move a hidden cursor, `←→` switch columns,
`Shift+←→` move an item across, `Shift+↑↓` reorder Included. In practice
you press `Enter` and an item you didn't choose jumps columns.

## Cause

Settings owns this control's state in its own `DualListState`, but the
`WidgetSpec::DualList` it projects to carried none of it: `focused` was
hard-coded `false` and there were no cursor fields at all. The widget
renderer's highlight branch was therefore unreachable, and the mouse
layout was `ControlLayoutInfo::DualList(Default::default())` — an empty
hit-test table.

## Changes

- Carry `active_included` / `available_cursor` / `included_cursor` /
  `hint` on `WidgetSpec::DualList`, seeded like `included` (all
  `#[serde(default)]`, so existing plugin specs are unaffected), and
  re-seed them from the Settings control on every frame.
- Give each column a two-column cursor gutter, so the state reads on a
  monochrome terminal as well as a colored one:
  - `▸ ` — cursor on the column that has the keyboard
  - `▹ ` — where the other column's cursor is parked
  - `▾ ` — under the active column's header

  The gutter is always reserved, so nothing reflows as the cursor moves.
- All colors go through **theme keys**, no literals: the cursor row keeps
  the `ui.popup_selection_{fg,bg}` flip, headers use `ui.help_key_fg`
  (active) / `ui.menu_disabled_fg` (idle), the parked marker
  `ui.menu_disabled_fg`, the hint `editor.whitespace_indicator_fg`.
- Render a key hint under the columns — `Enter to edit` while the row is
  merely selected, the full key list while editing — and swap the panel
  footer for one that names the real keys.
- Gate the in-column cursor on *editing*, not selection: outside edit
  mode `↑↓` still walks the settings list, so a cursor drawn in the
  columns would promise a movement the arrows don't make.
- Build the click geometry from the cells the widget actually painted, so
  clicking a row selects it.
- Size the control from `body_rows()` on both sides of the layout, which
  also fixes the columns being clipped one row short (the layout reserved
  `max(…, 5)` while the widget rendered `max(…, 6)`).

### Before

```
│>  Left                                                          │
│   Available                     Included                        │
│   Filename                      Workspace Trust                 │
│   Cursor (compact)              Remote Indicator                │
│   Chord                         Terminal Restart                │
```

### After (editing)

```
│>  Left                                                          │
│   ▾ Available                     Included                      │
│   ▸ Filename                    ▹ Workspace Trust               │
│     Cursor (compact)              Remote Indicator              │
│     Chord                         Terminal Restart              │
│     ↑↓ Select  ←→ Switch column  Shift+←→ Move item  Shift+↑↓ Reorder  Esc Done │
```

## Tests

Four e2e tests in `settings_status_bar_dual_list.rs` drive keyboard and
mouse events and assert only on rendered output. All four fail against
the parent commit and pass with the change:

- cursor + active-column markers appear on `Enter`, and *not* before it
- `Down` moves the cursor to a visibly different entry; `Right` hands the
  keyboard to Included and parks the Available cursor
- `Shift+Right` moves the entry under the cursor and focus follows it
- clicking a cell selects that row

`cargo fmt`, `cargo clippy --all-targets` (no new warnings in the changed
files), `cargo check --all-targets`, and `cargo check --all-targets
--features gui` are clean. Full e2e suite: 3267 passed; the 4 failures
are pre-existing parallel-execution flakes (2 locale tests that share
global locale state, a fake-LSP diagnostics test, a terminal tab-title
test) — all pass when run on their own.

## Notes

- `fresh.d.ts` regenerated per CONTRIBUTING; the `dualList()` plugin
  helper takes the new options so plugin-authored pickers can seed the
  cursor and supply their own legend.
- New i18n keys (`settings.dual_list_keys_hint`, `settings.help_duallist`)
  are in all 14 locales with real translations, reusing each file's
  existing vocabulary for move/reorder. The added words (select, column,
  done) are best-effort — worth a native speaker's eye.
- `crates/fresh-editor/plugins/check-types.sh` does not run in this
  environment: the installed `tsc` is 6.x, which removed
  `--moduleResolution node10`, so every file errors with TS5108 before
  reaching any real check. Type-checked `lib/widgets.ts` directly with
  `--moduleResolution bundler` instead; `dualList` is clean (the
  remaining errors there are pre-existing and belong to `row`, `number`,
  `dropdown`, and `text`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7oTKsrdqPbyaCCXrayJ6M)_