### PR TITLE
docs(changelog): restore tampered 0.4.6 section and prepare 0.4.7 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Release Notes
 
+## 0.4.7
+
+For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
+
+> Most options below can be changed in the **Settings UI** - run **Open Settings** from the command palette (`Ctrl+P`).
+
+### Features
+
+* **Guided code tours** - a walkthrough of a codebase, played in the editor: the steps on the left, the current step's explanation on the right, and the code it talks about open and highlighted above. Full guide: [Guided Code Tours](https://getfresh.dev/docs/features/code-tours).
+  * A tour is a small JSON file - `fresh --cmd help tour` prints the field reference, and an agent can write one and open it for you.
+  * **Tour: Open Workspace Tour...** browses the workspace root with hidden files shown, where tours live.
+  * The files it opens are ordinary buffers - navigate, edit, wander off; the tour waits.
+  * Several tours at once, and an unfinished one comes back on the next launch.
+  * VS Code [CodeTour](https://github.com/microsoft/codetour) files play as-is, and a tour written against another commit says so.
+* **Scripting the editor** - hand a running Fresh a short TypeScript program and it will do anything the plugin API can: open files, arrange panes, create a workspace, start a coding agent, open a tour. Mostly so the agent in your pane can arrange the editor around the task. Full guide: [Scripting the Editor](https://getfresh.dev/docs/features/scripting).
+  * `fresh --cmd script run` takes a one-liner on stdin or a program in a file; what it returns prints as JSON.
+  * `script check` / `api` / `types` check a program, search the API, and find the declarations.
+  * **Teach agent the Fresh CLI** briefs `claude`, `codex` and `opencode`, and is on by default.
+  * The grant is scoped to the workspace that made it, so one agent cannot reach a sibling's panes.
+* **Git-gutter hunks and unsaved edits show on the scrollbar** - a change below the fold is visible on the track instead of only in the gutter, matching the marks live diff already draws (#2713).
+* **The Orchestrator dock can be closed without a keybinding** - a `×` on its title bar and a new **View → Orchestrator Dock** row, with a live checkmark.
+* **Thrift syntax highlighting** - `.thrift` interface definition files now highlight out of the box (#2884, by @asukaminato0721).
+
+### Bug Fixes
+
+* **Replace-all now finishes on files with tens of thousands of matches** - four unrelated quadratic hot spots made a 60 000-match replace run for over a minute, or hang outright (#2893).
+* **The Shift key works with "Keyboard Report All Keys As Escape Codes"** - with that flag on, every shifted key typed its unshifted character (`Shift+A` inserted `a`), because the terminal reports the *base* key and the shift separately (#2880, reported by @akarinotomoshibi).
+* **TOML multiline arrays highlight correctly**, and bare dots are no longer misread as floats (#2887, by @asukaminato0721).
+* **Pasting works in the New Workspace and Run Agent dialogs** - `Ctrl+V`/`Ctrl+A`/`Ctrl+C`/`Ctrl+X` and bracketed paste reach the focused text field instead of the buffer behind the dialog, in daemon mode (`fresh -a`) too.
+* **Renaming or filing a workspace made with "Extract Tab to New Workspace" no longer hits its co-tenant** - both were keyed by the shared project root, so renaming or moving one did the same to the other.
+* **A restored workspace's agent can still drive the editor** - the script capability was never persisted, so after a restart `fresh --cmd script` failed as unauthorized in a workspace where it had worked.
+* **Live diff never refuses a file again** - checking out a very old revision of a large file used to render nothing at all and report "file too large for live diff"; live diff, the git gutter and the unsaved-changes indicator now share one diff engine that degrades detail instead of giving up.
+* **Reverting a file from outside Fresh refreshes the git gutter, live diff and merge-conflict markers** - running `git checkout` in another terminal left them showing the pre-revert state until the next save.
+* **Opening a file straight to a line no longer breaks syntax highlighting** - the parser could start mid-comment and read a stray backtick as opening a string that swallowed the viewport; whole files up to 1MB now parse from the start.
+* **Highlights taller than the window are drawn again** - an overlay starting above the top of the view and ending below the bottom vanished entirely, which hit diagnostics spanning a long block and diff hunks taller than the pane.
+* **The cursor can reach the last column when the vertical scrollbar is shown** - the column it reserves was being subtracted twice (by @ttenneb).
+* **Closing a file no longer pulls a dock panel into the editor split** - Search & Replace, Diagnostics or a tour panel could be adopted as a tab among your source files, and came back after every later close.
+* **Plugin panels handle the mouse properly** - a click on a border or empty padding no longer scrolls the panel's own header out of view, side-by-side lists route clicks to the column you clicked, the wheel scrolls the list under the pointer, and an overflowing list paints a scrollbar. Affects every widget panel (Search & Replace, Settings, the Orchestrator dock).
+* **A second panel opened in the Utility Dock renders like the first** instead of picking up a stray line-number gutter.
+
+### Internals
+
+* Continued flaky-e2e-test stabilization across the code-tour, live-diff and orchestrator-dock suites.
+
 ## 0.4.6
 
 For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
@@ -12,35 +56,17 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * If you have customized your status bar, open Settings → **Status Bar** and move **Terminal Restart** from *Available* to *Included* (`Shift+→`) under Left or Right.
 * **Tabs for same-named files say which file they are** - open two `mod.rs` and the tabs read `model/mod.rs` and `view/mod.rs` instead of `mod.rs 1` and `mod.rs 2`. Each tab grows only as much of its path as it takes to be unique, and tabs whose name is already unique are untouched (#2851, requested by @anddimario).
 * **Line-ending indicators** - `↵` at every line break and `␍` for the CR half of a CRLF, both off by default (#2798, requested by @akarinotomoshibi).
-* **Scrollbar markers for plugins** - `editor.setScrollbarMarkers` paints marks on the scrollbar track; git-gutter hunks, live-diff hunks and Markdown headings now use it (#2713, requested by @RetributionByRevenue).
-* **Unsaved changes show on the scrollbar** - the blue gutter bar for edits you haven't saved now has a matching mark on the track, so a change you left ten screens up is visible without scrolling to find it.
+* **Scrollbar markers for plugins** - `editor.setScrollbarMarkers` paints marks on the scrollbar track; live-diff hunks and Markdown headings now use it (#2713, requested by @RetributionByRevenue).
 * **File Explorer sticky parents** - a nested folder's expanded ancestors stay stacked at the top of the sidebar while you scroll (#2705, by @asukaminato0721).
 * **More graphics, docs and build-file grammars** - GLSL `.glslf`/`.glslv`, Wavefront `.obj`, Doxygen, Windows `.rc`, pkg-config, `.cmake.in` and `CMakeCache.txt` (by @asukaminato0721).
-* **Thrift syntax highlighting** - `.thrift` interface definition files now highlight out of the box.
 * **Broader LaTeX ecosystem highlighting** - TeX packages/classes, generated `.aux`/`.toc`, BibLaTeX, ConTeXt, BibTeX and `.bst`, plus `latexmkrc` (by @asukaminato0721).
 * **The Orchestrator dock's start-up state is configurable** - whether it opens on startup, its layout, and the starting state of the **all worktrees** and **show empty** checkboxes.
 * **Run Agent… and New Workspace are one dialog** - a "Launch in" switch picks the current workspace or a new one. Fixes `custom…` having nowhere to type a command.
 * **Plugins are told when settings change** - vi-mode's options now apply without an editor restart.
 * **Agents drive the editor with TypeScript** - `fresh --cmd script run` evaluates a script against the full plugin API, with `script api` / `script check` for discovery.
-* **The tour's description panel is a real text area** - click to place a caret, drag or Shift+arrows to select, `Ctrl+C` to copy exactly the rendered text; the panel stays read-only. Step text now renders through the same markdown engine as LSP hover docs, so links, nested emphasis and syntax-highlighted code fences work in tours, and hover docs gained `•`/`1.` list markers. Plugins get the same for free with `text({ markdown: true })`.
-* **VS Code CodeTour files play in Fresh** - loading a tour now auto-detects the format: CodeTour `.tour` files (the format used by the [CodeTour](https://github.com/microsoft/codetour) extension) are converted on load - `line`/`selection`/`pattern` anchors become highlighted ranges (patterns are resolved against the file's current content, so they survive edits), content-only steps keep their prose, untitled steps are named from their description's heading, and a commit-hash `ref` feeds the drift indicator. **Tour: Open Workspace Tour...** opens the same file browser as **Tour: Load Definition...** - anchored at the workspace root with hidden files shown, so the well-known dotfile locations (`.fresh-tour.json`, `.tour`, `main.tour`, `.tours/`, `.vscode/tours/`, `.github/tours/`) are one keystroke away; the tour to open is always the user's explicit pick, never a guess.
-* **`fresh --cmd help <topic>` - feature guides in the CLI** - `fresh --cmd help tour` explains how to author and open code tours, with a field reference *generated from the manifest schema the build ships* (and `--schema` to dump the raw JSON schema for validators or agents); `fresh --cmd help script` documents the script verbs and reports the build's actual API surface, counted from the generated TypeScript declarations rather than hard-coded.
-* **Guided code tours are a dock panel, not a popup** - a tour now opens in the shared bottom dock with a step rail, clickable Prev/Next, and a source line you can jump from, instead of a fixed 60x15 box floating over the code it was explaining. Step text is rendered as the markdown it is authored in - headings, bullets, emphasis and fenced code all survive, where the popup dropped the start of every wrapped line. Several tours can be open at once, one dock tab each, and an unfinished tour comes back on the next launch at the step you left it (closing one forgets it). `Ctrl+Alt+N` / `Ctrl+Alt+P` step the tour from the editor, so you can read the code with the panel still up.
-  * An agent that has just made a change can hand you a tour of it: with **Teach Fresh CLI** on, launched agents are shown how to write a `.fresh-tour.json` and open it.
 
 ### Bug Fixes
 
-* **Tour: Load Definition... can actually reach tour files again** - the picker used to open in the active file's directory with hidden files off, and tour files are dotfiles at the workspace root (`.fresh-tour.json`, `.tours/*.tour`) - so the browser showed nothing pickable. It now anchors at the workspace root with hidden files visible, and a name typed there resolves root-relative. Plugins get the same control: `editor.pickFile(label, directory?, showHidden?)`.
-* **The tour panel's mouse wheel scrolls the list you point at** - the wheel used to scroll the Steps rail no matter where the pointer was, so the description column could not be scrolled by mouse at all. Applies to every widget panel with more than one list.
-* **Overflowing lists in dock panels show a scrollbar** - the tour's Steps rail and description column scrolled with no visual indication there was more; panels mounted into a split never painted list scrollbars.
-* **A tour's selection highlight stays inside the panel** - the selected step and description rows used to paint a stray block of highlight at the right edge of the screen, past the panel border.
-* **Tour descriptions word-wrap instead of losing a character to `…`** - at many terminal widths, every full-width line of a step's text (and any long unbroken token) was ellipsis-truncated, eating the character it wrapped on.
-* **The Shift key works with "Keyboard Report All Keys As Escape Codes"** - with that flag on, every shifted key typed its unshifted character (`Shift+A` inserted `a`, `Shift+2` inserted `2`), because the terminal reports the *base* key and the shift separately (#2880, reported by @akarinotomoshibi).
-* **Highlights taller than the window are drawn again** - any overlay that started above the top of the view and ended below the bottom vanished entirely, because the viewport query needed one of its two endpoints to be on screen. A highlight covering everything you could see was the one case that failed. Affects diagnostics spanning a long block, large diff hunks, and guided-tour step ranges.
-* **Clicking a plugin panel where there is no control no longer scrolls it away** - a click on a panel's border or on empty padding used to move the panel's hidden cursor, and the viewport followed it, scrolling the panel's own header and buttons off screen with no way to bring them back. Affected every widget panel (Search & Replace, Settings, the Orchestrator dock).
-* **Side-by-side lists in a plugin panel route clicks to the column you clicked** - with two lists next to each other, every click in the right-hand one selected a row in the left-hand one.
-* **A second panel opened in the Utility Dock renders like the first** - it used to arrive with a line-number gutter the first panel did not have, and the columns that gutter took made its contents wrap. Visible with Diagnostics open beside Search & Replace.
-* **Closing a file a tour opened no longer pulls the tour panel up into the editor** - stepping through a code tour leaves the panel focused in the dock, and closing one of the files it opened made the tour panel take that tab's place among your source files, again after every close. Any dock panel could be adopted this way: a click into another split recorded the split you were *leaving* in the target split's tab history, and the next close there adopted it.
 * **Four dead settings** - the bracket-matching toggles, `file_explorer.respect_gitignore` and `languages.<id>.textmate_grammar` now take effect; `editor.highlight_timeout_ms` was removed rather than wired up (#2842).
 * **Files that are one very long line**
   * **Viewing one no longer pins a CPU core** (#2838, reported by @lovehumans).


### PR DESCRIPTION
## Summary

Prepares the `0.4.7` release notes, and repairs the released `0.4.6` section along the way.

**Two leading feature sections.** Guided Code Tours and Scripting the Editor are presented as launches, written from the documentation pages in #2909. The incremental fixes and tweaks each accumulated during development are folded into the feature description rather than itemized as bug fixes — a reader meeting the feature for the first time has nothing to un-learn.

**Changelog repair.** Several post-release commits had edited the already-tagged `## 0.4.6` section directly (bullets inserted, one existing bullet's text changed) instead of adding a new section. `## 0.4.6` — and every older section — is now byte-identical to its tag again. Every stray addition was checked against the commit log, the diff, and the linked issues/PRs before being moved; all of it was real, so nothing was dropped.

The remaining panel and mouse fixes stay under Bug Fixes, described as the general widget-panel fixes they are (they affect Search & Replace, Settings and the Orchestrator dock, not just tours).

New version is `0.4.7`, the next patch after the latest tag `v0.4.6`.

## Verification

- `## 0.4.6` and all older sections diff clean against `git show v0.4.6:CHANGELOG.md`.
- Every `#NNNN` cited (#2713, #2880, #2884, #2887, #2893) corresponds to a fix actually merged in `v0.4.6..HEAD`.
- No mention of the Web UI, and no attribution to `sinelaw` or `claude`.

## Note

`0.4.6` already carried a bullet announcing `fresh --cmd script run`. This release re-presents scripting as a headline feature now that it has a documentation page — intentional, but worth a look before publishing.

## Test plan

- [x] Older sections verified byte-identical to their tagged state
- [x] Issue numbers cross-referenced against GitHub issue/PR data
- [x] Feature sections cross-checked against the docs pages in #2909