### PR TITLE
plugin_budget: demote 50ms overrun to DEBUG, warn only past 500ms

### DIFF
--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -376,12 +376,23 @@ pub(crate) const PLUGIN_COMMAND_FRAME_BUDGET: std::time::Duration =
 pub(crate) const DRAIN_MIN_PER_PASS: usize = 8;
 
 /// A single plugin command handler taking longer than this on the editor
-/// thread is a defect: the work belongs in `plugin_offloop`. Logged at WARN
-/// naming the offending variant — see `dispatch_plugin_command_measured` for
-/// why that is a diagnostic rather than a failure, and which test does fail.
+/// thread is over budget: the work belongs in `plugin_offloop`. Logged at
+/// DEBUG naming the offending variant — a handler can cross 50ms on a loaded
+/// machine or a cold cache without anything being wrong, so this is a lead to
+/// follow when profiling, not a complaint aimed at the user. See
+/// `dispatch_plugin_command_measured` for why an overrun is a diagnostic
+/// rather than a failure, and which test does fail.
 #[cfg(feature = "plugins")]
 pub(crate) const PLUGIN_COMMAND_HANDLER_LIMIT: std::time::Duration =
     std::time::Duration::from_millis(50);
+
+/// An overrun this far past `PLUGIN_COMMAND_HANDLER_LIMIT` is a visible stall
+/// — ten frames' worth of editor thread — and no amount of machine noise
+/// explains it. Logged at WARN, so the noisy-but-harmless case stays at DEBUG
+/// while the genuinely broken handler still gets named by default.
+#[cfg(feature = "plugins")]
+pub(crate) const PLUGIN_COMMAND_HANDLER_HARD_LIMIT: std::time::Duration =
+    std::time::Duration::from_millis(500);
 
 /// The main editor struct - manages multiple buffers, clipboard, and rendering
 pub struct Editor {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -397,13 +397,21 @@ impl Editor {
             tracing::error!("Error handling plugin command {}: {}", label, e);
         }
         let elapsed = started.elapsed();
-        if elapsed > super::PLUGIN_COMMAND_HANDLER_LIMIT {
+        if elapsed > super::PLUGIN_COMMAND_HANDLER_HARD_LIMIT {
             tracing::warn!(
                 target: "plugin_budget",
                 handler = label,
                 elapsed_ms = elapsed.as_millis() as u64,
-                limit_ms = super::PLUGIN_COMMAND_HANDLER_LIMIT.as_millis() as u64,
+                limit_ms = super::PLUGIN_COMMAND_HANDLER_HARD_LIMIT.as_millis() as u64,
                 "plugin command handler blocked the editor thread — move this work to plugin_offloop"
+            );
+        } else if elapsed > super::PLUGIN_COMMAND_HANDLER_LIMIT {
+            tracing::debug!(
+                target: "plugin_budget",
+                handler = label,
+                elapsed_ms = elapsed.as_millis() as u64,
+                limit_ms = super::PLUGIN_COMMAND_HANDLER_LIMIT.as_millis() as u64,
+                "plugin command handler ran over its editor-thread budget"
             );
         }
     }


### PR DESCRIPTION
A handler crossing the 50ms editor-thread budget is a profiling lead, not
a defect the user can act on — a loaded machine or a cold cache gets there
without anything being wrong. Log that at DEBUG.

Add PLUGIN_COMMAND_HANDLER_HARD_LIMIT at 500ms — ten frames of blocked
editor thread, which machine noise doesn't explain — and keep WARN for
overruns past it, so a genuinely broken handler still gets named by
default.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014GdyYaf1xgZs8ekwMmaRQd