### PR TITLE
Show git hunks and unsaved changes on the scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * If you have customized your status bar, open Settings → **Status Bar** and move **Terminal Restart** from *Available* to *Included* (`Shift+→`) under Left or Right.
 * **Tabs for same-named files say which file they are** - open two `mod.rs` and the tabs read `model/mod.rs` and `view/mod.rs` instead of `mod.rs 1` and `mod.rs 2`. Each tab grows only as much of its path as it takes to be unique, and tabs whose name is already unique are untouched (#2851, requested by @anddimario).
 * **Line-ending indicators** - `↵` at every line break and `␍` for the CR half of a CRLF, both off by default (#2798, requested by @akarinotomoshibi).
-* **Scrollbar markers for plugins** - `editor.setScrollbarMarkers` paints marks on the scrollbar track; live-diff hunks and Markdown headings now use it (#2713, requested by @RetributionByRevenue).
+* **Scrollbar markers for plugins** - `editor.setScrollbarMarkers` paints marks on the scrollbar track; git-gutter hunks, live-diff hunks and Markdown headings now use it (#2713, requested by @RetributionByRevenue).
 * **File Explorer sticky parents** - a nested folder's expanded ancestors stay stacked at the top of the sidebar while you scroll (#2705, by @asukaminato0721).
 * **More graphics, docs and build-file grammars** - GLSL `.glslf`/`.glslv`, Wavefront `.obj`, Doxygen, Windows `.rc`, pkg-config, `.cmake.in` and `CMakeCache.txt` (by @asukaminato0721).
 * **Broader LaTeX ecosystem highlighting** - TeX packages/classes, generated `.aux`/`.toc`, BibLaTeX, ConTeXt, BibTeX and `.bst`, plus `latexmkrc` (by @asukaminato0721).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Tabs for same-named files say which file they are** - open two `mod.rs` and the tabs read `model/mod.rs` and `view/mod.rs` instead of `mod.rs 1` and `mod.rs 2`. Each tab grows only as much of its path as it takes to be unique, and tabs whose name is already unique are untouched (#2851, requested by @anddimario).
 * **Line-ending indicators** - `↵` at every line break and `␍` for the CR half of a CRLF, both off by default (#2798, requested by @akarinotomoshibi).
 * **Scrollbar markers for plugins** - `editor.setScrollbarMarkers` paints marks on the scrollbar track; git-gutter hunks, live-diff hunks and Markdown headings now use it (#2713, requested by @RetributionByRevenue).
+* **Unsaved changes show on the scrollbar** - the blue gutter bar for edits you haven't saved now has a matching mark on the track, so a change you left ten screens up is visible without scrolling to find it.
 * **File Explorer sticky parents** - a nested folder's expanded ancestors stay stacked at the top of the sidebar while you scroll (#2705, by @asukaminato0721).
 * **More graphics, docs and build-file grammars** - GLSL `.glslf`/`.glslv`, Wavefront `.obj`, Doxygen, Windows `.rc`, pkg-config, `.cmake.in` and `CMakeCache.txt` (by @asukaminato0721).
 * **Broader LaTeX ecosystem highlighting** - TeX packages/classes, generated `.aux`/`.toc`, BibLaTeX, ConTeXt, BibTeX and `.bst`, plus `latexmkrc` (by @asukaminato0721).

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1006,6 +1006,18 @@ pub struct ScrollbarMarker {
     #[ts(optional)]
     pub end: Option<u32>,
 
+    /// Optional 0-based end line, **inclusive**, making this a range marker.
+    /// Ignored when `end` is present.
+    ///
+    /// The line counterpart to `end`, for producers that work in line
+    /// coordinates — a `git diff` parser knows a hunk's first and last line
+    /// but not their byte offsets. Without it such a plugin has to emit one
+    /// marker per line to paint a hunk's streak, which costs a byte lookup
+    /// and two anchors per line for a resolution the track cannot show.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub end_line: Option<u32>,
+
     /// Marker color — RGB array or theme key. Theme keys resolve at render
     /// time, so markers follow theme changes.
     pub color: OverlayColorSpec,

--- a/crates/fresh-editor/plugins/git_gutter.ts
+++ b/crates/fresh-editor/plugins/git_gutter.ts
@@ -287,8 +287,13 @@ async function updateGitGutter(bufferId: number): Promise<void> {
     // Positions are 0-based logical lines: this plugin never reads the buffer
     // text — it parses `git diff` output — so line numbers are the only
     // coordinate it can supply honestly, and the editor converts each to a byte
-    // anchor at set time against the buffer being decorated. One mark per
-    // changed line paints the same proportional streak a byte range would.
+    // anchor at set time against the buffer being decorated.
+    //
+    // One mark per *hunk*, spanning `line`..`endLine`, not one per changed
+    // line. The track paints the same streak either way, but per-line markers
+    // cost a byte lookup and two anchors each: on a file with 20 000 changed
+    // lines that added ~27 ms to every save, on top of the same again when the
+    // projection re-read them.
     const scrollMarkers: ScrollbarMarker[] = [];
 
     // Apply new indicators
@@ -328,8 +333,15 @@ async function updateGitGutter(bufferId: number): Promise<void> {
             color[2],
             PRIORITY
           );
-          scrollMarkers.push({ line, color, priority: PRIORITY });
         }
+        // `endLine` is inclusive, so a one-line hunk marks one row.
+        const first = Math.max(0, hunk.startLine - 1);
+        scrollMarkers.push({
+          line: first,
+          endLine: Math.max(first, first + hunk.lineCount - 1),
+          color,
+          priority: PRIORITY,
+        });
       }
     }
 

--- a/crates/fresh-editor/plugins/git_gutter.ts
+++ b/crates/fresh-editor/plugins/git_gutter.ts
@@ -13,6 +13,10 @@ const editor = getEditor();
  * - │ (green): Added line
  * - │ (yellow): Modified line
  * - ▾ (red): Deleted line(s) below
+ *
+ * The same hunks are marked on the vertical scrollbar in the same colours, so
+ * uncommitted changes elsewhere in the file are visible without scrolling to
+ * find them.
  */
 
 // =============================================================================
@@ -20,6 +24,9 @@ const editor = getEditor();
 // =============================================================================
 
 const NAMESPACE = "git-gutter";
+/** Scrollbar markers live in their own namespace — a separate decoration
+ *  surface with its own store, so clearing one never disturbs the other. */
+const SCROLL_NAMESPACE = "git-gutter-scroll";
 const PRIORITY = 10; // Lower than diagnostics
 
 // Colors (RGB)
@@ -252,6 +259,7 @@ async function updateGitGutter(bufferId: number): Promise<void> {
       // Clear indicators for non-tracked files
       editor.debug("Git Gutter: file not tracked by git");
       editor.clearLineIndicators(bufferId, NAMESPACE);
+      editor.clearScrollbarMarkers(bufferId, SCROLL_NAMESPACE);
       state.hunks = [];
       // Signal to other plugins that git is not available for this buffer
       editor.setViewState(bufferId, "git_gutter_hunks", null);
@@ -272,6 +280,17 @@ async function updateGitGutter(bufferId: number): Promise<void> {
     // Clear existing indicators
     editor.clearLineIndicators(bufferId, NAMESPACE);
 
+    // Scrollbar marks, collected alongside the gutter glyphs and published in
+    // one batched command below. They reuse the gutter palette deliberately, so
+    // a hunk's glyph and its mark on the track are the same colour.
+    //
+    // Positions are 0-based logical lines: this plugin never reads the buffer
+    // text — it parses `git diff` output — so line numbers are the only
+    // coordinate it can supply honestly, and the editor converts each to a byte
+    // anchor at set time against the buffer being decorated. One mark per
+    // changed line paints the same proportional streak a byte range would.
+    const scrollMarkers: ScrollbarMarker[] = [];
+
     // Apply new indicators
     for (const hunk of hunks) {
       const color = COLORS[hunk.type];
@@ -291,11 +310,14 @@ async function updateGitGutter(bufferId: number): Promise<void> {
           color[2],
           PRIORITY
         );
+        // The deleted lines are gone from the new side, so the mark sits on the
+        // seam where they were — the same line the ▾ glyph points from.
+        scrollMarkers.push({ line, color, priority: PRIORITY });
       } else {
         // Added/modified indicators show on each affected line
         for (let i = 0; i < hunk.lineCount; i++) {
           // Line numbers are 1-indexed in diff, but 0-indexed in editor
-          const line = hunk.startLine - 1 + i;
+          const line = Math.max(0, hunk.startLine - 1 + i);
           editor.setLineIndicator(
             bufferId,
             line,
@@ -306,9 +328,16 @@ async function updateGitGutter(bufferId: number): Promise<void> {
             color[2],
             PRIORITY
           );
+          scrollMarkers.push({ line, color, priority: PRIORITY });
         }
       }
     }
+
+    // Replace the whole namespace in a single command: the diff above covers
+    // the entire file, so this set is complete and authoritative, and swapping
+    // it atomically means a refresh never shows a half-rebuilt track. An empty
+    // set clears the marks, which is what a file with no changes wants.
+    editor.setScrollbarMarkers(bufferId, SCROLL_NAMESPACE, scrollMarkers);
 
     state.hunks = hunks;
 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2435,6 +2435,17 @@ type ScrollbarMarker = {
 	*/
 	end?: number;
 	/**
+	* Optional 0-based end line, **inclusive**, making this a range marker.
+	* Ignored when `end` is present.
+	*
+	* The line counterpart to `end`, for producers that work in line
+	* coordinates — a `git diff` parser knows a hunk's first and last line
+	* but not their byte offsets. Without it such a plugin has to emit one
+	* marker per line to paint a hunk's streak, which costs a byte lookup
+	* and two anchors per line for a resolution the track cannot show.
+	*/
+	endLine?: number;
+	/**
 	* Marker color — RGB array or theme key. Theme keys resolve at render
 	* time, so markers follow theme changes.
 	*/

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -970,6 +970,15 @@ impl TextBuffer {
     /// Diff the current piece tree against the last saved snapshot.
     ///
     /// See `Persistence::diff_since_saved` for the algorithm.
+    /// Version of the state [`Self::diff_since_saved`] compares against.
+    ///
+    /// Changes on save, reload, and the first edit after either. A cache that
+    /// keys only on [`Self::version`] would miss a save, which replaces the
+    /// saved snapshot while leaving the content untouched.
+    pub fn save_state_version(&self) -> u64 {
+        self.persistence.save_state_version()
+    }
+
     pub fn diff_since_saved(&self) -> PieceTreeDiff {
         let _span = tracing::info_span!(
             "diff_since_saved",

--- a/crates/fresh-editor/src/model/buffer/persistence.rs
+++ b/crates/fresh-editor/src/model/buffer/persistence.rs
@@ -43,6 +43,15 @@ pub struct Persistence {
     /// reconstruction. Updated when loading from file or after
     /// saving.
     saved_file_size: Option<usize>,
+
+    /// Bumped by every write to `saved_root` or `modified`.
+    ///
+    /// [`Self::diff_since_saved`]'s answer depends on both, and a save
+    /// changes them without touching the buffer's content version — so a
+    /// render-side cache keyed only on content would keep showing the
+    /// pre-save diff. Consumers fold this in; see
+    /// [`TextBuffer::save_state_version`](super::TextBuffer::save_state_version).
+    save_state_version: u64,
 }
 
 impl Persistence {
@@ -59,7 +68,14 @@ impl Persistence {
             recovery_pending: false,
             saved_root,
             saved_file_size,
+            save_state_version: 0,
         }
+    }
+
+    /// Version of the save state — the pair (`saved_root`, `modified`) that
+    /// [`Self::diff_since_saved`] compares against.
+    pub fn save_state_version(&self) -> u64 {
+        self.save_state_version
     }
 
     pub fn fs(&self) -> &Arc<dyn FileSystem + Send + Sync> {
@@ -92,10 +108,12 @@ impl Persistence {
 
     pub fn set_modified(&mut self, modified: bool) {
         self.modified = modified;
+        self.save_state_version = self.save_state_version.wrapping_add(1);
     }
 
     pub fn clear_modified(&mut self) {
         self.modified = false;
+        self.save_state_version = self.save_state_version.wrapping_add(1);
     }
 
     pub fn is_recovery_pending(&self) -> bool {
@@ -115,6 +133,7 @@ impl Persistence {
     pub(super) fn mark_dirty(&mut self) {
         self.modified = true;
         self.recovery_pending = true;
+        self.save_state_version = self.save_state_version.wrapping_add(1);
     }
 
     pub fn saved_root(&self) -> &Arc<PieceTreeNode> {
@@ -123,6 +142,7 @@ impl Persistence {
 
     pub fn set_saved_root(&mut self, root: Arc<PieceTreeNode>) {
         self.saved_root = root;
+        self.save_state_version = self.save_state_version.wrapping_add(1);
     }
 
     pub fn saved_file_size(&self) -> Option<usize> {
@@ -140,6 +160,7 @@ impl Persistence {
     pub fn mark_saved_snapshot(&mut self, piece_tree: &PieceTree) {
         self.saved_root = piece_tree.root();
         self.modified = false;
+        self.save_state_version = self.save_state_version.wrapping_add(1);
     }
 
     /// Refresh the saved root to match the current tree structure
@@ -150,6 +171,7 @@ impl Persistence {
     pub fn refresh_saved_root_if_unmodified(&mut self, piece_tree: &PieceTree) {
         if !self.modified {
             self.saved_root = piece_tree.root();
+            self.save_state_version = self.save_state_version.wrapping_add(1);
         }
     }
 
@@ -227,6 +249,7 @@ impl Persistence {
 
         if modified {
             self.saved_root = PieceTree::from_leaves(&new_leaves).root();
+            self.save_state_version = self.save_state_version.wrapping_add(1);
         }
     }
 

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -274,9 +274,18 @@ impl ResolvedMarker {
             (None, Some(l)) => line_to_byte(l as usize)?,
             (None, None) => return None,
         };
+        // `end_line` is inclusive, so its *start* byte is the right end
+        // coordinate: the projection maps it to that line's row, which is the
+        // last row the streak should cover. An unresolvable end line degrades
+        // to a point marker rather than dropping the marker entirely.
+        let end = match (marker.end, marker.end_line) {
+            (Some(e), _) => Some(e as usize),
+            (None, Some(l)) => line_to_byte(l as usize),
+            (None, None) => None,
+        };
         Some(Self {
             start,
-            end: marker.end.map(|e| e as usize),
+            end,
             color: marker.color.clone(),
             priority: marker.priority.unwrap_or(0),
         })
@@ -633,6 +642,7 @@ mod tests {
             position: None,
             line: Some(42),
             end: None,
+            end_line: None,
             color: red(),
             priority: None,
         };
@@ -645,12 +655,44 @@ mod tests {
         );
     }
 
+    /// A line-coordinate producer (a `git diff` parser) can span a hunk with
+    /// one marker instead of one per line.
+    #[test]
+    fn from_api_resolves_an_inclusive_end_line() {
+        let m = ScrollbarMarker {
+            position: None,
+            line: Some(10),
+            end: None,
+            end_line: Some(14),
+            color: red(),
+            priority: None,
+        };
+        let r = ResolvedMarker::from_api(&m, |l| Some(l * 10)).unwrap();
+        assert_eq!((r.start, r.end), (100, Some(140)));
+    }
+
+    /// An explicit byte `end` wins, matching how `position` beats `line`.
+    #[test]
+    fn from_api_prefers_byte_end_over_end_line() {
+        let m = ScrollbarMarker {
+            position: Some(0),
+            line: None,
+            end: Some(55),
+            end_line: Some(14),
+            color: red(),
+            priority: None,
+        };
+        let r = ResolvedMarker::from_api(&m, |l| Some(l * 10)).unwrap();
+        assert_eq!(r.end, Some(55));
+    }
+
     #[test]
     fn from_api_prefers_byte_position_over_line() {
         let m = ScrollbarMarker {
             position: Some(7),
             line: Some(42),
             end: None,
+            end_line: None,
             color: red(),
             priority: None,
         };

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -22,7 +22,7 @@
 //! Building it is O(M) in the *marker* count; painting is O(track_height).
 //! Neither term is proportional to file size.
 //!
-//! The buckets are cached and rebuilt only when their [`BucketKey`] changes
+//! The buckets are cached and rebuilt only when their [`ProjectionKey`] changes
 //! (marker set, buffer content, geometry, or basis), so a steady-state frame
 //! costs one key comparison. This is the same version-keyed staleness idiom as
 //! [`crate::view::line_wrap_cache::LineWrapCache`].
@@ -283,16 +283,78 @@ impl ResolvedMarker {
     }
 }
 
+/// Marks the editor contributes itself, alongside the plugin-owned ones.
+///
+/// Today that is the unsaved-change diff (`Buffer::diff_since_saved`): the
+/// same byte ranges that draw the gutter's blue bar, in the same colour, so a
+/// change reads identically on both surfaces. Unlike plugin markers these are
+/// not anchored — they are derived from the buffer's own save snapshot and
+/// recomputed whenever [`ProjectionKey::core_version`] moves, so there is
+/// nothing to keep glued through edits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreMarks {
+    /// Half-open byte ranges in the current buffer.
+    pub ranges: Vec<std::ops::Range<usize>>,
+    pub color: OverlayColorSpec,
+    pub priority: i32,
+}
+
+impl CoreMarks {
+    /// The exact `(start, last covered byte)` pairs the projection looks up.
+    ///
+    /// A range is half-open, so its last covered byte is `end - 1`; projecting
+    /// `end` itself would spill the streak onto the row after the change
+    /// whenever a range stops on a row boundary.
+    ///
+    /// Callers that must pre-resolve coordinates — the logical-line basis
+    /// builds a byte→line map before projecting — have to seed that map from
+    /// *these* bytes. Deriving them in one place is what keeps the two sides
+    /// from disagreeing: a lookup miss would answer row 0 and pile marks at
+    /// the top of the track.
+    pub fn endpoints(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.ranges
+            .iter()
+            .map(|r| (r.start, r.end.saturating_sub(1).max(r.start)))
+    }
+}
+
 /// Cache key for a projected bucket column.
+///
+/// Public so a caller can probe [`ScrollbarMarkerBuckets::cached`] *before*
+/// computing the inputs a rebuild needs — gathering [`CoreMarks`] costs a
+/// whole-buffer diff, which must not happen on a steady-state frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct BucketKey {
+pub struct ProjectionKey {
     marker_version: u64,
     /// Buffer/decoration pipeline version — anchors move when the buffer
     /// changes even if the marker set itself did not.
     content_version: u64,
+    /// Version of the editor-contributed marks. Separate from
+    /// `content_version` because a save changes what they cover without
+    /// changing the content.
+    core_version: u64,
     track_height: u16,
     basis_tag: u8,
     basis_total: u64,
+}
+
+impl ProjectionKey {
+    pub fn new(
+        manager: &ScrollbarMarkerManager,
+        content_version: u64,
+        core_version: u64,
+        basis: MarkerBasis,
+        track_height: usize,
+    ) -> Self {
+        Self {
+            marker_version: manager.version(),
+            content_version,
+            core_version,
+            track_height: track_height.min(u16::MAX as usize) as u16,
+            basis_tag: basis.tag(),
+            basis_total: basis.total(),
+        }
+    }
 }
 
 /// One track cell's winning marker.
@@ -309,7 +371,7 @@ pub struct MarkerCell {
 /// `LineWrapCache` pattern in miniature).
 #[derive(Debug, Default)]
 pub struct ScrollbarMarkerBuckets {
-    entries: Vec<(BucketKey, Vec<Option<MarkerCell>>)>,
+    entries: Vec<(ProjectionKey, Vec<Option<MarkerCell>>)>,
 }
 
 /// How many distinct scrollbar geometries to keep projected at once.
@@ -324,8 +386,16 @@ impl ScrollbarMarkerBuckets {
         self.entries.clear();
     }
 
-    fn lookup(&self, key: &BucketKey) -> Option<usize> {
+    fn lookup(&self, key: &ProjectionKey) -> Option<usize> {
         self.entries.iter().position(|(k, _)| k == key)
+    }
+
+    /// The projection for `key`, if it is still cached.
+    ///
+    /// Lets a caller skip gathering the rebuild's inputs on a hit — see
+    /// [`CoreMarks`].
+    pub fn cached(&self, key: &ProjectionKey) -> Option<&[Option<MarkerCell>]> {
+        self.lookup(key).map(|i| self.entries[i].1.as_slice())
     }
 
     /// Most recently projected column for a track of this height, if one is
@@ -371,24 +441,17 @@ impl ScrollbarMarkerBuckets {
 pub fn project<'a>(
     manager: &ScrollbarMarkerManager,
     buckets: &'a mut ScrollbarMarkerBuckets,
+    key: ProjectionKey,
+    core: Option<&CoreMarks>,
     basis: MarkerBasis,
     track_height: usize,
-    content_version: u64,
     row_of_byte: impl FnMut(usize) -> u64,
 ) -> &'a [Option<MarkerCell>] {
-    let key = BucketKey {
-        marker_version: manager.version(),
-        content_version,
-        track_height: track_height.min(u16::MAX as usize) as u16,
-        basis_tag: basis.tag(),
-        basis_total: basis.total(),
-    };
-
     if let Some(idx) = buckets.lookup(&key) {
         return &buckets.entries[idx].1;
     }
 
-    let cells = build_cells(manager, basis, track_height, row_of_byte);
+    let cells = build_cells(manager, core, basis, track_height, row_of_byte);
 
     if buckets.entries.len() >= MAX_CACHED_PROJECTIONS {
         buckets.entries.remove(0);
@@ -400,6 +463,7 @@ pub fn project<'a>(
 
 fn build_cells(
     manager: &ScrollbarMarkerManager,
+    core: Option<&CoreMarks>,
     basis: MarkerBasis,
     track_height: usize,
     mut row_of_byte: impl FnMut(usize) -> u64,
@@ -411,28 +475,58 @@ fn build_cells(
     let total = basis.total().max(1);
     let h = track_height as u64;
 
-    for m in manager.resolved() {
-        let start_row = (row_of_byte(m.start).min(total.saturating_sub(1)) * h / total) as usize;
-        let end_row = match m.end {
-            Some(e) if e > m.start => {
+    // Core marks are laid down first, so a plugin marker of *equal* priority
+    // painted after them wins the cell — the same order of precedence the
+    // gutter applies between the blue unsaved bar and a plugin indicator.
+    // Core ranges project through `endpoints()` — the same pairs any caller
+    // that pre-resolves coordinates seeded its map from. (Plugin markers keep
+    // their documented exclusive-`end` projection: their ends are
+    // line-relative, where the difference is sub-cell.)
+    let core_marks = core.into_iter().flat_map(|c| {
+        c.endpoints()
+            .map(move |(s, e)| (s, Some(e), &c.color, c.priority))
+    });
+    let plugin_marks = manager
+        .resolved()
+        .into_iter()
+        .map(|m| (m.start, m.end, m.color, m.priority));
+
+    // `resolved()` returns owned colours while `core` lends them, so the two
+    // sources are walked as one sequence of (start, end, colour, priority)
+    // with the colour cloned once, at the cell it wins.
+    let mut paint = |start: usize, end: Option<usize>, color: &OverlayColorSpec, priority: i32| {
+        let start_row = (row_of_byte(start).min(total.saturating_sub(1)) * h / total) as usize;
+        let end_row = match end {
+            Some(e) if e > start => {
                 (row_of_byte(e).min(total.saturating_sub(1)) * h / total) as usize
             }
             _ => start_row,
         };
 
-        let last = end_row.min(track_height - 1);
-        for cell in cells[start_row..=last].iter_mut() {
+        // `max(start_row)` is a guard, not arithmetic: a `row_of_byte` that
+        // answered non-monotonically (a missing entry in a pre-resolved map,
+        // say) would otherwise index a backwards range and panic — in the
+        // render path, where a wrong mark is survivable and a crash is not.
+        let last = end_row.max(start_row).min(track_height - 1);
+        for cell in cells[start_row.min(last)..=last].iter_mut() {
             let better = match cell {
-                Some(existing) => m.priority >= existing.priority,
+                Some(existing) => priority >= existing.priority,
                 None => true,
             };
             if better {
                 *cell = Some(MarkerCell {
-                    color: m.color.clone(),
-                    priority: m.priority,
+                    color: color.clone(),
+                    priority,
                 });
             }
         }
+    };
+
+    for (start, end, color, priority) in core_marks {
+        paint(start, end, color, priority);
+    }
+    for (start, end, color, priority) in plugin_marks {
+        paint(start, end, &color, priority);
     }
 
     cells
@@ -573,16 +667,19 @@ mod tests {
         total: u64,
         track: usize,
     ) -> Vec<Option<MarkerCell>> {
+        project_bytes_with(mgr, None, total, track)
+    }
+
+    fn project_bytes_with(
+        mgr: &ScrollbarMarkerManager,
+        core: Option<&CoreMarks>,
+        total: u64,
+        track: usize,
+    ) -> Vec<Option<MarkerCell>> {
         let mut buckets = ScrollbarMarkerBuckets::new();
-        project(
-            mgr,
-            &mut buckets,
-            MarkerBasis::Bytes { total },
-            track,
-            0,
-            |b| b as u64,
-        )
-        .to_vec()
+        let basis = MarkerBasis::Bytes { total };
+        let key = ProjectionKey::new(mgr, 0, 0, basis, track);
+        project(mgr, &mut buckets, key, core, basis, track, |b| b as u64).to_vec()
     }
 
     #[test]
@@ -659,34 +756,23 @@ mod tests {
         mgr.set_markers("ns", vec![point(500, 0, red())]);
         let mut buckets = ScrollbarMarkerBuckets::new();
 
+        let basis = MarkerBasis::Bytes { total: 1000 };
         let mut calls = 0usize;
         for _ in 0..5 {
-            project(
-                &mgr,
-                &mut buckets,
-                MarkerBasis::Bytes { total: 1000 },
-                10,
-                0,
-                |b| {
-                    calls += 1;
-                    b as u64
-                },
-            );
+            let key = ProjectionKey::new(&mgr, 0, 0, basis, 10);
+            project(&mgr, &mut buckets, key, None, basis, 10, |b| {
+                calls += 1;
+                b as u64
+            });
         }
         assert_eq!(calls, 1, "steady-state frames must not re-project");
 
         mgr.set_markers("ns", vec![point(600, 0, red())]);
-        project(
-            &mgr,
-            &mut buckets,
-            MarkerBasis::Bytes { total: 1000 },
-            10,
-            0,
-            |b| {
-                calls += 1;
-                b as u64
-            },
-        );
+        let key = ProjectionKey::new(&mgr, 0, 0, basis, 10);
+        project(&mgr, &mut buckets, key, None, basis, 10, |b| {
+            calls += 1;
+            b as u64
+        });
         assert_eq!(calls, 2, "a marker change must invalidate the projection");
     }
 
@@ -698,19 +784,14 @@ mod tests {
             m
         };
         let mut buckets = ScrollbarMarkerBuckets::new();
+        let basis = MarkerBasis::Bytes { total: 1000 };
         let mut calls = 0usize;
         for v in [0u64, 0, 1] {
-            project(
-                &mgr,
-                &mut buckets,
-                MarkerBasis::Bytes { total: 1000 },
-                10,
-                v,
-                |b| {
-                    calls += 1;
-                    b as u64
-                },
-            );
+            let key = ProjectionKey::new(&mgr, v, 0, basis, 10);
+            project(&mgr, &mut buckets, key, None, basis, 10, |b| {
+                calls += 1;
+                b as u64
+            });
         }
         assert_eq!(calls, 2);
     }
@@ -720,21 +801,16 @@ mod tests {
         let mut mgr = ScrollbarMarkerManager::new();
         mgr.set_markers("ns", vec![point(500, 0, red())]);
         let mut buckets = ScrollbarMarkerBuckets::new();
+        let basis = MarkerBasis::Bytes { total: 1000 };
         let mut calls = 0usize;
         // Two splits at different heights, alternating frames.
         for _ in 0..4 {
             for h in [10usize, 25] {
-                project(
-                    &mgr,
-                    &mut buckets,
-                    MarkerBasis::Bytes { total: 1000 },
-                    h,
-                    0,
-                    |b| {
-                        calls += 1;
-                        b as u64
-                    },
-                );
+                let key = ProjectionKey::new(&mgr, 0, 0, basis, h);
+                project(&mgr, &mut buckets, key, None, basis, h, |b| {
+                    calls += 1;
+                    b as u64
+                });
             }
         }
         assert_eq!(calls, 2, "each geometry projects once, then stays cached");
@@ -754,5 +830,87 @@ mod tests {
         mgr.set_markers("ns", vec![point(10_000, 0, red())]);
         let cells = project_bytes(&mgr, 1000, 10);
         assert!(cells[9].is_some());
+    }
+
+    // --- editor-contributed marks ---
+
+    fn core(ranges: &[std::ops::Range<usize>], priority: i32) -> CoreMarks {
+        CoreMarks {
+            ranges: ranges.to_vec(),
+            color: blue(),
+            priority,
+        }
+    }
+
+    fn core_one(start: usize, end: usize, priority: i32) -> CoreMarks {
+        core(std::slice::from_ref(&(start..end)), priority)
+    }
+
+    /// The unsaved-change case: no plugin has set anything, and the editor's
+    /// own ranges still reach the track.
+    #[test]
+    fn core_marks_paint_with_no_plugin_markers_at_all() {
+        let mgr = ScrollbarMarkerManager::new();
+        let cells = project_bytes_with(&mgr, Some(&core_one(500, 510, 5)), 1000, 10);
+        assert_eq!(cells[5].as_ref().unwrap().color, blue());
+        assert!(cells[0].is_none() && cells[9].is_none());
+    }
+
+    /// A range spanning a chunk of the file paints a proportional streak, not
+    /// a dot — a big unsaved edit should read as a big mark.
+    #[test]
+    fn core_range_paints_every_row_it_spans() {
+        let mgr = ScrollbarMarkerManager::new();
+        let cells = project_bytes_with(&mgr, Some(&core_one(200, 600, 5)), 1000, 10);
+        let painted: Vec<usize> = cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_some())
+            .map(|(i, _)| i)
+            .collect();
+        // Bytes 200..=599 of 1000 over a 10-row track: rows 2 through 5. Row 6
+        // belongs to byte 600, which the half-open range does not cover.
+        assert_eq!(painted, vec![2, 3, 4, 5]);
+    }
+
+    /// Precedence mirrors the gutter: a plugin marker of equal-or-higher
+    /// priority takes the cell, so a git hunk (10) is never hidden by the
+    /// unsaved-change mark (5) they both land on.
+    #[test]
+    fn plugin_marker_outranks_a_core_mark_on_the_same_cell() {
+        let mut mgr = ScrollbarMarkerManager::new();
+        mgr.set_markers("ns", vec![point(500, 10, red())]);
+        let cells = project_bytes_with(&mgr, Some(&core_one(500, 501, 5)), 1000, 10);
+        assert_eq!(cells[5].as_ref().unwrap().color, red());
+    }
+
+    /// ...and a lower-priority plugin marker does not displace a core mark.
+    #[test]
+    fn core_mark_holds_its_cell_against_a_lower_priority_marker() {
+        let mut mgr = ScrollbarMarkerManager::new();
+        mgr.set_markers("ns", vec![point(500, 1, red())]);
+        let cells = project_bytes_with(&mgr, Some(&core_one(500, 501, 5)), 1000, 10);
+        assert_eq!(cells[5].as_ref().unwrap().color, blue());
+    }
+
+    /// The core version is keyed separately from the content version because a
+    /// save changes what the marks cover without touching the buffer.
+    #[test]
+    fn projection_reruns_when_the_core_version_changes() {
+        let mgr = ScrollbarMarkerManager::new();
+        let mut buckets = ScrollbarMarkerBuckets::new();
+        let basis = MarkerBasis::Bytes { total: 1000 };
+        let marks = core_one(500, 501, 5);
+        let mut calls = 0usize;
+        for core_version in [0u64, 0, 1] {
+            let key = ProjectionKey::new(&mgr, 0, core_version, basis, 10);
+            project(&mgr, &mut buckets, key, Some(&marks), basis, 10, |b| {
+                calls += 1;
+                b as u64
+            });
+        }
+        // A one-byte range needs a single coordinate lookup, so two calls
+        // across the three frames means exactly two rebuilds.
+        assert_eq!(calls, 2, "a save must invalidate the projection");
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -228,6 +228,14 @@ pub(super) fn fold_indicators_for_viewport(
     indicators
 }
 
+/// Colour of the unsaved-change decoration: the gutter bar *and* its mark on
+/// the scrollbar track, so one change never shows up in two different colours.
+pub(crate) const UNSAVED_CHANGE_FG: Color = Color::Rgb(100, 149, 237); // Cornflower blue
+
+/// Priority of the unsaved-change decoration on both surfaces. Below the git
+/// gutter's 10, so a committed-vs-HEAD hunk wins a cell they both want.
+pub(crate) const UNSAVED_CHANGE_PRIORITY: i32 = 5;
+
 /// Compute diff-since-saved indicators for the viewport.
 ///
 /// Calls `diff_since_saved()` to get byte ranges that differ from the saved
@@ -245,11 +253,7 @@ pub(super) fn diff_indicators_for_viewport(
     }
 
     let mut indicators = BTreeMap::new();
-    let indicator = LineIndicator::new(
-        "│",
-        Color::Rgb(100, 149, 237), // Cornflower blue
-        5,                         // Lower priority than git gutter (10)
-    );
+    let indicator = LineIndicator::new("│", UNSAVED_CHANGE_FG, UNSAVED_CHANGE_PRIORITY);
 
     let bytes = state.buffer.slice_bytes(viewport_start..viewport_end);
     if bytes.is_empty() {

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -279,7 +279,13 @@ pub(super) fn diff_indicators_for_viewport(
         for (i, &byte) in bytes[rel_lo..rel_hi].iter().enumerate() {
             if byte == b'\n' {
                 let next_line_start = viewport_start + rel_lo + i + 1;
-                if next_line_start < viewport_end {
+                // `< hi`, not just `< viewport_end`: a range is half-open, so
+                // one ending exactly on a line boundary — which is what
+                // inserting whole lines produces — covers no byte of the line
+                // that starts there. Marking it anyway put a bar on the first
+                // untouched line after every insertion, and that bar then
+                // vanished on save when git reported the real line set.
+                if next_line_start < hi && next_line_start < viewport_end {
                     indicators
                         .entry(next_line_start)
                         .or_insert_with(|| indicator.clone());

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -94,8 +94,79 @@ pub(super) fn scrollbar_line_counts(
     )
 }
 
-/// Project this buffer's plugin scrollbar markers onto a `track_height`-tall
-/// column, reusing the cached projection when nothing relevant changed.
+/// The editor's own contribution to the track: one mark per unsaved-change
+/// range, in the gutter bar's colour and priority.
+///
+/// `diff_since_saved` already returns whole-buffer byte ranges — the gutter
+/// only clips them to the viewport afterwards — so the scrollbar can show
+/// changes that are scrolled off screen without any extra diffing beyond the
+/// call itself. Returns `None` when the buffer matches what was saved, which
+/// is the `!modified` fast path inside the diff.
+fn unsaved_change_marks(
+    state: &EditorState,
+    track_height: usize,
+) -> Option<scrollbar_marker::CoreMarks> {
+    use crate::view::ui::split_rendering::folding::{UNSAVED_CHANGE_FG, UNSAVED_CHANGE_PRIORITY};
+
+    let diff = state.buffer.diff_since_saved();
+    if diff.equal || diff.byte_ranges.is_empty() {
+        return None;
+    }
+    let ranges = coalesce_within_a_cell(diff.byte_ranges, state.buffer.len(), track_height);
+
+    let Color::Rgb(r, g, b) = UNSAVED_CHANGE_FG else {
+        // The constant is an RGB literal; a non-RGB variant would have no
+        // `OverlayColorSpec` spelling and is not reachable.
+        return None;
+    };
+
+    Some(scrollbar_marker::CoreMarks {
+        ranges,
+        color: fresh_core::api::OverlayColorSpec::Rgb(r, g, b),
+        priority: UNSAVED_CHANGE_PRIORITY,
+    })
+}
+
+/// Merge ranges separated by less than one track cell's worth of bytes.
+///
+/// `diff_since_saved` can return thousands of ranges — a replace-all across a
+/// large file, before saving, produces one per hit. Projecting each costs two
+/// coordinate lookups, and `get_line_number` is a O(log n) tree descent
+/// (~0.5 µs measured), so 2 000 raw ranges would put milliseconds on the
+/// *typing* path to draw marks that a ≤200-cell track cannot tell apart.
+///
+/// Merging first bounds the projection at roughly two lookups per track row,
+/// whatever the edit count, and cannot lose a mark: a merged group spans every
+/// range inside it, so the streak painted is a superset of the true one, never
+/// a subset. That makes it a resolution choice rather than a silent cap.
+///
+/// Input from the diff is ascending and disjoint; out-of-order input would
+/// merely merge less, never mis-paint.
+fn coalesce_within_a_cell(
+    ranges: Vec<std::ops::Range<usize>>,
+    buffer_len: usize,
+    track_height: usize,
+) -> Vec<std::ops::Range<usize>> {
+    let cell_bytes = (buffer_len / track_height.max(1)).max(1);
+    let mut out: Vec<std::ops::Range<usize>> = Vec::new();
+    for r in ranges {
+        match out.last_mut() {
+            Some(last) if r.start <= last.end.saturating_add(cell_bytes) => {
+                last.end = last.end.max(r.end);
+            }
+            _ => out.push(r),
+        }
+    }
+    out
+}
+
+/// Project this buffer's scrollbar markers onto a `track_height`-tall column,
+/// reusing the cached projection when nothing relevant changed.
+///
+/// Two sources feed the column: the plugin-owned marker set, and the editor's
+/// own unsaved-change ranges — the same diff that draws the blue gutter bar,
+/// so an edit is visible on the track whether or not it has been saved and
+/// whether or not any plugin is loaded.
 ///
 /// Cost per frame is one key comparison in the steady state; a rebuild is
 /// O(M) in the marker count with an O(1)–O(log n) coordinate lookup each, and
@@ -107,11 +178,31 @@ pub(super) fn project_scrollbar_markers(
     basis: MarkerBasis,
     track_height: usize,
 ) -> Vec<Option<MarkerCell>> {
-    if state.scrollbar_markers.is_empty() || track_height == 0 {
+    // `is_modified()` is the same flag `diff_since_saved` short-circuits on,
+    // so an unmodified buffer with no plugin markers does no work at all.
+    if track_height == 0 || (state.scrollbar_markers.is_empty() && !state.buffer.is_modified()) {
         return Vec::new();
     }
 
     let content_version = state.buffer.version();
+    let key = scrollbar_marker::ProjectionKey::new(
+        &state.scrollbar_markers,
+        content_version,
+        state.buffer.save_state_version(),
+        basis,
+        track_height,
+    );
+
+    // Probe the cache before computing the unsaved-change ranges: that is a
+    // whole-buffer structure diff (O(leaves) once the buffer is modified), and
+    // a steady-state frame must not pay for it. The version pair in the key
+    // moves on every edit and on every save, which is exactly when the ranges
+    // can change.
+    if let Some(cells) = state.scrollbar_marker_buckets.cached(&key) {
+        return cells.to_vec();
+    }
+
+    let core = unsaved_change_marks(state, track_height);
 
     // Split the borrows: the projection reads the manager and the coordinate
     // source while writing the bucket cache.
@@ -120,33 +211,39 @@ pub(super) fn project_scrollbar_markers(
         MarkerBasis::Bytes { .. } => scrollbar_marker::project(
             &state.scrollbar_markers,
             &mut buckets,
+            key,
+            core.as_ref(),
             basis,
             track_height,
-            content_version,
             |byte| byte as u64,
         )
         .to_vec(),
         MarkerBasis::LogicalLines { .. } => {
-            // `get_line_number` needs `&mut Buffer`; markers are read from a
-            // snapshot first so the two borrows don't overlap.
+            // `get_line_number` needs `&mut Buffer`; both mark sources are read
+            // from a snapshot first so the two borrows don't overlap. Every
+            // byte the projection will ask about must be in the map — a miss
+            // would silently answer line 0 and pile marks at the top.
             let resolved = state.scrollbar_markers.resolved();
+            let core_bytes = core
+                .iter()
+                .flat_map(|c| c.endpoints())
+                .flat_map(|(s, e)| [s, e]);
+            let marker_bytes = resolved
+                .iter()
+                .flat_map(|m| std::iter::once(m.start).chain(m.end));
             let mut lines = std::collections::HashMap::with_capacity(resolved.len() * 2);
-            for m in &resolved {
+            for byte in core_bytes.chain(marker_bytes).collect::<Vec<_>>() {
                 lines
-                    .entry(m.start)
-                    .or_insert_with(|| state.buffer.get_line_number(m.start) as u64);
-                if let Some(e) = m.end {
-                    lines
-                        .entry(e)
-                        .or_insert_with(|| state.buffer.get_line_number(e) as u64);
-                }
+                    .entry(byte)
+                    .or_insert_with(|| state.buffer.get_line_number(byte) as u64);
             }
             scrollbar_marker::project(
                 &state.scrollbar_markers,
                 &mut buckets,
+                key,
+                core.as_ref(),
                 basis,
                 track_height,
-                content_version,
                 |byte| lines.get(&byte).copied().unwrap_or(0),
             )
             .to_vec()
@@ -164,9 +261,10 @@ pub(super) fn project_scrollbar_markers(
             scrollbar_marker::project(
                 &state.scrollbar_markers,
                 &mut buckets,
+                key,
+                core.as_ref(),
                 basis,
                 track_height,
-                content_version,
                 |byte| index.line_first_row(buffer.get_line_number(byte)) as u64,
             )
             .to_vec()
@@ -583,6 +681,11 @@ mod tests {
             text.push_str(line);
         }
         state.buffer.insert(0, &text);
+        // Stand in for a file just opened from disk: content present, nothing
+        // unsaved. Without this the buffer would carry an unsaved-change diff
+        // covering all of it, and every projection here would start with the
+        // editor's own marks already on the track.
+        state.buffer.mark_saved_snapshot();
         state
     }
 
@@ -734,11 +837,66 @@ mod tests {
         );
     }
 
-    /// A buffer with no markers must not allocate or project anything.
+    /// A saved buffer with no markers must not allocate or project anything.
     #[test]
     fn no_markers_means_no_projection_work() {
         let mut state = state_with_wrapping_lines(10);
         let cells = project_scrollbar_markers(&mut state, MarkerBasis::Bytes { total: 100 }, 20);
         assert!(cells.is_empty());
+    }
+
+    /// ...but an unsaved edit is a mark source of its own, so the same buffer
+    /// with no plugin markers at all still paints. This is what makes the
+    /// gutter's blue bar visible for changes scrolled off screen.
+    #[test]
+    fn an_unsaved_edit_projects_without_any_plugin_markers() {
+        let mut state = state_with_wrapping_lines(10);
+        let len = state.buffer.len();
+        state.buffer.insert(len / 2, "an unsaved edit");
+
+        let total = state.buffer.len() as u64;
+        let cells = project_scrollbar_markers(&mut state, MarkerBasis::Bytes { total }, 20);
+        let marked: Vec<usize> = cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_some())
+            .map(|(i, _)| i)
+            .collect();
+        // The structure diff reports leaf-granular ranges, so an insertion can
+        // cover a little more than the typed bytes — the mark is a streak
+        // around the edit, not necessarily a single row.
+        assert!(
+            !marked.is_empty() && marked.iter().all(|r| (8..=11).contains(r)),
+            "the edit is halfway through the buffer, so it marks the middle of \
+             a 20-row track; got {marked:?}"
+        );
+
+        // Saving it away clears the marks without any plugin involvement.
+        state.buffer.mark_saved_snapshot();
+        let cells = project_scrollbar_markers(&mut state, MarkerBasis::Bytes { total }, 20);
+        assert!(cells.is_empty(), "a saved buffer leaves the track clean");
+    }
+
+    /// Thousands of scattered unsaved edits must not put thousands of
+    /// coordinate lookups on the typing path: ranges within one track cell of
+    /// each other merge first, so the projection stays bounded by the track.
+    #[test]
+    fn dense_unsaved_edits_coalesce_to_the_track_resolution() {
+        let ranges: Vec<std::ops::Range<usize>> =
+            (0..2_000).map(|k| (k * 50)..(k * 50 + 1)).collect();
+        // 100 000 bytes over a 20-row track: one cell is 5 000 bytes, so the
+        // 2 000 single-byte ranges collapse to one group per cell.
+        let merged = coalesce_within_a_cell(ranges, 100_000, 20);
+        assert!(
+            merged.len() <= 21,
+            "expected at most one group per track row, got {}",
+            merged.len()
+        );
+        assert_eq!(merged.first().unwrap().start, 0);
+        assert_eq!(
+            merged.last().unwrap().end,
+            1_999 * 50 + 1,
+            "merging must still cover the last edit"
+        );
     }
 }

--- a/crates/fresh-editor/tests/e2e/markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose.rs
@@ -96,12 +96,19 @@ fn test_compose_mode_typing_no_flicker() {
     // ── Helpers ─────────────────────────────────────────────────────────
     let (content_start, content_end) = harness.content_area_rows();
     let content_rows = content_end - content_start + 1;
+    // The scrollbar column is dropped: this test is about the text area
+    // settling after an edit, and the track legitimately gains a mark for the
+    // unsaved change the keystroke just made.
     let extract_content = |screen: &str| -> Vec<String> {
         screen
             .lines()
             .skip(content_start)
             .take(content_rows)
-            .map(|l| l.to_string())
+            .map(|l| {
+                let mut chars: Vec<char> = l.chars().collect();
+                chars.pop();
+                chars.into_iter().collect()
+            })
             .collect()
     };
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -296,6 +296,7 @@ pub mod unicode_cursor;
 pub mod unicode_prompt_bugs;
 pub mod universal_lsp;
 pub mod unnamed_buffer_persistence;
+pub mod unsaved_change_gutter;
 pub mod update_notification;
 pub mod vertical_rulers;
 #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -1498,3 +1498,158 @@ fn test_indicator_line_shifting() {
     println!("Initial indicators: {:?}", lines_initial);
     println!("After shift indicators: {:?}", lines_after);
 }
+
+// =============================================================================
+// Git Gutter Scrollbar Markers
+// =============================================================================
+
+/// The half-block glyph a scrollbar marker paints.
+const SCROLLBAR_MARKER_GLYPH: &str = "▌";
+
+/// Rows of the scrollbar column showing a marker glyph, with the colour they
+/// were painted in.
+fn scrollbar_marker_rows(harness: &EditorTestHarness) -> Vec<(usize, Option<Color>)> {
+    let col = harness.buffer().area.width - 1;
+    let (first, last) = harness.content_area_rows();
+    (first..=last)
+        .filter(|row| harness.get_cell(col, *row as u16).as_deref() == Some(SCROLLBAR_MARKER_GLYPH))
+        .map(|row| {
+            (
+                row,
+                harness.get_cell_style(col, row as u16).and_then(|s| s.fg),
+            )
+        })
+        .collect()
+}
+
+/// The topmost row marked in a given colour, if any.
+fn first_marker_row(rows: &[(usize, Option<Color>)], color: Color) -> Option<usize> {
+    rows.iter()
+        .filter(|(_, fg)| *fg == Some(color))
+        .map(|(row, _)| *row)
+        .min()
+}
+
+/// A file long enough that most of it is off screen.
+fn numbered_lines(count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("line {i:04}")).collect()
+}
+
+/// The git gutter marks its hunks on the scrollbar, in the same colours as its
+/// gutter glyphs — so uncommitted changes below the fold are visible without
+/// scrolling to find them.
+// TODO: Fix git gutter tests on Windows - they fail due to git command output differences
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_git_gutter_marks_off_screen_hunks_on_scrollbar() {
+    let repo = GitTestRepo::new();
+    repo.setup_git_gutter_plugin();
+
+    let original = numbered_lines(200);
+    repo.create_file("long.txt", &format!("{}\n", original.join("\n")));
+    repo.git_add_all();
+    repo.git_commit("Commit the long file");
+
+    // Three hunks of different kinds, all far below the first screenful:
+    // an insertion, a deletion, and an in-place edit. Applied bottom-up so
+    // earlier edits don't shift the indices of later ones.
+    let mut changed = original.clone();
+    changed[150] = "line 0150 rewritten".to_string();
+    changed.drain(100..104);
+    changed.splice(60..60, ["added A".to_string(), "added B".to_string()]);
+    repo.modify_file("long.txt", &format!("{}\n", changed.join("\n")));
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    open_file(&mut harness, &repo.path, "long.txt");
+
+    // Every hunk is off screen, so the gutter alone tells the user nothing —
+    // the scrollbar marks are the only signal that this file has changes.
+    harness
+        .wait_until(|h| scrollbar_marker_rows(h).len() >= 3)
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert_eq!(
+        count_gutter_indicators(&screen, "│"),
+        0,
+        "the changed lines are all below the first screenful, so no gutter \
+         glyph should be visible:\n{screen}"
+    );
+
+    let rows = scrollbar_marker_rows(&harness);
+    let added = first_marker_row(&rows, Color::Rgb(80, 250, 123))
+        .unwrap_or_else(|| panic!("the inserted lines should mark the track green; saw {rows:?}"));
+    let deleted = first_marker_row(&rows, Color::Rgb(255, 85, 85))
+        .unwrap_or_else(|| panic!("the deletion should mark the track red; saw {rows:?}"));
+    let modified = first_marker_row(&rows, Color::Rgb(255, 184, 108))
+        .unwrap_or_else(|| panic!("the rewritten line should mark the track orange; saw {rows:?}"));
+
+    // Marks land proportionally to where their hunk sits in the file, so they
+    // appear in the same order down the track as the hunks do down the file.
+    assert!(
+        added < deleted && deleted < modified,
+        "marks should follow the hunks' order in the file, got \
+         added={added}, deleted={deleted}, modified={modified} ({rows:?})"
+    );
+}
+
+/// A file that matches HEAD leaves the scrollbar clean, and saving a change
+/// puts a mark on it — the marks track the diff rather than lingering.
+// TODO: Fix git gutter tests on Windows - they fail due to git command output differences
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_git_gutter_scrollbar_marks_appear_after_save() {
+    let repo = GitTestRepo::new();
+    repo.setup_git_gutter_plugin();
+
+    repo.create_file("long.txt", &format!("{}\n", numbered_lines(200).join("\n")));
+    repo.git_add_all();
+    repo.git_commit("Commit the long file");
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    open_file(&mut harness, &repo.path, "long.txt");
+    trigger_git_gutter_refresh(&mut harness);
+
+    // The status line reports the hunk count, so it tells us the plugin has
+    // finished a pass over the unchanged file without waiting on a timer.
+    harness.wait_for_screen_contains("0 change(s)").unwrap();
+    assert!(
+        scrollbar_marker_rows(&harness).is_empty(),
+        "a file matching HEAD should leave the scrollbar unmarked"
+    );
+
+    harness.type_text("brand new first line\n").unwrap();
+    save_file(&mut harness);
+    trigger_git_gutter_refresh(&mut harness);
+
+    harness
+        .wait_until(|h| !scrollbar_marker_rows(h).is_empty())
+        .unwrap();
+
+    let rows = scrollbar_marker_rows(&harness);
+    assert_eq!(
+        rows.first().map(|(_, fg)| *fg),
+        Some(Some(Color::Rgb(80, 250, 123))),
+        "the inserted line is an addition, so its mark is green; saw {rows:?}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
@@ -325,6 +325,14 @@ fn test_live_diff_highlights_empty_added_line() {
             s.contains("UNIQUE_NEW_FN_MARKER") && has_glyph(&s, '+')
         })
         .unwrap();
+    // The `+` glyphs land before the background overlays: `renderHunks` sends
+    // its gutter indicators first and its bg highlights after, and the editor
+    // drains plugin commands partway through a render. So the wait above can be
+    // satisfied by a frame that has the gutter but not yet the stripe, and the
+    // bg assertion below then samples a half-applied pass — which is how this
+    // failed on macOS CI while passing everywhere else. Wait for the plugin
+    // pipeline itself to go quiet before reading a cell.
+    harness.wait_for_async_quiescence(3).unwrap();
 
     let buf = harness.buffer();
     let mut marker_row: Option<u16> = None;

--- a/crates/fresh-editor/tests/e2e/plugins/vi_mode_autostart.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/vi_mode_autostart.rs
@@ -87,7 +87,15 @@ fn vi_mode_autostart_true_enables_vi_immediately() {
         .lines()
         .find(|l| l.contains("1 │"))
         .expect("expected line 1 in render");
-    let content = line1.rsplit('│').next().unwrap_or("").trim();
+    // `trim_end_matches('▌')` drops the scrollbar's unsaved-change mark: the
+    // buffer is dirty at this point, so the track carries one in the last
+    // column of the same row.
+    let content = line1
+        .rsplit('│')
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('▌')
+        .trim();
     assert_eq!(
         content, "X",
         "autoStart=true: vi-normal `i` should swallow the keystroke, \
@@ -116,7 +124,15 @@ fn vi_mode_autostart_false_leaves_vi_dormant() {
         .lines()
         .find(|l| l.contains("1 │"))
         .expect("expected line 1 in render");
-    let content = line1.rsplit('│').next().unwrap_or("").trim();
+    // `trim_end_matches('▌')` drops the scrollbar's unsaved-change mark: the
+    // buffer is dirty at this point, so the track carries one in the last
+    // column of the same row.
+    let content = line1
+        .rsplit('│')
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('▌')
+        .trim();
     assert_eq!(
         content, "iX",
         "autoStart=false: vi mode should stay off, both `i` and `X` \

--- a/crates/fresh-editor/tests/e2e/scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/scrollbar_markers.rs
@@ -28,6 +28,7 @@ fn marker(position: u32, color: OverlayColorSpec) -> ScrollbarMarker {
         position: Some(position),
         line: None,
         end: None,
+        end_line: None,
         color,
         priority: None,
     }
@@ -246,6 +247,7 @@ fn range_markers_paint_a_streak() {
             markers: vec![ScrollbarMarker {
                 position: Some(0),
                 line: None,
+                end_line: None,
                 end: Some(len / 2),
                 color: OverlayColorSpec::Rgb(0, 0, 255),
                 priority: None,
@@ -411,6 +413,7 @@ fn plugin_markers_and_unsaved_marks_coexist() {
                 position: Some(0),
                 line: None,
                 end: None,
+                end_line: None,
                 color: OverlayColorSpec::Rgb(255, 0, 0),
                 priority: Some(10),
             },

--- a/crates/fresh-editor/tests/e2e/scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/scrollbar_markers.rs
@@ -167,7 +167,16 @@ fn markers_follow_their_content_through_edits() {
         vec![marker(200, OverlayColorSpec::Rgb(255, 0, 0))],
     );
     harness.render().unwrap();
-    let before = marker_rows(&harness);
+    // Filtered by colour: the edit below also puts the editor's own
+    // unsaved-change marks on the track, and this test is about the plugin's.
+    let plugin_rows = |h: &EditorTestHarness| -> Vec<u16> {
+        marker_rows(h)
+            .into_iter()
+            .filter(|(_, fg)| *fg == Some(Color::Rgb(255, 0, 0)))
+            .map(|(row, _)| row)
+            .collect()
+    };
+    let before = plugin_rows(&harness);
     assert_eq!(before.len(), 1, "one marker expected, saw {before:?}");
 
     // Type a large block of new text at the very top of the buffer. The
@@ -180,17 +189,17 @@ fn markers_follow_their_content_through_edits() {
     harness.type_text(&format!("{inserted}\n")).unwrap();
     harness.render().unwrap();
 
-    let after = marker_rows(&harness);
+    let after = plugin_rows(&harness);
     assert_eq!(
         after.len(),
         1,
         "marker should survive the edit, saw {after:?}"
     );
     assert!(
-        after[0].0 > before[0].0,
+        after[0] > before[0],
         "marker should move down the track after inserting above it: {} -> {}",
-        before[0].0,
-        after[0].0
+        before[0],
+        after[0]
     );
 }
 
@@ -293,5 +302,153 @@ fn range_scoped_publish_preserves_markers_outside_the_range() {
         rows.len(),
         3,
         "the two out-of-range marks must survive alongside the new one, saw {rows:?}"
+    );
+}
+
+// =============================================================================
+// Unsaved changes
+// =============================================================================
+
+/// The colour the editor paints its own unsaved-change marks in — the same
+/// cornflower blue as the gutter bar for the same change.
+const UNSAVED_BLUE: Color = Color::Rgb(100, 149, 237);
+
+/// The gutter can only speak for the lines on screen. Typing near the top of a
+/// long file and scrolling away leaves no trace in the gutter — the scrollbar
+/// mark is the only thing that still says "there is an unsaved edit up there".
+#[test]
+fn unsaved_edits_are_marked_on_the_scrollbar_even_when_scrolled_away() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text(&long_content(400)).unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        marker_rows(&harness).is_empty(),
+        "an unmodified buffer must leave the track clean"
+    );
+
+    harness.type_text("edited near the top\n").unwrap();
+    harness.render().unwrap();
+
+    let rows = marker_rows(&harness);
+    assert_eq!(
+        rows.iter().map(|(_, fg)| *fg).collect::<Vec<_>>(),
+        vec![Some(UNSAVED_BLUE)],
+        "the edit should put one blue mark on the track, saw {rows:?}"
+    );
+    let (first, last) = harness.content_area_rows();
+    let position = (rows[0].0 as f64 - first as f64) / (last - first + 1) as f64;
+    assert!(
+        position < 0.15,
+        "the edit is near the top of the file, so its mark is near the top of \
+         the track: {position}"
+    );
+
+    // Scroll until the edit is off screen. The mark must survive: that is the
+    // whole point — the gutter bar for it is gone from view.
+    for _ in 0..6 {
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    assert!(
+        !harness.screen_to_string().contains("edited near the top"),
+        "the test needs the edited line scrolled out of view"
+    );
+    let rows = marker_rows(&harness);
+    assert_eq!(
+        rows.iter().map(|(_, fg)| *fg).collect::<Vec<_>>(),
+        vec![Some(UNSAVED_BLUE)],
+        "the mark must survive scrolling the edit off screen, saw {rows:?}"
+    );
+}
+
+/// Saving clears the marks: they track the diff against what is on disk, so
+/// once the file matches, nothing is left over.
+#[test]
+fn saving_clears_the_unsaved_change_marks() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let fixture = harness.load_buffer_from_text(&long_content(400)).unwrap();
+
+    harness.type_text("an unsaved edit\n").unwrap();
+    harness.render().unwrap();
+    assert!(
+        !marker_rows(&harness).is_empty(),
+        "the edit should be marked before saving"
+    );
+
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| marker_rows(h).is_empty())
+        .expect("saving should clear the unsaved-change marks");
+
+    drop(fixture);
+}
+
+/// Plugin markers and the editor's own marks share one track: a git hunk
+/// (priority 10) keeps its colour on a cell the unsaved-change mark (5) also
+/// wants, and the unsaved mark still shows everywhere else.
+#[test]
+fn plugin_markers_and_unsaved_marks_coexist() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let text = long_content(400);
+    harness.load_buffer_from_text(&text).unwrap();
+
+    // Edit at the top, so the unsaved mark lands on the track's first row.
+    harness.type_text("edited\n").unwrap();
+    harness.render().unwrap();
+
+    // A plugin marks the same top-of-file position, plus a spot near the end.
+    let len = text.len() as u32;
+    set_markers(
+        &mut harness,
+        vec![
+            ScrollbarMarker {
+                position: Some(0),
+                line: None,
+                end: None,
+                color: OverlayColorSpec::Rgb(255, 0, 0),
+                priority: Some(10),
+            },
+            marker(len - 1, OverlayColorSpec::Rgb(255, 0, 0)),
+        ],
+    );
+    harness.render().unwrap();
+
+    let rows = marker_rows(&harness);
+    assert_eq!(
+        rows.first().map(|(_, fg)| *fg),
+        Some(Some(Color::Rgb(255, 0, 0))),
+        "the higher-priority plugin marker wins the cell they share: {rows:?}"
+    );
+    assert_eq!(
+        rows.last().map(|(_, fg)| *fg),
+        Some(Some(Color::Rgb(255, 0, 0))),
+        "the plugin's other marker is unaffected: {rows:?}"
+    );
+}
+
+/// Past 5 000 lines the scrollbar switches from the wrapped-row basis to
+/// logical lines, and that path pre-resolves every byte the projection will
+/// ask about into a map. A regression here is not a wrong mark but a panic in
+/// the render loop, so the regime gets its own coverage.
+#[test]
+fn unsaved_marks_work_on_the_logical_line_basis() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text(&long_content(6_000)).unwrap();
+    harness.render().unwrap();
+
+    harness.type_text("edited\n").unwrap();
+    harness.render().unwrap();
+
+    let rows = marker_rows(&harness);
+    assert_eq!(
+        rows.iter().map(|(_, fg)| *fg).collect::<Vec<_>>(),
+        vec![Some(UNSAVED_BLUE)],
+        "the edit should be marked on a logical-line-basis scrollbar too, saw {rows:?}"
     );
 }

--- a/crates/fresh-editor/tests/e2e/unsaved_change_gutter.rs
+++ b/crates/fresh-editor/tests/e2e/unsaved_change_gutter.rs
@@ -1,0 +1,106 @@
+//! The gutter bar for unsaved changes (`diff_since_saved`), asserted on
+//! rendered cells in the indicator column.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::style::Color;
+
+/// Cornflower blue: the unsaved-change decoration on both the gutter and the
+/// scrollbar.
+const UNSAVED_BLUE: Color = Color::Rgb(100, 149, 237);
+
+fn content(lines: usize) -> String {
+    (0..lines)
+        .map(|i| format!("line {i:04}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Screen rows whose indicator column carries the unsaved-change bar.
+fn barred_rows(harness: &EditorTestHarness) -> Vec<usize> {
+    let (first, last) = harness.content_area_rows();
+    (first..=last)
+        .filter(|row| {
+            harness.get_cell(0, *row as u16).as_deref() == Some("│")
+                && harness
+                    .get_cell_style(0, *row as u16)
+                    .and_then(|s| s.fg)
+                    .is_some_and(|fg| fg == UNSAVED_BLUE)
+        })
+        .collect()
+}
+
+/// Inserting whole lines marks exactly the inserted lines.
+///
+/// The diff's byte ranges are half-open, and inserting whole lines produces a
+/// range that ends exactly on a line boundary. Counting that boundary as a
+/// marked line put a bar on the first *untouched* line after the insertion —
+/// visible as a bar that disappeared on save, once git reported the real line
+/// set for the same edit.
+#[test]
+fn inserting_lines_marks_only_the_inserted_lines() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text(&content(400)).unwrap();
+    harness.render().unwrap();
+    assert!(
+        barred_rows(&harness).is_empty(),
+        "an unmodified buffer has no unsaved-change bars"
+    );
+
+    // Three whole new lines at the start of line 5 (row 5 of the viewport).
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.type_text("NEW A\nNEW B\nNEW C\n").unwrap();
+    harness.render().unwrap();
+
+    let rows = barred_rows(&harness);
+    let screen = harness.screen_to_string();
+    assert_eq!(
+        rows.len(),
+        3,
+        "three lines were inserted, so three lines are changed; \
+         got {} bars\n{screen}",
+        rows.len()
+    );
+
+    // And they are the three rows showing the new text.
+    let text_rows: Vec<usize> = rows
+        .iter()
+        .map(|r| harness.get_screen_row(*r))
+        .filter(|line| line.contains("NEW "))
+        .enumerate()
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        text_rows.len(),
+        3,
+        "each bar should sit on one of the inserted lines\n{screen}"
+    );
+}
+
+/// Editing within a single line marks that line only.
+#[test]
+fn editing_one_line_marks_one_line() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text(&content(400)).unwrap();
+    harness.render().unwrap();
+
+    for _ in 0..9 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.type_text("EDIT").unwrap();
+    harness.render().unwrap();
+
+    let rows = barred_rows(&harness);
+    assert_eq!(
+        rows.len(),
+        1,
+        "one line was edited, so one bar is expected; got {rows:?}\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        harness.get_screen_row(rows[0]).contains("EDIT"),
+        "the bar should sit on the edited line"
+    );
+}


### PR DESCRIPTION
The gutter can only speak for the lines on screen. Scroll away from a change and the editor stops mentioning it. This closes that gap for both kinds of change the gutter shows.

## 1. Git-gutter hunks on the track (`git_gutter.ts`)

Live diff already marks its hunks on the scrollbar (#2713); the git gutter — which most users have on all the time — did not. It now publishes the same hunk set its glyphs come from:

- Own namespace (`git-gutter-scroll`), gutter palette reused, so a hunk's glyph and its mark are the same colour.
- One marker per hunk, spanning `line`..`endLine`. `ScrollbarMarker` gains `endLine` (the inclusive line counterpart to the byte `end`) for exactly this: a `git diff` parser knows a hunk's first and last line but not their byte offsets, and without it the plugin had to emit one marker per changed line.
- One batched whole-namespace replace — the diff covers the whole file, so the set is authoritative and swaps atomically. An empty set (or an untracked file) clears it.

## 2. Unsaved changes on the track (core)

The blue gutter bar for unsaved edits comes from `diff_since_saved`, which already returns **whole-buffer** byte ranges — the gutter just clips them to the viewport afterwards. So the same ranges can feed the scrollbar with no new diffing. The projection grows a second mark source next to the plugin-owned set, painting in the gutter bar's colour at its priority (5), so a git hunk (10) still wins a cell they both want. No plugin and no git repository required.

Three things it needs to stay cheap and correct:

- **The cache is probed before the diff is gathered**, so a steady-state frame pays a key comparison and nothing else. The key gains a new `save_state_version` on the buffer, because a save changes what the marks cover without touching the content version.
- **Ranges within one track cell of each other merge first.** A replace-all across a large file leaves thousands of unsaved ranges, and two coordinate lookups each (`get_line_number` is ~0.5 µs) would put milliseconds on the typing path to draw marks a ≤200-cell track cannot tell apart. Merging is lossless in coverage — a group spans every range inside it — so it is a resolution choice, not a silent cap.
- **Core ranges project through one `endpoints()` helper**, because the logical-line basis pre-resolves byte→line into a map and a lookup it never saw would answer row 0. A benchmark caught exactly that as an index panic in the render loop; the painter is now also guarded against a non-monotonic lookup.

## 3. Two defects found while testing this by hand

- **Inserting lines marked one line too many.** The diff's byte ranges are half-open, and inserting whole lines produces a range ending exactly on a line boundary. `diff_indicators_for_viewport` counted that boundary as changed, so inserting three lines put a bar on four — and the fourth vanished on save, when git reported the real line set. That read as the two surfaces disagreeing; they agree now because the bar is no longer wrong.
- **A hunk cost one marker per line.** Measured on a file with 20 000 changed lines: 28.6 ms in the command handler plus 24.4 ms in the next render, on every save. With `endLine` and one marker per hunk: 17.6 µs and a 2.8 ms render.

## Performance

Measured on this branch (release build). `diff_since_saved` prunes by `Arc` identity, so its cost tracks the *edit* count, not the file size:

| buffer state | diff cost | (10 MB file) |
|---|---|---|
| unmodified | 13 ns | 13 ns |
| 1 unsaved edit | 170 ns | 171 ns |
| 200 unsaved edits | 12 µs | 12 µs |
| ~2 200 unsaved edits | 261 µs | 132 µs |

Whole-frame A/B, worst case (200k lines, 2 000 scattered unsaved edits, 300 renders per sample, 3 samples):

- steady-state frames: 2.34–2.62 ms with, 2.34–2.53 ms without — within noise, as expected from the early-out and the cache probe.
- frames right after an edit: median 2.83 ms with, 2.65 ms without → **≈ +0.19 ms** on the pathological case. A single-edit buffer is ~0.2 µs.

## Tests

- `view::scrollbar_marker` unit tests: core marks paint with no plugin markers; a range paints the rows it spans and not the row after; priority precedence both ways; a save invalidates the projection; `endLine` resolves as an inclusive range and yields to an explicit byte `end`.
- `split_rendering::scrollbar` unit tests: an unsaved edit projects with no plugin markers and clears on save; dense edits coalesce to track resolution without losing the last edit.
- `e2e/scrollbar_markers.rs`: an edit near the top stays marked after scrolling it off screen; saving clears the marks; plugin markers and unsaved marks coexist; and the >5 000-line logical-line regime is covered on its own (that path is where the panic lived).
- `e2e/unsaved_change_gutter.rs`: inserting three lines marks exactly three; editing one line marks one. Fails without the off-by-one fix (4 bars vs 3).
- `e2e/plugins/gutter.rs`: git hunks below the fold show green/red/orange marks in file order while no gutter glyph is on screen; and a clean file stays unmarked until a change is saved.
- Three existing tests updated: two now ignore the scrollbar column, which legitimately changes when the buffer is dirty (`markdown_compose` flicker check, `vi_mode_autostart` line scrape), and `live_diff::test_live_diff_highlights_empty_added_line` now waits for plugin quiescence before reading a cell background instead of sampling a half-applied pass.

Also verified by hand in tmux against the real binary: marks appear in the gutter palette at proportional positions, survive scrolling the edit off screen, hand over from blue to git colours on save, and behave in the >5 000-line logical-line regime.