### PR TITLE
Restored terminals mint a new command token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **A restored agent terminal can drive the editor again** - the capability token behind `fresh --cmd` is per-process, so it cannot be persisted, and workspace restore (and PTY respawn) brought terminals back without minting a replacement. A restored agent saw `FRESH_SESSION` but no `FRESH_CMD_TOKEN`, so every `script run` it attempted failed with "no capability token" until the terminal was recreated from scratch.
 * **Four dead settings** - the bracket-matching toggles, `file_explorer.respect_gitignore` and `languages.<id>.textmate_grammar` now take effect; `editor.highlight_timeout_ms` was removed rather than wired up (#2842).
 * **Files that are one very long line**
   * **Viewing one no longer pins a CPU core** (#2838, reported by @lovehumans).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
-* **A restored agent terminal can drive the editor again** - the capability token behind `fresh --cmd` is per-process, so it cannot be persisted, and workspace restore (and PTY respawn) brought terminals back without minting a replacement. A restored agent saw `FRESH_SESSION` but no `FRESH_CMD_TOKEN`, so every `script run` it attempted failed with "no capability token" until the terminal was recreated from scratch.
+* **A restored agent terminal can drive the editor again** - restore and terminal restart now mint a new `fresh --cmd` capability token instead of bringing the terminal back without one.
 * **Four dead settings** - the bracket-matching toggles, `file_explorer.respect_gitignore` and `languages.<id>.textmate_grammar` now take effect; `editor.highlight_timeout_ms` was removed rather than wired up (#2842).
 * **Files that are one very long line**
   * **Viewing one no longer pins a CPU core** (#2838, reported by @lovehumans).

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -81,7 +81,7 @@ mod split_actions;
 mod stdin_stream;
 mod tab_drag;
 mod terminal;
-pub use terminal::PluginTerminalSpec;
+pub use terminal::{agent_command_env, PluginTerminalSpec};
 mod terminal_input;
 mod terminal_link;
 mod terminal_mouse;

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -97,10 +97,11 @@ pub struct PluginTerminalSpec {
     pub persistent: bool,
     pub command: Option<Vec<String>>,
     pub title: Option<String>,
-    /// Extra environment variables applied to the terminal's child
-    /// process, on top of the inherited + activated env. Applied after
-    /// the control vars (`TERM`, `FRESH_SESSION`). Empty adds nothing.
-    pub env: HashMap<String, String>,
+    /// Extra environment applied to the terminal's child process, on top of
+    /// the inherited + activated env and after the control vars (`TERM`,
+    /// `FRESH_SESSION`). Built by [`agent_command_env`], which decides whether
+    /// this terminal carries the editor-control capability.
+    pub env: crate::services::terminal::TerminalEnv,
 }
 
 /// Assemble the extra env for a terminal that hosts an agent which may drive
@@ -121,15 +122,21 @@ pub struct PluginTerminalSpec {
 /// plugin would", which belongs only in terminals a caller explicitly grants it
 /// to, not in every spawned subprocess.
 ///
-/// Shared by `create_window_with_terminal` (agents born in a new window) and
-/// `handle_create_terminal` (agents spawned into an existing window) so both
-/// paths mint and inject identically. `base_env` seeds the map (plugin-supplied
-/// env, empty when omitted).
-pub(crate) fn agent_command_env(
+/// The single constructor for [`TerminalEnv`], and so the one place any
+/// terminal's env is assembled: first launch, workspace restore, and PTY
+/// respawn all land here. `TerminalEnv` is otherwise unconstructible, which is
+/// what stops a new spawn path from quietly passing an empty map and returning
+/// a terminal that has silently lost the capability — restore and respawn each
+/// used to build their env inline, and both dropped the token that way.
+///
+/// Callers that legitimately grant nothing pass `allow_script: false`; they
+/// still get `FRESH_BIN`, and the grant question stays visible at the call site.
+/// `base_env` seeds the map (plugin-supplied env, empty when omitted).
+pub fn agent_command_env(
     window: fresh_core::WindowId,
     base_env: Option<HashMap<String, String>>,
     allow_script: bool,
-) -> HashMap<String, String> {
+) -> crate::services::terminal::TerminalEnv {
     let mut env = base_env.unwrap_or_default();
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe) = exe.to_str() {
@@ -159,7 +166,7 @@ pub(crate) fn agent_command_env(
         ));
         env.insert("FRESH_CMD_TOKEN".to_string(), token);
     }
-    env
+    crate::services::terminal::TerminalEnv::from_assembled(env)
 }
 
 /// Build a [`TerminalWrapper`] that runs `argv` directly as a local PTY child,
@@ -277,7 +284,7 @@ impl Window {
         cwd: Option<PathBuf>,
         persistent: bool,
         command_override: Option<Vec<String>>,
-        extra_env: HashMap<String, String>,
+        extra_env: crate::services::terminal::TerminalEnv,
     ) -> Option<TerminalId> {
         self.spawn_terminal_session_impl(cwd, persistent, command_override, extra_env, false)
     }
@@ -292,7 +299,7 @@ impl Window {
         cwd: Option<PathBuf>,
         persistent: bool,
         command_override: Option<Vec<String>>,
-        extra_env: HashMap<String, String>,
+        extra_env: crate::services::terminal::TerminalEnv,
     ) -> Option<TerminalId> {
         self.spawn_terminal_session_impl(cwd, persistent, command_override, extra_env, true)
     }
@@ -344,7 +351,7 @@ impl Window {
         cwd: Option<PathBuf>,
         persistent: bool,
         command_override: Option<Vec<String>>,
-        extra_env: HashMap<String, String>,
+        extra_env: crate::services::terminal::TerminalEnv,
         force_local: bool,
     ) -> Option<TerminalId> {
         let (cols, rows) = self.get_terminal_dimensions();
@@ -404,6 +411,9 @@ impl Window {
             let env_delta = self.terminal_env_delta(&wrapper);
             (wrapper, env_delta)
         };
+        // Read the grant before the env moves into the spawn, so it can be
+        // recorded here rather than by each caller.
+        let grants_script = extra_env.grants_script();
         match self.terminal_manager.spawn(
             cols,
             rows,
@@ -430,6 +440,9 @@ impl Window {
                 }
                 if !persistent {
                     self.ephemeral_terminals.insert(terminal_id);
+                }
+                if grants_script {
+                    self.script_terminals.insert(terminal_id);
                 }
                 Some(terminal_id)
             }
@@ -919,7 +932,9 @@ impl Window {
         // `None` command override — `Open Terminal` always spawns the
         // user's shell, never a one-off command. Plugin-driven
         // terminals route through `create_plugin_terminal` instead.
-        let terminal_id = self.spawn_terminal_session(None, true, None, HashMap::new())?;
+        // A plain user shell: no capability granted, but the decision is stated.
+        let terminal_id =
+            self.spawn_terminal_session(None, true, None, agent_command_env(self.id, None, false))?;
         let split_id = self
             .buffers
             .splits()
@@ -946,8 +961,12 @@ impl Window {
         argv: Vec<String>,
         title: String,
     ) -> Option<(TerminalId, BufferId)> {
-        let terminal_id =
-            self.spawn_local_terminal_session(None, true, Some(argv), HashMap::new())?;
+        let terminal_id = self.spawn_local_terminal_session(
+            None,
+            true,
+            Some(argv),
+            agent_command_env(self.id, None, false),
+        )?;
         let split_id = self
             .buffers
             .splits()
@@ -1097,6 +1116,9 @@ impl Window {
                 .filter(|argv| !argv.is_empty())
                 .cloned();
             let ephemeral = self.ephemeral_terminals.contains(&old_id);
+            // The reborn PTY needs a *new* token: the old one died with the
+            // process that minted it. Carry the grant, not the token.
+            let allow_script = self.script_terminals.contains(&old_id);
 
             let spawn = RespawnSpec {
                 old_id,
@@ -1108,6 +1130,7 @@ impl Window {
                 resume_argv,
                 launch_argv,
                 ephemeral,
+                allow_script,
             };
             match self.respawn_terminal_pty(buffer_id, spawn) {
                 Some(_) => revived += 1,
@@ -1162,7 +1185,9 @@ impl Window {
             crate::services::terminal::BackingMode::Continue,
             wrapper,
             env_delta,
-            HashMap::new(),
+            // Re-mint rather than reuse: the previous token is bound to the
+            // process that issued it, so a reborn PTY needs its own.
+            agent_command_env(self.id, None, spec.allow_script),
         ) {
             Ok(id) => id,
             Err(e) => {
@@ -1189,6 +1214,10 @@ impl Window {
             self.terminal_commands.remove(&spec.old_id);
             self.terminal_resume_commands.remove(&spec.old_id);
             self.ephemeral_terminals.remove(&spec.old_id);
+            self.script_terminals.remove(&spec.old_id);
+        }
+        if spec.allow_script {
+            self.script_terminals.insert(new_id);
         }
         if let Some(p) = spec.backing_path {
             self.terminal_backing_files.insert(new_id, p);
@@ -1294,8 +1323,10 @@ impl Window {
             .filter(|argv| !argv.is_empty() && self.resources.config.terminal.resume_agents);
         let launch_argv = exited.command.clone().filter(|argv| !argv.is_empty());
 
+        let allow_script = self.script_terminals.contains(&exited.terminal_id);
         let spec = RespawnSpec {
             old_id: exited.terminal_id,
+            allow_script,
             cols: exited.cols,
             rows: exited.rows,
             cwd: exited.cwd.clone(),
@@ -1352,6 +1383,9 @@ struct RespawnSpec {
     resume_argv: Option<Vec<String>>,
     launch_argv: Option<Vec<String>>,
     ephemeral: bool,
+    /// Whether the dead terminal held the editor-control grant, and so whether
+    /// the replacement PTY gets a freshly minted token.
+    allow_script: bool,
 }
 
 impl Editor {
@@ -1366,8 +1400,9 @@ impl Editor {
     /// placeholder buffer that would linger as a phantom tab).
     pub(crate) fn spawn_terminal_session(&mut self) -> Option<TerminalId> {
         // No command override — see comment on `Window::open_terminal_in_window`.
+        let env = agent_command_env(self.active_window().id, None, false);
         self.active_window_mut()
-            .spawn_terminal_session(None, true, None, HashMap::new())
+            .spawn_terminal_session(None, true, None, env)
     }
 
     /// Open a new terminal in the active window's current split, fire

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -880,6 +880,12 @@ pub struct Window {
     /// user-opened terminals are absent and persist as before.
     pub ephemeral_terminals: std::collections::HashSet<crate::services::terminal::TerminalId>,
 
+    /// Terminals granted editor control (`FRESH_CMD_TOKEN`) at spawn. The
+    /// token itself is per-process and cannot outlive a restart, so this
+    /// records the *grant* rather than the token: respawn re-mints from it,
+    /// and the workspace serialiser persists it so restore can too.
+    pub script_terminals: std::collections::HashSet<crate::services::terminal::TerminalId>,
+
     /// Argv each terminal was spawned with, when it ran a command other
     /// than the plain shell (e.g. an Orchestrator agent). Captured at spawn
     /// and persisted into the workspace so a restored workspace re-runs the
@@ -2222,6 +2228,7 @@ impl Window {
             pending_file_poll_rx: None,
             pending_dir_poll_rx: None,
             ephemeral_terminals: std::collections::HashSet::new(),
+            script_terminals: std::collections::HashSet::new(),
             terminal_commands: std::collections::HashMap::new(),
             terminal_resume_commands: std::collections::HashMap::new(),
             exited_terminals: HashMap::new(),

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -911,7 +911,10 @@ impl crate::app::window::Window {
             crate::services::terminal::BackingMode::Continue,
             wrapper_for_spawn,
             env_delta,
-            std::collections::HashMap::new(),
+            // A restored agent terminal needs a *new* token — the one it was
+            // spawned with died with the previous editor process. Without this
+            // it comes back able to see `FRESH_SESSION` but unable to use it.
+            crate::app::terminal::agent_command_env(self.id, None, terminal.allow_script),
         ) {
             Ok(id) => id,
             Err(e) => {
@@ -945,6 +948,9 @@ impl crate::app::window::Window {
                 self.terminal_resume_commands
                     .insert(terminal_id, resume.argv.clone());
             }
+        }
+        if terminal.allow_script {
+            self.script_terminals.insert(terminal_id);
         }
 
         // Create buffer for this terminal
@@ -2522,6 +2528,7 @@ impl crate::app::window::Window {
                     agent_resume,
                     exited: None,
                     title,
+                    allow_script: self.script_terminals.contains(&terminal_id),
                 });
             }
         }
@@ -2570,6 +2577,9 @@ impl crate::app::window::Window {
                 // The pre-exit tab title, not the "(exited)" form the tab is
                 // showing now — restore re-applies the marker itself.
                 title: exited.title.clone(),
+                // Nothing is spawned for an exited terminal, but the restart
+                // offer stays armed — so the grant has to survive with it.
+                allow_script: self.script_terminals.contains(&exited.terminal_id),
             });
         }
 

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -32,6 +32,43 @@ use std::thread;
 
 pub use fresh_core::TerminalId;
 
+/// The extra environment injected into a spawned terminal's child — `FRESH_BIN`
+/// always, plus `FRESH_CMD_TOKEN` when the terminal is granted editor control.
+///
+/// Deliberately opaque, with no `Default` and no public constructor: the only
+/// way to obtain one is [`crate::app::terminal::agent_command_env`], which
+/// takes an explicit `allow_script` and mints the token. That makes the grant a
+/// question every spawn path is *forced* to answer, rather than one it can skip
+/// by passing an empty map.
+///
+/// This matters because the capability is per-process and unforgeable: a
+/// terminal that comes back from workspace restore or a PTY respawn without a
+/// freshly minted token can never drive the editor again, and the failure is
+/// invisible until the user runs a command that needs it. Restore and respawn
+/// are exactly the paths that used to construct their env inline.
+#[derive(Debug, Clone)]
+pub struct TerminalEnv(HashMap<String, String>);
+
+impl TerminalEnv {
+    /// Wrap an assembled env map. Crate-visible so `agent_command_env` — which
+    /// owns the minting decision — can build one; call *that*, not this.
+    pub(crate) fn from_assembled(vars: HashMap<String, String>) -> Self {
+        Self(vars)
+    }
+
+    /// Whether this env carries the editor-control capability. The spawn path
+    /// uses it to record the grant centrally, so no individual caller has to
+    /// remember to — and a respawn can re-mint for exactly the terminals that
+    /// had it.
+    pub(crate) fn grants_script(&self) -> bool {
+        self.0.contains_key("FRESH_CMD_TOKEN")
+    }
+
+    fn into_map(self) -> HashMap<String, String> {
+        self.0
+    }
+}
+
 /// What a spawning terminal should do with the on-disk transcripts (rendered
 /// scrollback + raw PTY log) it is handed.
 ///
@@ -327,6 +364,8 @@ impl TerminalManager {
     /// * `backing_path` - Optional path for rendered scrollback (incremental streaming)
     /// * `backing_mode` - Whether this terminal *continues* the transcript
     ///   already in those files (restore / respawn) or starts a new one
+    /// * `extra_env` - See [`TerminalEnv`]: every spawn path must state whether
+    ///   this terminal carries the agent capability
     ///
     /// # Returns
     /// The terminal ID if successful
@@ -341,7 +380,7 @@ impl TerminalManager {
         backing_mode: BackingMode,
         terminal_wrapper: crate::services::authority::TerminalWrapper,
         env_delta: crate::services::env_provider::EnvDelta,
-        extra_env: HashMap<String, String>,
+        extra_env: TerminalEnv,
     ) -> Result<TerminalId, String> {
         let id = TerminalId(self.next_id);
         self.next_id += 1;
@@ -382,9 +421,10 @@ impl TerminalManager {
         backing_mode: BackingMode,
         terminal_wrapper: TerminalWrapper,
         env_delta: crate::services::env_provider::EnvDelta,
-        extra_env: HashMap<String, String>,
+        extra_env: TerminalEnv,
     ) -> Result<TerminalHandle, String> {
         let pty_pair = open_pty(cols, rows)?;
+        let extra_env = extra_env.into_map();
 
         // The active authority's terminal wrapper drives the shell command
         // unconditionally — local wraps `detect_shell()` with no args;

--- a/crates/fresh-editor/src/services/terminal/mod.rs
+++ b/crates/fresh-editor/src/services/terminal/mod.rs
@@ -54,7 +54,7 @@ pub mod term;
 #[cfg(windows)]
 pub mod windows_shell;
 
-pub use manager::{detect_shell, BackingMode, TerminalId, TerminalManager};
+pub use manager::{detect_shell, BackingMode, TerminalEnv, TerminalId, TerminalManager};
 pub use term::{PrependedHead, TerminalCell, TerminalState};
 #[cfg(windows)]
 pub use windows_shell::set_skip_app_execution_alias;

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -493,6 +493,13 @@ pub struct SerializedTerminalWorkspace {
     /// `command`. Absent in older workspaces and for plain terminals.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_resume: Option<AgentResume>,
+    /// Whether this terminal was granted editor control at spawn, i.e. it ran
+    /// an agent that may drive this editor. The capability token itself is
+    /// per-process and unforgeable, so it cannot be persisted — only the grant
+    /// can, and restore mints a fresh token from it. Absent (false) in
+    /// workspaces written before this field existed, and for plain terminals.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub allow_script: bool,
     /// Set when this terminal's process had already quit at save time.
     ///
     /// Restore then brings the buffer back as read-only scrollback with the

--- a/crates/fresh-editor/tests/e2e/blog_showcases.rs
+++ b/crates/fresh-editor/tests/e2e/blog_showcases.rs
@@ -5048,6 +5048,7 @@ impl Pool {
             for f in files {
                 h.open_file(&root.join(f)).unwrap();
             }
+            let window_id = h.editor().active_window().id;
             h.editor_mut()
                 .active_window_mut()
                 .create_plugin_terminal(fresh::app::PluginTerminalSpec {
@@ -5066,7 +5067,7 @@ impl Pool {
                         agent.to_string(),
                     ]),
                     title: Some(agent.to_string()),
-                    env: std::collections::HashMap::new(),
+                    env: fresh::app::agent_command_env(window_id, None, false),
                 })
                 .expect("agent terminal should spawn");
             h.tick_and_render().unwrap();

--- a/crates/fresh-editor/tests/e2e/restored_agent_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/restored_agent_terminal.rs
@@ -46,6 +46,7 @@ fn session_config() -> Config {
 /// `terminal_commands` entry marking it as a restorable *session* terminal.
 fn spawn_agent_terminal(window: &mut fresh::app::window::Window, argv: &[&str]) {
     let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+    let window_id = window.id;
     let (terminal_id, _buffer_id, _leaf) = window
         .create_plugin_terminal(fresh::app::PluginTerminalSpec {
             cwd: None,
@@ -55,7 +56,7 @@ fn spawn_agent_terminal(window: &mut fresh::app::window::Window, argv: &[&str]) 
             persistent: false, // ephemeral — exactly the Orchestrator agent case
             command: Some(argv.clone()),
             title: None,
-            env: std::collections::HashMap::new(),
+            env: fresh::app::agent_command_env(window_id, None, false),
         })
         .expect("agent terminal should spawn");
     // create_window_with_terminal records this marker; mirror it here so the
@@ -73,6 +74,7 @@ fn spawn_resumable_agent_terminal(
 ) {
     let launch: Vec<String> = launch.iter().map(|s| s.to_string()).collect();
     let resume: Vec<String> = resume.iter().map(|s| s.to_string()).collect();
+    let window_id = window.id;
     let (terminal_id, _buffer_id, _leaf) = window
         .create_plugin_terminal(fresh::app::PluginTerminalSpec {
             cwd: None,
@@ -82,11 +84,131 @@ fn spawn_resumable_agent_terminal(
             persistent: false,
             command: Some(launch.clone()),
             title: None,
-            env: std::collections::HashMap::new(),
+            env: fresh::app::agent_command_env(window_id, None, false),
         })
         .expect("agent terminal should spawn");
     window.terminal_commands.insert(terminal_id, launch);
     window.terminal_resume_commands.insert(terminal_id, resume);
+}
+
+/// Like `spawn_agent_terminal`, but grants the terminal editor control — the
+/// `allow_script` case, where `agent_command_env` mints a `FRESH_CMD_TOKEN`
+/// into the child's environment.
+fn spawn_granted_agent_terminal(window: &mut fresh::app::window::Window, argv: &[&str]) {
+    let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+    let window_id = window.id;
+    let (terminal_id, _buffer_id, _leaf) = window
+        .create_plugin_terminal(fresh::app::PluginTerminalSpec {
+            cwd: None,
+            direction: None,
+            ratio: None,
+            focus: true,
+            persistent: false,
+            command: Some(argv.clone()),
+            title: None,
+            env: fresh::app::agent_command_env(window_id, None, true),
+        })
+        .expect("agent terminal should spawn");
+    window.terminal_commands.insert(terminal_id, argv);
+}
+
+/// A restored agent terminal comes back able to drive the editor.
+///
+/// The capability token is per-process and unforgeable, so it cannot be
+/// persisted — restore has to mint a *new* one. Before the fix, restore (and
+/// PTY respawn) built the child env inline as an empty map, so a restored agent
+/// came back with `FRESH_SESSION` but no `FRESH_CMD_TOKEN`: every
+/// `fresh --cmd script …` it ran failed with "no capability token", silently,
+/// until the terminal was recreated from scratch.
+///
+/// Observed through the child process itself: the agent's argv writes its own
+/// `$FRESH_CMD_TOKEN` to a sentinel file. The sentinel is removed between the
+/// two sessions, so what lands there after restore came from the restored
+/// child. Asserting the token is *live* in this process — not merely non-empty
+/// — is what proves it was re-minted rather than carried over as a stale
+/// string.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses a Unix shell command
+fn test_restored_agent_terminal_gets_a_fresh_command_token() {
+    if !pty_available() {
+        eprintln!("Skipping restored-agent-token test: PTY not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    let sentinels = temp_dir.path().join("sentinels");
+    std::fs::create_dir(&sentinels).unwrap();
+    let token_file = sentinels.join("TOKEN");
+    // Write the token the child actually received, then stay alive so the
+    // terminal is live (not exited) at save time.
+    let cmd = format!(
+        "printf '%s' \"${{FRESH_CMD_TOKEN:-}}\" > '{}'; exec sleep 30",
+        token_file.display()
+    );
+    let argv = ["sh", "-c", cmd.as_str()];
+
+    // ---- Session 1: a granted agent terminal, then save. ----
+    {
+        let mut harness = EditorTestHarness::create(
+            120,
+            30,
+            HarnessOptions::new()
+                .with_config(session_config())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        spawn_granted_agent_terminal(harness.editor_mut().active_window_mut(), &argv);
+        harness.render().unwrap();
+        harness
+            .wait_until(|_| std::fs::read(&token_file).is_ok_and(|b| !b.is_empty()))
+            .expect("a granted terminal should receive a token when first spawned");
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Drop the first session's token so the file can only be repopulated by
+    // the restored child.
+    std::fs::remove_file(&token_file).unwrap();
+
+    // ---- Session 2: restart; the restored agent must get a new token. ----
+    {
+        let mut harness = EditorTestHarness::create(
+            120,
+            30,
+            HarnessOptions::new()
+                .with_config(session_config())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "session should have been restored");
+        harness.render().unwrap();
+
+        // Without the fix this never arrives: the restored child is spawned
+        // with an empty extra env, so `$FRESH_CMD_TOKEN` expands to "" and the
+        // sentinel stays empty.
+        harness
+            .wait_until(|_| std::fs::read(&token_file).is_ok_and(|b| !b.is_empty()))
+            .expect("a restored agent terminal should be given a command token");
+
+        let token = std::fs::read_to_string(&token_file).unwrap();
+        assert!(
+            fresh::server::command_access::may_script(token.trim()),
+            "the restored terminal's token should be live in this process, \
+             i.e. freshly minted rather than a stale value from the last run"
+        );
+    }
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/restored_terminal_dock_activation.rs
+++ b/crates/fresh-editor/tests/e2e/restored_terminal_dock_activation.rs
@@ -56,6 +56,7 @@ fn session_config() -> Config {
 /// workspace-save persists it.
 fn spawn_session_terminal(window: &mut fresh::app::window::Window, argv: &[&str]) {
     let argv: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+    let window_id = window.id;
     let (terminal_id, _buffer_id, _leaf) = window
         .create_plugin_terminal(PluginTerminalSpec {
             cwd: None,
@@ -65,7 +66,7 @@ fn spawn_session_terminal(window: &mut fresh::app::window::Window, argv: &[&str]
             persistent: false,
             command: Some(argv.clone()),
             title: None,
-            env: std::collections::HashMap::new(),
+            env: fresh::app::agent_command_env(window_id, None, false),
         })
         .expect("session terminal should spawn");
     window.terminal_commands.insert(terminal_id, argv);

--- a/crates/fresh-editor/tests/e2e/terminal_link.rs
+++ b/crates/fresh-editor/tests/e2e/terminal_link.rs
@@ -94,6 +94,7 @@ fn open_terminal_with_output(
     output: &[u8],
     visible_marker: &str,
 ) -> (TerminalId, BufferId) {
+    let window_id = harness.editor().active_window().id;
     let (terminal_id, buffer_id, _leaf) = harness
         .editor_mut()
         .active_window_mut()
@@ -105,7 +106,7 @@ fn open_terminal_with_output(
             persistent: false,
             command: Some(vec!["sleep".into(), "30".into()]),
             title: None,
-            env: std::collections::HashMap::new(),
+            env: fresh::app::agent_command_env(window_id, None, false),
         })
         .expect("spawn sleep terminal");
     harness.editor_mut().enter_terminal_mode();


### PR DESCRIPTION
## The bug

The capability token behind `fresh --cmd` is minted per process into an in-memory table, so it cannot outlive the editor that issued it.

Only the two *creation* paths went through `agent_command_env` to mint one — `create_window_with_terminal` and `handle_create_terminal`. Workspace restore and PTY respawn each assembled the child env inline as `HashMap::new()`:

- `app/workspace.rs` — startup restore
- `app/terminal.rs` — `respawn_terminal_pty` (remote reconnect, and the user-driven terminal restart)

A restored agent terminal came back with `FRESH_SESSION` and `FRESH_BIN` — both injected universally by the terminal manager — but no `FRESH_CMD_TOKEN`. Every `fresh --cmd script run` from it was refused with `no capability token: script evaluation is not authorized`, permanently, until the terminal was recreated from scratch.

That asymmetry is what made it invisible: the CLI looks correctly wired up right up until you run the one verb that needs the grant.

## The fix

Carry the *grant*, not the token — the token can't be persisted, but the decision to grant it can.

- `Window::script_terminals` records which terminals hold editor control. It is remapped on respawn alongside the other terminal-id-keyed maps, and persisted as `allow_script` on `SerializedTerminalWorkspace` (`#[serde(default)]`, so older workspaces load unchanged).
- Restore and respawn both mint a fresh token from it.

## Making it hard to reintroduce

`TerminalManager::spawn` no longer accepts a bare `HashMap`. It takes `TerminalEnv`, whose only constructor is `agent_command_env` — the function that owns the minting decision and takes an explicit `allow_script`. An empty env is no longer expressible by accident, and every spawn path is forced to answer the grant question.

The spawn path also reads the grant back off the env (`TerminalEnv::grants_script`) and registers it centrally, so no individual caller has to remember to. This follows CONTRIBUTING guideline 15 — prefer types that rule out invalid states over runtime guards.

Call sites that legitimately grant nothing now say so (`allow_script: false`) instead of passing an empty map.

## Test

`test_restored_agent_terminal_gets_a_fresh_command_token` in the existing restored-agent e2e suite, following the sentinel-file pattern already used by the agent-resume test.

The agent's argv writes its own `$FRESH_CMD_TOKEN` to a sentinel; the sentinel is deleted between the two sessions, so whatever lands there after restore came from the restored child. It asserts the token is **live in this process** via `command_access::may_script`, not merely non-empty — which is what proves it was re-minted rather than carried over as a stale string.

Semantic waiting throughout (`harness.wait_until`), no timers.