### PR TITLE
docs: zoom images on click

### DIFF
--- a/docs/.vitepress/theme/ImageZoom.vue
+++ b/docs/.vitepress/theme/ImageZoom.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+import { nextTick, onMounted, onUnmounted, ref } from "vue";
+import { onContentUpdated } from "vitepress";
+
+// Lightbox for screenshots and demo GIFs in the docs. Clicking any image in
+// the article body opens it full screen; clicking the enlarged image toggles
+// between "fit to screen" and 1:1 pixel size, which is what you want for
+// dense terminal screenshots.
+
+const mounted = ref(false);
+const open = ref(false);
+const src = ref("");
+const alt = ref("");
+const actualSize = ref(false);
+const closeButton = ref<HTMLButtonElement | null>(null);
+const stage = ref<HTMLElement | null>(null);
+
+let lastFocused: HTMLElement | null = null;
+let scrollLock = "";
+
+function zoomableImage(target: EventTarget | null): HTMLImageElement | null {
+  if (!(target instanceof HTMLImageElement)) return null;
+  // Linked images keep their link, and .no-zoom is the opt-out.
+  if (target.closest("a") || target.closest(".no-zoom")) return null;
+  if (!target.closest(".vp-doc")) return null;
+  return target;
+}
+
+function show(image: HTMLImageElement) {
+  lastFocused = document.activeElement as HTMLElement | null;
+  src.value = image.currentSrc || image.src;
+  alt.value = image.alt;
+  actualSize.value = false;
+  open.value = true;
+
+  scrollLock = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+  nextTick(() => closeButton.value?.focus());
+}
+
+function toggleActualSize() {
+  actualSize.value = !actualSize.value;
+  if (!actualSize.value) return;
+  // Start the 1:1 view from the middle of the image rather than its corner.
+  nextTick(() => {
+    const el = stage.value;
+    if (!el) return;
+    el.scrollLeft = (el.scrollWidth - el.clientWidth) / 2;
+    el.scrollTop = (el.scrollHeight - el.clientHeight) / 2;
+  });
+}
+
+function close() {
+  if (!open.value) return;
+  open.value = false;
+  document.body.style.overflow = scrollLock;
+  lastFocused?.focus();
+  lastFocused = null;
+}
+
+function onClick(event: MouseEvent) {
+  // Leave modified clicks alone so "open in new tab" still works on the image.
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return;
+  }
+  const image = zoomableImage(event.target);
+  if (!image) return;
+  event.preventDefault();
+  show(image);
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (open.value) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+    }
+    return;
+  }
+  // Images are given tabindex below, so Enter/Space opens them too.
+  if (event.key !== "Enter" && event.key !== " ") return;
+  const image = zoomableImage(event.target);
+  if (!image) return;
+  event.preventDefault();
+  show(image);
+}
+
+// Make the zoomable images reachable by keyboard after every page render.
+onContentUpdated(() => {
+  document.querySelectorAll<HTMLImageElement>(".vp-doc img").forEach((image) => {
+    if (!zoomableImage(image)) return;
+    image.tabIndex = 0;
+    image.setAttribute("role", "button");
+    image.setAttribute(
+      "aria-label",
+      image.alt ? `Zoom image: ${image.alt}` : "Zoom image",
+    );
+  });
+});
+
+onMounted(() => {
+  mounted.value = true;
+  document.addEventListener("click", onClick);
+  document.addEventListener("keydown", onKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", onClick);
+  document.removeEventListener("keydown", onKeydown);
+  if (open.value) document.body.style.overflow = scrollLock;
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="image-zoom-fade">
+      <div
+        v-if="mounted && open"
+        class="image-zoom"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="alt ? `Zoomed image: ${alt}` : 'Zoomed image'"
+        @click.self="close"
+      >
+        <div class="image-zoom-actions">
+          <a
+            class="image-zoom-button"
+            :href="src"
+            target="_blank"
+            rel="noopener"
+            title="Open image in a new tab"
+            @click.stop
+            >Open in new tab</a
+          >
+          <button
+            ref="closeButton"
+            class="image-zoom-button"
+            type="button"
+            title="Close (Esc)"
+            @click="close"
+          >
+            Close
+          </button>
+        </div>
+        <div
+          ref="stage"
+          :class="['image-zoom-stage', { 'is-scrollable': actualSize }]"
+          @click.self="close"
+        >
+          <img
+            :class="['image-zoom-image', { 'is-actual-size': actualSize }]"
+            :src="src"
+            :alt="alt"
+            @click.stop="toggleActualSize()"
+          />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style>
+.vp-doc img {
+  cursor: zoom-in;
+}
+
+.vp-doc a img,
+.vp-doc .no-zoom img {
+  cursor: inherit;
+}
+
+.vp-doc img:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+}
+
+.image-zoom {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(4px);
+}
+
+.image-zoom-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+}
+
+.image-zoom-button {
+  padding: 6px 14px;
+  border: 1px solid #2d2d2d;
+  border-radius: 8px;
+  background: #111111;
+  font-family: var(--vp-font-family-base);
+  font-size: 0.85em;
+  color: #d4d4d4 !important;
+  text-decoration: none !important;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.image-zoom-button:hover {
+  border-color: #00d9a3;
+  color: #00d9a3 !important;
+}
+
+.image-zoom-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 0 16px 16px;
+}
+
+/* At 1:1 the image can outgrow the stage. Flex centering would push its top
+   and left edges out of reach of the scrollbars, so fall back to block flow,
+   where auto margins collapse to zero once the image is the wider box. */
+.image-zoom-stage.is-scrollable {
+  display: block;
+}
+
+.image-zoom-image {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 8px;
+  cursor: zoom-in;
+}
+
+.image-zoom-image.is-actual-size {
+  display: block;
+  max-width: none;
+  max-height: none;
+  margin: 0 auto;
+  cursor: zoom-out;
+}
+
+.image-zoom-fade-enter-active,
+.image-zoom-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.image-zoom-fade-enter-from,
+.image-zoom-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import { useRoute, withBase } from "vitepress";
 import DefaultTheme from "vitepress/theme";
+import ImageZoom from "./ImageZoom.vue";
 
 const rssIcon = withBase("/rss.svg");
 
@@ -33,4 +34,5 @@ const isBlogEntry = computed(() => {
       </a>
     </template>
   </Layout>
+  <ImageZoom />
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "fresh-docs",
       "devDependencies": {
+        "feed": "^4.2.2",
         "vitepress": "^1.6.4"
       }
     },
@@ -1751,6 +1752,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/focus-trap": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
@@ -2167,6 +2181,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/search-insights": {
       "version": "2.17.3",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
@@ -2494,6 +2518,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/zwitch": {


### PR DESCRIPTION
Screenshots and demo GIFs in the docs are downscaled to the article width, which makes dense terminal captures unreadable. Clicking an image now opens it full screen instead of doing nothing.

## What changed

New `docs/.vitepress/theme/ImageZoom.vue`, mounted once from `Layout.vue`. No new dependencies — no `medium-zoom`, just a delegated click handler and a teleported overlay.

- Click any image in the article body → full-screen lightbox over a blurred backdrop.
- Click the enlarged image → toggles fit-to-screen ⇄ **1:1 pixel size**, scrollable and centred on open. This is the part that matters for terminal screenshots: at fit size the text is unreadable, at 1:1 it's crisp.
- Esc, backdrop click, or the Close button dismisses; focus returns to the image that opened it.
- An **"Open in new tab"** link in the overlay reaches the raw file, and Cmd/Ctrl/Shift-click on the image still does the native new-tab thing.
- Images get `tabindex` and `role="button"`, so Enter and Space open them too.
- Linked images opt out automatically (blog cards and the RSS icon keep their links); `.no-zoom` is the manual escape hatch.

Colours are hardcoded to the dark palette, matching the existing `.blog-rss` button styling in `custom.css` — the site is `appearance: "force-dark"`.

## Verification

Built the site and drove the built output in Chromium: cursor and `tabindex` on doc images, overlay open/close via Esc, backdrop and button, body scroll lock and restore, keyboard open via Enter, the new-tab href, and re-attachment after client-side navigation including back/forward. No page errors.

One bug caught and fixed during testing: with flex centring, an over-wide image at 1:1 had its left edge pushed to `x = -260` and unreachable by scrolling. The 1:1 view now falls back to block flow, where auto margins collapse to zero — `scrollWidth` went 1556 → 1832, so the whole image is reachable.

## Second commit

`package-lock.json` was out of sync: `feed` is declared in `package.json` but missing from the lockfile along with its transitive `xml-js`/`sax` deps, so `npm ci` could not install it. Fixed in its own commit, purely additive, no existing package versions change. Unrelated to the zoom feature and separable if you'd rather not carry it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqUwyRf3q5LhomSesYzR1u)_