### PR TITLE
Keep the search bar open while F3 steps through matches

### DIFF
--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -620,6 +620,29 @@
       "when": "normal"
     },
     {
+      "comment": "Step through matches without closing the search bar (VS Code / browser find)",
+      "key": "F3",
+      "modifiers": [],
+      "action": "find_next",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "key": "F3",
+      "modifiers": ["shift"],
+      "action": "find_previous",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "comment": "Alternative for Shift-F3 with the search bar open (works in more terminals)",
+      "key": "n",
+      "modifiers": ["ctrl", "shift"],
+      "action": "find_previous",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
       "comment": "Quick find - search for next occurrence of selection",
       "key": "F3",
       "modifiers": ["ctrl"],
@@ -1302,13 +1325,6 @@
       "comment": "Prompt context - Additional confirm bindings",
       "key": "f",
       "modifiers": ["ctrl"],
-      "action": "prompt_confirm",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "F3",
-      "modifiers": [],
       "action": "prompt_confirm",
       "args": {},
       "when": "prompt"

--- a/crates/fresh-editor/keymaps/macos-gui.json
+++ b/crates/fresh-editor/keymaps/macos-gui.json
@@ -123,6 +123,21 @@
       "when": "normal"
     },
     {
+      "comment": "Cmd+G / Cmd+Shift+G also step through matches while the search bar is open",
+      "key": "g",
+      "modifiers": ["super"],
+      "action": "find_next",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "key": "g",
+      "modifiers": ["super", "shift"],
+      "action": "find_previous",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
       "comment": "Cmd+H -> Replace (macOS standard)",
       "key": "h",
       "modifiers": ["super"],

--- a/crates/fresh-editor/keymaps/macos.json
+++ b/crates/fresh-editor/keymaps/macos.json
@@ -317,6 +317,21 @@
       "when": "normal"
     },
     {
+      "comment": "Ctrl+G / Ctrl+Alt+G also step through matches while the search bar is open",
+      "key": "g",
+      "modifiers": ["ctrl"],
+      "action": "find_next",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "key": "g",
+      "modifiers": ["ctrl", "alt"],
+      "action": "find_previous",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
       "key": "a",
       "modifiers": ["ctrl"],
       "action": "prompt_move_start",

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -3403,6 +3403,11 @@ impl Editor {
                 PromptType::Search | PromptType::ReplaceSearch | PromptType::QueryReplaceSearch
             ) {
                 let query = prompt.input.clone();
+                // Drop the committed matches: they were collected under the
+                // old flags, and F3/Shift+F3 now step through them while the
+                // bar is open (issue #2111). Clearing makes the next press
+                // re-run the search under the new flags.
+                self.active_window_mut().search_state = None;
                 self.update_search_highlights(&query);
             }
         } else if let Some(search_state) = &self.active_window().search_state {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -132,10 +132,18 @@ impl Editor {
             )
         });
         if is_search_prompt_active {
-            if let Some(ref search_state) = self.active_window().search_state {
-                let query = search_state.query.clone();
-                self.update_search_highlights(&query);
-            }
+            // Highlight what the bar currently holds, not the committed
+            // query: F3/Shift+F3 keep the bar open (issue #2111), so the user
+            // can edit the query after jumping, and history navigation swaps
+            // the input without re-highlighting. An empty bar highlights
+            // nothing.
+            let query = self
+                .active_window()
+                .prompt
+                .as_ref()
+                .map(|p| p.input.clone())
+                .unwrap_or_default();
+            self.update_search_highlights(&query);
         }
 
         // Determine if we need to show search options bar.

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -442,6 +442,9 @@ impl Editor {
     /// is used directly and viewport overlays are refreshed after the cursor
     /// moves.
     pub(super) fn find_next(&mut self) {
+        if self.run_pending_prompt_search(SearchDirection::Forward) {
+            return;
+        }
         self.find_match_in_direction(SearchDirection::Forward);
     }
 
@@ -451,7 +454,69 @@ impl Editor {
     /// (they auto-track buffer edits).  For large files, `search_state.matches`
     /// is used directly and viewport overlays are refreshed.
     pub(super) fn find_previous(&mut self) {
+        if self.run_pending_prompt_search(SearchDirection::Backward) {
+            return;
+        }
         self.find_match_in_direction(SearchDirection::Backward);
+    }
+
+    /// The query typed into an open find/replace *search* prompt, if one is
+    /// open.
+    ///
+    /// Only the pattern-entry prompts qualify: `Replace` / `QueryReplace`
+    /// share the `SearchPrompt` key context but their input is the
+    /// replacement text, not the pattern, so find-next there navigates the
+    /// already-committed search instead.
+    fn active_search_prompt_query(&self) -> Option<String> {
+        self.active_window().prompt.as_ref().and_then(|p| {
+            matches!(
+                p.prompt_type,
+                PromptType::Search | PromptType::ReplaceSearch | PromptType::QueryReplaceSearch
+            )
+            .then(|| p.input.clone())
+        })
+    }
+
+    /// Commit the query typed into an open search bar before stepping
+    /// through matches, and report whether that already moved the cursor.
+    ///
+    /// F3 / Shift+F3 stay live while the search bar is open — the bar keeps
+    /// the keyboard and the query stays editable, matching VS Code, Sublime
+    /// and browser find (issue #2111). The first press on a query that has
+    /// not been run yet (or has been edited since) runs it here, which lands
+    /// on the first match at/after the cursor exactly like Enter would;
+    /// later presses fall through to plain match stepping.
+    ///
+    /// Returns `true` when the search ran, meaning the caller must not step
+    /// again — the cursor is already on the match the user asked for.
+    fn run_pending_prompt_search(&mut self, direction: SearchDirection) -> bool {
+        let Some(query) = self.active_search_prompt_query() else {
+            return false;
+        };
+        if query.is_empty() {
+            // Empty bar: navigate whatever search is still active, if any.
+            return false;
+        }
+        let already_committed = self
+            .active_window()
+            .search_state
+            .as_ref()
+            .is_some_and(|s| s.query == query);
+        if already_committed {
+            return false;
+        }
+
+        self.perform_search(&query);
+
+        // `perform_search` stops at the first match at/after the cursor,
+        // which is where a forward search should land. A backward one wants
+        // the match before where the user was, so step once more.
+        if matches!(direction, SearchDirection::Backward)
+            && self.active_window().search_state.is_some()
+        {
+            self.find_match_in_direction(SearchDirection::Backward);
+        }
+        true
     }
 
     /// Navigate to the next or previous search match relative to the current
@@ -461,6 +526,13 @@ impl Editor {
     fn find_match_in_direction(&mut self, direction: SearchDirection) {
         let overlay_positions = self.get_search_match_positions();
         let is_large = self.active_state().buffer.is_large_file();
+
+        // While the search bar is open its incremental highlighting refreshes
+        // the overlays for the visible viewport only, so they are not the
+        // full match set and stepping through them would wrap inside the
+        // screen. `search_state.matches` is authoritative there instead — the
+        // prompt owns the keyboard, so no edit can shift the stored offsets.
+        let search_bar_open = self.active_search_prompt_query().is_some();
 
         // Snapshot cursor_pos up front so the `&mut search_state` borrow
         // below doesn't conflict with the read of self.windows.
@@ -479,8 +551,10 @@ impl Editor {
         if let Some(ref mut search_state) = self.active_window_mut().search_state {
             // Use overlay positions for small files (they auto-track edits),
             // otherwise reference search_state.matches directly to avoid cloning.
-            let use_overlays =
-                !is_large && !overlay_positions.is_empty() && search_state.search_range.is_none();
+            let use_overlays = !is_large
+                && !search_bar_open
+                && !overlay_positions.is_empty()
+                && search_state.search_range.is_none();
             let match_positions: &[usize] = if use_overlays {
                 &overlay_positions
             } else {

--- a/crates/fresh-editor/src/view/prompt_input.rs
+++ b/crates/fresh-editor/src/view/prompt_input.rs
@@ -285,6 +285,13 @@ impl InputHandler for Prompt {
                 InputResult::Consumed
             }
 
+            // The search bar is a bar, not a modal: function keys fall
+            // through to keybinding resolution instead of dying in the modal
+            // catch-all below, which is what keeps F3 / Shift+F3 (find
+            // next/previous) live while it is open (issue #2111). Other
+            // prompts stay fully modal.
+            KeyCode::F(_) if self.prompt_type.has_search_options() => InputResult::Ignored,
+
             _ => InputResult::Consumed, // Modal - consume all unhandled keys
         }
     }

--- a/crates/fresh-editor/tests/e2e/issue_2111_find_next_with_search_bar_open.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2111_find_next_with_search_bar_open.rs
@@ -5,14 +5,38 @@
 //! matching VS Code, Sublime and browser find. Before the fix the prompt
 //! swallowed the key as an unhandled modal key, so F3 did nothing at all
 //! until the bar had been closed with Enter.
+//!
+//! Everything here is asserted from the rendered screen: the status bar's
+//! `Ln N, Col M` for where the cursor landed, its `Match N of M` for the
+//! step count, the buffer rows for what scrolled into view, and the
+//! `Search: …` prompt line for the bar still being open.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use tempfile::TempDir;
 
-/// Byte offsets of every occurrence of `needle` in `haystack`.
-fn all_matches(haystack: &str, needle: &str) -> Vec<usize> {
-    haystack.match_indices(needle).map(|(pos, _)| pos).collect()
+/// Four lines, `alpha` on the last three — never on line 1, so the very
+/// first jump is visible in the status bar instead of coinciding with the
+/// cursor's starting `Ln 1, Col 1`.
+const CONTENT: &str = "one two three\nbeta alpha two\ngamma alpha three\ndelta alpha four\n";
+
+/// Where each `alpha` sits, as the status bar renders it.
+const MATCH_1: &str = "Ln 2, Col 6";
+const MATCH_2: &str = "Ln 3, Col 7";
+const MATCH_3: &str = "Ln 4, Col 7";
+
+fn harness_with(content: &str, dir: &TempDir) -> EditorTestHarness {
+    let file_path = dir.path().join("test.txt");
+    std::fs::write(&file_path, content).unwrap();
+
+    // Wide enough that the status bar renders `Match N of M` in full rather
+    // than eliding it.
+    let mut harness =
+        EditorTestHarness::create(120, 24, HarnessOptions::new().without_empty_plugins_dir())
+            .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+    harness
 }
 
 /// Open the search bar and type `query` — without confirming, so the bar
@@ -21,78 +45,43 @@ fn open_search_bar(harness: &mut EditorTestHarness, query: &str) {
     harness
         .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.wait_for_prompt().unwrap();
+    harness.wait_for_screen_contains("Search: ").unwrap();
     harness.type_text(query).unwrap();
-    harness.render().unwrap();
-}
-
-fn harness_with(content: &str, dir: &TempDir) -> EditorTestHarness {
-    let file_path = dir.path().join("test.txt");
-    std::fs::write(&file_path, content).unwrap();
-
-    let mut harness =
-        EditorTestHarness::create(80, 24, HarnessOptions::new().without_empty_plugins_dir())
-            .unwrap();
-    harness.open_file(&file_path).unwrap();
-    harness.render().unwrap();
     harness
+        .wait_for_screen_contains(&format!("Search: {query}"))
+        .unwrap();
 }
 
 #[test]
 fn test_f3_advances_matches_and_keeps_search_bar_open() {
-    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta alpha four\n";
-    let matches = all_matches(content, "alpha");
-    assert_eq!(matches.len(), 4, "fixture should hold four matches");
-
     let temp_dir = TempDir::new().unwrap();
-    let mut harness = harness_with(content, &temp_dir);
+    let mut harness = harness_with(CONTENT, &temp_dir);
 
     open_search_bar(&mut harness, "alpha");
+    harness.assert_screen_contains("Ln 1, Col 1");
 
-    // First F3 commits the typed query and lands on the first match at/after
-    // the cursor — the same spot Enter would pick, minus the closing.
+    // The first press commits the typed query and lands on the first match
+    // at/after the cursor — the same spot Enter would pick, minus the closing.
     harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
-    harness.process_async_and_render().unwrap();
-    assert_eq!(
-        harness.cursor_position(),
-        matches[0],
-        "first F3 should land on the first match"
-    );
-    assert!(
-        harness.editor().is_prompting(),
-        "the search bar must stay open after F3"
-    );
+    harness.wait_for_screen_contains(MATCH_1).unwrap();
+    harness.assert_screen_contains("Search: alpha");
 
-    // Each further press steps one match forward, wrapping at the end.
-    for expected in [matches[1], matches[2], matches[3], matches[0]] {
+    // Each further press steps one match forward, wrapping at the end. The
+    // status bar counts them off, and the bar stays on screen throughout.
+    for (press, expected) in [(2, MATCH_2), (3, MATCH_3), (1, MATCH_1)] {
         harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
-        harness.process_async_and_render().unwrap();
-        assert_eq!(
-            harness.cursor_position(),
-            expected,
-            "F3 should advance to the next match"
-        );
-        assert!(
-            harness.editor().is_prompting(),
-            "the search bar must stay open while stepping with F3"
-        );
+        harness
+            .wait_for_screen_contains(&format!("Match {press} of 3"))
+            .unwrap();
+        harness.assert_screen_contains(expected);
+        harness.assert_screen_contains("Search: alpha");
     }
-
-    // The query is still in the bar and still editable.
-    assert!(
-        harness.get_prompt_line().contains("alpha"),
-        "the query should still be shown in the search bar, got {:?}",
-        harness.get_prompt_line()
-    );
 }
 
 #[test]
 fn test_shift_f3_steps_backwards_with_search_bar_open() {
-    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta alpha four\n";
-    let matches = all_matches(content, "alpha");
-
     let temp_dir = TempDir::new().unwrap();
-    let mut harness = harness_with(content, &temp_dir);
+    let mut harness = harness_with(CONTENT, &temp_dir);
 
     open_search_bar(&mut harness, "alpha");
 
@@ -101,90 +90,76 @@ fn test_shift_f3_steps_backwards_with_search_bar_open() {
     harness
         .send_key(KeyCode::F(3), KeyModifiers::SHIFT)
         .unwrap();
-    harness.process_async_and_render().unwrap();
-    assert_eq!(
-        harness.cursor_position(),
-        matches[3],
-        "Shift+F3 from the top of the file should wrap to the last match"
-    );
-    assert!(
-        harness.editor().is_prompting(),
-        "the search bar must stay open after Shift+F3"
-    );
+    harness.wait_for_screen_contains(MATCH_3).unwrap();
+    harness.assert_screen_contains("Search: alpha");
 
-    for expected in [matches[2], matches[1], matches[0]] {
+    for (press, expected) in [(2, MATCH_2), (1, MATCH_1)] {
         harness
             .send_key(KeyCode::F(3), KeyModifiers::SHIFT)
             .unwrap();
-        harness.process_async_and_render().unwrap();
-        assert_eq!(
-            harness.cursor_position(),
-            expected,
-            "Shift+F3 should step to the previous match"
-        );
+        harness
+            .wait_for_screen_contains(&format!("Match {press} of 3"))
+            .unwrap();
+        harness.assert_screen_contains(expected);
+        harness.assert_screen_contains("Search: alpha");
     }
 }
 
 #[test]
 fn test_f3_with_search_bar_open_reaches_matches_below_the_viewport() {
-    // Matches every tenth line, well past the 24-row viewport: incremental
+    // A match every tenth line, far past the 24-row viewport: incremental
     // highlighting only paints the visible rows, so stepping must consult the
-    // committed match list rather than the on-screen overlays.
+    // committed match list rather than the on-screen overlays — otherwise it
+    // wraps inside the screen and never reaches line 60.
     let mut content = String::new();
-    for line in 0..120 {
+    for line in 1..=120 {
         if line % 10 == 0 {
-            content.push_str(&format!("needle on line {line}\n"));
+            content.push_str(&format!("needle here {line}\n"));
         } else {
             content.push_str(&format!("filler {line}\n"));
         }
     }
-    let matches = all_matches(&content, "needle");
-    assert_eq!(matches.len(), 12);
 
     let temp_dir = TempDir::new().unwrap();
     let mut harness = harness_with(&content, &temp_dir);
 
     open_search_bar(&mut harness, "needle");
+    // Line 60 is nowhere near the opening viewport.
+    harness.assert_screen_not_contains("needle here 60");
 
-    for expected in &matches {
+    for _ in 0..6 {
         harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
-        harness.process_async_and_render().unwrap();
-        assert_eq!(
-            harness.cursor_position(),
-            *expected,
-            "F3 should keep walking matches past the bottom of the viewport"
-        );
+        harness.render().unwrap();
     }
+
+    harness.wait_for_screen_contains("Match 6 of 12").unwrap();
+    harness.assert_screen_contains("Ln 60, Col 1");
+    // The viewport followed the cursor, so the sixth match is on screen.
+    harness.assert_screen_contains("needle here 60");
+    harness.assert_screen_contains("Search: needle");
 }
 
 #[test]
 fn test_editing_the_query_after_f3_re_runs_the_search() {
-    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta needle four\n";
+    // Same shape as CONTENT, but the last line holds a different word.
+    let content = "one two three\nbeta alpha two\ngamma alpha three\ndelta needle four\n";
     let temp_dir = TempDir::new().unwrap();
     let mut harness = harness_with(content, &temp_dir);
 
     open_search_bar(&mut harness, "alpha");
     harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
-    harness.process_async_and_render().unwrap();
-    assert_eq!(harness.cursor_position(), content.find("alpha").unwrap());
+    harness.wait_for_screen_contains(MATCH_1).unwrap();
 
     // The bar still owns the keyboard, so the query can be rewritten in place
-    // and the next F3 must search for the *new* text.
+    // (Ctrl+A selects the whole query) and the next F3 searches the new text.
     harness
         .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
         .unwrap();
     harness.type_text("needle").unwrap();
-    harness.render().unwrap();
+    harness.wait_for_screen_contains("Search: needle").unwrap();
 
     harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
-    harness.process_async_and_render().unwrap();
-    assert_eq!(
-        harness.cursor_position(),
-        content.find("needle").unwrap(),
-        "F3 after editing the query should search for the edited query"
-    );
-    assert!(
-        harness.editor().is_prompting(),
-        "the search bar must stay open throughout"
-    );
+    // "needle" only appears on line 4, at the column `alpha` used there.
+    harness.wait_for_screen_contains(MATCH_3).unwrap();
+    harness.assert_screen_contains("Search: needle");
 }

--- a/crates/fresh-editor/tests/e2e/issue_2111_find_next_with_search_bar_open.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2111_find_next_with_search_bar_open.rs
@@ -1,0 +1,190 @@
+//! Regression test for <https://github.com/sinelaw/fresh/issues/2111>:
+//!
+//! F3 / Shift+F3 must step through search matches while the search bar is
+//! still open — the bar keeps the keyboard and the query stays editable,
+//! matching VS Code, Sublime and browser find. Before the fix the prompt
+//! swallowed the key as an unhandled modal key, so F3 did nothing at all
+//! until the bar had been closed with Enter.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use tempfile::TempDir;
+
+/// Byte offsets of every occurrence of `needle` in `haystack`.
+fn all_matches(haystack: &str, needle: &str) -> Vec<usize> {
+    haystack.match_indices(needle).map(|(pos, _)| pos).collect()
+}
+
+/// Open the search bar and type `query` — without confirming, so the bar
+/// stays open exactly as it is when the user reaches for F3.
+fn open_search_bar(harness: &mut EditorTestHarness, query: &str) {
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text(query).unwrap();
+    harness.render().unwrap();
+}
+
+fn harness_with(content: &str, dir: &TempDir) -> EditorTestHarness {
+    let file_path = dir.path().join("test.txt");
+    std::fs::write(&file_path, content).unwrap();
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().without_empty_plugins_dir())
+            .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+    harness
+}
+
+#[test]
+fn test_f3_advances_matches_and_keeps_search_bar_open() {
+    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta alpha four\n";
+    let matches = all_matches(content, "alpha");
+    assert_eq!(matches.len(), 4, "fixture should hold four matches");
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = harness_with(content, &temp_dir);
+
+    open_search_bar(&mut harness, "alpha");
+
+    // First F3 commits the typed query and lands on the first match at/after
+    // the cursor — the same spot Enter would pick, minus the closing.
+    harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+    harness.process_async_and_render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        matches[0],
+        "first F3 should land on the first match"
+    );
+    assert!(
+        harness.editor().is_prompting(),
+        "the search bar must stay open after F3"
+    );
+
+    // Each further press steps one match forward, wrapping at the end.
+    for expected in [matches[1], matches[2], matches[3], matches[0]] {
+        harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+        harness.process_async_and_render().unwrap();
+        assert_eq!(
+            harness.cursor_position(),
+            expected,
+            "F3 should advance to the next match"
+        );
+        assert!(
+            harness.editor().is_prompting(),
+            "the search bar must stay open while stepping with F3"
+        );
+    }
+
+    // The query is still in the bar and still editable.
+    assert!(
+        harness.get_prompt_line().contains("alpha"),
+        "the query should still be shown in the search bar, got {:?}",
+        harness.get_prompt_line()
+    );
+}
+
+#[test]
+fn test_shift_f3_steps_backwards_with_search_bar_open() {
+    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta alpha four\n";
+    let matches = all_matches(content, "alpha");
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = harness_with(content, &temp_dir);
+
+    open_search_bar(&mut harness, "alpha");
+
+    // The cursor starts at the top of the file, so a backward search wraps to
+    // the last match.
+    harness
+        .send_key(KeyCode::F(3), KeyModifiers::SHIFT)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        matches[3],
+        "Shift+F3 from the top of the file should wrap to the last match"
+    );
+    assert!(
+        harness.editor().is_prompting(),
+        "the search bar must stay open after Shift+F3"
+    );
+
+    for expected in [matches[2], matches[1], matches[0]] {
+        harness
+            .send_key(KeyCode::F(3), KeyModifiers::SHIFT)
+            .unwrap();
+        harness.process_async_and_render().unwrap();
+        assert_eq!(
+            harness.cursor_position(),
+            expected,
+            "Shift+F3 should step to the previous match"
+        );
+    }
+}
+
+#[test]
+fn test_f3_with_search_bar_open_reaches_matches_below_the_viewport() {
+    // Matches every tenth line, well past the 24-row viewport: incremental
+    // highlighting only paints the visible rows, so stepping must consult the
+    // committed match list rather than the on-screen overlays.
+    let mut content = String::new();
+    for line in 0..120 {
+        if line % 10 == 0 {
+            content.push_str(&format!("needle on line {line}\n"));
+        } else {
+            content.push_str(&format!("filler {line}\n"));
+        }
+    }
+    let matches = all_matches(&content, "needle");
+    assert_eq!(matches.len(), 12);
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = harness_with(&content, &temp_dir);
+
+    open_search_bar(&mut harness, "needle");
+
+    for expected in &matches {
+        harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+        harness.process_async_and_render().unwrap();
+        assert_eq!(
+            harness.cursor_position(),
+            *expected,
+            "F3 should keep walking matches past the bottom of the viewport"
+        );
+    }
+}
+
+#[test]
+fn test_editing_the_query_after_f3_re_runs_the_search() {
+    let content = "alpha one\nbeta alpha two\ngamma alpha three\ndelta needle four\n";
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = harness_with(content, &temp_dir);
+
+    open_search_bar(&mut harness, "alpha");
+    harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+    harness.process_async_and_render().unwrap();
+    assert_eq!(harness.cursor_position(), content.find("alpha").unwrap());
+
+    // The bar still owns the keyboard, so the query can be rewritten in place
+    // and the next F3 must search for the *new* text.
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("needle").unwrap();
+    harness.render().unwrap();
+
+    harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+    harness.process_async_and_render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        content.find("needle").unwrap(),
+        "F3 after editing the query should search for the edited query"
+    );
+    assert!(
+        harness.editor().is_prompting(),
+        "the search bar must stay open throughout"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -82,6 +82,7 @@ pub mod issue_2029_file_explorer_terminal_focus;
 pub mod issue_2030_quit_confirm_and_disable;
 pub mod issue_2031_next_prev_window;
 pub mod issue_2035_preview_renders_buffer_groups;
+pub mod issue_2111_find_next_with_search_bar_open;
 pub mod issue_2119_wheel_scroll;
 pub mod issue_2124_quickfix_enter;
 pub mod issue_2283_dock_last_tab_close;

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -171,8 +171,8 @@ Configure `trim_trailing_whitespace_on_save` and `ensure_final_newline_on_save` 
 | `Ctrl+F` | Search in buffer |
 | `Ctrl+R` | Replace in buffer |
 | `Ctrl+Alt+R` | Interactive replace (y/n/!/q for each match) |
-| `F3` | Find next match |
-| `Shift+F3` | Find previous match |
+| `F3` | Find next match (works with the search bar open, which stays open) |
+| `Shift+F3` | Find previous match (likewise) |
 | `Alt+N` / `Ctrl+F3` | Find next occurrence of selection |
 | `Alt+P` / `Ctrl+Shift+F3` | Find previous occurrence of selection |
 

--- a/docs/features/search-replace.md
+++ b/docs/features/search-replace.md
@@ -9,6 +9,15 @@ The search toolbar shows toggle buttons for:
 - **Whole Word** — match complete words only
 - **Regex** — use regular expressions
 
+## Stepping Through Matches
+
+With the search bar open, `F3` jumps to the next match and `Shift+F3` to the
+previous one **without closing the bar**, so the query stays editable and the
+toggles stay reachable. The status bar reports `Match N of M` as you go. The
+same keys work after the bar is closed, continuing from the last search.
+
+`Enter` jumps to the current match and closes the bar; `Esc` cancels.
+
 ## Regex and Capture Groups
 
 When regex mode is enabled, the replacement string supports capture groups: `$1`, `$2`, or `${name}` for named groups. For example, searching for `(\w+): (\w+)` and replacing with `$2: $1` swaps the two words around the colon.


### PR DESCRIPTION
Fixes #2111.

## Behaviour

With the search bar open (`Ctrl+F`, Replace, Query Replace), `F3` jumps to the next match and `Shift+F3` to the previous one **without closing the bar** — the query stays editable, the match-mode toggles stay reachable, and the status bar reports `Match N of M`. This is option 1 from the issue (VS Code / Sublime / browser `Ctrl+F` behaviour), which @dragonfyre13 and @rsramkis both asked for in the thread.

The first press on a freshly typed query runs the search and lands on the first match at/after the cursor — the same spot `Enter` picks, minus the closing. Each press after that steps one match, wrapping at the ends. `Enter` (jump + close) and `Esc` (cancel) are unchanged, as is `F3` outside the bar.

## Why it did nothing before

`Prompt::handle_key_event` ends in `_ => InputResult::Consumed` ("modal — consume all unhandled keys"), so `F3` died in the prompt and never reached keybinding resolution. It was also only bound in the `normal` context.

## Changes

* `view/prompt_input.rs` — function keys return `Ignored` (falling through to keybinding resolution) while a find/replace prompt is up. Other prompts stay fully modal, so `F3` remains inert in e.g. Go-to-line.
* `keymaps/default.json` — `F3` / `Shift+F3` / `Ctrl+Shift+N` bound in the `searchPrompt` context; `macos.json` and `macos-gui.json` get the same for their `Ctrl+G` / `Cmd+G` aliases. The dead `F3 -> prompt_confirm` binding in the `prompt` context is removed — it never fired, and `F3` now means find-next.
* `app/search_ops.rs` — commits the bar's query on the first press, then steps; a backward first press steps once past the commit. Match positions come from `search_state` instead of the overlays while the bar is open: incremental highlighting only paints the visible rows, so stepping through overlays wrapped inside the viewport instead of walking the file.
* `app/render.rs` — the per-frame highlight refresh follows the bar's current input rather than the committed query, which otherwise repainted stale matches over the ones being typed towards (and left old ones on screen after history navigation).
* `app/input.rs` — toggling Case Sensitive / Whole Word / Regex drops the committed matches so the next press re-runs under the new flags.
* Docs: `docs/features/search-replace.md` gains a "Stepping Through Matches" section; the `docs/features/editing.md` shortcut table notes the bar stays open.

## Testing

* New `tests/e2e/issue_2111_find_next_with_search_bar_open.rs` — forward stepping with the bar staying open, backward stepping, matches past the bottom of the viewport, and re-running after the query is edited in place.
* `cargo test -p fresh-editor --lib` (3229) green; the `search`, `prompt`, `replace`, `find` and `keybinding` e2e filters green apart from `locale::test_locale_from_config_spanish_search_options` and `locale::test_locale_switch_updates_search_cancelled_message`, which fail identically on the unmodified tree (order-dependent global locale state).
* `cargo fmt` and `cargo clippy --all-targets` clean.
* Driven by hand in tmux against a debug build: before the fix `F3` moved nothing; after it, stepping wraps in both directions, the bar stays open and editable, off-screen matches are reachable, `Alt+W` re-runs the search, and `Enter` / `Esc` behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLUY53QWSkPkr27tENmJz6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLUY53QWSkPkr27tENmJz6)_