### PR TITLE
fix toml highlight is confusing #2887

### DIFF
--- a/crates/fresh-editor/src/grammars/toml.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/toml.sublime-syntax
@@ -32,21 +32,30 @@ contexts:
         3: punctuation.definition.table.end.toml
 
   key-value:
-    - match: '([A-Za-z0-9_-]+|"[^"]*"|''[^'']*'')\s*(=)'
+    # Keep top-level keys anchored to the start of the line. Without the
+    # anchor, text such as "USER=root" in a multiline string array is
+    # mistaken for another TOML assignment after the opening array line.
+    - match: '^\s*((?:[A-Za-z0-9_-]+|"[^"]*"|''[^'']*'')(?:\s*\.\s*(?:[A-Za-z0-9_-]+|"[^"]*"|''[^'']*''))*)\s*(=)'
       captures:
         1: entity.name.tag.toml
         2: punctuation.separator.key-value.toml
       push: value
 
   value:
-    - include: strings
-    - include: numbers
-    - include: booleans
-    - include: dates
-    - include: arrays
-    - include: inline-tables
+    - include: value-components
     - match: '$'
       pop: true
+
+  # Value rules without the end-of-line pop. Arrays include this context so
+  # that they remain open across lines instead of being popped by `value` at
+  # the end of their first line.
+  value-components:
+    - include: strings
+    - include: booleans
+    - include: dates
+    - include: numbers
+    - include: arrays
+    - include: inline-tables
 
   strings:
     # Multi-line basic strings
@@ -103,7 +112,10 @@ contexts:
     - match: '0b[01_]+'
       scope: constant.numeric.binary.toml
     # Float with exponent
-    - match: '[+-]?(\d[0-9_]*)?\.(\d[0-9_]*)?([eE][+-]?\d[0-9_]*)?'
+    - match: '[+-]?\d[0-9_]*\.\d[0-9_]*([eE][+-]?\d[0-9_]*)?'
+      scope: constant.numeric.float.toml
+    # Float with an exponent but no fractional part
+    - match: '[+-]?\d[0-9_]*[eE][+-]?\d[0-9_]*'
       scope: constant.numeric.float.toml
     # Float special values
     - match: '[+-]?(inf|nan)\b'
@@ -138,7 +150,7 @@ contexts:
         - match: '\]'
           scope: punctuation.definition.array.end.toml
           pop: true
-        - include: value
+        - include: value-components
         - match: ','
           scope: punctuation.separator.array.toml
         - include: comments
@@ -151,6 +163,16 @@ contexts:
         - match: '\}'
           scope: punctuation.definition.inline-table.end.toml
           pop: true
-        - include: key-value
+        - include: inline-key-value
         - match: ','
           scope: punctuation.separator.inline-table.toml
+
+  inline-key-value:
+    - match: '((?:[A-Za-z0-9_-]+|"[^"]*"|''[^'']*'')(?:\s*\.\s*(?:[A-Za-z0-9_-]+|"[^"]*"|''[^'']*''))*)\s*(=)'
+      captures:
+        1: entity.name.tag.toml
+        2: punctuation.separator.key-value.toml
+      push:
+        - include: value-components
+        - match: '(?=[,}])'
+          pop: true

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -2178,6 +2178,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_toml_multiline_array_strings_stay_strings() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("config.toml"), None, &registry);
+        assert_eq!(engine.backend_name(), "textmate");
+
+        let content = concat!(
+            "cmdline = [\n",
+            "  \"USER=root\",\n",
+            "  \"PATH=/bin:/benchmark\",\n",
+            "  \"init=/init\",\n",
+            "]\n",
+            "initramfs = \"test/initramfs/build/initramfs.cpio.gz\"\n",
+            "args = \"$(./tools/qemu_args.sh test)\"\n",
+            "package.metadata = { enabled = true, label = \"v1.2\" }\n",
+            "released = 2026-08-02\n",
+        );
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        for needle in [
+            "USER=root",
+            "/benchmark",
+            "init=/init",
+            ".cpio.gz",
+            "./tools",
+        ] {
+            let position = content.find(needle).unwrap();
+            assert_eq!(
+                engine.category_at_position(position),
+                Some(HighlightCategory::String),
+                "{needle:?} should be highlighted as part of its TOML string"
+            );
+        }
+
+        for needle in ["package.metadata", "enabled", "label"] {
+            let position = content.find(needle).unwrap();
+            assert_eq!(
+                engine.category_at_position(position),
+                Some(HighlightCategory::Property),
+                "{needle:?} should be highlighted as a TOML key"
+            );
+        }
+        assert_eq!(
+            engine.category_at_position(content.find("true").unwrap()),
+            Some(HighlightCategory::Number)
+        );
+        assert_eq!(
+            engine.category_at_position(content.find("2026-08-02").unwrap()),
+            Some(HighlightCategory::Constant)
+        );
+    }
+
     /// A recognized Markdown fence language must be highlighted with that
     /// language's grammar instead of the uniform `markup.raw` string color.
     #[test]


### PR DESCRIPTION
fix #2887

Corrected multiline TOML array state handling and string highlighting.
Prevented bare dots from being classified as floats.
Preserved dotted-key, inline-table, boolean, and date highlighting.
