### PR TITLE
Re-mint the agent capability token when a terminal is restored

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1236,6 +1236,7 @@ impl Editor {
                 .filter(|argv| !argv.is_empty())
                 .cloned(),
             ephemeral: window.ephemeral_terminals.contains(&terminal_id),
+            script_access: window.terminal_has_script_access(terminal_id),
             title: None,
         }
     }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4087,7 +4087,7 @@ impl Editor {
                 persistent,
                 command: command.clone(),
                 title: title.filter(|t| !t.is_empty()),
-                env: terminal_env,
+                env: terminal_env.clone(),
             };
             let spawned = target.create_plugin_terminal(spec);
             // Record the launch/resume argv exactly as `create_window_with_terminal`
@@ -4097,6 +4097,9 @@ impl Editor {
             // respawned a bare shell instead of the agent.
             if let Ok((terminal_id, _, _)) = &spawned {
                 target.mark_terminal_restorable(*terminal_id, command, resume);
+                // File the token this terminal's child was handed, so workspace
+                // capture persists the grant and a restore re-mints it.
+                target.record_terminal_script_token(*terminal_id, &terminal_env);
             }
             spawned
         };

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -162,6 +162,77 @@ pub(crate) fn agent_command_env(
     env
 }
 
+impl Window {
+    /// Remember which capability token `terminal_id`'s freshly-spawned child
+    /// was handed, reading it out of the env [`agent_command_env`] built.
+    ///
+    /// A no-op for a terminal spawned without `allowScript` (no token in the
+    /// map), so every spawn site can call it unconditionally. The membership
+    /// this records is what workspace capture persists and what a later
+    /// restore/respawn re-mints from.
+    pub(crate) fn record_terminal_script_token(
+        &mut self,
+        terminal_id: TerminalId,
+        env: &HashMap<String, String>,
+    ) {
+        if let Some(token) = env.get("FRESH_CMD_TOKEN") {
+            self.terminal_script_tokens
+                .insert(terminal_id, token.clone());
+        }
+    }
+
+    /// Re-arm the script capability for a terminal being spawned from a
+    /// *remembered* grant — workspace restore, an exited agent's restart, a
+    /// remote reconnect — and return the env to inject into the new PTY child.
+    ///
+    /// The grant is re-minted rather than carried: the token table is
+    /// in-memory and process-global, so the token a previous editor run
+    /// handed this terminal resolves to nothing here, and within one run the
+    /// respawned child never inherits the dead one's environment anyway.
+    /// Without this a restored agent comes back able to *reach* the editor
+    /// (`FRESH_SESSION` is injected for every local terminal) but not to drive
+    /// it — every `fresh --cmd script run` fails with "no capability token:
+    /// script evaluation is not authorized" until the workspace is recreated
+    /// from scratch (fresh#2903).
+    ///
+    /// The new token is bound to *this* window, which is the right target: a
+    /// restored workspace is a new `WindowId`, and the terminal is coming back
+    /// inside it. Any token the terminal's previous incarnation held is
+    /// revoked on the way past so repeated restarts don't pile up live grants.
+    ///
+    /// `key` is the terminal id the token is filed under — the predicted id at
+    /// restore, the dying terminal's id at respawn. Callers re-key it onto the
+    /// real id afterwards, exactly as they do for the backing/log paths.
+    pub(crate) fn remint_terminal_script_env(
+        &mut self,
+        key: TerminalId,
+    ) -> HashMap<String, String> {
+        if let Some(stale) = self.terminal_script_tokens.remove(&key) {
+            crate::server::command_access::revoke(&stale);
+        }
+        let env = agent_command_env(self.id, None, true);
+        self.record_terminal_script_token(key, &env);
+        env
+    }
+
+    /// Move a terminal's script-token entry onto the id the manager actually
+    /// handed out, for the spawn paths that have to guess the id up front.
+    pub(crate) fn rekey_terminal_script_token(&mut self, from: TerminalId, to: TerminalId) {
+        if from == to {
+            return;
+        }
+        if let Some(token) = self.terminal_script_tokens.remove(&from) {
+            self.terminal_script_tokens.insert(to, token);
+        }
+    }
+
+    /// Whether `terminal_id`'s child holds a script capability token — the
+    /// grant workspace capture persists and a respawn re-mints.
+    pub(crate) fn terminal_has_script_access(&self, terminal_id: TerminalId) -> bool {
+        self.terminal_script_tokens.contains_key(&terminal_id)
+    }
+}
+
 /// Build a [`TerminalWrapper`] that runs `argv` directly as a local PTY child,
 /// mirroring `Authority::terminal_command`'s `CommandWrap::Direct` arm but
 /// unconditionally local — it consults no window authority. Used for terminals
@@ -1097,6 +1168,7 @@ impl Window {
                 .filter(|argv| !argv.is_empty())
                 .cloned();
             let ephemeral = self.ephemeral_terminals.contains(&old_id);
+            let script_access = self.terminal_has_script_access(old_id);
 
             let spawn = RespawnSpec {
                 old_id,
@@ -1108,6 +1180,7 @@ impl Window {
                 resume_argv,
                 launch_argv,
                 ephemeral,
+                script_access,
             };
             match self.respawn_terminal_pty(buffer_id, spawn) {
                 Some(_) => revived += 1,
@@ -1151,6 +1224,15 @@ impl Window {
         let wrapper = self.apply_remote_terminal_env(wrapper);
         let env_delta = self.terminal_env_delta(&wrapper);
 
+        // An agent that was granted editor control keeps it across the
+        // respawn: the reborn child gets a freshly-minted token bound to this
+        // window, since the one its predecessor carried died with that PTY.
+        let extra_env = if spec.script_access {
+            self.remint_terminal_script_env(spec.old_id)
+        } else {
+            HashMap::new()
+        };
+
         let new_id = match self.terminal_manager.spawn(
             spec.cols,
             spec.rows,
@@ -1162,7 +1244,7 @@ impl Window {
             crate::services::terminal::BackingMode::Continue,
             wrapper,
             env_delta,
-            HashMap::new(),
+            extra_env,
         ) {
             Ok(id) => id,
             Err(e) => {
@@ -1183,6 +1265,7 @@ impl Window {
         // Re-key every terminal-id-keyed entry onto the reborn terminal. The
         // values come from the caller's spec rather than the maps, so this is
         // correct even when the exit path already dropped the old entries.
+        self.rekey_terminal_script_token(spec.old_id, new_id);
         if new_id != spec.old_id {
             self.terminal_backing_files.remove(&spec.old_id);
             self.terminal_log_files.remove(&spec.old_id);
@@ -1304,6 +1387,7 @@ impl Window {
             resume_argv,
             launch_argv,
             ephemeral: exited.ephemeral,
+            script_access: exited.script_access,
         };
         let Some(new_id) = self.respawn_terminal_pty(buffer_id, spec) else {
             // Put the record back so the user can retry the restart.
@@ -1352,6 +1436,11 @@ struct RespawnSpec {
     resume_argv: Option<Vec<String>>,
     launch_argv: Option<Vec<String>>,
     ephemeral: bool,
+    /// Whether the terminal being reborn held a script capability token. The
+    /// reborn child is minted a new one (see
+    /// [`Window::remint_terminal_script_env`]) rather than inheriting the dead
+    /// one's, which it could not see anyway.
+    script_access: bool,
 }
 
 impl Editor {

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -4210,6 +4210,7 @@ mod exited_terminal_tests {
             command: command.map(argv),
             resume: resume.map(argv),
             ephemeral: true,
+            script_access: false,
             title: None,
         }
     }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -112,6 +112,10 @@ pub struct ExitedTerminal {
     pub resume: Option<Vec<String>>,
     /// Whether the dead terminal was ephemeral (plugin/Orchestrator-created).
     pub ephemeral: bool,
+    /// Whether the dead terminal's child held a script capability token, so a
+    /// restart mints it a new one instead of bringing the agent back unable to
+    /// drive the editor.
+    pub script_access: bool,
     /// The tab title as it read *before* the exit marker was appended, so a
     /// restart can put it back. `None` for an auto-named tab, which re-derives
     /// its name from the reborn process.
@@ -899,6 +903,19 @@ pub struct Window {
     /// just re-run their launch command.
     pub terminal_resume_commands:
         std::collections::HashMap<crate::services::terminal::TerminalId, Vec<String>>,
+
+    /// Terminals whose child was handed a `FRESH_CMD_TOKEN` capability token
+    /// (`allowScript`), mapped to the token that terminal's *current*
+    /// incarnation carries.
+    ///
+    /// Membership — not the token value — is what survives a restart: it is
+    /// persisted as the workspace's `script_access` flag and re-minted on
+    /// restore, because the token table is in-memory and process-global, so
+    /// the string a previous run handed out means nothing to this one. The
+    /// value is kept so a respawn can revoke the token its predecessor held
+    /// instead of leaving it in the table for the life of the process.
+    pub terminal_script_tokens:
+        std::collections::HashMap<crate::services::terminal::TerminalId, String>,
 
     /// Terminals whose process has quit while their buffer stayed open,
     /// keyed by that buffer. Everything needed to respawn the same process
@@ -2229,6 +2246,7 @@ impl Window {
             ephemeral_terminals: std::collections::HashSet::new(),
             terminal_commands: std::collections::HashMap::new(),
             terminal_resume_commands: std::collections::HashMap::new(),
+            terminal_script_tokens: std::collections::HashMap::new(),
             exited_terminals: HashMap::new(),
             plugin_dev_workspaces: HashMap::new(),
             status_bar_values: HashMap::new(),

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -435,7 +435,7 @@ impl crate::app::Editor {
                 persistent: false, // ephemeral by default; orchestrator owns persistence
                 command,
                 title: title.filter(|t| !t.is_empty()),
-                env: terminal_env,
+                env: terminal_env.clone(),
             })
         };
 
@@ -460,6 +460,11 @@ impl crate::app::Editor {
         // command on restore — see `restore_terminal_from_workspace`.
         if let Some(target) = self.windows.get_mut(&id) {
             target.mark_terminal_restorable(terminal_id, Some(restore_command), resume);
+            // File the token this terminal's child was handed, so workspace
+            // capture persists the grant and a restore re-mints it — without
+            // it a restored agent keeps its conversation but loses the ability
+            // to drive the editor.
+            target.record_terminal_script_token(terminal_id, &terminal_env);
         }
 
         // The switch has now committed (the spawn succeeded and the active

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -900,6 +900,15 @@ impl crate::app::window::Window {
         };
         let wrapper_for_spawn = self.apply_remote_terminal_env(wrapper_for_spawn);
         let env_delta = self.terminal_env_delta(&wrapper_for_spawn);
+        // A terminal saved with the script grant comes back holding it: mint a
+        // token bound to *this* (restored) window and stamp it into the child's
+        // environment. The saved workspace records only that the grant existed
+        // — the token itself belonged to the editor run that is gone.
+        let extra_env = if terminal.script_access {
+            self.remint_terminal_script_env(predicted_id)
+        } else {
+            std::collections::HashMap::new()
+        };
         let terminal_id = match self.terminal_manager.spawn(
             terminal.cols,
             terminal.rows,
@@ -911,7 +920,7 @@ impl crate::app::window::Window {
             crate::services::terminal::BackingMode::Continue,
             wrapper_for_spawn,
             env_delta,
-            std::collections::HashMap::new(),
+            extra_env,
         ) {
             Ok(id) => id,
             Err(e) => {
@@ -925,6 +934,7 @@ impl crate::app::window::Window {
         };
 
         // Ensure maps keyed by actual ID
+        self.rekey_terminal_script_token(predicted_id, terminal_id);
         if terminal_id != predicted_id {
             self.terminal_log_files
                 .insert(terminal_id, log_path.clone());
@@ -1018,6 +1028,9 @@ impl crate::app::window::Window {
                 // A restored terminal is re-persisted by the branch above on
                 // the next save, so it must not be treated as throwaway.
                 ephemeral: false,
+                // Nothing is spawned here, so no token is minted — the grant
+                // is carried so the restart (which does spawn) mints one.
+                script_access: terminal.script_access,
                 title: terminal.title.clone(),
             },
         );
@@ -2522,6 +2535,7 @@ impl crate::app::window::Window {
                     agent_resume,
                     exited: None,
                     title,
+                    script_access: self.terminal_has_script_access(terminal_id),
                 });
             }
         }
@@ -2570,6 +2584,7 @@ impl crate::app::window::Window {
                 // The pre-exit tab title, not the "(exited)" form the tab is
                 // showing now — restore re-applies the marker itself.
                 title: exited.title.clone(),
+                script_access: exited.script_access,
             });
         }
 

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -511,6 +511,26 @@ pub struct SerializedTerminalWorkspace {
     /// re-derive their name the same way after restore.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Whether this terminal's child was granted editor control — the
+    /// Orchestrator's `allowScript`, which stamps a `FRESH_CMD_TOKEN`
+    /// capability token into the agent's environment.
+    ///
+    /// Only the *grant* is persisted, never the token: the token table is
+    /// in-memory and process-global, so the string this terminal carried in a
+    /// previous run means nothing to the run that restores it. Restore mints a
+    /// fresh token bound to the restored window (see
+    /// `Window::remint_terminal_script_env`); without this flag a restored
+    /// agent came back unable to drive the editor at all. Absent for plain
+    /// terminals and in workspaces written before this field existed — which
+    /// read back as `false`, i.e. no grant, the safe direction.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub script_access: bool,
+}
+
+/// `skip_serializing_if` helper: keeps the default-`false` capability flag out
+/// of the JSON for the overwhelming majority of terminals that never had it.
+fn is_false(v: &bool) -> bool {
+    !*v
 }
 
 /// The saved state of a terminal whose process had quit before the editor did.

--- a/crates/fresh-editor/tests/terminal_restore_script_token.rs
+++ b/crates/fresh-editor/tests/terminal_restore_script_token.rs
@@ -23,7 +23,12 @@
 //! Own integration binary because it sets the process-global `XDG_DATA_HOME`
 //! to isolate workspace persistence, mirroring `terminal_restore_live.rs`.
 //! Skips when there is no PTY.
-#![cfg(target_os = "linux")]
+//!
+//! Gated on `plugins`: the grant under test *is* a plugin-API capability
+//! ("may drive this editor as a plugin would"), and the spawn path that hands
+//! it out is the plugin `createTerminal` command, which the trimmed
+//! no-plugins build doesn't compile at all.
+#![cfg(all(target_os = "linux", feature = "plugins"))]
 
 use fresh::config::Config;
 use fresh::config_io::DirectoryContext;

--- a/crates/fresh-editor/tests/terminal_restore_script_token.rs
+++ b/crates/fresh-editor/tests/terminal_restore_script_token.rs
@@ -1,0 +1,213 @@
+//! Regression: an agent terminal restored from the workspace must come back
+//! holding a *live* capability token (fresh#2903).
+//!
+//! The Orchestrator spawns every workspace's agent with `allowScript`, which
+//! mints a `FRESH_CMD_TOKEN` bound to that window and stamps it into the
+//! child's environment; that token is what authorizes `fresh --cmd script
+//! run`. The token table is in-memory and process-global by design — nothing
+//! about it is persisted — and the saved workspace recorded everything a
+//! terminal needs to come back (argv, resume argv, transcript paths, title)
+//! *except* that it ever held the grant. So restore respawned the PTY with no
+//! extra environment at all: the agent came back able to reach the editor
+//! (`FRESH_SESSION` rides every local terminal) but not to drive it, and every
+//! script it submitted was refused with "no capability token: script
+//! evaluation is not authorized" until the workspace was recreated by hand.
+//!
+//! The assertion is on what the *child process* saw: the terminal runs a
+//! command that prints `$FRESH_CMD_TOKEN` into its own transcript, so the
+//! test reads back the value the restored agent would itself read, and then
+//! checks that value is a token this editor honours — resolvable, carrying
+//! the script grant, and pointed at the restored window rather than the one
+//! that died.
+//!
+//! Own integration binary because it sets the process-global `XDG_DATA_HOME`
+//! to isolate workspace persistence, mirroring `terminal_restore_live.rs`.
+//! Skips when there is no PTY.
+#![cfg(target_os = "linux")]
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::model::filesystem::StdFileSystem;
+use fresh::server::command_access;
+use fresh_core::api::PluginCommand;
+use std::path::Path;
+use std::sync::Arc;
+
+/// Marker the terminal's child prints, followed by whatever
+/// `$FRESH_CMD_TOKEN` held when it started. `none` when the variable is unset
+/// — which is precisely the regression, so it must be a value the test can
+/// read rather than an empty line it might mistake for missing output.
+const MARKER: &str = "FRESH_CMD_TOKEN_IS:";
+
+fn isolated_dir_context(base: &Path) -> DirectoryContext {
+    let xdg_data = base.join("xdg-data");
+    std::fs::create_dir_all(&xdg_data).unwrap();
+    std::env::set_var("XDG_DATA_HOME", &xdg_data);
+    DirectoryContext {
+        data_dir: xdg_data.join("fresh"),
+        config_dir: base.join("config"),
+        home_dir: Some(base.join("home")),
+        documents_dir: None,
+        downloads_dir: None,
+    }
+}
+
+fn editor_in(project: &Path, dir_context: &DirectoryContext) -> fresh::app::Editor {
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+    fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project.to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap()
+}
+
+fn pty_available() -> bool {
+    use portable_pty::{native_pty_system, PtySize};
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// Spawn an agent terminal the way the Orchestrator's "Run Agent…" does —
+/// through the plugin `createTerminal` API with `allowScript`, which is what
+/// mints the token. The child announces the token it was given and then parks
+/// on `cat`, so the terminal is still *live* when the workspace is saved (an
+/// exited one restores dead, by design, and would never respawn).
+fn spawn_agent_terminal(editor: &mut fresh::app::Editor) {
+    let script = format!("printf '{MARKER}%s\\n' \"${{FRESH_CMD_TOKEN:-none}}\"; exec cat");
+    editor
+        .handle_plugin_command(PluginCommand::CreateTerminal {
+            cwd: None,
+            direction: None,
+            ratio: None,
+            focus: Some(true),
+            // Ephemeral, like every plugin-created terminal; carrying a launch
+            // command is what makes it a restorable session terminal anyway.
+            persistent: false,
+            window_id: None,
+            command: Some(vec!["sh".to_string(), "-c".to_string(), script]),
+            title: None,
+            resume: None,
+            env: None,
+            allow_script: true,
+            request_id: 0,
+        })
+        .expect("agent terminal should spawn");
+}
+
+/// The raw PTY transcript of the active window's only terminal. Restore
+/// *continues* this file, so it accumulates one announcement per incarnation.
+fn transcript_path(editor: &fresh::app::Editor) -> std::path::PathBuf {
+    let window = editor.active_window();
+    let terminal_id = window
+        .last_focused_terminal()
+        .expect("the window has a terminal");
+    window
+        .terminal_log_files
+        .get(&terminal_id)
+        .cloned()
+        .expect("a spawned terminal records its log file")
+}
+
+/// Block until the transcript holds at least `count` announcements, then
+/// return the last one's token.
+///
+/// Semantic wait, no deadline: the PTY reader thread writes this file on its
+/// own, so the only thing to wait for is the child having run. A regression
+/// keeps the *count* honest — a restore that spawns without the grant still
+/// announces, it just announces `none`.
+fn nth_announced_token(path: &Path, count: usize) -> String {
+    loop {
+        let transcript = std::fs::read_to_string(path).unwrap_or_default();
+        let announcements: Vec<&str> = transcript.split(MARKER).skip(1).collect();
+        if announcements.len() >= count {
+            return announcements[count - 1]
+                .split(|c: char| c.is_whitespace())
+                .next()
+                .unwrap_or_default()
+                .to_string();
+        }
+        std::thread::yield_now();
+    }
+}
+
+#[test]
+fn a_restored_agent_terminal_can_still_drive_the_editor() {
+    if !pty_available() {
+        eprintln!("Skipping: no PTY available in this environment");
+        return;
+    }
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let dir_context = isolated_dir_context(sandbox.path());
+    let project = sandbox.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+
+    // Session 1: an agent is running with editor control when the editor quits.
+    let first_token = {
+        let mut e1 = editor_in(&project, &dir_context);
+        spawn_agent_terminal(&mut e1);
+        let log = transcript_path(&e1);
+        let token = nth_announced_token(&log, 1);
+        assert!(
+            command_access::may_script(&token),
+            "sanity: a freshly spawned agent terminal is handed a token that \
+             authorizes scripts, got {token:?}"
+        );
+        e1.save_workspace().unwrap();
+        token
+    };
+
+    // Session 2: cold reboot, exactly what the user gets on relaunch.
+    let mut e2 = editor_in(&project, &dir_context);
+    e2.restore_active_window_on_launch(false).unwrap();
+    let restored_window = e2.active_window_id();
+
+    let log = transcript_path(&e2);
+    let restored_token = nth_announced_token(&log, 2);
+
+    assert_ne!(
+        restored_token, "none",
+        "the restored agent's child must be handed a capability token; without \
+         one every `fresh --cmd script run` it makes is refused with \"no \
+         capability token: script evaluation is not authorized\""
+    );
+    assert_ne!(
+        restored_token, first_token,
+        "the restored agent must get a token minted for this run, not the \
+         string the dead editor handed its predecessor"
+    );
+
+    let grant = command_access::lookup(&restored_token)
+        .expect("the restored agent's token must resolve in this editor");
+    assert!(
+        grant.may_script,
+        "the restored agent's token must carry the script grant, not just be \
+         addressable"
+    );
+    assert_eq!(
+        grant.window_id,
+        Some(restored_window.0),
+        "the restored agent's token must drive the window it came back in"
+    );
+}


### PR DESCRIPTION
## The bug

Create Orchestrator workspaces with terminals, quit the editor, reopen it, switch to a previously open workspace, and run `fresh --cmd script …` in the restored terminal:

```
$ echo "return 1+1;" | "$FRESH_BIN" --cmd script run -
no capability token: script evaluation is not authorized
```

A brand-new workspace's terminal works fine. Only restored ones are affected.

Reproduced manually in tmux against a real editor and real PTYs before changing anything: in the restored terminal `FRESH_CMD_TOKEN` is empty while `FRESH_SESSION` and `FRESH_BIN` are both set — so the agent can reach the editor but not drive it.

## Cause

The Orchestrator spawns every workspace's agent with `allowScript`, which mints a `FRESH_CMD_TOKEN` bound to that window and stamps it into the child's environment (`app/terminal.rs::agent_command_env`). The token table (`server/command_access.rs`) is in-memory and process-global by design — nothing about it is persisted.

The saved workspace recorded everything a terminal needs to come back — launch argv, agent-resume argv, transcript paths, title, exited state — *except* that it ever held the grant. So `restore_terminal_from_workspace` respawned the PTY with an empty extra-env map. `respawn_terminal_pty` (the exited-agent restart and the remote-reconnect sweep) had the same gap.

## Fix

Persist the **grant**, never the token:

- `SerializedTerminalWorkspace` gains `script_access: bool` (serde default, skipped when false — workspaces written before this field read back as no grant, the safe direction).
- `Window` gains `terminal_script_tokens: HashMap<TerminalId, String>`. Membership is the grant; the value is kept only so a respawn can revoke its predecessor's token instead of leaving it live in the table. Recorded at both spawn sites from the env `agent_command_env` built.
- Restore and respawn call `Window::remint_terminal_script_env`, which revokes the stale token and mints a new one bound to *this* window — a restored workspace is a new `WindowId`, and `FRESH_SESSION` rides along via the same helper. Token entries re-key onto the real terminal id exactly as the backing/log paths already do.
- `ExitedTerminal` carries `script_access` too, so restarting an agent that had exited re-arms it as well.

## Testing

New integration test `crates/fresh-editor/tests/terminal_restore_script_token.rs`. The terminal's child prints the `FRESH_CMD_TOKEN` it was actually handed, so the test reads back the value the restored agent would itself read, then checks it resolves, carries the script grant, and is bound to the restored window. Verified it fails without the fix (the restored child announces `none`) and passes with it.

`cargo fmt --check`, `cargo check --all-targets` and `cargo clippy --all-targets` are clean. No GUI code touched. Not yet re-run: the manual tmux flow against the patched binary, and the wider test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_013BFdGBXewxSHGuVDVmUUDb)_