### PR TITLE
Refresh disk-derived plugin state when a file is reset by an external tool; fix code-tour key-drop flake

### DIFF
--- a/crates/fresh-core/src/hooks.rs
+++ b/crates/fresh-core/src/hooks.rs
@@ -25,6 +25,14 @@ pub enum HookArgs {
     /// After a buffer is successfully saved
     AfterFileSave { buffer_id: BufferId, path: PathBuf },
 
+    /// A buffer was reloaded from disk — auto-revert picked up an external
+    /// change (e.g. `git checkout <ref> -- <file>` run in another terminal)
+    /// or the user ran an explicit revert. Fires after the new content is
+    /// live. Reloads don't go through `AfterFileSave`, so plugins that
+    /// surface disk-derived state (git gutter, etc.) must subscribe to this
+    /// too or their decorations go stale on every external reset.
+    AfterFileRevert { buffer_id: BufferId, path: PathBuf },
+
     /// The file explorer mutated the filesystem (paste, duplicate, ...)
     /// without going through a buffer save. Plugins that surface
     /// filesystem-derived state (git status decorations, etc.) use this

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -4352,19 +4352,24 @@ function review_toggle_watch() {
 }
 registerHandler("review_toggle_watch", review_toggle_watch);
 
-editor.on("after_file_save", () => {
-    if (!reviewWatchEnabled || state.groupId === null) return true;
-    // Range reviews are ref-to-ref; working-tree saves don't change them.
-    if (state.mode === 'range') return true;
-    const myGen = ++reviewWatchGen;
-    void editor.delay(WATCH_DEBOUNCE_MS).then(() => {
-        // Superseded by a later save, or the review closed / watch turned
-        // off while we waited.
-        if (myGen !== reviewWatchGen || !reviewWatchEnabled || state.groupId === null) return;
-        void refreshMagitData();
+// A save and an external reset (auto-revert reload, e.g. `git checkout
+// <ref> -- <file>` in another terminal) both change the working tree the
+// review diffs against, so they share one refresh handler.
+for (const event of ["after_file_save", "after_file_revert"] as const) {
+    editor.on(event, () => {
+        if (!reviewWatchEnabled || state.groupId === null) return true;
+        // Range reviews are ref-to-ref; working-tree changes don't affect them.
+        if (state.mode === 'range') return true;
+        const myGen = ++reviewWatchGen;
+        void editor.delay(WATCH_DEBOUNCE_MS).then(() => {
+            // Superseded by a later change, or the review closed / watch
+            // turned off while we waited.
+            if (myGen !== reviewWatchGen || !reviewWatchEnabled || state.groupId === null) return;
+            void refreshMagitData();
+        });
+        return true;
     });
-    return true;
-});
+}
 
 // --- Hunk navigation for side-by-side diff view ---
 

--- a/crates/fresh-editor/plugins/code-tour.ts
+++ b/crates/fresh-editor/plugins/code-tour.ts
@@ -952,7 +952,11 @@ async function revealStep(t: TourInstance): Promise<void> {
   // Naming a split explicitly would bypass that guard and let the step's
   // source land beside the panels.
   editor.openFile(step.file_path, step.lines[0], 1);
-  await editor.delay(30);
+  // `openFile` is a queued FIFO command — wait for the queue, not the clock.
+  // A fixed 30 ms said nothing about whether the host had drained it; on a
+  // loaded runner it often hadn't, `stepBufferId` below then missed the
+  // buffer, and the step silently painted no highlight at all.
+  await editor.flush();
 
   const bufferId = stepBufferId(step.file_path);
   if (bufferId) {
@@ -1050,21 +1054,33 @@ function targetTour(): TourInstance | null {
 }
 
 function dispatch(action: WidgetAction): void {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) t.panel.command(action);
 }
 
 // ============================================================================
 // Handlers — panel mode
 // ============================================================================
+//
+// These handlers resolve their tour with `targetTour()`, not
+// `tourForActiveBuffer()` alone. The mode that binds them is attached to the
+// tour panel's buffer, so the key can only have been pressed *in a panel* —
+// but the handler runs on the plugin thread after the fact, and the
+// active-buffer snapshot it would read may be mid-flight: a step's own
+// `revealStep` chain moves focus to the source file (`openFile`) and back
+// (`focusSplit`), and a key dispatched around that window used to resolve to
+// the source buffer, find no tour, and be dropped without a trace — `n`
+// pressed right after a step landed simply did nothing. `lastTourId` is
+// maintained at open and on every step change, so the fallback names the
+// tour the user is driving.
 
 registerHandler("tour_panel_next", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) goToStep(t, t.step + 1).catch((e) => editor.error(`code-tour: ${e}`));
 });
 
 registerHandler("tour_panel_prev", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) goToStep(t, t.step - 1).catch((e) => editor.error(`code-tour: ${e}`));
 });
 
@@ -1077,17 +1093,17 @@ registerHandler("tour_panel_page_up", () => dispatch(widgetKey("PageUp")));
 registerHandler("tour_panel_page_down", () => dispatch(widgetKey("PageDown")));
 
 registerHandler("tour_panel_jump", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) jumpToCode(t);
 });
 
 registerHandler("tour_panel_rehighlight", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) revealStep(t).catch((e) => editor.error(`code-tour: ${e}`));
 });
 
 registerHandler("tour_panel_steps", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (!t) return;
   if (!t.railOpen || t.dockWidth < RAIL_MIN_WIDTH) {
     t.railOpen = true;
@@ -1098,7 +1114,7 @@ registerHandler("tour_panel_steps", () => {
 });
 
 registerHandler("tour_panel_close", () => {
-  const t = tourForActiveBuffer();
+  const t = targetTour();
   if (t) closeTour(t, true);
 });
 

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -231,6 +231,12 @@ editor.on("after_file_open", () => {
 editor.on("after_file_save", () => {
   refreshGitExplorerDecorations();
 });
+// A reloaded buffer means the file changed on disk without a save — e.g.
+// `git checkout <ref> -- <file>` in another terminal — so its git status
+// badge may be stale.
+editor.on("after_file_revert", () => {
+  refreshGitExplorerDecorations();
+});
 editor.on("after_file_explorer_change", () => {
   refreshGitExplorerDecorations();
 });

--- a/crates/fresh-editor/plugins/git_gutter.ts
+++ b/crates/fresh-editor/plugins/git_gutter.ts
@@ -490,6 +490,29 @@ editor.on("after_file_save", (args) => {
 
   return true;
 });
+editor.on("after_file_revert", (args) => {
+  const bufferId = args.buffer_id;
+
+  // A reload replaced the buffer content (auto-revert after an external
+  // change like `git checkout <ref> -- <file>`, or an explicit revert),
+  // which drops the old indicators along with the old buffer state — but
+  // never goes through after_file_save. Re-diff so the gutter and
+  // scrollbar reflect the reloaded content.
+  const state = bufferStates.get(bufferId);
+  if (state) {
+    state.filePath = args.path;
+  } else {
+    bufferStates.set(bufferId, {
+      filePath: args.path,
+      hunks: [],
+      updating: false,
+    });
+  }
+
+  updateGitGutter(bufferId);
+
+  return true;
+});
 editor.on("buffer_closed", (args) => {
   bufferStates.delete(args.buffer_id);
   return true;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -4517,6 +4517,18 @@ interface HookEventMap {
 		buffer_id: number;
 	};
 	/**
+	* Fired after a buffer is reloaded from disk: auto-revert picked up an
+	* external change (e.g. `git checkout <ref> -- <file>` in another
+	* terminal), or the user ran an explicit revert. Reloads don't fire
+	* `after_file_save`, so plugins that surface disk-derived state
+	* (git gutter, etc.) should subscribe to this too or their decorations
+	* go stale on every external reset.
+	*/
+	after_file_revert: {
+		path: string;
+		buffer_id: number;
+	};
+	/**
 	* Fired by the file explorer after a paste/duplicate/etc. mutates
 	* the filesystem without going through a buffer save. Plugins that
 	* surface FS-derived state (git status badges, etc.) should

--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -1513,6 +1513,21 @@ editor.on("after_file_save", (args) => {
   return true;
 });
 
+editor.on("after_file_revert", (args) => {
+  const state = states.get(args.buffer_id);
+  if (!state) return true;
+  // The buffer was reloaded from disk (auto-revert after an external change,
+  // or an explicit revert). The disk-mode reference *is* the file on disk,
+  // so it is stale now; every mode needs a recompute against the reloaded
+  // content — the edit hooks don't fire for a wholesale buffer replacement.
+  state.filePath = args.path;
+  if (state.mode.kind === "disk") {
+    dropReference(state);
+  }
+  recompute(args.buffer_id).catch((e) => editor.error(`live-diff: ${e}`));
+  return true;
+});
+
 editor.on("buffer_closed", (args) => {
   states.delete(args.buffer_id);
   return true;

--- a/crates/fresh-editor/plugins/merge_conflict.ts
+++ b/crates/fresh-editor/plugins/merge_conflict.ts
@@ -1761,6 +1761,15 @@ editor.on("after_file_open", async (data) => {
     editor.t("status.detected_file", { path: data.path }),
   );
 });
+editor.on("after_file_revert", async (data) => {
+  // The buffer was reloaded because the file changed on disk while open
+  // (e.g. `git merge` / `git checkout` ran in another terminal) — conflict
+  // markers may have appeared or vanished. Same TTL bypass as file-open.
+  detectionLastCheck.delete(data.path);
+  await detectMergeConflictFor(data.path, () =>
+    editor.t("status.detected_file", { path: data.path }),
+  );
+});
 
 // =============================================================================
 // Command Registration - Dynamic based on merge mode state

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -584,6 +584,17 @@ impl Editor {
         // Notify LSP that the file was changed
         self.notify_lsp_file_changed(&path);
 
+        // Fire AfterFileRevert hook — the reload replaced the buffer content
+        // without going through the save path, so plugins tracking
+        // disk-derived state (git gutter, etc.) need this to re-scan.
+        self.plugin_manager.read().unwrap().run_hook(
+            "after_file_revert",
+            crate::services::plugins::hooks::HookArgs::AfterFileRevert {
+                buffer_id,
+                path: path.clone(),
+            },
+        );
+
         self.active_window_mut().status_message = Some(t!("status.reverted").to_string());
         Ok(true)
     }
@@ -1242,6 +1253,17 @@ impl Editor {
 
         // Notify LSP that the file was changed
         self.notify_lsp_file_changed(path);
+
+        // Fire AfterFileRevert hook — same contract as the active-buffer
+        // revert path: a reload is not a save, and plugins tracking
+        // disk-derived state need to re-scan the reloaded buffer.
+        self.plugin_manager.read().unwrap().run_hook(
+            "after_file_revert",
+            crate::services::plugins::hooks::HookArgs::AfterFileRevert {
+                buffer_id,
+                path: path.to_path_buf(),
+            },
+        );
 
         Ok(())
     }

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -425,6 +425,17 @@ A sample project for testing.
     pub fn stage_file(&self, relative_path: &str) {
         self.git_add(&[relative_path]);
     }
+
+    /// Reset a file's index and working-tree state to `refspec`, the way an
+    /// external tool would (`git checkout <ref> -- <path>` in another
+    /// terminal while the editor has the file open).
+    pub fn git_checkout_file(&self, refspec: &str, relative_path: &str) {
+        run_git_mutation(
+            &self.path,
+            &["checkout", refspec, "--", relative_path],
+            "checkout",
+        );
+    }
 }
 
 /// Helper to restore original directory

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -193,29 +193,49 @@ fn load_tour(harness: &mut EditorTestHarness, manifest: &str, tab_marker: &str) 
             screen.contains(tab_marker) && screen.contains("jump to code")
         })
         .unwrap();
-    // Opening a step is an async chain — open the file, await, paint the
-    // overlay, then hand focus back to the panel. Content on screen does not
-    // mean that chain has finished, and until it has focus is still on the
-    // editor, where a key types into the source file instead of stepping the
-    // tour.
-    //
-    // Wait for where focus actually landed, read off the status bar: the tour
-    // buffer is read-only plain text (`[RO]` … `Text`), while the editor shows
-    // a cursor position and the file's language. Plugin-thread quiescence was
-    // the obvious gate and is the wrong one — it is a heuristic that reports
-    // quiet while the handoff is still in flight, which is exactly how this
-    // timed out on CI but never locally.
-    wait_for_panel_focus(harness);
+    // Opening a step is an async chain — open the file, paint the overlay,
+    // then hand focus back to the panel. Content on screen does not mean that
+    // chain has finished; wait for its rendered end state before the caller
+    // sends a key.
+    wait_for_step_settled(harness);
 }
 
-/// Block until keyboard focus is on the tour panel, read off the status bar:
-/// the tour buffer is read-only plain text (`[RO]` … `Text`), while the editor
-/// split shows a cursor position and the file's language.
-fn wait_for_panel_focus(harness: &mut EditorTestHarness) {
+/// Screen rows (within the editor area) whose column 20 carries the step
+/// highlight's background colour. The highlight is painted `extendToLineEnd`,
+/// so column 20 is covered for every fixture file in this module.
+fn highlighted_rows(h: &EditorTestHarness) -> Vec<u16> {
+    (2..30u16)
+        .filter(|row| {
+            h.get_cell_style(20, *row)
+                .is_some_and(|s| s.bg == Some(ratatui::style::Color::Rgb(42, 74, 106)))
+        })
+        .collect()
+}
+
+/// Block until the current step's async chain has fully landed, read entirely
+/// off rendered output: a step highlight is painted in the editor AND the
+/// panel holds focus (status bar shows the tour buffer's `[RO]` … `Text`,
+/// where the editor split would show a cursor position and the file's
+/// language) — both in the same frame.
+///
+/// Panel focus alone is not a sound wait: the panel is focused *twice* per
+/// step — transiently, before `revealStep` opens the step's file (focus →
+/// editor split), and finally when the chain hands focus back. A wait that
+/// returns on the transient state lets the next key race the chain — the key
+/// is dispatched to the plugin, whose handler then resolves it against a
+/// mid-flight active-buffer snapshot — which is how this module used to time
+/// out on CI. The highlight only paints after the file open, so
+/// highlight ∧ panel-focus is first true once the chain is done. (A
+/// previously-loaded tour's highlight can satisfy the highlight half, so
+/// tests that navigate by key load a single tour.)
+///
+/// Plugin-thread quiescence is deliberately not used here — it is a
+/// heuristic that reports quiet while the handoff is still in flight.
+fn wait_for_step_settled(harness: &mut EditorTestHarness) {
     harness
         .wait_until(|h| {
             let screen = h.screen_to_string();
-            screen.contains("[RO]") && screen.contains("Text")
+            !highlighted_rows(h).is_empty() && screen.contains("[RO]") && screen.contains("Text")
         })
         .unwrap();
 }
@@ -224,15 +244,10 @@ fn wait_for_panel_focus(harness: &mut EditorTestHarness) {
 ///
 /// Changing step re-runs the same async chain as loading one: open the step's
 /// file — which moves focus to the editor split — paint the overlay, then hand
-/// focus back to the panel. The panel header updates at the *start* of that
-/// chain, so waiting only for "Step N of M" returns while focus is still on the
-/// editor, and the next key typed goes into the source file instead of stepping
-/// the tour.
-///
-/// That is what hung this module on CI three runs running: the `n` was fine,
-/// and the `p` after it landed in wide.rs, so "Step 1 of 2" never came back and
-/// the wait blocked until nextest killed it at 180s. Only one test sends a
-/// second navigation key, and only that test timed out.
+/// focus back to the panel. Waiting only for "Step N of M" is not enough: the
+/// header can repaint mid-chain (a dock resize re-renders it with the new step
+/// already set), so the wait continues to the chain's rendered end state
+/// before the caller trusts focus or sends another key.
 fn press_step_key(harness: &mut EditorTestHarness, key: char, expect: &str) {
     harness
         .send_key(KeyCode::Char(key), KeyModifiers::NONE)
@@ -240,9 +255,7 @@ fn press_step_key(harness: &mut EditorTestHarness, key: char, expect: &str) {
     harness
         .wait_until(|h| h.screen_to_string().contains(expect))
         .unwrap();
-    // The header moved; let the rest of the chain finish before trusting focus.
-    harness.wait_for_async_quiescence(3).unwrap();
-    wait_for_panel_focus(harness);
+    wait_for_step_settled(harness);
 }
 
 /// Screen row (0-based) of the first line containing `needle`.
@@ -713,22 +726,17 @@ fn test_step_range_is_highlighted_in_the_editor() {
     press_step_key(&mut harness, 'n', "Step 2 of 2");
 
     // The highlight is a background colour, so read rendered cell styles
-    // rather than the plain text. Painting it is the tail of an async chain,
-    // so wait for it to land — waiting for *a* highlighted row and then
-    // asserting *which* rows carry it keeps the check from passing vacuously.
-    let highlighted = |h: &EditorTestHarness| -> Vec<u16> {
-        (2..30u16)
-            .filter(|row| {
-                h.get_cell_style(20, *row)
-                    .is_some_and(|s| s.bg == Some(ratatui::style::Color::Rgb(42, 74, 106)))
-            })
-            .collect()
-    };
-    harness.wait_until(|h| !highlighted(h).is_empty()).unwrap();
+    // rather than the plain text. `press_step_key` already waited for *a*
+    // highlighted row; step 2's range fills the pane, and waiting for more
+    // rows than step 1's three-line range could ever paint keeps the check
+    // from passing on step 1's leftovers.
+    harness
+        .wait_until(|h| highlighted_rows(h).len() > 10)
+        .unwrap();
 
     // The step's range is taller than the pane, so every code row on screen
     // carries it — contiguously, with no unhighlighted gap in the middle.
-    let rows = highlighted(&harness);
+    let rows = highlighted_rows(&harness);
     let (first, last) = (rows[0], rows[rows.len() - 1]);
     assert_eq!(
         rows,

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -1653,3 +1653,80 @@ fn test_git_gutter_scrollbar_marks_appear_after_save() {
         "the inserted line is an addition, so its mark is green; saw {rows:?}"
     );
 }
+
+/// Resetting an open file to a different state with an external tool
+/// (`git checkout <ref> -- <file>` in another terminal) auto-reverts the
+/// buffer — and the gutter and scrollbar must re-diff against HEAD, not
+/// keep showing the pre-reset (empty) state.
+// TODO: Fix git gutter tests on Windows - they fail due to git command output differences
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_git_gutter_refreshes_after_external_git_checkout() {
+    let repo = GitTestRepo::new();
+    repo.setup_git_gutter_plugin();
+
+    // v1: 200 plain numbered lines.
+    let v1 = numbered_lines(200);
+    repo.create_file("long.txt", &format!("{}\n", v1.join("\n")));
+    repo.git_add_all();
+    repo.git_commit("v1");
+
+    // v2 (HEAD): two lines rewritten near the top, where they are on screen.
+    let mut v2 = v1.clone();
+    v2[4] = "line 0004 CHANGED IN HEAD".to_string();
+    v2[5] = "line 0005 CHANGED IN HEAD".to_string();
+    repo.modify_file("long.txt", &format!("{}\n", v2.join("\n")));
+    repo.git_add_all();
+    repo.git_commit("v2");
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    open_file(&mut harness, &repo.path, "long.txt");
+    trigger_git_gutter_refresh(&mut harness);
+
+    // The working tree matches HEAD, so the plugin's first pass reports no
+    // hunks — the status line proves the pass completed.
+    harness.wait_for_screen_contains("0 change(s)").unwrap();
+    assert!(
+        !has_gutter_indicator(&harness.screen_to_string(), "│"),
+        "a file matching HEAD should have no gutter indicators"
+    );
+
+    // Filesystems with 1s mtime granularity need the reset's mtime to land
+    // after the open's recorded mtime, or auto-revert won't see a change.
+    harness.sleep(std::time::Duration::from_millis(2100));
+
+    // Externally reset the file to its v1 state while it is open.
+    repo.git_checkout_file("HEAD~1", "long.txt");
+
+    // Auto-revert reloads the buffer from disk.
+    harness
+        .wait_until(|h| !h.get_buffer_content().unwrap().contains("CHANGED IN HEAD"))
+        .expect("auto-revert should reload the externally reset file");
+
+    // The reverted content differs from HEAD on the two rewritten lines, so
+    // the gutter must show modified indicators without any user action...
+    wait_for_indicator(&mut harness, "│");
+
+    // ...and the same hunk must be marked on the scrollbar.
+    harness
+        .wait_until(|h| !scrollbar_marker_rows(h).is_empty())
+        .expect("the re-diffed hunk should mark the scrollbar too");
+
+    let rows = scrollbar_marker_rows(&harness);
+    assert_eq!(
+        rows.first().map(|(_, fg)| *fg),
+        Some(Some(Color::Rgb(255, 184, 108))),
+        "the reset lines differ from HEAD as modifications, so their mark is \
+         orange; saw {rows:?}"
+    );
+}

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -581,6 +581,15 @@ interface HookEventMap {
   before_file_save: { path: string; buffer_id: number };
   after_file_save: { path: string; buffer_id: number };
   /**
+   * Fired after a buffer is reloaded from disk: auto-revert picked up an
+   * external change (e.g. `git checkout <ref> -- <file>` in another
+   * terminal), or the user ran an explicit revert. Reloads don't fire
+   * `after_file_save`, so plugins that surface disk-derived state
+   * (git gutter, etc.) should subscribe to this too or their decorations
+   * go stale on every external reset.
+   */
+  after_file_revert: { path: string; buffer_id: number };
+  /**
    * Fired by the file explorer after a paste/duplicate/etc. mutates
    * the filesystem without going through a buffer save. Plugins that
    * surface FS-derived state (git status badges, etc.) should


### PR DESCRIPTION
## Problem

Saving a file from inside the editor updates the git gutter and its scrollbar markers, but resetting an open file with an external tool — e.g. running `git checkout HEAD~300 -- README.md` in another terminal — auto-reverts the buffer without updating them. The gutter and scrollbar keep showing the pre-reset state (typically: nothing), even though the file now differs from HEAD.

Reproduced interactively in tmux with a debug build: after an external `git checkout HEAD~1 -- file.txt`, the buffer content reloaded correctly but the gutter column and scrollbar track stayed empty while `git diff HEAD` reported 7 changed lines. The in-editor save path showed markers correctly.

## Root cause

The reload paths — `revert_file()` for the active buffer and `revert_buffer_by_id()` for background buffers (`crates/fresh-editor/src/app/file_operations.rs`) — replace the buffer's `EditorState` wholesale, which drops the plugin's old line indicators, and fire no plugin hook. The `git_gutter` plugin only re-diffs on `after_file_open`, `after_file_save`, and `buffer_activated`, so nothing tells it the content changed.

## Commit 1 — `after_file_revert` hook + git gutter fix

- Add an `AfterFileRevert` hook variant (`after_file_revert`) to `fresh-core`, fired from both reload paths after the new content is live. It covers auto-revert and the explicit Revert command alike.
- Subscribe `git_gutter.ts` to it, mirroring its `after_file_save` handler, so the gutter and scrollbar markers re-diff against HEAD after every reload.
- Expose the event in the plugin API type map (`ts_export.rs`) and regenerate `fresh.d.ts`.

## Commit 2 — subscribe the other disk-state plugins

Audited all 86 plugins for state derived from the file on disk that goes stale on an external reset. Wired four more to the new hook:

- **git_explorer** — the file's git status badge in the tree
- **live_diff** — the disk-mode reference *is* the file on disk, and the edit hooks don't fire for a wholesale buffer replacement
- **merge_conflict** — conflict markers can appear or vanish when git runs in another terminal (same reasoning as its file-open TTL bypass)
- **audit_mode** — the review watch re-diffs the working tree on save; a reload changes the working tree the same way

Deliberately not subscribed: `git_statusbar` (branch-only — a file revert cannot change the branch; HEAD mutations are caught by its `path_changed` watch), `diff_nav` (reads git_gutter's shared view state, refreshed transitively), LSP wrappers (core already notifies LSP on reload), and `lines_changed`-driven renderers that self-heal.

## Commit 3 — fix the `code_tour_dock` highlight-test flake

`e2e::code_tour_dock::test_step_range_is_highlighted_in_the_editor` kept timing out on CI, stuck on "Step 1 of 2" after pressing `n`. The key was delivered to the panel's mode binding — and then silently dropped by the plugin: every step change runs an async chain (open the step's file, paint the highlight, hand focus back to the panel), and the panel-mode handlers resolved their tour via `tourForActiveBuffer()` — the active-buffer snapshot at *handler* time on the plugin thread. A key dispatched around the chain's file-open window resolved to the source buffer, found no tour, and hit a bare `if (t)`. Three timing holes closed:

- **Key drop:** the panel-mode handlers now fall back to `targetTour()` (`lastTourId`) — the same resolution the palette commands already use. The mode is attached to the panel's buffer, so the key can only have come from a tour panel.
- **Fixed timer:** `revealStep` waited a hard-coded 30 ms after `openFile` (a queued FIFO command) before looking the buffer up; on a loaded runner the queue hadn't drained and the step painted no highlight at all. Now `await editor.flush()` — wait for the queue, not the clock.
- **Unsound test wait:** `wait_for_panel_focus` could return on the *transient* panel focus that exists before `revealStep` steals it, letting the next key race the chain. The settle wait now requires the step highlight and panel focus in the same rendered frame — first true only once the chain is done — and replaces the `wait_for_async_quiescence` heuristic the module itself documented as unreliable.

The CI interleaving is cross-thread and did not yield to deterministic local reproduction (three widening attempts each serialized the pipeline instead); the fix is backed by mechanism analysis plus the full module green (12 tests) and the four key/click-racing tests green over 10 consecutive stress rounds.

## Testing

- New e2e test `test_git_gutter_refreshes_after_external_git_checkout` drives the exact reported scenario: commit v1, commit v2, open the file (gutter settles at "0 change(s)"), run `git checkout HEAD~1 -- long.txt` externally, wait for auto-revert, and assert — on rendered output only — that modified-line gutter indicators and an orange scrollbar marker appear. **Fails (times out) without the fix, passes with it.**
- 134 e2e tests across the gutter, live_diff, audit_mode, git, and merge_conflict suites pass.
- Full `code_tour_dock` module passes; key-racing tests stress-tested 10×.
- `cargo check --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets` clean (no new warnings in touched files); plugin type-check clean for all edited plugins (the pre-existing type errors are byte-identical on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfxhdGTx6J6xX7EXSXCAe1