### PR TITLE
vi mode: make `.` replay the insert command instead of injecting buffer text

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -40,6 +40,7 @@ interface LastChange {
   findCharTarget?: string;   // For operator+find-char: the target character
   count?: number;            // Count used with the command
   insertedText?: string;     // Text inserted during insert mode
+  insertCommand?: string;    // For type "insert": the command that entered insert mode (i/a/I/A/o/O)
 }
 
 interface ViState {
@@ -55,6 +56,7 @@ interface ViState {
   visualHead: number | null; // Active end of computed visual selections
   visualRange: { start: number; end: number } | null; // Characterwise visual range for computed motions
   insertStartPos: number | null; // Cursor position when entering insert mode
+  pendingInsertCommand: string | null; // Insert-entering command (i/a/I/A/o/O) awaiting '.' recording
   visualBlockAnchor: { line: number; col: number } | null; // For visual block mode
   lastWordSearch: { text: string; direction: WordSearchDirection; wholeWord: boolean } | null; // For n/N after * or #
 }
@@ -72,6 +74,7 @@ const state: ViState = {
   visualHead: null,
   visualRange: null,
   insertStartPos: null,
+  pendingInsertCommand: null,
   visualBlockAnchor: null,
   lastWordSearch: null,
 };
@@ -191,18 +194,34 @@ function switchMode(newMode: ViMode): void {
 async function captureInsertedText(): Promise<void> {
   if (state.insertStartPos === null) return;
 
+  const startPos = state.insertStartPos;
+  state.insertStartPos = null;
+  const insertCommand = state.pendingInsertCommand;
+  state.pendingInsertCommand = null;
+
   const endPos = editor.getCursorPosition();
-  if (endPos === null || endPos <= state.insertStartPos) {
-    state.insertStartPos = null;
+  let text = "";
+  if (endPos !== null && endPos > startPos) {
+    const bufferId = editor.getActiveBufferId();
+    text = (await editor.getBufferText(bufferId, startPos, endPos)) ?? "";
+  }
+
+  if (insertCommand !== null) {
+    // Insert entered via i/a/I/A/o/O: '.' replays the command's cursor
+    // motion plus the typed text. An empty i/a/I/A insert is not a change
+    // (Vim keeps the previous one for '.'), but o/O open a line even when
+    // nothing is typed, which alone is repeatable.
+    if (text.length > 0 || insertCommand === "o" || insertCommand === "O") {
+      state.lastChange = { type: "insert", insertCommand };
+      if (text.length > 0) {
+        state.lastChange.insertedText = text;
+      }
+    }
     return;
   }
 
-  const bufferId = editor.getActiveBufferId();
-  const text = await editor.getBufferText(bufferId, state.insertStartPos, endPos);
-
-  if (text && text.length > 0) {
-    // Only record if we have a pending insert change or if there was actual text inserted
-    if (state.lastChange?.type === "insert" || !state.lastChange) {
+  if (text.length > 0) {
+    if (!state.lastChange || state.lastChange.type === "insert") {
       state.lastChange = {
         type: "insert",
         insertedText: text,
@@ -214,8 +233,6 @@ async function captureInsertedText(): Promise<void> {
       state.lastChange.insertedText = text;
     }
   }
-
-  state.insertStartPos = null;
 }
 
 // Get the current count (defaults to 1 if no count specified)
@@ -1700,41 +1717,87 @@ async function vi_search_word_backward() : Promise<void> {
 registerHandler("vi_search_word_backward", vi_search_word_backward);
 
 // Mode switching
+//
+// Each insert-entering command records itself in `pendingInsertCommand` so
+// the Escape-time capture can build a `lastChange` that '.' replays by
+// re-executing the command's cursor motion at the new cursor and then
+// re-inserting the recorded keystrokes (Vim `:help .`). Commands that
+// reposition the cursor before inserting must also flush the editor's
+// command queue first: `executeAction` is queued and applied on the editor
+// thread, so without the flush `switchMode("insert")` would record the
+// PRE-reposition cursor position as `insertStartPos`, and the '.' capture
+// would span intervening buffer text instead of just the typed keystrokes
+// (issue #2443: `o`/`a`/`A` + `.` injected unrelated line content).
+async function enterInsertRepositioned(command: string): Promise<void> {
+  await editor.flush();
+  state.pendingInsertCommand = command;
+  switchMode("insert");
+}
+
 function vi_insert_before() : void {
+  // No repositioning, so no flush needed: the cursor snapshot is already
+  // accurate. Recording the entering command keeps a stale previous change
+  // (e.g. an `x`) from swallowing this insert's recording at capture time.
+  state.pendingInsertCommand = "i";
   switchMode("insert");
 }
 registerHandler("vi_insert_before", vi_insert_before);
 
-function vi_insert_after() : void {
+async function vi_insert_after() : Promise<void> {
   editor.executeAction("move_right");
-  switchMode("insert");
+  await enterInsertRepositioned("a");
 }
 registerHandler("vi_insert_after", vi_insert_after);
 
-function vi_insert_line_start() : void {
+async function vi_insert_line_start() : Promise<void> {
   editor.executeAction("move_line_start");
-  switchMode("insert");
+  await enterInsertRepositioned("I");
 }
 registerHandler("vi_insert_line_start", vi_insert_line_start);
 
-function vi_insert_line_end() : void {
+async function vi_insert_line_end() : Promise<void> {
   editor.executeAction("move_line_end");
-  switchMode("insert");
+  await enterInsertRepositioned("A");
 }
 registerHandler("vi_insert_line_end", vi_insert_line_end);
 
-function vi_open_below() : void {
+async function vi_open_below() : Promise<void> {
   editor.executeAction("move_line_end");
   editor.executeAction("insert_newline");
-  switchMode("insert");
+  await enterInsertRepositioned("o");
 }
 registerHandler("vi_open_below", vi_open_below);
 
-function vi_open_above() : void {
-  editor.executeAction("move_line_start");
-  editor.executeAction("insert_newline");
-  editor.executeAction("move_up");
-  switchMode("insert");
+// Open a line above the cursor's line and leave the cursor at its start.
+// Implemented with an explicit insert at the line-start byte offset instead of
+// `insert_newline` + `move_up`: the offsets are computed from the pre-command
+// cursor, so the new empty line and the cursor position cannot disagree.
+async function openLineAbove(): Promise<boolean> {
+  const bufferId = editor.getActiveBufferId();
+  if (isActiveBufferEditingDisabled(bufferId)) {
+    return false;
+  }
+  const range = await getLinewiseRange(1);
+  if (range === null) {
+    // Empty buffer: open an (empty) line below the cursor's empty line.
+    if (editor.getBufferLength(bufferId) === 0) {
+      editor.insertText(bufferId, 0, "\n");
+      editor.setBufferCursor(bufferId, 0);
+      return true;
+    }
+    return false;
+  }
+  editor.insertText(range.bufferId, range.start, range.lineTerminator);
+  editor.setBufferCursor(range.bufferId, range.start);
+  return true;
+}
+
+async function vi_open_above() : Promise<void> {
+  if (!(await openLineAbove())) {
+    switchMode("normal");
+    return;
+  }
+  await enterInsertRepositioned("O");
 }
 registerHandler("vi_open_above", vi_open_above);
 
@@ -2068,9 +2131,35 @@ async function vi_repeat() : Promise<void> {
     }
 
     case "insert": {
-      // Pure insert (i, a, o, O)
+      // Pure insert (i, a, I, A, o, O): re-execute the entering command's
+      // cursor motion at the current cursor, then re-insert the recorded
+      // keystrokes (Vim `:help .`). Replaying only the text without the
+      // motion — or vice versa — is what corrupted buffers in issue #2443.
+      switch (change.insertCommand) {
+        case "a":
+          editor.executeAction("move_right");
+          break;
+        case "I":
+          editor.executeAction("move_line_start");
+          break;
+        case "A":
+          editor.executeAction("move_line_end");
+          break;
+        case "o":
+          editor.executeAction("move_line_end");
+          editor.executeAction("insert_newline");
+          break;
+        case "O":
+          if (!(await openLineAbove())) {
+            return;
+          }
+          break;
+      }
       if (change.insertedText) {
         editor.insertAtCursor(change.insertedText);
+        // Leave the cursor on the last inserted character, exactly as
+        // Escape does when the original insert ended.
+        editor.executeAction("move_left_in_line");
       }
       break;
     }

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -1605,3 +1605,304 @@ fn test_vi_bug_2441_comma_repeats_find_reverse() {
     send_key(&mut harness, ',');
     harness.wait_until(|h| h.cursor_position() == 4).unwrap();
 }
+
+// =============================================================================
+// Issue #2443: dot-repeat (`.`) of the cursor-repositioning insert commands
+// (`o`/`O`/`a`/`A`) corrupted the buffer: the recorded change spanned from the
+// PRE-reposition cursor position to the insert end, so replay re-inserted
+// intervening buffer text instead of only the typed keystrokes.
+//
+// These reproducers observe only what is on screen: the rendered text rows and
+// the status line's mode and `Ln N, Col N` readouts.
+// =============================================================================
+
+/// First screen row that shows buffer text (row 0 is the menu bar, row 1 the
+/// tab bar).
+const FIRST_TEXT_ROW: u16 = 2;
+
+/// Consecutive identical frames that count as "the editor has finished
+/// reacting". Used only to decide that a *wrong* result is final; the expected
+/// result short-circuits the wait as soon as it renders.
+const SETTLED_RENDERS: usize = 20;
+
+/// The buffer lines as rendered, with the line-number gutter stripped and the
+/// scrollbar column dropped.
+///
+/// A line the editor renders empty comes back as `""`; rows past the end of the
+/// buffer come back as the `~` filler verbatim, so an expectation that lists the
+/// filler also pins the buffer's line count.
+fn rendered_buffer_lines(harness: &EditorTestHarness, count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| {
+            let row = harness.screen_row_text(FIRST_TEXT_ROW + i as u16);
+            // The scrollbar paints a block glyph in the last column of some
+            // rows; it is chrome, not buffer text.
+            let row = row.trim_end_matches(['▌', '▐', '█', ' ']).to_string();
+            if let Some((_gutter, text)) = row.split_once(" │ ") {
+                text.to_string()
+            } else if row.ends_with('│') {
+                // Gutter with no text after it: an empty buffer line.
+                String::new()
+            } else {
+                row
+            }
+        })
+        .collect()
+}
+
+/// Wait for the rendered buffer rows to become exactly `expected`, and fail with
+/// a diff if the screen settles on anything else.
+///
+/// Both arms wait on observed state rather than elapsed time: the success arm
+/// fires the moment the expected rows render, and the failure arm fires once the
+/// screen has stopped changing. The failure arm is what makes these reproducers
+/// useful regression guards — waiting only for the expected text means a
+/// regression never asserts at all, it just runs until the external test timeout
+/// kills it, which reports a hang instead of naming the corrupted text.
+fn assert_renders(harness: &mut EditorTestHarness, expected: &[&str]) {
+    let mut previous = String::new();
+    let mut settled = 0usize;
+    harness
+        .wait_until(|h| {
+            if rendered_buffer_lines(h, expected.len()) == expected {
+                return true;
+            }
+            let screen = h.screen_to_string();
+            if screen == previous {
+                settled += 1;
+            } else {
+                previous = screen;
+                settled = 0;
+            }
+            settled >= SETTLED_RENDERS
+        })
+        .unwrap();
+
+    assert_eq!(
+        rendered_buffer_lines(harness, expected.len()),
+        expected,
+        "editor settled on the wrong buffer text"
+    );
+}
+
+/// Wait for the status line to report the cursor on the given 1-based line.
+fn wait_cursor_line(harness: &mut EditorTestHarness, line: usize) {
+    harness
+        .wait_for_screen_contains(&format!("Ln {line},"))
+        .unwrap();
+}
+
+/// Wait for the status line to report the given 1-based line and column.
+fn wait_cursor_at(harness: &mut EditorTestHarness, line: usize, col: usize) {
+    harness
+        .wait_for_screen_contains(&format!("Ln {line}, Col {col}"))
+        .unwrap();
+}
+
+/// Wait for the status line to show vi insert mode.
+fn wait_insert_indicator(harness: &mut EditorTestHarness) {
+    harness.wait_for_screen_contains("-- INSERT --").unwrap();
+}
+
+/// Leave insert mode, waiting for the status line to show normal mode again.
+fn escape_to_normal(harness: &mut EditorTestHarness) {
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.wait_for_screen_contains("-- NORMAL --").unwrap();
+}
+
+/// `o hello Esc` then `.` on another line must open a line below it containing
+/// exactly the typed text. BUG: `.` injected the original line's content plus
+/// the typed text mid-word (`charalpha` / `hellolie`).
+#[test]
+fn test_vi_bug_2443_dot_repeat_open_below() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbravo\ncharlie\ndelta\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'o');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("hello").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(
+        &mut harness,
+        &["alpha", "hello", "bravo", "charlie", "delta", "", "~"],
+    );
+
+    // Move from the inserted "hello" line down to "charlie", waiting for each
+    // motion to land so `.` replays at the intended position.
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 3);
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 4);
+
+    send_key(&mut harness, '.');
+    assert_renders(
+        &mut harness,
+        &[
+            "alpha", "hello", "bravo", "charlie", "hello", "delta", "", "~",
+        ],
+    );
+}
+
+/// `a Y Esc` then `.` on another line must append the typed text after the
+/// cursor. BUG: `.` re-injected the original line's leading character
+/// (`aYbravo` instead of `bYravo`).
+#[test]
+fn test_vi_bug_2443_dot_repeat_append_after_cursor() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbravo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'a');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("Y").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(&mut harness, &["aYlpha", "bravo", "", "~"]);
+
+    // `j` then `0`: land on the `b` of "bravo".
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 2);
+    send_key(&mut harness, '0');
+    wait_cursor_at(&mut harness, 2, 1);
+
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["aYlpha", "bYravo", "", "~"]);
+}
+
+/// `A X Esc` then `.` on another line must append the typed text at end of
+/// line. BUG: `.` injected the entire original line's content at the cursor
+/// (`bravalphaXo` instead of `bravoX`).
+#[test]
+fn test_vi_bug_2443_dot_repeat_append_line_end() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbravo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'A');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("X").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(&mut harness, &["alphaX", "bravo", "", "~"]);
+
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 2);
+
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["alphaX", "bravoX", "", "~"]);
+}
+
+/// `O` must open the empty line above the current line AND leave the cursor on
+/// it, so the typed text goes into the new line. BUG: the empty line opened at
+/// the right place but the cursor landed on the line above it, so the text
+/// corrupted that line (`bheyravo`), and `.` afterwards reported "No change to
+/// repeat".
+#[test]
+fn test_vi_bug_2443_open_above_cursor_placement_and_repeat() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbravo\ncharlie\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Move to "charlie".
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 2);
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 3);
+
+    send_key(&mut harness, 'O');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("hey").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(&mut harness, &["alpha", "bravo", "hey", "charlie", "", "~"]);
+
+    // `.` must repeat the whole change: open a line above and insert "hey".
+    send_key(&mut harness, '.');
+    assert_renders(
+        &mut harness,
+        &["alpha", "bravo", "hey", "hey", "charlie", "", "~"],
+    );
+}
+
+/// An insert entered with `i` after an unrelated `x` must be recorded for `.`.
+/// BUG: `.` still repeated the old `x` (the insert was never recorded), so the
+/// second line lost a character instead of gaining the typed one.
+#[test]
+fn test_vi_bug_2443_insert_after_delete_char_is_recorded() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "abc\nxyz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'x');
+    assert_renders(&mut harness, &["bc", "xyz", "", "~"]);
+
+    send_key(&mut harness, 'i');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("Q").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(&mut harness, &["Qbc", "xyz", "", "~"]);
+
+    // `j` then `0`: land on the `x` of "xyz".
+    send_key(&mut harness, 'j');
+    wait_cursor_line(&mut harness, 2);
+    send_key(&mut harness, '0');
+    wait_cursor_at(&mut harness, 2, 1);
+
+    // `.` must repeat the insert (`iQ`), not the earlier `x`.
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["Qbc", "Qxyz", "", "~"]);
+}
+
+/// Control: dot-repeat of a plain `i` insert (already correct before the fix)
+/// keeps working, so the fix cannot regress it.
+#[test]
+fn test_vi_bug_2443_control_dot_repeat_insert_before() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "alpha\nbravo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'i');
+    wait_insert_indicator(&mut harness);
+    harness.type_text("AB").unwrap();
+    escape_to_normal(&mut harness);
+    assert_renders(&mut harness, &["ABalpha", "bravo", "", "~"]);
+
+    // Cursor rests on `B` (col 2). `j` keeps the column, so `.` inserts before
+    // the `r` of "bravo".
+    send_key(&mut harness, 'j');
+    wait_cursor_at(&mut harness, 2, 2);
+
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["ABalpha", "bABravo", "", "~"]);
+}
+
+/// Control: dot-repeat of `x` (already correct before the fix) keeps deleting
+/// successive characters, so the fix cannot regress it.
+#[test]
+fn test_vi_bug_2443_control_dot_repeat_delete_char() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "abcdef\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    send_key(&mut harness, 'x');
+    assert_renders(&mut harness, &["bcdef", "", "~"]);
+
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["cdef", "", "~"]);
+
+    send_key(&mut harness, '.');
+    assert_renders(&mut harness, &["def", "", "~"]);
+}


### PR DESCRIPTION
Fixes #2443
Refs #2447

## Motivation

Dot-repeat of the cursor-repositioning insert commands silently corrupted the buffer. `o hello Esc` then `.` on another line injected the *original* line's content plus a newline plus the typed text mid-word; `a Y Esc` then `.` re-injected the original line's leading character; `A X Esc` then `.` injected the entire original line's content. `i` and `x` repeated correctly, which is what localised the defect to the commands that move the cursor before inserting.

Two related defects came out of the same code path:

- **`O` was broken before `.` was involved at all**: the empty line opened in the right place, but the cursor landed one line *above* it, so the typed text corrupted the preceding line, and `.` afterwards reported "No change to repeat".
- **An insert following an `x` was never recorded**: `x`, then later `i`+text+`Esc`, then `.` repeated the old `x`.

## The fix (all inside `crates/fresh-editor/plugins/vi_mode.ts`)

The recording model was "remember the byte span from the cursor at insert-mode entry to the cursor at Escape". That span was wrong because `executeAction("move_line_end")` / `move_right` / `insert_newline` are *queued* and applied on the editor thread, while `getCursorPosition()` reads the plugin's state snapshot — so the recorded start was the **pre**-reposition cursor, and the captured "inserted text" was really the intervening buffer text, which `.` then re-inserted verbatim.

Per Vim (`:help .`), the change is now recorded as *the command plus the literally typed text*, and replay re-executes the command's semantics at the new cursor:

- `i`/`a`/`I`/`A`/`o`/`O` each record which command entered insert mode (`pendingInsertCommand`).
- The repositioning ones `await editor.flush()` before switching to insert mode, so `insertStartPos` is the post-reposition cursor and the Escape-time capture spans exactly the typed keystrokes.
- `vi_repeat`'s `insert` branch re-executes the motion (`move_right` / `move_line_start` / `move_line_end` / `move_line_end`+`insert_newline` / open-line-above) and then inserts the recorded text, leaving the cursor where Escape would have.
- `O` no longer uses `insert_newline` + `move_up`. It inserts the buffer's own line terminator at the line-start byte offset and sets the cursor there — both derived from the same pre-command cursor, so the new line and the cursor cannot disagree. The same helper is reused by `.`.
- Recording the entering command also fixes the `x`-then-`i` case: the capture no longer refuses to overwrite an unrelated previous change.

No Rust code changed; the plugin is embedded in the binary, so a rebuild is required to pick it up.

## Tests

Added to `crates/fresh-editor/tests/e2e/vi_mode_bugs.rs`. They drive real keystrokes and observe **only rendered output**: the text rows (line-number gutter and scrollbar chrome stripped) and the status line's mode indicator and `Ln N, Col N` readout. Nothing reads the buffer, cursor, or editor mode out of the model. Each test gets its own `TempDir` project root and internal clipboard.

The assertion helper (`assert_renders`) waits for *either* the expected rows or a screen that has stopped changing, then asserts. Both arms observe state; neither is a wall-clock deadline. The second arm is what makes these useful: waiting only for the expected text means a regression never asserts at all — it runs until the external timeout kills it and reports a hang instead of naming the corruption. That was measured, not assumed: an earlier revision of the helper turned the reverted-plugin runs into stalls, and with the settle arm the same runs fail in ~1.6s quoting the exact wrong text.

### With the fix

Rebased onto `origin/master` (clean; master had not touched `plugins/vi_mode.ts`, `tests/e2e/vi_mode_bugs.rs`, or the e2e harness). On that rebased tree, the seven tests were run by name from a freshly built `e2e_tests` binary: **7 passed; 0 failed**.

### Without the fix

`plugins/vi_mode.ts` reverted to master's copy, the binary rebuilt, each test run individually. Because the shared build directory is used by other work and served stale artifacts more than once, every binary used here was verified to actually contain (or, for the reverted build, to not contain) this change before being run.

| Test | Keys | Result without the fix |
|---|---|---|
| `..._dot_repeat_open_below` | `o hello Esc`, `j j`, `.` | **FAILED 1.61s** — `["alpha","hello","bravo","charalpha","hellolie","delta"]` vs expected `[…,"charlie","hello","delta"]` |
| `..._dot_repeat_append_after_cursor` | `a Y Esc`, `j 0`, `.` | **FAILED 1.66s** — `["aYlpha","aYbravo"]` vs expected `["aYlpha","bYravo"]` |
| `..._dot_repeat_append_line_end` | `A X Esc`, `j`, `.` | **FAILED 1.67s** — `["alphaX","bravalphaXo"]` vs expected `["alphaX","bravoX"]` |
| `..._open_above_cursor_placement_and_repeat` | `j j O hey Esc`, `.` | **FAILED 1.60s** — `["alpha","bheyravo","","charlie"]` vs expected `["alpha","bravo","hey","charlie"]` |
| `..._insert_after_delete_char_is_recorded` | `x`, `i Q Esc`, `j 0`, `.` | **FAILED 1.61s** — `["Qbc","yz"]` (the `x` replayed) vs expected `["Qbc","Qxyz"]` |
| `..._control_dot_repeat_insert_before` | `i AB Esc`, `j`, `.` | ok 0.28s — control, pins a path that was already correct |
| `..._control_dot_repeat_delete_char` | `x`, `.`, `.` | ok 0.26s — control, pins a path that was already correct |

### Manual validation

Walked every case from the issue's reproduction comment in tmux (isolated `HOME`, private tmux socket) against a freshly built binary, on `alpha`/`bravo`/`charlie`/`delta`/`echo`. The plugin file on this branch is byte-identical to the copy that binary was built from.

| Keys | Observed buffer |
|---|---|
| `o hello Esc`, `j j`, `.` | `alpha` / `hello` / `bravo` / `charlie` / `hello` / `delta` / `echo` ✅ |
| `a Y Esc`, `j 0 .` | `aYlpha` / `bYravo` ✅ |
| `A X Esc`, `j .` | `alphaX` / `bravoX` ✅ |
| `j j O hey Esc` | `alpha` / `bravo` / `hey` / `charlie` — cursor on the opened line ✅ |
| …then `.` | `alpha` / `bravo` / `hey` / `hey` / `charlie` ✅ |
| `x`, `i Q Esc`, `j 0 .` | `Qlpha` / `Qbravo` ✅ (the insert repeats, not the `x`) |
| `i AB Esc`, `j .` | `ABalpha` / `bABravo` ✅ |
| `x`, `.`, `.` | `alpha` → `lpha` → `ha` ✅ |

### Other checks

- `cargo fmt -p fresh-editor` — no changes.
- `plugins/check-types.sh vi_mode.ts` — four `ActionSpec.args` errors, all pre-existing: the same four are reported when the checker is run against master's copy of the file. This change adds none.

### Not run

Stated explicitly so the reviewer does not assume otherwise: **`cargo clippy` and `cargo check` (including `--features gui`) were not run on this branch**, and no suite broader than the seven tests named above was run after the rebase. CI covers those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y