### PR TITLE
Keep each split's edit point put when another split edits the buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 ### Bug Fixes
 
 * **Replace-all now finishes on files with tens of thousands of matches** - four unrelated quadratic hot spots made a 60 000-match replace run for over a minute, or hang outright (#2893).
+* **Two splits on the same file keep independent edit points** - editing in one pane moved the other pane's cursor to the edit and scrolled it there, so the second edit point had to be repositioned after every change. Plain typing was unaffected, but any action that emits more than one event (`Ctrl+T` transpose, `Alt+↑`/`Alt+↓` move line, toggle comment) took the bulk-edit path, which reset other panes' cursors instead of shifting them by the edit (#2878, reported by @FreekyFrank).
 * **The Shift key works with "Keyboard Report All Keys As Escape Codes"** - with that flag on, every shifted key typed its unshifted character (`Shift+A` inserted `a`), because the terminal reports the *base* key and the shift separately (#2880, reported by @akarinotomoshibi).
 * **TOML multiline arrays highlight correctly**, and bare dots are no longer misread as floats (#2887, by @asukaminato0721).
 * **Pasting works in the New Workspace and Run Agent dialogs** - `Ctrl+V`/`Ctrl+A`/`Ctrl+C`/`Ctrl+X` and bracketed paste reach the focused text field instead of the buffer behind the dialog, in daemon mode (`fresh -a`) too.

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -3925,9 +3925,17 @@ impl Window {
     /// Adjust cursors in other splits that share the same buffer after
     /// an edit. The split that originated the event already had its
     /// cursors moved by `BufferState::apply`; this method walks every
-    /// other split displaying the same buffer and shifts (or, for a
-    /// `BulkEdit`, resets) their cursors so they don't dangle past
-    /// freshly-deleted text.
+    /// other split displaying the same buffer and shifts their cursors by
+    /// the edit deltas so they keep pointing at the same text instead of
+    /// dangling past freshly-deleted bytes.
+    ///
+    /// Every edit shape funnels through the same `adjust_for_edit` loop,
+    /// `BulkEdit` included. `BulkEdit` used to *assign* the originating
+    /// split's new cursor position to every other split, which teleported
+    /// a second view of the file to wherever the edit happened. Any
+    /// multi-event editing action (transpose, move-line, toggle-comment,
+    /// …) takes the bulk path even with a single cursor, so editing in
+    /// one pane dragged every other pane along (issue #2878).
     pub fn adjust_other_split_cursors_for_event(&mut self, event: &Event) {
         let current_buffer_id = self.active_buffer();
         let buffer_len = self
@@ -3941,22 +3949,6 @@ impl Window {
         let current_split_id = mgr.active_split();
         let splits_for_buffer = mgr.splits_for_buffer(current_buffer_id);
 
-        if let Event::BulkEdit { new_cursors, .. } = event {
-            for split_id in splits_for_buffer {
-                if split_id == current_split_id {
-                    continue;
-                }
-                if let Some(view_state) = vs_map.get_mut(&split_id) {
-                    if let Some((_, pos, _)) = new_cursors.first() {
-                        let new_pos = (*pos).min(buffer_len);
-                        view_state.cursors.primary_mut().position = new_pos;
-                        view_state.cursors.primary_mut().anchor = None;
-                    }
-                }
-            }
-            return;
-        }
-
         let adjustments: Vec<(usize, usize, usize)> = match event {
             Event::Insert { position, text, .. } => {
                 vec![(*position, 0, text.len())]
@@ -3964,6 +3956,11 @@ impl Window {
             Event::Delete { range, .. } => {
                 vec![(range.start, range.len(), 0)]
             }
+            // `edits` is sorted descending by position, which is safe to
+            // replay in order: each adjustment leaves a cursor at or after
+            // the edit it just shifted for, so the comparison against the
+            // next (lower) edit position still reflects pre-edit order.
+            Event::BulkEdit { edits, .. } => edits.clone(),
             Event::Batch { events, .. } => events
                 .iter()
                 .filter_map(|e| match e {
@@ -3989,6 +3986,13 @@ impl Window {
                         .cursors
                         .adjust_for_edit(*edit_pos, *old_len, *new_len);
                 }
+                // A cursor can still sit past the end when the edit shrank
+                // the tail out from under it; clamp so no view holds an
+                // out-of-bounds position.
+                view_state.cursors.map(|cursor| {
+                    cursor.position = cursor.position.min(buffer_len);
+                    cursor.anchor = cursor.anchor.map(|a| a.min(buffer_len));
+                });
             }
         }
     }

--- a/crates/fresh-editor/tests/e2e/issue_2878_split_cursor_independence.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2878_split_cursor_independence.rs
@@ -1,0 +1,106 @@
+//! Issue #2878: two splits on the same file must keep independent edit points.
+//!
+//! Editing in one split used to teleport every other split showing the same
+//! buffer to the edit position. Plain typing was fine — it emits a single
+//! `Insert` — but any action that emits more than one event (transpose,
+//! move-line, toggle-comment, …) takes the bulk-edit path, which *assigned*
+//! the editing split's cursor position to all the others. The reporter hit it
+//! with Ctrl+T and had to reposition the second pane's edit point after every
+//! such edit.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// 200 numbered lines, wide enough to tell any two apart on screen.
+fn numbered_lines() -> String {
+    (1..=200)
+        .map(|i| format!("line {:03}: the quick brown fox\n", i))
+        .collect()
+}
+
+/// Run a command palette entry by name.
+fn run_command(harness: &mut EditorTestHarness, query: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(query).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// Ctrl+T in the first split must leave the second split parked where the
+/// user put it, rather than dragging it to the edited line.
+#[test]
+fn test_transpose_in_one_split_leaves_other_split_in_place() {
+    let mut harness = EditorTestHarness::new(160, 40).unwrap();
+    harness.load_buffer_from_text(&numbered_lines()).unwrap();
+
+    // Split; focus lands in the new (second) split, cursor at the top.
+    run_command(&mut harness, "split vert");
+
+    // Park the second split's edit point far down the file.
+    harness
+        .send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 150)
+        .unwrap();
+    harness.assert_screen_contains("line 151");
+
+    // Back to the first split, and put its cursor between two characters
+    // so transpose has something to swap.
+    run_command(&mut harness, "prev split");
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The edit landed in the first split: "line 001" -> "lnie 001".
+    harness.assert_screen_contains("lnie 001");
+
+    // Return to the second split and nudge its cursor — that is when a
+    // cursor moved out from under the user reveals itself, by scrolling
+    // the pane to wherever it was moved to.
+    run_command(&mut harness, "next split");
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The second split is still showing line 151. Before the fix its cursor
+    // had been reset to the transpose position, so this pane jumped to the
+    // top of the file and line 151 was nowhere on screen.
+    harness.assert_screen_contains("line 151");
+}
+
+/// The same guarantee for Alt+Down (move line down) — transpose is only one
+/// of the multi-event editing actions that took the bulk path.
+#[test]
+fn test_move_line_in_one_split_leaves_other_split_in_place() {
+    let mut harness = EditorTestHarness::new(160, 40).unwrap();
+    harness.load_buffer_from_text(&numbered_lines()).unwrap();
+
+    run_command(&mut harness, "split vert");
+    harness
+        .send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 150)
+        .unwrap();
+    harness.assert_screen_contains("line 151");
+
+    run_command(&mut harness, "prev split");
+    harness.send_key(KeyCode::Down, KeyModifiers::ALT).unwrap();
+    harness.render().unwrap();
+
+    run_command(&mut harness, "next split");
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("line 151");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -98,6 +98,7 @@ pub mod issue_2796_key_release_duplicates;
 #[cfg(feature = "plugins")]
 pub mod issue_2810_session_escape_flush;
 pub mod issue_2843_single_line_viewport;
+pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
Fixes #2878.

## The bug

Two splits on one file are supposed to hold independent cursors, but `adjust_other_split_cursors_for_event` had a `BulkEdit` branch that *assigned* the editing split's new cursor position to every other split showing the buffer, instead of shifting it by the edit:

```rust
view_state.cursors.primary_mut().position = new_pos;
view_state.cursors.primary_mut().anchor = None;
```

Plain typing never hit this — a single cursor emits one `Insert` — which is why the report looked so hard to pin down. But `apply_action_as_events` routes any action emitting more than one event through `apply_events_as_bulk_edit`, and several single-cursor actions emit two: `handle_transpose_chars` pushes a `Delete` + an `Insert`. So `Ctrl+T`, `Alt+↑`/`Alt+↓`, toggle comment and friends teleported every other pane's cursor to the edit, and the pane scrolled there on the next keystroke.

The reporter identified `Ctrl+T` as one of the triggers, which is what made it reproducible.

## Reproduction

1. Open a 200-line file, `Ctrl+P` → "Split Vertical"
2. In the right pane, `Ctrl+G` → 150
3. Click into the left pane at line 3
4. Press `Ctrl+T`
5. Click back into the right pane and press any key → it is at line 3, not 150

## The fix

`BulkEdit` now feeds its own `edits` list into the same `adjust_for_edit` loop that `Insert`/`Delete`/`Batch` already use. That list is the merged, descending-sorted `(pos, del_len, ins_len)` tuples this path already replays through `replay_bulk_marker_adjustments` to shift markers, so cursors and markers now move by identical deltas. Replaying it in descending order is safe: each adjustment leaves a cursor at or after the edit it just shifted for, so the comparison against the next (lower) edit position still reflects pre-edit order.

Cursors are clamped to the buffer length afterwards, which keeps the out-of-bounds guard the old reset was providing.

## Tests

`crates/fresh-editor/tests/e2e/issue_2878_split_cursor_independence.rs` — two e2e tests driving keys and asserting only on rendered output: one for transpose, one for move-line. Both fail on master (the second pane collapses to line 1 and `line 151` is nowhere on screen) and pass with the fix.

`cargo fmt`, `cargo clippy --all-targets` and `cargo check --all-targets` are clean; the 3201 lib unit tests pass, as do all 130 split-related e2e tests. Two full e2e runs on this branch produced *different* failure sets (locale, remote-fs, visual-regression, terminal-title) and every one of those passes in isolation — load-sensitive flakes in my container, none touching split cursor adjustment.

## Also noticed, not fixed here

Two smaller things surfaced while reproducing, both independent of this diff:

- A pane scrolled without moving its cursor snaps back on the next edit or on opening the palette — `skip_ensure_visible` is one-shot.
- Other panes' `top_byte` is not re-anchored across an edit, so inserting above a pane drifts its top line by a fraction of a line.

---
_Generated by [Claude Code](https://claude.ai/code/session_015iafTDHpx9WZ3iTepg5aNE)_