### PR TITLE
Fix the Windows CI timeout in custom_agent_is_typable_when_running_in_the_current_workspace

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -885,6 +885,15 @@ fn focused_line(screen: &str) -> String {
     lines[0].to_string()
 }
 
+/// Like [`focused_line`], but `None` instead of a panic when the marker count
+/// is not exactly one. For `wait_until` conditions, which see intermediate
+/// frames where a focus handoff is still in flight.
+fn focused_line_opt(screen: &str) -> Option<String> {
+    let mut lines = screen.lines().filter(|l| l.contains('▸'));
+    let first = lines.next()?;
+    lines.next().is_none().then(|| first.to_string())
+}
+
 /// Open the form on a non-git workspace (so the worktree toggle and
 /// Branch field are absent — a predictable, minimal field set).
 fn open_form_on(workspace: &PathBuf) -> EditorTestHarness {
@@ -1684,8 +1693,16 @@ fn custom_agent_is_typable_when_running_in_the_current_workspace() {
         );
     }
     harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+    // The selector paints "custom…" immediately, but the preset hands focus to
+    // the command box through a plugin round-trip that can land a tick later.
+    // Gate on the marker rather than the label: a key sent inside that window
+    // goes to the selector instead of the box, and is lost.
     harness
-        .wait_until(|h| h.screen_to_string().contains("custom"))
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("custom")
+                && focused_line_opt(&screen).is_some_and(|l| !l.contains("Agent:"))
+        })
         .unwrap();
 
     // Focus followed the preset onto the command field, so the user can just


### PR DESCRIPTION
`e2e::plugins::orchestrator_new_dialog::custom_agent_is_typable_when_running_in_the_current_workspace` times out on Windows CI (180s, seen on #2865 and unrelated to that branch — it dates to the test's introduction in 5c998866c).

### What happens

nextest's kill dumped the stuck screen:

```
│  Agent: [custom…  ▼]
│╭─ Agent Command ─────╮
││ ▸ [zcustomcmd     ] ││
```

The test types `zzcustomcmd`; the box holds `zcustomcmd`. One leading character is gone, so `wait_until(contains("zzcustomcmd"))` never fires, and `wait_until` is unbounded.

### Why

Picking `custom…` paints the label on the selector right away, but `applyAgentPreset` (orchestrator.ts:6698) re-renders the form and *then* hands focus to `cmd` via `setFocusKey`/`snapFormFocusTo` — a plugin round-trip. The gate was `wait_until(contains("custom"))`, which is already satisfied during that window, so the test typed while focus was still on the dropdown.

Probing the window directly confirms it:

```
PROBE pre-type contains(custom)=true focus=Some("│▸ Agent: [custom…  ▼] │")
PROBE no-wait:  ││ ▸ [zcustomcmd ] ││     <- the CI string, reproduced locally
```

Linux and macOS pass only because the one `tick_and_render` inside `wait_until` happens to complete the round-trip before the first keystroke. Windows' slower plugin thread does not.

### Fix

Gate on the focus marker leaving the selector rather than on the label. With that gate the same reproduction yields `zzcustomcmd`.

`focused_line` can't be used in a `wait_until` condition — it asserts exactly one `▸` on screen, and a frame mid-handoff legitimately has none — so this adds a `focused_line_opt` sibling returning `None` in that case.

### Not addressed

The same race exists in the real editor: pick `custom…` and type instantly on a loaded machine and the first character goes to the dropdown. Closing that needs the focus handoff to be synchronous with key handling, which the plugin can't do from its side — separate work.

### Verification

- All 27 `orchestrator_new_dialog` tests pass
- `cargo fmt --check` clean; no new clippy warnings on the changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)