### PR TITLE
Publish the whole orchestrator dock through its plugin API, on one code path

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4725,9 +4725,10 @@ function runDockMenuOption(optKey: string): void {
       openCreateFolderDialog(null, sessionId);
       return;
     }
-    assignSessionToFolder(sessionId, target === "root" ? null : target);
+    // Through the published verb, so the menu and a script file a workspace
+    // the same way (and both refuse a placeholder that is still being created).
+    apiMoveWorkspace(sessionId, target === "root" ? null : target);
     closeDockMenu();
-    refreshOpenDialog();
     return;
   }
   closeDockMenu();
@@ -4926,38 +4927,38 @@ function buildCreateFolderSpec(): WidgetSpec {
 // Commit the dialog: create the folder and (when the checkbox is on)
 // file the target session under it. No-op on an empty name, so the
 // dialog stays open for the user to type one.
+// Every branch below goes through a published API verb rather than calling
+// the folder/name stores directly, so the dialog and a script share one
+// implementation of each operation — including the guards (a workspace still
+// being created cannot be renamed or filed) and the dock refresh.
 function submitCreateFolder(): void {
   const d = createFolderDialog;
   if (!d) return;
   if (d.renameSessionId !== null) {
     // Workspace rename: an empty name clears the manual name and lets the
     // auto-name / host label take back over.
-    const s = orchestratorSessions.get(d.renameSessionId);
-    if (s) renameWorkspace(s, d.name.value);
+    apiRenameWorkspace(d.renameSessionId, d.name.value);
     closeCreateFolderDialog();
-    if (openPanel && dockMode) refreshOpenDialog();
     return;
   }
   if (d.renameId !== null) {
     // Rename mode: an emptied-out name keeps the current one (renaming
-    // to nothing is never what the user meant).
+    // to nothing is never what the user meant), so the verb — which rejects
+    // an empty name — is only called when there is one.
     const trimmed = d.name.value.trim();
-    if (trimmed) renameFolder(d.renameId, trimmed);
+    if (trimmed) apiRenameFolder(d.renameId, trimmed);
     closeCreateFolderDialog();
-    if (openPanel && dockMode) refreshOpenDialog();
     return;
   }
-  // Empty name ⇒ the default ("New Folder"), matching the placeholder.
+  // Empty name ⇒ the default ("New Folder"), matching the placeholder. The
+  // verb rejects an empty name, so the dialog's own default is applied here
+  // rather than inside it — a script passing "" meant something else.
   const name = d.name.value.trim() || editor.t("dock.new_folder_default");
-  const id = createFolder(name, d.parent);
+  const id = apiCreateFolder(name, d.parent);
   if (d.organizeCurrent && d.sessionId != null) {
-    assignSessionToFolder(d.sessionId, id);
+    apiMoveWorkspace(d.sessionId, id);
   }
   closeCreateFolderDialog();
-  if (openPanel && dockMode) {
-    openPanel.setExpandedKeys("sessions", Array.from(loadExpanded()));
-    refreshOpenDialog();
-  }
 }
 
 // Tear down the dialog and hand keyboard focus back to the dock.
@@ -5400,8 +5401,10 @@ function stopOne(id: number): boolean {
 // ---------------------------------------------------------------------
 // Archive manifest — `<XDG>/orchestrator/<repo-slug>/archived.json`.
 // Records sessions that have been archived (stopped + worktree moved
-// to `.archived/`). Used today by the Archive action; Unarchive and
-// "Show archived" surface in a follow-up phase.
+// to `.archived/`). Written by the Archive action, read back by
+// `listArchived` / `unarchiveWorkspace` on the plugin API. No dock UI
+// surfaces archived rows yet; when one does it reads the same two
+// functions rather than re-walking the manifests.
 // ---------------------------------------------------------------------
 
 interface ArchivedSession {
@@ -5414,6 +5417,15 @@ interface ArchivedSession {
   branch: string;
   /** ISO 8601 timestamp of when the session was archived. */
   archived_at: string;
+  /**
+   * Repo the entry belongs to. The manifest lives under a *slug* of this
+   * path, and slugging is one-way, so without it a reader that found the
+   * file by scanning the data directory cannot name the repo the entry
+   * came from — which `git worktree move` needs to put it back. Absent in
+   * manifests written before this field existed; `archivedRepoRoot`
+   * recovers it from the archived worktree itself in that case.
+   */
+  repo_root?: string;
 }
 
 interface ArchiveManifest {
@@ -5454,6 +5466,113 @@ function saveArchiveManifest(repoRoot: string, m: ArchiveManifest): boolean {
   const dir = editor.pathDirname(path);
   if (!editor.createDir(editor.localPath(dir))) return false;
   return editor.writeFile(editor.localPath(path), JSON.stringify(m, null, 2));
+}
+
+/// Every archive manifest on this machine, paired with the entries it holds.
+///
+/// The manifests are keyed by a *slug* of the repo root, and slugging is
+/// one-way, so the scan cannot name the repo from the directory name. Newer
+/// entries carry `repo_root`; for older ones the repo is recovered from the
+/// archived worktree itself (`archivedRepoRoot`) at the point it is needed,
+/// which is the one place that needs it.
+function scanArchiveManifests(): { slug: string; manifest: ArchiveManifest }[] {
+  const base = editor.pathJoin(editor.getDataDir(), "orchestrator");
+  const out: { slug: string; manifest: ArchiveManifest }[] = [];
+  let entries: DirEntry[];
+  try {
+    entries = editor.readDir(editor.localPath(base));
+  } catch (_) {
+    return out;
+  }
+  // A machine that has never archived anything has no directory here at all;
+  // both shapes of "nothing to read" have to be tolerated (see
+  // `scanSessionContent`, which reads its directory the same way).
+  if (!entries) return out;
+  for (const e of entries) {
+    // `.archived` and `.sync-workspace` are the graveyard and the sync
+    // worktree, not per-repo state directories.
+    if (!e.is_dir || e.name.startsWith(".")) continue;
+    const path = editor.pathJoin(base, e.name, "archived.json");
+    const raw = editor.readFile(editor.localPath(path));
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && Array.isArray(parsed.sessions)) {
+        out.push({ slug: e.name, manifest: parsed as ArchiveManifest });
+      }
+    } catch (_) {
+      // A corrupt manifest hides its own repo's archive rather than
+      // failing the whole listing — same tolerance as `loadArchiveManifest`.
+    }
+  }
+  return out;
+}
+
+/// The repo an archived entry belongs to: the recorded `repo_root` when the
+/// entry has one, else resolved from the archived worktree on disk (a linked
+/// worktree still points at its main checkout, even from the graveyard).
+/// `null` when neither is available — a manifest entry whose directory is
+/// gone, which unarchive cannot act on anyway.
+async function archivedRepoRoot(e: ArchivedSession): Promise<string | null> {
+  if (e.repo_root) return e.repo_root;
+  if (!editor.fileExists(editor.localPath(e.root))) return null;
+  return await resolveCanonicalRepoRoot(e.root);
+}
+
+/// Move an archived worktree back to where it came from and drop its manifest
+/// entry. Reverses `archiveOne`'s graveyard move; an entry archived in place
+/// (`original_root === root`, no move happened) just leaves the manifest, and
+/// the directory is already where it belongs.
+///
+/// Does NOT trigger sync — the caller batches that, matching the other
+/// lifecycle cores.
+async function unarchiveOne(e: ArchivedSession): Promise<LifecycleResult> {
+  const repoRoot = await archivedRepoRoot(e);
+  if (!repoRoot) return { ok: false, err: editor.t("err.not_git_repo") };
+
+  const moved = e.original_root !== e.root;
+  if (moved) {
+    if (!editor.fileExists(editor.localPath(e.root))) {
+      return { ok: false, err: `archived worktree is gone: ${e.root}`, repoRoot };
+    }
+    // Refuse rather than clobber: something else already occupies the path
+    // this worktree wants back, and `git worktree move` would fail anyway —
+    // with a message about a destination the user never named.
+    if (editor.fileExists(editor.localPath(e.original_root))) {
+      return {
+        ok: false,
+        err: `something already exists at ${e.original_root}`,
+        repoRoot,
+      };
+    }
+    const parent = editor.pathDirname(e.original_root);
+    if (!editor.createDir(editor.localPath(parent))) {
+      return { ok: false, err: editor.t("err.could_not_create", { path: parent }), repoRoot };
+    }
+    const res = await spawnCollect(
+      "git",
+      ["-C", repoRoot, "worktree", "move", e.root, e.original_root],
+      repoRoot,
+    );
+    if (res.exit_code !== 0) {
+      return {
+        ok: false,
+        err: lastNonEmptyLine(res.stderr) || editor.t("err.worktree_move_failed"),
+        repoRoot,
+      };
+    }
+  }
+
+  const manifest = loadArchiveManifest(repoRoot);
+  manifest.sessions = manifest.sessions.filter((x) => x.root !== e.root);
+  saveArchiveManifest(repoRoot, manifest);
+  // Nothing re-adds the row to the model here: the worktree is back on disk,
+  // so the discovered-worktree scan picks it up as an unopened row the next
+  // time it runs (and `focusWorkspace` / Enter opens it). Forcing a window
+  // open would make unarchive mean "restore *and* launch", which is not what
+  // the archive action's inverse should do.
+  void refreshDiscoveredWorktrees();
+  return { ok: true, repoRoot };
 }
 
 // Pick a session id to make active so that `excludeId` can be
@@ -5630,6 +5749,7 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
       original_root: s.root,
       branch: s.branch || s.label,
       archived_at: new Date().toISOString(),
+      repo_root: repoRoot,
     });
     saveArchiveManifest(repoRoot, manifest);
     // A discovered row has no window_closed hook to drop it — remove it
@@ -5658,6 +5778,7 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
     original_root: s.root,
     branch: s.branch || s.label,
     archived_at: new Date().toISOString(),
+    repo_root: repoRoot,
   });
   saveArchiveManifest(repoRoot, manifest);
   orchestratorSessions.delete(id);
@@ -5952,12 +6073,66 @@ async function deleteOne(id: number): Promise<LifecycleResult> {
   return { ok: true, repoRoot };
 }
 
+/// Outcome of a lifecycle batch: how many targets the action ran on
+/// successfully, and the last failure reason when some did not.
+interface LifecycleBatchResult {
+  ran: number;
+  ok: number;
+  lastErr: string;
+}
+
+/// Run Archive / Delete over `targets`, batching one sync per touched repo.
+///
+/// This is the single execution path for the destructive lifecycle actions:
+/// the picker's confirmed action calls it with its whole selection, and the
+/// plugin API's `archiveWorkspace` / `deleteWorkspace` call it with one id.
+/// `onProgress` is how the picker drives its "Archiving 2/3…" markers without
+/// this core knowing anything about the dialog — a headless caller passes
+/// nothing.
+///
+/// Targets are NOT re-filtered here: both callers check eligibility first (the
+/// picker to report "nothing eligible", the API to throw the reason), and
+/// silently dropping an ineligible id would turn the API's refusal into a
+/// success.
+async function runLifecycleBatch(
+  action: "archive" | "delete",
+  targets: number[],
+  onProgress?: (doneIndex: number, id: number) => void,
+): Promise<LifecycleBatchResult> {
+  const touchedRepos = new Set<string>();
+  let okCount = 0;
+  let lastErr = "";
+  for (let i = 0; i < targets.length; i++) {
+    const id = targets[i];
+    const res = action === "archive" ? await archiveOne(id) : await deleteOne(id);
+    if (res.ok) {
+      okCount += 1;
+      if (res.repoRoot) touchedRepos.add(res.repoRoot);
+    } else {
+      lastErr = res.err ?? editor.t("err.failed");
+    }
+    onProgress?.(i, id);
+  }
+  // The cores deliberately skip this so a batch pushes once per repo rather
+  // than once per workspace.
+  for (const repo of touchedRepos) triggerSyncAsync(repo);
+  return { ran: targets.length, ok: okCount, lastErr };
+}
+
+/// Signal the agent process groups of `targets`. Shared by the picker's
+/// confirmed Stop and the API's `stopWorkspace`; returns how many were
+/// signalled.
+function runStopBatch(targets: number[]): number {
+  let n = 0;
+  for (const id of targets) if (stopOne(id)) n += 1;
+  return n;
+}
+
 // Unified runner for a confirmed Stop / Archive / Delete over one or
 // many ids. Re-filters to eligible targets at execution time (the
 // selection or single row may have gone stale between confirm and
-// run), drives the in-flight progress markers, runs the per-id cores
-// sequentially, prunes acted-on ids from the selection, and triggers
-// one sync per touched repo at the end.
+// run), drives the in-flight progress markers, runs the shared batch
+// cores, and prunes acted-on ids from the selection.
 async function runConfirmedAction(
   action: BulkAction,
   ids: number[],
@@ -5971,8 +6146,7 @@ async function runConfirmedAction(
   }
 
   if (action === "stop") {
-    let n = 0;
-    for (const id of targets) if (stopOne(id)) n += 1;
+    const n = runStopBatch(targets);
     editor.setStatus(editor.t("status.stop_sent", { count: String(n) }));
     // Stop leaves sessions in place; drop them from the selection so
     // the bulk bar reflects that the action ran.
@@ -5989,22 +6163,15 @@ async function runConfirmedAction(
   }
   refreshOpenDialog();
 
-  const touchedRepos = new Set<string>();
-  let okCount = 0;
-  let lastErr = "";
-  for (let i = 0; i < targets.length; i++) {
-    const id = targets[i];
-    const res = action === "archive" ? await archiveOne(id) : await deleteOne(id);
-    if (res.ok) {
-      okCount += 1;
-      if (res.repoRoot) touchedRepos.add(res.repoRoot);
-    } else {
-      lastErr = res.err ?? editor.t("err.failed");
-    }
-    openDialog?.selectedIds.delete(id);
-    if (openDialog?.bulkInFlight) openDialog.bulkInFlight.done = i + 1;
-    refreshOpenDialog();
-  }
+  const { ok: okCount, lastErr } = await runLifecycleBatch(
+    action,
+    targets,
+    (i, id) => {
+      openDialog?.selectedIds.delete(id);
+      if (openDialog?.bulkInFlight) openDialog.bulkInFlight.done = i + 1;
+      refreshOpenDialog();
+    },
+  );
   if (openDialog) {
     openDialog.inFlight = null;
     openDialog.bulkInFlight = null;
@@ -6018,7 +6185,6 @@ async function runConfirmedAction(
   } else {
     editor.setStatus(editor.t("status.bulk_done", { verb, count: String(okCount) }));
   }
-  for (const repo of touchedRepos) triggerSyncAsync(repo);
   refreshOpenDialog();
   // The batch emptied the selection, so the pane is back in
   // single-preview mode — restore focus to Visit (the bulk buttons
@@ -6162,79 +6328,34 @@ function toggleSelectCurrent(): void {
 }
 registerHandler("orchestrator_toggle_select", toggleSelectCurrent);
 
+// Flip the picker between "this project" and "all projects". Through the
+// published verb, which remembers the choice for the next open and keeps the
+// highlighted session selected across the flip. The filter value is untouched
+// — toggling scope with an active filter just widens/narrows the search base.
 function toggleScope(): void {
   if (!openDialog) return;
-  openDialog.scope = openDialog.scope === "current" ? "all" : "current";
-  // Remember the choice for the next time the picker opens.
-  lastOpenScope = openDialog.scope;
-  // Keep the highlighted session selected across the scope flip
-  // when it survives into the new list; otherwise fall back to the
-  // top. The filter value is untouched — toggling scope with an
-  // active filter just widens/narrows the global-search base.
-  const prevId = openDialog.filteredIds[openDialog.selectedIndex];
-  openDialog.filteredIds = filterSessions(openDialog.filter.value);
-  const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
-  openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
-  refreshOpenDialog();
+  apiSetDockFilter({ scope: openDialog.scope === "current" ? "all" : "current" });
 }
 
 registerHandler("orchestrator_toggle_scope", toggleScope);
 
-// Flip "Show all worktrees" — reveal/hide the discovered on-disk
-// worktree rows. Preserves the highlighted row across the re-filter
-// where possible; drops now-hidden discovered rows from the bulk
-// selection. Shared by the Alt+T chord and the checkbox click.
+// Flip "Show all worktrees" — reveal/hide the discovered on-disk worktree
+// rows. Shared by the Alt+T chord and the checkbox click, and both go
+// through the published `setDockFilter`, which owns writing the flag,
+// re-filtering, preserving the highlighted row and pruning the selection.
 function toggleShowWorktrees(): void {
   if (!openDialog) return;
-  openDialog.showWorktrees = !openDialog.showWorktrees;
-  lastShowWorktrees = openDialog.showWorktrees;
-  // Hiding worktrees shouldn't leave them lingering in the selection.
-  if (!openDialog.showWorktrees) {
-    for (const id of [...openDialog.selectedIds]) {
-      if (orchestratorSessions.get(id)?.discovered) {
-        openDialog.selectedIds.delete(id);
-      }
-    }
-  }
-  const prevId = openDialog.filteredIds[openDialog.selectedIndex];
-  openDialog.filteredIds = filterSessions(openDialog.filter.value);
-  const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
-  openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
-  refreshOpenDialog();
-  // Turning "Show all worktrees" ON re-scans *now* so the rows reflect every
-  // project's on-disk worktrees at this moment — not just whatever the single
-  // scan at dialog-open time happened to catch. Discovery walks every known
-  // project (each open/persisted session's repo, plus the cwd repo), so a
-  // fresh scan here is what makes the toggle show worktrees across all
-  // projects rather than a stale subset. Async; `refreshDiscoveredWorktrees`
-  // re-renders the dialog when the scan lands.
-  if (openDialog.showWorktrees) {
-    void refreshDiscoveredWorktrees();
-  }
+  apiSetDockFilter({ worktrees: !openDialog.showWorktrees });
 }
 
 registerHandler("orchestrator_toggle_worktrees", toggleShowWorktrees);
 
 // Flip "Show empty/1-file sessions" — reveal/hide the trivial restored
-// shells. Preserves the highlighted row across the re-filter where
-// possible; drops now-hidden rows from the bulk selection. Shared by the
-// Alt+I chord and the checkbox click.
+// shells. `showEmpty` is the inverse of the stored `hideTrivial`, so
+// flipping the flag means passing the *current* `hideTrivial` through.
 function toggleHideTrivial(): void {
   if (!openDialog) return;
-  openDialog.hideTrivial = !openDialog.hideTrivial;
-  lastHideTrivial = openDialog.hideTrivial;
-  const prevId = openDialog.filteredIds[openDialog.selectedIndex];
-  openDialog.filteredIds = filterSessions(openDialog.filter.value);
-  // Hiding trivial rows shouldn't leave them lingering in the selection.
-  if (openDialog.hideTrivial) {
-    const visible = new Set(openDialog.filteredIds);
-    for (const id of [...openDialog.selectedIds]) {
-      if (!visible.has(id)) openDialog.selectedIds.delete(id);
-    }
-  }
-  const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
-  openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
-  refreshOpenDialog();
+  apiSetDockFilter({ showEmpty: openDialog.hideTrivial });
 }
 
 registerHandler("orchestrator_toggle_trivial", toggleHideTrivial);
@@ -8503,13 +8624,187 @@ function cancelForm(): void {
 
 type CaptureResult = { ok: true; spec: CreateSpec } | { ok: false; error: string };
 
+// ---------------------------------------------------------------------
+// Spec builders — plain values in, a `CreateSpec` out.
+//
+// These are the single construction path for a workspace create. The
+// dialog reaches them through `captureCreateSpec` (which does nothing but
+// read its fields), and the plugin API's `newWorkspace` reaches them
+// directly with the caller's options. Neither side builds a spec of its
+// own, so a new agent flag or a changed default lands in both at once —
+// the API used to assemble the local spec inline and had already drifted
+// into being a second, near-copy of the local branch below.
+// ---------------------------------------------------------------------
+
+/// Per-agent launch options, gated on what the resolved agent supports.
+/// Shared by every backend so a bare terminal (or a command that isn't a
+/// known agent) never gets stray flags or a prompt appended.
+interface AgentOptionInputs {
+  auto: boolean;
+  prompt: string;
+  teach: boolean;
+}
+
+function gateAgentOptions(
+  cmd: string,
+  o: AgentOptionInputs,
+): { auto: boolean; startPrompt: string; teachFreshCli: boolean } {
+  const entry = agentEntryForCmd(cmd);
+  return {
+    auto: !!entry?.auto && o.auto,
+    startPrompt: entry?.prompt ? o.prompt : "",
+    teachFreshCli: !!entry?.systemPrompt && o.teach,
+  };
+}
+
+interface LocalSpecInputs extends AgentOptionInputs {
+  projectPath: string;
+  /// Explicit workspace name; "" ⇒ auto-generated at create time.
+  name: string;
+  cmd: string;
+  branch: string;
+  newBranch: string;
+  createWorktree: boolean;
+  /// Row label to show while the create runs. "" ⇒ derived from the name /
+  /// the project's basename, which is what the dialog's placeholder shows.
+  displayLabel?: string;
+}
+
+function buildLocalSpec(o: LocalSpecInputs): CreateSpec {
+  return {
+    backend: "local",
+    projectPath: o.projectPath,
+    name: o.name,
+    cmd: o.cmd,
+    ...gateAgentOptions(o.cmd, o),
+    branch: o.branch,
+    newBranch: o.newBranch,
+    createWorktree: o.createWorktree,
+    displayLabel: o.displayLabel ||
+      o.name ||
+      editor.pathBasename(o.projectPath) ||
+      editor.t("dock.pending_default_name"),
+    displayProject: o.projectPath,
+  };
+}
+
+interface SshSpecInputs extends AgentOptionInputs {
+  /// `[user@]host[:port]`, or a pasted `ssh://…`.
+  host: string;
+  name: string;
+  cmd: string;
+  /// Remote directory to root the session at.
+  remotePath: string;
+  /// Identity file passed to ssh.
+  identity: string;
+  /// Extra ssh arguments, already split into argv.
+  extraArgs: string[];
+}
+
+function buildSshSpec(o: SshSpecInputs): CaptureResult {
+  // Parse `[user@]host[:port]` (also tolerates a pasted `ssh://…`). The user
+  // is optional — a bare `host` lets ssh resolve it from its own config.
+  const raw = o.host.trim().replace(/^ssh:\/\//, "");
+  const portMatch = raw.match(/^(.+):(\d+)$/);
+  const port = portMatch ? parseInt(portMatch[2], 10) : null;
+  const hostPart = portMatch ? portMatch[1] : raw;
+  const at = hostPart.indexOf("@");
+  const user = at > 0 ? hostPart.slice(0, at) : undefined;
+  const host = at >= 0 ? hostPart.slice(at + 1) : hostPart;
+  if (!host) return { ok: false, error: editor.t("err.ssh_host_required") };
+  const agentArgv = splitAgentCmd(o.cmd);
+  const target = user ? `${user}@${host}` : host;
+  const label = o.name || `ssh:${target}`;
+  const spec: RemoteAgentSpec = {
+    transport: {
+      kind: "ssh",
+      ...(user ? { user } : {}),
+      host,
+      port,
+      identity_file: o.identity || null,
+      remote_path: o.remotePath || null,
+      ...(o.extraArgs.length > 0 ? { extra_args: o.extraArgs } : {}),
+    },
+    base_env: [],
+    window: true,
+    label,
+    command: agentArgv.length > 0 ? agentArgv : undefined,
+  };
+  return {
+    ok: true,
+    spec: {
+      backend: "ssh",
+      spec,
+      facet: { kind: "ssh", detail: target, state: "starting" },
+      displayLabel: label,
+      displayProject: target,
+      persistCmd: o.cmd,
+    },
+  };
+}
+
+interface K8sSpecInputs {
+  /// Named target from `.fresh/k8s.json`; when set, `pod` is still required.
+  target: string;
+  context: string;
+  namespace: string;
+  pod: string;
+  workspace: string;
+  name: string;
+  cmd: string;
+}
+
+function buildK8sSpec(o: K8sSpecInputs): CaptureResult {
+  if (o.target && !o.pod) return { ok: false, error: editor.t("err.k8s_named_target") };
+  if (!o.namespace || !o.pod) {
+    return { ok: false, error: editor.t("err.k8s_ns_pod_required") };
+  }
+  const agentArgv = splitAgentCmd(o.cmd);
+  const detail = `${o.namespace}/${o.pod}`;
+  const label = o.name || `k8s:${detail}`;
+  const spec: RemoteAgentSpec = {
+    transport: {
+      kind: "kubectl-exec",
+      context: o.context || null,
+      namespace: o.namespace,
+      pod: o.pod,
+      container: null,
+      workspace: o.workspace || null,
+    },
+    base_env: [],
+    // Born-attached: a new window beside the local ones (not a global
+    // restart). Core records nothing about us — the orchestrator tracks the
+    // session via the `window_created` hook once the connect succeeds.
+    window: true,
+    label,
+    command: agentArgv.length > 0 ? agentArgv : undefined,
+  };
+  return {
+    ok: true,
+    spec: {
+      backend: "kubernetes",
+      spec,
+      facet: { kind: "kubernetes", detail, state: "starting" },
+      displayLabel: label,
+      displayProject: detail,
+      persistCmd: "",
+    },
+  };
+}
+
 // Resolve the (about-to-close) form into a `CreateSpec`, or return the
 // validation error that keeps the form open. Reads field values only — no
 // async work, no side effects — so the background worker never touches form
-// state that no longer exists.
+// state that no longer exists. The spec itself is built by the shared
+// builders above, which the plugin API calls with the same shapes.
 function captureCreateSpec(f: NewSessionForm): CaptureResult {
   const cmd = f.cmd.value.trim();
   const sessionName = f.name.value.trim();
+  const agentOptions: AgentOptionInputs = {
+    auto: f.autoMode,
+    prompt: f.startPrompt.value.trim(),
+    teach: f.teachFreshCli,
+  };
 
   if (f.backend === "local") {
     // Project Path: typed value wins; otherwise the resolved canonical-root
@@ -8519,115 +8814,46 @@ function captureCreateSpec(f: NewSessionForm): CaptureResult {
     const projectPath = f.projectPath.value.trim() ||
       f.defaultProjectPath ||
       localProjectDefault();
-    const displayLabel = sessionName ||
-      f.defaultSessionName ||
-      editor.pathBasename(projectPath) ||
-      editor.t("dock.pending_default_name");
     return {
       ok: true,
-      spec: {
-        backend: "local",
+      spec: buildLocalSpec({
+        ...agentOptions,
         projectPath,
         name: sessionName,
         cmd,
-        // Only carry agent options for a command that resolves to an agent
-        // that supports them, so a bare terminal / custom command never gets
-        // stray flags or a prompt appended.
-        auto: !!agentEntryForCmd(cmd)?.auto && f.autoMode,
-        startPrompt: agentEntryForCmd(cmd)?.prompt ? f.startPrompt.value.trim() : "",
-        teachFreshCli: !!agentEntryForCmd(cmd)?.systemPrompt && f.teachFreshCli,
         branch: f.branch.value.trim(),
         newBranch: f.newBranch.value.trim(),
         createWorktree: f.createWorktree,
-        displayLabel,
-        displayProject: projectPath,
-      },
+        // The form has a third fallback the API has no equivalent for: the
+        // auto-generated `<project>-N` shown as the Name field's placeholder.
+        displayLabel: sessionName || f.defaultSessionName,
+      }),
     };
   }
 
   if (f.backend === "kubernetes") {
-    const target = f.k8sTarget.value.trim();
-    const namespace = f.k8sNamespace.value.trim();
-    const pod = f.k8sPod.value.trim();
-    if (target && !pod) return { ok: false, error: editor.t("err.k8s_named_target") };
-    if (!namespace || !pod) return { ok: false, error: editor.t("err.k8s_ns_pod_required") };
-    const agentArgv = splitAgentCmd(cmd);
-    const detail = `${namespace}/${pod}`;
-    const label = sessionName || `k8s:${namespace}/${pod}`;
-    const spec: RemoteAgentSpec = {
-      transport: {
-        kind: "kubectl-exec",
-        context: f.k8sContext.value.trim() || null,
-        namespace,
-        pod,
-        container: null,
-        workspace: f.k8sWorkspace.value.trim() || null,
-      },
-      base_env: [],
-      // Born-attached: a new window beside the local ones (not a global
-      // restart). Core records nothing about us — the orchestrator tracks the
-      // session via the `window_created` hook once the connect succeeds.
-      window: true,
-      label,
-      command: agentArgv.length > 0 ? agentArgv : undefined,
-    };
-    return {
-      ok: true,
-      spec: {
-        backend: "kubernetes",
-        spec,
-        facet: { kind: "kubernetes", detail, state: "starting" },
-        displayLabel: label,
-        displayProject: detail,
-        persistCmd: "",
-      },
-    };
+    return buildK8sSpec({
+      target: f.k8sTarget.value.trim(),
+      context: f.k8sContext.value.trim(),
+      namespace: f.k8sNamespace.value.trim(),
+      pod: f.k8sPod.value.trim(),
+      workspace: f.k8sWorkspace.value.trim(),
+      name: sessionName,
+      cmd,
+    });
   }
 
   if (f.backend === "ssh") {
-    // Parse `[user@]host[:port]` (also tolerates a pasted `ssh://…`). The user
-    // is optional — a bare `host` lets ssh resolve it from its own config.
-    const raw = f.sshHost.value.trim().replace(/^ssh:\/\//, "");
-    const portMatch = raw.match(/^(.+):(\d+)$/);
-    const port = portMatch ? parseInt(portMatch[2], 10) : null;
-    const hostPart = portMatch ? portMatch[1] : raw;
-    const at = hostPart.indexOf("@");
-    const user = at > 0 ? hostPart.slice(0, at) : undefined;
-    const host = at >= 0 ? hostPart.slice(at + 1) : hostPart;
-    if (!host) return { ok: false, error: editor.t("err.ssh_host_required") };
-    const identity = f.sshIdentity.value.trim();
-    const remotePath = f.sshPath.value.trim();
-    const extraArgs = f.sshOptions.value.trim()
-      ? f.sshOptions.value.trim().split(/\s+/)
-      : [];
-    const agentArgv = splitAgentCmd(cmd);
-    const target = user ? `${user}@${host}` : host;
-    const spec: RemoteAgentSpec = {
-      transport: {
-        kind: "ssh",
-        ...(user ? { user } : {}),
-        host,
-        port,
-        identity_file: identity || null,
-        remote_path: remotePath || null,
-        ...(extraArgs.length > 0 ? { extra_args: extraArgs } : {}),
-      },
-      base_env: [],
-      window: true,
-      label: sessionName || `ssh:${target}`,
-      command: agentArgv.length > 0 ? agentArgv : undefined,
-    };
-    return {
-      ok: true,
-      spec: {
-        backend: "ssh",
-        spec,
-        facet: { kind: "ssh", detail: target, state: "starting" },
-        displayLabel: sessionName || `ssh:${target}`,
-        displayProject: target,
-        persistCmd: cmd,
-      },
-    };
+    const options = f.sshOptions.value.trim();
+    return buildSshSpec({
+      ...agentOptions,
+      host: f.sshHost.value.trim(),
+      name: sessionName,
+      cmd,
+      remotePath: f.sshPath.value.trim(),
+      identity: f.sshIdentity.value.trim(),
+      extraArgs: options ? options.split(/\s+/) : [],
+    });
   }
 
   // devcontainer — no runtime plugin-to-plugin attach yet.
@@ -9236,6 +9462,19 @@ async function runRemoteCreate(id: number): Promise<void> {
     // hook adopted the facet). Drop the placeholder.
     orchestratorSessions.delete(id);
     savePendingSpecs();
+    // Hand a waiting caller its ids. The attach dove into the born window, so
+    // it is the active one right now — before the `restoreActiveWindow` below
+    // puts focus back. Without this a caller awaiting a remote create waited
+    // forever: the local worker settles its outcome and this one never did,
+    // which went unnoticed while `newWorkspace` was local-only.
+    const bornId = editor.activeWindow();
+    const born = editor.listWindows().find((w) => w.id === bornId);
+    settleCreateOutcome(id, {
+      ok: true,
+      windowId: bornId,
+      workspaceId: born?.stable_id,
+      root: born?.root,
+    });
     if (spec.persistCmd) editor.setGlobalState("orchestrator.last_cmd", spec.persistCmd);
     if (visit) {
       // Create & Visit: the attach already made the born window active; hand
@@ -9547,12 +9786,23 @@ export type RunAgentOptions = {
   teach?: boolean;
 };
 
-export type NewWorkspaceOptions = RunAgentOptions & {
+/// Options shared by every `newWorkspace` backend.
+export type NewWorkspaceCommon = RunAgentOptions & {
+  /** Workspace name. Default: the next auto-generated `<project>-N` locally,
+   *  or `ssh:<target>` for a remote one. */
+  name?: string;
+  /** Move focus into the new workspace once it is up. Default false — an agent
+   *  asking for a workspace should not yank the human's focus into it. */
+  visit?: boolean;
+};
+
+/// A workspace on this machine: the dialog's "Local" backend.
+export type LocalWorkspaceOptions = NewWorkspaceCommon & {
+  /** Omit (or `"local"`) for a workspace on this machine. */
+  backend?: "local";
   /** Project directory the workspace roots at. Default: this workspace's
    *  project. Must exist. */
   path?: string;
-  /** Workspace name. Default: the next auto-generated `<project>-N`. */
-  name?: string;
   /** Existing branch to check out in the new worktree. Default: the repo's
    *  default branch. */
   branch?: string;
@@ -9561,10 +9811,27 @@ export type NewWorkspaceOptions = RunAgentOptions & {
   /** Create a git worktree for the workspace. Default true; ignored for a
    *  non-git path. */
   worktree?: boolean;
-  /** Move focus into the new workspace once it is up. Default false — an agent
-   *  asking for a workspace should not yank the human's focus into it. */
-  visit?: boolean;
 };
+
+/// A workspace on a remote host over SSH: the dialog's "SSH" backend, whose
+/// fields these mirror one-for-one.
+export type SshWorkspaceOptions = NewWorkspaceCommon & {
+  backend: "ssh";
+  /** `host`, `user@host`, `user@host:port`, or a pasted `ssh://…`. The user
+   *  is optional — a bare host lets ssh resolve it from its own config.
+   *  Required. */
+  host: string;
+  /** Remote directory to root the session at. Default: ssh's landing
+   *  directory on the host. */
+  path?: string;
+  /** Identity file to authenticate with (ssh's `-i`). */
+  identity?: string;
+  /** Extra ssh arguments, e.g. `"-J jump"` or `["-o", "ProxyCommand=…"]`.
+   *  A string is split on whitespace, like the dialog's field. */
+  sshOptions?: string | string[];
+};
+
+export type NewWorkspaceOptions = LocalWorkspaceOptions | SshWorkspaceOptions;
 
 /// One workspace, as `listWorkspaces()` reports it.
 export type WorkspaceSummary = {
@@ -9612,6 +9879,29 @@ export type WorkspaceSummary = {
   backend?: string;
 };
 
+/// One archived workspace, as `listArchived()` reports it. An archived
+/// workspace has no window and no dock row — its worktree has been moved out
+/// to the graveyard — so it is identified by path, not by `workspaceId`.
+export type ArchivedWorkspace = {
+  /** Current path of the archived worktree. This is the identity
+   *  `unarchiveWorkspace` takes. */
+  archivedRoot: string;
+  /** Where the worktree lived before it was archived, and where
+   *  `unarchiveWorkspace` puts it back. Equal to `archivedRoot` for a
+   *  workspace that was archived in place (nothing was moved). */
+  originalRoot: string;
+  /** Display name it had on the dock. */
+  name: string;
+  /** Branch the worktree was on. */
+  branch: string;
+  /** ISO 8601 timestamp of when it was archived. */
+  archivedAt: string;
+  /** Repo it belongs to, when known. Manifests written by older versions
+   *  did not record it; it is recovered from the worktree on demand, so an
+   *  empty value here does not prevent `unarchiveWorkspace` from working. */
+  projectPath: string;
+};
+
 /// One dock folder, as `listFolders()` reports it.
 export type FolderSummary = {
   /** Stable folder id — what `moveWorkspace` / `createFolder` take. */
@@ -9640,6 +9930,10 @@ export type DockFilterOptions = {
   worktrees?: boolean;
   /** Show workspaces with no edited files (the "show empty" checkbox). */
   showEmpty?: boolean;
+  /** The modal picker's scope control: `"current"` foregrounds the active
+   *  window's project, `"all"` lists every project. The dock uses `project`
+   *  instead, so this only shows up when the picker is open. */
+  scope?: "current" | "all";
 };
 
 /// Public surface of the bundled `orchestrator` plugin, reachable through
@@ -9656,8 +9950,13 @@ export type OrchestratorApi = {
   /** Launch a coding agent in THIS workspace — the headless twin of the
    *  "Run Agent…" dialog. Resolves once the agent's terminal is up. */
   runAgent(options?: RunAgentOptions): Promise<AgentLaunchResult>;
-  /** Create a workspace (a git worktree by default) and launch a coding agent
-   *  in it — the headless twin of the "New Workspace" dialog.
+  /** Create a workspace and launch a coding agent in it — the headless twin
+   *  of the "New Workspace" dialog, including its backend switch.
+   *
+   *  Omit `backend` (or pass `"local"`) for a workspace on this machine: a
+   *  git worktree by default. Pass `backend: "ssh"` with a `host` for one on
+   *  a remote host, which mirrors the dialog's SSH fields — remote path,
+   *  identity file, and extra ssh arguments.
    *
    *  Unlike the dialog, which returns to the user immediately and reports
    *  progress on the dock, this waits for the create to finish: a caller has no
@@ -9739,6 +10038,27 @@ export type OrchestratorApi = {
    *  Throws if the workspace cannot be deleted, or if the delete fails. */
   deleteWorkspace(target: string | number): Promise<boolean>;
 
+  // ── the archive ────────────────────────────────────────────────────────
+  // Archived workspaces are off the dock entirely: no window, no row, their
+  // worktree moved out to the graveyard. These two are how a caller sees
+  // them and brings one back.
+
+  /** Every archived workspace on this machine, across every repo, newest
+   *  first. */
+  listArchived(): ArchivedWorkspace[];
+  /** Put an archived workspace back where it came from: its worktree returns
+   *  to `originalRoot` and its archive entry is dropped. `target` is the
+   *  `archivedRoot` (or the `name`) that `listArchived()` reports.
+   *
+   *  The workspace comes back as an unopened worktree on the dock rather
+   *  than a running session — the inverse of Archive, not "restore and
+   *  launch". Call `focusWorkspace` after it to open one.
+   *
+   *  Resolves `false` when nothing matches; throws when the restore itself
+   *  fails — most usefully when something already occupies `originalRoot`,
+   *  which it refuses to overwrite. */
+  unarchiveWorkspace(target: string): Promise<boolean>;
+
   // ── dock view state ────────────────────────────────────────────────────
   // Both apply to the dock whether or not it is open: with the dock closed
   // they set what it will show the next time it opens, which is the same
@@ -9772,30 +10092,67 @@ function trimmed(value: string | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+/// The per-agent options in the shape the shared spec builders take. The
+/// gating against what the resolved agent actually supports happens inside
+/// `gateAgentOptions`, so this only has to supply the caller's intent and the
+/// API's defaults (teach on, auto off — the dialog's defaults too).
+function agentOptionsFrom(options: RunAgentOptions): AgentOptionInputs {
+  return {
+    auto: options.auto ?? false,
+    prompt: trimmed(options.prompt),
+    teach: options.teach ?? true,
+  };
+}
+
 async function runAgent(options: RunAgentOptions = {}): Promise<AgentLaunchResult> {
   const cmd = trimmed(options.agent);
-  const entry = agentEntryForCmd(cmd);
-  // Mirror `submitForm`'s current-workspace branch: the per-agent options are
-  // only honoured for an agent whose registry entry supports each, so a bare
-  // terminal never gets stray flags appended.
+  // Same gating and the same launch function as `submitForm`'s
+  // current-workspace branch, so a bare terminal never gets stray flags.
+  const gated = gateAgentOptions(cmd, agentOptionsFrom(options));
   await launchAgentInCurrentWorkspace(cmd, {
-    auto: !!entry?.auto && (options.auto ?? false),
-    prompt: entry?.prompt ? trimmed(options.prompt) : "",
-    teachFreshCli: !!entry?.systemPrompt && (options.teach ?? true),
+    auto: gated.auto,
+    prompt: gated.startPrompt,
+    teachFreshCli: gated.teachFreshCli,
   });
   // The agent runs in the workspace the caller is already in; returning its ids
   // means a caller never has to correlate "which workspace did that land in".
   return currentWorkspaceIds();
 }
 
-async function newWorkspace(
-  options: NewWorkspaceOptions = {},
-): Promise<AgentLaunchResult> {
+/// Build the caller's options into the same `CreateSpec` the dialog submits.
+/// Every field goes through the shared builders — this function only supplies
+/// the API's defaults and the validation the dialog gets from its own widgets
+/// (a path field that completes against the filesystem, a host field that
+/// refuses to submit empty).
+function specForNewWorkspace(options: NewWorkspaceOptions): CreateSpec {
   const cmd = trimmed(options.agent);
-  const entry = agentEntryForCmd(cmd);
+  const name = trimmed(options.name);
+  const agentOptions = agentOptionsFrom(options);
+
+  if (options.backend === "ssh") {
+    const raw = options.sshOptions;
+    const extraArgs = Array.isArray(raw)
+      ? raw.map((a) => String(a).trim()).filter((a) => a !== "")
+      : trimmed(raw)
+        ? trimmed(raw).split(/\s+/)
+        : [];
+    const built = buildSshSpec({
+      ...agentOptions,
+      host: trimmed(options.host),
+      name,
+      cmd,
+      remotePath: trimmed(options.path),
+      identity: trimmed(options.identity),
+      extraArgs,
+    });
+    // The dialog keeps itself open on a bad host and shows the message; a
+    // caller gets the same message as a thrown error.
+    if (!built.ok) throw new Error(built.error);
+    return built.spec;
+  }
+
   const requestedPath = trimmed(options.path);
   const projectPath = requestedPath || localProjectDefault();
-  const name = trimmed(options.name);
   // A path the caller passed has to exist. The dialog's field completes against
   // the filesystem, so a human sees a wrong path immediately; a caller passing
   // `path` by hand does not, and the create would otherwise "succeed" into a
@@ -9803,28 +10160,25 @@ async function newWorkspace(
   if (requestedPath && !editor.fileExists(editor.localPath(requestedPath))) {
     throw new Error(`project path does not exist: ${requestedPath}`);
   }
-  // Local backend only: ssh/kubernetes workspaces need connection details that
-  // deserve their own verb (and their own validation), and a caller asking for
-  // a sibling workspace wants the local case.
-  const spec: CreateSpec = {
-    backend: "local",
+  return buildLocalSpec({
+    ...agentOptions,
     projectPath,
     // "" ⇒ `runLocalCreate` allocates the next `<project>-N` name, the same
     // default the dialog's placeholder shows.
     name,
     cmd,
-    auto: !!entry?.auto && (options.auto ?? false),
-    startPrompt: entry?.prompt ? trimmed(options.prompt) : "",
-    teachFreshCli: !!entry?.systemPrompt && (options.teach ?? true),
     branch: trimmed(options.branch),
     newBranch: trimmed(options.newBranch),
     // Worktree by default (the dialog's default too); `runLocalCreate` demotes
     // it to false on its own when the path isn't a git tree.
     createWorktree: options.worktree ?? true,
-    displayLabel: name || editor.pathBasename(projectPath) ||
-      editor.t("dock.pending_default_name"),
-    displayProject: projectPath,
-  };
+  });
+}
+
+async function newWorkspace(
+  options: NewWorkspaceOptions = {},
+): Promise<AgentLaunchResult> {
+  const spec = specForNewWorkspace(options);
   const pendingId = startPendingWorkspace(spec, { visit: options.visit ?? false });
   const outcome = await awaitCreateOutcome(pendingId);
   if (!outcome.ok) {
@@ -10049,14 +10403,15 @@ function apiStopWorkspace(target: string | number): boolean {
   const s = resolveWorkspace(target);
   if (!s) return false;
   requireEligible(s, "stop");
-  if (!stopOne(s.id)) throw new Error("stop failed");
+  // Same batch runner as the picker's confirmed Stop, over one id.
+  if (runStopBatch([s.id]) === 0) throw new Error("stop failed");
   refreshOpenDialog();
   return true;
 }
 
-/// Archive / delete share everything but which `*One` they call: both check
-/// eligibility, both await the result, both throw on failure, and both fire
-/// the cross-machine manifest sync the picker's confirmed action fires.
+/// Archive / delete over a single workspace, through the same batch runner
+/// the picker's confirmed action uses — so the cross-machine manifest sync,
+/// and anything added to that path later, applies to a scripted archive too.
 async function runLifecycle(
   target: string | number,
   action: "archive" | "delete",
@@ -10064,13 +10419,57 @@ async function runLifecycle(
   const s = resolveWorkspace(target);
   if (!s) return false;
   requireEligible(s, action);
-  const res = action === "archive" ? await archiveOne(s.id) : await deleteOne(s.id);
-  if (!res.ok) {
-    throw new Error(res.err || `${action} failed`);
+  const res = await runLifecycleBatch(action, [s.id]);
+  if (res.ok === 0) {
+    throw new Error(res.lastErr || `${action} failed`);
   }
-  // The manifest changed, so the same background push the confirmed action
-  // triggers has to run here too — otherwise a scripted archive is invisible
-  // on the user's other machines.
+  refreshOpenDialog();
+  return true;
+}
+
+function apiListArchived(): ArchivedWorkspace[] {
+  const out: ArchivedWorkspace[] = [];
+  for (const { manifest } of scanArchiveManifests()) {
+    for (const e of manifest.sessions) {
+      out.push({
+        archivedRoot: e.root,
+        originalRoot: e.original_root,
+        name: e.label,
+        branch: e.branch,
+        archivedAt: e.archived_at,
+        projectPath: e.repo_root ?? "",
+      });
+    }
+  }
+  // Newest first: the one a caller is most likely to want back is the one it
+  // just archived.
+  out.sort((a, b) => (a.archivedAt < b.archivedAt ? 1 : a.archivedAt > b.archivedAt ? -1 : 0));
+  return out;
+}
+
+async function apiUnarchiveWorkspace(target: string): Promise<boolean> {
+  const want = trimmed(target);
+  if (!want) return false;
+  // Match on the archived path first (unique), then the display name, which
+  // is what a human reads off the listing. A name shared by two archived
+  // workspaces resolves to the newest, matching the listing's own order.
+  let match: ArchivedSession | null = null;
+  for (const { manifest } of scanArchiveManifests()) {
+    for (const e of manifest.sessions) {
+      if (e.root === want) {
+        match = e;
+        break;
+      }
+      if (e.label === want && (!match || e.archived_at > match.archived_at)) {
+        match = e;
+      }
+    }
+    if (match && match.root === want) break;
+  }
+  if (!match) return false;
+  const res = await unarchiveOne(match);
+  if (!res.ok) throw new Error(res.err || "unarchive failed");
+  // The manifest changed, so push it the same way the archive path does.
   if (res.repoRoot) triggerSyncAsync(res.repoRoot);
   refreshOpenDialog();
   return true;
@@ -10088,7 +10487,18 @@ function apiSetDockView(view: "card" | "compact"): void {
   refreshOpenDialog();
 }
 
-function apiSetDockFilter(options: DockFilterOptions = {}): void {
+function apiSetDockFilter(
+  options: DockFilterOptions = {},
+  // Internal, and deliberately absent from the published signature: set when
+  // the call comes from the filter box's own `change` event. The box already
+  // holds the text and owns the caret, so the value must not be pushed back
+  // (that would move the caret to the end and make mid-string editing jump).
+  fromWidget?: { cursorByte?: number },
+): void {
+  // The row the user is looking at, so it can be kept highlighted across the
+  // re-filter below. Captured before anything changes.
+  const prevId = openDialog?.filteredIds[openDialog.selectedIndex];
+
   // Each control is written to its remembered module value *and* to the open
   // dialog's live state. The remembered value is what makes this work with
   // the dock closed: the next open seeds from it, so setting a filter ahead
@@ -10097,11 +10507,12 @@ function apiSetDockFilter(options: DockFilterOptions = {}): void {
     const value = options.text;
     if (openDialog) {
       openDialog.filter.value = value;
-      openDialog.filter.cursor = utf8Len(value);
+      openDialog.filter.cursor = fromWidget?.cursorByte ?? utf8Len(value);
       // The filter box is a controlled widget with its own buffer: updating
       // our state only changes what we filter *by*, so the typed text has to
-      // be pushed back explicitly or the list and the box disagree.
-      openPanel?.setValue("filter", value, utf8Len(value));
+      // be pushed back explicitly or the list and the box disagree. Not when
+      // the box is where the value came from — see `fromWidget`.
+      if (!fromWidget) openPanel?.setValue("filter", value, utf8Len(value));
     }
   }
   if (options.project !== undefined) {
@@ -10120,12 +10531,43 @@ function apiSetDockFilter(options: DockFilterOptions = {}): void {
     lastHideTrivial = !options.showEmpty;
     if (openDialog) openDialog.hideTrivial = !options.showEmpty;
   }
+  if (options.scope === "current" || options.scope === "all") {
+    lastOpenScope = options.scope;
+    if (openDialog) openDialog.scope = options.scope;
+  }
+
+  if (openDialog) {
+    openDialog.filteredIds = filterSessions(openDialog.filter.value);
+    // Pruning is deliberately limited to the two *visibility* checkboxes.
+    // A row hidden by the search box or the project menu stays checked on
+    // purpose — `selectedSessions()` counts checked-but-filtered-out rows, so
+    // a bulk action survives narrowing the list to find the next member. A
+    // row hidden by "all worktrees" / "show empty" is a different matter: the
+    // user just said they do not want that class of row at all.
+    if (options.worktrees === false || options.showEmpty === false) {
+      const visible = new Set(openDialog.filteredIds);
+      for (const id of [...openDialog.selectedIds]) {
+        if (!visible.has(id)) openDialog.selectedIds.delete(id);
+      }
+    }
+    // Keep the highlight on the same row when it survived the narrowing.
+    const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
+    openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
+  }
   refreshOpenDialog();
   // A search force-opens every folder so matches aren't buried, and restores
   // the user's expansion set when it clears — the same reconciliation the
   // typed-into filter box runs. `refreshOpenDialog` just rebuilt the tree, so
   // `dockKeys` is current.
   if (dockMode) applyDockExpansion();
+  // Turning "all worktrees" ON re-scans *now* so the rows reflect every
+  // project's on-disk worktrees at this moment — not just whatever the single
+  // scan at dialog-open time happened to catch. Discovery walks every known
+  // project (each open/persisted session's repo, plus the cwd repo), so a
+  // fresh scan here is what makes the toggle show worktrees across all
+  // projects rather than a stale subset. Async; `refreshDiscoveredWorktrees`
+  // re-renders the dialog when the scan lands.
+  if (options.worktrees === true) void refreshDiscoveredWorktrees();
 }
 
 editor.exportPluginApi("orchestrator", {
@@ -10142,6 +10584,8 @@ editor.exportPluginApi("orchestrator", {
   stopWorkspace: apiStopWorkspace,
   archiveWorkspace: (target: string | number) => runLifecycle(target, "archive"),
   deleteWorkspace: (target: string | number) => runLifecycle(target, "delete"),
+  listArchived: apiListArchived,
+  unarchiveWorkspace: apiUnarchiveWorkspace,
   setDockView: apiSetDockView,
   setDockFilter: apiSetDockFilter,
 });
@@ -10547,7 +10991,7 @@ editor.on("widget_event", (e) => {
           return;
         }
         if (e.widget_key === "ctx-delete-folder") {
-          deleteFolder(target.id);
+          apiDeleteFolder(target.id);
           closeDockContextMenuAndRestoreDock();
           return;
         }
@@ -10902,20 +11346,17 @@ editor.on("widget_event", (e) => {
         // search without retyping it. Esc/editor-click still clear, so
         // the one-key escape from a stale filter is unchanged.
         if (!wasDive && openDialog.filter.value !== "") {
-          openDialog.filter.value = "";
-          openDialog.filter.cursor = 0;
           dockFocus = "list";
-          const activeId = editor.activeWindow();
-          const all = filterSessions("");
-          openDialog.filteredIds = all;
-          const activeIdx = all.indexOf(activeId);
+          // Clearing goes through the shared path, which also pushes the
+          // empty value back into the (controlled) text box — without that
+          // the list would show every session while the box still read
+          // "gamma".
+          apiSetDockFilter({ text: "" });
+          // Then override the highlight: leaving the dock lands on the
+          // *active* session, not on whatever row the abandoned search had
+          // highlighted.
+          const activeIdx = openDialog.filteredIds.indexOf(editor.activeWindow());
           openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
-          // The filter input is a controlled widget: clearing our
-          // local state only changes what we *filter by*. The text
-          // box keeps its own buffer until we push the empty value
-          // back, so reset it explicitly — otherwise the list shows
-          // every session while the box still reads "gamma".
-          openPanel?.setValue("filter", "", 0);
           refreshOpenDialog();
         } else {
           // Re-render so the keyboard hints drop off the blurred dock.
@@ -11071,26 +11512,18 @@ editor.on("widget_event", (e) => {
       const value = payload.value;
       const cursor = payload.cursorByte;
       if (typeof value !== "string") return;
-      openDialog.filter.value = value;
-      if (typeof cursor === "number") openDialog.filter.cursor = cursor;
       // Filter change implies the user has moved on from any
       // previous error — clear the banner so it doesn't shadow
-      // the typing experience.
+      // the typing experience. Before the re-render below.
       clearDialogError();
-      // Preserve highlighted session across the filter narrowing
-      // when possible — if the previously selected id is still in
-      // the new filtered set, keep it; otherwise reset to 0.
-      const prevId = openDialog.filteredIds[openDialog.selectedIndex];
-      const next = filterSessions(value);
-      openDialog.filteredIds = next;
-      const nextIdx = prevId !== undefined ? next.indexOf(prevId) : -1;
-      openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
-      refreshOpenDialog();
-      // The tree force-opens every folder while a search is active (so
-      // matches aren't buried) and restores the user's expansion set when
-      // the search clears. `refreshOpenDialog` just rebuilt the tree, so
-      // `dockKeys` is current.
-      if (dockMode) applyDockExpansion();
+      // Same path a script's `setDockFilter({ text })` takes: it re-filters,
+      // preserves the highlighted session where it survives, re-renders and
+      // reconciles the tree's expansion. `fromWidget` keeps the caret where
+      // the user put it instead of snapping it to the end.
+      apiSetDockFilter(
+        { text: value },
+        { cursorByte: typeof cursor === "number" ? cursor : undefined },
+      );
       return;
     }
     // Right-click on a tree node → open its context menu. Only the dock
@@ -11311,13 +11744,11 @@ editor.on("widget_event", (e) => {
       openMoveToFolderForCurrent();
       return;
     }
-    // Dock "view" button → flip card ⇄ compact density and re-render.
+    // Dock "view" button → flip card ⇄ compact density. Routed through the
+    // published verb so the button and a script take the same path (which
+    // also pins the override, so a later re-open doesn't undo the flip).
     if (e.event_type === "activate" && e.widget_key === "view-toggle") {
-      dockView = dockView === "card" ? "compact" : "card";
-      // Pin it for the rest of the session — the configured default only
-      // decides where the dock *starts*.
-      dockViewOverride = dockView;
-      if (openPanel) openPanel.update(buildDockSpec());
+      apiSetDockView(dockView === "card" ? "compact" : "card");
       return;
     }
     // Dock project dropdown: the toolbar button toggles the menu open,

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -9568,10 +9568,29 @@ export type NewWorkspaceOptions = RunAgentOptions & {
 
 /// One workspace, as `listWorkspaces()` reports it.
 export type WorkspaceSummary = {
-  /** Durable identity — survives editor restarts. Record this one. */
+  /** What kind of row this is — the dock lists three, and they are not
+   *  interchangeable:
+   *   * `"live"` — a real workspace with an editor window behind it. The
+   *     only kind with a usable `workspaceId` and a positive `windowId`.
+   *   * `"discovered"` — a worktree found on disk that has never been
+   *     opened. No window yet, so `workspaceId` is `""` and `windowId` is a
+   *     synthetic *negative* placeholder. `focusWorkspace` opens it.
+   *   * `"pending"` — a placeholder for a workspace still being created (or
+   *     one whose create failed and is waiting for a retry). Same synthetic
+   *     ids, and it cannot be renamed, filed, or acted on until it lands.
+   *  Branch on this rather than on the sign of `windowId`. */
+  kind: "live" | "discovered" | "pending";
+  /** Durable identity — survives editor restarts. Record this one. Empty
+   *  for a `discovered` / `pending` row, which has no window yet. */
   workspaceId: string;
-  /** Per-process window id; valid only for this editor run. */
+  /** Per-process window id; valid only for this editor run. Negative for a
+   *  `discovered` / `pending` row (see `kind`). */
   windowId: number;
+  /** `true` for the one workspace the editor is focused on right now. */
+  active: boolean;
+  /** Dock folder this workspace is filed under (`listFolders()` reports the
+   *  set), or `null` when it sits at the top level. */
+  folderId: string | null;
   /** Display name shown on the dock. */
   name: string;
   /** Filesystem root (the worktree, for a worktree workspace). */
@@ -9593,8 +9612,46 @@ export type WorkspaceSummary = {
   backend?: string;
 };
 
+/// One dock folder, as `listFolders()` reports it.
+export type FolderSummary = {
+  /** Stable folder id — what `moveWorkspace` / `createFolder` take. */
+  folderId: string;
+  /** Display name shown on the dock. */
+  name: string;
+  /** Parent folder, or `null` for a top-level one. */
+  parent: string | null;
+  /** Nesting level, 0 for a top-level folder. Reported so a caller can
+   *  render the tree without re-deriving it from `parent`. */
+  depth: number;
+};
+
+/// What the dock is filtering by. Every field is optional; an omitted one is
+/// left as it is, so a caller can flip one control without disturbing the
+/// rest.
+export type DockFilterOptions = {
+  /** The dock's search box. `""` clears it. */
+  text?: string;
+  /** Restrict the dock to one project (a `projectPath` from
+   *  `listWorkspaces()`), or `null` for every project. Not validated — a
+   *  project with no workspaces just lists nothing. */
+  project?: string | null;
+  /** Show on-disk worktrees that have no open workspace (the "all
+   *  worktrees" checkbox). */
+  worktrees?: boolean;
+  /** Show workspaces with no edited files (the "show empty" checkbox). */
+  showEmpty?: boolean;
+};
+
 /// Public surface of the bundled `orchestrator` plugin, reachable through
 /// `editor.getPluginApi("orchestrator")`.
+///
+/// One convention runs through the whole surface: a verb returns `false`
+/// when the thing it was pointed at does not exist (no workspace with that
+/// id, no folder with that id) and *throws* when it does exist but the
+/// operation was refused or failed. So a caller that trusts its ids can
+/// ignore the return value and let a real failure surface as a rejected
+/// promise / thrown error, and a caller that is guessing can branch on the
+/// boolean without wrapping everything in try/catch.
 export type OrchestratorApi = {
   /** Launch a coding agent in THIS workspace — the headless twin of the
    *  "Run Agent…" dialog. Resolves once the agent's terminal is up. */
@@ -9625,6 +9682,73 @@ export type OrchestratorApi = {
    *  Resolves `true` once the workspace is active, `false` if no workspace
    *  matches. */
   focusWorkspace(target: string | number): Promise<boolean>;
+
+  // ── organising the dock ────────────────────────────────────────────────
+  // The headless twins of the dock's row context menu and its "New Task… ▾"
+  // / "Move…" dropdowns. `target` is a `workspaceId` or a `windowId`, the
+  // same pair `focusWorkspace` accepts.
+
+  /** Rename a workspace — the dock's "Rename…". Omit `name` (or pass an
+   *  empty one) to clear the manual name and let the auto-name (the
+   *  terminal's title) or the host label take back over.
+   *
+   *  Throws for a workspace still being created — it has no durable
+   *  identity to hang a name on yet. */
+  renameWorkspace(target: string | number, name?: string): boolean;
+  /** File a workspace under a dock folder — the dock's "Move to Folder…".
+   *  `null` moves it back to the top level.
+   *
+   *  Throws on an unknown `folderId`, and for a workspace still being
+   *  created. */
+  moveWorkspace(target: string | number, folderId: string | null): boolean;
+
+  /** Every dock folder, parents before children, siblings in the order the
+   *  dock shows them. */
+  listFolders(): FolderSummary[];
+  /** Create a dock folder and return its new id. `parent` nests it under an
+   *  existing folder; omitted (or `null`) puts it at the top level.
+   *
+   *  Throws on an empty name or an unknown `parent`. */
+  createFolder(name: string, parent?: string | null): string;
+  /** Rename a dock folder. Throws on an empty name. */
+  renameFolder(folderId: string, name: string): boolean;
+  /** Delete a dock folder. Nothing inside is lost: its child folders and
+   *  member workspaces reparent to its own parent, exactly as the dock's
+   *  "Delete Folder" does. */
+  deleteFolder(folderId: string): boolean;
+
+  // ── lifecycle ──────────────────────────────────────────────────────────
+  // The headless twins of the picker's Stop / Archive / Delete, each with
+  // the same eligibility rules the buttons enforce — an ineligible target
+  // throws rather than quietly doing nothing.
+
+  /** Signal the workspace's agent process group (SIGTERM, then SIGKILL for
+   *  an agent that ignores it) and leave the workspace in place.
+   *
+   *  Throws for a workspace with no agent terminal to signal. */
+  stopWorkspace(target: string | number): boolean;
+  /** Stop the workspace and move its worktree to the archive, recording it
+   *  in the archive manifest so it can be recovered later. Resolves once the
+   *  move has finished.
+   *
+   *  Throws if the workspace cannot be archived, or if the archive fails. */
+  archiveWorkspace(target: string | number): Promise<boolean>;
+  /** Forget the workspace, removing its worktree when it owns one outright.
+   *  Resolves once the removal has finished.
+   *
+   *  Throws if the workspace cannot be deleted, or if the delete fails. */
+  deleteWorkspace(target: string | number): Promise<boolean>;
+
+  // ── dock view state ────────────────────────────────────────────────────
+  // Both apply to the dock whether or not it is open: with the dock closed
+  // they set what it will show the next time it opens, which is the same
+  // thing the in-dock controls do for the rest of the session.
+
+  /** Dock row density: `"card"` (the multi-line pill) or `"compact"` (one
+   *  line per workspace) — the dock's "view" button. */
+  setDockView(view: "card" | "compact"): void;
+  /** Set any of the dock's filter controls. See `DockFilterOptions`. */
+  setDockFilter(options?: DockFilterOptions): void;
 };
 
 declare global {
@@ -9722,12 +9846,22 @@ function listWorkspaces(): WorkspaceSummary[] {
   // folded in, and a caller listing right after creating should see it.
   reconcileSessions();
   const windows = editor.listWindows();
+  const activeId = editor.activeWindow();
   return [...orchestratorSessions.values()].map((session) => {
     const win = windows.find((w) => w.id === session.id);
     const git = session.git?.info;
     return {
+      // The three row kinds the dock lists. A caller used to have to infer
+      // this from a negative `windowId` — a sentinel the type never named.
+      kind: session.pending
+        ? "pending" as const
+        : session.discovered
+          ? "discovered" as const
+          : "live" as const,
       workspaceId: win?.stable_id ?? "",
       windowId: session.id,
+      active: session.id === activeId,
+      folderId: folderOfSession(session.id),
       name: session.label,
       root: session.root,
       projectPath: session.projectPath,
@@ -9758,17 +9892,7 @@ function listWorkspaces(): WorkspaceSummary[] {
 /// there isn't one. That is what `attachToWorktree` does, and doing it behind
 /// one verb means a caller never has to learn the distinction.
 async function focusWorkspace(target: string | number): Promise<boolean> {
-  reconcileSessions();
-  const windows = editor.listWindows();
-
-  // Match on either identity. `workspaceId` (the host's `stable_id`) is the
-  // one worth recording; `windowId` is accepted because it is right there in
-  // the same summary and a caller reaching for it is not wrong to.
-  const match = [...orchestratorSessions.values()].find((session) => {
-    if (typeof target === "number") return session.id === target;
-    const stable = windows.find((w) => w.id === session.id)?.stable_id;
-    return !!target && stable === target;
-  });
+  const match = resolveWorkspace(target);
   if (!match) return false;
 
   if (match.discovered) {
@@ -9789,11 +9913,237 @@ async function focusWorkspace(target: string | number): Promise<boolean> {
   return true;
 }
 
+/// Resolve the `workspaceId | windowId` pair every workspace verb takes to a
+/// live session, or `null` when nothing matches.
+///
+/// Reconciles first for the same reason `listWorkspaces` does: a workspace
+/// created moments ago is only in the model once the host's window list has
+/// been folded in, and a caller acting on an id it was just handed should not
+/// have to sleep first.
+function resolveWorkspace(target: string | number): AgentSession | null {
+  reconcileSessions();
+  // Match on either identity. `workspaceId` (the host's `stable_id`) is the
+  // one worth recording; `windowId` is accepted because it is right there in
+  // the same summary and a caller reaching for it is not wrong to.
+  if (typeof target === "number") return orchestratorSessions.get(target) ?? null;
+  if (!target) return null;
+  const windows = editor.listWindows();
+  for (const session of orchestratorSessions.values()) {
+    const stable = windows.find((w) => w.id === session.id)?.stable_id;
+    if (stable === target) return session;
+  }
+  return null;
+}
+
+/// A workspace still being created has no durable identity and no worktree
+/// yet — the dock offers it Retry / Dismiss and nothing else, so the verbs
+/// that organise a *real* workspace refuse it here rather than writing a name
+/// or a folder assignment against a placeholder key that is about to vanish.
+function rejectPending(s: AgentSession, verb: string): void {
+  if (s.pending) {
+    throw new Error(`workspace is still being created and cannot be ${verb}`);
+  }
+}
+
+/// Push folder-tree changes into an open dock. The tree's expansion set is
+/// host-owned state seeded from the plugin's persisted set, so a folder
+/// created or deleted behind the dock's back has to be re-seeded before the
+/// re-render — the same two steps `submitCreateFolder` runs.
+function refreshDockTree(): void {
+  if (openPanel && dockMode) {
+    openPanel.setExpandedKeys("sessions", Array.from(loadExpanded()));
+  }
+  refreshOpenDialog();
+}
+
+function apiRenameWorkspace(target: string | number, name?: string): boolean {
+  const s = resolveWorkspace(target);
+  if (!s) return false;
+  rejectPending(s, "renamed");
+  // An omitted / empty name clears the manual rename, exactly as submitting
+  // the dialog's emptied-out field does.
+  renameWorkspace(s, typeof name === "string" ? name : "");
+  refreshOpenDialog();
+  return true;
+}
+
+function apiMoveWorkspace(
+  target: string | number,
+  folderId: string | null,
+): boolean {
+  const s = resolveWorkspace(target);
+  if (!s) return false;
+  rejectPending(s, "filed");
+  // An unknown folder id throws rather than silently filing at the top
+  // level: `assignSessionToFolder` would happily record it, and the row
+  // would then read as unfiled because `folderOfSession` drops assignments
+  // to folders that don't exist — a move that reports success and does
+  // nothing is the worst of both.
+  if (folderId !== null && !folderById(folderId)) {
+    throw new Error(`no such folder: ${folderId}`);
+  }
+  assignSessionToFolder(s.id, folderId);
+  refreshDockTree();
+  return true;
+}
+
+function apiListFolders(): FolderSummary[] {
+  const out: FolderSummary[] = [];
+  // Depth-first from the top level, so parents precede their children and
+  // siblings come out in the order `childFoldersOf` gives the dock.
+  const walk = (parent: string | null, depth: number): void => {
+    for (const f of childFoldersOf(parent)) {
+      out.push({ folderId: f.id, name: f.name, parent: f.parent ?? null, depth });
+      walk(f.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  return out;
+}
+
+function apiCreateFolder(name: string, parent?: string | null): string {
+  const clean = trimmed(name);
+  // The dialog falls back to "New Folder" on an empty submit because a human
+  // who typed nothing meant "just make me one". A caller passing an empty
+  // string meant something else — most likely a variable that didn't hold
+  // what they thought — so it is an error rather than a silent default.
+  if (!clean) throw new Error("folder name must not be empty");
+  const parentId = parent ?? null;
+  if (parentId !== null && !folderById(parentId)) {
+    throw new Error(`no such folder: ${parentId}`);
+  }
+  const id = createFolder(clean, parentId);
+  refreshDockTree();
+  return id;
+}
+
+function apiRenameFolder(folderId: string, name: string): boolean {
+  if (!folderById(folderId)) return false;
+  const clean = trimmed(name);
+  if (!clean) throw new Error("folder name must not be empty");
+  renameFolder(folderId, clean);
+  refreshOpenDialog();
+  return true;
+}
+
+function apiDeleteFolder(folderId: string): boolean {
+  if (!folderById(folderId)) return false;
+  // `deleteFolder` reparents the subtree one level up, so nothing inside is
+  // lost — same as the dock's "Delete Folder".
+  deleteFolder(folderId);
+  refreshDockTree();
+  return true;
+}
+
+/// Shared guard for the three lifecycle verbs: the picker disables a button
+/// it cannot honour, and a caller deserves the reason rather than a no-op.
+function requireEligible(s: AgentSession, action: BulkAction): void {
+  if (bulkEligible(action, s.id)) return;
+  if (action === "stop") {
+    throw new Error("workspace has no agent process to stop");
+  }
+  throw new Error(`workspace cannot be ${action === "archive" ? "archived" : "deleted"}`);
+}
+
+function apiStopWorkspace(target: string | number): boolean {
+  const s = resolveWorkspace(target);
+  if (!s) return false;
+  requireEligible(s, "stop");
+  if (!stopOne(s.id)) throw new Error("stop failed");
+  refreshOpenDialog();
+  return true;
+}
+
+/// Archive / delete share everything but which `*One` they call: both check
+/// eligibility, both await the result, both throw on failure, and both fire
+/// the cross-machine manifest sync the picker's confirmed action fires.
+async function runLifecycle(
+  target: string | number,
+  action: "archive" | "delete",
+): Promise<boolean> {
+  const s = resolveWorkspace(target);
+  if (!s) return false;
+  requireEligible(s, action);
+  const res = action === "archive" ? await archiveOne(s.id) : await deleteOne(s.id);
+  if (!res.ok) {
+    throw new Error(res.err || `${action} failed`);
+  }
+  // The manifest changed, so the same background push the confirmed action
+  // triggers has to run here too — otherwise a scripted archive is invisible
+  // on the user's other machines.
+  if (res.repoRoot) triggerSyncAsync(res.repoRoot);
+  refreshOpenDialog();
+  return true;
+}
+
+function apiSetDockView(view: "card" | "compact"): void {
+  if (view !== "card" && view !== "compact") {
+    throw new Error(`unknown dock view: ${view}`);
+  }
+  dockView = view;
+  // Pin it for the rest of the session, exactly as the toolbar's "view"
+  // button does — the `defaultView` setting only decides where the dock
+  // *starts*, so without the override a later re-open would undo this.
+  dockViewOverride = view;
+  refreshOpenDialog();
+}
+
+function apiSetDockFilter(options: DockFilterOptions = {}): void {
+  // Each control is written to its remembered module value *and* to the open
+  // dialog's live state. The remembered value is what makes this work with
+  // the dock closed: the next open seeds from it, so setting a filter ahead
+  // of opening the dock does what a caller expects instead of nothing.
+  if (typeof options.text === "string") {
+    const value = options.text;
+    if (openDialog) {
+      openDialog.filter.value = value;
+      openDialog.filter.cursor = utf8Len(value);
+      // The filter box is a controlled widget with its own buffer: updating
+      // our state only changes what we filter *by*, so the typed text has to
+      // be pushed back explicitly or the list and the box disagree.
+      openPanel?.setValue("filter", value, utf8Len(value));
+    }
+  }
+  if (options.project !== undefined) {
+    const key = options.project ?? "";
+    lastDockProjectFilter = key === "" ? null : key;
+    // `pickProject` re-filters, closes any open dropdown and re-renders; it
+    // is a no-op with the dialog closed, which the remembered value covers.
+    if (openDialog) pickProject(key);
+  }
+  if (typeof options.worktrees === "boolean") {
+    lastShowWorktrees = options.worktrees;
+    if (openDialog) openDialog.showWorktrees = options.worktrees;
+  }
+  if (typeof options.showEmpty === "boolean") {
+    // The stored flag is the inverse of the user-facing checkbox.
+    lastHideTrivial = !options.showEmpty;
+    if (openDialog) openDialog.hideTrivial = !options.showEmpty;
+  }
+  refreshOpenDialog();
+  // A search force-opens every folder so matches aren't buried, and restores
+  // the user's expansion set when it clears — the same reconciliation the
+  // typed-into filter box runs. `refreshOpenDialog` just rebuilt the tree, so
+  // `dockKeys` is current.
+  if (dockMode) applyDockExpansion();
+}
+
 editor.exportPluginApi("orchestrator", {
   runAgent,
   newWorkspace,
   listWorkspaces,
   focusWorkspace,
+  renameWorkspace: apiRenameWorkspace,
+  moveWorkspace: apiMoveWorkspace,
+  listFolders: apiListFolders,
+  createFolder: apiCreateFolder,
+  renameFolder: apiRenameFolder,
+  deleteFolder: apiDeleteFolder,
+  stopWorkspace: apiStopWorkspace,
+  archiveWorkspace: (target: string | number) => runLifecycle(target, "archive"),
+  deleteWorkspace: (target: string | number) => runLifecycle(target, "delete"),
+  setDockView: apiSetDockView,
+  setDockFilter: apiSetDockFilter,
 });
 
 // Form key bindings — each delegates to smart-key dispatch on the

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -10092,6 +10092,24 @@ function trimmed(value: string | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+/// Yield once, so the caller's `await` is attached before anything below can
+/// throw.
+///
+/// An `async` function that throws before its first `await` returns an
+/// *already-rejected* promise. The runtime's rejection tracker fires the
+/// moment a promise rejects with no handler attached — which is one tick
+/// before the caller's `await` can attach one — so a validation failure the
+/// caller catches perfectly well still gets reported as an unhandled
+/// rejection, and under the plugin test harness
+/// (`set_panic_on_js_errors(true)`) that kills the plugin thread. Yielding
+/// first makes the returned promise *pending*, so the rejection lands on a
+/// promise someone is already watching.
+///
+/// Every async verb that can reject on its arguments starts with this.
+function yieldToCaller(): Promise<void> {
+  return Promise.resolve();
+}
+
 /// The per-agent options in the shape the shared spec builders take. The
 /// gating against what the resolved agent actually supports happens inside
 /// `gateAgentOptions`, so this only has to supply the caller's intent and the
@@ -10178,6 +10196,8 @@ function specForNewWorkspace(options: NewWorkspaceOptions): CreateSpec {
 async function newWorkspace(
   options: NewWorkspaceOptions = {},
 ): Promise<AgentLaunchResult> {
+  // Before `specForNewWorkspace`, which rejects a bad host / missing path.
+  await yieldToCaller();
   const spec = specForNewWorkspace(options);
   const pendingId = startPendingWorkspace(spec, { visit: options.visit ?? false });
   const outcome = await awaitCreateOutcome(pendingId);
@@ -10416,6 +10436,8 @@ async function runLifecycle(
   target: string | number,
   action: "archive" | "delete",
 ): Promise<boolean> {
+  // Before `requireEligible`, which rejects an ineligible workspace.
+  await yieldToCaller();
   const s = resolveWorkspace(target);
   if (!s) return false;
   requireEligible(s, action);

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -55,6 +55,7 @@ pub mod orchestrator_attach_worktree;
 pub mod orchestrator_new_dialog;
 pub mod orchestrator_new_session_renders;
 pub mod orchestrator_open_cross_project;
+pub mod orchestrator_plugin_api;
 pub mod package_manager;
 pub mod plugin;
 pub mod plugin_authoring;

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
@@ -430,8 +430,17 @@ fn unarchiving_something_not_archived_returns_false() {
 /// An SSH create with no host is refused with the dialog's own message, and
 /// nothing is spawned. The API and the form reach the same validation because
 /// they build the spec with the same function.
+///
+/// The refusal must also leave the plugin host alive. An `async` verb that
+/// throws before its first `await` returns an already-rejected promise, and
+/// the runtime reports that as an unhandled rejection *even though the caller
+/// catches it* — the tracker fires a tick before `await` attaches a handler.
+/// Under this harness (`set_panic_on_js_errors`) that kills the plugin thread,
+/// so the last step here drives a second command through the plugin and waits
+/// for its answer: if the refusal had poisoned the host, nothing would come
+/// back.
 #[test]
-fn an_ssh_create_without_a_host_is_refused_with_the_dialogs_message() {
+fn an_ssh_create_without_a_host_is_refused_without_killing_the_plugin_host() {
     let (_tmp, mut h) = harness();
     open_dock(&mut h);
 
@@ -449,4 +458,9 @@ fn an_ssh_create_without_a_host_is_refused_with_the_dialogs_message() {
         !dock_column(&screen).contains("ssh:"),
         "a refused ssh create still added a dock row:\n{screen}"
     );
+
+    // The plugin still answers.
+    run_command(&mut h, "Probe List Archived");
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_ARCHIVED"))
+        .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
@@ -113,6 +113,35 @@ registerHandler("probe_unknown_folder", function () {
     }
 });
 
+// The archive starts empty and stays readable — a caller can ask before
+// anything has ever been archived without special-casing the answer.
+registerHandler("probe_list_archived", function () {
+    const rows = orch().listArchived();
+    report("PROBE_ARCHIVED " + rows.length);
+});
+
+// Unarchiving something that was never archived is a `false`, not a throw.
+registerHandler("probe_unarchive_missing", async function () {
+    try {
+        const ok = await orch().unarchiveWorkspace("never-archived");
+        report(ok ? "PROBE_UNARCH_TRUE" : "PROBE_UNARCH_FALSE");
+    } catch (e: any) {
+        report("PROBE_UNARCH_THREW " + e.message);
+    }
+});
+
+// An SSH create with no host is refused before anything is spawned — the
+// dialog keeps itself open on the same condition. Proves the API reaches
+// the shared spec builder's validation rather than a copy of it.
+registerHandler("probe_ssh_no_host", async function () {
+    try {
+        await orch().newWorkspace({ backend: "ssh", host: "" });
+        report("PROBE_SSH_RAN");
+    } catch (e: any) {
+        report("PROBE_SSH_REFUSED " + e.message);
+    }
+});
+
 editor.registerCommand("Probe File Under Folder", "", "probe_file_under_folder", null);
 editor.registerCommand("Probe Rename Workspace", "", "probe_rename", null);
 editor.registerCommand("Probe List Folders", "", "probe_list_folders", null);
@@ -121,6 +150,9 @@ editor.registerCommand("Probe Filter Text", "", "probe_filter_text", null);
 editor.registerCommand("Probe Stop Workspace", "", "probe_stop", null);
 editor.registerCommand("Probe Unknown Target", "", "probe_unknown_target", null);
 editor.registerCommand("Probe Unknown Folder", "", "probe_unknown_folder", null);
+editor.registerCommand("Probe List Archived", "", "probe_list_archived", null);
+editor.registerCommand("Probe Unarchive Missing", "", "probe_unarchive_missing", null);
+editor.registerCommand("Probe Ssh No Host", "", "probe_ssh_no_host", null);
 "#;
 
 /// A git project with the orchestrator plugin and the API probe installed.
@@ -363,4 +395,58 @@ fn an_unknown_folder_id_throws_instead_of_filing_at_top_level() {
         .unwrap();
     h.assert_screen_contains("PROBE_FOLDER_REFUSED");
     h.assert_screen_contains("no such folder");
+}
+
+/// `listArchived` answers on a machine that has never archived anything —
+/// it walks the per-repo manifest directory, and a missing directory is an
+/// empty archive, not a failure.
+#[test]
+fn list_archived_reports_an_empty_archive_rather_than_failing() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe List Archived");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_ARCHIVED"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_ARCHIVED 0");
+}
+
+/// Unarchiving a name that is not in the archive returns `false` — the same
+/// "the thing does not exist" convention the workspace verbs follow, rather
+/// than an exception a caller has to distinguish from a real restore failure.
+#[test]
+fn unarchiving_something_not_archived_returns_false() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe Unarchive Missing");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_UNARCH_"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_UNARCH_FALSE");
+}
+
+/// An SSH create with no host is refused with the dialog's own message, and
+/// nothing is spawned. The API and the form reach the same validation because
+/// they build the spec with the same function.
+#[test]
+fn an_ssh_create_without_a_host_is_refused_with_the_dialogs_message() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe Ssh No Host");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_SSH_"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_SSH_REFUSED");
+    // The dialog's own localized string for the same condition.
+    h.assert_screen_contains("a host is required");
+    // No pending row appeared on the dock: the refusal happened before any
+    // connect was started.
+    let screen = h.screen_to_string();
+    assert!(
+        !dock_column(&screen).contains("ssh:"),
+        "a refused ssh create still added a dock row:\n{screen}"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs
@@ -1,0 +1,366 @@
+//! E2E coverage for the Orchestrator's *plugin API* — the surface a script
+//! (or another plugin) reaches through `editor.getPluginApi("orchestrator")`.
+//!
+//! The API used to publish only the two create dialogs plus "focus a
+//! workspace", so everything a user does *after* a workspace exists — rename
+//! it, file it under a folder, change what the dock shows, act on its
+//! lifecycle — was reachable from the dock's menus and from nowhere else.
+//! These tests pin the verbs that closed that gap.
+//!
+//! Per CONTRIBUTING.md §2 they drive keyboard/mouse only and assert on
+//! rendered output: a probe plugin registers one command per scenario, the
+//! command is run from the palette, and the assertion is what the dock (or
+//! the status line) then shows.
+
+#![cfg(feature = "plugins")]
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::path::PathBuf;
+
+/// A probe plugin: one palette command per API verb under test.
+///
+/// Results are written into the open buffer rather than the status bar,
+/// because the status segment truncates to about twenty columns and the
+/// interesting part of a folder listing or a refusal message is past that.
+/// The buffer renders at the editor's full width beside the dock.
+///
+/// Every command resolves its target the way a real caller would — through
+/// `listWorkspaces()`, picking the row it marks `active` — so the summary
+/// fields are exercised alongside the verbs.
+const PROBE_PLUGIN: &str = r#"
+const editor = getEditor();
+
+function orch(): any {
+    return editor.getPluginApi("orchestrator");
+}
+
+// The workspace the editor is focused on, as `listWorkspaces()` reports it.
+function me(): any {
+    return orch().listWorkspaces().find((w: any) => w.active);
+}
+
+// Report a result where a screen assertion can read all of it.
+function report(msg: string): void {
+    const id = editor.getActiveBufferId();
+    if (id !== null && id !== undefined) editor.insertText(id, 0, msg);
+}
+
+registerHandler("probe_file_under_folder", function () {
+    const o = orch();
+    const id = o.createFolder("Reviews");
+    o.moveWorkspace(me().workspaceId, id);
+    report("PROBE_FILED " + id);
+});
+
+registerHandler("probe_rename", function () {
+    orch().renameWorkspace(me().windowId, "RenamedByScript");
+    report("PROBE_RENAMED");
+});
+
+registerHandler("probe_list_folders", function () {
+    const o = orch();
+    const outer = o.createFolder("Outer");
+    o.createFolder("Inner", outer);
+    const shown = o.listFolders()
+        .map(function (f: any) { return f.depth + "-" + f.name; })
+        .join("/");
+    report("PROBE_FOLDERS " + shown);
+});
+
+registerHandler("probe_compact", function () {
+    orch().setDockView("compact");
+    report("PROBE_COMPACT");
+});
+
+registerHandler("probe_filter_text", function () {
+    orch().setDockFilter({ text: "zzzznomatch" });
+    report("PROBE_FILTERED");
+});
+
+// The launch workspace has no agent terminal, so Stop is refused. The
+// picker greys the button out; a caller gets the reason instead.
+registerHandler("probe_stop", function () {
+    try {
+        orch().stopWorkspace(me().windowId);
+        report("PROBE_STOP_RAN");
+    } catch (e: any) {
+        report("PROBE_STOP_REFUSED " + e.message);
+    }
+});
+
+// An id that matches nothing is a `false`, not a throw — the convention the
+// whole surface follows so a caller that is guessing can branch.
+registerHandler("probe_unknown_target", function () {
+    const o = orch();
+    try {
+        const ok = o.renameWorkspace("ws-does-not-exist", "nope");
+        report(ok ? "PROBE_UNKNOWN_TRUE" : "PROBE_UNKNOWN_FALSE");
+    } catch (e: any) {
+        report("PROBE_UNKNOWN_THREW");
+    }
+});
+
+// An unknown *folder* is the other half of the convention: the workspace
+// exists, so the refusal is an error rather than a silent top-level filing.
+registerHandler("probe_unknown_folder", function () {
+    try {
+        orch().moveWorkspace(me().windowId, "df-nope");
+        report("PROBE_FOLDER_RAN");
+    } catch (e: any) {
+        report("PROBE_FOLDER_REFUSED " + e.message);
+    }
+});
+
+editor.registerCommand("Probe File Under Folder", "", "probe_file_under_folder", null);
+editor.registerCommand("Probe Rename Workspace", "", "probe_rename", null);
+editor.registerCommand("Probe List Folders", "", "probe_list_folders", null);
+editor.registerCommand("Probe Compact View", "", "probe_compact", null);
+editor.registerCommand("Probe Filter Text", "", "probe_filter_text", null);
+editor.registerCommand("Probe Stop Workspace", "", "probe_stop", null);
+editor.registerCommand("Probe Unknown Target", "", "probe_unknown_target", null);
+editor.registerCommand("Probe Unknown Folder", "", "probe_unknown_folder", null);
+"#;
+
+/// A git project with the orchestrator plugin and the API probe installed.
+fn setup_project() -> (tempfile::TempDir, PathBuf) {
+    fresh::i18n::set_locale("en");
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let root = temp_dir.path().join("alphaproj");
+    fs::create_dir(&root).unwrap();
+    let plugins_dir = root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+    fs::write(plugins_dir.join("api_probe.ts"), PROBE_PLUGIN).unwrap();
+    fs::write(root.join("readme.txt"), "hello\n").unwrap();
+    let ok = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&root)
+        .status()
+        .unwrap()
+        .success();
+    assert!(ok);
+    (temp_dir, root)
+}
+
+fn harness() -> (tempfile::TempDir, EditorTestHarness) {
+    let (tmp, root) = setup_project();
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root).unwrap();
+    h.render().unwrap();
+    (tmp, h)
+}
+
+/// Toggle the dock open and wait for it to render *and* take keyboard focus
+/// (the plugin sets focus asynchronously after the mount, so a key dispatched
+/// on render alone can land before the dock is listening).
+fn open_dock(h: &mut EditorTestHarness) {
+    run_command(h, "Orchestrator: Toggle Dock");
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator") && h.editor().is_dock_focused())
+        .unwrap();
+}
+
+/// Run a command by its palette name.
+fn run_command(h: &mut EditorTestHarness, name: &str) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text(name).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains(name))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+}
+
+/// The dock's own columns of the screen. The editor beside it carries the
+/// project name in its own chrome, so any "the dock does / does not list X"
+/// assertion has to be scoped to the dock's column or it reads the editor's
+/// tab bar by accident. 32 is inside the dock at this harness width (the
+/// responsive default lands at 34 for a 120-column terminal).
+fn dock_column(screen: &str) -> String {
+    screen
+        .lines()
+        .map(|l| l.chars().take(32).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Expand the dock's collapsible "Filters" section, which holds the density
+/// button and the two checkboxes.
+fn expand_filters(h: &mut EditorTestHarness) {
+    let screen = h.screen_to_string();
+    let frow = screen
+        .lines()
+        .position(|l| l.contains("Filters"))
+        .unwrap_or_else(|| panic!("screen missing 'Filters':\n{screen}")) as u16;
+    h.mouse_click(3, frow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Manage"))
+        .unwrap();
+}
+
+/// `createFolder` + `moveWorkspace` put the workspace under the folder on the
+/// dock — the headless twin of "New Folder…" plus "Move to Folder…".
+#[test]
+fn create_folder_and_move_workspace_files_the_row_on_the_dock() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+    // The workspace starts at the top level: no folder on the dock at all.
+    h.assert_screen_contains("alphaproj");
+    h.assert_screen_not_contains("Reviews");
+
+    run_command(&mut h, "Probe File Under Folder");
+
+    // The folder now renders, and the workspace renders underneath it rather
+    // than at the top level.
+    h.wait_until(|h| h.screen_to_string().contains("Reviews"))
+        .unwrap();
+    let screen = h.screen_to_string();
+    let dock = dock_column(&screen);
+    let folder_row = dock
+        .lines()
+        .position(|l| l.contains("Reviews"))
+        .unwrap_or_else(|| panic!("dock missing 'Reviews':\n{screen}"));
+    let ws_row = dock
+        .lines()
+        .skip(folder_row + 1)
+        .position(|l| l.contains("alphaproj"))
+        .unwrap_or_else(|| panic!("workspace never rendered below its folder:\n{screen}"));
+    // A card is a bordered three-line pill, so "directly under" is a few
+    // rows, not one — but it is nowhere near the whole dock.
+    assert!(
+        ws_row < 6,
+        "workspace should sit just under its folder, not {ws_row} rows below:\n{screen}"
+    );
+    // Nothing is left at the top level above the folder.
+    assert!(
+        !dock
+            .lines()
+            .take(folder_row)
+            .any(|l| l.contains("alphaproj")),
+        "workspace still listed above its folder:\n{screen}"
+    );
+}
+
+/// `renameWorkspace` relabels the row — the headless twin of "Rename…".
+#[test]
+fn rename_workspace_relabels_the_row_on_the_dock() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+    h.assert_screen_contains("alphaproj");
+    h.assert_screen_not_contains("RenamedByScript");
+
+    run_command(&mut h, "Probe Rename Workspace");
+
+    h.wait_until(|h| h.screen_to_string().contains("RenamedByScript"))
+        .unwrap();
+}
+
+/// `listFolders` reports what the dock shows, parents before children, with
+/// the nesting depth a caller needs to render the tree.
+#[test]
+fn list_folders_reports_the_tree_the_dock_renders() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe List Folders");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_FOLDERS"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_FOLDERS 0-Outer/1-Inner");
+    // ...and both really are on the dock.
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("Outer") && s.contains("Inner")
+    })
+    .unwrap();
+}
+
+/// `setDockView` flips the density the dock's own "view" button flips.
+#[test]
+fn set_dock_view_switches_the_dock_to_compact() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+    expand_filters(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("view: card"))
+        .unwrap();
+
+    run_command(&mut h, "Probe Compact View");
+
+    h.wait_until(|h| h.screen_to_string().contains("view: compact"))
+        .unwrap();
+    h.assert_screen_not_contains("view: card");
+}
+
+/// `setDockFilter` drives the dock's search box: a needle nothing matches
+/// empties the list, and the box shows the needle that did it.
+#[test]
+fn set_dock_filter_narrows_the_dock_list() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+    h.assert_screen_contains("alphaproj");
+
+    run_command(&mut h, "Probe Filter Text");
+
+    h.wait_until(|h| h.screen_to_string().contains("zzzznomatch"))
+        .unwrap();
+    let screen = h.screen_to_string();
+    // The dock column is the leading ~32 cells of each row; the editor to its
+    // right still has the project name in its own chrome, so scope the
+    // "no workspace listed" assertion to the dock's own columns.
+    let dock: String = screen
+        .lines()
+        .map(|l| l.chars().take(32).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !dock.contains("alphaproj"),
+        "filtered-out workspace still listed on the dock:\n{screen}"
+    );
+}
+
+/// Stop is refused for a workspace with no agent process, with the reason —
+/// the picker greys the button out, a caller gets an error it can read.
+#[test]
+fn stop_workspace_refuses_a_workspace_with_no_agent() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe Stop Workspace");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_STOP_"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_STOP_REFUSED");
+    h.assert_screen_contains("no agent process to stop");
+}
+
+/// An id that matches no workspace returns `false` rather than throwing —
+/// the convention that lets a caller branch without try/catch.
+#[test]
+fn an_unknown_workspace_id_returns_false_instead_of_throwing() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe Unknown Target");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_UNKNOWN_"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_UNKNOWN_FALSE");
+}
+
+/// An unknown folder id is the other half of that convention: the workspace
+/// exists, so a move that cannot be honoured throws instead of quietly
+/// filing the row at the top level.
+#[test]
+fn an_unknown_folder_id_throws_instead_of_filing_at_top_level() {
+    let (_tmp, mut h) = harness();
+    open_dock(&mut h);
+
+    run_command(&mut h, "Probe Unknown Folder");
+
+    h.wait_until(|h| h.screen_to_string().contains("PROBE_FOLDER_"))
+        .unwrap();
+    h.assert_screen_contains("PROBE_FOLDER_REFUSED");
+    h.assert_screen_contains("no such folder");
+}

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -132,9 +132,39 @@ echo '
 ' | fresh --cmd script run
 ```
 
-`renameWorkspace`, `moveWorkspace`, the four folder verbs (`listFolders`, `createFolder`, `renameFolder`, `deleteFolder`), the lifecycle three (`stopWorkspace`, `archiveWorkspace`, `deleteWorkspace`) and the dock's own view controls (`setDockView`, `setDockFilter`) are all the headless twins of controls on the dock — same code path, same rules. A verb returns `false` when the thing it was pointed at does not exist, and throws when it exists but the operation was refused, so an agent that finished with a workspace can archive it and know whether it worked.
+`renameWorkspace`, `moveWorkspace`, the four folder verbs (`listFolders`, `createFolder`, `renameFolder`, `deleteFolder`), the lifecycle three (`stopWorkspace`, `archiveWorkspace`, `deleteWorkspace`) and the dock's own view controls (`setDockView`, `setDockFilter`) are all the headless twins of controls on the dock. Not lookalikes — the menu item and the script call run the same function, so a rule about what may be archived, or a fix to how a folder is deleted, lands in both at once. A verb returns `false` when the thing it was pointed at does not exist, and throws when it exists but the operation was refused, so an agent that finished with a workspace can archive it and know whether it worked.
 
-The one part of the dock that is not published is creating a workspace on a remote backend — SSH and Kubernetes need connection details that deserve their own verb, so `newWorkspace` is local-only.
+### Bring one back
+
+Archiving a workspace does not destroy it: the worktree moves to a graveyard and the entry is recorded, so it can come back later — on this machine or another one.
+
+```sh
+echo '
+  const orch = editor.getPluginApi("orchestrator");
+  return orch.listArchived().map(a => `${a.name}  ${a.branch}  ${a.archivedAt}`);
+' | fresh --cmd script run
+```
+
+`unarchiveWorkspace(name)` puts one back where it came from. It returns as an unopened worktree on the dock rather than a running session — the inverse of Archive, not "restore and launch" — so follow it with `focusWorkspace` when you want it open. It refuses rather than overwrites if something has since taken the path it wants back.
+
+### Start a workspace on another machine
+
+`newWorkspace` takes the same backend switch the dialog does:
+
+```sh
+echo '
+  return editor.getPluginApi("orchestrator").newWorkspace({
+    backend: "ssh",
+    host: "build@ci-01:2222",
+    path: "/srv/checkout",
+    identity: "~/.ssh/ci",
+    sshOptions: "-J bastion",
+    agent: "claude",
+  })
+' | fresh --cmd script run
+```
+
+Every field mirrors the dialog's SSH form. Kubernetes is the one backend still dialog-only.
 
 ## Finding your way around
 

--- a/docs/features/scripting.md
+++ b/docs/features/scripting.md
@@ -115,7 +115,26 @@ echo 'return editor.getPluginApi("orchestrator").newWorkspace({ agent: "claude",
 {"workspaceId":"ws-18c8fc1278905b84-6","windowId":7,"root":"…/orchestrator/fresh-2"}
 ```
 
-That is a git worktree, a window, and an agent running in it — one line, and it resolves once the workspace is actually up. Plugins publish their surfaces this way, so anything the editor's own dialogs can do is reachable from a script.
+That is a git worktree, a window, and an agent running in it — one line, and it resolves once the workspace is actually up.
+
+### Tidy up after yourself
+
+Creating a workspace is the interesting half; what you do with it afterwards is the other. The dock's own menus are published too, so a script can name a workspace, file it, and eventually clear it away:
+
+```sh
+echo '
+  const orch = editor.getPluginApi("orchestrator");
+  const reviews = orch.listFolders().find(f => f.name === "Reviews")?.folderId
+    ?? orch.createFolder("Reviews");
+  const ws = orch.listWorkspaces().find(w => w.active);
+  orch.renameWorkspace(ws.workspaceId, "flaky-test #4192");
+  orch.moveWorkspace(ws.workspaceId, reviews);
+' | fresh --cmd script run
+```
+
+`renameWorkspace`, `moveWorkspace`, the four folder verbs (`listFolders`, `createFolder`, `renameFolder`, `deleteFolder`), the lifecycle three (`stopWorkspace`, `archiveWorkspace`, `deleteWorkspace`) and the dock's own view controls (`setDockView`, `setDockFilter`) are all the headless twins of controls on the dock — same code path, same rules. A verb returns `false` when the thing it was pointed at does not exist, and throws when it exists but the operation was refused, so an agent that finished with a workspace can archive it and know whether it worked.
+
+The one part of the dock that is not published is creating a workspace on a remote backend — SSH and Kubernetes need connection details that deserve their own verb, so `newWorkspace` is local-only.
 
 ## Finding your way around
 


### PR DESCRIPTION
## Why

A review of `editor.getPluginApi("orchestrator")` against the dock's actual user-facing operations turned up a wide gap. The API published four verbs — `runAgent`, `newWorkspace`, `listWorkspaces`, `focusWorkspace` — which covers the two create dialogs and Visit, and nothing else. Everything a user does to a workspace *after* it exists was reachable from the dock's menus and from nowhere else.

`docs/features/scripting.md` also claimed "anything the editor's own dialogs can do is reachable from a script", which was not true for this plugin.

## What changed

### 1. The missing verbs

| Group | Verbs |
|---|---|
| Organisation | `renameWorkspace`, `moveWorkspace`, `listFolders`, `createFolder`, `renameFolder`, `deleteFolder` |
| Lifecycle | `stopWorkspace`, `archiveWorkspace`, `deleteWorkspace` |
| Archive | `listArchived`, `unarchiveWorkspace` |
| Dock state | `setDockView`, `setDockFilter` |

`newWorkspace` also gains the dialog's **backend switch**: `backend: "ssh"` with `host`, `path`, `identity` and `sshOptions`, mirroring the SSH form field-for-field. Kubernetes stays dialog-only.

**Read side** — `WorkspaceSummary` gains `kind`, `active` and `folderId`. `kind` (`"live" | "discovered" | "pending"`) retires the worst wart: a discovered-on-disk or still-being-created row was distinguishable from a real workspace only by the **sign of its `windowId`**, a sentinel the type never named.

### 2. One implementation per operation

This is the part that makes the rest honest. `newWorkspace` had drifted into a second copy of the form's local branch — same defaults, same agent-option gating, same spec fields, assembled independently.

- **Spec construction** is now three builders taking plain values. `captureCreateSpec` does nothing but read form fields and hand them over; the API calls the same builders. So the SSH backend the API gains *is* the dialog's SSH backend, down to the host parsing and the "a host is required" message.
- **Each existing entry point now routes through the published verb** rather than touching the stores: the folder dialog's submit, the "Move to folder…" dropdown, the folder context menu's Delete, the dock's "view" button, both Filters checkboxes, the picker's scope toggle, the search box's `change`, and the blur-clears-the-search path.
- **Stop / Archive / Delete share a batch runner** with the picker's confirmed action — so a scripted archive gets the cross-machine manifest push that previously lived only in the confirm path.

Two behaviours are deliberately **not** unified, and are commented where they diverge:
- the bulk selection survives a search or project change but is pruned by the two visibility checkboxes (a hidden-by-search row is still a member; a hidden-by-"show empty" row is not);
- the filter box's own `change` keeps the caret where the user put it instead of snapping it to the end.

### 3. A latent bug this surfaced

The remote create worker never called `settleCreateOutcome` on success. Harmless while `newWorkspace` was local-only; the moment a caller can await an SSH create, it would have hung forever. It now settles from the born window the attach dove into.

### Archive details

Manifest entries record `repo_root`. The manifests live under a one-way slug of the repo root, so a reader that finds one by scanning the data directory cannot otherwise name the repo — which `git worktree move` needs to put the worktree back. Older entries recover it from the archived worktree itself.

Unarchiving returns the workspace as an **unopened worktree**, not a running session — the inverse of Archive, not "restore and launch" — and refuses rather than clobbers when something has taken the original path back.

## Convention

`false` when the thing pointed at does not exist; a throw when it exists but the operation was refused or failed. A caller that trusts its ids can let failures surface; one that is guessing can branch without try/catch.

## Testing

`crates/fresh-editor/tests/e2e/plugins/orchestrator_plugin_api.rs` — 11 tests, all passing. Per CONTRIBUTING.md §2 they drive the palette/mouse only and assert on rendered output: a probe plugin registers one command per scenario, and the assertion is what the dock (or the buffer beside it) then shows.

Several pin the error convention rather than a happy path, since that is what a caller has to trust. The SSH test asserts the refusal carries the *dialog's own* localized message and that no dock row appears — the observable proof that the API reaches the shared validation rather than a copy of it.

Regression runs after the refactor, since it touches paths the dialog and dock use:

- `cargo test --test e2e_tests orchestrator` — **144 passed, 0 failed**
- `cargo test --test e2e_tests -- dock workspace sessions` — **228 passed, 0 failed**
- `cargo clippy -p fresh-editor --all-targets` — exit 0, nothing in the new file
- `cargo fmt` clean
- plugin type check: error set byte-identical to the pre-change baseline (the 13 that remain are pre-existing, from a stale checked-in `fresh.d.ts`)

Nothing needed regenerating per §6: `fresh.d.ts` and `config-schema.json` derive from Rust types this PR does not touch, and the orchestrator's own declarations are emitted into `plugins.d.ts` at load time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176BdCFBC9BYrCmqXng8ugq