### PR TITLE
Orchestrator dock: rename/move only the targeted workspace, not its root co-tenants

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -963,11 +963,15 @@ function configuredHideTrivial(): boolean {
 // lists every project's sessions, so the organisation is global, not
 // per-project) and persist across restarts.
 //
-// A session is assigned by its *canonical root path*, not its numeric
-// window id: the id churns (a discovered on-disk worktree carries a
-// synthetic negative id that becomes a positive window id the moment it
-// is opened) and isn't stable run-to-run, whereas the root is the
-// session's durable identity (§3 of orchestrator-sessions.md).
+// A session is assigned by a durable key, not its numeric window id:
+// the id churns (a discovered on-disk worktree carries a synthetic
+// negative id that becomes a positive window id the moment it is
+// opened) and isn't stable run-to-run. The durable key is the window's
+// stable id when the host reports one (`stableIdKey` — co-tenant
+// workspaces share a root, so a per-root key would file them all
+// together), falling back to the canonical root path for windowless
+// rows and entries written before stable-id keying (§3 of
+// orchestrator-sessions.md).
 // =============================================================================
 
 interface DockFolder {
@@ -1065,9 +1069,27 @@ function sessionNodeKey(id: number): string {
   return SESSION_NODE_PREFIX + id;
 }
 
-// The durable key a session is filed under (see the section header).
-function sessionAssignKey(s: AgentSession): string {
-  return normRoot(s.root);
+// Durable store key for a workspace-scoped entry (manual name, folder
+// assignment). Keyed by the host's stable id: co-tenant workspaces (a
+// tab extracted to a new workspace) share one root, so a per-root key
+// would apply the entry to all of them at once. The bare root remains
+// both the legacy key (entries written before stable-id keying) and the
+// only key available for rows without a live window (discovered
+// worktrees).
+function stableIdKey(stableId: string): string {
+  return "id:" + stableId;
+}
+
+// Whether another live workspace co-tenants `s`'s root. When one does, a
+// legacy per-root store entry may still describe *that* workspace, so
+// writers must leave it alone — touching it is the "renaming the
+// extracted workspace renamed the original too" bug, and its
+// move-to-folder twin.
+function hasLiveCoTenant(s: AgentSession): boolean {
+  const rootKey = normRoot(s.root);
+  return [...orchestratorSessions.values()].some(
+    (o) => o.id !== s.id && !o.discovered && o.id > 0 && normRoot(o.root) === rootKey,
+  );
 }
 
 function folderById(id: string): DockFolder | undefined {
@@ -1089,10 +1111,17 @@ function childFoldersOf(parent: string | null): DockFolder[] {
 
 // The folder a live session is filed under, or null when it is unfiled
 // or its folder was deleted out from under it (treated as top level).
+// The session's own stable-id entry wins; an empty string there is an
+// explicit "top level" (recorded when unfiling next to a co-tenant, so
+// the legacy per-root entry can't pull the row back into a folder).
+// Only a session with no entry of its own falls back to the legacy /
+// windowless per-root entry.
 function folderOfSession(id: number): string | null {
   const s = orchestratorSessions.get(id);
   if (!s) return null;
-  const a = loadAssign()[sessionAssignKey(s)];
+  const assign = loadAssign();
+  const own = s.stableId ? assign[stableIdKey(s.stableId)] : undefined;
+  const a = own !== undefined ? own : assign[normRoot(s.root)];
   return a && folderById(a) ? a : null;
 }
 
@@ -1218,22 +1247,12 @@ function saveNames(): void {
   editor.setGlobalState(WORKSPACE_NAMES_KEY, (dockNames ?? {}) as unknown as object);
 }
 
-// Store key for a workspace's manual name. Keyed by the durable stable id
-// when the host reports one: co-tenant workspaces (a tab extracted to a
-// new workspace) share one root, so a per-root key would rename them all
-// at once. The bare root remains both the legacy key (entries written
-// before stable-id keying) and the only key available for rows without a
-// live window (discovered worktrees).
-function nameKeyById(stableId: string): string {
-  return "id:" + stableId;
-}
-
 // The manual name pinned to a workspace, if any: its own stable-id entry
 // first, else the legacy / windowless per-root entry.
 function customNameFor(stableId: string | undefined, root: string): string | undefined {
   const store = loadNames();
   if (stableId) {
-    const own = store[nameKeyById(stableId)];
+    const own = store[stableIdKey(stableId)];
     if (own) return own;
   }
   return store[normRoot(root)];
@@ -1270,21 +1289,17 @@ function renameWorkspace(s: AgentSession, name: string): void {
   const rootKey = normRoot(s.root);
   const store = loadNames();
   const trimmed = name.trim();
-  // Whether another live workspace co-tenants this root. If so, the
-  // legacy per-root entry (when one exists) still names *that* workspace,
-  // so it must be left alone — touching it is exactly the "renaming the
-  // extracted workspace renamed the original too" bug.
-  const hasCoTenant = [...orchestratorSessions.values()].some(
-    (o) => o.id !== s.id && !o.discovered && o.id > 0 && normRoot(o.root) === rootKey,
-  );
   if (s.stableId) {
-    const idKey = nameKeyById(s.stableId);
+    const idKey = stableIdKey(s.stableId);
     if (trimmed) store[idKey] = trimmed;
     else delete store[idKey];
     // Keep the per-root entry in step when it can only mean this
     // workspace, so root-keyed lookups (a later discovered row at this
     // root, a legacy workspace file) agree with the rename / clear.
-    if (!hasCoTenant) {
+    // With a co-tenant present the entry may still name *that*
+    // workspace, so it is left alone — touching it is exactly the
+    // "renaming the extracted workspace renamed the original too" bug.
+    if (!hasLiveCoTenant(s)) {
       if (trimmed) store[rootKey] = trimmed;
       else delete store[rootKey];
     }
@@ -1325,9 +1340,27 @@ function assignSessionToFolder(id: number, folderId: string | null): void {
   const s = orchestratorSessions.get(id);
   if (!s) return;
   const assign = loadAssign();
-  const key = sessionAssignKey(s);
-  if (folderId) assign[key] = folderId;
-  else delete assign[key];
+  const rootKey = normRoot(s.root);
+  if (s.stableId) {
+    const idKey = stableIdKey(s.stableId);
+    const coTenant = hasLiveCoTenant(s);
+    if (folderId) assign[idKey] = folderId;
+    // Unfiling next to a co-tenant records an explicit "top level" ("")
+    // rather than deleting the entry — a bare delete would fall back to
+    // the co-tenant's legacy per-root entry and the move wouldn't stick.
+    else if (coTenant) assign[idKey] = "";
+    else delete assign[idKey];
+    // Keep the per-root entry in step when it can only mean this
+    // workspace, so root-keyed lookups (a later discovered row at this
+    // root, a legacy workspace file) agree with the move.
+    if (!coTenant) {
+      if (folderId) assign[rootKey] = folderId;
+      else delete assign[rootKey];
+    }
+  } else {
+    if (folderId) assign[rootKey] = folderId;
+    else delete assign[rootKey];
+  }
   saveAssign();
 }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -72,9 +72,16 @@ type CompletionItem = { value: string; kind?: "history" };
 interface AgentSession {
   // Editor's stable session id.
   id: number;
+  // Durable workspace identity (`ws-…`) reported by the host window.
+  // Unlike `root` it distinguishes co-tenant workspaces sharing one
+  // project root (e.g. a tab extracted to a new workspace), so manual
+  // renames are keyed by it. Undefined for rows without a live window
+  // (discovered worktrees, pending placeholders) and for legacy
+  // workspace files that predate stable ids.
+  stableId?: string;
   // Resolved display name shown in the dock / picker. Computed by
   // `workspaceDisplayName` from three sources, most-specific first: a
-  // manual rename (`renameWorkspace`, persisted per root), else an
+  // manual rename (`renameWorkspace`, persisted per workspace), else an
   // auto-name tracking the terminal's tab title (constant workspace
   // prefix + the terminal/process title), else `hostLabel`.
   label: string;
@@ -1179,7 +1186,7 @@ function sessionLastActiveDay(s: AgentSession): number {
 // ── Workspace names: manual rename + terminal-tracking auto-name ─────────
 //
 // A workspace's display name comes from three sources, most-specific first:
-//   1. a manual rename (persisted per canonical root, survives restarts),
+//   1. a manual rename (persisted per workspace, survives restarts),
 //   2. else, when it has a terminal that reports a title, an auto-name that
 //      tracks that terminal: a constant prefix (the workspace's own name, so
 //      you can still tell which workspace it is) + the changing terminal/
@@ -1211,9 +1218,30 @@ function saveNames(): void {
   editor.setGlobalState(WORKSPACE_NAMES_KEY, (dockNames ?? {}) as unknown as object);
 }
 
-// The manual name pinned to this session's root, if any.
+// Store key for a workspace's manual name. Keyed by the durable stable id
+// when the host reports one: co-tenant workspaces (a tab extracted to a
+// new workspace) share one root, so a per-root key would rename them all
+// at once. The bare root remains both the legacy key (entries written
+// before stable-id keying) and the only key available for rows without a
+// live window (discovered worktrees).
+function nameKeyById(stableId: string): string {
+  return "id:" + stableId;
+}
+
+// The manual name pinned to a workspace, if any: its own stable-id entry
+// first, else the legacy / windowless per-root entry.
+function customNameFor(stableId: string | undefined, root: string): string | undefined {
+  const store = loadNames();
+  if (stableId) {
+    const own = store[nameKeyById(stableId)];
+    if (own) return own;
+  }
+  return store[normRoot(root)];
+}
+
+// The manual name pinned to this session, if any.
 function workspaceCustomName(s: AgentSession): string | undefined {
-  return loadNames()[normRoot(s.root)];
+  return customNameFor(s.stableId, s.root);
 }
 
 // Compute the display name for a session from the three sources above.
@@ -1239,11 +1267,31 @@ function applyResolvedLabel(s: AgentSession): void {
 // refresh its resolved label. Clearing lets the auto-name / host label take
 // over again.
 function renameWorkspace(s: AgentSession, name: string): void {
-  const key = normRoot(s.root);
+  const rootKey = normRoot(s.root);
   const store = loadNames();
   const trimmed = name.trim();
-  if (trimmed) store[key] = trimmed;
-  else delete store[key];
+  // Whether another live workspace co-tenants this root. If so, the
+  // legacy per-root entry (when one exists) still names *that* workspace,
+  // so it must be left alone — touching it is exactly the "renaming the
+  // extracted workspace renamed the original too" bug.
+  const hasCoTenant = [...orchestratorSessions.values()].some(
+    (o) => o.id !== s.id && !o.discovered && o.id > 0 && normRoot(o.root) === rootKey,
+  );
+  if (s.stableId) {
+    const idKey = nameKeyById(s.stableId);
+    if (trimmed) store[idKey] = trimmed;
+    else delete store[idKey];
+    // Keep the per-root entry in step when it can only mean this
+    // workspace, so root-keyed lookups (a later discovered row at this
+    // root, a legacy workspace file) agree with the rename / clear.
+    if (!hasCoTenant) {
+      if (trimmed) store[rootKey] = trimmed;
+      else delete store[rootKey];
+    }
+  } else {
+    if (trimmed) store[rootKey] = trimmed;
+    else delete store[rootKey];
+  }
   saveNames();
   applyResolvedLabel(s);
 }
@@ -1744,7 +1792,8 @@ function reconcileSessions(): void {
       if (remote) pendingRemoteFacet = null;
       orchestratorSessions.set(s.id, {
         id: s.id,
-        label: loadNames()[normRoot(s.root)] ?? s.label,
+        stableId: s.stable_id || undefined,
+        label: customNameFor(s.stable_id || undefined, s.root) ?? s.label,
         hostLabel: s.label,
         root: s.root,
         projectPath: s.project_path,
@@ -1760,7 +1809,9 @@ function reconcileSessions(): void {
       });
     } else {
       // Track the host's raw label, then re-resolve the display name (a
-      // manual rename or terminal auto-name overrides it).
+      // manual rename or terminal auto-name overrides it). The stable id
+      // is adopted first — the manual-name lookup is keyed by it.
+      existing.stableId = s.stable_id || undefined;
       existing.hostLabel = s.label;
       applyResolvedLabel(existing);
       existing.root = s.root;
@@ -1879,7 +1930,7 @@ async function refreshDiscoveredWorktrees(): Promise<void> {
         } else {
           orchestratorSessions.set(id, {
             id,
-            label: loadNames()[normRoot(wt.path)] ?? label,
+            label: customNameFor(undefined, wt.path) ?? label,
             hostLabel: label,
             root: wt.path,
             projectPath: listed.mainRoot,
@@ -5431,6 +5482,7 @@ async function ensureReplacementWindow(projectRoot: string): Promise<boolean> {
     // close-and-switch below sees a second live window.
     orchestratorSessions.set(result.windowId, {
       id: result.windowId,
+      stableId: result.stableId || undefined,
       label,
       hostLabel: label,
       root: projectRoot,
@@ -9045,7 +9097,8 @@ async function runLocalCreate(id: number): Promise<void> {
     savePendingSpecs();
     orchestratorSessions.set(winId, {
       id: winId,
-      label: loadNames()[normRoot(root)] ?? sessionName,
+      stableId: result.stableId || undefined,
+      label: customNameFor(result.stableId || undefined, root) ?? sessionName,
       hostLabel: sessionName,
       root,
       projectPath: effectiveProjectPath,
@@ -9300,7 +9353,8 @@ async function attachToWorktree(opts: {
     }
     orchestratorSessions.set(id, {
       id,
-      label: loadNames()[normRoot(opts.root)] ?? opts.label,
+      stableId: result.stableId || undefined,
+      label: customNameFor(result.stableId || undefined, opts.root) ?? opts.label,
       hostLabel: opts.label,
       root: opts.root,
       projectPath: opts.projectPath,

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -3896,3 +3896,95 @@ fn renaming_extracted_co_tenant_workspace_leaves_original_name_alone() {
         "the original workspace should keep its 'alphaproj' label, got screen:\n{screen}"
     );
 }
+
+/// Filing a workspace extracted from a tab ("Extract Tab to New
+/// Workspace") into a folder must move ONLY that workspace. Folder
+/// assignments used to be keyed per root — and the extracted co-tenant
+/// shares the original's project root, so moving either filed both. Like
+/// manual names, assignments are now keyed by the window's durable
+/// stable id, the root key surviving only as a legacy / windowless
+/// fallback.
+#[test]
+fn moving_extracted_co_tenant_workspace_to_folder_leaves_original_unfiled() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(160, 45, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+
+    // Extract a file tab into a co-tenant workspace over the same root.
+    h.open_file(&root.join("readme.txt")).unwrap();
+    h.render().unwrap();
+    run_palette_command(&mut h, "Extract Tab to New Workspace");
+    h.wait_until(|h| {
+        h.screen_to_string()
+            .contains("Extracted readme.txt into workspace alphaproj (2)")
+    })
+    .unwrap();
+
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("alphaproj (2)"))
+        .unwrap();
+
+    // Create an empty folder "Docs" (organize checkbox off).
+    let new_row = row_of(&h, "New Task") as u16;
+    h.mouse_click(4, new_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Folder"))
+        .unwrap();
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Folder name"))
+        .unwrap();
+    h.type_text("Docs").unwrap();
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        !s.contains("Folder name") && s.contains("Docs")
+    })
+    .unwrap();
+
+    // Right-click the EXTRACTED workspace's row → "Move to Folder…" →
+    // pick "Docs" (cursor starts on "Top level"; ↓ lands on the folder).
+    let session_row = row_of(&h, "alphaproj (2)") as u16;
+    h.mouse_right_click(4, session_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Move to Folder"))
+        .unwrap();
+    let (mcol, mrow) = pos_of(&h, "Move to Folder");
+    h.mouse_click(mcol, mrow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Top level"))
+        .unwrap();
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+
+    // The move landed once the folder header reports a member count at
+    // all (an empty folder shows none). Waiting on the bare "(" keeps
+    // this settle-wait bug-agnostic, so the count assertion below fails
+    // fast instead of hanging a broken build in `wait_until`.
+    h.wait_until(|h| {
+        h.screen_to_string()
+            .lines()
+            .any(|l| l.contains("Docs") && l.contains("("))
+    })
+    .unwrap();
+    // Exactly ONE member — the extracted workspace. Per-root assignment
+    // used to file the original co-tenant too, reading "Docs (2)".
+    let screen = h.screen_to_string();
+    assert!(
+        screen
+            .lines()
+            .any(|l| l.contains("Docs") && l.contains("(1)")),
+        "the folder should hold only the extracted workspace (the original \
+         co-tenant must not be filed with it), got screen:\n{screen}"
+    );
+    // The original workspace still renders on a row of its own, outside
+    // the folder (its title row names it without the co-tenant counter).
+    assert!(
+        screen
+            .lines()
+            .any(|l| l.contains("alphaproj") && !l.contains("(2)") && !l.contains("Docs")),
+        "the original workspace should still render as its own top-level row, \
+         got screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -3817,3 +3817,82 @@ fn view_menu_row_toggles_the_dock_with_a_live_checkbox() {
     h.wait_until(|h| !h.screen_to_string().contains("New Task"))
         .unwrap();
 }
+
+// ── workspace rename stays per-workspace across co-tenants ─────────────────
+
+/// Renaming a workspace extracted from a tab ("Extract Tab to New
+/// Workspace") must rename ONLY that workspace. The extracted co-tenant
+/// shares the source's project root, and manual names used to be persisted
+/// per root — so renaming the new workspace silently renamed the original
+/// too (and vice versa). Names are now keyed by the window's durable
+/// stable id; the root key survives only as a legacy / windowless
+/// fallback.
+#[test]
+fn renaming_extracted_co_tenant_workspace_leaves_original_name_alone() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(160, 45, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+
+    // A file-backed tab is required for extraction.
+    h.open_file(&root.join("readme.txt")).unwrap();
+    h.render().unwrap();
+
+    // Extract the tab into a co-tenant workspace over the same root.
+    run_palette_command(&mut h, "Extract Tab to New Workspace");
+    h.wait_until(|h| {
+        h.screen_to_string()
+            .contains("Extracted readme.txt into workspace alphaproj (2)")
+    })
+    .unwrap();
+
+    // The dock lists both co-tenants.
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("alphaproj (2)"))
+        .unwrap();
+
+    // Right-click the extracted workspace's row → "Rename…" → the centered
+    // Rename Workspace dialog, pre-filled with "alphaproj (2)".
+    let row = row_of(&h, "alphaproj (2)") as u16;
+    h.mouse_right_click(4, row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Rename…"))
+        .unwrap();
+    let (rcol, rrow) = pos_of(&h, "Rename…");
+    h.mouse_click(rcol, rrow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Rename Workspace"))
+        .unwrap();
+    h.assert_screen_contains("Workspace name");
+
+    // Replace the pre-filled name wholesale with a distinct one.
+    for _ in 0.."alphaproj (2)".len() {
+        h.send_key(KeyCode::Backspace, KeyModifiers::NONE).unwrap();
+    }
+    h.type_text("extracted-ws").unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        !s.contains("Rename Workspace") && s.contains("extracted-ws")
+    })
+    .unwrap();
+
+    // Only the extracted workspace carries the new name...
+    let screen = h.screen_to_string();
+    let renamed_rows = screen
+        .lines()
+        .filter(|l| l.contains("extracted-ws"))
+        .count();
+    assert_eq!(
+        renamed_rows, 1,
+        "exactly one dock row should carry the new name (renaming the \
+         extracted co-tenant must not rename the original), got screen:\n{screen}"
+    );
+    // ...and the original workspace still shows its own label on a row of
+    // its own (a row naming it WITHOUT the new name).
+    assert!(
+        screen
+            .lines()
+            .any(|l| l.contains("alphaproj") && !l.contains("extracted-ws")),
+        "the original workspace should keep its 'alphaproj' label, got screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Problem

"Extract Tab to New Workspace" creates a co-tenant workspace over the **same project root** (that's the point — the "(2)" counter label distinguishes them). But the orchestrator dock persisted both **manual workspace renames** and **folder assignments** keyed by the workspace's root path, so the original and the extracted workspace shared one store entry:

- renaming either workspace renamed **both** (as reported),
- filing either workspace into a dock folder filed **both**.

Reproduced interactively in tmux: extract `notes.txt` into "alpha-proj (2)", rename it via the dock context menu → both dock rows take the new name, backed by a single root-keyed entry in `orchestrator.dock.names`.

## Fix

Key both stores by the window's durable `stable_id` (`ws-…`), which the host mints precisely to distinguish co-tenants and which survives restarts (`stableIdKey` → `id:ws-…` entries). The bare root path survives as a fallback for entries written before this change and for rows without a live window (discovered worktrees).

Writer semantics (shared between `renameWorkspace` and `assignSessionToFolder`):
- With no live co-tenant over the root, the legacy per-root entry is kept in step so root-keyed lookups still agree.
- With a co-tenant present, the per-root entry is left alone — touching it is exactly the reported bug.
- Unfiling next to a co-tenant records an explicit top-level sentinel (`""`) instead of deleting the assignment, so the legacy root entry can't pull the row back into a folder.

`AgentSession` now carries the host's `stable_id`, adopted at every session-construction/reconcile site.

## Verification

Interactive, in tmux against the built editor (fresh XDG dirs each run):
- Rename "alpha-proj (2)" → only it changes; rename the original → only it changes; both names survive an editor restart under their own `id:ws-…` entries.
- Move "alpha-proj (2)" into a new folder → the folder reads "(1)" with only that row filed; survives restart; moving it back to Top level sticks.

New e2e tests (`crates/fresh-editor/tests/e2e/orchestrator_dock.rs`) drive the same flows — palette extraction, dock right-click → Rename…/Move to Folder…, dialog/dropdown submit — and both fail against the old keying and pass with the fix (verified both ways).

Suites: all 78+1 `orchestrator_dock`, 10 `extract_tab_to_workspace`, and 130 orchestrator-matching e2e tests pass; the plugin type-check reports the same 13 pre-existing errors before and after (none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012s5LEq2bXww71qCBkYQnm1

---
_Generated by [Claude Code](https://claude.ai/code/session_012s5LEq2bXww71qCBkYQnm1)_