### PR TITLE
Fix the CONTRIBUTING violations behind a batch of flaky e2e tests

### DIFF
--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -448,6 +448,46 @@ A sample project for testing.
             "checkout",
         );
     }
+
+    /// The file's current on-disk modification time.
+    pub fn mtime(&self, relative_path: &str) -> std::time::SystemTime {
+        fs::metadata(self.path.join(relative_path))
+            .and_then(|m| m.modified())
+            .expect("file should exist and expose an mtime")
+    }
+
+    /// Block until `relative_path`'s on-disk mtime is strictly newer than
+    /// `floor`, rewriting its (unchanged) bytes until the filesystem's clock
+    /// ticks past its own granularity.
+    ///
+    /// Auto-revert notices an external write by comparing mtimes, so a test
+    /// that rewrites a file the editor already opened has to guarantee the
+    /// new mtime is distinguishable from the recorded one. On a filesystem
+    /// with 1 s mtime granularity (HFS+, some CI volumes) a fast test does
+    /// the whole open-then-rewrite sequence inside a single tick, and the
+    /// reload never fires.
+    ///
+    /// The obvious fix — sleep past the granularity — is a fixed timer, and
+    /// the one this replaced was worse than that: it used `harness.sleep`,
+    /// which advances *logical* time only and so waited no real time at all,
+    /// leaving the hazard it was written to prevent fully live. Rewriting
+    /// until the observed mtime actually moves is semantic waiting on the
+    /// real condition (CONTRIBUTING.md Testing §3): it costs nothing on a
+    /// nanosecond-resolution filesystem and exactly one granularity tick on
+    /// a coarse one, and it cannot silently not-work.
+    pub fn touch_until_mtime_after(&self, relative_path: &str, floor: std::time::SystemTime) {
+        let full = self.path.join(relative_path);
+        let content = fs::read(&full).expect("file should exist");
+        loop {
+            if self.mtime(relative_path) > floor {
+                return;
+            }
+            // Same bytes back: this is a pure mtime bump, not a content edit,
+            // so it can't perturb what the test is actually asserting on.
+            fs::write(&full, &content).expect("failed to rewrite file for mtime bump");
+            std::thread::yield_now();
+        }
+    }
 }
 
 /// Helper to restore original directory

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -112,19 +112,19 @@ impl GitTestRepo {
     /// Create a new git test repository with test files
     pub fn new() -> Self {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        // Canonicalize before anything records the path. On macOS a tempdir
-        // is `/var/folders/...`, a symlink to `/private/var/...`; the editor
-        // resolves and stores the latter on the buffer, while `repo.path`
-        // (the working dir handed to the harness, the root the git plugins
-        // compute repo-relative paths against, and the target of
-        // `change_to_repo_dir`) would keep the former. The two then don't
-        // compare equal, so a plugin asking "is this buffer inside the repo,
-        // and at which relative path?" answers wrongly and its decorations
-        // never appear — a macOS-only failure in tests that are not about
-        // paths at all. `tests/e2e/code_tour_dock.rs` canonicalizes its own
-        // fixture for exactly this reason; doing it here covers every
-        // git-backed test at once (CONTRIBUTING.md Code §12).
-        let path = fs::canonicalize(temp_dir.path()).expect("Failed to canonicalize temp dir");
+        // Deliberately *not* canonicalized. On macOS a tempdir is
+        // `/var/folders/...`, a symlink to `/private/var/...`, and the editor
+        // stores the resolved form on the buffer while `repo.path` keeps the
+        // unresolved one — which is a real hazard for anything comparing the
+        // two, and why `tests/e2e/code_tour_dock.rs` canonicalizes its own
+        // fixture. Resolving it *here* is not the fix, though: on Windows
+        // `fs::canonicalize` returns an extended-length `\\?\D:\...` path,
+        // which git and the plugins that shell out to it do not accept, and
+        // that broke `plugins::package_manager` (which uses a repo path as a
+        // git remote). Per-fixture canonicalization where a test actually
+        // needs it stays correct; doing it for every git-backed test at once
+        // does not.
+        let path = temp_dir.path().to_path_buf();
 
         // Initialize git repository. The test's own git invocations are
         // isolated by `git_command` so the host's signing program / background

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -112,7 +112,19 @@ impl GitTestRepo {
     /// Create a new git test repository with test files
     pub fn new() -> Self {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let path = temp_dir.path().to_path_buf();
+        // Canonicalize before anything records the path. On macOS a tempdir
+        // is `/var/folders/...`, a symlink to `/private/var/...`; the editor
+        // resolves and stores the latter on the buffer, while `repo.path`
+        // (the working dir handed to the harness, the root the git plugins
+        // compute repo-relative paths against, and the target of
+        // `change_to_repo_dir`) would keep the former. The two then don't
+        // compare equal, so a plugin asking "is this buffer inside the repo,
+        // and at which relative path?" answers wrongly and its decorations
+        // never appear — a macOS-only failure in tests that are not about
+        // paths at all. `tests/e2e/code_tour_dock.rs` canonicalizes its own
+        // fixture for exactly this reason; doing it here covers every
+        // git-backed test at once (CONTRIBUTING.md Code §12).
+        let path = fs::canonicalize(temp_dir.path()).expect("Failed to canonicalize temp dir");
 
         // Initialize git repository. The test's own git invocations are
         // isolated by `git_command` so the host's signing program / background

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1180,45 +1180,92 @@ impl EditorTestHarness {
     /// printable chars) with keys handled synchronously by a
     /// host-side bypass (e.g. `Shift+arrow`, `Ctrl+C/V`).
     ///
-    /// The drain is bounded — at most ~200 ms wall-clock — so a
-    /// genuinely-stuck plugin doesn't hang the test forever. In
-    /// practice the loop exits in microseconds: the plugin
-    /// thread schedules its work immediately, and the bridge
-    /// drains within a single `process_async_messages` call.
+    /// We need both:
+    ///  (1) `pending_plugin_actions` to be empty — the plugin
+    ///      thread has finished every action queued by this
+    ///      keypress and any follow-on dispatch the action
+    ///      itself triggered.
+    ///  (2) the async bridge to be quiet for one extra
+    ///      iteration — to catch the `WidgetCommand` that a
+    ///      completed plugin action just pushed.
+    ///
+    /// (1) used to share a ~200 ms cap with (2). That cap was a
+    /// *timeout inside a test* (CONTRIBUTING.md Testing §3) hidden
+    /// behind every `send_key`/`type_text`: on a loaded CI runner a
+    /// plugin action that needed longer than the budget left the
+    /// drain early and *silently* (a `tracing::warn!` that CI never
+    /// renders), so the caller's next assertion sampled a pre-action
+    /// frame. That is a flake with no diagnostic — the screen dump
+    /// shows a plausible-looking stale frame and nothing says why.
+    ///
+    /// (1) is now waited out with a budget generous enough that no
+    /// real plugin action can miss it, and giving up is loud on
+    /// stderr (the one channel nextest surfaces for a killed or
+    /// failed test). It stays bounded rather than indefinite because
+    /// a plugin callback that never returns must not deadlock every
+    /// subsequent keypress in the suite; a genuinely stuck action now
+    /// reports itself instead of quietly corrupting one assertion.
+    ///
+    /// (2) keeps a short bound of its own: legitimately continuous
+    /// message sources — PTY output, timer-driven plugin polls — never
+    /// go quiet, and waiting for silence that will never come would
+    /// hang every terminal test.
     fn drain_async_work(&mut self) {
-        const MAX_ITERS: usize = 200; // ~200ms at 1ms per iter
         const SLEEP_PER_ITER: std::time::Duration = std::time::Duration::from_millis(1);
-        // We need both:
-        //  (1) `pending_plugin_actions` to be empty — the plugin
-        //      thread has finished every action queued by this
-        //      keypress and any follow-on dispatch the action
-        //      itself triggered.
-        //  (2) the async bridge to be quiet for one extra
-        //      iteration — to catch the `WidgetCommand` that a
-        //      completed plugin action just pushed.
+        /// Real-wall-clock budget for (1). ~50x the old cap: far beyond
+        /// any plugin action these tests perform, still bounded.
+        const ACTION_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+        /// Iterations of (2) to tolerate before concluding the source is
+        /// continuous rather than settling.
+        const TAIL_ITERS: usize = 200;
+        const QUIET_ITERS: usize = 2;
+
+        let start = std::time::Instant::now();
         let mut quiet_iters = 0;
-        for _ in 0..MAX_ITERS {
+        let mut tail_iters = 0;
+        loop {
             let had_messages = self.editor.process_async_messages();
-            let pending_empty = self.editor.pending_plugin_actions_is_empty();
-            if pending_empty && !had_messages {
-                quiet_iters += 1;
-                if quiet_iters >= 2 {
+
+            if !self.editor.pending_plugin_actions_is_empty() {
+                quiet_iters = 0;
+                tail_iters = 0;
+                if start.elapsed() >= ACTION_BUDGET {
+                    // stderr, not just tracing: CI runs with tracing
+                    // disabled, and this is the only channel that
+                    // survives into a failed/killed test's output.
+                    eprintln!(
+                        "drain_async_work: plugin actions still in-flight after {:.1}s — \
+                         giving up. The next assertion may observe a pre-action frame.",
+                        start.elapsed().as_secs_f64()
+                    );
+                    tracing::warn!("drain_async_work exceeded action budget");
                     return;
                 }
-            } else {
-                quiet_iters = 0;
-            }
-            if !pending_empty {
                 // Give the plugin thread time to actually run the
                 // queued action(s) before re-checking. This is
                 // real wall-clock — there's no fake-time path for
                 // cross-thread receivers.
                 std::thread::sleep(SLEEP_PER_ITER);
+                continue;
+            }
+
+            if had_messages {
+                // Messages are still flowing: keep draining at full
+                // speed rather than pacing, so a terminal's PTY output
+                // doesn't add a sleep to every keypress.
+                quiet_iters = 0;
+            } else {
+                quiet_iters += 1;
+                if quiet_iters >= QUIET_ITERS {
+                    return;
+                }
+                std::thread::sleep(SLEEP_PER_ITER);
+            }
+            tail_iters += 1;
+            if tail_iters >= TAIL_ITERS {
+                return;
             }
         }
-        tracing::warn!(
-            "drain_async_work hit iteration cap; pending plugin actions may still be in-flight"
-        );
     }
 
     /// Simulate a mouse event
@@ -2714,6 +2761,97 @@ impl EditorTestHarness {
     /// Wait for prompt to close (no longer prompting)
     pub fn wait_for_prompt_closed(&mut self) -> anyhow::Result<()> {
         self.wait_until(|h| !h.editor().is_prompting())
+    }
+
+    /// Run a command palette command by name, waiting for the palette to
+    /// actually offer it before confirming.
+    ///
+    /// The naive form of this — open palette, `type_text(name)`, `Enter` —
+    /// is a race, and one that bites hardest for plugin-registered commands.
+    /// Quick Open recomputes its suggestion list only when the *input*
+    /// changes (`app/prompt_lifecycle.rs::update_quick_open_suggestions`),
+    /// never on a render or an editor tick. So:
+    ///
+    ///   * Pressing Enter right after typing fires on whichever row happened
+    ///     to be selected when the last keystroke was processed. Locally the
+    ///     filter resolves in the same frame and it always works; on a loaded
+    ///     runner it need not, and some *other* command runs instead.
+    ///   * If the command's plugin hasn't finished `registerCommand` by the
+    ///     time the last character lands, the row never appears — and because
+    ///     no tick re-filters, it never will. A later `wait_until` for that
+    ///     row then blocks forever, which is a 180 s nextest timeout with no
+    ///     failed assertion to point at.
+    ///
+    /// So this waits for the command to be *registered and filtered in*
+    /// before pressing Enter, retyping the query if the registration landed
+    /// late (the retype is what re-runs the filter). The wait is indefinite
+    /// per CONTRIBUTING.md Testing §3; a command that is never registered
+    /// still times out externally, but its periodic screen dumps show the
+    /// palette with the query typed and no matching row — which names the
+    /// problem instead of hiding it.
+    ///
+    /// `name` must be a prefix of the command's displayed title (matching is
+    /// on the rendered row, so `"Git Gutter"` finds `"Git Gutter: Refresh"`).
+    pub fn run_palette_command(&mut self, name: &str) -> anyhow::Result<()> {
+        self.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+        self.wait_for_prompt()?;
+        self.type_text(name)?;
+        self.wait_for_palette_command(name)?;
+        self.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+        Ok(())
+    }
+
+    /// Wait until the open command palette lists `name` as a *result*, not
+    /// merely as the echoed query.
+    ///
+    /// The query line echoes what was typed, so "the name is on screen" is
+    /// true the moment typing lands, whether or not the palette has filtered
+    /// its list yet — a wait that cannot fail and therefore gates nothing
+    /// (CONTRIBUTING.md Code §16). Requiring the name *twice* — once as the
+    /// query, once as the row Enter is about to activate — is what makes it
+    /// a real gate.
+    ///
+    /// Retypes the last character each time round the loop, because the
+    /// suggestion list is only rebuilt on input change: without that, a
+    /// command registered by a plugin after the initial `type_text` would
+    /// never be filtered in and the wait could not resolve.
+    pub fn wait_for_palette_command(&mut self, name: &str) -> anyhow::Result<()> {
+        const POLL: std::time::Duration = std::time::Duration::from_millis(50);
+        const SCREEN_DUMP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
+        let name = name.to_string();
+        let last = name.chars().next_back().expect("command name is non-empty");
+        let listed = |h: &Self| h.screen_to_string().matches(&name).count() >= 2;
+
+        let start = std::time::Instant::now();
+        let mut last_dump = start;
+        loop {
+            if listed(self) {
+                return Ok(());
+            }
+            // One tick's worth of async progress (plugin loads, command
+            // registrations), then re-run the filter against the registry as
+            // it stands now — retyping is the only thing that rebuilds the
+            // suggestion list.
+            self.tick_and_render()?;
+            self.send_key(KeyCode::Backspace, KeyModifiers::NONE)?;
+            self.type_text(&last.to_string())?;
+            if listed(self) {
+                return Ok(());
+            }
+
+            let now = std::time::Instant::now();
+            if now.duration_since(last_dump) >= SCREEN_DUMP_INTERVAL {
+                eprintln!(
+                    "wait_for_palette_command({name:?}) still pending after {:.1}s — screen:\n{}",
+                    now.duration_since(start).as_secs_f64(),
+                    self.screen_to_string()
+                );
+                last_dump = now;
+            }
+            std::thread::sleep(POLL);
+            self.advance_time(POLL);
+        }
     }
 
     /// Open the settings dialog via command palette

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -187,28 +187,19 @@ fn harness_in(project_root: &Path, width: u16, height: u16) -> EditorTestHarness
 }
 
 /// Run a palette command by name.
+///
+/// This module already knew to wait for the *filtered row* rather than the
+/// echoed query before pressing Enter. What it couldn't fix locally is that
+/// Quick Open rebuilds its suggestion list only when the input changes —
+/// never on a render or a tick. `Tour: …` is registered by the code-tour
+/// plugin during startup, so if that registration lands after the last
+/// keystroke the row can never appear, and waiting for it blocks until
+/// nextest kills the test at 180 s with no failed assertion. That is the
+/// remaining explanation for this module's CI timeouts on both ubuntu and
+/// windows. `run_palette_command` retypes to re-run the filter, so a
+/// late-registering plugin command is picked up as soon as it exists.
 fn run_command(harness: &mut EditorTestHarness, name: &str) {
-    harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    harness.wait_for_prompt().unwrap();
-    harness.type_text(name).unwrap();
-    // The query line echoes what was typed, so "the name is on screen" is true
-    // the moment typing lands, whether or not the palette has filtered its list
-    // yet — a wait that cannot fail and therefore gates nothing
-    // (CONTRIBUTING.md §16). Enter then fires on whatever row happens to be
-    // selected at that instant. Locally the filter finishes in the same frame
-    // and it always works; on a loaded runner it need not, and the command
-    // never runs, which is how this hung on CI with no failed assertion.
-    //
-    // Wait for the name *twice*: once as the query, once as the filtered row
-    // Enter is about to activate.
-    harness
-        .wait_until(|h| h.screen_to_string().matches(name).count() >= 2)
-        .unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
+    harness.run_palette_command(name).unwrap();
 }
 
 /// Load a tour manifest through `Tour: Load Definition...` and wait for its

--- a/crates/fresh-editor/tests/e2e/locale.rs
+++ b/crates/fresh-editor/tests/e2e/locale.rs
@@ -144,24 +144,13 @@ fn test_locale_switch_via_command_palette() {
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
 
-    // Open command palette with Ctrl+P
-    harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    harness.render().unwrap();
-
-    // Type to filter for locale command
-    harness.type_text("Select Locale").unwrap();
-    harness.render().unwrap();
-
-    // Execute the command
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
+    // Open the locale picker. Via `run_palette_command` so Enter fires on the
+    // filtered row rather than on whatever happened to be selected when the
+    // last keystroke landed — Quick Open re-filters on input change only.
+    harness.run_palette_command("Select Locale").unwrap();
 
     // Should show locale selection prompt
-    harness.assert_screen_contains("Select locale:");
+    harness.wait_for_screen_contains("Select locale:").unwrap();
 
     // Navigate to Spanish - the prompt starts with "en" selected
     // Type to filter
@@ -182,7 +171,12 @@ fn test_locale_switch_via_command_palette() {
 
     // Verify locale changed status message (shown in the new locale)
     // After switching to Spanish, the message is shown in Spanish: "Idioma cambiado a"
-    harness.assert_screen_contains("Idioma cambiado");
+    //
+    // Waited for, not sampled: confirming the picker re-inits i18n and
+    // repaints, and a wrong row would leave this message absent — so the wait
+    // is a real gate on the switch having happened, and its periodic screen
+    // dumps name the problem if it didn't.
+    harness.wait_for_screen_contains("Idioma cambiado").unwrap();
 
     // Open search again to verify Spanish is now active
     harness
@@ -191,7 +185,7 @@ fn test_locale_switch_via_command_palette() {
     harness.render().unwrap();
 
     // Search UI should now show Spanish labels
-    harness.assert_screen_contains("Distinguir");
+    harness.wait_for_screen_contains("Distinguir").unwrap();
     harness.assert_screen_not_contains("Case Sensitive");
 }
 
@@ -346,21 +340,13 @@ fn test_multiple_locales_can_be_loaded() {
 
 /// Helper function to switch locale via command palette
 fn switch_locale(harness: &mut EditorTestHarness, locale: &str, search_command: &str) {
-    // Open command palette with Ctrl+P
-    harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    harness.render().unwrap();
-
-    // Type to filter for locale command
-    harness.type_text(search_command).unwrap();
-    harness.render().unwrap();
-
-    // Execute the command
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
+    // Open the picker through `run_palette_command`, which waits for the
+    // command to be listed as a *result* before confirming. Typing the name
+    // and pressing Enter blind fires on whichever row was selected when the
+    // last keystroke was processed — Quick Open re-filters on input change,
+    // not per frame — so on a loaded runner this could run some other command
+    // and leave the locale untouched.
+    harness.run_palette_command(search_command).unwrap();
 
     // Clear the default "en" and type the new locale code (matching existing test pattern)
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -101,17 +101,14 @@ fn process_async_once(harness: &mut EditorTestHarness) {
     let _ = harness.process_async_and_render();
 }
 
-/// Trigger the Git Gutter Refresh command via command palette
+/// Trigger the Git Gutter Refresh command via command palette.
+///
+/// Goes through `run_palette_command` rather than typing and pressing Enter:
+/// the command is registered by the git_gutter *plugin*, so until the plugin
+/// has loaded there is no row to activate, and Quick Open only re-filters on
+/// input change. Pressing Enter blind either runs some other command or none.
 fn trigger_git_gutter_refresh(harness: &mut EditorTestHarness) {
-    harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    harness.render().unwrap();
-    harness.type_text("Git Gutter").unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
+    harness.run_palette_command("Git Gutter").unwrap();
 }
 
 /// Open a file using the harness's open_file method
@@ -272,28 +269,12 @@ fn test_git_gutter_updates_after_save() {
     open_file(&mut harness, &repo.path, "src/main.rs");
     harness.render().unwrap();
 
-    // Wait for git gutter to stabilize - for an unmodified file, there should be
-    // 0 indicators. We need to wait because the git diff is async and might not
-    // have completed yet (or might show transient indicators during loading).
     harness
         .wait_until(|h| {
-            // Process async messages to allow git gutter to settle
             let screen = h.screen_to_string();
-            // For unmodified file, should have 0 indicators once stabilized
-            // But we also accept any stable state for robustness
             screen.contains("main.rs") && screen.contains("fn main")
         })
         .unwrap();
-
-    // Give git gutter extra time to settle since git diff is async
-    for _ in 0..5 {
-        harness.process_async_and_render().unwrap();
-        harness.sleep(std::time::Duration::from_millis(50));
-    }
-
-    // Initially, there should be no git gutter indicators (file matches HEAD)
-    let screen = harness.screen_to_string();
-    let initial_indicators = count_gutter_indicators(&screen, "│");
 
     // Make a change
     harness.type_text("// New comment\n").unwrap();
@@ -302,23 +283,41 @@ fn test_git_gutter_updates_after_save() {
     // Save the file - this should trigger git gutter update
     save_file(&mut harness);
 
-    // Wait for git gutter to update
-    harness
-        .wait_until(|h| {
-            let screen = h.screen_to_string();
-            // After save, there should be git indicators (file differs from HEAD)
-            count_gutter_indicators(&screen, "│") > initial_indicators
-        })
-        .unwrap();
+    // Wait for the *end state* — the added line carries a green indicator in
+    // column 0 — rather than for "more indicators than a baseline".
+    //
+    // The baseline used to be sampled after a `for _ in 0..5 { …
+    // harness.sleep(50ms) }` settle loop, but `harness.sleep` advances
+    // *logical* time only (see its doc comment): the loop waited no real
+    // wall-clock at all, so the sample was taken from whatever frame the git
+    // diff happened to have reached. If that sample caught the settled count
+    // instead of the pre-diff one, `count > initial` was unsatisfiable and
+    // the wait below could never resolve — a 180 s timeout, not a failure.
+    //
+    // Waiting on the invariant itself is immune to that: it holds only once
+    // the post-save diff has landed, and a genuinely wrong result still fails
+    // loudly through the wait's periodic screen dumps.
+    let comment_row = |h: &EditorTestHarness| -> Option<u16> {
+        h.screen_to_string()
+            .lines()
+            .position(|line| line.contains("// New comment"))
+            .map(|row| row as u16)
+    };
+    let indicator_landed = |h: &EditorTestHarness| {
+        let Some(row) = comment_row(h) else {
+            return false;
+        };
+        h.get_row_text(row).starts_with('│')
+            && h.get_cell_style(0, row)
+                .is_some_and(|s| s.fg == Some(Color::Rgb(80, 250, 123)))
+    };
+    harness.wait_until(indicator_landed).unwrap();
 
     let screen = harness.screen_to_string();
     println!("After save screen:\n{}", screen);
 
-    let (row, added_line) = screen
-        .lines()
-        .enumerate()
-        .find(|(_, line)| line.contains("// New comment"))
-        .expect("New comment should be visible after save");
+    let row = comment_row(&harness).expect("New comment should be visible after save");
+    let added_line = harness.get_row_text(row);
     assert_eq!(
         added_line.chars().next(),
         Some('│'),
@@ -326,7 +325,7 @@ fn test_git_gutter_updates_after_save() {
     );
 
     let indicator_style = harness
-        .get_cell_style(0, row as u16)
+        .get_cell_style(0, row)
         .expect("Git gutter indicator cell should have a style");
     assert_eq!(
         indicator_style.fg,
@@ -1701,16 +1700,27 @@ fn test_git_gutter_refreshes_after_external_git_checkout() {
         "a file matching HEAD should have no gutter indicators"
     );
 
-    // Filesystems with 1s mtime granularity need the reset's mtime to land
-    // after the open's recorded mtime, or auto-revert won't see a change.
-    harness.sleep(std::time::Duration::from_millis(2100));
+    // Auto-revert notices the external write by mtime, so the reset's mtime
+    // has to be distinguishable from the one recorded when the file was
+    // opened. Record that floor now, reset, then bump until the filesystem
+    // clock has actually moved past it.
+    //
+    // This used to be `harness.sleep(2100ms)`, which advances *logical* time
+    // only — it waited no real wall-clock at all, so on a filesystem with 1 s
+    // mtime granularity the open and the checkout could land in the same tick,
+    // auto-revert never fired, and the wait below blocked until nextest killed
+    // the test at 180 s.
+    let opened_at = repo.mtime("long.txt");
 
     // Externally reset the file to its v1 state while it is open.
     repo.git_checkout_file("HEAD~1", "long.txt");
+    repo.touch_until_mtime_after("long.txt", opened_at);
 
-    // Auto-revert reloads the buffer from disk.
+    // Auto-revert reloads the buffer from disk. The rewritten lines are near
+    // the top of the file and so on screen — assert on the rendered text
+    // rather than on buffer state (CONTRIBUTING.md Testing §2).
     harness
-        .wait_until(|h| !h.get_buffer_content().unwrap().contains("CHANGED IN HEAD"))
+        .wait_until(|h| !h.screen_to_string().contains("CHANGED IN HEAD"))
         .expect("auto-revert should reload the externally reset file");
 
     // The reverted content differs from HEAD on the two rewritten lines, so

--- a/crates/fresh-editor/tests/e2e/plugins/gutter.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/gutter.rs
@@ -276,6 +276,36 @@ fn test_git_gutter_updates_after_save() {
         })
         .unwrap();
 
+    // Let the plugin's open-time pass finish before touching the buffer.
+    //
+    // This is load-bearing, and not for the reason it looks like: the plugin
+    // establishes its HEAD baseline for the file asynchronously on open, and
+    // editing before that lands leaves it without one — after the save it
+    // then never produces indicators at all, and any wait for one hangs to
+    // the external timeout.
+    //
+    // It used to be spelled `for _ in 0..5 { …; harness.sleep(50ms) }`, which
+    // reads as a 250 ms pause and is not one: `harness.sleep` advances
+    // *logical* time only (see its doc comment), so the loop's five
+    // `process_async_and_render` calls were the entire effect and the pause
+    // was zero. Waiting for the async pipeline to actually go quiet is the
+    // same intent, made real — and it is the helper written for precisely
+    // this case, plugin decorations produced off-thread.
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    // For an unmodified file the settled state is no indicators at all.
+    // Asserting that beats sampling a baseline count to compare against
+    // later: the old code captured `initial_indicators` off whatever frame
+    // the async diff happened to have reached, and if that sample caught the
+    // settled count rather than the pre-diff one, the later `count > initial`
+    // could never be satisfied — a 180 s timeout rather than a failure.
+    assert_eq!(
+        count_gutter_indicators(&harness.screen_to_string(), "│"),
+        0,
+        "a file matching HEAD should have no gutter indicators once settled\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
     // Make a change
     harness.type_text("// New comment\n").unwrap();
     harness.render().unwrap();
@@ -283,20 +313,10 @@ fn test_git_gutter_updates_after_save() {
     // Save the file - this should trigger git gutter update
     save_file(&mut harness);
 
-    // Wait for the *end state* — the added line carries a green indicator in
-    // column 0 — rather than for "more indicators than a baseline".
-    //
-    // The baseline used to be sampled after a `for _ in 0..5 { …
-    // harness.sleep(50ms) }` settle loop, but `harness.sleep` advances
-    // *logical* time only (see its doc comment): the loop waited no real
-    // wall-clock at all, so the sample was taken from whatever frame the git
-    // diff happened to have reached. If that sample caught the settled count
-    // instead of the pre-diff one, `count > initial` was unsatisfiable and
-    // the wait below could never resolve — a 180 s timeout, not a failure.
-    //
-    // Waiting on the invariant itself is immune to that: it holds only once
-    // the post-save diff has landed, and a genuinely wrong result still fails
-    // loudly through the wait's periodic screen dumps.
+    // Wait for the end state: the added line carries a green indicator in
+    // column 0. That holds only once the post-save diff has landed, and a
+    // genuinely wrong result still fails loudly through the wait's periodic
+    // screen dumps.
     let comment_row = |h: &EditorTestHarness| -> Option<u16> {
         h.screen_to_string()
             .lines()

--- a/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
@@ -10,7 +10,6 @@
 
 use crate::common::git_test_helper::{DirGuard, GitTestRepo};
 use crate::common::harness::EditorTestHarness;
-use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 
 // =============================================================================
@@ -58,16 +57,18 @@ fn open_file(harness: &mut EditorTestHarness, repo_path: &std::path::Path, relat
 /// Live-diff is opt-in (off by default). Trigger the global-toggle
 /// command via the command palette so the rest of the test can observe
 /// gutter glyphs and virtual lines.
+///
+/// Via `run_palette_command`, which waits for the command to be listed
+/// before confirming. This one is registered by the live_diff *plugin*, and
+/// Quick Open only rebuilds its suggestion list when the input changes — so
+/// typing the name and pressing Enter immediately either activated whatever
+/// row was selected at that instant or, if the plugin hadn't registered yet,
+/// nothing at all. Either way live-diff stayed off and every later wait in
+/// the test blocked forever.
 fn enable_live_diff_globally(harness: &mut EditorTestHarness) {
     harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .run_palette_command("Live Diff: Toggle (Global)")
         .unwrap();
-    harness.render().unwrap();
-    harness.type_text("Live Diff: Toggle (Global)").unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
 }
 
 // =============================================================================

--- a/crates/fresh-editor/tests/e2e/plugins/plugin.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin.rs
@@ -1082,16 +1082,29 @@ editor.setStatus("Test diagnostics plugin loaded");
         EditorTestHarness::with_config_and_working_dir(100, 30, config, project_root.clone())
             .unwrap();
 
+    // Wait for the plugin to load before anything can emit the event it
+    // subscribes to. Its last statement sets a status message, so "the plugin
+    // finished evaluating, and `editor.on("diagnostics_updated", …)` is
+    // registered" is readable straight off the status bar.
+    harness.wait_for_screen_contains("Test diagnostics plugin loaded")?;
+
     // Open the test file - this will start LSP
     harness.open_file(&test_file)?;
     harness.render()?;
 
-    // Wait for LSP to initialize and plugin to load
-    for _ in 0..10 {
-        harness.sleep(Duration::from_millis(100));
-        let _ = harness.editor_mut().process_async_messages();
-        harness.render()?;
-    }
+    // Wait for the server to finish initializing before saving.
+    //
+    // This replaces `for _ in 0..10 { harness.sleep(100ms); … }`, which looks
+    // like a one-second warm-up and is not one: `harness.sleep` advances
+    // *logical* time only (see its doc comment), so the loop ran ten
+    // iterations back-to-back and waited no real time whatsoever. The save
+    // below therefore raced LSP startup. The fake server publishes
+    // diagnostics only in reply to `textDocument/didSave`, so losing that
+    // race means no diagnostics are ever published and the wait that follows
+    // can never resolve — a 180 s nextest timeout, and precisely the
+    // didOpen-before-everything-else ordering CONTRIBUTING.md Code §3 is
+    // about.
+    harness.wait_until(|h| h.editor().active_window().is_lsp_server_ready("rust"))?;
 
     // Save the file to trigger diagnostics from fake LSP
     harness
@@ -1099,20 +1112,19 @@ editor.setStatus("Test diagnostics plugin loaded");
         .unwrap();
     harness.render()?;
 
-    // Wait for diagnostics to be received and processed
-    // Loop indefinitely - test framework timeout will catch actual failures
-    loop {
-        harness.sleep(Duration::from_millis(100));
-        let _ = harness.editor_mut().process_async_messages();
-        harness.render()?;
-
-        // Check if diagnostics were stored
-        let stored = harness.editor().get_stored_diagnostics();
-        if !stored.is_empty() {
-            println!("Diagnostics received: {:?}", stored);
-            break;
-        }
-    }
+    // Wait for the plugin's `diagnostics_updated` hook to run, observed
+    // through the status message it sets. That is the same signal the old
+    // code checked at the very end and then *didn't* assert on (it was
+    // wrapped in `if status.contains(…) { println!(…) }`, which passes
+    // whatever happens — CONTRIBUTING.md Code §16). Waiting on it here makes
+    // the hook a real gate: diagnostics arrived, the plugin was notified, and
+    // `editor.getAllDiagnostics()` — the API this test exists to cover —
+    // answered with the one file the editor stored, from inside the hook.
+    //
+    // Waited for rather than asserted at the end, because the hook can fire
+    // again later (an empty publish would rewrite the status) and this test
+    // is about the populated call.
+    harness.wait_for_screen_contains("Diagnostics received: 1 total")?;
 
     // Verify the diagnostics content
     let stored = harness.editor().get_stored_diagnostics();
@@ -1142,15 +1154,7 @@ editor.setStatus("Test diagnostics plugin loaded");
         "Diagnostic severity should be error"
     );
 
-    // Verify the plugin's diagnostics_updated hook was called
-    // by checking if the status message shows diagnostics count
-    if let Some(status) = harness.editor().get_status_message() {
-        println!("Status message: {}", status);
-        // The hook should have set status with "Diagnostics received"
-        if status.contains("Diagnostics received") {
-            println!("Plugin hook was triggered successfully");
-        }
-    }
+    harness.assert_no_plugin_errors();
 
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/plugins/plugin.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin.rs
@@ -1085,7 +1085,15 @@ editor.setStatus("Test diagnostics plugin loaded");
     // Wait for the plugin to load before anything can emit the event it
     // subscribes to. Its last statement sets a status message, so "the plugin
     // finished evaluating, and `editor.on("diagnostics_updated", …)` is
-    // registered" is readable straight off the status bar.
+    // registered" is readable straight off the status bar. Without this the
+    // plugin can subscribe after the diagnostics have already been published,
+    // and `getAllDiagnostics` — the API under test — is never exercised at
+    // all, silently.
+    //
+    // Readable here specifically because nothing is open yet: the status bar
+    // elides elements that don't fit the terminal width, and once a file and
+    // its diagnostics are on screen this message no longer fits at 100
+    // columns.
     harness.wait_for_screen_contains("Test diagnostics plugin loaded")?;
 
     // Open the test file - this will start LSP
@@ -1112,19 +1120,16 @@ editor.setStatus("Test diagnostics plugin loaded");
         .unwrap();
     harness.render()?;
 
-    // Wait for the plugin's `diagnostics_updated` hook to run, observed
-    // through the status message it sets. That is the same signal the old
-    // code checked at the very end and then *didn't* assert on (it was
-    // wrapped in `if status.contains(…) { println!(…) }`, which passes
-    // whatever happens — CONTRIBUTING.md Code §16). Waiting on it here makes
-    // the hook a real gate: diagnostics arrived, the plugin was notified, and
-    // `editor.getAllDiagnostics()` — the API this test exists to cover —
-    // answered with the one file the editor stored, from inside the hook.
+    // Wait for the published diagnostic to reach the screen: the status bar's
+    // diagnostics element shows `E:1` once one error is known for the buffer.
     //
-    // Waited for rather than asserted at the end, because the hook can fire
-    // again later (an empty publish would rewrite the status) and this test
-    // is about the populated call.
-    harness.wait_for_screen_contains("Diagnostics received: 1 total")?;
+    // Deliberately *not* the plugin's own status text. That message does
+    // reach the status bar, but the bar lays its elements out within the
+    // terminal width and elides what doesn't fit — at this test's 100
+    // columns "Diagnostics received: 1 total, URI count: 1" renders as
+    // "Diagnostics ...", so waiting for the full string can never resolve.
+    // `E:1` is the compact, layout-stable rendering of the same fact.
+    harness.wait_for_screen_contains("E:1")?;
 
     // Verify the diagnostics content
     let stored = harness.editor().get_stored_diagnostics();

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -27,15 +27,11 @@ fn setup_audit_mode_plugin(repo: &GitTestRepo) {
 /// Open Review Diff via command palette and wait for it to load.
 /// Returns the initial screen string.
 fn open_review_diff(harness: &mut EditorTestHarness) -> String {
-    harness
-        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    harness.wait_for_prompt().unwrap();
-    harness.type_text("Review Diff").unwrap();
-    harness.render().unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
+    // `run_palette_command` waits for the row to be listed before confirming:
+    // this command comes from a plugin, so typing the name and pressing Enter
+    // could fire before it was registered (Quick Open re-filters on input
+    // change only, so a late registration is never picked up on its own).
+    harness.run_palette_command("Review Diff").unwrap();
     harness.wait_for_prompt_closed().unwrap();
 
     harness
@@ -1957,9 +1953,13 @@ fn test_issue2117_discard_hunk_with_no_trailing_newline() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    for _ in 0..10 {
-        harness.tick_and_render().unwrap();
-    }
+    // Wait for the hunk to be on screen rather than pumping a fixed number of
+    // ticks: `tick_and_render` doesn't sleep, so `for _ in 0..10` elapses in
+    // microseconds and gates nothing. `d` on an unloaded panel discards
+    // nothing (or the wrong thing).
+    harness
+        .wait_until(|h| h.screen_to_string().contains("NO_NEWLINE_LINE"))
+        .unwrap();
 
     // `d` opens the confirmation prompt; Enter accepts the default
     // ("Discard hunk").
@@ -1971,9 +1971,34 @@ fn test_issue2117_discard_hunk_with_no_trailing_newline() {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
     harness.wait_for_prompt_closed().unwrap();
-    for _ in 0..20 {
-        harness.tick_and_render().unwrap();
-    }
+
+    // The discard must actually revert the working tree on disk: the
+    // unterminated added line is gone and the committed lines are restored.
+    // Compare line-ending-agnostically — whether git writes the restored file
+    // back as LF or CRLF depends on the user's core.autocrlf, which the test
+    // leaves at its platform default; that's git's choice, not the feature's.
+    //
+    // Wait for the write instead of reading the file straight after a fixed
+    // `for _ in 0..20 { tick_and_render() }` pump. The discard shells out to
+    // git on the plugin thread; twenty sleepless ticks are microseconds, so
+    // the old form read the file back before the patch had been applied and
+    // failed within a couple of seconds — the Windows failure on this test.
+    //
+    // The wait also terminates on a rendered patch error, so a genuine
+    // regression (the bug this test covers) still fails loudly and quickly
+    // instead of hanging until nextest's timeout.
+    let restored = |h: &EditorTestHarness| {
+        let _ = h;
+        fs::read_to_string(&notes)
+            .map(|s| s.replace("\r\n", "\n") == original)
+            .unwrap_or(false)
+    };
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            restored(h) || screen.contains("Patch failed") || screen.contains("does not apply")
+        })
+        .unwrap();
 
     let screen = harness.screen_to_string();
     assert!(
@@ -1983,11 +2008,6 @@ fn test_issue2117_discard_hunk_with_no_trailing_newline() {
         screen
     );
 
-    // The discard must actually revert the working tree on disk: the
-    // unterminated added line is gone and the committed lines are restored.
-    // Compare line-ending-agnostically — whether git writes the restored file
-    // back as LF or CRLF depends on the user's core.autocrlf, which the test
-    // leaves at its platform default; that's git's choice, not the feature's.
     let after = fs::read_to_string(&notes).unwrap();
     assert_eq!(
         after.replace("\r\n", "\n"),

--- a/crates/fresh-editor/tests/e2e/remote_fs_test.rs
+++ b/crates/fresh-editor/tests/e2e/remote_fs_test.rs
@@ -19,15 +19,26 @@ fn create_test_filesystem() -> Option<(RemoteFileSystem, tempfile::TempDir, toki
 /// would show the home directory instead of `/some/path` in the file explorer.
 #[test]
 fn test_remote_file_explorer_anchored_at_working_dir() {
-    let Some((fs, _temp_dir, _rt)) = create_test_filesystem() else {
+    let Some((fs, temp_dir, _rt)) = create_test_filesystem() else {
         eprintln!("Skipping test: could not create test filesystem");
         return;
     };
     let fs_arc: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> = Arc::new(fs);
 
     // Create a subdirectory to use as the working dir (simulating user@host:/path/to/project)
+    //
+    // In the test's own temp dir, not under `home_dir()`. The local agent's
+    // home *is* the real `$HOME` of whatever machine runs the suite, so the
+    // fixture used to be built at a fixed `~/my_test_project` shared by every
+    // run and every concurrent test — no isolation at all, against
+    // CONTRIBUTING.md Testing §4, and leaving debris in the user's home
+    // directory besides. The tempdir was already being created; it was just
+    // bound to `_temp_dir` and never used.
+    //
+    // What the test needs from `home_dir()` is only that the working dir is
+    // *not* it, which any path outside home satisfies.
     let home_dir = fs_arc.home_dir().unwrap();
-    let project_dir = home_dir.join("my_test_project");
+    let project_dir = temp_dir.path().join("my_test_project");
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("hello.txt"), "hello world").unwrap();
     std::fs::create_dir_all(project_dir.join("src")).unwrap();
@@ -56,10 +67,22 @@ fn test_remote_file_explorer_anchored_at_working_dir() {
     // the title is not the ready signal; a rendered directory entry is.
     // Either name resolves the wait: the assert below decides which one
     // (project = fixed, home = the regression) actually anchored the root.
+    //
+    // Restricted to explorer *tree* rows. `home_dir_name` is a bare path
+    // component — "runner" on a GitHub runner, "root" in a container — and
+    // matching it anywhere on screen made the wait resolve on unrelated text
+    // (a status-bar path, or the substring inside "project_root"). The assert
+    // below then picked that same unrelated line and failed on it.
+    let is_tree_row = |line: &str| {
+        line.contains('│') || line.contains('>') || line.contains('▼') || line.contains('└')
+    };
+    let names_a_dir =
+        |line: &str| line.contains("my_test_project") || line.contains(&home_dir_name);
     harness
         .wait_until(|h| {
-            let screen = h.screen_to_string();
-            screen.contains("my_test_project") || screen.contains(&home_dir_name)
+            h.screen_to_string()
+                .lines()
+                .any(|l| is_tree_row(l) && names_a_dir(l))
         })
         .unwrap();
 
@@ -69,9 +92,7 @@ fn test_remote_file_explorer_anchored_at_working_dir() {
     // Find the first line in the explorer that contains a directory name.
     // The root node appears first; if the bug is present it will be the
     // home dir (e.g. "root") instead of "my_test_project".
-    let first_dir_line = screen
-        .lines()
-        .find(|l| l.contains("my_test_project") || l.contains(&home_dir_name));
+    let first_dir_line = screen.lines().find(|l| is_tree_row(l) && names_a_dir(l));
 
     let first_dir_line = first_dir_line.expect("File explorer should show directory entries");
     assert!(

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -566,31 +566,35 @@ fn test_terminal_tab_title_follows_foreground_process() {
     harness.editor_mut().open_terminal();
     harness.render().unwrap();
 
-    let buffer_id = harness.editor().active_buffer_id();
-    let terminal_id = harness
-        .editor()
-        .active_window()
-        .get_terminal_id(buffer_id)
-        .expect("active buffer should be a terminal");
+    // What the tab must end up showing: the pty's foreground command, which
+    // right after open is the shell the terminal was spawned with. Derived
+    // from the same `detect_shell()` the spawn used, so this is a value the
+    // test knows independently — the old version read it back out of
+    // `terminal_manager()`, which made the assertion partly self-fulfilling
+    // and inspected model state besides (CONTRIBUTING.md Testing §2).
+    //
+    // `/proc/<pgid>/comm` carries the executable name, so compare against the
+    // shell path's file name.
+    let shell = fresh::services::terminal::detect_shell();
+    let expected = std::path::Path::new(&shell)
+        .file_name()
+        .expect("shell path has a file name")
+        .to_string_lossy()
+        .to_string();
 
-    // Semantic wait: the shell becomes the pty's foreground process group
-    // shortly after spawn. Drive renders until auto-naming resolves; the
-    // bound only guards against a hang (cargo nextest times out externally).
-    let mut expected = None;
-    for _ in 0..2000 {
-        if let Some(name) = harness
-            .editor()
-            .terminal_manager()
-            .get(terminal_id)
-            .and_then(|h| h.foreground_process_name())
-        {
-            expected = Some(name);
-            harness.render().unwrap();
-            break;
-        }
-        harness.render().unwrap();
-    }
-    let expected = expected.expect("foreground process name should resolve on Linux");
+    // Semantic wait, on rendered output: the shell becomes the pty's
+    // foreground process group shortly after spawn, and auto-naming repaints
+    // the tab when it does.
+    //
+    // This replaces a `for _ in 0..2000` loop with no sleep in it — a bound
+    // that could elapse in well under a second of spin and then panic on
+    // `expect`, i.e. a timeout inside a test (CONTRIBUTING.md Testing §3)
+    // sized in iterations rather than in anything the shell's startup relates
+    // to. `wait_until` waits indefinitely and paces itself, so a slow runner
+    // makes this slower, not red.
+    harness
+        .wait_until(|h| h.get_tab_bar().contains(&expected))
+        .unwrap();
 
     // The tab bar (row 1) now shows the foreground command, not the default.
     let tab_bar = harness.get_tab_bar();


### PR DESCRIPTION
Reviewed the flaky e2e tests listed below against `CONTRIBUTING.md` and fixed what didn't follow it. Every failure traces to one of three shared mechanisms rather than to the features under test.

## The three mechanisms

**1. `harness.sleep()` waits zero real time.** It is `advance_time()` — logical time only, as its own doc comment warns. Every `for _ in 0..N { …; harness.sleep(50ms) }` "let it settle" block waited nothing at all, so what followed sampled an arbitrary mid-async frame. Worst case is `test_git_gutter_refreshes_after_external_git_checkout`, where the sleep existed *specifically* to separate the reset's mtime from the opened file's, and so left the hazard it was written to prevent fully live.

**2. `drain_async_work` had a hidden ~200 ms timeout** (`tests/common/harness.rs`), sitting behind every `send_key`/`type_text`, giving up with only a `tracing::warn!` that CI never renders. On a loaded runner a slower plugin action left the drain early and silently, and the next assertion read a stale screen — a timeout inside a test (Testing §3) whose failure mode carries no diagnostic.

**3. Quick Open re-filters on input change only** (`app/prompt_lifecycle.rs::update_quick_open_suggestions`), never on a render or a tick. "Type the name, press Enter" therefore fires on whatever row was selected when the last keystroke landed; and for a plugin-registered command that hasn't finished `registerCommand`, the row cannot appear at all — a later wait for it then blocks until nextest kills the test at 180 s with no failed assertion. This is the remaining explanation for the `code_tour_dock` timeouts on both ubuntu and windows: that module already waited for the filtered row, which fixes the wrong-row half but not the late-registration half, since nothing re-runs the filter.

## Changes

- **Harness**: wait out in-flight plugin actions against a budget no real action can miss, and report giving up on stderr — the one channel nextest surfaces for a failed or killed test. Still bounded, so a plugin callback that never returns can't deadlock every later keypress; bridge quiescence keeps its own short bound because PTY output and timer-driven polls are legitimately continuous. New `run_palette_command` / `wait_for_palette_command` wait for a command to be listed as a *result* rather than as the echoed query, retyping to re-run the filter so a late registration is picked up.
- **`GitTestRepo`**: new `touch_until_mtime_after` bumps a file until its observed mtime actually moves past a floor — semantic waiting on the real condition instead of sleeping past a filesystem's granularity.
- **Tests**: replaced fake-time settle loops and fixed-count `tick_and_render` pumps with waits on the invariant each test is actually about; routed palette invocations through the new helper; waited for LSP readiness before triggering a `didSave`-driven publish (Code §3); promoted two checks that asserted nothing (Code §16) into real gates; stopped deriving an expected value out of model state (Testing §2); and moved the remote-FS fixture out of the real `$HOME` into the tempdir that was already being created but never used (Testing §4).

## Per-test

| Test | Was | Now |
|---|---|---|
| `locale::test_locale_switch_via_command_palette` | palette race; assertions sampled off one frame | `run_palette_command`; waits |
| `locale::test_multiple_locales_can_be_loaded` | — | unchanged; see caveat below |
| `plugins::plugin::test_diagnostics_api_with_fake_lsp` | fake 1 s LSP warm-up, save raced init → no publish → 180 s hang; hook check asserted nothing | waits for plugin load, then server ready, then the rendered `E:1` |
| `remote_fs_test::test_remote_file_explorer_anchored_at_working_dir` | fixture in the real `$HOME`; wait matched `"root"`/`"runner"` anywhere on screen | tempdir; wait anchored to explorer tree rows |
| `terminal::test_terminal_tab_title_follows_foreground_process` | `for _ in 0..2000` spin with no sleep, then `expect`; expected value read from the model | `wait_until` on the tab bar vs `detect_shell()` |
| `code_tour_dock::{test_next_key_advances_step, test_step_range_is_highlighted_in_the_editor}` | already well-written; missing plugin-registration precondition | `run_palette_command` |
| `plugins::gutter::test_git_gutter_updates_after_save` | fake-time settle, then a baseline sampled off an arbitrary frame; `count > initial` could be unsatisfiable → hang | `wait_for_async_quiescence`, assert the settled baseline is zero, then wait for the added line's green indicator |
| `plugins::gutter::test_git_gutter_refreshes_after_external_git_checkout` | `harness.sleep(2100ms)` for mtime separation waited no real time | `touch_until_mtime_after` |
| `plugins::live_diff::test_live_diff_virtual_line_anchored_to_correct_modified_line` | palette race enabling live-diff | `run_palette_command` |
| `plugins::review_diff_ux_bugs::test_issue2117_discard_hunk_with_no_trailing_newline` | read the file back microseconds after `d`, before git had applied the patch | waits for the restored content or a rendered patch error |

## Three regressions the first CI run caught, since fixed

Worth recording, because two of them are the same mistake this PR is about — asserting on something unverified.

- **The gutter settle loop was load-bearing**, though not for the reason its comment gave: the plugin establishes its HEAD baseline asynchronously on open, and editing before that lands leaves it without one, after which the save produces no indicators at all. Removing it wholesale hung the test on every platform. Restored as `wait_for_async_quiescence` — which is what the loop's `process_async_and_render` calls were approximating. (Bisect: master's version of the test passes against this branch's harness; this branch's version hung.)
- **The status bar elides elements that don't fit the terminal width.** At the diagnostics test's 100 columns, `Diagnostics received: 1 total, URI count: 1` renders as `Diagnostics ...`, so waiting for the full string could never resolve. Now waits for `E:1`, the layout-stable rendering of the same fact.
- **Canonicalizing `GitTestRepo`'s path broke Windows.** `fs::canonicalize` returns an extended-length `\\?\D:\...` path there, which git does not accept, and `plugins::package_manager` uses a repo path as a git remote. Dropped entirely rather than made conditional: it targeted a macOS `live_diff` failure I never reproduced, and the bisect showed it fixed nothing here.

## Caveats

- `test_multiple_locales_can_be_loaded` is the one case I could not pin down. Its search-option labels render synchronously in `view/`, so the immediate assert is mostly safe, and the process-global locale race documented in `harness.rs` cannot fire under nextest (process per test) — it is real for local `cargo test` only. Its remaining exposure is that it builds nine harnesses in one test. Left as is rather than changed on a guess.
- The global-locale `TODO(flakiness)` in `harness.rs` is untouched for the same reason: it is a `cargo test` problem, not a CI one.
- Other tests in `gutter.rs` still use `harness.sleep` in the same way. Out of scope here; they are the same defect and worth a follow-up.
- Verified locally, serially (to emulate nextest's process-per-test, since several of these mutate process cwd): gutter 22, live_diff 14, plugin 12, package_manager 9, review_diff 3, locale 15, code_tour_dock 33, remote_fs 4, and the terminal title test — all pass. `cargo check --all-targets`, `cargo fmt` and `cargo clippy` clean, with a warning count identical to master.