### PR TITLE
fix(viewport): use rendered width for cursor visibility

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -409,7 +409,12 @@ pub(crate) fn compute_buffer_layout(
     // Ensure cursor is visible using Layout-aware check (handles virtual lines)
     let primary = *cursors.primary();
     let top_byte_before_scroll = viewport.top_byte();
-    let scrolled = viewport.ensure_visible_in_layout(&view_data.lines, &primary, gutter_width);
+    let scrolled = viewport.ensure_visible_in_layout_with_render_width(
+        &view_data.lines,
+        &primary,
+        render_area.width as usize,
+        gutter_width,
+    );
 
     // If we scrolled AND `top_byte` changed, rebuild view_data from the new
     // top_byte (the old view_data no longer matches what's visible).  We
@@ -445,7 +450,12 @@ pub(crate) fn compute_buffer_layout(
                 None,
             );
             // The rebuild is unanchored, so the layout pass owns the offsets again.
-            let _ = viewport.ensure_visible_in_layout(&rebuilt.lines, &primary, gutter_width);
+            let _ = viewport.ensure_visible_in_layout_with_render_width(
+                &rebuilt.lines,
+                &primary,
+                render_area.width as usize,
+                gutter_width,
+            );
             rebuilt
         } else {
             view_data

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -1279,6 +1279,22 @@ impl Viewport {
         cursor: &Cursor,
         gutter_width: usize,
     ) -> bool {
+        let render_width = self.width as usize;
+        self.ensure_visible_in_layout_with_render_width(
+            view_lines,
+            cursor,
+            render_width,
+            gutter_width,
+        )
+    }
+
+    pub(crate) fn ensure_visible_in_layout_with_render_width(
+        &mut self,
+        view_lines: &[ViewLine],
+        cursor: &Cursor,
+        render_width: usize,
+        gutter_width: usize,
+    ) -> bool {
         // Check if we should skip sync due to session restore
         // This prevents the restored scroll position from being overwritten
         if self.should_skip_resize_sync() {
@@ -1326,7 +1342,13 @@ impl Viewport {
         // `ensure_visible_in_rows`, which runs before anything is built and
         // decides in absolute rows; this pass sees only the window it was
         // handed and cannot reach past it, which is what made the two disagree.
-        self.scroll_cursor_column_into_view(view_lines, cursor, cursor_view_line, gutter_width);
+        self.scroll_cursor_column_into_view(
+            view_lines,
+            cursor,
+            cursor_view_line,
+            render_width,
+            gutter_width,
+        );
         false
     }
 
@@ -1339,6 +1361,7 @@ impl Viewport {
         view_lines: &[ViewLine],
         cursor: &Cursor,
         cursor_view_line: usize,
+        render_width: usize,
         gutter_width: usize,
     ) {
         if cursor_view_line >= view_lines.len() {
@@ -1389,14 +1412,20 @@ impl Viewport {
         let line_visual_width = line
             .visual_width()
             .saturating_sub(usize::from(line.ends_with_newline));
-        self.ensure_column_visible_simple(cursor_visual_col, line_visual_width, gutter_width);
+        self.ensure_column_visible_simple(
+            cursor_visual_col,
+            line_visual_width,
+            render_width,
+            gutter_width,
+        );
     }
 
-    /// Simple column visibility check (doesn't need buffer)
+    /// Renderer/layout-only column visibility check using laid-out line geometry.
     fn ensure_column_visible_simple(
         &mut self,
         column: usize,
         line_length: usize,
+        render_width: usize,
         gutter_width: usize,
     ) {
         // Skip if line wrapping is enabled (all columns visible via wrapping)
@@ -1405,10 +1434,10 @@ impl Viewport {
             return;
         }
 
-        let scrollbar_width = 1;
-        let visible_width = (self.width as usize)
-            .saturating_sub(gutter_width)
-            .saturating_sub(scrollbar_width);
+        // `render_width` is the geometry used to build and draw these lines.
+        // It may be narrower than this viewport in compose mode, and already
+        // accounts for a shown vertical scrollbar column.
+        let visible_width = render_width.saturating_sub(gutter_width);
 
         if visible_width == 0 {
             return;
@@ -2221,13 +2250,10 @@ impl Viewport {
         line_length: usize,
         buffer: &mut Buffer,
     ) {
-        // Calculate visible width (accounting for line numbers gutter which is dynamic)
+        // `self.width` is the content width; split layout has already removed
+        // any vertical scrollbar column.
         let gutter_width = self.gutter_width(buffer);
-        // Also account for scrollbar (always present, takes 1 column)
-        let scrollbar_width = 1;
-        let visible_width = (self.width as usize)
-            .saturating_sub(gutter_width)
-            .saturating_sub(scrollbar_width);
+        let visible_width = (self.width as usize).saturating_sub(gutter_width);
 
         if visible_width == 0 {
             return; // Terminal too narrow
@@ -2712,6 +2738,35 @@ mod tests {
             expected_bottom,
             lines_from_top
         );
+    }
+
+    #[test]
+    fn ensure_column_visible_simple_uses_explicit_render_width() {
+        // Compose mode can render a narrow centered page inside a wide viewport.
+        let mut vp = Viewport::new(80, 24);
+        vp.line_wrap_enabled = false;
+        vp.horizontal_scroll_offset = 0;
+
+        vp.ensure_column_visible_simple(12, 13, 6, 0);
+
+        assert_eq!(
+            vp.left_column, 7,
+            "the layout path must use its passed render width, not viewport width"
+        );
+    }
+
+    #[test]
+    fn ensure_column_visible_does_not_reserve_scrollbar_inside_content_width() {
+        let mut buffer = Buffer::from_str_test("x".repeat(20).as_str());
+        let mut vp = Viewport::new(10, 24);
+        vp.line_wrap_enabled = false;
+        vp.horizontal_scroll_offset = 0;
+
+        // The one-line buffer has a six-column gutter, leaving columns 0..=3
+        // visible within the viewport's content width.
+        vp.ensure_column_visible(3, 20, &mut buffer);
+
+        assert_eq!(vp.left_column, 0);
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -296,6 +296,7 @@ pub mod universal_lsp;
 pub mod unnamed_buffer_persistence;
 pub mod update_notification;
 pub mod vertical_rulers;
+pub mod vertical_scrollbar_cursor_extent;
 #[cfg(feature = "plugins")]
 pub mod vi_mode;
 #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/tests/e2e/vertical_scrollbar_cursor_extent.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_scrollbar_cursor_extent.rs
@@ -1,0 +1,97 @@
+//! Renderer/layout regression coverage for cursor extent beside a vertical scrollbar.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+fn config(show_vertical_scrollbar: bool) -> Config {
+    let mut config = Config::default();
+    config.editor.line_wrap = false;
+    config.editor.line_numbers = false;
+    config.editor.show_vertical_scrollbar = show_vertical_scrollbar;
+    config
+}
+
+fn fixture() -> String {
+    // The suffix covers a double-width CJK grapheme, a combining sequence,
+    // and a wide emoji before the final ASCII cell.
+    let mut text = format!("{}界e\u{301}🙂Z", "x".repeat(32));
+    for _ in 0..40 {
+        text.push_str("\nshort");
+    }
+    text
+}
+
+fn assert_scrollbar_column(harness: &EditorTestHarness, column: u16, present: bool) {
+    let (first_row, last_row) = harness.content_area_rows();
+    for row in first_row..=last_row {
+        let has_scrollbar = harness.is_scrollbar_thumb_at(column, row as u16)
+            || harness.is_scrollbar_track_at(column, row as u16);
+        assert_eq!(
+            has_scrollbar, present,
+            "scrollbar style at ({column}, {row}) should be {present}"
+        );
+    }
+}
+
+fn assert_left_cell(
+    harness: &mut EditorTestHarness,
+    expected_cell: &str,
+    width_to_next: u16,
+    next_x: u16,
+    expected_y: u16,
+) -> (u16, u16) {
+    harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let (x, y) = harness.screen_cursor_position();
+    assert_eq!(harness.get_cell(x, y).as_deref(), Some(expected_cell));
+    assert_eq!(x + width_to_next, next_x);
+    assert_eq!(y, expected_y);
+    (x, y)
+}
+
+fn assert_cursor_extent(show_vertical_scrollbar: bool) {
+    let mut harness =
+        EditorTestHarness::with_config(13, 12, config(show_vertical_scrollbar)).unwrap();
+    harness.load_buffer_from_text(&fixture()).unwrap();
+
+    // End may invoke a pre-render buffer-aware visibility pass; rendering then
+    // invokes the renderer/layout-only pass with the renderer-synced content width.
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let screen_width = harness
+        .screen_to_string()
+        .lines()
+        .next()
+        .expect("rendered screen has a first row")
+        .chars()
+        .count() as u16;
+    let edge = screen_width.saturating_sub(1);
+    let last_content_cell = if show_vertical_scrollbar {
+        edge.saturating_sub(1)
+    } else {
+        edge
+    };
+    assert_scrollbar_column(&harness, edge, show_vertical_scrollbar);
+    assert_eq!(harness.screen_cursor_position().0, last_content_cell);
+
+    let eol_y = harness.screen_cursor_position().1;
+    let (z_x, z_y) = assert_left_cell(&mut harness, "Z", 1, last_content_cell, eol_y);
+    let (emoji_x, emoji_y) = assert_left_cell(&mut harness, "🙂", 2, z_x, z_y);
+    let (combining_x, combining_y) =
+        assert_left_cell(&mut harness, "e\u{301}", 1, emoji_x, emoji_y);
+    let (_, cjk_y) = assert_left_cell(&mut harness, "界", 2, combining_x, combining_y);
+    assert_eq!(cjk_y, z_y);
+}
+
+#[test]
+fn end_uses_last_content_cell_when_vertical_scrollbar_is_shown() {
+    assert_cursor_extent(true);
+}
+
+#[test]
+fn end_uses_screen_edge_when_vertical_scrollbar_is_hidden() {
+    assert_cursor_extent(false);
+}


### PR DESCRIPTION
## Summary

Horizontal cursor visibility reserved a vertical-scrollbar column twice: split layout had already removed that column from the viewport content width, while both the buffer-aware and rendered-layout visibility paths subtracted another cell. This left the final content cell unreachable and could make wide glyphs appear to interfere with the scrollbar edge.

Remove the duplicate reservation from the buffer-aware path. For the rendered-layout path, pass the authoritative `render_area.width` through an internal helper and subtract only the gutter. The existing public `ensure_visible_in_layout` signature remains source-compatible and delegates using the viewport width.

Using the explicit render width is necessary because compose mode can render a narrower area than `Viewport::width`; it is the same coordinate-space correction, not a separate scrolling feature.

## Regression coverage

- unit test proves content-width visibility does not reserve another scrollbar cell
- unit test proves the layout path honors an explicit render width narrower than the viewport
- rendered E2Es cover vertical scrollbar shown and hidden
- every scrollbar row retains track/thumb styling when shown and no scrollbar styling when hidden
- EOL caret and final `Z` reach the correct content edge
- CJK, combining text, and emoji occupy their expected terminal cells beside the edge

The rendered regression fails on the parent, where the shown and hidden cases place the cursor one cell too far left. A subtract-one mutation also makes the focused content-width unit fail (`left_column` becomes 1).

## Validation

- focused viewport unit tests
- vertical scrollbar cursor E2Es
- compose-mode regression
- horizontal scrolling E2Es
- split-view E2Es
- scrollbar-marker E2Es
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

## Performance / scope

No scans, allocations, caches, or background work are added. The production change removes duplicate arithmetic and passes an existing width through the rendered-layout call chain.