### PR TITLE
Auto-indent engine gaps: braceless TS/JS bodies and live keyword dedent

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -1688,7 +1688,7 @@
           "default": null
         },
         "decrease_indent_pattern": {
-          "description": "If the new line's leading text matches, that line is dedented one level.\nExample — a line starting with a closing bracket: `^\\s*[\\}\\]\\)]`.",
+          "description": "If the new line's leading text matches, that line is dedented one level.\nExample — a line starting with a closing bracket: `^\\s*[\\}\\]\\)]`.\n\nAlso fires live while typing: at the keystroke where the pattern first\nmatches the whole line, the line is re-indented one level shallower.\nInclude the statement's terminator in the pattern when the language has\none (e.g. Python's `:`), like VS Code's `decreaseIndentPattern`, so an\nidentifier starting with a keyword never triggers a transient dedent.",
           "type": [
             "string",
             "null"

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2794,6 +2794,12 @@ pub struct IndentRulesConfig {
 
     /// If the new line's leading text matches, that line is dedented one level.
     /// Example — a line starting with a closing bracket: `^\s*[\}\]\)]`.
+    ///
+    /// Also fires live while typing: at the keystroke where the pattern first
+    /// matches the whole line, the line is re-indented one level shallower.
+    /// Include the statement's terminator in the pattern when the language has
+    /// one (e.g. Python's `:`), like VS Code's `decreaseIndentPattern`, so an
+    /// identifier starting with a keyword never triggers a transient dedent.
     #[serde(default)]
     pub decrease_indent_pattern: Option<String>,
 

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -903,7 +903,7 @@ fn handle_auto_dedent(
 
 /// Electric keyword dedent (issue #2582): typing the character that turns the
 /// line into exactly "leading whitespace + a `decrease_indent_pattern` trigger
-/// token" (Python `else`, Ruby `end`, a custom `CLOSE`, …) re-indents the line
+/// token" (Python `else:`, Ruby `end`, a custom `CLOSE`, …) re-indents the line
 /// one level shallower — the keyword analogue of the electric `}` handled by
 /// [`handle_auto_dedent`].
 ///
@@ -1301,7 +1301,7 @@ fn insert_char_events(
         }
 
         // Electric keyword dedent (issue #2582): typing the char that
-        // completes a dedent-trigger line (`else`, `end`, custom `CLOSE`, …)
+        // completes a dedent-trigger line (`else:`, `end`, custom `CLOSE`, …)
         // re-indents the line the same way `}` does above.
         if auto_indent
             && !is_closing_delimiter
@@ -6467,7 +6467,7 @@ mod tests {
 
     // ========================================================================
     // Issue #2582: electric keyword dedent — typing the character that
-    // completes a dedent trigger (`else`, custom `CLOSE`, …) re-indents the
+    // completes a dedent trigger (`else:`, custom `CLOSE`, …) re-indents the
     // line one level shallower, the way `}` already does. Cursor sits at end
     // of the typed prefix (where real typing happens).
     // ========================================================================
@@ -6516,50 +6516,82 @@ mod tests {
     }
 
     #[test]
-    fn test_typing_else_dedents_python_line() {
-        // Canonical #2582 case: `if a:` / body / typing `else` on a line that
-        // inherited the body indent. The final `e` completes the trigger and
-        // must re-indent the line to column 0.
+    fn test_typing_else_colon_dedents_python_line() {
+        // Canonical #2582 case: `if a:` / body / typing `else:` on a line that
+        // inherited the body indent. The bare keyword must NOT move the line
+        // (it could still grow into an identifier such as `elsewhere`); the
+        // statement-final `:` completes the trigger and re-indents the line to
+        // column 0 — VS Code / ms-python behavior.
         let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\n    els");
         type_char(&mut state, &mut cursors, 'e');
         assert_eq!(
             state.buffer.to_string().unwrap(),
-            "if a:\n    x = 1\nelse",
-            "typing the char completing `else` must dedent the line"
+            "if a:\n    x = 1\n    else",
+            "the bare keyword must not dedent — the statement is incomplete"
+        );
+        type_char(&mut state, &mut cursors, ':');
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\nelse:",
+            "the `:` completing the statement must dedent the line"
         );
         assert_eq!(cursors.primary().position, state.buffer.len());
+    }
 
-        // The following `:` must not fire a second dedent.
+    #[test]
+    fn test_typing_elif_condition_dedents_at_colon() {
+        // A condition-carrying trigger: `elif x > 0` stays put while typed and
+        // dedents exactly at the `:` keystroke.
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\n    elif x > 0");
         type_char(&mut state, &mut cursors, ':');
-        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = 1\nelse:");
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\nelif x > 0:"
+        );
         assert_eq!(cursors.primary().position, state.buffer.len());
+    }
+
+    #[test]
+    fn test_typing_elsewhere_never_dedents() {
+        // An identifier that merely starts with the keyword must never fire —
+        // neither while typed nor when a `:` follows (annotation-style).
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\n    els");
+        for ch in "ewhere:".chars() {
+            type_char(&mut state, &mut cursors, ch);
+        }
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\n    elsewhere:"
+        );
     }
 
     #[test]
     fn test_typing_else_mid_line_does_not_reindent() {
-        // The trigger word appearing mid-line (here as part of an expression)
-        // must never re-indent the line.
+        // The trigger appearing mid-line (here as part of an expression) must
+        // never re-indent the line, even once its `:` is typed.
         let (mut state, mut cursors) = python_state_with("if a:\n    x = els");
         type_char(&mut state, &mut cursors, 'e');
-        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = else");
+        type_char(&mut state, &mut cursors, ':');
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = else:");
     }
 
     #[test]
     fn test_typing_case_directly_under_match_keeps_indent() {
-        // `case` typed as the first body line under `match x:` belongs inside
-        // the block — it must not be pulled out to the header's level.
-        let (mut state, mut cursors) = python_state_with("match x:\n    cas");
-        type_char(&mut state, &mut cursors, 'e');
-        assert_eq!(state.buffer.to_string().unwrap(), "match x:\n    case");
+        // `case _:` typed as the first body line under `match x:` belongs
+        // inside the block — the completing `:` must not pull it out to the
+        // header's level.
+        let (mut state, mut cursors) = python_state_with("match x:\n    case _");
+        type_char(&mut state, &mut cursors, ':');
+        assert_eq!(state.buffer.to_string().unwrap(), "match x:\n    case _:");
     }
 
     #[test]
     fn test_typing_else_on_manually_dedented_line_is_noop() {
         // The user already dedented the line to (or past) the target: typing
         // the trigger must leave their indent alone.
-        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\nels");
-        type_char(&mut state, &mut cursors, 'e');
-        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = 1\nelse");
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\nelse");
+        type_char(&mut state, &mut cursors, ':');
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = 1\nelse:");
     }
 }
 

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -901,6 +901,118 @@ fn handle_auto_dedent(
     });
 }
 
+/// Electric keyword dedent (issue #2582): typing the character that turns the
+/// line into exactly "leading whitespace + a `decrease_indent_pattern` trigger
+/// token" (Python `else`, Ruby `end`, a custom `CLOSE`, …) re-indents the line
+/// one level shallower — the keyword analogue of the electric `}` handled by
+/// [`handle_auto_dedent`].
+///
+/// Deliberately conservative, mirroring how VS Code's `decreaseIndentPattern`
+/// re-indents while typing:
+/// - fires only with the cursor at end of line;
+/// - fires only at the keystroke where the trigger regex first consumes the
+///   whole line content, so later keystrokes on the same line never re-fire
+///   and a trigger appearing mid-line never fires at all;
+/// - only ever dedents — a line the user already dedented at or below the
+///   target is left alone;
+/// - skipped when the previous non-blank line opens a block, so a block's
+///   first body line (e.g. Python `case` right under `match x:`) is never
+///   pulled out of the block it belongs to.
+///
+/// Returns `true` when it emitted events (the typed char included), so the
+/// caller skips the normal insertion for this cursor.
+#[allow(clippy::too_many_arguments)]
+fn handle_keyword_dedent(
+    state: &mut EditorState,
+    events: &mut Vec<Event>,
+    cursor_id: CursorId,
+    ch: char,
+    insert_position: usize,
+    line_start: usize,
+    char_after: Option<u8>,
+    tab_size: usize,
+) -> bool {
+    // A real trigger is leading whitespace plus a short token; capping the
+    // examined prefix keeps this O(1) per keystroke on long lines.
+    const MAX_PREFIX_BYTES: usize = 128;
+    if insert_position - line_start > MAX_PREFIX_BYTES {
+        return false;
+    }
+    // Cursor must be at end of line (VS Code re-evaluates only while typing
+    // the leading token at end-of-line).
+    if !matches!(char_after, None | Some(b'\n') | Some(b'\r')) {
+        return false;
+    }
+    let Some(rules) = buffer_indent_rules(state) else {
+        return false;
+    };
+
+    // Masked view of the line content before the cursor (comment/string bytes
+    // blanked to spaces, same convention as the rules tier), and the current
+    // visual indent while we're scanning.
+    let prefix_bytes = state.buffer.slice_bytes(line_start..insert_position);
+    let mut before = String::with_capacity(prefix_bytes.len() + 1);
+    let mut current_indent = 0;
+    let mut in_leading_ws = true;
+    for (i, &b) in prefix_bytes.iter().enumerate() {
+        if b == b'\r' {
+            continue;
+        }
+        if in_leading_ws {
+            match b {
+                b' ' => current_indent += 1,
+                b'\t' => current_indent += tab_size,
+                _ => in_leading_ws = false,
+            }
+        }
+        if byte_is_code(state, line_start + i) {
+            before.push(b as char);
+        } else {
+            before.push(' ');
+        }
+    }
+
+    // Fire exactly when this keystroke completes the trigger.
+    let mut after = before.clone();
+    after.push(ch);
+    if !rules.decrease_consumes_line(&after) || rules.decrease_consumes_line(&before) {
+        return false;
+    }
+
+    let Some(target_indent) =
+        rules.on_type_dedent_target(&state.buffer, line_start, tab_size, |b| {
+            byte_is_code(state, b)
+        })
+    else {
+        return false;
+    };
+    if target_indent >= current_indent {
+        return false;
+    }
+
+    // Replace the whole prefix with re-indented content + the typed char in
+    // one Delete + one Insert, mirroring `handle_auto_dedent` (single undo
+    // step; cursor ends up after the typed char).
+    let prefix = state.get_text_range(line_start, insert_position);
+    events.push(Event::Delete {
+        range: line_start..insert_position,
+        deleted_text: prefix.clone(),
+        cursor_id,
+    });
+    let use_tabs = state.buffer_settings.use_tabs;
+    let mut text = indent_to_string(target_indent, use_tabs, tab_size);
+    // Splitting after leading whitespace is char-boundary-safe: space/tab are
+    // single-byte ASCII.
+    text.push_str(prefix.trim_start_matches([' ', '\t']));
+    text.push(ch);
+    events.push(Event::Insert {
+        position: line_start,
+        text,
+        cursor_id,
+    });
+    true
+}
+
 /// Check if auto-close should happen based on character after cursor.
 fn should_auto_close(char_after: Option<u8>) -> bool {
     let is_alphanumeric_after = char_after
@@ -1132,6 +1244,7 @@ fn insert_char_events(
         }
 
         // Delete selection if present
+        let had_selection = data.selection.is_some();
         if let (Some(range), Some(text)) = (data.selection, data.deleted_text) {
             events.push(Event::Delete {
                 range,
@@ -1184,6 +1297,26 @@ fn insert_char_events(
                 data.line_start,
                 tab_size,
             );
+            continue;
+        }
+
+        // Electric keyword dedent (issue #2582): typing the char that
+        // completes a dedent-trigger line (`else`, `end`, custom `CLOSE`, …)
+        // re-indents the line the same way `}` does above.
+        if auto_indent
+            && !is_closing_delimiter
+            && !had_selection
+            && handle_keyword_dedent(
+                state,
+                events,
+                data.cursor_id,
+                ch,
+                data.insert_position,
+                data.line_start,
+                data.char_after,
+                tab_size,
+            )
+        {
             continue;
         }
 
@@ -6330,6 +6463,103 @@ mod tests {
         let text = "x".repeat(200_000);
         let state = state_with(&text);
         assert_eq!(line_start_and_blank_prefix(&state, text.len()), (0, false));
+    }
+
+    // ========================================================================
+    // Issue #2582: electric keyword dedent — typing the character that
+    // completes a dedent trigger (`else`, custom `CLOSE`, …) re-indents the
+    // line one level shallower, the way `}` already does. Cursor sits at end
+    // of the typed prefix (where real typing happens).
+    // ========================================================================
+
+    /// Python-highlighted state with `text` inserted and the cursor at its end.
+    fn python_state_with(text: &str) -> (EditorState, Cursors) {
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let registry = crate::primitives::grammar::GrammarRegistry::load(
+            &crate::primitives::grammar::LocalGrammarLoader::embedded_only(),
+        );
+        state.set_language_from_name("test.py", &registry);
+        let mut cursors = Cursors::new();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: text.to_string(),
+                cursor_id: CursorId(0),
+            },
+        );
+        (state, cursors)
+    }
+
+    /// Type one character through the real InsertChar action (auto-indent on).
+    fn type_char(state: &mut EditorState, cursors: &mut Cursors, ch: char) {
+        let events = action_to_events(
+            state,
+            cursors,
+            Action::InsertChar(ch),
+            4,
+            true,
+            true,
+            true,
+            80,
+            24,
+        )
+        .unwrap();
+        for event in events {
+            state.apply(cursors, &event);
+        }
+    }
+
+    #[test]
+    fn test_typing_else_dedents_python_line() {
+        // Canonical #2582 case: `if a:` / body / typing `else` on a line that
+        // inherited the body indent. The final `e` completes the trigger and
+        // must re-indent the line to column 0.
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\n    els");
+        type_char(&mut state, &mut cursors, 'e');
+        assert_eq!(
+            state.buffer.to_string().unwrap(),
+            "if a:\n    x = 1\nelse",
+            "typing the char completing `else` must dedent the line"
+        );
+        assert_eq!(cursors.primary().position, state.buffer.len());
+
+        // The following `:` must not fire a second dedent.
+        type_char(&mut state, &mut cursors, ':');
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = 1\nelse:");
+        assert_eq!(cursors.primary().position, state.buffer.len());
+    }
+
+    #[test]
+    fn test_typing_else_mid_line_does_not_reindent() {
+        // The trigger word appearing mid-line (here as part of an expression)
+        // must never re-indent the line.
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = els");
+        type_char(&mut state, &mut cursors, 'e');
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = else");
+    }
+
+    #[test]
+    fn test_typing_case_directly_under_match_keeps_indent() {
+        // `case` typed as the first body line under `match x:` belongs inside
+        // the block — it must not be pulled out to the header's level.
+        let (mut state, mut cursors) = python_state_with("match x:\n    cas");
+        type_char(&mut state, &mut cursors, 'e');
+        assert_eq!(state.buffer.to_string().unwrap(), "match x:\n    case");
+    }
+
+    #[test]
+    fn test_typing_else_on_manually_dedented_line_is_noop() {
+        // The user already dedented the line to (or past) the target: typing
+        // the trigger must leave their indent alone.
+        let (mut state, mut cursors) = python_state_with("if a:\n    x = 1\nels");
+        type_char(&mut state, &mut cursors, 'e');
+        assert_eq!(state.buffer.to_string().unwrap(), "if a:\n    x = 1\nelse");
     }
 }
 

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -186,6 +186,23 @@ impl IndentCalculator {
         if let Some(indent) =
             self.calculate_indent_tree_sitter(buffer, position, language, tab_size)
         {
+            // Braceless control-flow body (issue #2492): the JS/TS
+            // `indents.scm` captures `)` as `@dedent`, so a braceless head
+            // like `if (x)` ends in a @dedent token and tree-sitter reports
+            // "keep level" for the body line below it. The regex rules tier
+            // already recognises these heads (`indent_next_line`); when it
+            // dictates a deeper body indent than tree-sitter produced, prefer
+            // it. Languages whose rules have no `indent_next_line` pattern
+            // (and languages with no rules at all) are unaffected.
+            if let Some(rules) = crate::primitives::indent_rules::rules_for_id(language.id()) {
+                if let Some(head_indent) =
+                    rules.braceless_head_body_indent(buffer, position, tab_size)
+                {
+                    if head_indent > indent {
+                        return Some(head_indent);
+                    }
+                }
+            }
             return Some(indent);
         }
 
@@ -1426,6 +1443,68 @@ mod tests {
         assert!(indent.is_some());
         // Should suggest indenting
         assert!(indent.unwrap() >= 4);
+    }
+
+    // ============================================================================
+    // Issue #2492: a braceless control-flow head (`if (x)` with no `{`) must
+    // indent its body line in TypeScript/JavaScript, matching the C family.
+    // The JS/TS `indents.scm` captures `)` as @dedent, so before the fix
+    // tree-sitter reported "keep level" for these heads and the body landed
+    // at the head's own column.
+    // ============================================================================
+
+    #[test]
+    fn test_ts_js_braceless_if_indents_body() {
+        let mut calc = IndentCalculator::new();
+        for lang in [Language::TypeScript, Language::JavaScript] {
+            let buffer = Buffer::from_str_test("if (a)");
+            let indent = calc.calculate_indent(&buffer, buffer.len(), &lang, 4);
+            assert_eq!(
+                indent,
+                Some(4),
+                "braceless if body should indent one level in {:?} (got {:?})",
+                lang,
+                indent
+            );
+        }
+    }
+
+    #[test]
+    fn test_ts_braceless_while_and_for_indent_body() {
+        let mut calc = IndentCalculator::new();
+        for head in ["while (a)", "for (let i = 0; i < n; i++)"] {
+            let buffer = Buffer::from_str_test(head);
+            let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+            assert_eq!(indent, Some(4), "after {head:?} (got {:?})", indent);
+        }
+    }
+
+    #[test]
+    fn test_ts_braceless_if_nested_indents_from_head() {
+        let mut calc = IndentCalculator::new();
+        let buffer = Buffer::from_str_test("function f() {\n    if (a)");
+        let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+        assert_eq!(indent, Some(8), "got {:?}", indent);
+    }
+
+    #[test]
+    fn test_ts_braced_if_body_indent_unchanged() {
+        // Control: the braced head still indents exactly one level (the
+        // braceless-head override must not fire — the head ends with `{`).
+        let mut calc = IndentCalculator::new();
+        let buffer = Buffer::from_str_test("if (a) {");
+        let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+        assert_eq!(indent, Some(4), "got {:?}", indent);
+    }
+
+    #[test]
+    fn test_ts_plain_statement_keeps_indent() {
+        // Control: a statement line ending in `)` that is not a control head
+        // must not trigger the braceless-head override.
+        let mut calc = IndentCalculator::new();
+        let buffer = Buffer::from_str_test("if (a) {\n    foo(b)");
+        let indent = calc.calculate_indent(&buffer, buffer.len(), &Language::TypeScript, 4);
+        assert_eq!(indent, Some(4), "got {:?}", indent);
     }
 
     // ============================================================================

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -275,6 +275,42 @@ impl IndentRules {
         Some(visual_indent(buffer, cur.start, position, tab_size) + tab_size.max(1))
     }
 
+    /// True when `line` (a line's masked content) is exactly leading
+    /// whitespace plus a `decrease` trigger token: the regex matches and the
+    /// match consumes the entire text. Used by the electric keyword dedent
+    /// (issue #2582) to fire only at the keystroke that completes the trigger
+    /// — a trigger appearing mid-line, or with anything typed after it, never
+    /// re-fires.
+    pub fn decrease_consumes_line(&self, line: &str) -> bool {
+        self.decrease
+            .as_ref()
+            .and_then(|r| r.find(line))
+            .is_some_and(|m| m.start() == 0 && m.end() == line.len())
+    }
+
+    /// Target indent for a line whose typed content just completed a
+    /// `decrease` trigger (issue #2582): one unit shallower than the previous
+    /// non-blank line.
+    ///
+    /// Returns `None` when that previous line opens a block (or is a
+    /// braceless head): the trigger would be the block's *first* body line —
+    /// e.g. Python `case` typed right under `match x:` — and dedenting it
+    /// would pull it out of the block it belongs to.
+    pub fn on_type_dedent_target<F: Fn(usize) -> bool>(
+        &self,
+        buffer: &Buffer,
+        line_start: usize,
+        tab_size: usize,
+        is_code: F,
+    ) -> Option<usize> {
+        let reference = prev_nonblank_line(buffer, line_start)?;
+        let ref_code = code_view(buffer, reference.start, reference.end, &is_code);
+        if self.increases(&ref_code) || matches(&self.indent_next_line, &ref_code) {
+            return None;
+        }
+        let base = visual_indent(buffer, reference.start, reference.end, tab_size);
+        Some(base.saturating_sub(tab_size.max(1)))
+    }
 }
 
 fn matches(re: &Option<Regex>, text: &str) -> bool {
@@ -926,6 +962,74 @@ mod tests {
     #[test]
     fn smali_plain_field_does_not_indent() {
         assert_eq!(indent("smali", ".field public static count:I = 0\n", 4), 0);
+    }
+
+    // ---- Electric keyword dedent (issue #2582) ----------------------------
+
+    #[test]
+    fn python_decrease_consumes_line_only_for_pure_trigger() {
+        let r = rules_for_id("python").unwrap();
+        // Fires exactly at the keystroke completing the trigger token…
+        assert!(r.decrease_consumes_line("    else"));
+        assert!(r.decrease_consumes_line("elif"));
+        // …not before it is complete, not after more text follows, and never
+        // for a trigger appearing mid-line.
+        assert!(!r.decrease_consumes_line("    els"));
+        assert!(!r.decrease_consumes_line("    else:"));
+        assert!(!r.decrease_consumes_line("    x = else"));
+        assert!(!r.decrease_consumes_line("    "));
+    }
+
+    #[test]
+    fn python_on_type_dedent_target_is_one_level_shallower() {
+        // Typing `else` under a body line dedents to one level shallower than
+        // that line — the issue #2582 canonical case.
+        let content = "if a:\n    x = 1\n    els";
+        let line_start = content.rfind('\n').unwrap() + 1;
+        let target = rules_for_id("python").unwrap().on_type_dedent_target(
+            &buf(content),
+            line_start,
+            4,
+            |_| true,
+        );
+        assert_eq!(target, Some(0));
+    }
+
+    #[test]
+    fn python_on_type_dedent_skipped_for_first_body_line() {
+        // `case` typed directly under `match x:`: the previous line opens the
+        // block, so the trigger is its first body line and must stay put.
+        let content = "match x:\n    cas";
+        let line_start = content.rfind('\n').unwrap() + 1;
+        let target = rules_for_id("python").unwrap().on_type_dedent_target(
+            &buf(content),
+            line_start,
+            4,
+            |_| true,
+        );
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn custom_close_trigger_on_type_dedent() {
+        // A config-style custom pattern, compiled directly (no global
+        // USER_RULES mutation, so this can run in parallel with other tests).
+        let r = IndentRules::compile_parts(
+            Some(r"^\s*OPEN\b"),
+            Some(r"^\s*CLOSE\b"),
+            None,
+            None,
+            None,
+            false,
+        );
+        assert!(r.decrease_consumes_line("    CLOSE"));
+        assert!(!r.decrease_consumes_line("    CLOS"));
+        let content = "OPEN\n    x\n    CLOS";
+        let line_start = content.rfind('\n').unwrap() + 1;
+        assert_eq!(
+            r.on_type_dedent_target(&buf(content), line_start, 4, |_| true),
+            Some(0)
+        );
     }
 
     // ---- Braceless control heads (issue #2492) ----------------------------

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -511,8 +511,13 @@ const SMALI_LIKE: IndentRulesDef = IndentRulesDef {
 
 const PYTHON: IndentRulesDef = IndentRulesDef {
     increase: Some(r":\s*$"),
-    // Best-effort: a moved-down midblock keyword dedents to its header.
-    decrease: Some(r"^\s*(elif|else|except|finally|case)\b"),
+    // Midblock keywords dedent to their header — but only once the
+    // statement-final `:` is present, mirroring ms-python's
+    // decreaseIndentPattern `^\s*(elif\s.*|else\s*|except.*|finally\s*):`.
+    // Requiring the colon makes the on-type dedent (issue #2582) fire at the
+    // `:` keystroke and keeps identifiers like `elsewhere` from ever matching.
+    // The trailing `\s*` lets a whole-line match tolerate trailing whitespace.
+    decrease: Some(r"^\s*(elif\s.*|else\s*|except.*|finally\s*|case\s.*):\s*"),
     indent_next_line: None,
     dedent_next_line: Some(r"^\s*(return|pass|raise|break|continue)\b"),
     self_close: None,
@@ -830,6 +835,19 @@ mod tests {
     }
 
     #[test]
+    fn python_moved_down_else_dedents_on_enter() {
+        // Enter pressed just before `else:` — the moved-down tail still
+        // matches the colon-carrying decrease pattern (the pattern is not
+        // end-anchored), so the Enter-time dedent path keeps working.
+        let content = "if x:\n    a = 1\n    else: b()";
+        let pos = content.find("else").unwrap();
+        let got = rules_for_id("python")
+            .unwrap()
+            .calculate_indent(&buf(content), pos, 4, |_| true);
+        assert_eq!(got, 0);
+    }
+
+    #[test]
     fn python_colon_in_string_does_not_indent() {
         // `x = {"a": 1}` ends with `}` not `:`, but check a dict-literal colon
         // inside a string is ignored: `s = "key:"`.
@@ -969,22 +987,32 @@ mod tests {
     #[test]
     fn python_decrease_consumes_line_only_for_pure_trigger() {
         let r = rules_for_id("python").unwrap();
-        // Fires exactly at the keystroke completing the trigger token…
-        assert!(r.decrease_consumes_line("    else"));
-        assert!(r.decrease_consumes_line("elif"));
-        // …not before it is complete, not after more text follows, and never
-        // for a trigger appearing mid-line.
+        // Fires exactly at the `:` keystroke that completes the statement
+        // (ms-python's decreaseIndentPattern contract)…
+        assert!(r.decrease_consumes_line("    else:"));
+        assert!(r.decrease_consumes_line("elif x > 0:"));
+        assert!(r.decrease_consumes_line("    except ValueError:"));
+        assert!(r.decrease_consumes_line("    finally:"));
+        // …tolerating trailing whitespace after the colon…
+        assert!(r.decrease_consumes_line("    else:  "));
+        // …but never before the colon completes the statement…
         assert!(!r.decrease_consumes_line("    els"));
-        assert!(!r.decrease_consumes_line("    else:"));
-        assert!(!r.decrease_consumes_line("    x = else"));
+        assert!(!r.decrease_consumes_line("    else"));
+        assert!(!r.decrease_consumes_line("elif"));
+        // …never for identifiers that merely start with a keyword…
+        assert!(!r.decrease_consumes_line("    elsewhere:"));
+        assert!(!r.decrease_consumes_line("    else_value"));
+        // …and never once more text follows, or for a mid-line occurrence.
+        assert!(!r.decrease_consumes_line("    else: pass"));
+        assert!(!r.decrease_consumes_line("    x = else:"));
         assert!(!r.decrease_consumes_line("    "));
     }
 
     #[test]
     fn python_on_type_dedent_target_is_one_level_shallower() {
-        // Typing `else` under a body line dedents to one level shallower than
-        // that line — the issue #2582 canonical case.
-        let content = "if a:\n    x = 1\n    els";
+        // Typing the `:` completing `else:` under a body line dedents to one
+        // level shallower than that line — the issue #2582 canonical case.
+        let content = "if a:\n    x = 1\n    else";
         let line_start = content.rfind('\n').unwrap() + 1;
         let target = rules_for_id("python").unwrap().on_type_dedent_target(
             &buf(content),
@@ -997,9 +1025,9 @@ mod tests {
 
     #[test]
     fn python_on_type_dedent_skipped_for_first_body_line() {
-        // `case` typed directly under `match x:`: the previous line opens the
-        // block, so the trigger is its first body line and must stay put.
-        let content = "match x:\n    cas";
+        // `case _:` typed directly under `match x:`: the previous line opens
+        // the block, so the trigger is its first body line and must stay put.
+        let content = "match x:\n    case _";
         let line_start = content.rfind('\n').unwrap() + 1;
         let target = rules_for_id("python").unwrap().on_type_dedent_target(
             &buf(content),

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -247,6 +247,34 @@ impl IndentRules {
     fn increases(&self, code: &str) -> bool {
         matches(&self.increase, code) && !matches(&self.self_close, code)
     }
+
+    /// Body indent dictated by a braceless control head being split at
+    /// `position`, or `None` when the rule does not apply.
+    ///
+    /// When the text before the cursor on the current line matches
+    /// `indent_next_line` (a braceless `if (x)` / `for (…)` / `while (x)`
+    /// head, or a bare `else`), the line created below it is that head's
+    /// one-shot body: head indent + one unit. Used by the tree-sitter indent
+    /// path (issue #2492), whose JS/TS `indents.scm` captures `)` as `@dedent`
+    /// and therefore reports "keep level" for exactly these heads.
+    pub fn braceless_head_body_indent(
+        &self,
+        buffer: &Buffer,
+        position: usize,
+        tab_size: usize,
+    ) -> Option<usize> {
+        self.indent_next_line.as_ref()?;
+        let cur = line_bounds(buffer, position);
+        // Only a non-empty head on the line being split qualifies; a blank
+        // line means the one-shot body line has already been consumed.
+        first_nonws(buffer, cur.start, position)?;
+        let head = code_view(buffer, cur.start, position, &|_| true);
+        if !matches(&self.indent_next_line, &head) {
+            return None;
+        }
+        Some(visual_indent(buffer, cur.start, position, tab_size) + tab_size.max(1))
+    }
+
 }
 
 fn matches(re: &Option<Regex>, text: &str) -> bool {
@@ -898,6 +926,30 @@ mod tests {
     #[test]
     fn smali_plain_field_does_not_indent() {
         assert_eq!(indent("smali", ".field public static count:I = 0\n", 4), 0);
+    }
+
+    // ---- Braceless control heads (issue #2492) ----------------------------
+
+    #[test]
+    fn braceless_head_dictates_body_indent() {
+        let r = rules_for_id("typescript").unwrap();
+        let head = "    if (a)";
+        assert_eq!(
+            r.braceless_head_body_indent(&buf(head), head.len(), 4),
+            Some(8)
+        );
+        // A braced head is not a braceless one.
+        let braced = "    if (a) {";
+        assert_eq!(
+            r.braceless_head_body_indent(&buf(braced), braced.len(), 4),
+            None
+        );
+        // A plain statement is not a head.
+        let stmt = "    foo(a);";
+        assert_eq!(
+            r.braceless_head_body_indent(&buf(stmt), stmt.len(), 4),
+            None
+        );
     }
 
     // ---- registry ---------------------------------------------------------

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -294,13 +294,35 @@ behavior, so you can override just one thing.
 | Field | When it matches | Effect |
 |-------|-----------------|--------|
 | `increase_indent_pattern` | the reference line | the new line is **one level deeper** |
-| `decrease_indent_pattern` | the new line's leading text | that line is **one level shallower** |
+| `decrease_indent_pattern` | the new line's leading text | that line is **one level shallower** (also fires live while typing — see below) |
 | `indent_next_line_pattern` | the reference line | the **next line only** is one level deeper (one-shot; doesn't persist) |
 | `dedent_next_line_pattern` | the reference line | the **following line** is one level shallower (one-shot) |
 | `self_close_pattern` | the reference line | cancels `increase_indent_pattern` for that line (stops one-liners like `def f; end` from over-indenting) |
 
 The indent step is one unit of the language's `tab_size` (tabs or spaces per
 your `use_tabs` setting).
+
+#### Dedent while typing
+
+`decrease_indent_pattern` also fires **as you type**, not just on Enter — the
+keyword analogue of the electric `}`. On each keystroke the pattern is matched
+against the whole line: at the keystroke where it first matches the entire line
+content (leading whitespace included, trailing whitespace tolerated), the line
+is re-indented one level shallower.
+
+Because the check runs on every keystroke, include the statement's terminator
+in the pattern when the language has one — exactly as VS Code's
+`decreaseIndentPattern` does. For example, `^\s*end$` fires only once `end` is
+the whole line, while `^\s*end\b` behaves the same while typing but also
+matches when text follows the keyword. Fresh's built-in Python rule requires
+the statement-final colon (mirroring ms-python):
+
+```text
+^\s*(elif\s.*|else\s*|except.*|finally\s*|case\s.*):\s*
+```
+
+so `else:` dedents at the `:` keystroke, a bare `else` does not move, and an
+identifier such as `elsewhere` can never trigger a dedent.
 
 #### Examples
 


### PR DESCRIPTION
Fixes #2492
Fixes #2582

Two related gaps in the auto-indent engine, plus a follow-up commit tightening the live-dedent trigger data.

## #2492 — braceless control-flow bodies not indented in TS/JS

`if (a)` + Enter left the body at column 0 in TypeScript/JavaScript while C (and every rules-tier curly language) indented it.

**Root cause:** languages with a bundled tree-sitter grammar route through the AST indent tier, whose JS/TS `indents.scm` captures `)` as `@dedent`. A braceless head ends in a `@dedent` token, so the "line ends with a closing token → keep level" branch wins and the regex rules tier — whose `indent_next_line` pattern already handles braceless heads — is never consulted.

**Fix (contained fallback):** after the tree-sitter tier produces an indent, consult the language's rules for a braceless head (`IndentRules::braceless_head_body_indent`, matched against `indent_next_line`); prefer its deeper body indent when it applies. Languages without an `indent_next_line` pattern (Go in practice, JSON, Templ, and everything off the tree-sitter path — including C) are untouched.

## #2582 — typing a dedent trigger does not re-indent the line

Typing `else:` in a Python body, or a custom `decrease_indent_pattern` token (`CLOSE`, `end`), left the line over-indented and the error compounded on the next Enter; only `}` had electric dedent.

**Fix:** the electric-`}` path is extended to keyword triggers. When a typed character turns the line into exactly *leading whitespace + a `decrease_indent_pattern` trigger* and the cursor is at end of line, the line re-indents one level shallower than the previous non-blank line (VS Code / Sublime / Vim behavior).

### Trigger contract

The engine's rule is deliberately simple and unchanged from the first version: on each keystroke the line is matched against `decrease_indent_pattern`, and the dedent fires at the keystroke where the pattern **first consumes the whole line** (leading whitespace included, trailing whitespace tolerated). There is no restore-on-unmatch, no separate terminator config, and no reindent when Enter leaves the line.

**Which keystroke that is, is decided by the pattern — which is exactly how VS Code's `decreaseIndentPattern` works.** The built-in Python-family pattern therefore requires the statement-final colon, mirroring ms-python's `^\s*(elif\s.*|else\s*|except.*|finally\s*):`:

```
^\s*(elif\s.*|else\s*|except.*|finally\s*|case\s.*):\s*
```

so:

- `else:`, `elif x > 0:`, `except ValueError:`, `finally:` dedent on the `:` keystroke — the moment the statement is unambiguous;
- a bare `else` does not move the line;
- an identifier that merely begins with a keyword (`elsewhere`, `else_value`) can never fire, at any point while typing;
- `case _:` typed as the first body line under `match x:` still stays inside its block.

Only the Python family has a syntactic statement terminator, so only its pattern changed. The keyword-delimited families (Ruby/Lua/Bash/Fish/Pascal `end`, `fi`, `until`, …) have no terminator to include and are left as they are — VS Code-land behaves the same way there. The pattern is not end-anchored, so the pre-existing Enter-time (line-split) dedent path still recognizes a moved-down `else: …` tail.

The remaining engine safeguards are unchanged:
- fires only with the cursor at end of line, and only at the first whole-line match, so later keystrokes never re-fire and mid-line occurrences never fire;
- only ever dedents; a line the user already dedented at/below the target is left alone;
- skipped when the previous non-blank line opens a block, so a block's first body line is never pulled out of its block;
- prefix scan capped at 128 bytes (O(1) per keystroke on long lines) and scope-masked, so triggers inside strings/comments are ignored.

`docs/configuration` now documents this for custom patterns: `decrease_indent_pattern` is matched against the whole line on every keystroke, so include the terminator in the pattern when the language has one (`^\s*end$` rather than `^\s*end\b`).

## Tests

Verified in this environment (run and observed):

- `cargo test -p fresh-editor --lib indent` — **145 passed, 0 failed** (unit tests for the rules tier, including the updated `python_decrease_consumes_line_only_for_pure_trigger`, the new Enter-time `python_moved_down_else_dedents_on_enter`, and the colon-based on-type target tests).
- `cargo test -p fresh-editor --lib test_typing` — action-level tests through the real `InsertChar` action: **all passed**, covering `test_typing_else_colon_dedents_python_line`, `test_typing_elif_condition_dedents_at_colon`, `test_typing_elsewhere_never_dedents`, `test_typing_else_mid_line_does_not_reindent`, `test_typing_case_directly_under_match_keeps_indent`, `test_typing_else_on_manually_dedented_line_is_noop`.
- **Fails-without-fix check performed**: with the Python `decrease` pattern reverted to the old bare-keyword form, `python_decrease_consumes_line_only_for_pure_trigger` and 3 of the action-level typing tests fail; restoring the colon pattern makes them pass.
- `cargo clippy -p fresh-editor --lib` — no new warnings from the touched code.
- `cargo fmt` — clean.
- Config-schema regenerated (`generate_schema`) so the committed `config-schema.json` matches the updated doc comment; the schema-related unit tests pass.
- Manual tmux validation with a freshly built debug binary (Python file): `if a:` ⏎ `x = 1` ⏎ typing `else` leaves the line at the body indent, the following `:` dedents it to column 1; typing `elsewhere = 3` on an indented line never dedents.
- Earlier (pre-follow-up-commit) run of the full `cargo test -p fresh-editor --lib` suite and `cargo test -p fresh-editor --test e2e_tests -- indent` (115 passed) covered the first two commits.

Not re-verified in this environment: the full lib suite and the e2e `-- indent` suite were **not** re-run after this final commit and after the rebase onto current `master` (build capacity was constrained); CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y)_