### PR TITLE
Parse whole files up to 1MB in the tree-sitter highlighter

### DIFF
--- a/crates/fresh-editor/src/primitives/highlighter.rs
+++ b/crates/fresh-editor/src/primitives/highlighter.rs
@@ -1,13 +1,17 @@
 //! Syntax highlighting with tree-sitter
 //!
 //! # Design
-//! - **Viewport-only parsing**: Only highlights visible lines for instant performance with large files
-//! - **Incremental updates**: Re-parses only edited regions
+//! - **Whole-file parsing for normal files**: Buffers at or below
+//!   `MAX_PARSE_BYTES` are parsed from offset 0, because a parse that starts
+//!   at an arbitrary mid-file offset can begin inside a multi-line construct
+//!   (a block comment or template literal) and mis-highlight everything after
+//!   it — e.g. a backtick inside chopped JSDoc text opens a phantom template
+//!   literal that swallows the whole viewport as a string. Matches the policy
+//!   of the syntect-based `TextMateEngine`.
+//! - **Viewport-only parsing for large files**: Above `MAX_PARSE_BYTES`, only
+//!   the viewport plus `context_bytes` of surrounding text is parsed, keeping
+//!   a jump into a 1GB file instant at the cost of best-effort accuracy.
 //! - **Lazy initialization**: Parsing happens on first render
-//!
-//! # Performance
-//! Must work instantly when loading a 1GB file and jumping to an arbitrary offset.
-//! This is achieved by only parsing the visible viewport (~50 lines), not the entire file.
 
 use crate::model::buffer::Buffer;
 use crate::view::theme::Theme;
@@ -166,10 +170,21 @@ impl Highlighter {
             }
         }
 
-        // Cache miss - need to parse
-        // Extend range for context (helps with multi-line constructs like strings, comments, nested blocks)
-        let parse_start = viewport_start.saturating_sub(context_bytes);
-        let parse_end = (viewport_end + context_bytes).min(buffer.len());
+        // Cache miss - need to parse.
+        //
+        // For buffers up to MAX_PARSE_BYTES, parse the whole file: starting a
+        // parse mid-file can land inside a multi-line construct (block
+        // comment, template literal) and derail highlighting for everything
+        // that follows. Larger buffers fall back to the viewport window plus
+        // `context_bytes` of context, which is best-effort.
+        let (parse_start, parse_end) = if buffer.len() <= MAX_PARSE_BYTES {
+            (0, buffer.len())
+        } else {
+            (
+                viewport_start.saturating_sub(context_bytes),
+                (viewport_end + context_bytes).min(buffer.len()),
+            )
+        };
         let parse_range = parse_start..parse_end;
 
         // Limit parse size for safety
@@ -491,6 +506,72 @@ mod tests {
                 viewport_end
             );
         }
+    }
+
+    #[test]
+    fn test_jump_open_mid_file_matches_whole_file_parse() {
+        // Regression test: opening a file directly at a line (`fresh
+        // file.ts:1118`) used to start the parse at `viewport_start -
+        // context_bytes`, an arbitrary byte offset. When that offset fell
+        // inside a block comment containing a backtick, tree-sitter read the
+        // backtick as opening a template literal that ran until the next
+        // backtick in a later comment, highlighting the entire viewport —
+        // real code — as one giant string.
+        let mut content = String::from("/**\n");
+        for _ in 0..120 {
+            content.push_str(" * plain filler line without special punctuation.\n");
+        }
+        content.push_str(" * a stray backtick ` lives here.\n");
+        for _ in 0..10 {
+            content.push_str(" * more filler after the backtick.\n");
+        }
+        content.push_str(" */\n");
+        let comment_end = content.len();
+        for i in 0..40 {
+            content.push_str(&format!(
+                "function f{i}(x: number): number {{ return x + {i}; }}\n"
+            ));
+        }
+        content.push_str("// the matching backtick ` closes the phantom template here\n");
+        for i in 40..60 {
+            content.push_str(&format!(
+                "function f{i}(x: number): number {{ return x + {i}; }}\n"
+            ));
+        }
+        let buffer = Buffer::from_str_test(&content);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        // Ground truth: parse from the start of the file.
+        let mut full = Highlighter::new(Language::TypeScript).unwrap();
+        let full_spans = full.highlight_viewport(&buffer, 0, content.len(), &theme, content.len());
+
+        // Jump-open: viewport over the code, positioned so the pre-fix parse
+        // window (viewport_start - context_bytes) started inside the comment,
+        // after which exactly one backtick preceded the code.
+        let viewport_start = comment_end + 500;
+        let viewport_end = comment_end + 1500;
+        let mut jump = Highlighter::new(Language::TypeScript).unwrap();
+        let jump_spans =
+            jump.highlight_viewport(&buffer, viewport_start, viewport_end, &theme, 2000);
+
+        let clip = |spans: &[HighlightSpan]| -> Vec<(usize, usize, Option<HighlightCategory>)> {
+            spans
+                .iter()
+                .filter(|s| s.range.start < viewport_end && s.range.end > viewport_start)
+                .map(|s| {
+                    (
+                        s.range.start.max(viewport_start),
+                        s.range.end.min(viewport_end),
+                        s.category,
+                    )
+                })
+                .collect()
+        };
+        assert_eq!(
+            clip(&full_spans),
+            clip(&jump_spans),
+            "viewport highlighting after a jump-open must match a whole-file parse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Opening a file directly at a line (`fresh crates/fresh-editor/plugins/live_diff.ts:1118`) can show broken syntax highlighting; scrolling up eventually "repairs" it and it stays repaired.

The tree-sitter `Highlighter::highlight_viewport` started its parse at `viewport_start - context_bytes` — an arbitrary raw byte offset. When that offset landed inside a block comment whose prose contains backticks (very common in JSDoc, e.g. `` `lines_changed` ``), tree-sitter read a backtick as opening a template literal that terminated at a later backtick, swallowing the entire viewport as one giant `String` span. Scrolling moves the chop point; most chop points are benign (~97% in `live_diff.ts`), which is why scrolling "fixes" it and it stays fixed.

Reproduced deterministically by comparing chopped-viewport spans against a whole-file parse across all jump targets in `live_diff.ts`: 10 of ~317 sampled targets rendered **all 45 visible lines** as a single string span (e.g. opening at line 421, `const middle: DiffOp[] = [];` was one `String` span instead of keyword/variable/type). The exact trigger line depends on terminal geometry and file content byte-for-byte.

## Fix

Parse from offset 0 for buffers at or below `MAX_PARSE_BYTES` (1 MB) — the same policy the syntect `TextMateEngine` already uses (`grammar/types.rs`). The windowed best-effort parse is kept for larger files so jumping into huge files stays instant. As a side benefit, the span cache now covers the whole file for normal-sized files, so scrolling no longer re-parses at every cache edge.

## Testing

- New regression test `test_jump_open_mid_file_matches_whole_file_parse` constructs the failure (backtick inside a comment before the viewport, matching backtick after it) and asserts jump-open spans equal a whole-file parse. Verified it **fails without the fix** (viewport collapses to `[(6892, 7892, Some(String))]`) and passes with it.
- Full `fresh-editor` lib suite: 3210 passed, 0 failed.
- `cargo fmt`, `cargo clippy` (no new warnings), `cargo check --all-targets` clean.
- Verified interactively in tmux (debug build, `file:line` open at several targets): highlighting is correct at open and stable across scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dySZV9UzXm3AjcxXu9g39

---
_Generated by [Claude Code](https://claude.ai/code/session_014dySZV9UzXm3AjcxXu9g39)_