### PR TITLE
fix(lsp): re-sync full-document changes as didClose+didOpen  (avoid at least Roslyn C# LSP crash)

### DIFF
--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -149,6 +149,23 @@ fn log_response_error(code: i64, message: &str, server_name: &str, language: &st
     }
 }
 
+/// The change-sync kind the server negotiated (`textDocumentSync.change`).
+/// Unknown / unset defaults to `NONE`, which callers treat as "not FULL" — i.e. the
+/// server requires ranged incremental changes, so a full-document (`range: None`)
+/// change must be re-expressed (see `handle_did_change_sequential`).
+fn negotiated_change_sync_kind(
+    caps: Option<&ServerCapabilities>,
+) -> lsp_types::TextDocumentSyncKind {
+    use lsp_types::{TextDocumentSyncCapability, TextDocumentSyncKind};
+    match caps.and_then(|c| c.text_document_sync.as_ref()) {
+        Some(TextDocumentSyncCapability::Kind(k)) => *k,
+        Some(TextDocumentSyncCapability::Options(o)) => {
+            o.change.unwrap_or(TextDocumentSyncKind::NONE)
+        }
+        None => TextDocumentSyncKind::NONE,
+    }
+}
+
 /// Check if a document is already open and should skip didOpen.
 /// Returns true if the document is already open (should skip), false if it should proceed.
 fn should_skip_did_open(
@@ -1372,6 +1389,41 @@ impl LspState {
                 self.language
             );
             return Ok(());
+        }
+
+        // A content change with `range: None` is a full-document replacement, which is
+        // only valid when the server negotiated FULL text sync. Strict servers (notably
+        // Roslyn / Microsoft.CodeAnalysis.LanguageServer) negotiate INCREMENTAL and throw
+        // a NullReferenceException in ProtocolConversions.RangeToLinePositionSpan on the
+        // null range — which faults the request queue and closes the server's stdout, so
+        // edits stop syncing and completion/hover die on the line being typed. When the
+        // negotiated kind isn't FULL, re-sync the whole document via didClose + didOpen:
+        // didOpen carries the complete text with no range, so it's correct under any sync
+        // kind. (Per-keystroke edits use ranged incremental changes and are unaffected.)
+        // A full-replace is always emitted as the sole change in its batch (see the
+        // `range: None` construction sites — file reload, workspace restore, plugin
+        // edits, event_apply resync), so nothing meaningful precedes or follows it. If a
+        // future caller ever mixes a full-replace with trailing ranged edits, the
+        // early-return below would silently drop those trailing edits.
+        let full_replace_text = content_changes
+            .iter()
+            .rev()
+            .find(|c| c.range.is_none())
+            .map(|c| c.text.clone());
+        if let Some(full_text) = full_replace_text {
+            let kind = negotiated_change_sync_kind(self.capabilities.lock().unwrap().as_ref());
+            if kind != lsp_types::TextDocumentSyncKind::FULL {
+                tracing::debug!(
+                    "LSP ({}): re-syncing full-document change as didClose+didOpen (server change-sync = {:?}, not FULL): {}",
+                    self.language,
+                    kind,
+                    uri.as_str()
+                );
+                self.handle_did_close(uri.clone()).await?;
+                return self
+                    .handle_did_open_sequential(uri, full_text, (*self.language).clone(), _pending)
+                    .await;
+            }
         }
 
         // Check if this document was recently opened and wait if needed
@@ -5119,6 +5171,68 @@ mod tests {
     /// A `workspace/configuration` request item asking for `section`.
     fn config_item(section: &str) -> Value {
         serde_json::json!({ "section": section })
+    }
+
+    // The full-document didChange → didClose+didOpen re-sync (which fixes the Roslyn
+    // NullReferenceException crash on a `range: None` change under INCREMENTAL sync)
+    // keys off this helper, so pin down how each capability shape is read.
+    #[test]
+    fn negotiated_change_sync_kind_reads_every_capability_shape() {
+        use lsp_types::{
+            TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+        };
+
+        // No capabilities yet (e.g. before initialize) → NONE, so we re-sync (safe).
+        assert_eq!(
+            negotiated_change_sync_kind(None),
+            TextDocumentSyncKind::NONE
+        );
+
+        // Server sent no textDocumentSync at all → NONE.
+        let bare = ServerCapabilities::default();
+        assert_eq!(
+            negotiated_change_sync_kind(Some(&bare)),
+            TextDocumentSyncKind::NONE
+        );
+
+        // Shorthand `Kind(INCREMENTAL)` — what Roslyn sends; must NOT read as FULL.
+        let kind_incremental = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                TextDocumentSyncKind::INCREMENTAL,
+            )),
+            ..Default::default()
+        };
+        assert_eq!(
+            negotiated_change_sync_kind(Some(&kind_incremental)),
+            TextDocumentSyncKind::INCREMENTAL
+        );
+
+        // Options form with explicit `change: FULL` — the one case we leave alone.
+        let opts_full = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    change: Some(TextDocumentSyncKind::FULL),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        assert_eq!(
+            negotiated_change_sync_kind(Some(&opts_full)),
+            TextDocumentSyncKind::FULL
+        );
+
+        // Options form with no `change` field → NONE (treated as not-FULL → re-sync).
+        let opts_none = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions::default(),
+            )),
+            ..Default::default()
+        };
+        assert_eq!(
+            negotiated_change_sync_kind(Some(&opts_none)),
+            TextDocumentSyncKind::NONE
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -5235,6 +5235,145 @@ mod tests {
         );
     }
 
+    // Build an `LspState` wired to a throwaway `cat` child — a stdin sink that drains
+    // our tiny notifications without blocking. Returns the child so the caller keeps it
+    // (and its stdin pipe) alive for the duration of the test; `kill_on_drop` reaps it
+    // when the binding goes out of scope. `change_sync` sets the negotiated
+    // `textDocumentSync.change` capability (None = no capability advertised).
+    fn test_state_with_sync(
+        change_sync: Option<lsp_types::TextDocumentSyncKind>,
+    ) -> (LspState, tokio::process::Child) {
+        let mut child = tokio::process::Command::new("cat")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn cat as a stdin sink");
+        let stdin = child.stdin.take().expect("child stdin");
+        // async_tx is unused by the didOpen/didChange/didClose paths under test; the
+        // receiver may drop (sends are best-effort) without affecting the assertions.
+        let (async_tx, _async_rx) = std_mpsc::channel();
+        let caps = change_sync.map(|k| ServerCapabilities {
+            text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Kind(k)),
+            ..Default::default()
+        });
+        let state = LspState {
+            stdin: Arc::new(tokio::sync::Mutex::new(stdin)),
+            next_id: Arc::new(AtomicI64::new(1)),
+            capabilities: Arc::new(Mutex::new(caps)),
+            document_versions: Arc::new(Mutex::new(HashMap::new())),
+            pending_opens: Arc::new(Mutex::new(HashMap::new())),
+            initialized: Arc::new(AtomicBool::new(true)),
+            async_tx,
+            language: Arc::new("rust".to_string()),
+            server_name: Arc::new("test-server".to_string()),
+            active_requests: Arc::new(Mutex::new(HashMap::new())),
+            language_id_overrides: Arc::new(HashMap::new()),
+        };
+        (state, child)
+    }
+
+    fn ranged_change(text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range: Some(lsp_types::Range::new(
+                lsp_types::Position::new(0, 0),
+                lsp_types::Position::new(0, 0),
+            )),
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    fn full_change(text: &str) -> TextDocumentContentChangeEvent {
+        TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: text.to_string(),
+        }
+    }
+
+    // The actual fix: a full-document (`range: None`) change must NOT be sent as a
+    // didChange when the server negotiated INCREMENTAL — Roslyn throws a
+    // NullReferenceException on the null range. It is re-synced via didClose + didOpen,
+    // which removes the document and re-opens it at version 0. The tracked version is a
+    // faithful proxy: a normal didChange increments it, a close+open resets it to 0.
+    // Without the fix this test fails (the full change would bump the version to 2).
+    #[tokio::test]
+    async fn full_document_change_under_incremental_resyncs_via_close_open() {
+        let (state, _child) =
+            test_state_with_sync(Some(lsp_types::TextDocumentSyncKind::INCREMENTAL));
+        let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+        let uri: Uri = "file:///test.rs".parse().unwrap();
+        let path = PathBuf::from("/test.rs");
+        let version = || state.document_versions.lock().unwrap().get(&path).copied();
+
+        // Open the document so changes aren't skipped; didOpen tracks version 0.
+        state
+            .handle_did_open_sequential(uri.clone(), "fn main() {}".into(), "rust".into(), &pending)
+            .await
+            .unwrap();
+        assert_eq!(version(), Some(0));
+        // Drop the didOpen grace marker so the ranged didChange below doesn't sleep.
+        state.pending_opens.lock().unwrap().clear();
+
+        // A ranged change is unaffected: it goes out as a normal didChange (version bumps).
+        state
+            .handle_did_change_sequential(uri.clone(), vec![ranged_change("x")], &pending)
+            .await
+            .unwrap();
+        assert_eq!(
+            version(),
+            Some(1),
+            "ranged incremental change should pass through as a didChange"
+        );
+
+        // The full-document change re-syncs: didClose (removes) + didOpen (re-adds at 0).
+        state
+            .handle_did_change_sequential(
+                uri.clone(),
+                vec![full_change("fn main() {}\n")],
+                &pending,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            version(),
+            Some(0),
+            "full-document change under INCREMENTAL should re-sync via didClose+didOpen"
+        );
+    }
+
+    // Guard the other side of the condition: under FULL sync the server accepts a
+    // `range: None` change directly, so we must leave it alone — it stays a didChange and
+    // the version bumps (no spurious close+open). Catches an over-eager fix.
+    #[tokio::test]
+    async fn full_document_change_under_full_sync_passes_through() {
+        let (state, _child) = test_state_with_sync(Some(lsp_types::TextDocumentSyncKind::FULL));
+        let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+        let uri: Uri = "file:///test.rs".parse().unwrap();
+        let path = PathBuf::from("/test.rs");
+
+        state
+            .handle_did_open_sequential(uri.clone(), "fn main() {}".into(), "rust".into(), &pending)
+            .await
+            .unwrap();
+        state.pending_opens.lock().unwrap().clear();
+
+        state
+            .handle_did_change_sequential(
+                uri.clone(),
+                vec![full_change("fn main() {}\n")],
+                &pending,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            state.document_versions.lock().unwrap().get(&path).copied(),
+            Some(1),
+            "under FULL sync a full-document change stays a didChange (no reset)"
+        );
+    }
+
     #[test]
     fn workspace_configuration_resolves_section_from_init_options() {
         // harper-ls pulls the "harper-ls" section; it must receive the inner


### PR DESCRIPTION
**Bug:** Roslyn negotiates INCREMENTAL sync, then throws `NullReferenceException` on a full-document change (`range: None`). That faults its request queue and closes stdout — completion/hover die on the line you're typing, while hover still works on untouched code, so the server looks healthy.

**Fix:** in `handle_did_change_sequential` (the single chokepoint for every didChange) — when a change has `range: None` and the negotiated sync kind isn't FULL, re-sync as **didClose + didOpen**. didOpen carries the whole text with no range, valid under any sync kind.

- Generic LSP layer, **not** C#-gated — applies to any server that negotiated non-FULL sync, i.e. nearly all of them. Roslyn is just the one that crashes instead of silently tolerating the invalid payload.
- Fires only on full-document paths: file reload, workspace restore, plugin edits, `event_apply` resync.
- Per-keystroke ranged edits are untouched.

**Tests:** unit test over every `TextDocumentSync` capability shape, plus a behavioural one — under INCREMENTAL a full-document change resets the tracked version to 0 (proving close+open), a ranged change still bumps it, and under FULL it stays a didChange. Both fail without the fix.

**Refs:** [LSP 3.17 — Text Document Synchronization](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#text-document-synchronization) · [Roslyn `ProtocolConversions.cs`](https://github.com/dotnet/roslyn/blob/main/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs)