### PR TITLE
Shift types its character again under report-all-keys (#2880)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **The Shift key works with "Keyboard Report All Keys As Escape Codes"** - with that flag on, every shifted key typed its unshifted character (`Shift+A` inserted `a`, `Shift+2` inserted `2`), because the terminal reports the *base* key and the shift separately (#2880, reported by @akarinotomoshibi).
 * **Four dead settings** - the bracket-matching toggles, `file_explorer.respect_gitignore` and `languages.<id>.textmate_grammar` now take effect; `editor.highlight_timeout_ms` was removed rather than wired up (#2842).
 * **Files that are one very long line**
   * **Viewing one no longer pins a CPU core** (#2838, reported by @lovehumans).

--- a/crates/fresh-editor/tests/e2e/csi_u_session_input.rs
+++ b/crates/fresh-editor/tests/e2e/csi_u_session_input.rs
@@ -74,6 +74,38 @@ fn test_csi_u_sequences_not_inserted_as_literal_text() {
     }
 }
 
+/// End-to-end: with `keyboard_report_all_keys_as_escape_codes` on, every
+/// printable key arrives as a CSI u sequence carrying the *base* key plus a
+/// shift modifier. Typing shifted keys must put the shifted characters on
+/// screen — before the fix the base characters were typed instead, so `A`
+/// showed up as `a` and the Shift key looked dead (issue #2880).
+#[test]
+fn test_shifted_keys_type_their_character_on_screen() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let mut parser = InputParser::new();
+
+    // Shift+F, Shift+r, Shift+e (the shifted codepoint reported alongside the
+    // base key), then Shift+1 and Shift+/ for the symbols a keyboard layout —
+    // not the character's case — decides.
+    let sequences: &[&[u8]] = &[
+        b"\x1b[102:70;2u",
+        b"\x1b[114:82;2u",
+        b"\x1b[101:69;2u",
+        b"\x1b[49:33;2u",
+        b"\x1b[47:63;2u",
+    ];
+    for seq in sequences {
+        for event in parser.parse(seq) {
+            if let Event::Key(ke) = event {
+                harness.send_key(ke.code, ke.modifiers).unwrap();
+            }
+        }
+    }
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("FRE!?");
+}
+
 /// InputParser must map CSI u sequences to the correct KeyCode and modifiers.
 /// Covers: special keycodes (Enter, Tab, Esc, Backspace, Space), printable
 /// chars, no-modifier and multi-modifier combinations.

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -696,19 +696,24 @@ impl InputParser {
     fn dispatch_csi_u(&mut self, params: &[u8], out: &mut Vec<Event>) {
         let params_str = std::str::from_utf8(params).unwrap_or("");
         let parts: Vec<&str> = params_str.split(';').collect();
-        let codepoint: u32 = parts
-            .first()
-            .and_then(|s| first_subparam(s).parse().ok())
-            .unwrap_or(0);
+        let key_field = parts.first().copied().unwrap_or("");
+        let codepoint: u32 = first_subparam(key_field).parse().unwrap_or(0);
         let mods_field = parts.get(1).copied().unwrap_or("");
         let mods_param: u16 = first_subparam(mods_field).parse().unwrap_or(1);
-        let modifiers = modifiers_from_param(mods_param);
+        let mut modifiers = modifiers_from_param(mods_param);
         // The modifier field may carry an event-type sub-parameter
         // (`mods:event-type`): 1=press, 2=repeat, 3=release. Preserve it as the
         // key event's kind so a release is not reported as a fresh press (which
         // would fire every keystroke twice once event-type reporting is on).
         let kind = event_kind_of(mods_field);
-        if let Some(code) = functional_or_char(codepoint) {
+        if let Some(mut code) = functional_or_char(codepoint) {
+            // A shifted key must arrive as the character it types, exactly as
+            // it does over the legacy encoding — the case (or symbol) carries
+            // the shift, so the modifier bit goes with it.
+            if let Some(shifted) = shifted_char(key_field, code, modifiers) {
+                code = KeyCode::Char(shifted);
+                modifiers.remove(KeyModifiers::SHIFT);
+            }
             out.push(Event::Key(KeyEvent::new_with_kind(code, modifiers, kind)));
         }
     }
@@ -752,6 +757,69 @@ fn csi_key(code: KeyCode, params: &[u8]) -> Event {
 /// we key off the primary (base) value of each.
 fn first_subparam(field: &str) -> &str {
     field.split(':').next().unwrap_or(field)
+}
+
+/// The character a shifted CSI-u key should be reported as, or `None` to keep
+/// the key as its base codepoint plus the SHIFT modifier.
+///
+/// Over the legacy encoding a shifted key arrives as the character it types —
+/// Shift+A is the byte `0x41`, Shift+2 is `0x40` — and nothing downstream ever
+/// sees a SHIFT bit. Under `REPORT_ALL_KEYS_AS_ESCAPE_CODES` every printable
+/// key moves to the CSI-u form instead, where the field is the *base* key
+/// (`CSI 97:65;2u` for Shift+A: base 97, shifted 65). Reporting only the base
+/// made every shifted key type its unshifted character — `A` inserted `a`, `@`
+/// inserted `2` — which is what made the shift key look dead once the flag was
+/// on (sinelaw/fresh#2880). Resolving the shifted character here keeps the two
+/// encodings interchangeable, so keybindings, text insertion and the embedded
+/// terminal's pty encoding all stay oblivious to which one the terminal speaks.
+///
+/// Two cases are deliberately left alone:
+/// - **CONTROL held.** `Ctrl+Shift+A` must stay `Ctrl+Shift+a` so it resolves
+///   to a `Ctrl+Shift+A` binding rather than collapsing onto `Ctrl+A` (which is
+///   what uppercasing plus a dropped SHIFT would normalize to).
+/// - **A shifted codepoint the terminal did not send** for anything but a
+///   letter. Without `REPORT_ALTERNATE_KEYS` the shifted codepoint is absent,
+///   and only the keyboard layout knows that Shift+2 is `@` — but Shift+letter
+///   is the letter's uppercase on every Latin layout, so that much is safe to
+///   derive. Non-letters keep their base plus SHIFT rather than guess.
+fn shifted_char(key_field: &str, code: KeyCode, modifiers: KeyModifiers) -> Option<char> {
+    if !modifiers.contains(KeyModifiers::SHIFT) || modifiers.contains(KeyModifiers::CONTROL) {
+        return None;
+    }
+    let KeyCode::Char(base) = code else {
+        return None;
+    };
+    match shifted_subparam(key_field) {
+        // The terminal told us what the key types: take it, unless it is a
+        // functional key's Private Use Area codepoint (never printable text).
+        Some(codepoint) => match functional_or_char(codepoint)? {
+            KeyCode::Char(shifted) => Some(shifted),
+            _ => None,
+        },
+        None if modifiers == KeyModifiers::SHIFT => uppercase_letter(base),
+        None => None,
+    }
+}
+
+/// The shifted codepoint of a kitty `unicode:shifted:base` key field, if the
+/// terminal reported one. An empty sub-parameter (`97::29`, the way a key field
+/// carries a base-layout code with no shifted code) is "not reported".
+fn shifted_subparam(key_field: &str) -> Option<u32> {
+    key_field.split(':').nth(1)?.parse().ok()
+}
+
+/// The single-character uppercase of a letter, or `None` if the key is not a
+/// letter (`4`), is already uppercase, or uppercases to several characters
+/// (`ß` → `SS`, which is not a keystroke).
+fn uppercase_letter(base: char) -> Option<char> {
+    if !base.is_alphabetic() {
+        return None;
+    }
+    let mut upper = base.to_uppercase();
+    match (upper.next(), upper.next()) {
+        (Some(c), None) if c != base => Some(c),
+        _ => None,
+    }
 }
 
 /// Map a Unicode codepoint from CSI-u / modifyOtherKeys to a key code.

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -286,12 +286,130 @@ fn csi_u_alternate_keys_subparameters() {
     // Shift+'a' reported as base 97, shifted 65: CSI 97:65 ; 2 u
     assert_eq!(
         keys(&p.parse(b"\x1b[97:65;2u")),
-        vec![(KeyCode::Char('a'), KeyModifiers::SHIFT)]
+        vec![(KeyCode::Char('A'), KeyModifiers::empty())]
     );
     // A modifier field may carry an event-type sub-param: CSI 13 ; 5:1 u
     assert_eq!(
         keys(&p.parse(b"\x1b[13;5:1u")),
         vec![(KeyCode::Enter, KeyModifiers::CONTROL)]
+    );
+    // A base-layout code with no shifted code (`97::29`) is not a shifted key.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97::29u")),
+        vec![(KeyCode::Char('a'), KeyModifiers::empty())]
+    );
+}
+
+/// With `REPORT_ALL_KEYS_AS_ESCAPE_CODES` every printable key arrives in the
+/// CSI-u form, where the key field is the *base* key and the shift lives in the
+/// modifier field. Reporting the base made every shifted key type its unshifted
+/// character, which read as the shift key being dead (sinelaw/fresh#2880).
+#[test]
+fn csi_u_shifted_keys_report_the_character_they_type() {
+    let mut p = InputParser::new();
+    for (bytes, expected) in [
+        (&b"\x1b[97:65;2u"[..], 'A'),   // Shift+a
+        (&b"\x1b[50:64;2u"[..], '@'),   // Shift+2 on a US layout
+        (&b"\x1b[47:63;2u"[..], '?'),   // Shift+/
+        (&b"\x1b[232:200;2u"[..], 'È'), // Shift+è, non-ASCII
+    ] {
+        assert_eq!(
+            keys(&p.parse(bytes)),
+            vec![(KeyCode::Char(expected), KeyModifiers::empty())],
+            "{:?} should type {expected}",
+            String::from_utf8_lossy(bytes)
+        );
+    }
+}
+
+/// Without `REPORT_ALTERNATE_KEYS` the terminal sends no shifted codepoint.
+/// Shift+letter is the letter's uppercase on every Latin layout, so it is
+/// resolved anyway; anything else would be a guess at the layout and keeps its
+/// base key plus the SHIFT modifier.
+#[test]
+fn csi_u_shifted_keys_without_alternate_key_reporting() {
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[99;2u")),
+        vec![(KeyCode::Char('C'), KeyModifiers::empty())]
+    );
+    assert_eq!(
+        keys(&p.parse(b"\x1b[50;2u")),
+        vec![(KeyCode::Char('2'), KeyModifiers::SHIFT)]
+    );
+}
+
+/// The shifted character replaces the base key for the modifier combinations
+/// that type text, but never for Ctrl: `Ctrl+Shift+A` has to stay distinct from
+/// `Ctrl+A`, which is what `Char('A')` with the SHIFT bit dropped would
+/// normalize to.
+#[test]
+fn csi_u_shifted_keys_alongside_other_modifiers() {
+    let mut p = InputParser::new();
+    // Alt+Shift+f
+    assert_eq!(
+        keys(&p.parse(b"\x1b[102:70;4u")),
+        vec![(KeyCode::Char('F'), KeyModifiers::ALT)]
+    );
+    // Ctrl+Shift+a
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97:65;6u")),
+        vec![(
+            KeyCode::Char('a'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT
+        )]
+    );
+    // Ctrl+Shift+a with alternate keys off
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97;6u")),
+        vec![(
+            KeyCode::Char('a'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT
+        )]
+    );
+}
+
+/// A shifted key still carries its event type: substituting the character must
+/// not turn a release into a press.
+#[test]
+fn csi_u_shifted_key_keeps_its_event_type() {
+    let mut p = InputParser::new();
+    match &p.parse(b"\x1b[97:65;2:3u")[0] {
+        Event::Key(ke) => {
+            assert_eq!(ke.code, KeyCode::Char('A'));
+            assert_eq!(ke.modifiers, KeyModifiers::empty());
+            assert_eq!(ke.kind, KeyEventKind::Release);
+        }
+        other => panic!("expected key, got {:?}", other),
+    }
+}
+
+/// The full kitty key event is
+/// `CSI unicode-key-code:alternate-key-codes ; modifiers:event-type ; text-as-codepoints u`.
+/// fresh does not request the associated text (that needs `REPORT_ASSOCIATED_TEXT`),
+/// but a terminal that sends the field anyway must not derail the key.
+#[test]
+fn csi_u_ignores_a_trailing_text_parameter() {
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[97:65;2;65u")),
+        vec![(KeyCode::Char('A'), KeyModifiers::empty())]
+    );
+}
+
+/// Functional keys have no shifted character. Shift+Tab keeps its own key code
+/// rather than being replaced by whatever the sub-parameter holds.
+#[test]
+fn csi_u_shifted_functional_keys_are_untouched() {
+    let mut p = InputParser::new();
+    assert_eq!(
+        keys(&p.parse(b"\x1b[9;2u")),
+        vec![(KeyCode::Tab, KeyModifiers::SHIFT)]
+    );
+    // Shift+F13, whose PUA codepoint must never become a printable character.
+    assert_eq!(
+        keys(&p.parse(b"\x1b[57376;2u")),
+        vec![(KeyCode::F(13), KeyModifiers::SHIFT)]
     );
 }
 


### PR DESCRIPTION
Fixes #2880.

## The bug

With `keyboard_report_all_keys_as_escape_codes` enabled, every shifted printable key typed its **unshifted** character — `Shift+A` inserted `a`, `Shift+2` inserted `2` — which is why the shift key looked dead.

Reproduced in tmux against a debug build, injecting the exact bytes a kitty-protocol terminal sends:

| keystroke | bytes | before | after |
|---|---|---|---|
| `Shift+a` | `ESC[97:65;2u` | `a` | `A` |
| `Shift+b` | `ESC[98:66;2u` | `b` | `B` |
| `Shift+c` (no alternate keys) | `ESC[99;2u` | `c` | `C` |
| `Shift+2` | `ESC[50:64;2u` | `2` | `@` |
| `Shift+/` | `ESC[47:63;2u` | `/` | `?` |
| `Shift+a`, flag off | `0x41` | `A` | `A` |

## Cause

The flag moves printable keys off the legacy encoding — where `Shift+A` is simply the byte `0x41` and no SHIFT bit exists — and onto the kitty CSI-u form, whose key field is the **base** key with the shift reported separately:

```
CSI unicode-key-code:shifted-key-code:base-layout-key-code ; modifiers:event-type u
```

`dispatch_csi_u` kept only the base codepoint (`first_subparam`), so the event became `Char('a')` + SHIFT. Everything downstream then typed the base character: text insertion, and the embedded terminal's pty encoding (which papered over letters with an ASCII `to_ascii_uppercase`, but not symbols).

## Fix

Resolve the character the key actually types once, at the parser boundary, so both encodings produce identical events and nothing downstream needs to know which one the terminal speaks:

- take the terminal's **shifted codepoint** when it sends one (`97:65` → `A`), rejecting Private Use Area codepoints so a functional key can never become text;
- fall back to the letter's **uppercase** when `REPORT_ALTERNATE_KEYS` is off and the shifted codepoint is therefore absent — Shift+letter is the letter's uppercase on every Latin layout. Non-letters keep base+SHIFT rather than guess at the layout (nothing but the layout knows `Shift+2` is `@`);
- **drop the SHIFT bit** once the character carries the shift, which is exactly how the legacy path already reports it — and `normalize_key` re-infers SHIFT for keybinding lookup, so `Shift+P` bindings keep matching.

`Ctrl+Shift` is deliberately left as base+SHIFT: substituting there would produce `Char('A')` + CONTROL, which `normalize_key` collapses onto the `Ctrl+A` binding. (crossterm substitutes unconditionally and has this exact ambiguity.)

Behavior matches the [kitty keyboard protocol spec](https://sw.kovidgoyal.net/kitty/keyboard-protocol/): the shifted key is the shifted version of the key in the active layout, and is sent *only* when shift is also in the modifier field. The `text-as-codepoints` third parameter needs `REPORT_ASSOCIATED_TEXT`, which fresh does not request — a test pins that an unsolicited one is ignored rather than derailing the key.

## Tests

New parser tests cover shifted letters/symbols/non-ASCII, the no-alternate-keys fallback, Alt+Shift and Ctrl+Shift, event-type preservation on a shifted release, functional keys, an empty shifted sub-parameter (`97::29`), and a trailing text parameter. `cargo test -p fresh-input-parser` (107) and `cargo test -p fresh-editor --lib` (3194) pass; verified end-to-end in tmux against the debug build, including that `Ctrl+S` still saves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtwHRNpWUXjKJ5ohwUBzSh)_