### PR TITLE
Fix Ctrl+V/Ctrl+A/Ctrl+C/Ctrl+X in New Workspace and Run Agent dialog text fields

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -3178,7 +3178,8 @@ impl Editor {
                     let key_event = crossterm::event::KeyEvent::new(code, modifiers);
                     let resolved = {
                         let keybindings = self.keybindings.read().unwrap();
-                        keybindings.resolve(&key_event, crate::input::keybindings::KeyContext::Normal)
+                        keybindings
+                            .resolve(&key_event, crate::input::keybindings::KeyContext::Normal)
                     };
                     match resolved {
                         Action::Paste => {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -3164,6 +3164,49 @@ impl Editor {
             // editor (blur) and falls through so the editor handles it
             // (e.g. Ctrl-P opens the command palette).
             if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                // Clipboard chords on a focused Text field belong to the
+                // field, not the editor: Ctrl+V must paste into the
+                // New-Session form's Project Path, not be swallowed (and
+                // Ctrl+A / Ctrl+C / Ctrl+X select/copy/cut the field's
+                // own text). Resolve against the Normal context — the
+                // same lookup the buffer-mounted widget routing in
+                // `handle_action` uses — and route the clipboard actions
+                // to the widget. Everything else keeps the swallow/blur
+                // behaviour below.
+                if self.panel_focused_widget_is_text(&panel_key) {
+                    use crate::input::keybindings::Action;
+                    let key_event = crossterm::event::KeyEvent::new(code, modifiers);
+                    let resolved = {
+                        let keybindings = self.keybindings.read().unwrap();
+                        keybindings.resolve(&key_event, crate::input::keybindings::KeyContext::Normal)
+                    };
+                    match resolved {
+                        Action::Paste => {
+                            if let Some(text) = self.clipboard.paste() {
+                                // Normalise line endings to LF, matching the
+                                // Action::Paste widget branch; single-line
+                                // TextEdit strips embedded newlines itself.
+                                let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+                                self.handle_widget_insert_str(&panel_key, &normalized);
+                                self.set_status_message(t!("clipboard.pasted").to_string());
+                            }
+                            return true;
+                        }
+                        Action::Copy => {
+                            self.handle_widget_copy(&panel_key);
+                            return true;
+                        }
+                        Action::Cut => {
+                            self.handle_widget_cut(&panel_key);
+                            return true;
+                        }
+                        Action::SelectAll => {
+                            self.handle_widget_select_all(&panel_key);
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
                 if matches!(
                     self.panel(slot).map(|f| f.placement),
                     Some(super::PanelPlacement::LeftDock { .. })

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -864,6 +864,89 @@ fn bracketed_paste_ignored_when_non_text_widget_focused() {
     );
 }
 
+/// `Ctrl+V` must paste the editor clipboard into the focused dialog
+/// field — same destination as a terminal bracketed paste, different
+/// entry path (a key event resolved through the keybinding table, not
+/// an `Event::Paste`).
+///
+/// Regression: the centered modal's key dispatcher swallowed every
+/// Ctrl-chord that had no mode binding, so Ctrl+V (and Ctrl+A / Ctrl+C /
+/// Ctrl+X) died before reaching the focused Text widget. Text copied
+/// from a buffer with Ctrl+C could not be pasted into the New-Workspace
+/// or Run-Agent dialogs at all.
+#[test]
+fn ctrl_v_pastes_into_focused_dialog_field() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("CTRLV_MARKER".to_string());
+
+    open_new_session_form(&mut harness);
+
+    // The Project Path text field is focused on open.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()).contains("CTRLV_MARKER"))
+        .unwrap();
+
+    // And it must not have leaked into the buffer underneath.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| {
+            !h.screen_to_string()
+                .contains("ORCHESTRATOR :: New Workspace")
+        })
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("CTRLV_MARKER"),
+        "Ctrl+V must not leak into the buffer behind the dialog. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// `Ctrl+A` selects the focused field's text, so a following paste
+/// replaces it instead of appending — the standard select-all-then-paste
+/// gesture. Same regression class as `ctrl_v_pastes_into_focused_dialog_field`:
+/// the modal swallowed the chord, the selection never happened, and the
+/// paste appended after the old text.
+#[test]
+fn ctrl_a_selects_field_text_so_paste_replaces_it() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+
+    harness.type_text("OLDTEXT").unwrap();
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()).contains("OLDTEXT"))
+        .unwrap();
+
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.send_paste("NEWTEXT").unwrap();
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()).contains("NEWTEXT"))
+        .unwrap();
+
+    let value = project_path_field_value(&harness.screen_to_string());
+    assert!(
+        !value.contains("OLDTEXT"),
+        "paste after Ctrl+A must replace the selected field text, not append. \
+         Field value: {:?}. Screen:\n{}",
+        value,
+        harness.screen_to_string(),
+    );
+}
+
 // ===========================================================================
 // Focus model: visible `▸` marker, linear Tab, ←/→ within selectors,
 // scoped Esc, and the Ctrl+Enter submit shortcut.


### PR DESCRIPTION
## Problem

Paste didn't work correctly in the Orchestrator **New Workspace** and **Run Agent…** dialogs: terminal bracketed paste reached the focused text field, but the keyboard clipboard chords did not. Text copied from a buffer with Ctrl+C could not be pasted into any dialog field with Ctrl+V, and Ctrl+A was dead, so the common "select all, paste over" gesture silently appended instead of replacing.

**Root cause**: the centered-modal key dispatcher (`dispatch_floating_widget_key`) swallows every Ctrl/Alt chord that has no plugin mode binding — intentionally, so chords like Ctrl+P can't leak past the modal — but that also killed Ctrl+V / Ctrl+A / Ctrl+C / Ctrl+X before they could reach the focused Text widget.

## Fix

In the Ctrl/Alt-chord branch, when the panel's focused widget is a Text field, resolve the chord against the Normal keybinding context and route **Paste / Copy / Cut / Select-All** to that widget — the same destination the bracketed-paste path (`paste_bracketed_into_focused_panel`) already uses. All other chords keep the existing swallow (centered modal) / blur (dock) behaviour. This also gives the dock's text filter working clipboard chords instead of blurring on them.

## Verification

Reproduced and verified interactively by driving the real editor in a tmux pane, across **every text field of both dialogs** (25/25 checks passing):

- Bracketed paste into: Project Path, Workspace Name, Start prompt, Agent Command, Checkout branch, New branch (local backend); Host, Remote Path, Identity, Options (SSH); Target, Context, Namespace, Pod, Workspace path (Kubernetes); Run Agent's Agent Command + Start prompt
- Ctrl+V pastes the editor clipboard into the focused field
- Ctrl+A + paste replaces the field text instead of appending
- Multi-line paste flattens into single-line fields (newline → space), nothing leaks
- Pasted values survive Tab-away re-renders (plugin mirror stays in sync)
- Paste with focus on a non-text control (backend tab, agent dropdown) is swallowed, not leaked into the buffer behind the modal

Automated coverage:

- Two new e2e regression tests: `ctrl_v_pastes_into_focused_dialog_field`, `ctrl_a_selects_field_text_so_paste_replaces_it`
- 365 existing e2e tests across the orchestrator, paste, settings, and dock suites all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqW3Ef9cBt4c4naHSJA2TM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqW3Ef9cBt4c4naHSJA2TM)_