### PR TITLE
docs(changelog): fold wrap-index/plugin-budget work into 0.4.6 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Scrolling**
   * **PageUp/PageDown no longer stall crossing a collapsed fold** - a page of scroll budget was spent stepping through the fold's hidden lines; a fold now costs one row, like its header.
   * **A residual cursor stall moving through revealed Markdown syntax** is fixed (#1574).
-* **A busy plugin (e.g. Grep in Project) can no longer freeze the editor** - plugin-triggered work now runs off the UI thread under a per-frame budget instead of blocking rendering for seconds.
+* **Heavy background work can no longer freeze the editor** - grep-in-project, closing a terminal, and other plugin- or buffer-triggered work now run off the UI thread under a per-frame budget instead of blocking rendering for seconds.
 * **Dashboard**
   * **A misbehaving section can no longer break the panel or hang the dock** - overflow, errors and slow sections are now contained and refresh independently, showing "stale" instead of freezing or blanking.
+* **`fresh --cmd` from an agent terminal no longer hangs forever** - the command channel wasn't drained in every host, so `cmd list`/`cmd run` calls could block indefinitely; a stuck request now times out with a diagnosable error instead (#2837).
+* **Settings → Status Bar picker's cursor is now visible, and clicking a row works** - arrows previously moved an invisible selection with no indication of which list (Available/Included) had the keyboard.
 * **Terminal**
   * **A new terminal no longer inherits another's scrollback**, and a restored one comes back live rather than frozen (#2828).
   * **Scroll-back re-wraps when the pane resizes** - splitting, maximizing or dropping a tab left every line clipped (#2844).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * **Viewing one no longer pins a CPU core** (#2838, reported by @lovehumans).
   * **Highlighting survives past the first wrapped rows**, and the wheel no longer snaps to a 100 KB boundary (#2843).
   * **Typing and cursor movement no longer slow down** as the cursor moves right.
+* **Scrolling**
+  * **PageUp/PageDown no longer stall crossing a collapsed fold** - a page of scroll budget was spent stepping through the fold's hidden lines; a fold now costs one row, like its header.
+  * **A residual cursor stall moving through revealed Markdown syntax** is fixed (#1574).
+* **A busy plugin (e.g. Grep in Project) can no longer freeze the editor** - plugin-triggered work now runs off the UI thread under a per-frame budget instead of blocking rendering for seconds.
+* **Dashboard**
+  * **A misbehaving section can no longer break the panel or hang the dock** - overflow, errors and slow sections are now contained and refresh independently, showing "stale" instead of freezing or blanking.
 * **Terminal**
   * **A new terminal no longer inherits another's scrollback**, and a restored one comes back live rather than frozen (#2828).
   * **Scroll-back re-wraps when the pane resizes** - splitting, maximizing or dropping a tab left every line clipped (#2844).
@@ -52,7 +58,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Internals
 
-* Flaky-e2e-test stabilization across the review-diff line-staging and orchestrator-dock suites.
+* Continued the viewport/wrap-index rebuild (a single coordinate system that now also models folds and decorations) and moved plugin-triggered work off the editor thread under a frame budget, plus further flaky-e2e-test stabilization across the review-diff line-staging, scrolling, vi-mode and orchestrator-dock suites.
 
 ## 0.4.5
 


### PR DESCRIPTION
## Summary
- The 0.4.6 `CHANGELOG.md` section (added in #2852) was drafted before 103 more commits landed on `master` (the wrap-index/viewport-placement rebuild, off-loop plugin scheduling, and other fixes).
- **Note:** the initial pass here ran against a shallow clone whose history happened to stop right at the changelog-prep commit's ancestor boundary, so `v0.4.5` didn't resolve as an ancestor of `HEAD` and only ~50 of the 153 new commits were visible. After unshallowing the clone, `v0.4.5` correctly resolves as an ancestor and the full range was re-audited, turning up two more real fixes that the first pass missed.
- This updates the existing (unreleased) `## 0.4.6` section to cover the user-facing fixes from the full `v0.4.5..HEAD` range instead of leaving them undocumented:
  - PageUp/PageDown no longer stall crossing a collapsed fold.
  - A residual cursor stall moving through revealed Markdown syntax is fixed (#1574).
  - Heavy background work (grep-in-project, terminal close, other plugin/buffer work) can no longer freeze the editor.
  - A misbehaving Dashboard section can no longer break the panel or hang the dock.
  - `fresh --cmd` from an agent terminal no longer hangs forever (#2837).
  - The Settings → Status Bar Available/Included picker's cursor is now visible and clicking a row works.
  - Internals bullet expanded to mention the viewport/wrap-index rebuild and the frame-budgeted plugin scheduling, plus additional flaky-e2e stabilization.
- No other section of `CHANGELOG.md` was touched — verified `git diff v0.4.5..HEAD -- CHANGELOG.md` shows only additions inside the new `## 0.4.6` section, with every prior tagged section byte-identical to its `v0.4.5` state.

## Test plan
- [x] `git diff v0.4.5..HEAD -- CHANGELOG.md` contains only additions, confined to the `## 0.4.6` section (re-verified against the full, unshallowed history)
- [x] Every `#NNNN` cited in the new bullets corresponds to a fix actually present in `v0.4.5..HEAD`
- [x] No attribution to `sinelaw` or `claude` in the new content (all of the covered commits are internal/owner work)
- [x] No mention of the Web UI (one of the newly-reviewed commits, #2837, touches the web bridge and GUI daemon paths too, but the described fix and wording here cover only the non-stealth daemon/agent-terminal behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLC39u4hqac5oFxdPJGgTB