### PR TITLE
Four small fixes: bun.lock JSONC highlighting, TS 7 tsconfigs, Ctrl+H docs, Rust LSP command name

### DIFF
--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -4600,6 +4600,9 @@ impl Config {
                     "launch.json".to_string(),
                     "extensions.json".to_string(),
                     "argv.json".to_string(),
+                    // Bun's text lockfile is JSONC (trailing commas), not
+                    // strict JSON (#2921).
+                    "bun.lock".to_string(),
                 ],
                 grammar: "jsonc".to_string(),
                 comment_prefix: Some("//".to_string()),
@@ -9428,6 +9431,25 @@ mod tests {
                  Add a LanguageConfig with the correct file extensions so detect_language() \
                  can map files to this language.",
                 lsp_key
+            );
+        }
+    }
+
+    /// Well-known JSONC filenames must route to the `jsonc` language so
+    /// they get JSON highlighting instead of falling through to plain
+    /// text. Regression test for #2921: `bun.lock` is JSONC (trailing
+    /// commas) but no default language claimed it.
+    #[test]
+    fn test_default_languages_map_jsonc_filenames() {
+        use crate::services::lsp::manager::detect_language;
+        use std::path::Path;
+
+        let languages = Config::default_languages();
+        for filename in ["bun.lock", "tsconfig.json", "devcontainer.json"] {
+            assert_eq!(
+                detect_language(Path::new(filename), &languages),
+                Some("jsonc".to_string()),
+                "expected `{filename}` to be detected as jsonc"
             );
         }
     }

--- a/crates/fresh-editor/src/init_script.rs
+++ b/crates/fresh-editor/src/init_script.rs
@@ -233,12 +233,15 @@ const editor = getEditor();
 
 /// `tsconfig.json` for the user's init.ts. Matches the plugin-dev
 /// workspace (no DOM, no ambient types) so LSP behaviour is consistent
-/// with plugins.
+/// with plugins. `moduleResolution` must be `bundler` (matching
+/// `plugins/tsconfig.json` and `check-types.sh`): TypeScript 7 removed
+/// the old `node` (node10) resolution mode, so a tsserver reading this
+/// file would fail with TS5108 (#2872).
 const INIT_TSCONFIG: &str = r#"{
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
@@ -680,6 +683,20 @@ mod tests {
     fn init_ts_path_is_under_config_dir() {
         let p = init_ts_path(Path::new("/tmp/fresh"));
         assert_eq!(p, PathBuf::from("/tmp/fresh/init.ts"));
+    }
+
+    /// TypeScript 7 removed `moduleResolution: node` (node10); a tsserver
+    /// reading a generated tsconfig that still uses it fails with TS5108.
+    /// The generated config must use `bundler`, matching
+    /// `plugins/tsconfig.json` and `check-types.sh` (#2872).
+    #[test]
+    fn generated_tsconfig_does_not_use_removed_module_resolution() {
+        let parsed: serde_json::Value = serde_json::from_str(INIT_TSCONFIG)
+            .expect("generated tsconfig.json must be valid JSON");
+        assert_eq!(
+            parsed["compilerOptions"]["moduleResolution"], "bundler",
+            "moduleResolution must be `bundler`; `node` (node10) was removed in TypeScript 7"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/plugins/plugin_dev_workspace.rs
+++ b/crates/fresh-editor/src/services/plugins/plugin_dev_workspace.rs
@@ -23,11 +23,15 @@ pub struct PluginDevWorkspace {
 /// - No DOM lib (plugins run in QuickJS, not a browser)
 /// - `types: []` prevents picking up @types/node or other ambient types
 /// - `skipLibCheck: true` avoids checking fresh.d.ts itself
+/// - `moduleResolution: bundler` (matching `plugins/tsconfig.json` and
+///   `check-types.sh`): TypeScript 7 removed the old `node` (node10)
+///   resolution mode, so a tsserver reading this file would fail with
+///   TS5108 (#2872)
 const TSCONFIG_CONTENT: &str = r#"{
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
@@ -112,5 +116,24 @@ impl PluginDevWorkspace {
 impl Drop for PluginDevWorkspace {
     fn drop(&mut self) {
         self.cleanup();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// TypeScript 7 removed `moduleResolution: node` (node10); a tsserver
+    /// reading a generated tsconfig that still uses it fails with TS5108.
+    /// The generated config must use `bundler`, matching
+    /// `plugins/tsconfig.json` and `check-types.sh` (#2872).
+    #[test]
+    fn generated_tsconfig_does_not_use_removed_module_resolution() {
+        let parsed: serde_json::Value = serde_json::from_str(TSCONFIG_CONTENT)
+            .expect("generated tsconfig.json must be valid JSON");
+        assert_eq!(
+            parsed["compilerOptions"]["moduleResolution"], "bundler",
+            "moduleResolution must be `bundler`; `node` (node10) was removed in TypeScript 7"
+        );
     }
 }

--- a/docs/blog/editing/index.md
+++ b/docs/blog/editing/index.md
@@ -21,7 +21,7 @@ Place your cursor on a word, press **Ctrl+W** to select it, then **Ctrl+D** to s
 
 ## Search & Replace
 
-**Ctrl+H** opens find-and-replace with live highlighting as you type. Supports regex with capture groups (`$1`, `$2`), find-in-selection, and a confirm-each toggle.
+**Ctrl+R** opens find-and-replace with live highlighting as you type. Supports regex with capture groups (`$1`, `$2`), find-in-selection, and a confirm-each toggle. (Ctrl+H is deliberately not used: terminals transmit it as Backspace, so Fresh binds it to delete-word-backward instead.)
 
 <div class="showcase-demo">
   <img src="./search-replace/showcase.gif" alt="Search and replace demo" />

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -57,13 +57,13 @@ The macOS keymap is designed around these constraints:
 
 **Ctrl+Shift combinations don't work.** Some macOS terminals cannot reliably send Ctrl+Shift sequences. For example, Ctrl+Shift+Z produces a caron character (ˇ) instead of being recognized as a key chord. The macOS keymap uses Ctrl+Alt as an alternative modifier.
 
-**Some Ctrl keys are ASCII control characters.** In terminal protocols, Ctrl+J is Line Feed (newline), Ctrl+M is Carriage Return (Enter), and Ctrl+I is Tab. Binding actions to these keys causes erratic behavior. The macOS keymap avoids these collisions.
+**Some Ctrl keys are ASCII control characters.** In terminal protocols, Ctrl+J is Line Feed (newline), Ctrl+M is Carriage Return (Enter), Ctrl+I is Tab, and Ctrl+H is Backspace. Binding actions to these keys causes erratic behavior. The macOS keymap avoids these collisions. This is also why find-and-replace is on **Ctrl+R** rather than Ctrl+H: most terminals transmit Ctrl+H as Backspace, so Fresh treats it as Ctrl+Backspace (delete previous word) in every keymap.
 
 **International keyboards use Alt for essential characters.** On German, French, and other ISO layouts, Alt (Option) combined with letters produces characters like @, [, ], {, and }. The macOS keymap avoids Alt+letter combinations that would block character input.
 
 **Unix readline conventions are preserved.** Terminal users expect Ctrl+Y to "yank" (paste from the kill ring), Ctrl+K to kill to end of line, and Ctrl+U to kill to start of line. The macOS keymap respects these conventions rather than overriding them with GUI editor shortcuts.
 
-Use the **Command Palette** (Ctrl+P) or **Show Keybindings** (Ctrl+H) to discover the actual key bindings, or view the keymap file directly at `keymaps/macos.json`.
+Use the **Command Palette** (Ctrl+P) or run **Show Keyboard Shortcuts** from it to discover the actual key bindings, or view the keymap file directly at `keymaps/macos.json`.
 
 #### Recommended Terminal Emulators
 

--- a/docs/features/lsp.md
+++ b/docs/features/lsp.md
@@ -209,7 +209,7 @@ Some LSP servers expect a different `languageId` than Fresh's internal language 
 
 ### Rust LSP Mode Switching
 
-Use "Switch Rust Analyzer Mode" from the command palette to toggle between Full and Reduced Memory modes for rust-analyzer.
+Use "Rust LSP: Configure Mode" from the command palette to toggle between Full and Reduced Memory modes for rust-analyzer.
 
 ## Configuring Language Detection via Settings UI
 


### PR DESCRIPTION
Four small, independent fixes — one commit each.

Fixes #2921
Fixes #2872
Fixes #2109
Refs #2598 (fixes only the documentation mismatch noted in that issue; the Reduced Memory mode behavior itself is untouched)

## Motivation & changes

**#2921 — `bun.lock` opened with no JSON highlighting.** No default language claimed the filename, so it fell through to plain Text. Bun's text lockfile is JSONC (trailing commas), so `bun.lock` is now in the `jsonc` filenames list in the default language configs (`crates/fresh-editor/src/config.rs`). Verified interactively in tmux against a debug build: opening `bun.lock` now shows "JSON with Comments" in the status bar with distinct per-token colors (keys/numbers/punctuation) instead of Text with plain foreground.

**#2872 — TS5108 with TypeScript 7.** `check-types.sh` was already fixed (69d3575), but two *generated* tsconfigs still hardcoded `"moduleResolution": "node"` (node10), which TypeScript 7 removed — a TS 7 tsserver reading them fails with `error TS5108`. Both `INIT_TSCONFIG` (`src/init_script.rs`) and `TSCONFIG_CONTENT` (`src/services/plugins/plugin_dev_workspace.rs`) now use `"moduleResolution": "bundler"`, matching the checked-in `plugins/tsconfig.json` and `check-types.sh`, so tsserver and the type-check script agree.

**#2109 — docs claimed Ctrl+H opens find-and-replace.** The actual binding is deliberate: terminals transmit Ctrl+H as 0x08/Backspace, so Fresh maps it to delete-word-backward and puts replace on Ctrl+R — a user following the docs would silently delete a word. `docs/blog/editing/index.md` now says Ctrl+R with a note on why Ctrl+H is avoided; `docs/configuration/keyboard.md` drops the bogus "Show Keybindings (Ctrl+H)" (the palette command is "Show Keyboard Shortcuts" and has no default key binding) and the ASCII-control-character caveat paragraph now lists Ctrl+H = Backspace and explains the binding choice.

**#2598 (docs line only) — wrong palette command name.** `docs/features/lsp.md` told users to run "Switch Rust Analyzer Mode"; the command registered by `plugins/rust-lsp.ts` is "Rust LSP: Configure Mode".

## Tests

- New: `config::tests::test_default_languages_map_jsonc_filenames` — maps `bun.lock` / `tsconfig.json` / `devcontainer.json` through `detect_language()` against the default language configs. Verified it fails without the config change (`bun.lock` → `None`) and passes with it.
- New: `generated_tsconfig_does_not_use_removed_module_resolution` in both `init_script.rs` and `plugin_dev_workspace.rs` — assert the generated tsconfig uses `bundler`. Verified both fail without the change and pass with it.
- Ran: `cargo test -p fresh-editor --lib` (the three tests above, plus the full lib test binary compiled), `cargo fmt --check`, `cargo clippy -p fresh-editor` (only pre-existing warnings in untouched files).
- Manual: tmux session against a debug build — `bun.lock` renders with JSONC highlighting and the correct status-bar filetype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y)_