### PR TITLE
test: skip plugin loading in property-test harnesses to fix CI timeout

### DIFF
--- a/crates/fresh-editor/tests/common/scenario/property.rs
+++ b/crates/fresh-editor/tests/common/scenario/property.rs
@@ -41,11 +41,20 @@ pub struct BufferState {
 /// `run_buffer_actions` (renders before/after each action, like the
 /// real event loop) so layout-dependent moves resolve.
 ///
+/// Plugins are skipped for the same reason `check_buffer_scenario`
+/// skips them: the observable is buffer text + caret state reached
+/// through core `Action` dispatch, which plugins cannot affect. This
+/// matters more here than for a single scenario — property tests call
+/// this in a loop (a 32-case property evaluating twice per case builds
+/// 64 editors), so the ~440 ms of TS transpile + QuickJS per
+/// plugin-loaded harness multiplies into minutes on slow CI runners
+/// and pushes the test into nextest's terminate timeout.
+///
 /// Harness construction failures (out of disk, etc.) still panic; an
 /// external driver should already trust its environment.
 pub fn evaluate_actions(initial_text: &str, actions: &[Action]) -> BufferState {
-    let mut harness = EditorTestHarness::with_temp_project(80, 24)
-        .expect("EditorTestHarness::with_temp_project failed");
+    let mut harness = EditorTestHarness::with_temp_project_no_plugins(80, 24)
+        .expect("EditorTestHarness::with_temp_project_no_plugins failed");
     let _fixture = harness
         .load_buffer_from_text(initial_text)
         .expect("load_buffer_from_text failed");


### PR DESCRIPTION
## What was failing

`semantic::properties::property_dispatch_is_deterministic` flaked on Windows CI by hitting nextest's terminate timeout (`slow-timeout = 60s` × `terminate-after 3` = 180s), showing up as `TERMINATING [>180.000s]`.

## Root cause

It wasn't timing-sensitive logic — the test was simply doing far too much work. The shared helper `evaluate_actions` built each per-case harness with `EditorTestHarness::with_temp_project`, which loads the **full embedded plugin set**. Measured cost per harness:

```
CONSTRUCT: with_plugins=589ms  no_plugins=29ms
```

The determinism property evaluates every generated case *twice* (same input → same output), so 32 proptest cases construct **64 fully-plugin-loaded editors inside a single test**. That reached 44.6s even on a fast Linux box; on a slower Windows runner it crosses the terminate threshold.

The `Cannot drop a runtime in a context where blocking is not allowed` panics in the CI log are a symptom of the same thing: plugin-driven async work still holding `Arc<Runtime>` clones as each of those 64 harnesses is torn down, so the runtime's last reference drops on its own `editor-async` worker thread. Teardown noise on non-test threads — the actual failure was the timeout.

## The change

One line: `evaluate_actions` now builds harnesses with `with_temp_project_no_plugins`.

This also removes an inconsistency rather than introducing one. `check_buffer_scenario` and the combination driver `run_scenarios_with_reset_between` already ran without plugins; `evaluate_actions` was the last holdout. The design intent is stated explicitly at `buffer_scenario.rs:198` — every consumer routes through `run_buffer_actions` "so a `BufferScenario` has exactly one evaluation semantics." Before this change the shadow differential evaluated a scenario with plugins while `check_buffer_scenario` evaluated that same scenario without them.

## Verifying no coverage is lost

`with_temp_project_no_plugins` carries a deliberate "don't reach for this casually" warning, so this was checked empirically rather than assumed. A temporary probe ran identical generated action sequences through two editors — one plugin-loaded, one not — and compared the full `BufferState` (buffer text, primary caret, all carets, selection text) field-by-field:

```
PROBE_RESULT: 0 differing cases out of 24
```

The 589ms vs 29ms construction gap above confirms the probe was not vacuous — the plugin-enabled side really did transpile and evaluate the embedded plugins. The probe was removed again; this PR contains only the one-line change.

Tracing the hooks that could plausibly reach the observable: `after_insert` / `after_delete` / `lines_changed` are registered only by `live_diff.ts` and `markdown_compose.ts`, and `cursor_moved` only by `audit_mode.ts`, `git_log.ts`, and `theme_editor.ts`. All write decorations (conceals, virtual lines, scrollbar markers), never buffer text. The one indirect path — conceals shifting layout-dependent moves like `MoveDown`, which resolve because `run_buffer_actions` renders between actions — is closed here because `evaluate_actions` always loads `test_buffer.txt` while `markdown_compose` activates on markdown.

The shadow differential is structurally unaffected: the only `ShadowModel` impl is the identity `BufferShadow`, whose `evaluate` also calls `evaluate_actions`, so both sides move together and it remains an identity.

## What this does give up

A tripwire, not coverage: a future plugin that mutates text or carets on those hooks, or adds conceals to plain-text buffers, would no longer be caught by these property tests. That tripwire was accidental — `check_buffer_scenario` never had it. If it's wanted deliberately, the right shape is a single cheap plugin-enabled differential test rather than paying 589ms on each of 64 property harnesses.

## Results

| | before | after |
|---|---|---|
| `property_dispatch_is_deterministic` | 44.6s | **6.4s** |

Full `semantic::` suite after rebasing onto current master: **666 passed, 0 failed, 7 ignored**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD7t7CrBdyV1uqkhubmorF)_