### PR TITLE
Page motion counts rendered rows, so folds cost one row not many

### DIFF
--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1910,6 +1910,7 @@ impl Window {
                 // Resolved before the mutable buffer borrow below: the
                 // row-space path needs only `&Buffer`.
                 let scroll_geometry = wrap_scroll_geometry(view_state, state);
+                let hidden_ranges = collapsed_hidden_ranges(view_state, state, buffer_id);
                 let top_byte_before = view_state.viewport.top_byte();
                 if let Some(geometry) = scroll_geometry {
                     // Row arithmetic off the wrap index: no text is read, so a
@@ -1929,6 +1930,7 @@ impl Window {
                         &mut state.buffer,
                         &soft_breaks,
                         &virtual_lines,
+                        &hidden_ranges,
                         lines_to_scroll,
                     );
                 } else {
@@ -1937,6 +1939,7 @@ impl Window {
                         &mut state.buffer,
                         &soft_breaks,
                         &virtual_lines,
+                        &hidden_ranges,
                         lines_to_scroll,
                     );
                 }
@@ -2000,15 +2003,18 @@ impl Window {
             return false;
         };
         let viewport = &mut ps.view_state.active_state_mut().viewport;
+        // The preview loads plain file buffers and exposes no fold controls,
+        // so there are never collapsed regions to skip here.
         if delta < 0 {
             viewport.scroll_up(
                 buffer,
                 &soft_breaks,
                 &virtual_lines,
+                &[],
                 delta.unsigned_abs() as usize,
             );
         } else {
-            viewport.scroll_down(buffer, &soft_breaks, &virtual_lines, delta as usize);
+            viewport.scroll_down(buffer, &soft_breaks, &virtual_lines, &[], delta as usize);
         }
         viewport.set_skip_ensure_visible();
         true
@@ -4024,12 +4030,14 @@ impl Window {
                 .with_buffer_and_split(buffer_id, split_id, |state, view_state| {
                     let soft_breaks = state.collect_soft_break_positions();
                     let virtual_lines = state.collect_virtual_line_positions();
+                    let hidden_ranges = collapsed_hidden_ranges(view_state, state, buffer_id);
                     let buffer = &mut state.buffer;
                     if line_offset > 0 {
                         view_state.viewport.scroll_down(
                             buffer,
                             &soft_breaks,
                             &virtual_lines,
+                            &hidden_ranges,
                             line_offset as usize,
                         );
                     } else {
@@ -4037,6 +4045,7 @@ impl Window {
                             buffer,
                             &soft_breaks,
                             &virtual_lines,
+                            &hidden_ranges,
                             line_offset.unsigned_abs(),
                         );
                     }
@@ -4234,6 +4243,25 @@ mod exited_terminal_tests {
         assert!(!e.resumes_agent());
         assert_eq!(e.program_name(), Some("bash"));
     }
+}
+
+/// Byte ranges the renderer hides for `buffer_id`'s collapsed folds, in the
+/// form the viewport scroll primitives consume. A scroll that counts these
+/// lines spends its budget on rows nobody sees, so the viewport stalls while
+/// the cursor runs ahead into the hidden region.
+fn collapsed_hidden_ranges(
+    view_state: &crate::view::split::SplitViewState,
+    state: &crate::state::EditorState,
+    buffer_id: BufferId,
+) -> Vec<(usize, usize)> {
+    let Some(folds) = view_state.keyed_states.get(&buffer_id).map(|bs| &bs.folds) else {
+        return Vec::new();
+    };
+    state
+        .fold_ranges(folds)
+        .into_iter()
+        .map(|r| (r.start, r.end))
+        .collect()
 }
 
 /// The wrap-index geometry for a split, when one is already built for it.

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -205,6 +205,70 @@ impl Viewport {
             .copied()
     }
 
+    /// First byte at or after `pos` that the renderer actually draws.
+    /// A collapsed body occupies no rows, so a scroll walk must step over
+    /// it wholesale instead of paying a row per hidden line. Loops because
+    /// folds can be adjacent or nested; each jump strictly advances.
+    fn skip_hidden_forward(hidden_ranges: &[(usize, usize)], pos: usize) -> usize {
+        let mut p = pos;
+        while let Some((_, end)) = Self::containing_hidden_range(hidden_ranges, p) {
+            p = end;
+        }
+        p
+    }
+
+    /// Line start of the row the reader sees for `pos`: a position inside a
+    /// collapsed body maps back to that fold's header line, the one row the
+    /// whole region draws. Each jump strictly retreats, so this terminates.
+    fn visible_row_start(buffer: &Buffer, hidden_ranges: &[(usize, usize)], pos: usize) -> usize {
+        let mut p = pos;
+        while let Some((start, _)) = Self::containing_hidden_range(hidden_ranges, p) {
+            if start == 0 {
+                return 0;
+            }
+            p = crate::view::folding::indent_folding::find_line_start_byte(buffer, start - 1);
+        }
+        p
+    }
+
+    /// Walk `lines` rendered rows down from `start`, skipping collapsed bodies.
+    fn walk_down_visible_lines(
+        buffer: &mut Buffer,
+        hidden_ranges: &[(usize, usize)],
+        start: usize,
+        lines: usize,
+    ) -> usize {
+        let mut position = Self::skip_hidden_forward(hidden_ranges, start);
+        for _ in 0..lines {
+            let mut iter = buffer.line_iterator(position, 80);
+            if iter.next_line().is_none() {
+                break;
+            }
+            position = Self::skip_hidden_forward(hidden_ranges, iter.current_position());
+        }
+        position
+    }
+
+    /// Walk `lines` rendered rows up from `start`, collapsing each hidden
+    /// body to the single header row it draws.
+    fn walk_up_visible_lines(
+        buffer: &mut Buffer,
+        hidden_ranges: &[(usize, usize)],
+        start: usize,
+        lines: usize,
+    ) -> usize {
+        let mut position = Self::visible_row_start(buffer, hidden_ranges, start);
+        for _ in 0..lines {
+            let mut iter = buffer.line_iterator(position, 80);
+            if iter.prev().is_none() {
+                return 0;
+            }
+            let pos = iter.current_position();
+            position = Self::visible_row_start(buffer, hidden_ranges, pos);
+        }
+        position
+    }
+
     /// Mark viewport to skip sync on next resize (used after session restore)
     pub fn set_skip_resize_sync(&mut self) {
         self.skip_resize_sync = true;
@@ -579,23 +643,32 @@ impl Viewport {
     ///
     /// `soft_breaks` is a sorted slice of plugin-injected break byte positions.
     /// Pass an empty slice when there are no plugin breaks (raw mode, etc.).
+    ///
+    /// `hidden_ranges` holds `(start_byte, end_byte)` for collapsed folds so the
+    /// walk counts rendered rows, not logical lines. Without it a page of scroll
+    /// budget is spent on lines nobody can see and the viewport barely moves.
     pub fn scroll_up(
         &mut self,
         buffer: &mut Buffer,
         soft_breaks: &[(usize, u16)],
         virtual_lines: &[usize],
+        hidden_ranges: &[(usize, usize)],
         lines: usize,
     ) {
         if self.line_wrap_enabled {
-            self.scroll_up_visual(buffer, soft_breaks, virtual_lines, lines);
+            self.scroll_up_visual(buffer, soft_breaks, virtual_lines, hidden_ranges, lines);
         } else {
-            let mut iter = buffer.line_iterator(self.top_byte(), 80);
-            for _ in 0..lines {
-                if iter.prev().is_none() {
-                    break;
+            let new_position = if hidden_ranges.is_empty() {
+                let mut iter = buffer.line_iterator(self.top_byte(), 80);
+                for _ in 0..lines {
+                    if iter.prev().is_none() {
+                        break;
+                    }
                 }
-            }
-            let new_position = iter.current_position();
+                iter.current_position()
+            } else {
+                Self::walk_up_visible_lines(buffer, hidden_ranges, self.top_byte(), lines)
+            };
             self.set_top_byte_with_limit(buffer, soft_breaks, virtual_lines, new_position);
         }
     }
@@ -660,7 +733,7 @@ impl Viewport {
 
         self.set_top_byte(line_start);
         self.set_top_view_line_offset(match_row_in_line);
-        self.scroll_up(buffer, &[], &[], half);
+        self.scroll_up(buffer, &[], &[], &[], half);
     }
 
     /// Scroll down by N lines (byte-based)
@@ -668,23 +741,32 @@ impl Viewport {
     ///
     /// `soft_breaks` is a sorted slice of plugin-injected break byte positions.
     /// Pass an empty slice when there are no plugin breaks (raw mode, etc.).
+    ///
+    /// `hidden_ranges` holds `(start_byte, end_byte)` for collapsed folds so the
+    /// walk counts rendered rows, not logical lines. Without it a page of scroll
+    /// budget is spent on lines nobody can see and the viewport barely moves.
     pub fn scroll_down(
         &mut self,
         buffer: &mut Buffer,
         soft_breaks: &[(usize, u16)],
         virtual_lines: &[usize],
+        hidden_ranges: &[(usize, usize)],
         lines: usize,
     ) {
         if self.line_wrap_enabled {
-            self.scroll_down_visual(buffer, soft_breaks, virtual_lines, lines);
+            self.scroll_down_visual(buffer, soft_breaks, virtual_lines, hidden_ranges, lines);
         } else {
-            let mut iter = buffer.line_iterator(self.top_byte(), 80);
-            for _ in 0..lines {
-                if iter.next_line().is_none() {
-                    break;
+            let new_position = if hidden_ranges.is_empty() {
+                let mut iter = buffer.line_iterator(self.top_byte(), 80);
+                for _ in 0..lines {
+                    if iter.next_line().is_none() {
+                        break;
+                    }
                 }
-            }
-            let new_position = iter.current_position();
+                iter.current_position()
+            } else {
+                Self::walk_down_visible_lines(buffer, hidden_ranges, self.top_byte(), lines)
+            };
             self.set_top_byte_with_limit(buffer, soft_breaks, virtual_lines, new_position);
         }
     }
@@ -696,6 +778,7 @@ impl Viewport {
         buffer: &mut Buffer,
         soft_breaks: &[(usize, u16)],
         virtual_lines: &[usize],
+        hidden_ranges: &[(usize, usize)],
         visual_rows: usize,
     ) {
         if visual_rows == 0 {
@@ -733,8 +816,13 @@ impl Viewport {
                 return;
             }
 
+            // A collapsed body draws as its header row, so land on the header
+            // and charge the whole region one row rather than one per line.
+            let raw_start = iter.current_position();
+            let line_start = Self::visible_row_start(buffer, hidden_ranges, raw_start);
+            iter = buffer.line_iterator(line_start, 80);
+
             // Get the line content to calculate how many visual rows it has
-            let line_start = iter.current_position();
             let (line_end, line_content) = if let Some((_, content)) = iter.next_logical_line() {
                 let end = iter.current_position();
                 (end, content.trim_end_matches(['\n', '\r']).to_string())
@@ -778,6 +866,7 @@ impl Viewport {
         buffer: &mut Buffer,
         soft_breaks: &[(usize, u16)],
         virtual_lines: &[usize],
+        hidden_ranges: &[(usize, usize)],
         visual_rows: usize,
     ) {
         if visual_rows == 0 {
@@ -839,7 +928,12 @@ impl Viewport {
 
         // Continue scrolling through subsequent lines
         loop {
-            let line_start = iter.current_position();
+            let raw_start = iter.current_position();
+            let line_start = Self::skip_hidden_forward(hidden_ranges, raw_start);
+            if line_start != raw_start {
+                // Collapsed body: no rows drawn, so step past it for free.
+                iter = buffer.line_iterator(line_start, 80);
+            }
 
             // Check for end of buffer
             if line_start >= buffer_len {
@@ -2441,17 +2535,59 @@ mod tests {
         let mut buffer = Buffer::from_str_test(&content);
         let mut vp = Viewport::new(80, 24);
 
-        vp.scroll_down(&mut buffer, &[], &[], 10);
+        vp.scroll_down(&mut buffer, &[], &[], &[], 10);
         // Check that we scrolled down (top_byte should be > 0)
         assert!(vp.top_byte() > 0);
 
         let prev_top = vp.top_byte();
-        vp.scroll_up(&mut buffer, &[], &[], 5);
+        vp.scroll_up(&mut buffer, &[], &[], &[], 5);
         // Check that we scrolled up (top_byte should be less than before)
         assert!(vp.top_byte() < prev_top);
 
-        vp.scroll_up(&mut buffer, &[], &[], 100);
+        vp.scroll_up(&mut buffer, &[], &[], &[], 100);
         assert_eq!(vp.top_byte(), 0); // Can't scroll past 0
+    }
+
+    /// A collapsed fold draws one header row, so a scroll of N rows must
+    /// cross it for free. Counting its hidden lines instead spends the whole
+    /// page budget on rows nobody sees and the viewport barely moves.
+    #[test]
+    fn scroll_skips_collapsed_fold_bodies() {
+        // 200 lines; lines 10..=99 (0-based) are hidden behind a header at 9.
+        let mut content = String::new();
+        for i in 0..200 {
+            content.push_str(&format!("line{i}\n"));
+        }
+        let mut buffer = Buffer::from_str_test(&content);
+        let line_start = |n: usize| -> usize {
+            content
+                .split_inclusive('\n')
+                .take(n)
+                .map(|l| l.len())
+                .sum::<usize>()
+        };
+        let hidden = [(line_start(10), line_start(100))];
+
+        // 24 rendered rows down from line 0: lines 0..=9 are ten rows, the
+        // fold body is none, so the remaining 14 land on line 114.
+        let mut vp = Viewport::new(80, 30);
+        vp.scroll_down(&mut buffer, &[], &[], &hidden, 24);
+        assert_eq!(vp.top_byte(), line_start(114));
+
+        // Scrolling back the same distance returns to the start.
+        vp.scroll_up(&mut buffer, &[], &[], &hidden, 24);
+        assert_eq!(vp.top_byte(), 0);
+
+        // A step that ends inside the fold lands past it, never on a hidden
+        // line — the cursor follows the viewport top, so it must be visible.
+        let mut vp = Viewport::new(80, 30);
+        vp.scroll_down(&mut buffer, &[], &[], &hidden, 10);
+        assert_eq!(vp.top_byte(), line_start(100));
+
+        // Without the fold the same walk is pure logical lines.
+        let mut vp = Viewport::new(80, 30);
+        vp.scroll_down(&mut buffer, &[], &[], &[], 24);
+        assert_eq!(vp.top_byte(), line_start(24));
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/folding.rs
+++ b/crates/fresh-editor/tests/e2e/folding.rs
@@ -32,6 +32,26 @@ fn set_fold_range_with_text(
         .set_from_lsp(&state.buffer, &mut state.marker_list, ranges);
 }
 
+/// Install several LSP folding ranges at once — [`set_fold_range`] replaces
+/// whatever was there before, so it can't build a multi-fold document.
+fn set_fold_ranges(harness: &mut EditorTestHarness, ranges: &[(usize, usize)]) {
+    let state = harness.editor_mut().active_state_mut();
+    let ranges: Vec<FoldingRange> = ranges
+        .iter()
+        .map(|&(start_line, end_line)| FoldingRange {
+            start_line: start_line as u32,
+            end_line: end_line as u32,
+            start_character: None,
+            end_character: None,
+            kind: None,
+            collapsed_text: None,
+        })
+        .collect();
+    state
+        .folding_ranges
+        .set_from_lsp(&state.buffer, &mut state.marker_list, ranges);
+}
+
 fn set_top_line(harness: &mut EditorTestHarness, line: usize) {
     let top_byte = {
         let buffer = &mut harness.editor_mut().active_state_mut().buffer;
@@ -1597,4 +1617,92 @@ fn test_fold_unfold_at_end_of_large_file_gutter_click() {
 
     harness.assert_screen_contains("b_body_1");
     harness.assert_screen_contains("b_body_3");
+}
+
+/// PageDown must advance the viewport by one page of *rendered* rows.
+///
+/// A collapsed region draws a single header row, so crossing it costs one
+/// row. Counting its hidden lines instead spends the page budget off-screen:
+/// the viewport stalls while the cursor runs ahead into text nobody can see,
+/// and consecutive presses stop moving the screen at all.
+#[test]
+fn test_page_down_advances_a_full_page_across_collapsed_folds() {
+    /// Rows of file content currently on screen, top-down.
+    fn visible_rows(harness: &EditorTestHarness) -> Vec<String> {
+        let (first, last) = harness.content_area_rows();
+        (first..=last)
+            .map(|row| harness.get_row_text(row as u16).trim_end().to_string())
+            .collect()
+    }
+
+    /// How far one PageDown moved the screen, in rendered rows, read only
+    /// from the screen: where the new top row sat on the previous screen.
+    fn page_advance(harness: &mut EditorTestHarness) -> usize {
+        let before = visible_rows(harness);
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+        let after = visible_rows(harness);
+        before
+            .iter()
+            .position(|row| *row == after[0])
+            .unwrap_or_else(|| {
+                panic!(
+                    "PageDown left no overlap with the previous screen.\n\
+                     previous top: {:?}\nnew top:      {:?}",
+                    before[0], after[0]
+                )
+            })
+    }
+
+    let content: String = (0..500).map(|i| format!("line {i}\n")).collect();
+
+    // Control run on the same file with nothing folded. Measuring the page
+    // here keeps the assertion free of the viewport height and the
+    // page-overlap constant.
+    let mut plain = EditorTestHarness::new(80, 24).unwrap();
+    let plain_fixture = TestFixture::new("page_plain.py", &content).unwrap();
+    plain.open_file(&plain_fixture.path).unwrap();
+    plain.render().unwrap();
+    let page = page_advance(&mut plain);
+    assert!(
+        page > 1,
+        "control PageDown should advance a page, got {page}"
+    );
+
+    // Same file, two collapsed regions: lines 11..=100 and 131..=180.
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let fixture = TestFixture::new("page_folded.py", &content).unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    set_fold_ranges(&mut harness, &[(10, 100), (130, 180)]);
+    harness.render().unwrap();
+    let buffer_id = harness.editor().active_buffer();
+    for header_line in [10usize, 130] {
+        harness
+            .editor_mut()
+            .active_window_mut()
+            .toggle_fold_at_line(buffer_id, header_line);
+    }
+    harness.render().unwrap();
+    let collapsed = visible_rows(&harness);
+    assert!(
+        collapsed.iter().any(|row| row.contains("line 101")),
+        "fold should be collapsed before paging.\nScreen:\n{}",
+        collapsed.join("\n")
+    );
+
+    // Each press must cover the same ground as the unfolded control. Press 1
+    // crosses the first collapsed region and press 3 the second; counting
+    // hidden lines makes press 1 fall short, after which the screen stops
+    // moving while the cursor walks the hidden lines.
+    for press in 1..=4 {
+        let advance = page_advance(&mut harness);
+        assert_eq!(
+            advance,
+            page,
+            "PageDown #{press} moved {advance} rendered rows, expected {page}\nScreen:\n{}",
+            visible_rows(&harness).join("\n")
+        );
+    }
 }


### PR DESCRIPTION
## The bug

PageDown does not consistently move one page. Reproduced interactively in tmux on `main.rs`, one keypress and one capture at a time, 191x49:

| press | viewport top | cursor |
|---|---|---|
| 1 | 1 → 44 | 44 |
| 2 | 44 → 154 | 87 |
| 3 | 154 → 154 | 130 |
| 4 | 154 → 202 | 173 |
| 5–11 | **frozen at 502** | 259 → 302 → 345 → 388 → 431 → 474 |
| 12+ | 517 → 560 → 603 → 646 | matches top |

Five consecutive presses left the screen completely still while the cursor marched through lines that were inside collapsed folds and not on screen at all. From press 12 on — past the last fold — the same key was exact: +43 rows every time, cursor always on the top visible row. That contrast is what pinned it to folds rather than to the page arithmetic.

## Cause

`handle_page_motion` scrolls the viewport a page of view rows and lands the cursor at the new top, which is the right design. But `Viewport::scroll_down`/`scroll_up` walked *logical lines* via `buffer.line_iterator`, and a collapsed fold's hidden body is logical lines that draw nothing. A page of scroll budget got spent inside a fold, so the viewport stalled while the cursor ran ahead into hidden text.

`handle_scroll_event` already collected soft breaks and virtual lines for these calls — collapsed folds were simply never passed.

## Fix

`scroll_up`/`scroll_down` now take the renderer's own hidden-byte set (`fold_skip_set`, via the new `collapsed_hidden_ranges` helper) and count rendered rows: step over each collapsed body for free going down, collapse it back to its header row going up. Both the no-wrap and wrap paths are covered.

The no-fold path is left exactly as it was, so the common case keeps its current cost. The mouse-wheel path gets the same fix; its downstream snap-out-of-a-fold patch stays, since the row-space wrap-index path still walks separately.

## Verification

Interactively in tmux on a 600-line fixture with lines 12–301 folded away, 27 text rows, overlap 3 — so one page is 24 rendered rows:

```
top:  1 → 315 → 339 → 363 → 387      (PageDown, +24 rendered rows each)
top:  387 → 363 → 339 → 315 → 1      (PageUp, exact inverse, clamps at 1)
```

The cursor sits on the top visible row at every step. Press 1 crosses the fold correctly: 10 rows of lines 1–11, then 14 more into the tail.

Also added a `scroll_skips_collapsed_fold_bodies` unit test covering the cross-fold step, the round trip, a step that would land inside a fold, and the unchanged no-fold walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)