### PR TITLE
CLI argument parsing: fail loudly on malformed ssh:// URLs; support vim-style +N line args

### DIFF
--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Ukončit démon",
   "cli.cmd.session_open_file": "Otevřít soubory v démonu (--wait blokuje až do dokončení)",
   "cli.file_syntax.line": "Otevřít na řádku 10",
+  "cli.file_syntax.plus_line": "Otevřít na řádku 10 (styl vim)",
   "cli.file_syntax.line_col": "Otevřít na řádku 10, sloupec 5",
   "cli.file_syntax.range": "Vybrat řádky 10 až 20",
   "cli.file_syntax.range_col": "Vybrat od řádku 10 sloupec 5 po řádek 20 sloupec 1",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Einen Daemon beenden",
   "cli.cmd.session_open_file": "Dateien in einem Daemon öffnen (--wait blockiert bis zum Abschluss)",
   "cli.file_syntax.line": "In Zeile 10 öffnen",
+  "cli.file_syntax.plus_line": "In Zeile 10 öffnen (vim-Stil)",
   "cli.file_syntax.line_col": "In Zeile 10, Spalte 5 öffnen",
   "cli.file_syntax.range": "Zeilen 10 bis 20 auswählen",
   "cli.file_syntax.range_col": "Von Zeile 10, Spalte 5 bis Zeile 20, Spalte 1 auswählen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -39,6 +39,7 @@
   "cli.cmd.session_kill": "Terminate a daemon",
   "cli.cmd.session_open_file": "Open files in a daemon (--wait blocks until done)",
   "cli.file_syntax.line": "Open at line 10",
+  "cli.file_syntax.plus_line": "Open at line 10 (vim-style)",
   "cli.file_syntax.line_col": "Open at line 10, column 5",
   "cli.file_syntax.range": "Select lines 10 to 20",
   "cli.file_syntax.range_col": "Select from line 10 column 5 to line 20 column 1",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Terminar un demonio",
   "cli.cmd.session_open_file": "Abrir archivos en un demonio (--wait bloquea hasta finalizar)",
   "cli.file_syntax.line": "Abrir en la línea 10",
+  "cli.file_syntax.plus_line": "Abrir en la línea 10 (estilo vim)",
   "cli.file_syntax.line_col": "Abrir en la línea 10, columna 5",
   "cli.file_syntax.range": "Seleccionar las líneas 10 a 20",
   "cli.file_syntax.range_col": "Seleccionar desde la línea 10 columna 5 hasta la línea 20 columna 1",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Terminer un démon",
   "cli.cmd.session_open_file": "Ouvrir des fichiers dans un démon (--wait bloque jusqu'à la fin)",
   "cli.file_syntax.line": "Ouvrir à la ligne 10",
+  "cli.file_syntax.plus_line": "Ouvrir à la ligne 10 (style vim)",
   "cli.file_syntax.line_col": "Ouvrir à la ligne 10, colonne 5",
   "cli.file_syntax.range": "Sélectionner les lignes 10 à 20",
   "cli.file_syntax.range_col": "Sélectionner de la ligne 10 colonne 5 à la ligne 20 colonne 1",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Termina un demone",
   "cli.cmd.session_open_file": "Apre i file in un demone (--wait blocca finché non termina)",
   "cli.file_syntax.line": "Apre alla riga 10",
+  "cli.file_syntax.plus_line": "Apre alla riga 10 (stile vim)",
   "cli.file_syntax.line_col": "Apre alla riga 10, colonna 5",
   "cli.file_syntax.range": "Seleziona le righe da 10 a 20",
   "cli.file_syntax.range_col": "Seleziona dalla riga 10 colonna 5 alla riga 20 colonna 1",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "デーモンを終了します",
   "cli.cmd.session_open_file": "デーモンでファイルを開きます（--wait は完了までブロック）",
   "cli.file_syntax.line": "10 行目で開く",
+  "cli.file_syntax.plus_line": "10 行目で開く（vim 形式）",
   "cli.file_syntax.line_col": "10 行目 5 列目で開く",
   "cli.file_syntax.range": "10 行目から 20 行目を選択する",
   "cli.file_syntax.range_col": "10 行目 5 列目から 20 行目 1 列目までを選択する",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "데몬을 종료합니다",
   "cli.cmd.session_open_file": "데몬에서 파일을 엽니다 (--wait 는 완료될 때까지 블로킹)",
   "cli.file_syntax.line": "10번째 줄에서 열기",
+  "cli.file_syntax.plus_line": "10번째 줄에서 열기 (vim 스타일)",
   "cli.file_syntax.line_col": "10번째 줄, 5번째 열에서 열기",
   "cli.file_syntax.range": "10에서 20번째 줄까지 선택",
   "cli.file_syntax.range_col": "10번째 줄 5번째 열부터 20번째 줄 1번째 열까지 선택",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Encerra um daemon",
   "cli.cmd.session_open_file": "Abre arquivos em um daemon (--wait bloqueia até concluir)",
   "cli.file_syntax.line": "Abre na linha 10",
+  "cli.file_syntax.plus_line": "Abre na linha 10 (estilo vim)",
   "cli.file_syntax.line_col": "Abre na linha 10, coluna 5",
   "cli.file_syntax.range": "Seleciona da linha 10 à 20",
   "cli.file_syntax.range_col": "Seleciona da linha 10 coluna 5 até a linha 20 coluna 1",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Завершить демон",
   "cli.cmd.session_open_file": "Открыть файлы в демоне (--wait блокирует до завершения)",
   "cli.file_syntax.line": "Открыть на строке 10",
+  "cli.file_syntax.plus_line": "Открыть на строке 10 (в стиле vim)",
   "cli.file_syntax.line_col": "Открыть на строке 10, столбце 5",
   "cli.file_syntax.range": "Выделить строки с 10 по 20",
   "cli.file_syntax.range_col": "Выделить со строки 10 столбца 5 по строку 20 столбец 1",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "ปิดเดมอน",
   "cli.cmd.session_open_file": "เปิดไฟล์ในเดมอน (--wait จะค้างไว้จนกว่าจะเสร็จ)",
   "cli.file_syntax.line": "เปิดที่บรรทัด 10",
+  "cli.file_syntax.plus_line": "เปิดที่บรรทัด 10 (แบบ vim)",
   "cli.file_syntax.line_col": "เปิดที่บรรทัด 10 คอลัมน์ 5",
   "cli.file_syntax.range": "เลือกบรรทัด 10 ถึง 20",
   "cli.file_syntax.range_col": "เลือกจากบรรทัด 10 คอลัมน์ 5 ถึงบรรทัด 20 คอลัมน์ 1",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Завершити демон",
   "cli.cmd.session_open_file": "Відкрити файли в демоні (--wait блокує до завершення)",
   "cli.file_syntax.line": "Відкрити на рядку 10",
+  "cli.file_syntax.plus_line": "Відкрити на рядку 10 (у стилі vim)",
   "cli.file_syntax.line_col": "Відкрити на рядку 10, стовпчик 5",
   "cli.file_syntax.range": "Вибрати рядки з 10 по 20",
   "cli.file_syntax.range_col": "Вибрати з рядка 10 стовпчика 5 до рядка 20 стовпчика 1",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "Kết thúc một daemon",
   "cli.cmd.session_open_file": "Mở các tệp trong một daemon (--wait sẽ chặn cho đến khi hoàn tất)",
   "cli.file_syntax.line": "Mở tại dòng 10",
+  "cli.file_syntax.plus_line": "Mở tại dòng 10 (kiểu vim)",
   "cli.file_syntax.line_col": "Mở tại dòng 10, cột 5",
   "cli.file_syntax.range": "Chọn dòng 10 đến 20",
   "cli.file_syntax.range_col": "Chọn từ dòng 10 cột 5 tới dòng 20 cột 1",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -44,6 +44,7 @@
   "cli.cmd.session_kill": "终止一个守护进程",
   "cli.cmd.session_open_file": "在守护进程中打开文件（--wait 会阻塞至完成）",
   "cli.file_syntax.line": "在第 10 行打开",
+  "cli.file_syntax.plus_line": "在第 10 行打开（vim 风格）",
   "cli.file_syntax.line_col": "在第 10 行第 5 列打开",
   "cli.file_syntax.range": "选择第 10 至 20 行",
   "cli.file_syntax.range_col": "从第 10 行第 5 列选择到第 20 行第 1 列",

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1252,35 +1252,50 @@ fn default_ssh_user() -> Option<String> {
 }
 
 /// Parse the part of an `ssh://` URL after the `ssh://` prefix.
-/// Returns `None` for any shape we don't recognise (missing `/path`,
-/// empty host, bad port, missing user with no `$USER` fallback).
-fn parse_ssh_url_rest(rest: &str) -> Option<RemoteLocation> {
+/// `default_user` fills in when the URL omits `user@` (normally
+/// `default_ssh_user()`; injected so tests don't depend on the
+/// runner's environment).  Returns a human-readable reason for any
+/// shape we don't recognise (missing `/path`, empty host, bad port,
+/// missing user with no fallback) — the caller reports it as a hard
+/// error, never as a silent local-path fallback (#2221).
+fn parse_ssh_url_rest(rest: &str, default_user: Option<&str>) -> Result<RemoteLocation, String> {
     // Authority and path are separated by the first `/`.  Missing
     // slash means no path, which we reject — consistent with the
     // scp-style branch that requires a non-empty path component.
-    let (authority, path_and_rest) = rest.split_once('/')?;
-    if path_and_rest.is_empty() {
-        return None;
-    }
+    let (authority, path_and_rest) = rest
+        .split_once('/')
+        .filter(|(_, path)| !path.is_empty())
+        .ok_or_else(|| {
+            "missing remote path (expected ssh://[user@]host[:port]/path)".to_string()
+        })?;
 
     // Optional `user@` prefix on the authority.
     let (user, host_and_port) = match authority.split_once('@') {
         Some((u, rest)) if !u.is_empty() && !u.contains(' ') => (u.to_string(), rest),
-        Some(_) => return None, // empty or space-bearing user
-        None => (default_ssh_user()?, authority),
+        Some(_) => return Err("empty or invalid user before '@'".to_string()),
+        None => match default_user {
+            Some(u) => (u.to_string(), authority),
+            None => {
+                return Err("no user given and neither $USER nor $USERNAME is set; \
+                     specify one explicitly (ssh://user@host/path)"
+                    .to_string());
+            }
+        },
     };
 
     // Optional `:port` on the host.
     let (host, port) = match host_and_port.rsplit_once(':') {
         Some((h, p)) => {
-            let parsed_port = p.parse::<u16>().ok()?;
+            let parsed_port = p
+                .parse::<u16>()
+                .map_err(|_| format!("invalid port {:?}", p))?;
             (h, Some(parsed_port))
         }
         None => (host_and_port, None),
     };
 
     if host.is_empty() || host.contains(' ') {
-        return None;
+        return Err("empty or invalid host".to_string());
     }
 
     let (path_tail, line, column) = parse_path_with_line_col(path_and_rest);
@@ -1289,7 +1304,7 @@ fn parse_ssh_url_rest(rest: &str) -> Option<RemoteLocation> {
     // same absolute path they'd get from `ssh://host/etc/hosts`.
     let path = format!("/{}", path_tail);
 
-    Some(RemoteLocation {
+    Ok(RemoteLocation {
         user,
         host: host.to_string(),
         port,
@@ -1325,7 +1340,7 @@ fn extract_ssh_url_from_files(files: &[String]) -> AnyhowResult<Option<String>> 
         .iter()
         .filter(|f| *f != "-")
         .map(|f| parse_location(f))
-        .collect();
+        .collect::<AnyhowResult<Vec<_>>>()?;
 
     let remotes: Vec<&RemoteLocation> = parsed
         .iter()
@@ -1372,8 +1387,13 @@ fn parse_ssh_url_arg(url: &str) -> AnyhowResult<RemoteLocation> {
     let rest = url
         .strip_prefix("ssh://")
         .ok_or_else(|| anyhow::anyhow!("--ssh-url expects an ssh:// URL, got {:?}", url))?;
-    parse_ssh_url_rest(rest)
-        .ok_or_else(|| anyhow::anyhow!("--ssh-url is not a valid ssh:// URL: {:?}", url))
+    parse_ssh_url_rest(rest, default_ssh_user().as_deref()).map_err(|reason| {
+        anyhow::anyhow!(
+            "--ssh-url is not a valid ssh:// URL ({}): {:?}",
+            reason,
+            url
+        )
+    })
 }
 
 /// Parse a location that may be local, scp-style remote, or an
@@ -1387,15 +1407,32 @@ fn parse_ssh_url_arg(url: &str) -> AnyhowResult<RemoteLocation> {
 /// When `ssh://` omits the user, the current login name (`$USER` /
 /// `$USERNAME`) is used.  The URL form is the only way to pass a
 /// port.  The path must be non-empty in both remote forms.
-fn parse_location(input: &str) -> ParsedLocation {
+///
+/// The `ssh://` scheme is claimed exclusively: a malformed `ssh://`
+/// argument is a hard error, never a local-path fallback.  Silently
+/// opening a local buffer named `ssh://host/...` hid the failure and
+/// invited saving to a bogus local path (#2221).  A genuine local
+/// file whose name starts with `ssh://` can still be opened as
+/// `./ssh://...`.
+fn parse_location(input: &str) -> AnyhowResult<ParsedLocation> {
+    parse_location_with_default_user(input, default_ssh_user().as_deref())
+}
+
+/// `parse_location` with the `$USER`/`$USERNAME` fallback injected,
+/// so tests can pin it without mutating the process environment.
+fn parse_location_with_default_user(
+    input: &str,
+    default_user: Option<&str>,
+) -> AnyhowResult<ParsedLocation> {
     if let Some(rest) = input.strip_prefix("ssh://") {
-        return match parse_ssh_url_rest(rest) {
-            Some(loc) => ParsedLocation::Remote(loc),
-            // Malformed `ssh://` — treat the whole input as a local
-            // filename rather than letting scp-style parsing match
-            // the `ssh://user@host:bad-port/...` slice and produce a
-            // nonsense user like `ssh://user`.
-            None => ParsedLocation::Local(parse_file_location(input)),
+        return match parse_ssh_url_rest(rest, default_user) {
+            Ok(loc) => Ok(ParsedLocation::Remote(loc)),
+            Err(reason) => Err(anyhow::anyhow!(
+                "invalid ssh:// URL {:?}: {}. \
+                 To open a local file with this name, prefix it with ./",
+                input,
+                reason
+            )),
         };
     }
 
@@ -1417,20 +1454,20 @@ fn parse_location(input: &str) -> ParsedLocation {
             {
                 let (path, line, column) = parse_path_with_line_col(path_and_rest);
 
-                return ParsedLocation::Remote(RemoteLocation {
+                return Ok(ParsedLocation::Remote(RemoteLocation {
                     user: user.to_string(),
                     host: host.to_string(),
                     port: None,
                     path,
                     line,
                     column,
-                });
+                }));
             }
         }
     }
 
     // Not a remote path, parse as local
-    ParsedLocation::Local(parse_file_location(input))
+    Ok(ParsedLocation::Local(parse_file_location(input)))
 }
 
 /// Holds resources needed for remote editing (kept alive for duration of session)
@@ -1634,7 +1671,7 @@ fn initialize_app(args: &Args) -> AnyhowResult<SetupState> {
         .iter()
         .filter(|f| *f != "-")
         .map(|f| parse_location(f))
-        .collect();
+        .collect::<AnyhowResult<Vec<_>>>()?;
 
     // Check for remote locations - for now, collect them separately
     let remote_locations: Vec<&RemoteLocation> = parsed_locations
@@ -3095,9 +3132,11 @@ fn run_open_files_command(
     let local_files: Vec<String> = if ssh_url.is_some() {
         files
             .iter()
+            // Parse errors were already surfaced by
+            // `extract_ssh_url_from_files` above.
             .filter_map(|f| match parse_location(f) {
-                ParsedLocation::Remote(r) => Some(r.path),
-                ParsedLocation::Local(_) => None,
+                Ok(ParsedLocation::Remote(r)) => Some(r.path),
+                _ => None,
             })
             .collect()
     } else {
@@ -4655,9 +4694,11 @@ fn run_attach(session_name: Option<&str>, files: &[String]) -> AnyhowResult<()> 
         let local_files: Vec<String> = if ssh_url.is_some() {
             files
                 .iter()
+                // Parse errors were already surfaced by
+                // `extract_ssh_url_from_files` above.
                 .filter_map(|f| match parse_location(f) {
-                    ParsedLocation::Remote(r) => Some(r.path),
-                    ParsedLocation::Local(_) => None,
+                    Ok(ParsedLocation::Remote(r)) => Some(r.path),
+                    _ => None,
                 })
                 .collect()
         } else {
@@ -6456,7 +6497,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_local_simple() {
-        let loc = parse_location("file.txt");
+        let loc = parse_location("file.txt").unwrap();
         match loc {
             ParsedLocation::Local(fl) => {
                 assert_eq!(fl.path, PathBuf::from("file.txt"));
@@ -6468,7 +6509,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_local_with_line() {
-        let loc = parse_location("/path/to/file.rs:42");
+        let loc = parse_location("/path/to/file.rs:42").unwrap();
         match loc {
             ParsedLocation::Local(fl) => {
                 assert_eq!(fl.path, PathBuf::from("/path/to/file.rs"));
@@ -6480,7 +6521,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_remote_simple() {
-        let loc = parse_location("user@host:/path/to/file.rs");
+        let loc = parse_location("user@host:/path/to/file.rs").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "user");
@@ -6495,7 +6536,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_remote_with_line() {
-        let loc = parse_location("alice@server.com:/home/alice/project/main.rs:42");
+        let loc = parse_location("alice@server.com:/home/alice/project/main.rs:42").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "alice");
@@ -6510,7 +6551,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_remote_with_line_and_col() {
-        let loc = parse_location("bob@example.org:src/lib.rs:100:25");
+        let loc = parse_location("bob@example.org:src/lib.rs:100:25").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "bob");
@@ -6525,7 +6566,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_remote_relative_path() {
-        let loc = parse_location("user@host:relative/path/file.txt");
+        let loc = parse_location("user@host:relative/path/file.txt").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "user");
@@ -6539,7 +6580,7 @@ mod tests {
     #[test]
     fn test_parse_location_email_like_not_remote() {
         // An email-like string without a path should be treated as local
-        let loc = parse_location("user@host");
+        let loc = parse_location("user@host").unwrap();
         match loc {
             ParsedLocation::Local(fl) => {
                 assert_eq!(fl.path, PathBuf::from("user@host"));
@@ -6551,7 +6592,7 @@ mod tests {
     #[test]
     fn test_parse_location_at_in_path_local() {
         // A local path that happens to contain @ should still be local
-        let loc = parse_location("/path/with@sign/file.txt");
+        let loc = parse_location("/path/with@sign/file.txt").unwrap();
         match loc {
             ParsedLocation::Local(fl) => {
                 assert_eq!(fl.path, PathBuf::from("/path/with@sign/file.txt"));
@@ -6561,12 +6602,13 @@ mod tests {
     }
 
     // Tests for the URL-style `ssh://` remote form.  The `$USER`
-    // fallback-dependent cases set the env var explicitly so they
-    // don't depend on the test runner's environment.
+    // fallback-dependent cases inject the default user through
+    // `parse_location_with_default_user` so they don't depend on (or
+    // race over) the test runner's environment.
 
     #[test]
     fn test_parse_location_ssh_url_user_and_path() {
-        let loc = parse_location("ssh://alice@host.example/home/alice/main.rs");
+        let loc = parse_location("ssh://alice@host.example/home/alice/main.rs").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "alice");
@@ -6582,7 +6624,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_ssh_url_with_port() {
-        let loc = parse_location("ssh://bob@server:2222/etc/hosts");
+        let loc = parse_location("ssh://bob@server:2222/etc/hosts").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "bob");
@@ -6596,7 +6638,7 @@ mod tests {
 
     #[test]
     fn test_parse_location_ssh_url_with_port_and_line_col() {
-        let loc = parse_location("ssh://bob@server:2222/src/lib.rs:42:7");
+        let loc = parse_location("ssh://bob@server:2222/src/lib.rs:42:7").unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "bob");
@@ -6611,27 +6653,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_location_ssh_url_default_user_from_env() {
-        // Temporarily override $USER so the test doesn't depend on
-        // whatever the runner has set.
-        let prev_user = std::env::var("USER").ok();
-        let prev_username = std::env::var("USERNAME").ok();
-        // SAFETY: single-threaded test; no other thread reads $USER.
-        unsafe {
-            std::env::set_var("USER", "envuser");
-        }
-        let loc = parse_location("ssh://host.example/tmp/file.txt");
-        // Restore before asserting so a panic doesn't poison later tests.
-        unsafe {
-            match prev_user {
-                Some(ref v) => std::env::set_var("USER", v),
-                None => std::env::remove_var("USER"),
-            }
-            match prev_username {
-                Some(ref v) => std::env::set_var("USERNAME", v),
-                None => std::env::remove_var("USERNAME"),
-            }
-        }
+    fn test_parse_location_ssh_url_default_user_fallback() {
+        // No `user@` in the URL → the injected default (normally
+        // `$USER` / `$USERNAME`) fills in.
+        let loc =
+            parse_location_with_default_user("ssh://host.example/tmp/file.txt", Some("envuser"))
+                .unwrap();
         match loc {
             ParsedLocation::Remote(rl) => {
                 assert_eq!(rl.user, "envuser");
@@ -6644,39 +6671,98 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_location_ssh_url_missing_path_is_local() {
-        // `ssh://host` with no `/path` is malformed — fall through to
-        // the local parser, which stores the whole thing as a filename.
-        let loc = parse_location("ssh://host.example");
+    fn test_parse_location_ssh_url_no_user_no_env_is_error() {
+        // #2221: a userless `ssh://` URL with no `$USER`/`$USERNAME`
+        // fallback must fail loudly — never silently degrade to a
+        // local file named `ssh://...` (typing into that buffer and
+        // saving would write to a bogus local path).
+        let err = parse_location_with_default_user("ssh://localhost/etc/hosts", None)
+            .expect_err("userless ssh:// URL without $USER must be an error, not a local path");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("ssh://"),
+            "error should name the scheme: {msg}"
+        );
+        assert!(
+            msg.contains("$USER"),
+            "error should explain the cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_parse_location_ssh_url_missing_path_is_error() {
+        // `ssh://host` with no `/path` is malformed — hard error, not
+        // a local-path fallback.
+        let err = parse_location_with_default_user("ssh://host.example", Some("alice"))
+            .expect_err("ssh:// URL without a path must be an error");
+        assert!(format!("{}", err).contains("path"));
+    }
+
+    #[test]
+    fn test_parse_location_ssh_url_bad_port_is_error() {
+        // Non-numeric port → hard error, not a local-path fallback.
+        let err =
+            parse_location_with_default_user("ssh://alice@host:not-a-port/file", Some("alice"))
+                .expect_err("ssh:// URL with a bad port must be an error");
+        assert!(format!("{}", err).contains("port"));
+    }
+
+    #[test]
+    fn test_parse_location_ssh_url_empty_user_is_error() {
+        // `@` with an empty user is malformed — hard error.
+        assert!(parse_location_with_default_user("ssh://@host/path", Some("alice")).is_err());
+    }
+
+    #[test]
+    fn test_parse_location_ssh_url_userless_with_default_and_port() {
+        // Userless URL + default user still parses ports and line/col.
+        let loc =
+            parse_location_with_default_user("ssh://host:2200/var/log/syslog:12:3", Some("bob"))
+                .unwrap();
         match loc {
-            ParsedLocation::Local(fl) => {
-                assert_eq!(fl.path, PathBuf::from("ssh://host.example"));
+            ParsedLocation::Remote(rl) => {
+                assert_eq!(rl.user, "bob");
+                assert_eq!(rl.host, "host");
+                assert_eq!(rl.port, Some(2200));
+                assert_eq!(rl.path, "/var/log/syslog");
+                assert_eq!(rl.line, Some(12));
+                assert_eq!(rl.column, Some(3));
             }
-            ParsedLocation::Remote(_) => panic!("Expected local, got remote"),
+            ParsedLocation::Local(_) => panic!("Expected remote, got local"),
         }
     }
 
     #[test]
-    fn test_parse_location_ssh_url_bad_port_is_local() {
-        // Non-numeric port → falls through to local.
-        let loc = parse_location("ssh://alice@host:not-a-port/file");
+    fn test_parse_location_scp_style_unaffected_by_missing_user_env() {
+        // scp-style carries its user explicitly; the `$USER` fallback
+        // plays no part.
+        let loc = parse_location_with_default_user("root@localhost:/etc/hosts", None).unwrap();
         match loc {
-            ParsedLocation::Local(fl) => {
-                assert_eq!(fl.path, PathBuf::from("ssh://alice@host:not-a-port/file"));
+            ParsedLocation::Remote(rl) => {
+                assert_eq!(rl.user, "root");
+                assert_eq!(rl.host, "localhost");
+                assert_eq!(rl.path, "/etc/hosts");
             }
-            ParsedLocation::Remote(_) => panic!("Expected local, got remote"),
+            ParsedLocation::Local(_) => panic!("Expected remote, got local"),
         }
     }
 
     #[test]
-    fn test_parse_location_ssh_url_empty_user_is_local() {
-        // `@` with an empty user is malformed — fall through to local.
-        let loc = parse_location("ssh://@host/path");
-        match loc {
-            ParsedLocation::Local(fl) => {
-                assert_eq!(fl.path, PathBuf::from("ssh://@host/path"));
+    fn test_parse_location_weird_local_names_still_local() {
+        // Only the exact `ssh://` scheme is claimed; other odd names
+        // stay local files, even with no `$USER` fallback available.
+        for input in [
+            "ssh:file.txt",
+            "ssh:/host/path",
+            "sshfile",
+            "./ssh://host/path",
+        ] {
+            match parse_location_with_default_user(input, None).unwrap() {
+                ParsedLocation::Local(fl) => {
+                    assert_eq!(fl.path, PathBuf::from(input), "input: {input}");
+                }
+                ParsedLocation::Remote(_) => panic!("Expected local for {input:?}"),
             }
-            ParsedLocation::Remote(_) => panic!("Expected local, got remote"),
         }
     }
 

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1049,6 +1049,73 @@ fn build_file_requests(
     requests
 }
 
+/// Recognise a vim-style `+N` CLI argument.  Returns the line number
+/// for `+<digits>` (saturating at `usize::MAX` — the jump clamps to
+/// the buffer end anyway, matching `file:huge`), `None` for anything
+/// else.  A bare `+` is NOT claimed: it stays an ordinary filename
+/// (vim's "+ = last line" has no `file:line` equivalent).
+fn parse_plus_line_arg(arg: &str) -> Option<usize> {
+    let digits = arg.strip_prefix('+')?;
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(digits.parse::<usize>().unwrap_or(usize::MAX))
+}
+
+/// Fold vim-style `+N` arguments into the file list, so
+/// `fresh +50 file.txt` behaves exactly like `fresh file.txt:50`
+/// (#1926).  Previously `+50` was opened as a literal (empty) file
+/// named `+50`, and in trailing position that stray buffer also stole
+/// focus from the real file.
+///
+/// Vim-like, the line applies to the first file argument; an explicit
+/// `file:line` location on that file wins over the `+N`.  The stdin
+/// marker `-` is skipped when picking the target.  A file literally
+/// named `+50` can still be opened as `./+50` (same escape hatch vim
+/// uses).
+fn apply_plus_line_args(files: Vec<String>) -> AnyhowResult<Vec<String>> {
+    let mut line: Option<usize> = None;
+    let mut plus_count = 0usize;
+    let mut rest: Vec<String> = Vec::with_capacity(files.len());
+    for f in files {
+        match parse_plus_line_arg(&f) {
+            Some(n) => {
+                plus_count += 1;
+                line = Some(n);
+            }
+            None => rest.push(f),
+        }
+    }
+    let Some(line) = line else {
+        return Ok(rest);
+    };
+    if plus_count > 1 {
+        anyhow::bail!("Too many '+<line>' arguments (at most one is allowed)");
+    }
+    match rest.iter_mut().find(|f| f.as_str() != "-") {
+        Some(target) => {
+            // Only annotate a file that carries no explicit location
+            // yet — `fresh +50 file.txt:10` keeps the explicit 10.
+            // Remote specs (`user@host:path`, `ssh://…`) take the
+            // same `:line` suffix, so they work too.  A malformed
+            // `ssh://` target is left alone; it errors downstream.
+            let has_line = match parse_location(target) {
+                Ok(ParsedLocation::Local(fl)) => fl.line.is_some(),
+                Ok(ParsedLocation::Remote(rl)) => rl.line.is_some(),
+                Err(_) => true,
+            };
+            if !has_line {
+                target.push_str(&format!(":{}", line));
+            }
+            Ok(rest)
+        }
+        None => anyhow::bail!(
+            "'+{line}' requires a file argument (e.g. 'fresh +{line} file.txt', \
+             which is equivalent to 'fresh file.txt:{line}')"
+        ),
+    }
+}
+
 fn parse_file_location(input: &str) -> FileLocation {
     use std::path::{Component, Path};
 
@@ -5140,6 +5207,10 @@ fn build_localized_after_help() -> String {
         t("cli.file_syntax.line")
     ));
     out.push_str(&format!(
+        "  +10 file.txt                 {}\n",
+        t("cli.file_syntax.plus_line")
+    ));
+    out.push_str(&format!(
         "  file.txt:10:5                {}\n",
         t("cli.file_syntax.line_col")
     ));
@@ -5323,7 +5394,13 @@ fn real_main() -> AnyhowResult<()> {
     }
 
     // Convert to legacy Args format for compatibility
-    let args: Args = cli.into();
+    let mut args: Args = cli.into();
+
+    // Fold vim-style `+N` line arguments into the file list before any
+    // consumer (TUI, GUI, web, attach, nested forward) sees it, so
+    // `fresh +50 file.txt` == `fresh file.txt:50` everywhere (#1926).
+    args.files = apply_plus_line_args(std::mem::take(&mut args.files))?;
+    let args = args;
 
     // Expose `FRESH_INTERACTIVE=1` on the editor's process env when Fresh
     // is launched as a human-interactive editor (stdin is a TTY, not a
@@ -6764,6 +6841,106 @@ mod tests {
                 ParsedLocation::Remote(_) => panic!("Expected local for {input:?}"),
             }
         }
+    }
+
+    // Tests for vim-style `+N` CLI line arguments (#1926).  Without
+    // the fold, `+50` used to open as a literal empty buffer named
+    // `+50` (and, trailing, steal focus from the real file).
+
+    fn plus_args(args: &[&str]) -> AnyhowResult<Vec<String>> {
+        apply_plus_line_args(args.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn test_plus_line_arg_before_file() {
+        assert_eq!(
+            plus_args(&["+50", "file.txt"]).unwrap(),
+            vec!["file.txt:50"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_after_file() {
+        // Trailing position used to be the worst case: the stray `+50`
+        // buffer stole focus from file.txt.
+        assert_eq!(
+            plus_args(&["file.txt", "+50"]).unwrap(),
+            vec!["file.txt:50"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_applies_to_first_file() {
+        // Vim-like: the line goes to the first file argument.
+        assert_eq!(
+            plus_args(&["a.txt", "+7", "b.txt"]).unwrap(),
+            vec!["a.txt:7", "b.txt"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_zero_and_huge() {
+        // `+0` is passed through; the jump clamps to line 1 downstream,
+        // same as `file:0`.
+        assert_eq!(plus_args(&["+0", "f"]).unwrap(), vec!["f:0"]);
+        // A line number beyond usize::MAX saturates instead of turning
+        // back into a filename; the jump clamps to the buffer end.
+        assert_eq!(
+            plus_args(&["+99999999999999999999999999", "f"]).unwrap(),
+            vec![format!("f:{}", usize::MAX)]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_explicit_location_wins() {
+        // An explicit file:line on the target beats the `+N`.
+        assert_eq!(
+            plus_args(&["+50", "file.txt:10"]).unwrap(),
+            vec!["file.txt:10"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_remote_specs() {
+        // Remote specs take the same `:line` suffix.
+        assert_eq!(
+            plus_args(&["+9", "user@host:/etc/hosts"]).unwrap(),
+            vec!["user@host:/etc/hosts:9"]
+        );
+        assert_eq!(
+            plus_args(&["+9", "ssh://alice@host/etc/hosts"]).unwrap(),
+            vec!["ssh://alice@host/etc/hosts:9"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_skips_stdin_marker() {
+        assert_eq!(
+            plus_args(&["-", "+3", "file.txt"]).unwrap(),
+            vec!["-", "file.txt:3"]
+        );
+    }
+
+    #[test]
+    fn test_plus_line_arg_non_matching_args_untouched() {
+        // Bare `+`, `./+50`, and `+abc` are ordinary filenames, not
+        // line arguments.
+        for name in ["+", "./+50", "+abc", "+5x"] {
+            assert_eq!(plus_args(&[name, "f"]).unwrap(), vec![name, "f"]);
+        }
+        // And with no `+N` at all the list is passed through as-is.
+        assert_eq!(plus_args(&["a", "b"]).unwrap(), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_plus_line_arg_without_file_is_error() {
+        assert!(plus_args(&["+50"]).is_err());
+        assert!(plus_args(&["-", "+50"]).is_err());
+    }
+
+    #[test]
+    fn test_plus_line_arg_multiple_is_error() {
+        assert!(plus_args(&["+1", "+2", "file.txt"]).is_err());
     }
 
     // Tests for the client→daemon plumbing: a remote spec on the

--- a/docs/features/ssh.md
+++ b/docs/features/ssh.md
@@ -13,6 +13,13 @@ The URL form is the only one that accepts a non-standard port and is
 the only one where the user is optional (it defaults to `$USER` /
 `$USERNAME`).
 
+The `ssh://` scheme is claimed exclusively: an argument starting with
+`ssh://` is always treated as a remote spec, and a malformed one
+(missing path, bad port, or no user when neither `$USER` nor
+`$USERNAME` is set) is an error at startup — it never falls back to
+opening a local file. A genuine local file whose name starts with
+`ssh://` can still be opened as `./ssh://...`.
+
 ```bash
 # scp-style: open a specific file
 fresh deploy@server.example.com:/etc/nginx/nginx.conf


### PR DESCRIPTION
Fixes #2221
Fixes #1926

Two CLI argument-parsing fixes, one commit each (plus a docs note).

## Motivation

**#2221 — ssh:// silently degrades to a local file.** A userless `ssh://host/path` run without `$USER`/`$USERNAME` in the environment (and any other malformed `ssh://` argument: missing path, bad port, empty user) fell back to opening a *local* buffer literally named `ssh://...`. No error, no SSH attempt — and saving that buffer offered to create a local `ssh://host/...` directory, a data-loss trap for anyone following the documented URL form.

**#1926 — vim-style `+N`.** `fresh +50 file.txt` opened a stray empty buffer named `+50`, and in trailing position (`fresh file.txt +50`) that stray buffer also stole focus from the real file.

## The fix

**ssh://**: `parse_location` now returns a `Result`, and the `ssh://` scheme is claimed exclusively — anything starting with `ssh://` that doesn't parse as a remote spec fails startup with the specific reason, e.g.:

```
invalid ssh:// URL "ssh://localhost/etc/hosts": no user given and neither $USER nor
$USERNAME is set; specify one explicitly (ssh://user@host/path). To open a local file
with this name, prefix it with ./
```

The `$USER`/`$USERNAME` fallback is injected as a parameter (`parse_location_with_default_user`) so tests cover the no-`$USER` case without racing over the process environment. Local files with odd names (`ssh:file`, `ssh:/x`, `./ssh://x`) are untouched — only the exact scheme prefix is claimed. Note this intentionally changes the previous "malformed ssh:// is a local filename" tests: opening a local file that is literally named `ssh://...` now requires the `./` prefix (same escape hatch vim uses for `+50`-style names).

**+N**: `+N` arguments are folded into the file list once, right after clap parsing and before any consumer (TUI, GUI, web, attach, nested forward) sees it, by rewriting the target to the *exact same* `file:line` syntax path that already existed — `fresh +50 file.txt` == `fresh file.txt:50`, including remote specs (`fresh +50 user@host:/path`). Vim-parallel rules:

- the line applies to the first file argument (any position, so the trailing-focus-steal case is fixed too);
- an explicit `file:line` on the target beats `+N`;
- at most one `+N` is accepted; `+N` with no file argument is an error with a hint;
- `+0` and beyond-EOF lines clamp exactly like `file:0` / `file:huge` (verified: `+99999` on a 100-line file lands on the last line);
- bare `+` (vim: "last line") is **not** claimed — it has no `file:line` equivalent — and stays an ordinary filename, as do `./+50` and `+abc`. A real file named `+50` is still openable as `./+50` (breaking change relative to bare `+50`, matching vim's behavior).

`--help` documents the new form in the file-location syntax section; the new `cli.file_syntax.plus_line` key is translated in all 14 locales.

## Tests

New unit tests (all in `crates/fresh-editor/src/main.rs`):

- ssh://: userless URL with no default user → error naming `$USER`; missing path / bad port / empty user → errors (these previously asserted the silent local fallback — assertions flipped to the correct behavior, so they fail without the fix); userless + injected default user works, incl. port and `:line:col`; scp-style unaffected by missing `$USER`; weird local names (`ssh:file.txt`, `ssh:/host/path`, `sshfile`, `./ssh://host/path`) stay local.
- `+N`: leading/trailing/multi-file placement, `+0`, saturation of absurdly large numbers, explicit `file:line` precedence, remote specs, stdin `-` skipping, bare `+` / `./+50` / `+abc` untouched, no-file and multiple-`+N` errors.

Ran: `cargo test -p fresh-editor --bin fresh` (70 passed), `cargo test -p fresh-editor --lib i18n` (locale parity), `cargo check -p fresh-editor --all-targets`, `cargo check -p fresh-editor --all-targets --features gui`, `cargo fmt`, `cargo clippy -p fresh-editor` (no new warnings).

Manual validation (tmux, debug build, isolated `$HOME`):

- `env -u USER -u USERNAME fresh --no-restore ssh://localhost/etc/hosts` → clean startup error (above), exit 1, no editor, no local buffer.
- `fresh --no-restore ssh://root@localhost/etc/hosts` → still prints `Connecting via SSH to root@localhost...` (control).
- `fresh +50 test.txt` and `fresh test.txt +50` → single `test.txt` tab, status bar `Ln 50, Col 1`, no `+50` buffer, no focus steal.
- `fresh +0 test.txt` → `Ln 1`; `fresh +99999 test.txt` → last line.
- `fresh +50` → clear error with hint; `fresh ./+50` opens the literal file.
- `fresh --help` shows `+10 file.txt  Open at line 10 (vim-style)`.

## Notes for review

- Startup errors from these paths print through anyhow with `RUST_BACKTRACE=1` (force-set in `real_main`), so a backtrace follows the message — same as existing startup errors (e.g. mixed local/remote); not new to this PR.
- On #1926's `deferred` label: the issue thread contains no argument against the syntax — the owner's only comment was a clarifying question ("from CLI, in addition to filename:line?", answered yes) — so this implements it fully; happy to trim to just the stray-buffer fix if the deferral was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y)_