### PR TITLE
lsp: unlock auto-import completions; suppress hover under modal dialogs

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -269,12 +269,9 @@ impl Editor {
                 } => {
                     self.handle_lsp_code_action_resolved(action);
                 }
-                AsyncMessage::LspCompletionResolved {
-                    request_id: _,
-                    item,
-                } => {
+                AsyncMessage::LspCompletionResolved { request_id, item } => {
                     if let Ok(resolved) = item {
-                        self.handle_completion_resolved(resolved);
+                        self.handle_completion_resolved(request_id, resolved);
                     }
                 }
                 AsyncMessage::LspFormatting {

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1431,6 +1431,16 @@ impl Editor {
             return false;
         }
 
+        // Suppress hover while a modal overlay (Open File dialog, command
+        // palette, menu, …) covers the editor: the tracked position maps to
+        // the buffer behind the overlay, and the resulting popup would render
+        // on top of the dialog (sinelaw/fresh#2912). This also covers a hover
+        // armed just before the modal opened — the pending timer must not
+        // fire underneath it.
+        if self.modal_overlay_active() {
+            return false;
+        }
+
         let hover_delay = std::time::Duration::from_millis(self.config.editor.mouse_hover_delay_ms);
 
         // Get hover state without borrowing self

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -134,35 +134,14 @@ impl Editor {
         }
 
         // Get the partial word at cursor to filter completions
-        use crate::primitives::word_navigation::find_completion_word_start;
-        let cursor_pos = self.active_cursors().primary().position;
-        let (word_start, cursor_pos) = {
-            let state = self.active_state();
-            let word_start = find_completion_word_start(&state.buffer, cursor_pos);
-            (word_start, cursor_pos)
-        };
-        let prefix = if word_start < cursor_pos {
-            self.active_state_mut()
-                .get_text_range(word_start, cursor_pos)
-                .to_lowercase()
-        } else {
-            String::new()
-        };
+        use crate::app::popup_actions::completion_matches_prefix;
+        let prefix = self.completion_word_prefix();
 
-        let matches_prefix = |item: &lsp_types::CompletionItem| -> bool {
-            prefix.is_empty()
-                || item.label.to_lowercase().starts_with(&prefix)
-                || item
-                    .filter_text
-                    .as_ref()
-                    .map(|ft| ft.to_lowercase().starts_with(&prefix))
-                    .unwrap_or(false)
-        };
+        let any_new_match = items
+            .iter()
+            .any(|item| completion_matches_prefix(item, &prefix));
 
-        let filtered_items: Vec<&lsp_types::CompletionItem> =
-            items.iter().filter(|item| matches_prefix(item)).collect();
-
-        if filtered_items.is_empty() && self.active_window().completion_items.is_none() {
+        if !any_new_match && self.active_window().completion_items.is_none() {
             tracing::debug!("No completion items match prefix '{}'", prefix);
             return Ok(());
         }
@@ -178,32 +157,24 @@ impl Editor {
             }
         }
 
-        // Rebuild popup from ALL merged items (not just the new batch)
-        let all_items = self.active_window_mut().completion_items.as_ref().unwrap();
-        let all_filtered: Vec<&lsp_types::CompletionItem> = all_items
+        // Only the *LSP* results open the popup from this path; a response
+        // that leaves nothing matching is not a reason to show buffer-word
+        // candidates. Checked before rebuilding so a late non-matching
+        // response can't drop the mapping behind a popup already on screen.
+        let any_stored_match = self
+            .active_window()
+            .completion_items
             .iter()
-            .filter(|item| matches_prefix(item))
-            .collect();
-
-        if all_filtered.is_empty() {
+            .flatten()
+            .any(|item| completion_matches_prefix(item, &prefix));
+        if !any_stored_match {
             tracing::debug!("No completion items match prefix '{}'", prefix);
             return Ok(());
         }
 
-        // Build LSP popup items, then append buffer-word items below.
-        let mut all_popup_items =
-            crate::app::popup_actions::lsp_items_to_popup_items(&all_filtered);
-        let buffer_word_items = self.get_buffer_completion_popup_items();
-        // Deduplicate: skip buffer-word items whose label already appears in LSP results.
-        let lsp_labels: std::collections::HashSet<String> = all_popup_items
-            .iter()
-            .map(|i| i.text.to_lowercase())
-            .collect();
-        all_popup_items.extend(
-            buffer_word_items
-                .into_iter()
-                .filter(|item| !lsp_labels.contains(&item.text.to_lowercase())),
-        );
+        // Rebuild popup rows from ALL merged items (not just the new batch),
+        // recording which candidate each LSP row came from.
+        let all_popup_items = self.build_completion_popup_rows();
 
         let popup_data =
             crate::app::popup_actions::build_completion_popup_from_items(all_popup_items, 0);
@@ -674,7 +645,7 @@ impl Editor {
                 self.active_window_mut().send_lsp_cancel_request(request_id);
             }
         }
-        self.active_window_mut().completion_items = None;
+        self.active_window_mut().clear_completion_items();
 
         // Get the current buffer and cursor position
         let cursor_pos = self.active_cursors().primary().position;
@@ -737,7 +708,10 @@ impl Editor {
     ///
     /// Called when no LSP servers are available for the current buffer.
     fn show_buffer_word_completion_popup(&mut self) {
-        let items = self.get_buffer_completion_popup_items();
+        // Goes through the shared row builder so the popup-row → LSP-item
+        // mapping is reset (to "no LSP rows") by the same code that fills
+        // it — no separate place to forget.
+        let items = self.build_completion_popup_rows();
         if items.is_empty() {
             return;
         }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -15,6 +15,7 @@ use rust_i18n::t;
 use std::io;
 use std::time::{Duration, Instant};
 
+use crate::app::window::LspCompletionCandidate;
 use crate::model::event::{BufferId, Event};
 use crate::primitives::word_navigation::{find_word_end, find_word_start};
 use crate::view::prompt::{Prompt, PromptType};
@@ -108,18 +109,20 @@ impl Editor {
         request_id: u64,
         items: Vec<lsp_types::CompletionItem>,
     ) -> AnyhowResult<()> {
-        // Check if this is one of the pending completion requests
-        if !self
+        // Check if this is one of the pending completion requests. Removing
+        // it also names the server that answered — the candidates below are
+        // only resolvable against that one.
+        let Some(server) = self
             .active_window_mut()
             .pending_completion_requests
             .remove(&request_id)
-        {
+        else {
             tracing::debug!(
                 "Ignoring completion response for outdated request {}",
                 request_id
             );
             return Ok(());
-        }
+        };
 
         if items.is_empty() {
             tracing::debug!("No completion items received");
@@ -146,14 +149,22 @@ impl Editor {
             return Ok(());
         }
 
-        // Store/extend original items for type-to-filter (merge from multiple servers)
+        // Store/extend original items for type-to-filter (merge from
+        // multiple servers). This is the merge point, so it is also where
+        // each candidate's origin has to be stamped on: once several
+        // servers' results sit in one list, nothing else can tell them
+        // apart.
+        let candidates = items.into_iter().map(|item| LspCompletionCandidate {
+            item,
+            server: Some(server),
+        });
         match &mut self.active_window_mut().completion_items {
             Some(existing) => {
-                existing.extend(items);
+                existing.extend(candidates);
                 tracing::debug!("Extended completion items, now {} total", existing.len());
             }
             None => {
-                self.active_window_mut().completion_items = Some(items);
+                self.active_window_mut().completion_items = Some(candidates.collect());
             }
         }
 
@@ -166,7 +177,7 @@ impl Editor {
             .completion_items
             .iter()
             .flatten()
-            .any(|item| completion_matches_prefix(item, &prefix));
+            .any(|candidate| completion_matches_prefix(&candidate.item, &prefix));
         if !any_stored_match {
             tracing::debug!("No completion items match prefix '{}'", prefix);
             return Ok(());
@@ -636,6 +647,7 @@ impl Editor {
                 .active_window_mut()
                 .pending_completion_requests
                 .drain()
+                .map(|(request_id, _server)| request_id)
                 .collect();
             for request_id in ids {
                 tracing::debug!(
@@ -681,14 +693,16 @@ impl Editor {
                         request_id
                     );
                 }
-                (request_id, result.is_ok())
+                (request_id, handle.id(), result.is_ok())
             },
         );
 
+        // Remember which server each request went to: its response's
+        // candidates can only be resolved against that same server.
         let mut sent_ids = Vec::new();
-        for (request_id, ok) in &results {
+        for (request_id, server, ok) in &results {
             if *ok {
-                sent_ids.push(*request_id);
+                sent_ids.push((*request_id, *server));
             }
         }
         // Advance the ID counter past all allocated IDs
@@ -2176,7 +2190,26 @@ impl Editor {
     }
 
     /// Handle a resolved completion item — apply additional_text_edits (e.g. auto-imports).
-    pub(crate) fn handle_completion_resolved(&mut self, item: lsp_types::CompletionItem) {
+    ///
+    /// Only the answer to the resolve request that is still outstanding may
+    /// edit the buffer. Responses are applied as the server returned them
+    /// (no lookup by label), so accepting the *reply* of a request the user
+    /// has moved past would insert an import for a candidate that is no
+    /// longer the accepted one.
+    pub(crate) fn handle_completion_resolved(
+        &mut self,
+        request_id: u64,
+        item: lsp_types::CompletionItem,
+    ) {
+        if self.active_window().pending_completion_resolve_request != Some(request_id) {
+            tracing::debug!(
+                "Ignoring completionItem/resolve response for outdated request {}",
+                request_id
+            );
+            return;
+        }
+        self.active_window_mut().pending_completion_resolve_request = None;
+
         if let Some(additional_edits) = item.additional_text_edits {
             if !additional_edits.is_empty() {
                 tracing::info!(

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1651,9 +1651,18 @@ impl Editor {
             .cursors
     }
 
-    /// Set completion items for type-to-filter (for testing)
+    /// Set completion items for type-to-filter (for testing).
+    ///
+    /// The items come from no server, so nothing can be resolved against
+    /// one: a `completionItem/resolve` needs the server that minted the
+    /// item's opaque `data`.
     pub fn set_completion_items(&mut self, items: Vec<lsp_types::CompletionItem>) {
-        self.active_window_mut().completion_items = Some(items);
+        self.active_window_mut().completion_items = Some(
+            items
+                .into_iter()
+                .map(crate::app::window::LspCompletionCandidate::unattributed)
+                .collect(),
+        );
     }
 
     /// Get the viewport for the active split

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -828,10 +828,15 @@ impl Editor {
 
         // Suppress LSP hover when a popup is already visible (e.g. theme info popup,
         // tab context menu, or the status-bar LSP status popup) to avoid hover
-        // tooltips overlapping other popups.
+        // tooltips overlapping other popups. Same for any modal overlay (Open
+        // File dialog, command palette, menu, …): mouse positions over the
+        // overlay map to the buffer *behind* it, so tracking them would fire
+        // hover requests for invisible content and render the popup on top of
+        // the dialog (sinelaw/fresh#2912).
         if self.active_window_mut().theme_info_popup.is_some()
             || self.active_window().context_menu_core().is_some()
             || self.is_lsp_status_popup_open()
+            || self.modal_overlay_active()
         {
             if self
                 .active_window_mut()

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -404,6 +404,32 @@ impl Editor {
         crate::app::overlay::any_layer_blocks_terminal_input(&self.overlay_layers())
     }
 
+    /// True iff a modal overlay — a prompt (Open File dialog, command
+    /// palette, …), the menu, a full-screen modal (settings, keybinding
+    /// editor, calibration wizard, workspace trust), a native context menu,
+    /// or the centered widget modal — currently covers the editor content.
+    ///
+    /// Derived from the same [`Editor::overlay_layers`] stack the keyboard
+    /// and mouse dispatchers consult, so there is a single notion of
+    /// modality. The popup band is deliberately excluded: the hover and
+    /// completion popups themselves live there, and mouse hover has its own
+    /// popup-aware handling (`update_lsp_hover_state`). The dock and the
+    /// editor base are not modal.
+    ///
+    /// Used to suppress mouse-hover LSP requests while a modal overlay is
+    /// up: positions under the pointer map to the buffer *behind* the
+    /// overlay, so a hover there would query — and render a popup for —
+    /// content the user cannot see (sinelaw/fresh#2912).
+    pub(crate) fn modal_overlay_active(&self) -> bool {
+        use crate::app::overlay::LayerKind;
+        self.overlay_layers().iter().any(|l| {
+            !matches!(
+                l.kind,
+                LayerKind::Popup | LayerKind::Dock | LayerKind::Editor
+            )
+        })
+    }
+
     /// Determine the current keybinding context based on UI state.
     ///
     /// Returns the `KeyContext` of the topmost overlay layer that owns the

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -626,10 +626,10 @@ impl Editor {
         let row = popup.selected_index()?;
         match self.active_window().completion_popup_lsp_items.get(row) {
             Some(item) => Some(SelectedCompletionRow::Lsp(Box::new(item.clone()))),
-            // Past the LSP rows: a buffer-word row.
+            // No candidate recorded for this row.
             None => popup
                 .selected_item()
-                .map(|item| SelectedCompletionRow::BufferWord(item.text.clone())),
+                .map(|item| SelectedCompletionRow::Text(item.text.clone())),
         }
     }
 
@@ -640,20 +640,25 @@ impl Editor {
         previous: &SelectedCompletionRow,
         rows: &[crate::model::event::PopupListItemData],
     ) -> Option<usize> {
-        let lsp_rows = &self.active_window().completion_popup_lsp_items;
         match previous {
-            SelectedCompletionRow::Lsp(item) => lsp_rows.iter().position(|i| i == item.as_ref()),
-            // Buffer-word rows carry no payload beyond their text, so two
-            // of them with the same text are interchangeable and the text
-            // is identity enough — but only *among the buffer-word rows*:
-            // an LSP row sharing that label is a different candidate, with
-            // its own import.
-            SelectedCompletionRow::BufferWord(text) => rows
+            SelectedCompletionRow::Lsp(item) => self
+                .active_window()
+                .completion_popup_lsp_items
                 .iter()
-                .enumerate()
-                .skip(lsp_rows.len())
-                .find(|(_, row)| row.text == *text)
-                .map(|(index, _)| index),
+                .position(|i| i == item.as_ref()),
+            // A row with no candidate recorded behind it carries no payload
+            // beyond the text it inserts, so its text is identity enough —
+            // and identity semantics only buy anything where duplicates
+            // exist, which is the LSP rows. Search the whole list rather
+            // than only the buffer-word tail: popups that were not built by
+            // `build_completion_popup_rows` (plugin-supplied lists, and the
+            // ones tests inject) have *no* row → candidate mapping, so
+            // every one of their rows lands here and a tail-only search
+            // would never find them. This cannot quietly promote a plain
+            // buffer word into an auto-import candidate, because
+            // `build_completion_popup_rows` drops any buffer word whose
+            // text an LSP row already occupies — the two never coexist.
+            SelectedCompletionRow::Text(text) => rows.iter().position(|row| row.text == *text),
         }
     }
 
@@ -738,8 +743,10 @@ enum SelectedCompletionRow {
     /// An LSP candidate, identified by the candidate itself. Boxed because
     /// a `CompletionItem` is large next to the other variant.
     Lsp(Box<LspCompletionCandidate>),
-    /// A buffer-word row, identified by its text (it has no other payload).
-    BufferWord(String),
+    /// A row with no LSP candidate recorded behind it — a buffer word, or
+    /// any row of a popup this module did not build. Identified by its
+    /// text, which is all such a row carries.
+    Text(String),
 }
 
 /// Whether a completion candidate survives the word prefix at the cursor.

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -168,20 +168,24 @@ impl Editor {
             }
 
             Some(PopupResolver::Completion) => {
-                // Grab the selected item's label + insert-text before we
-                // mutate the popup stack — insert_completion_text edits
-                // the buffer, which invalidates the borrow.
-                let completion_info = self
-                    .active_state()
-                    .popups
-                    .top()
-                    .and_then(|p| p.selected_item())
-                    .map(|item| (item.text.clone(), item.data.clone()));
-                if let Some((label, insert_text)) = completion_info {
+                // Grab the selected *row* — its insert-text and its index —
+                // before we mutate the popup stack: insert_completion_text
+                // edits the buffer, which invalidates the borrow.
+                //
+                // The row index is what identifies the accepted candidate.
+                // Labels don't: an auto-import list offers one `HashMap`
+                // row per crate exporting one, and looking the item back
+                // up by label applied the *first* such row's import
+                // regardless of which one was selected (#2952).
+                let selection = self.active_state().popups.top().and_then(|p| {
+                    p.selected_index()
+                        .zip(p.selected_item().map(|item| item.data.clone()))
+                });
+                if let Some((row, insert_text)) = selection {
                     if let Some(text) = insert_text {
                         self.insert_completion_text(text);
                     }
-                    self.apply_completion_additional_edits(&label);
+                    self.apply_completion_additional_edits(row);
                 }
                 self.hide_popup();
                 PopupConfirmResult::Done
@@ -313,15 +317,20 @@ impl Editor {
     /// If the item already has additional_text_edits, apply them directly.
     /// If not and the server supports completionItem/resolve, send a resolve request
     /// so the server can fill them in (the response is handled asynchronously).
-    fn apply_completion_additional_edits(&mut self, label: &str) {
-        // Find the matching CompletionItem from stored items
+    ///
+    /// `popup_row` is the index of the accepted row in the completion popup;
+    /// `Window::completion_popup_lsp_items` maps it back to the exact
+    /// candidate the row was built from. Rows past the end of that mapping
+    /// are buffer-word candidates and carry no LSP edits.
+    fn apply_completion_additional_edits(&mut self, popup_row: usize) {
         let item = self
-            .active_window_mut()
-            .completion_items
-            .as_ref()
-            .and_then(|items| items.iter().find(|item| item.label == label).cloned());
+            .active_window()
+            .completion_popup_lsp_items
+            .get(popup_row)
+            .cloned();
 
         let Some(item) = item else { return };
+        let label = item.label.clone();
 
         if let Some(edits) = &item.additional_text_edits {
             if !edits.is_empty() {
@@ -394,7 +403,7 @@ impl Editor {
 
             Some(PopupResolver::Completion) => {
                 self.hide_popup();
-                self.active_window_mut().completion_items = None;
+                self.active_window_mut().clear_completion_items();
             }
 
             Some(PopupResolver::RemoteIndicator) => {
@@ -426,7 +435,7 @@ impl Editor {
 
             Some(PopupResolver::None) | None => {
                 self.hide_popup();
-                self.active_window_mut().completion_items = None;
+                self.active_window_mut().clear_completion_items();
             }
         }
     }
@@ -544,17 +553,9 @@ impl Editor {
         self.refilter_completion_popup();
     }
 
-    /// Re-filter the completion popup based on current prefix.
-    /// If no items match, dismiss the popup.
-    fn refilter_completion_popup(&mut self) {
-        // Get stored LSP completion items (may be empty if no LSP).
-        let lsp_items = self
-            .active_window_mut()
-            .completion_items
-            .clone()
-            .unwrap_or_default();
-
-        // Get current prefix
+    /// Lowercased word prefix at the primary cursor — what completion
+    /// candidates are filtered against.
+    pub(crate) fn completion_word_prefix(&mut self) -> String {
         let (word_start, cursor_pos) = {
             let cursor_pos = self.active_cursors().primary().position;
             let state = self.active_state();
@@ -562,48 +563,64 @@ impl Editor {
             (word_start, cursor_pos)
         };
 
-        let prefix = if word_start < cursor_pos {
+        if word_start < cursor_pos {
             self.active_state_mut()
                 .get_text_range(word_start, cursor_pos)
                 .to_lowercase()
         } else {
             String::new()
-        };
+        }
+    }
 
-        // Filter LSP items
-        let filtered_lsp: Vec<&lsp_types::CompletionItem> = if prefix.is_empty() {
-            lsp_items.iter().collect()
-        } else {
-            lsp_items
-                .iter()
-                .filter(|item| {
-                    item.label.to_lowercase().starts_with(&prefix)
-                        || item
-                            .filter_text
-                            .as_ref()
-                            .map(|ft| ft.to_lowercase().starts_with(&prefix))
-                            .unwrap_or(false)
-                })
-                .collect()
-        };
+    /// Build the rows of the completion popup for the word prefix at the
+    /// cursor: the stored LSP candidates that still match, followed by
+    /// buffer-word candidates the server didn't already offer.
+    ///
+    /// This is the only writer of `Window::completion_popup_lsp_items`, and
+    /// it fills it from the very list it converts into rows — so the accept
+    /// path can turn "the selected row" back into "the candidate that row
+    /// was built from" without guessing. Recovering the item by label
+    /// instead is what shipped the wrong auto-import in #2952: labels
+    /// repeat across auto-import candidates.
+    pub(crate) fn build_completion_popup_rows(
+        &mut self,
+    ) -> Vec<crate::model::event::PopupListItemData> {
+        let prefix = self.completion_word_prefix();
 
-        // Build combined items: LSP first, then buffer-word results.
-        let mut all_popup_items = lsp_items_to_popup_items(&filtered_lsp);
-        let buffer_word_items = self.get_buffer_completion_popup_items();
-        let lsp_labels: std::collections::HashSet<String> = all_popup_items
+        let matching: Vec<lsp_types::CompletionItem> = self
+            .active_window()
+            .completion_items
             .iter()
-            .map(|i| i.text.to_lowercase())
+            .flatten()
+            .filter(|item| completion_matches_prefix(item, &prefix))
+            .cloned()
             .collect();
-        all_popup_items.extend(
+
+        let mut rows = lsp_items_to_popup_items(&matching.iter().collect::<Vec<_>>());
+        self.active_window_mut().completion_popup_lsp_items = matching;
+
+        // Buffer-word candidates go below, minus anything the server
+        // already offers under the same label.
+        let lsp_labels: std::collections::HashSet<String> =
+            rows.iter().map(|i| i.text.to_lowercase()).collect();
+        let buffer_word_items = self.get_buffer_completion_popup_items();
+        rows.extend(
             buffer_word_items
                 .into_iter()
                 .filter(|item| !lsp_labels.contains(&item.text.to_lowercase())),
         );
+        rows
+    }
+
+    /// Re-filter the completion popup based on current prefix.
+    /// If no items match, dismiss the popup.
+    fn refilter_completion_popup(&mut self) {
+        let all_popup_items = self.build_completion_popup_rows();
 
         // If no items match from either source, dismiss popup.
         if all_popup_items.is_empty() {
             self.hide_popup();
-            self.active_window_mut().completion_items = None;
+            self.active_window_mut().clear_completion_items();
             return;
         }
 
@@ -665,6 +682,19 @@ pub(crate) fn build_completion_popup_from_items(
         max_height: 15,
         bordered: true,
     }
+}
+
+/// Whether a completion candidate survives the word prefix at the cursor.
+///
+/// `prefix` must already be lowercased (see `Editor::completion_word_prefix`).
+pub(crate) fn completion_matches_prefix(item: &lsp_types::CompletionItem, prefix: &str) -> bool {
+    prefix.is_empty()
+        || item.label.to_lowercase().starts_with(prefix)
+        || item
+            .filter_text
+            .as_ref()
+            .map(|ft| ft.to_lowercase().starts_with(prefix))
+            .unwrap_or(false)
 }
 
 /// Convert LSP `CompletionItem`s to `PopupListItemData`s.

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -687,9 +687,29 @@ pub(crate) fn lsp_items_to_popup_items(
                 _ => None,
             };
 
+            // Prefer `labelDetails` for the dimmed text next to the label:
+            // we advertise `labelDetailsSupport`, so servers put the
+            // import path of an auto-import candidate there (rust-analyzer:
+            // "(use std::collections::HashMap)") while the label stays the
+            // bare identifier the accept path inserts. Fall back to `detail`
+            // when a server doesn't use labelDetails.
+            let detail = item
+                .label_details
+                .as_ref()
+                .and_then(|ld| {
+                    let text = match (&ld.detail, &ld.description) {
+                        (Some(d), Some(desc)) => format!("{} {}", d.trim_start(), desc),
+                        (Some(d), None) => d.trim_start().to_string(),
+                        (None, Some(desc)) => desc.clone(),
+                        (None, None) => return None,
+                    };
+                    Some(text)
+                })
+                .or_else(|| item.detail.clone());
+
             PopupListItemData {
                 text: item.label.clone(),
-                detail: item.detail.clone(),
+                detail,
                 icon,
                 data: item
                     .insert_text
@@ -698,4 +718,47 @@ pub(crate) fn lsp_items_to_popup_items(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Auto-import candidates carry their import path in `labelDetails`
+    /// (we advertise `labelDetailsSupport`, sinelaw/fresh#2603). The popup
+    /// item must show that path as the dimmed detail while keeping the
+    /// bare identifier as both the visible label and the inserted text.
+    #[test]
+    fn lsp_items_to_popup_items_renders_label_details() {
+        let item = lsp_types::CompletionItem {
+            label: "HashMap".to_string(),
+            label_details: Some(lsp_types::CompletionItemLabelDetails {
+                detail: Some(" (use std::collections::HashMap)".to_string()),
+                description: None,
+            }),
+            kind: Some(lsp_types::CompletionItemKind::STRUCT),
+            ..Default::default()
+        };
+        let popup_items = lsp_items_to_popup_items(&[&item]);
+        assert_eq!(popup_items.len(), 1);
+        assert_eq!(popup_items[0].text, "HashMap");
+        assert_eq!(
+            popup_items[0].detail.as_deref(),
+            Some("(use std::collections::HashMap)")
+        );
+        // The accepted insert text must stay the bare identifier.
+        assert_eq!(popup_items[0].data.as_deref(), Some("HashMap"));
+    }
+
+    /// Servers that don't use `labelDetails` keep their `detail` rendering.
+    #[test]
+    fn lsp_items_to_popup_items_falls_back_to_detail() {
+        let item = lsp_types::CompletionItem {
+            label: "test_function".to_string(),
+            detail: Some("fn test_function()".to_string()),
+            ..Default::default()
+        };
+        let popup_items = lsp_items_to_popup_items(&[&item]);
+        assert_eq!(popup_items[0].detail.as_deref(), Some("fn test_function()"));
+    }
 }

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -612,9 +612,54 @@ impl Editor {
         rows
     }
 
+    /// The candidate behind the highlighted completion row, described in
+    /// terms that survive rebuilding the rows.
+    ///
+    /// Read *before* `build_completion_popup_rows` runs, since that call
+    /// overwrites the row → item mapping this reads.
+    fn selected_completion_row(&self) -> Option<SelectedCompletionRow> {
+        let popup = self.active_state().popups.top()?;
+        let row = popup.selected_index()?;
+        match self.active_window().completion_popup_lsp_items.get(row) {
+            Some(item) => Some(SelectedCompletionRow::Lsp(Box::new(item.clone()))),
+            // Past the LSP rows: a buffer-word row.
+            None => popup
+                .selected_item()
+                .map(|item| SelectedCompletionRow::BufferWord(item.text.clone())),
+        }
+    }
+
+    /// Where the previously selected candidate ended up among the freshly
+    /// built `rows`, or `None` if the new prefix filtered it out.
+    fn completion_row_of(
+        &self,
+        previous: &SelectedCompletionRow,
+        rows: &[crate::model::event::PopupListItemData],
+    ) -> Option<usize> {
+        let lsp_rows = &self.active_window().completion_popup_lsp_items;
+        match previous {
+            SelectedCompletionRow::Lsp(item) => lsp_rows.iter().position(|i| i == item.as_ref()),
+            // Buffer-word rows carry no payload beyond their text, so two
+            // of them with the same text are interchangeable and the text
+            // is identity enough — but only *among the buffer-word rows*:
+            // an LSP row sharing that label is a different candidate, with
+            // its own import.
+            SelectedCompletionRow::BufferWord(text) => rows
+                .iter()
+                .enumerate()
+                .skip(lsp_rows.len())
+                .find(|(_, row)| row.text == *text)
+                .map(|(index, _)| index),
+        }
+    }
+
     /// Re-filter the completion popup based on current prefix.
     /// If no items match, dismiss the popup.
     fn refilter_completion_popup(&mut self) {
+        // What the user has highlighted, captured before the rows (and the
+        // mapping behind them) are rebuilt.
+        let previous_selection = self.selected_completion_row();
+
         let all_popup_items = self.build_completion_popup_rows();
 
         // If no items match from either source, dismiss popup.
@@ -624,17 +669,14 @@ impl Editor {
             return;
         }
 
-        // Get current selection to try preserving it
-        let current_selection = self
-            .active_state()
-            .popups
-            .top()
-            .and_then(|p| p.selected_item())
-            .map(|item| item.text.clone());
-
-        // Try to preserve selection
-        let selected = current_selection
-            .and_then(|sel| all_popup_items.iter().position(|item| item.text == sel))
+        // Keep the highlight on the candidate the user picked, identified
+        // by the *item* behind the row rather than by its label: an
+        // auto-import list offers one `HashMap` row per crate exporting
+        // one, and matching on the label snapped the highlight back to the
+        // first of them on every further keystroke (#2952). A candidate
+        // the new prefix filtered out falls back to the first row.
+        let selected = previous_selection
+            .and_then(|previous| self.completion_row_of(&previous, &all_popup_items))
             .unwrap_or(0);
 
         let popup_data = build_completion_popup_from_items(all_popup_items, selected);
@@ -682,6 +724,18 @@ pub(crate) fn build_completion_popup_from_items(
         max_height: 15,
         bordered: true,
     }
+}
+
+/// The highlighted completion row, in terms that outlive the rows
+/// themselves — so typing another character can put the highlight back on
+/// the same candidate rather than on the first row that happens to share
+/// its label.
+enum SelectedCompletionRow {
+    /// An LSP candidate, identified by the item itself. Boxed because a
+    /// `CompletionItem` is large next to the other variant.
+    Lsp(Box<lsp_types::CompletionItem>),
+    /// A buffer-word row, identified by its text (it has no other payload).
+    BufferWord(String),
 }
 
 /// Whether a completion candidate survives the word prefix at the cursor.

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -3,6 +3,7 @@
 //! This module contains handlers for popup-related actions like confirmation and cancellation.
 
 use super::Editor;
+use crate::app::window::LspCompletionCandidate;
 use crate::model::event::Event;
 use crate::primitives::snippet::{expand_snippet, is_snippet};
 use crate::primitives::word_navigation::find_completion_word_start;
@@ -323,13 +324,14 @@ impl Editor {
     /// candidate the row was built from. Rows past the end of that mapping
     /// are buffer-word candidates and carry no LSP edits.
     fn apply_completion_additional_edits(&mut self, popup_row: usize) {
-        let item = self
+        let candidate = self
             .active_window()
             .completion_popup_lsp_items
             .get(popup_row)
             .cloned();
 
-        let Some(item) = item else { return };
+        let Some(candidate) = candidate else { return };
+        let item = &candidate.item;
         let label = item.label.clone();
 
         if let Some(edits) = &item.additional_text_edits {
@@ -347,14 +349,15 @@ impl Editor {
             }
         }
 
-        // No additional_text_edits present — try resolve if server supports it
-        if self.active_window().server_supports_completion_resolve() {
-            tracing::info!(
-                "Completion '{}' has no additional_text_edits, sending completionItem/resolve",
-                label
-            );
-            self.active_window_mut().send_completion_resolve(item);
-        }
+        // No additional_text_edits present — ask the server that offered
+        // this candidate to fill them in. `send_completion_resolve` gates
+        // on *that* server's capability; a sibling server for the same
+        // language advertising resolve is not an answer.
+        tracing::info!(
+            "Completion '{}' has no additional_text_edits, sending completionItem/resolve",
+            label
+        );
+        self.active_window_mut().send_completion_resolve(&candidate);
     }
 
     /// Handle PopupCancel action.
@@ -587,16 +590,17 @@ impl Editor {
     ) -> Vec<crate::model::event::PopupListItemData> {
         let prefix = self.completion_word_prefix();
 
-        let matching: Vec<lsp_types::CompletionItem> = self
+        let matching: Vec<LspCompletionCandidate> = self
             .active_window()
             .completion_items
             .iter()
             .flatten()
-            .filter(|item| completion_matches_prefix(item, &prefix))
+            .filter(|candidate| completion_matches_prefix(&candidate.item, &prefix))
             .cloned()
             .collect();
 
-        let mut rows = lsp_items_to_popup_items(&matching.iter().collect::<Vec<_>>());
+        let mut rows =
+            lsp_items_to_popup_items(&matching.iter().map(|c| &c.item).collect::<Vec<_>>());
         self.active_window_mut().completion_popup_lsp_items = matching;
 
         // Buffer-word candidates go below, minus anything the server
@@ -731,9 +735,9 @@ pub(crate) fn build_completion_popup_from_items(
 /// the same candidate rather than on the first row that happens to share
 /// its label.
 enum SelectedCompletionRow {
-    /// An LSP candidate, identified by the item itself. Boxed because a
-    /// `CompletionItem` is large next to the other variant.
-    Lsp(Box<lsp_types::CompletionItem>),
+    /// An LSP candidate, identified by the candidate itself. Boxed because
+    /// a `CompletionItem` is large next to the other variant.
+    Lsp(Box<LspCompletionCandidate>),
     /// A buffer-word row, identified by its text (it has no other payload).
     BufferWord(String),
 }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -379,6 +379,20 @@ pub struct Window {
     /// Original LSP completion items (for type-to-filter).
     pub completion_items: Option<Vec<lsp_types::CompletionItem>>,
 
+    /// The LSP `CompletionItem` behind each *LSP row* of the completion
+    /// popup currently on screen, in row order. Rows past the end of this
+    /// vector are buffer-word candidates, which have no LSP item behind
+    /// them.
+    ///
+    /// Written only by `Editor::build_completion_popup_rows`, from the same
+    /// filtered list it converts into popup rows — so "popup row N" and
+    /// "entry N here" are the same candidate by construction. The accept
+    /// path needs that identity because completion *labels* are not
+    /// unique: with auto-import candidates advertised (#2603) a server
+    /// offers one `HashMap` row per crate exporting one, each with a
+    /// different `use` line.
+    pub completion_popup_lsp_items: Vec<lsp_types::CompletionItem>,
+
     /// Scheduled completion-trigger time (debounced quick-suggestions).
     pub scheduled_completion_trigger: Option<std::time::Instant>,
 
@@ -2179,6 +2193,7 @@ impl Window {
             next_lsp_request_id: 0,
             pending_completion_requests: std::collections::HashSet::new(),
             completion_items: None,
+            completion_popup_lsp_items: Vec::new(),
             scheduled_completion_trigger: None,
             dabbrev_state: None,
             pending_goto_definition_request: None,
@@ -2867,6 +2882,15 @@ impl Window {
     /// Number of in-flight completion requests for this window.
     pub fn pending_completion_requests_count(&self) -> usize {
         self.pending_completion_requests.len()
+    }
+
+    /// Forget the completion candidates: both the stored LSP items used
+    /// for type-to-filter and the popup-row → item mapping built from
+    /// them. Clearing them together keeps a dismissed popup from leaving
+    /// a mapping behind that a later accept could read.
+    pub fn clear_completion_items(&mut self) {
+        self.completion_items = None;
+        self.completion_popup_lsp_items.clear();
     }
 
     /// Number of stored completion items currently visible in this

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -247,6 +247,33 @@ impl TerminalBuffer {
     }
 }
 
+/// An LSP completion candidate together with the server that offered it.
+///
+/// A language can be served by several servers at once and their results
+/// are merged into one popup, so a candidate on its own is not enough to
+/// act on: `CompletionItem::data` is an opaque handle that only its own
+/// server can interpret, and `completionItem/resolve` — the request that
+/// supplies auto-imports for servers that defer them — is meaningless when
+/// sent anywhere else. Keeping the origin next to the item makes "which
+/// server does this belong to?" answerable wherever the candidate travels.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LspCompletionCandidate {
+    /// The candidate as the server sent it.
+    pub item: lsp_types::CompletionItem,
+
+    /// `LspHandle::id()` of the server that offered `item`, or `None` for
+    /// candidates that came from no server (injected directly in tests).
+    pub server: Option<u64>,
+}
+
+impl LspCompletionCandidate {
+    /// A candidate with no server behind it — nothing can be resolved
+    /// against a server that doesn't exist.
+    pub fn unattributed(item: lsp_types::CompletionItem) -> Self {
+        Self { item, server: None }
+    }
+}
+
 pub struct Window {
     /// Stable identifier. The base window is always `WindowId(1)`.
     pub id: WindowId,
@@ -373,16 +400,20 @@ pub struct Window {
     /// namespace needed. Starts at 0 per window.
     pub next_lsp_request_id: u64,
 
-    /// Pending LSP completion request ids (multi-server).
-    pub pending_completion_requests: std::collections::HashSet<u64>,
+    /// In-flight LSP completion requests, each mapped to the server it was
+    /// sent to (`LspHandle::id()`). A language can be served by several
+    /// servers at once and every one of them gets its own request, so the
+    /// map is what tells a response which server produced it — the
+    /// candidates it carries are only resolvable against that server.
+    pub pending_completion_requests: std::collections::HashMap<u64, u64>,
 
-    /// Original LSP completion items (for type-to-filter).
-    pub completion_items: Option<Vec<lsp_types::CompletionItem>>,
+    /// Original LSP completion candidates (for type-to-filter), merged
+    /// from every server that answered.
+    pub completion_items: Option<Vec<LspCompletionCandidate>>,
 
-    /// The LSP `CompletionItem` behind each *LSP row* of the completion
-    /// popup currently on screen, in row order. Rows past the end of this
-    /// vector are buffer-word candidates, which have no LSP item behind
-    /// them.
+    /// The candidate behind each *LSP row* of the completion popup
+    /// currently on screen, in row order. Rows past the end of this vector
+    /// are buffer-word candidates, which have no LSP item behind them.
     ///
     /// Written only by `Editor::build_completion_popup_rows`, from the same
     /// filtered list it converts into popup rows — so "popup row N" and
@@ -391,7 +422,13 @@ pub struct Window {
     /// unique: with auto-import candidates advertised (#2603) a server
     /// offers one `HashMap` row per crate exporting one, each with a
     /// different `use` line.
-    pub completion_popup_lsp_items: Vec<lsp_types::CompletionItem>,
+    pub completion_popup_lsp_items: Vec<LspCompletionCandidate>,
+
+    /// Id of the in-flight `completionItem/resolve` request, if any. Only
+    /// the answer to *that* request may edit the buffer: a late reply to a
+    /// resolve the user has already moved past would apply an import for a
+    /// candidate that is no longer the accepted one.
+    pub pending_completion_resolve_request: Option<u64>,
 
     /// Scheduled completion-trigger time (debounced quick-suggestions).
     pub scheduled_completion_trigger: Option<std::time::Instant>,
@@ -1364,7 +1401,11 @@ impl Window {
     pub(crate) fn cancel_pending_lsp_requests(&mut self) {
         self.scheduled_completion_trigger = None;
         if !self.pending_completion_requests.is_empty() {
-            let ids: Vec<u64> = self.pending_completion_requests.drain().collect();
+            let ids: Vec<u64> = self
+                .pending_completion_requests
+                .drain()
+                .map(|(request_id, _server)| request_id)
+                .collect();
             for request_id in ids {
                 tracing::debug!("Canceling pending LSP completion request {}", request_id);
                 self.send_lsp_cancel_request(request_id);
@@ -1535,27 +1576,6 @@ impl Window {
     }
 
     /// True iff at least one LSP server attached to the active buffer's
-    /// language advertises `completionItem/resolve`.
-    pub(crate) fn server_supports_completion_resolve(&self) -> bool {
-        let Some(language) = self
-            .buffers
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-        else {
-            return false;
-        };
-        {
-            let lsp = &self.lsp;
-            for sh in lsp.get_handles(&language) {
-                if sh.capabilities.completion_resolve {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    /// True iff at least one LSP server attached to the active buffer's
     /// language advertises `textDocument/rename` (and therefore the
     /// `prepareRename` request, which the editor surfaces only through
     /// the rename feature flag).
@@ -1619,11 +1639,23 @@ impl Window {
         }
     }
 
-    /// Send `completionItem/resolve` for `item` to the first LSP server
-    /// (in language order) that advertises `completion_resolve` for the
-    /// active buffer's language. No-op if no server is running or no
-    /// server supports the resolve.
-    pub(crate) fn send_completion_resolve(&mut self, item: lsp_types::CompletionItem) {
+    /// Send `completionItem/resolve` for `candidate` to **the server that
+    /// offered it**, if that server advertises `completion_resolve`.
+    ///
+    /// Asking any other server is wrong by construction: the item's `data`
+    /// is a private handle minted by its own server, so a different one
+    /// answers with an error or with edits for something else entirely —
+    /// and resolve is where auto-imports come from, so that lands as a
+    /// wrong `use` line in the user's file. The capability question has
+    /// the same shape: "some server for this language resolves" says
+    /// nothing about the one that produced this candidate.
+    ///
+    /// No-op for candidates with no server behind them, or when that
+    /// server is gone or can't resolve.
+    pub(crate) fn send_completion_resolve(&mut self, candidate: &LspCompletionCandidate) {
+        let Some(server) = candidate.server else {
+            return;
+        };
         let Some(language) = self
             .buffers
             .get(&self.active_buffer())
@@ -1634,19 +1666,34 @@ impl Window {
         let request_id = self.alloc_lsp_request_id();
         {
             let lsp = &mut self.lsp;
-            for sh in lsp.get_handles_mut(&language) {
-                if sh.capabilities.completion_resolve {
-                    if let Err(e) = sh.handle.completion_resolve(request_id, item.clone()) {
-                        tracing::warn!(
-                            "Failed to send completionItem/resolve to '{}': {}",
-                            sh.name,
-                            e
-                        );
-                    }
-                    return;
-                }
+            let Some(sh) = lsp
+                .get_handles_mut(&language)
+                .into_iter()
+                .find(|sh| sh.handle.id() == server)
+            else {
+                tracing::debug!("Completion's server is no longer running; not resolving");
+                return;
+            };
+            if !sh.capabilities.completion_resolve {
+                tracing::debug!(
+                    "Server '{}' offered the completion but does not support resolve",
+                    sh.name
+                );
+                return;
+            }
+            if let Err(e) = sh
+                .handle
+                .completion_resolve(request_id, candidate.item.clone())
+            {
+                tracing::warn!(
+                    "Failed to send completionItem/resolve to '{}': {}",
+                    sh.name,
+                    e
+                );
+                return;
             }
         }
+        self.pending_completion_resolve_request = Some(request_id);
     }
 
     /// Apply an event to a buffer + the cursors of a split inside this
@@ -2191,9 +2238,10 @@ impl Window {
             prompt: None,
             bridge,
             next_lsp_request_id: 0,
-            pending_completion_requests: std::collections::HashSet::new(),
+            pending_completion_requests: std::collections::HashMap::new(),
             completion_items: None,
             completion_popup_lsp_items: Vec::new(),
+            pending_completion_resolve_request: None,
             scheduled_completion_trigger: None,
             dabbrev_state: None,
             pending_goto_definition_request: None,

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -62,6 +62,12 @@ const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
 /// LSP error codes that should not surface as user-visible warnings.
 ///
 /// From [LSP 3.17 specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/):
+/// - RequestCancelled (-32800): the spec-mandated reply to a request the
+///   *client* withdrew with `$/cancelRequest`. We withdraw superseded
+///   requests ourselves on every cursor move, edit and scroll (see
+///   `Window::cancel_pending_lsp_requests`) and on request timeout, so this
+///   error is the answer we asked for — warning about it means warning about
+///   our own bookkeeping (sinelaw/fresh#2952).
 /// - ContentModified (-32801): "If clients receive a ContentModified error,
 ///   it generally should not show it in the UI for the end-user."
 /// - ServerCancelled (-32802): Server cancelled the request (e.g. due to newer request).
@@ -73,6 +79,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
 /// suppressed: we want genuine protocol mismatches to surface so they can
 /// be diagnosed. The correct way to avoid MethodNotFound is to check the
 /// server's advertised capabilities before sending the request.
+const LSP_ERROR_REQUEST_CANCELLED: i64 = -32800;
 const LSP_ERROR_CONTENT_MODIFIED: i64 = -32801;
 const LSP_ERROR_SERVER_CANCELLED: i64 = -32802;
 
@@ -110,7 +117,9 @@ fn is_informational_method(method: &str) -> bool {
 /// Whether a JSON-RPC error response should be logged at debug rather than warn.
 /// See `LSP_ERROR_*` constants above for the rationale behind each suppressed code.
 fn is_suppressed_error_code(code: i64) -> bool {
-    code == LSP_ERROR_CONTENT_MODIFIED || code == LSP_ERROR_SERVER_CANCELLED
+    code == LSP_ERROR_REQUEST_CANCELLED
+        || code == LSP_ERROR_CONTENT_MODIFIED
+        || code == LSP_ERROR_SERVER_CANCELLED
 }
 
 /// Whether an error response for `method` with `code` should be downgraded from
@@ -5692,6 +5701,12 @@ mod tests {
         // ContentModified and ServerCancelled are normal during editing.
         assert!(is_suppressed_error_code(LSP_ERROR_CONTENT_MODIFIED));
         assert!(is_suppressed_error_code(LSP_ERROR_SERVER_CANCELLED));
+
+        // RequestCancelled is the answer to *our own* `$/cancelRequest`:
+        // every cursor move withdraws the in-flight completion/semantic-token
+        // requests, and rust-analyzer duly replies `-32800 canceled by
+        // client`. Warning about it warns the user about our bookkeeping.
+        assert!(is_suppressed_error_code(LSP_ERROR_REQUEST_CANCELLED));
 
         // Every other JSON-RPC / LSP error must still surface so genuine
         // protocol mismatches stay debuggable — including MethodNotFound

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -357,7 +357,8 @@ impl LspClientState {
 fn create_client_capabilities() -> ClientCapabilities {
     use lsp_types::{
         CodeActionClientCapabilities, CodeActionKindLiteralSupport, CodeActionLiteralSupport,
-        CompletionClientCapabilities, DiagnosticClientCapabilities, DiagnosticTag,
+        CompletionClientCapabilities, CompletionItemCapability,
+        CompletionItemCapabilityResolveSupport, DiagnosticClientCapabilities, DiagnosticTag,
         DiagnosticWorkspaceClientCapabilities, DocumentFormattingClientCapabilities,
         DocumentHighlightClientCapabilities, DocumentRangeFormattingClientCapabilities,
         DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities,
@@ -432,6 +433,45 @@ fn create_client_capabilities() -> ClientCapabilities {
             // entitled to never register the provider. See sinelaw/fresh#2195.
             completion: Some(CompletionClientCapabilities {
                 dynamic_registration: Some(true),
+                completion_item: Some(CompletionItemCapability {
+                    // Declare that `additionalTextEdits` may be filled in
+                    // lazily via `completionItem/resolve`: on accept we apply
+                    // eager edits directly and otherwise send a resolve
+                    // request whose response is applied in
+                    // `handle_completion_resolved` (auto-imports). Servers
+                    // gate features on this — rust-analyzer only offers
+                    // unimported symbols ("flyimport") when the client can
+                    // resolve `additionalTextEdits` (sinelaw/fresh#2603).
+                    //
+                    // `documentation` is listed because rust-analyzer only
+                    // advertises `resolveProvider` when the client can also
+                    // resolve documentation lazily (verified against
+                    // rust-analyzer 1.94.1: with `additionalTextEdits` alone
+                    // it still defers the import edit to resolve but reports
+                    // `resolveProvider: false`, so a spec-compliant client
+                    // never resolves and the import is lost). Deferring
+                    // documentation costs nothing here: the completion popup
+                    // renders label/detail only, never `documentation`.
+                    resolve_support: Some(CompletionItemCapabilityResolveSupport {
+                        properties: vec![
+                            "documentation".to_string(),
+                            "additionalTextEdits".to_string(),
+                        ],
+                    }),
+                    // We render `labelDetails` next to the label in the
+                    // completion popup (`lsp_items_to_popup_items`). Without
+                    // this flag rust-analyzer folds the import path into the
+                    // label itself ("HashMap (use std::collections::HashMap)"),
+                    // which the accept path would then insert literally into
+                    // the buffer.
+                    label_details_support: Some(true),
+                    // `snippetSupport` is deliberately NOT advertised: the
+                    // accept path only detects snippet syntax heuristically
+                    // (`is_snippet`) and does not track `insertTextFormat`,
+                    // so inviting servers to switch every insertion to
+                    // snippet format is not safe yet.
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
             hover: Some(HoverClientCapabilities {
@@ -5248,6 +5288,62 @@ mod tests {
     /// A `workspace/configuration` request item asking for `section`.
     fn config_item(section: &str) -> Value {
         serde_json::json!({ "section": section })
+    }
+
+    /// Reproducer for sinelaw/fresh#2603: rust-analyzer only offers
+    /// unimported symbols ("flyimport") when the client declares it can
+    /// resolve `additionalTextEdits` lazily via `completionItem/resolve`.
+    /// The client applies those edits (`handle_completion_resolved`), so the
+    /// initialize capabilities must advertise it.
+    #[test]
+    fn client_capabilities_advertise_completion_resolve_additional_text_edits() {
+        let caps = create_client_capabilities();
+        let completion_item = caps
+            .text_document
+            .as_ref()
+            .and_then(|td| td.completion.as_ref())
+            .and_then(|c| c.completion_item.as_ref())
+            .expect("completion.completionItem capabilities must be advertised");
+        let resolve = completion_item
+            .resolve_support
+            .as_ref()
+            .expect("completionItem.resolveSupport must be advertised");
+        assert!(
+            resolve
+                .properties
+                .iter()
+                .any(|p| p == "additionalTextEdits"),
+            "resolveSupport.properties must contain additionalTextEdits, got {:?}",
+            resolve.properties
+        );
+        // rust-analyzer only advertises `resolveProvider` when documentation
+        // is lazily resolvable too; without it the deferred import edit is
+        // unreachable (see create_client_capabilities).
+        assert!(
+            resolve.properties.iter().any(|p| p == "documentation"),
+            "resolveSupport.properties must contain documentation, got {:?}",
+            resolve.properties
+        );
+    }
+
+    /// The completion popup renders `labelDetails` (import path of an
+    /// auto-import candidate) next to the label, so the client must
+    /// advertise `labelDetailsSupport`. Without it rust-analyzer folds
+    /// "(use …)" into the label itself, which the accept path would insert
+    /// literally into the buffer.
+    #[test]
+    fn client_capabilities_advertise_completion_label_details() {
+        let caps = create_client_capabilities();
+        let completion_item = caps
+            .text_document
+            .as_ref()
+            .and_then(|td| td.completion.as_ref())
+            .and_then(|c| c.completion_item.as_ref())
+            .expect("completion.completionItem capabilities must be advertised");
+        assert_eq!(completion_item.label_details_support, Some(true));
+        // Snippet support is intentionally not advertised until the accept
+        // path tracks `insertTextFormat` (see create_client_capabilities).
+        assert_eq!(completion_item.snippet_support, None);
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -485,6 +485,18 @@ impl Popup {
         }
     }
 
+    /// Index of the currently selected row (if this is a list popup and the
+    /// row exists). Rows are indexed independently of `scroll_offset`, so
+    /// this is a stable handle on the row the user is looking at — which is
+    /// how the completion accept path tells apart candidates that share a
+    /// label.
+    pub fn selected_index(&self) -> Option<usize> {
+        match &self.content {
+            PopupContent::List { items, selected } if *selected < items.len() => Some(*selected),
+            _ => None,
+        }
+    }
+
     /// Get the actual visible content height (accounting for borders)
     fn visible_height(&self) -> usize {
         let border_offset = if self.bordered { 2 } else { 0 };

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1616,6 +1616,115 @@ done
         dir.join("fake_lsp_server_duplicate_labels.sh")
     }
 
+    /// Write the script for a fake LSP server that offers **one
+    /// `HashMap` candidate whose auto-import only it can produce**, and
+    /// return the path. One script, run once per configured server: a
+    /// language served by several servers at once (fresh supports that as
+    /// a first-class list) merges all of their candidates into one popup.
+    ///
+    /// Takes the log-file path as its first argument and the server's own
+    /// name as its second. The name is both the candidate's `data` handle
+    /// and the crate in the `use` line the server answers
+    /// `completionItem/resolve` with — so the import that lands names the
+    /// server that was actually asked. A server can only mint its own
+    /// import, which is the point: `data` is opaque and server-private, so
+    /// resolving a candidate against a *different* server produces
+    /// somebody else's `use` line (sinelaw/fresh#2952).
+    ///
+    /// The candidates carry no `additionalTextEdits`, so the import has to
+    /// come from resolve — rust-analyzer's actual behaviour.
+    pub fn write_per_server_import_script(
+        dir: &std::path::Path,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let script = r#"#!/bin/bash
+
+LOG_FILE="${1:-/tmp/fake_lsp_per_server_import_log.txt}"
+NAME="${2:-server}"
+> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    if [ -n "$method" ]; then
+        echo "$method" >> "$LOG_FILE"
+    fi
+
+case "$method" in
+    "initialize")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"resolveProvider":true,"triggerCharacters":["."]},"textDocumentSync":1}}}'
+        ;;
+    "textDocument/completion")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use '"$NAME"'::HashMap)"},"data":"'"$NAME"'"}]}}'
+        ;;
+    "completionItem/resolve")
+        # This server knows one import and one only — its own. Handed a
+        # candidate minted by a sibling server it cannot do better, which
+        # is exactly why the request has to go to the right server.
+        echo "RESOLVE:$msg" >> "$LOG_FILE"
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"label":"HashMap","kind":22,"insertText":"HashMap","additionalTextEdits":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"newText":"use '"$NAME"'::HashMap;\n"}]}}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didSave"|"textDocument/didClose"|"initialized"|"$/cancelRequest")
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    *)
+        if [ -n "$msg_id" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        fi
+        ;;
+esac
+done
+"#;
+
+        let script_path = dir.join("fake_lsp_server_per_server_import.sh");
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        Ok(script_path)
+    }
+
     /// Spawn a fake LSP server that returns hover content WITHOUT a range
     ///
     /// This simulates LSP servers like pyrefly that don't return the hover range.

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1335,6 +1335,149 @@ done
         dir.join("fake_lsp_server_logging.sh")
     }
 
+    /// Spawn a fake LSP server that mimics rust-analyzer's "flyimport"
+    /// gating (sinelaw/fresh#2603), as observed against rust-analyzer 1.94.1:
+    ///
+    /// - The auto-import completion candidate (`HashMap`, carrying its
+    ///   import path in `labelDetails` and delivering the `use` line lazily
+    ///   through `completionItem/resolve`) is only offered when the client's
+    ///   `initialize` capabilities declare
+    ///   `completionItem.resolveSupport.properties` containing
+    ///   `"additionalTextEdits"`. Otherwise the completion list is empty.
+    /// - `completionProvider.resolveProvider` is only advertised as `true`
+    ///   when the client can also resolve `"documentation"` lazily — even
+    ///   though the import edit is still deferred to resolve. A client that
+    ///   declares only `additionalTextEdits` therefore never resolves (it
+    ///   respects `resolveProvider: false`) and silently loses the import.
+    ///
+    /// Like the logging server, it takes a log-file path as its first
+    /// argument and appends every received method name to it, so tests can
+    /// wait for `textDocument/didOpen` before requesting completion.
+    pub fn spawn_flyimport(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+# Log file path (passed as first argument, or default)
+LOG_FILE="${1:-/tmp/fake_lsp_flyimport_log.txt}"
+> "$LOG_FILE"
+
+# Function to read a message
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+# Function to send a message
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+# Whether the client can lazily resolve additionalTextEdits
+# (rust-analyzer gates flyimport candidates on this).
+RESOLVE_ADDITIONAL_EDITS=0
+
+# Main loop
+while true; do
+    msg=$(read_message)
+
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    if [ -n "$method" ]; then
+        echo "$method" >> "$LOG_FILE"
+    fi
+
+case "$method" in
+    "initialize")
+        if echo "$msg" | grep -q '"additionalTextEdits"'; then
+            RESOLVE_ADDITIONAL_EDITS=1
+        fi
+        # Like rust-analyzer: resolveProvider is only advertised when the
+        # client can lazily resolve documentation, even though the import
+        # edit itself is deferred to resolve. Match "documentation" inside a
+        # resolveSupport "properties" array specifically — the capability
+        # payload also contains "documentation" as a semantic-token modifier.
+        if echo "$msg" | grep -Eq '"properties":[^]]*"documentation"'; then
+            RESOLVE_PROVIDER=true
+        else
+            RESOLVE_PROVIDER=false
+        fi
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"resolveProvider":'$RESOLVE_PROVIDER',"triggerCharacters":["."]},"textDocumentSync":1}}}'
+        ;;
+    "textDocument/completion")
+        if [ "$RESOLVE_ADDITIONAL_EDITS" = "1" ]; then
+            # The flyimport candidate: bare label, import path in
+            # labelDetails, additionalTextEdits deferred to resolve.
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use std::collections::HashMap)"}}]}}'
+        else
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[]}}'
+        fi
+        ;;
+    "completionItem/resolve")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use std::collections::HashMap)"},"additionalTextEdits":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"newText":"use std::collections::HashMap;\n"}]}}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didSave"|"textDocument/didClose"|"initialized"|"$/cancelRequest")
+        # Notifications - no response needed
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    *)
+        # Respond to any unhandled requests to prevent pending request buildup
+        if [ -n "$msg_id" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        fi
+        ;;
+esac
+done
+"#;
+
+        let script_path = Self::flyimport_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Get the path to the flyimport fake LSP server script
+    pub fn flyimport_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_flyimport.sh")
+    }
+
     /// Get the default log file path used by the logging server
     pub fn default_log_path() -> std::path::PathBuf {
         std::path::PathBuf::from("/tmp/fake_lsp_log.txt")

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1483,6 +1483,139 @@ done
         std::path::PathBuf::from("/tmp/fake_lsp_log.txt")
     }
 
+    /// Spawn a fake LSP server that offers **two candidates sharing one
+    /// label** — exactly what an auto-import list looks like once
+    /// unimported symbols are advertised (sinelaw/fresh#2603): every crate
+    /// exporting a `HashMap` contributes a row labelled `HashMap`, and the
+    /// rows differ only in the `use` line they bring along.
+    ///
+    /// The first row imports `wrong_crate::HashMap`, the second
+    /// `std::collections::HashMap`, so a client that recovers the accepted
+    /// item by *label* rather than by identity visibly inserts the wrong
+    /// import (sinelaw/fresh#2952).
+    ///
+    /// Takes the log-file path as its first argument (every received method
+    /// name is appended to it, so tests can wait for `textDocument/didOpen`)
+    /// and the delivery mode as its second:
+    ///
+    /// - `"eager"` — both items carry their own `additionalTextEdits`.
+    /// - `"resolve"` — neither does; the import arrives through
+    ///   `completionItem/resolve`, keyed on the item's `data` field. This
+    ///   is rust-analyzer's actual behaviour.
+    pub fn spawn_duplicate_labels(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+LOG_FILE="${1:-/tmp/fake_lsp_duplicate_labels_log.txt}"
+MODE="${2:-eager}"
+> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+WRONG_EDIT='[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"newText":"use wrong_crate::HashMap;\n"}]'
+RIGHT_EDIT='[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"newText":"use std::collections::HashMap;\n"}]'
+
+while true; do
+    msg=$(read_message)
+
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    if [ -n "$method" ]; then
+        echo "$method" >> "$LOG_FILE"
+    fi
+
+case "$method" in
+    "initialize")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"resolveProvider":true,"triggerCharacters":["."]},"textDocumentSync":1}}}'
+        ;;
+    "textDocument/completion")
+        # Two candidates, same label, different imports. The wrong one is
+        # deliberately first: accepting the second must not pick it up.
+        if [ "$MODE" = "resolve" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use wrong_crate::HashMap)"},"data":"wrong_crate"},{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use std::collections::HashMap)"},"data":"std"}]}}'
+        else
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use wrong_crate::HashMap)"},"data":"wrong_crate","additionalTextEdits":'"$WRONG_EDIT"'},{"label":"HashMap","kind":22,"insertText":"HashMap","labelDetails":{"detail":" (use std::collections::HashMap)"},"data":"std","additionalTextEdits":'"$RIGHT_EDIT"'}]}}'
+        fi
+        ;;
+    "completionItem/resolve")
+        # Answer the item that was actually sent: the `data` tag is what
+        # tells the two same-labelled candidates apart.
+        echo "RESOLVE:$msg" >> "$LOG_FILE"
+        if echo "$msg" | grep -q '"data":"wrong_crate"'; then
+            EDIT="$WRONG_EDIT"
+        else
+            EDIT="$RIGHT_EDIT"
+        fi
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"label":"HashMap","kind":22,"insertText":"HashMap","additionalTextEdits":'"$EDIT"'}}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didSave"|"textDocument/didClose"|"initialized"|"$/cancelRequest")
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    *)
+        if [ -n "$msg_id" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        fi
+        ;;
+esac
+done
+"#;
+
+        let script_path = Self::duplicate_labels_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Get the path to the duplicate-label fake LSP server script
+    pub fn duplicate_labels_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_duplicate_labels.sh")
+    }
+
     /// Spawn a fake LSP server that returns hover content WITHOUT a range
     ///
     /// This simulates LSP servers like pyrefly that don't return the hover range.

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -10152,3 +10152,100 @@ fn lsp_spawn_failure_writes_stub_log_for_view_log_popup() -> anyhow::Result<()> 
 
     Ok(())
 }
+
+/// Reproducer for sinelaw/fresh#2603: completions never offered unimported
+/// symbols because the client didn't advertise
+/// `completionItem.resolveSupport.properties: ["additionalTextEdits"]`, and
+/// rust-analyzer gates its auto-import ("flyimport") candidates on exactly
+/// that capability.
+///
+/// The fake server replicates the gating: it only returns the `HashMap`
+/// auto-import candidate when the `initialize` capabilities contain
+/// `"additionalTextEdits"`, carries the import path in `labelDetails`, and
+/// delivers the `use` line lazily via `completionItem/resolve`.
+///
+/// Without the capability fix this test times out waiting for the candidate:
+/// the server (like rust-analyzer) never offers it.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_completion_offers_unimported_symbol_and_applies_auto_import() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_flyimport(temp_dir.path())?;
+
+    let log_file = temp_dir.path().join("flyimport_test_log.txt");
+    let test_file = temp_dir.path().join("main.rs");
+    std::fs::write(&test_file, "fn main() {\n    let m = HashMa\n}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::flyimport_script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![log_file.to_string_lossy().to_string()]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the server to be initialized and the document opened.
+    harness.wait_until(|_| {
+        std::fs::read_to_string(&log_file)
+            .unwrap_or_default()
+            .contains("textDocument/didOpen")
+    })?;
+
+    // Put the cursor at the end of "    let m = HashMa" and request
+    // completion explicitly.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.send_key(KeyCode::End, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)?;
+
+    // The unimported symbol must be offered, tagged with its import path
+    // (labelDetails rendered next to the label).
+    harness.wait_until(|h| {
+        h.screen_to_string()
+            .contains("HashMap (use std::collections::HashMap)")
+    })?;
+
+    // Accept the candidate: the identifier replaces the typed prefix, and
+    // the auto-import `use` line arrives through completionItem/resolve.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+    harness.wait_until(|h| {
+        h.screen_to_string()
+            .contains("use std::collections::HashMap;")
+    })?;
+
+    let buffer = harness.get_buffer_content().unwrap();
+    assert_eq!(
+        buffer, "use std::collections::HashMap;\nfn main() {\n    let m = HashMap\n}\n",
+        "accepting the auto-import completion must insert both the identifier \
+         and the use line"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -10249,3 +10249,123 @@ fn test_completion_offers_unimported_symbol_and_applies_auto_import() -> anyhow:
 
     Ok(())
 }
+
+/// Reproducer for sinelaw/fresh#2912: while a modal dialog (Open File,
+/// command palette) is open, mouse motion over the dialog area kept firing
+/// LSP hover requests for the buffer *behind* it, and the hover popups
+/// rendered on top of the dialog.
+///
+/// The mouse-motion tracker (`update_lsp_hover_state`) ignored modal
+/// overlays entirely, and the debounce timer (`check_mouse_hover_timer`)
+/// only gated on `mouse_hover_enabled` — so both a fresh motion over the
+/// dialog and a hover armed just before the dialog opened produced hover
+/// requests underneath it.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_no_hover_requests_while_modal_dialog_open() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
+    // Enough lines that buffer text sits behind the Open File dialog area.
+    let mut content = String::new();
+    for i in 0..25 {
+        content.push_str(&format!("fn hover_target_{i}() {{}}\n"));
+    }
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, content)?;
+
+    let mut config = fresh::config::Config::default();
+    // Fire the hover debounce on the next tick so the control phase below
+    // doesn't depend on wall-clock waits.
+    config.editor.mouse_hover_delay_ms = 0;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Control: with no modal open, hovering a symbol produces a hover popup
+    // (proves the hover pipeline works in this setup, so the suppression
+    // assertions below can't pass vacuously).
+    harness.mouse_move(6, 2)?;
+    harness.wait_until(|h| h.screen_to_string().contains("Test hover content"))?;
+
+    // Leaving the editor area dismisses the popup and clears hover state.
+    harness.mouse_move(40, 0)?;
+    assert!(
+        !harness.editor().active_state().popups.is_visible(),
+        "hover popup should be dismissed when the mouse leaves the editor area"
+    );
+
+    // Open the Open File dialog.
+    harness.send_key(KeyCode::Char('o'), KeyModifiers::CONTROL)?;
+    harness.render()?;
+    harness.assert_screen_contains("Open file:");
+
+    // Mouse motion over the dialog area must not arm a hover for the buffer
+    // content behind it...
+    harness.mouse_move(8, 20)?;
+    assert!(
+        harness.editor().get_mouse_hover_state().is_none(),
+        "mouse motion over a modal dialog must not track hover for the buffer behind it"
+    );
+    // ...and the debounce timer must not fire a request either.
+    assert!(
+        !harness.editor_mut().check_mouse_hover_timer(),
+        "hover timer must not fire while a modal dialog is open"
+    );
+
+    // A hover armed just before the dialog opened must not fire underneath
+    // it: close the dialog, arm a hover, reopen, then run the timer.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.mouse_move(6, 3)?;
+    assert!(
+        harness.editor().get_mouse_hover_state().is_some(),
+        "hover should be armed again once the dialog is closed"
+    );
+    harness.send_key(KeyCode::Char('o'), KeyModifiers::CONTROL)?;
+    harness.render()?;
+    harness.assert_screen_contains("Open file:");
+    assert!(
+        !harness.editor_mut().check_mouse_hover_timer(),
+        "a hover armed before the dialog opened must not fire while it is up"
+    );
+
+    // And nothing hover-related renders over the dialog.
+    harness.render()?;
+    assert!(
+        !harness.screen_to_string().contains("Test hover content"),
+        "no hover popup may render on top of the dialog"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -5658,6 +5658,27 @@ fn test_completion_backspace_refilters() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Screen row showing the completion entry whose label is `label`, and
+/// whether the selection background is painted across that label — the way
+/// the user tells which row is highlighted.
+fn completion_row_is_highlighted(harness: &EditorTestHarness, label: &str) -> bool {
+    let screen = harness.screen_to_string();
+    let row = screen
+        .lines()
+        .position(|line| line.contains(label))
+        .unwrap_or_else(|| panic!("no popup row for '{label}'; screen was:\n{screen}"))
+        as u16;
+    let column = harness
+        .screen_row_text(row)
+        .find(label)
+        .expect("label located on this row") as u16;
+    let selection_bg = harness.editor().theme().popup_selection_bg;
+    harness
+        .get_cell_style(column, row)
+        .and_then(|style| style.bg)
+        == Some(selection_bg)
+}
+
 /// Test type-to-filter preserves selection when possible
 #[test]
 fn test_completion_type_to_filter_preserves_selection() -> anyhow::Result<()> {
@@ -5739,17 +5760,10 @@ fn test_completion_type_to_filter_preserves_selection() -> anyhow::Result<()> {
     harness.render()?;
 
     // Verify test_beta is selected
-    let selected = harness
-        .editor()
-        .active_state()
-        .popups
-        .top()
-        .and_then(|p| p.selected_item())
-        .map(|item| item.text.clone());
-    assert_eq!(
-        selected,
-        Some("test_beta".to_string()),
-        "test_beta should be selected"
+    assert!(
+        completion_row_is_highlighted(&harness, "test_beta"),
+        "precondition: test_beta should be the highlighted row; screen was:\n{}",
+        harness.screen_to_string()
     );
 
     // Type 's' to filter (all items still match "tes")
@@ -5757,17 +5771,18 @@ fn test_completion_type_to_filter_preserves_selection() -> anyhow::Result<()> {
     harness.render()?;
 
     // Verify selection is preserved
-    let selected_after = harness
-        .editor()
-        .active_state()
-        .popups
-        .top()
-        .and_then(|p| p.selected_item())
-        .map(|item| item.text.clone());
-    assert_eq!(
-        selected_after,
-        Some("test_beta".to_string()),
-        "Selection should be preserved after filtering"
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("test_alpha") && screen.contains("test_beta"),
+        "all three candidates still match the narrower prefix; screen was:\n{screen}"
+    );
+    assert!(
+        completion_row_is_highlighted(&harness, "test_beta"),
+        "the highlight must stay on the row the user picked; screen was:\n{screen}"
+    );
+    assert!(
+        !completion_row_is_highlighted(&harness, "test_alpha"),
+        "only one row may be highlighted; screen was:\n{screen}"
     );
 
     Ok(())

--- a/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
@@ -19,6 +19,13 @@
 //! inserted `use oxc_allocator::HashMap` instead, both for candidates that
 //! ship their edits eagerly and (rust-analyzer's real behaviour) for
 //! candidates whose edits arrive through `completionItem/resolve`.
+//!
+//! The same "which candidate is this, really?" question has three answers
+//! to get right, one test each here: accepting a row, keeping the
+//! highlight on it while typing narrows the list, and — when a language is
+//! served by several servers at once — sending its `completionItem/resolve`
+//! to the server that offered it rather than to whichever server happens
+//! to advertise resolve first.
 
 use crate::common::fake_lsp::FakeLspServer;
 use crate::common::harness::EditorTestHarness;
@@ -261,6 +268,123 @@ fn test_resolve_deferred_import_follows_the_selected_candidate() -> anyhow::Resu
             && !screen.contains("use wrong_crate::HashMap;"),
         "the resolve request must carry the candidate the user selected, so \
          the resolved import is std::collections::HashMap; screen was:\n{screen}"
+    );
+
+    Ok(())
+}
+
+/// Open the completion popup against **two** servers for one language,
+/// each offering a `HashMap` candidate whose import only that server can
+/// produce.
+fn open_two_server_popup(temp_dir: &tempfile::TempDir) -> anyhow::Result<EditorTestHarness> {
+    let script = FakeLspServer::write_per_server_import_script(temp_dir.path())?;
+    let test_file = temp_dir.path().join("main.rs");
+    std::fs::write(&test_file, "fn main() {\n    let m = HashMa\n}\n")?;
+
+    let server = |name: &str| fresh::services::lsp::LspServerConfig {
+        command: script.to_string_lossy().to_string(),
+        args: Some(vec![
+            temp_dir
+                .path()
+                .join(format!("{name}_log.txt"))
+                .to_string_lossy()
+                .to_string(),
+            name.to_string(),
+        ]),
+        enabled: true,
+        auto_start: true,
+        process_limits: fresh::services::process_limits::ProcessLimits::default(),
+        initialization_options: None,
+        env: Default::default(),
+        language_id_overrides: Default::default(),
+        root_markers: Default::default(),
+        name: Some(name.to_string()),
+        only_features: None,
+        except_features: None,
+    };
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        // `alpha` is first, so it is also the first server advertising
+        // completion-resolve support — the server the resolve request used
+        // to go to no matter which candidate was accepted.
+        fresh::types::LspLanguageConfig::Multi(vec![server("alpha"), server("beta")]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.send_key(KeyCode::End, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)?;
+
+    // Both servers' candidates on screen means both have answered, so the
+    // merged list is complete — no timer involved.
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("HashMap (use alpha::HashMap)")
+            && screen.contains("HashMap (use beta::HashMap)")
+    })?;
+
+    Ok(harness)
+}
+
+/// With several servers behind one language, `completionItem/resolve` must
+/// go to the server that offered the accepted candidate.
+///
+/// `CompletionItem::data` is an opaque, server-private handle, so a sibling
+/// server cannot answer for it — and resolve is where auto-imports come
+/// from, so asking the wrong one lands the wrong `use` line. The client
+/// used to send the resolve to the first server advertising resolve
+/// support for the language, which is only ever right by luck.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_resolve_goes_to_the_server_that_offered_the_candidate() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut harness = open_two_server_popup(&temp_dir)?;
+
+    // Select `beta`'s candidate — the two servers answer independently, so
+    // which row it landed on is whichever the screen shows.
+    let beta_row = row_showing(&harness, "beta::HashMap");
+    if !row_is_highlighted(&harness, beta_row) {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+        harness.render()?;
+    }
+    let beta_row = row_showing(&harness, "beta::HashMap");
+    assert!(
+        row_is_highlighted(&harness, beta_row),
+        "precondition: beta's candidate is selected; screen was:\n{}",
+        harness.screen_to_string()
+    );
+
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+
+    // Whichever server was asked answers with its own import, so either
+    // one landing ends the wait and the assertion below decides which was
+    // correct — a wrong resolve fails instead of hanging.
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("use beta::HashMap;") || screen.contains("use alpha::HashMap;")
+    })?;
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("use beta::HashMap;") && !screen.contains("use alpha::HashMap;"),
+        "the resolve must be sent to beta — the server that offered the \
+         accepted candidate — so beta's import is the one that lands; \
+         screen was:\n{screen}"
     );
 
     Ok(())

--- a/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
@@ -1,0 +1,176 @@
+//! E2E reproduction for sinelaw/fresh#2952: accepting a completion applied
+//! *another* candidate's auto-import.
+//!
+//! Once the client advertises `resolveSupport.additionalTextEdits` (#2603),
+//! servers offer unimported symbols — and then duplicate labels become the
+//! norm rather than the exception. rust-analyzer offers one `HashMap` row
+//! per crate exporting one:
+//!
+//! ```text
+//! S HashMap        (use oxc_allocator::HashMap)
+//! S HashMapStrategy (use proptest::collection::HashMapStrategy)
+//! S HashMap        (use std::collections::HashMap)
+//! ```
+//!
+//! The accept path passed only the selected row's *label* down to
+//! `apply_completion_additional_edits`, which recovered the item with
+//! `completion_items.iter().find(|i| i.label == label)` — the first row
+//! sharing the label. Selecting the `std::collections::HashMap` row
+//! inserted `use oxc_allocator::HashMap` instead, both for candidates that
+//! ship their edits eagerly and (rust-analyzer's real behaviour) for
+//! candidates whose edits arrive through `completionItem/resolve`.
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Start an editor against the duplicate-label fake server in `mode`
+/// (`"eager"` or `"resolve"`), with the completion popup open on two
+/// candidates both labelled `HashMap`.
+fn open_duplicate_label_popup(
+    temp_dir: &tempfile::TempDir,
+    mode: &str,
+) -> anyhow::Result<EditorTestHarness> {
+    let log_file = temp_dir.path().join(format!("dup_label_{mode}_log.txt"));
+    let test_file = temp_dir.path().join("main.rs");
+    std::fs::write(&test_file, "fn main() {\n    let m = HashMa\n}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::duplicate_labels_script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![
+                log_file.to_string_lossy().to_string(),
+                mode.to_string(),
+            ]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the server to be initialized and the document opened.
+    harness.wait_until(|_| {
+        std::fs::read_to_string(&log_file)
+            .unwrap_or_default()
+            .contains("textDocument/didOpen")
+    })?;
+
+    // Put the cursor at the end of "    let m = HashMa" and ask for
+    // completions.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.send_key(KeyCode::End, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)?;
+
+    // Both same-labelled candidates must be on screen, told apart only by
+    // the import path in their labelDetails.
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("HashMap (use wrong_crate::HashMap)")
+            && screen.contains("HashMap (use std::collections::HashMap)")
+    })?;
+
+    Ok(harness)
+}
+
+/// Accepting the *second* of two same-labelled candidates must apply that
+/// candidate's `additionalTextEdits`, not the first one's.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_accepting_second_same_label_candidate_applies_its_own_import() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_duplicate_labels(temp_dir.path())?;
+
+    let mut harness = open_duplicate_label_popup(&temp_dir, "eager")?;
+
+    // Move down to the std::collections candidate and accept it.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+
+    // Either import landing ends the wait; the assertions below decide
+    // which one was correct, so applying the wrong one fails the test
+    // instead of hanging on a condition that will never hold.
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("use std::collections::HashMap;")
+            || screen.contains("use wrong_crate::HashMap;")
+    })?;
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("use std::collections::HashMap;")
+            && !screen.contains("use wrong_crate::HashMap;"),
+        "accepting the second candidate must apply its own auto-import, not \
+         the first candidate's; screen was:\n{screen}"
+    );
+    assert!(
+        screen.contains("let m = HashMap"),
+        "the identifier itself must still be inserted; screen was:\n{screen}"
+    );
+
+    Ok(())
+}
+
+/// Same, for candidates whose imports are deferred to
+/// `completionItem/resolve` — rust-analyzer's actual behaviour, and the
+/// path that decides which `use` line the user ends up with in practice.
+/// The wrong item being *sent* is enough to lose here: the server answers
+/// the item it was given.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_resolve_deferred_import_follows_the_selected_candidate() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_duplicate_labels(temp_dir.path())?;
+
+    let mut harness = open_duplicate_label_popup(&temp_dir, "resolve")?;
+
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        // Either import landing ends the wait; the assertion below decides
+        // which one was correct, so a wrong import fails instead of hanging.
+        screen.contains("use std::collections::HashMap;")
+            || screen.contains("use wrong_crate::HashMap;")
+    })?;
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("use std::collections::HashMap;")
+            && !screen.contains("use wrong_crate::HashMap;"),
+        "the resolve request must carry the candidate the user selected, so \
+         the resolved import is std::collections::HashMap; screen was:\n{screen}"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_duplicate_label_import_2952.rs
@@ -24,6 +24,31 @@ use crate::common::fake_lsp::FakeLspServer;
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 
+/// Screen row showing the popup entry whose import path is `import`.
+fn row_showing(harness: &EditorTestHarness, import: &str) -> u16 {
+    let needle = format!("(use {import})");
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .position(|line| line.contains(&needle))
+        .unwrap_or_else(|| panic!("no popup row for '{needle}'; screen was:\n{screen}")) as u16
+}
+
+/// Whether the popup row at `row` is the highlighted one, judged the way
+/// the user judges it: by the selection background painted across it.
+fn row_is_highlighted(harness: &EditorTestHarness, row: u16) -> bool {
+    let selection_bg = harness.editor().theme().popup_selection_bg;
+    let text = harness.screen_row_text(row);
+    let column = text
+        .find("HashMap")
+        .unwrap_or_else(|| panic!("row {row} does not show a candidate: {text:?}"))
+        as u16;
+    harness
+        .get_cell_style(column, row)
+        .and_then(|style| style.bg)
+        == Some(selection_bg)
+}
+
 /// Start an editor against the duplicate-label fake server in `mode`
 /// (`"eager"` or `"resolve"`), with the completion popup open on two
 /// candidates both labelled `HashMap`.
@@ -131,6 +156,72 @@ fn test_accepting_second_same_label_candidate_applies_its_own_import() -> anyhow
     assert!(
         screen.contains("let m = HashMap"),
         "the identifier itself must still be inserted; screen was:\n{screen}"
+    );
+
+    Ok(())
+}
+
+/// Typing one more character re-filters the list — and must leave the
+/// highlight on the candidate the user had picked, not snap it back to the
+/// first row sharing that candidate's label.
+///
+/// Both `HashMap` rows survive typing the `p` of `HashMap`, so the
+/// selection has somewhere to stay; restoring it by label put it on the
+/// wrong (first) row, and accepting then applied that row's import.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_typing_another_character_keeps_the_selected_candidate_highlighted() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_duplicate_labels(temp_dir.path())?;
+
+    let mut harness = open_duplicate_label_popup(&temp_dir, "eager")?;
+
+    // Pick the std::collections candidate.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.render()?;
+    assert!(
+        row_is_highlighted(&harness, row_showing(&harness, "std::collections::HashMap")),
+        "precondition: the second candidate is the selected one; screen was:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Type the last character of the word. Both candidates still match, so
+    // the popup keeps both rows.
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::NONE)?;
+    harness.wait_until(|h| h.screen_to_string().contains("let m = HashMap"))?;
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("HashMap (use wrong_crate::HashMap)")
+            && screen.contains("HashMap (use std::collections::HashMap)"),
+        "both candidates must survive the narrower prefix; screen was:\n{screen}"
+    );
+    assert!(
+        row_is_highlighted(&harness, row_showing(&harness, "std::collections::HashMap")),
+        "the highlight must stay on the candidate the user selected; screen was:\n{screen}"
+    );
+    assert!(
+        !row_is_highlighted(&harness, row_showing(&harness, "wrong_crate::HashMap")),
+        "only one row may be highlighted; screen was:\n{screen}"
+    );
+
+    // And accepting from there still applies the selected candidate's import.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("use std::collections::HashMap;")
+            || screen.contains("use wrong_crate::HashMap;")
+    })?;
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("use std::collections::HashMap;")
+            && !screen.contains("use wrong_crate::HashMap;"),
+        "accepting after the re-filter must apply the highlighted candidate's \
+         auto-import; screen was:\n{screen}"
     );
 
     Ok(())

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -133,6 +133,7 @@ pub mod lsp_code_action_diagnostic_context;
 pub mod lsp_code_action_modal;
 pub mod lsp_code_action_resolve_and_commands;
 pub mod lsp_completion_duplicate_entries_1514;
+pub mod lsp_completion_duplicate_label_import_2952;
 pub mod lsp_completion_dynamic_registration;
 pub mod lsp_completion_french_locale;
 pub mod lsp_completion_popup_behavior;


### PR DESCRIPTION
Fixes #2603
Fixes #2912

Three LSP-client fixes, one commit each.

## 1. Auto-import completions were unreachable (#2603)

`create_client_capabilities()` sent `CompletionClientCapabilities` with no
`completionItem` sub-capabilities. rust-analyzer gates its unimported-symbol
candidates ("flyimport") on the client declaring
`completionItem.resolveSupport.properties ⊇ ["additionalTextEdits"]`, so every
candidate that would need an auto-import was silently dropped and the
documented "auto-imports are applied when you accept a completion" flow could
never trigger. The client machinery already applied `additionalTextEdits`
both eagerly and via `completionItem/resolve` — only the advertisement was
missing.

The initialize capabilities now declare:

- **`resolveSupport.properties: ["documentation", "additionalTextEdits"]`** —
  `additionalTextEdits` is what unlocks flyimport and what the accept path
  consumes (`apply_completion_additional_edits` /
  `handle_completion_resolved`). `documentation` is required in practice:
  validated against rust-analyzer 1.94.1, with `additionalTextEdits` alone it
  still offers the candidate and still defers the import edit to resolve, but
  reports `completionProvider.resolveProvider: false` — so a spec-compliant
  client never resolves and the import is silently lost. Deferring
  documentation costs nothing because the completion popup renders
  label/detail only, never `documentation`.
- **`labelDetailsSupport: true`** — with resolve support on, rust-analyzer
  moves the `(use std::collections::HashMap)` annotation into `labelDetails`;
  without this flag it folds that text into the label itself, which the
  accept path would insert literally into the buffer. The popup now renders
  `labelDetails` as the dimmed detail next to the (bare-identifier) label.

Deliberately **not** advertised, because the client does not implement them:

- `snippetSupport` — the accept path detects snippet syntax only
  heuristically (`is_snippet`) and does not track `insertTextFormat`, so
  inviting servers to switch every insertion to snippet format is unsafe.
- other `resolveSupport` properties (`detail`, `command`, …) — the resolve
  response is only consumed for its additional edits.

## 2. Hover popups fired through modal dialogs (#2912)

While a modal dialog (Open File, command palette, menu, …) was open, mouse
motion over the dialog kept arming and firing LSP hover requests for the
buffer *behind* it (positions map straight through to covered content), and
the hover popups rendered on top of the dialog.

Both ends of the hover pipeline are now gated on the overlay stack the input
routers already consult (`Editor::overlay_layers`) via a new
`modal_overlay_active()` predicate — no parallel notion of modality:

- `update_lsp_hover_state` (mouse motion) no longer tracks hover — and
  dismisses any transient hover popup — while a modal overlay is active;
- `check_mouse_hover_timer` no longer fires a request for a hover armed just
  before the modal opened.

The popup band is excluded from the predicate (the hover/completion popups
themselves live there and keep their existing popup-aware handling); the dock
and the editor base are not modal. This generalizes the #2244/#2245 fix,
which covered only the LSP-status popup.

## 3. Accepting a completion applied another candidate's import

Found while testing this PR: with flyimport unlocked, the popup offers several
rows sharing one label —

```
S HashMap (use oxc_allocator::HashMap)
S HashMapStrategy (use proptest::collection::HashMapStrategy)
S HashMap (use std::collections::HashMap)
```

— and accepting the last one inserted `use oxc_allocator::HashMap`.

The accept path passed only the selected row's **label** to
`apply_completion_additional_edits`, which recovered the item with
`completion_items.iter().find(|item| item.label == label)`: the first
candidate sharing the label, not the selected one. Its eager
`additionalTextEdits` were applied — and that same wrong item was the one sent
to `send_completion_resolve`, which is the path that actually decides the
import for rust-analyzer since it defers `additionalTextEdits` to
`completionItem/resolve`. Latent before this PR (without unimported symbols,
duplicate labels were rare); advertising flyimport makes them the norm.

Accept is identity-based now. `Editor::build_completion_popup_rows` builds the
popup rows and records the candidate behind each LSP row
(`Window::completion_popup_lsp_items`) in one pass, and the accept path
resolves the selected row index through that mapping. A bare index into
`completion_items` would not be enough — the popup is a prefix-filtered view
with buffer-word rows appended, so popup row ≠ stored index; recording the
mapping where the rows are built is what makes the index meaningful. All three
popup-building paths (first response, type-to-filter rebuild, buffer-words
only) go through that one function. The `completionItem/resolve` *response*
handler needed no change: it applies the edits from the item the server
returned rather than re-finding one by label.

## Tests

All fail without their fix (verified by stashing the src changes):

- `client_capabilities_advertise_completion_resolve_additional_text_edits`,
  `client_capabilities_advertise_completion_label_details` (unit,
  `async_handler.rs`) — initialize capabilities contain
  resolveSupport/labelDetails.
- `lsp_items_to_popup_items_renders_label_details`,
  `lsp_items_to_popup_items_falls_back_to_detail` (unit, `popup_actions.rs`)
  — labelDetails renders as detail, label/insert text stay bare.
- `test_completion_offers_unimported_symbol_and_applies_auto_import` (e2e) —
  drives a fake LSP that replicates rust-analyzer's observed gating (both the
  flyimport item gating on `additionalTextEdits` and `resolveProvider` gating
  on `documentation`): `HashMa` + Ctrl+Space must offer
  `HashMap (use std::collections::HashMap)` on screen, and accepting must
  insert the `use` line via `completionItem/resolve` (times out without the
  fix — the candidate is never offered).
- `test_no_hover_requests_while_modal_dialog_open` (e2e) — control hover
  works, then with the Open File dialog up neither fresh mouse motion nor a
  pre-armed hover timer produces a hover (failed at the first suppression
  assertion without the fix).
- `test_accepting_second_same_label_candidate_applies_its_own_import`,
  `test_resolve_deferred_import_follows_the_selected_candidate` (e2e) — a new
  fake server (`FakeLspServer::spawn_duplicate_labels`) offers two candidates
  both labelled `HashMap`, the wrong one first, with the import delivered
  eagerly in one test and through `completionItem/resolve` (keyed on the
  item's `data`, as rust-analyzer does) in the other. Down + Tab must leave
  `use std::collections::HashMap;` on screen and never
  `use wrong_crate::HashMap;`. Both insert the wrong import without the fix.

Ran: the four unit tests, all five new e2e tests, the LSP/completion e2e
modules (`-- e2e::lsp_completion e2e::lsp::`, 122 passed) and the `--lib`
`popup_actions` / `async_handler` / completion unit tests (70 passed),
`cargo fmt`, `cargo clippy -p fresh-editor --all-targets` (no new warnings on
the touched files), plus manual validation of the first two fixes against real
rust-analyzer 1.94.1 in tmux with a debug build: `HashMa` + Ctrl+Space offers
`HashMap (use std::collections::HashMap)`, accepting inserts
`use std::collections::HashMap;` at the top of the file; with the Open File
dialog open, mouse motion over the dialog produces no hover popups, while the
same motion without the dialog does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y)_