### PR TITLE
refactor: lift pointer hit-testing out of Editor into a pure layer

### DIFF
--- a/crates/fresh-editor/src/app/file_open_input.rs
+++ b/crates/fresh-editor/src/app/file_open_input.rs
@@ -855,62 +855,19 @@ impl Editor {
 
     /// Compute hover target for file browser
     pub fn compute_file_browser_hover(&self, x: u16, y: u16) -> Option<super::types::HoverTarget> {
-        use super::types::HoverTarget;
-
+        // The ladder lives in the pure hit-test layer; this shell supplies
+        // the layout plus the list state (scroll offset, entry count) that
+        // the row probe needs.
         let layout = self.active_window().file_browser_layout.as_ref()?;
-
-        // Check "Show Hidden" checkbox first (priority over navigation shortcuts)
-        if layout.is_on_show_hidden_checkbox(x, y) {
-            return Some(HoverTarget::FileBrowserShowHiddenCheckbox);
-        }
-
-        // Check "Detect Encoding" checkbox
-        if layout.is_on_detect_encoding_checkbox(x, y) {
-            return Some(HoverTarget::FileBrowserDetectEncodingCheckbox);
-        }
-
-        // Check navigation shortcuts
-        if layout.is_in_nav(x, y) {
-            if let Some(idx) = layout.nav_shortcut_at(x, y) {
-                return Some(HoverTarget::FileBrowserNavShortcut(idx));
-            }
-        }
-
-        // Check column headers
-        if layout.is_in_header(x, y) {
-            if let Some(mode) = layout.header_column_at(x) {
-                return Some(HoverTarget::FileBrowserHeader(mode));
-            }
-        }
-
-        // Check file list entries
-        if layout.is_in_list(x, y) {
-            let scroll_offset = self
-                .active_window()
-                .file_open_state
-                .as_ref()
-                .map(|s| s.scroll_offset)
-                .unwrap_or(0);
-
-            if let Some(idx) = layout.click_to_index(y, scroll_offset) {
-                let total_entries = self
-                    .active_window()
-                    .file_open_state
-                    .as_ref()
-                    .map(|s| s.entries.len())
-                    .unwrap_or(0);
-
-                if idx < total_entries {
-                    return Some(HoverTarget::FileBrowserEntry(idx));
-                }
-            }
-        }
-
-        // Check scrollbar
-        if layout.is_in_scrollbar(x, y) {
-            return Some(HoverTarget::FileBrowserScrollbar);
-        }
-
-        None
+        let state = self.active_window().file_open_state.as_ref();
+        crate::app::hit_test::file_browser_target(
+            &crate::app::hit_test::FileBrowserHit {
+                layout,
+                scroll_offset: state.map(|s| s.scroll_offset).unwrap_or(0),
+                entry_count: state.map(|s| s.entries.len()).unwrap_or(0),
+            },
+            x,
+            y,
+        )
     }
 }

--- a/crates/fresh-editor/src/app/hit_test.rs
+++ b/crates/fresh-editor/src/app/hit_test.rs
@@ -71,9 +71,14 @@ pub(crate) struct HoverHitView<'a> {
     pub open_menu: Option<(usize, &'a MenuLayout)>,
     /// The file-explorer panel's area.
     pub file_explorer_area: Option<Rect>,
-    /// Pre-resolved file-explorer status-indicator hit (see module docs):
-    /// `Some` only when the pointer is actually on an indicator slot.
-    pub explorer_status_indicator: Option<HoverTarget>,
+    /// Resolves the file-explorer status-indicator hit (see module docs).
+    ///
+    /// A closure, not a value: it scans the window's buffers for unsaved
+    /// changes, takes the theme lock and runs the explorer's slot layout,
+    /// and `hover_target` runs on every mouse-move event. The ladder calls
+    /// it only if it actually reaches that rung — so a hover that a popup
+    /// or the menu bar claims first never pays for it.
+    pub explorer_status_indicator: &'a dyn Fn() -> Option<HoverTarget>,
     /// `(container, direction, x, y, length)` per split separator.
     pub separators: &'a [(ContainerId, SplitDirection, u16, u16, u16)],
     /// `(split, row, start_col, end_col)` per close-split button.
@@ -193,9 +198,10 @@ pub(crate) fn chrome_target(view: &HoverHitView<'_>, col: u16, row: u16) -> Opti
         }
 
         // Renderer/theme-dependent probe, resolved by the shell — see the
-        // module docs. It sits here so the *ordering* (after the close
-        // button, before the border) stays in this ladder.
-        if let Some(indicator) = view.explorer_status_indicator.clone() {
+        // module docs. Called here and only here, so it keeps both its
+        // place in the ladder (after the close button, before the border)
+        // and its cost off every other hover.
+        if let Some(indicator) = (view.explorer_status_indicator)() {
             return Some(indicator);
         }
 
@@ -412,7 +418,7 @@ mod tests {
                 menu_bar: None,
                 open_menu: None,
                 file_explorer_area: None,
-                explorer_status_indicator: None,
+                explorer_status_indicator: &|| None,
                 separators: &self.separators,
                 close_split_buttons: &self.close_split_buttons,
                 maximize_split_buttons: &self.maximize_split_buttons,
@@ -516,9 +522,10 @@ mod tests {
     fn explorer_status_indicator_ranks_between_close_button_and_border() {
         let fx = Fixture::empty();
         let indicator = HoverTarget::FileExplorerStatusIndicator("/x".into());
+        let resolve = || Some(HoverTarget::FileExplorerStatusIndicator("/x".into()));
         let mut v = fx.view();
         v.file_explorer_area = Some(rect(0, 0, 30, 10));
-        v.explorer_status_indicator = Some(indicator.clone());
+        v.explorer_status_indicator = &resolve;
 
         // It beats the border…
         assert_eq!(hover_target(&v, 29, 5), Some(indicator));
@@ -633,5 +640,53 @@ mod tests {
     fn empty_layout_claims_nothing() {
         let fx = Fixture::empty();
         assert_eq!(hover_target(&fx.view(), 5, 5), None);
+    }
+
+    /// The status-indicator probe is expensive (it scans buffers for
+    /// unsaved changes and takes the theme lock) and `hover_target` runs
+    /// on every mouse move — so it must not be consulted unless the
+    /// ladder actually reaches that rung.
+    #[test]
+    fn status_indicator_probe_is_not_consulted_unless_reached() {
+        use std::cell::Cell;
+
+        let calls = Cell::new(0usize);
+        let resolve = || {
+            calls.set(calls.get() + 1);
+            None
+        };
+
+        let mut fx = Fixture::empty();
+        let area = rect(0, 0, 20, 4);
+        fx.popups.push((0, area, area, 0, 4, None, 0));
+
+        let mut v = fx.view();
+        v.file_explorer_area = Some(rect(0, 0, 30, 10));
+        v.explorer_status_indicator = &resolve;
+
+        // A popup claims the cell first, so the probe is never run.
+        assert_eq!(
+            hover_target(&v, 3, 2),
+            Some(HoverTarget::PopupListItem(0, 2))
+        );
+        assert_eq!(calls.get(), 0, "an overlay hit must not pay for the probe");
+
+        // The close button also short-circuits ahead of it.
+        assert_eq!(
+            hover_target(&v, 28, 0),
+            Some(HoverTarget::FileExplorerCloseButton)
+        );
+        assert_eq!(
+            calls.get(),
+            0,
+            "the close button must not pay for it either"
+        );
+
+        // Reaching the explorer body does consult it (once).
+        assert_eq!(
+            hover_target(&v, 29, 5),
+            Some(HoverTarget::FileExplorerBorder)
+        );
+        assert_eq!(calls.get(), 1);
     }
 }

--- a/crates/fresh-editor/src/app/hit_test.rs
+++ b/crates/fresh-editor/src/app/hit_test.rs
@@ -1,0 +1,637 @@
+//! Pure pointer hit-testing: which UI target is under a screen cell.
+//!
+//! The mouse counterpart to [`crate::input::router`]. Everything here is a
+//! free function over the layout the last render recorded — no `Editor`,
+//! no layout caches, no mutation: the view names each rect and slice it
+//! reads. `Editor` stays the imperative shell: it supplies
+//! the recorded layout and acts on the returned [`HoverTarget`].
+//!
+//! Why this is worth having as its own layer:
+//!
+//!   - **The precedence ladder is the product.** "A click on the tab-bar
+//!     row where a context menu overlaps belongs to the menu" is a rule,
+//!     not a side effect. Ordering bugs here are the ones users report as
+//!     "the button doesn't work", and they were previously only reachable
+//!     by driving a whole editor. The tests at the bottom of this file
+//!     pin the ordering directly.
+//!   - **One ladder, not two.** Hover and click both ask "what is under
+//!     the pointer?" over the same geometry; keeping the answer in one
+//!     place is what stops them drifting (the same reasoning that put the
+//!     overlay stack in `app/overlay.rs`).
+//!
+//! The one probe that cannot live here is the file-explorer *status
+//! indicator*: its column depends on the theme, the plugin decoration
+//! cache and the explorer renderer's slot layout. The shell resolves that
+//! one and passes the result in as [`HoverHitView::explorer_status_indicator`],
+//! so the *ordering* still lives here even though that probe's geometry
+//! does not.
+
+use ratatui::layout::Rect;
+
+use std::collections::HashMap;
+
+use super::types::{ContextMenu, ContextMenuHit, HoverTarget, PopupAreaLayout};
+use crate::model::event::{BufferId, ContainerId, LeafId, SplitDirection};
+use crate::view::ui::menu::MenuLayout;
+use crate::view::ui::status_bar::{SearchOptionsLayout, StatusBarClickable};
+use crate::view::ui::tabs::{TabHit, TabLayout};
+use crate::view::ui::FileBrowserLayout;
+
+/// True when `(col, row)` falls inside `rect`.
+pub(crate) fn in_rect(col: u16, row: u16, rect: Rect) -> bool {
+    col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
+}
+
+/// Exactly the layout the ladder reads — borrowed slices and rects, not
+/// whole layout caches.
+///
+/// Naming each field is deliberate: the shell has to state what it is
+/// handing over, a new layout field cannot silently drift into the
+/// decision, and tests construct precise values instead of fabricating a
+/// blank cache and hoping the zeros are meaningful.
+pub(crate) struct HoverHitView<'a> {
+    // --- floating overlays (drawn on top of the chrome) ---
+    /// The open native context menu (tab / "+" new-tab / file-explorer)
+    /// and the frame it is clamped to. All three share one geometry core,
+    /// so one hit-test covers them.
+    pub context_menu: Option<(&'a ContextMenu, FrameSize)>,
+    /// `(inner_rect, scroll_start_idx, visible_count, total_count)` of the
+    /// suggestion list (command palette / autocomplete).
+    pub suggestions: Option<(Rect, usize, usize, usize)>,
+    /// Popup list areas, bottom-most first (the ladder walks them in
+    /// reverse so the topmost popup wins).
+    pub popups: &'a [PopupAreaLayout],
+    /// The file-browser dialog while it is open.
+    pub file_browser: Option<FileBrowserHit<'a>>,
+
+    // --- permanent chrome ---
+    /// The menu-bar layout, present only while the bar is visible.
+    pub menu_bar: Option<&'a MenuLayout>,
+    /// The open dropdown's index and layout, if a menu is open.
+    pub open_menu: Option<(usize, &'a MenuLayout)>,
+    /// The file-explorer panel's area.
+    pub file_explorer_area: Option<Rect>,
+    /// Pre-resolved file-explorer status-indicator hit (see module docs):
+    /// `Some` only when the pointer is actually on an indicator slot.
+    pub explorer_status_indicator: Option<HoverTarget>,
+    /// `(container, direction, x, y, length)` per split separator.
+    pub separators: &'a [(ContainerId, SplitDirection, u16, u16, u16)],
+    /// `(split, row, start_col, end_col)` per close-split button.
+    pub close_split_buttons: &'a [(LeafId, u16, u16, u16)],
+    /// `(split, row, start_col, end_col)` per maximize-split button.
+    pub maximize_split_buttons: &'a [(LeafId, u16, u16, u16)],
+    /// Tab layouts per split.
+    pub tabs: &'a HashMap<LeafId, TabLayout>,
+    /// `(split, buffer, content_rect, scrollbar_rect, thumb_start,
+    /// thumb_end)` per split — only the scrollbar parts are read here.
+    pub split_scrollbars: &'a [(LeafId, BufferId, Rect, Rect, usize, usize)],
+    /// The status bar's row, when it is drawn.
+    pub status_bar_row: Option<u16>,
+    /// `(id, row, start_col, end_col)` per clickable status-bar segment.
+    pub status_bar_clickable: &'a [(StatusBarClickable, u16, u16, u16)],
+    /// The search-options bar's checkbox layout.
+    pub search_options: Option<&'a SearchOptionsLayout>,
+}
+
+/// The rendered frame's extent, used to clamp context-menu geometry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+/// The target under `(col, row)`, or `None` when the pointer is over
+/// ordinary buffer content (or nothing interactive).
+///
+/// Floating overlays are tested before permanent chrome because they
+/// render on top of it.
+pub(crate) fn hover_target(view: &HoverHitView<'_>, col: u16, row: u16) -> Option<HoverTarget> {
+    floating_overlay_target(view, col, row).or_else(|| chrome_target(view, col, row))
+}
+
+/// Hit-test the floating overlay layers: context menus, the command
+/// palette / autocomplete suggestions, popup lists, and the file-browser
+/// dialog. These always render on top of the chrome and must be checked
+/// first.
+pub(crate) fn floating_overlay_target(
+    view: &HoverHitView<'_>,
+    col: u16,
+    row: u16,
+) -> Option<HoverTarget> {
+    // The native context menus (tab / "+" new-tab / file-explorer) all
+    // render on top and share one geometry core, so a single hit-test
+    // over the open menu covers all three. An interior (item) row yields
+    // a hover target; border rows and outside positions fall through to
+    // the chrome below.
+    if let Some((core, frame)) = view.context_menu {
+        if let ContextMenuHit::Item(item_idx) = core.hit(col, row, frame.width, frame.height) {
+            return Some(HoverTarget::ContextMenuItem(item_idx));
+        }
+    }
+
+    // Suggestions (command palette, autocomplete).
+    if let Some((inner_rect, start_idx, _visible_count, total_count)) = view.suggestions {
+        if in_rect(col, row, inner_rect) {
+            let relative_row = (row - inner_rect.y) as usize;
+            let item_idx = start_idx + relative_row;
+            if item_idx < total_count {
+                return Some(HoverTarget::SuggestionItem(item_idx));
+            }
+        }
+    }
+
+    // Popups, topmost first (the last one drawn is on top).
+    for (popup_idx, _popup_rect, inner_rect, scroll_offset, num_items, _, _) in
+        view.popups.iter().rev()
+    {
+        if in_rect(col, row, *inner_rect) && *num_items > 0 {
+            let relative_row = (row - inner_rect.y) as usize;
+            let item_idx = scroll_offset + relative_row;
+            if item_idx < *num_items {
+                return Some(HoverTarget::PopupListItem(*popup_idx, item_idx));
+            }
+        }
+    }
+
+    // File-browser dialog.
+    if let Some(fb) = view.file_browser.as_ref() {
+        if let Some(hover) = file_browser_target(fb, col, row) {
+            return Some(hover);
+        }
+    }
+
+    None
+}
+
+/// Hit-test the permanent chrome: menu bar, file explorer panel, split
+/// separators, split controls, tabs, scrollbars, status bar and search
+/// options. Called only after floating overlays have been ruled out.
+pub(crate) fn chrome_target(view: &HoverHitView<'_>, col: u16, row: u16) -> Option<HoverTarget> {
+    // Menu bar (only clickable while visible).
+    if let Some(menu_layout) = view.menu_bar {
+        if let Some(menu_idx) = menu_layout.menu_at(col, row) {
+            return Some(HoverTarget::MenuBarItem(menu_idx));
+        }
+    }
+
+    // Open dropdown (and any nested submenus).
+    if let Some((active_idx, menu_layout)) = view.open_menu {
+        if let Some(hover) = menu_dropdown_target(menu_layout, active_idx, col, row) {
+            return Some(hover);
+        }
+    }
+
+    // File explorer: close button, then the (pre-resolved) status
+    // indicator, then the resize border.
+    if let Some(explorer_area) = view.file_explorer_area {
+        let close_button_x = explorer_area.x + explorer_area.width.saturating_sub(3);
+        if row == explorer_area.y
+            && col >= close_button_x
+            && col < explorer_area.x + explorer_area.width
+        {
+            return Some(HoverTarget::FileExplorerCloseButton);
+        }
+
+        // Renderer/theme-dependent probe, resolved by the shell — see the
+        // module docs. It sits here so the *ordering* (after the close
+        // button, before the border) stays in this ladder.
+        if let Some(indicator) = view.explorer_status_indicator.clone() {
+            return Some(indicator);
+        }
+
+        // The border is the rightmost drawn column of the explorer area,
+        // not one past it.
+        let border_x = explorer_area.x + explorer_area.width.saturating_sub(1);
+        if col == border_x && row >= explorer_area.y && row < explorer_area.y + explorer_area.height
+        {
+            return Some(HoverTarget::FileExplorerBorder);
+        }
+    }
+
+    // Split separators.
+    for (split_id, direction, sep_x, sep_y, sep_length) in view.separators {
+        let is_on_separator = match direction {
+            SplitDirection::Horizontal => {
+                row == *sep_y && col >= *sep_x && col < sep_x + sep_length
+            }
+            SplitDirection::Vertical => col == *sep_x && row >= *sep_y && row < sep_y + sep_length,
+        };
+        if is_on_separator {
+            return Some(HoverTarget::SplitSeparator(*split_id, *direction));
+        }
+    }
+
+    // Split control buttons sit on top of the tab row, so they win over
+    // the tab hit-test below.
+    for (split_id, btn_row, start_col, end_col) in view.close_split_buttons {
+        if row == *btn_row && col >= *start_col && col < *end_col {
+            return Some(HoverTarget::CloseSplitButton(*split_id));
+        }
+    }
+    for (split_id, btn_row, start_col, end_col) in view.maximize_split_buttons {
+        if row == *btn_row && col >= *start_col && col < *end_col {
+            return Some(HoverTarget::MaximizeSplitButton(*split_id));
+        }
+    }
+
+    // Tabs.
+    for (split_id, tab_layout) in view.tabs {
+        match tab_layout.hit_test(col, row) {
+            Some(TabHit::CloseButton(target)) => {
+                return Some(HoverTarget::TabCloseButton(target, *split_id));
+            }
+            Some(TabHit::TabName(target)) => {
+                return Some(HoverTarget::TabName(target, *split_id));
+            }
+            Some(TabHit::ScrollLeft)
+            | Some(TabHit::ScrollRight)
+            | Some(TabHit::BarBackground)
+            | Some(TabHit::NewTabButton)
+            | None => {}
+        }
+    }
+
+    // Vertical scrollbars: thumb vs track.
+    for (split_id, _buffer_id, _content_rect, scrollbar_rect, thumb_start, thumb_end) in
+        view.split_scrollbars
+    {
+        if in_rect(col, row, *scrollbar_rect) {
+            let relative_row = row.saturating_sub(scrollbar_rect.y) as usize;
+            let is_on_thumb = relative_row >= *thumb_start && relative_row < *thumb_end;
+            return Some(if is_on_thumb {
+                HoverTarget::ScrollbarThumb(*split_id)
+            } else {
+                HoverTarget::ScrollbarTrack(*split_id, relative_row as u16)
+            });
+        }
+    }
+
+    // Status bar: one generic hit-test over every clickable segment
+    // recorded last frame (encoding, LSP, remote, …).
+    if let Some(status_row) = view.status_bar_row {
+        if row == status_row {
+            for (id, indicator_row, start, end) in view.status_bar_clickable {
+                if row == *indicator_row && col >= *start && col < *end {
+                    return Some(HoverTarget::StatusBarClickable(*id));
+                }
+            }
+        }
+    }
+
+    // Search-options bar checkboxes.
+    if let Some(layout) = view.search_options {
+        use crate::view::ui::status_bar::SearchOptionsHover;
+        if let Some(hover) = layout.checkbox_at(col, row) {
+            return Some(match hover {
+                SearchOptionsHover::CaseSensitive => HoverTarget::SearchOptionCaseSensitive,
+                SearchOptionsHover::WholeWord => HoverTarget::SearchOptionWholeWord,
+                SearchOptionsHover::Regex => HoverTarget::SearchOptionRegex,
+                SearchOptionsHover::ConfirmEach => HoverTarget::SearchOptionConfirmEach,
+                SearchOptionsHover::None => return None,
+            });
+        }
+    }
+
+    None
+}
+
+/// Hit-test an open menu dropdown and its submenu chain. Submenus render
+/// on top of their parent, so they are checked first.
+pub(crate) fn menu_dropdown_target(
+    menu_layout: &MenuLayout,
+    menu_index: usize,
+    col: u16,
+    row: u16,
+) -> Option<HoverTarget> {
+    if let Some((depth, item_idx)) = menu_layout.submenu_item_at(col, row) {
+        return Some(HoverTarget::SubmenuItem(depth, item_idx));
+    }
+    if let Some(item_idx) = menu_layout.item_at(col, row) {
+        return Some(HoverTarget::MenuDropdownItem(menu_index, item_idx));
+    }
+    None
+}
+
+/// The file-browser dialog's layout plus the list state its row
+/// hit-test needs. `scroll_offset` and `entry_count` come from
+/// `file_open_state`, which is not layout data — passing them keeps the
+/// row probe pure rather than reaching back into the editor.
+pub(crate) struct FileBrowserHit<'a> {
+    pub layout: &'a FileBrowserLayout,
+    pub scroll_offset: usize,
+    pub entry_count: usize,
+}
+
+/// Hit-test the file-browser dialog. The checkboxes are checked before
+/// the navigation shortcuts because they overlap that band.
+pub(crate) fn file_browser_target(fb: &FileBrowserHit<'_>, x: u16, y: u16) -> Option<HoverTarget> {
+    let layout = fb.layout;
+    if layout.is_on_show_hidden_checkbox(x, y) {
+        return Some(HoverTarget::FileBrowserShowHiddenCheckbox);
+    }
+    if layout.is_on_detect_encoding_checkbox(x, y) {
+        return Some(HoverTarget::FileBrowserDetectEncodingCheckbox);
+    }
+    if layout.is_in_nav(x, y) {
+        if let Some(idx) = layout.nav_shortcut_at(x, y) {
+            return Some(HoverTarget::FileBrowserNavShortcut(idx));
+        }
+    }
+    if layout.is_in_header(x, y) {
+        if let Some(mode) = layout.header_column_at(x) {
+            return Some(HoverTarget::FileBrowserHeader(mode));
+        }
+    }
+    // File list rows: `click_to_index` maps a screen row to an index in
+    // the scrolled list; entries past the end are empty space.
+    if layout.is_in_list(x, y) {
+        if let Some(idx) = layout.click_to_index(y, fb.scroll_offset) {
+            if idx < fb.entry_count {
+                return Some(HoverTarget::FileBrowserEntry(idx));
+            }
+        }
+    }
+    if layout.is_in_scrollbar(x, y) {
+        return Some(HoverTarget::FileBrowserScrollbar);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::event::SplitId;
+    use crate::view::ui::status_bar::StatusBarClickable;
+
+    fn leaf(n: usize) -> LeafId {
+        LeafId(SplitId(n))
+    }
+
+    fn rect(x: u16, y: u16, width: u16, height: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Storage the borrowed view points at. Every field is named at the
+    /// construction site below, so adding a field to [`HoverHitView`]
+    /// fails to compile here rather than silently defaulting to "absent".
+    struct Fixture {
+        popups: Vec<PopupAreaLayout>,
+        separators: Vec<(ContainerId, SplitDirection, u16, u16, u16)>,
+        close_split_buttons: Vec<(LeafId, u16, u16, u16)>,
+        maximize_split_buttons: Vec<(LeafId, u16, u16, u16)>,
+        tabs: HashMap<LeafId, TabLayout>,
+        split_scrollbars: Vec<(LeafId, BufferId, Rect, Rect, usize, usize)>,
+        status_bar_clickable: Vec<(StatusBarClickable, u16, u16, u16)>,
+    }
+
+    impl Fixture {
+        /// Nothing on screen. Tests add only the elements they exercise.
+        fn empty() -> Self {
+            Self {
+                popups: Vec::new(),
+                separators: Vec::new(),
+                close_split_buttons: Vec::new(),
+                maximize_split_buttons: Vec::new(),
+                tabs: HashMap::new(),
+                split_scrollbars: Vec::new(),
+                status_bar_clickable: Vec::new(),
+            }
+        }
+
+        fn view(&self) -> HoverHitView<'_> {
+            HoverHitView {
+                context_menu: None,
+                suggestions: None,
+                popups: &self.popups,
+                file_browser: None,
+                menu_bar: None,
+                open_menu: None,
+                file_explorer_area: None,
+                explorer_status_indicator: None,
+                separators: &self.separators,
+                close_split_buttons: &self.close_split_buttons,
+                maximize_split_buttons: &self.maximize_split_buttons,
+                tabs: &self.tabs,
+                split_scrollbars: &self.split_scrollbars,
+                status_bar_row: None,
+                status_bar_clickable: &self.status_bar_clickable,
+                search_options: None,
+            }
+        }
+    }
+
+    /// A suggestion popup drawn over the tab row wins: floating overlays
+    /// are painted on top of the chrome, so the pointer belongs to them.
+    /// This is the precedence rule that used to live in two separate
+    /// ladders and could drift between them.
+    #[test]
+    fn floating_overlay_beats_chrome_underneath() {
+        let mut fx = Fixture::empty();
+        // A close-split button occupying the same cell as a suggestion row.
+        fx.close_split_buttons.push((leaf(1), 5, 10, 20));
+
+        let mut v = fx.view();
+        v.suggestions = Some((rect(0, 5, 40, 3), 0, 3, 3));
+        assert_eq!(
+            hover_target(&v, 12, 5),
+            Some(HoverTarget::SuggestionItem(0)),
+            "the overlay drawn on top must win over the chrome button beneath it"
+        );
+
+        // With no overlay, the same cell resolves to the chrome button.
+        assert_eq!(
+            hover_target(&fx.view(), 12, 5),
+            Some(HoverTarget::CloseSplitButton(leaf(1)))
+        );
+    }
+
+    /// Suggestion rows are offset by the list's scroll position, and a row
+    /// past the end of the list is empty space (falls through).
+    #[test]
+    fn suggestion_row_accounts_for_scroll_and_end_of_list() {
+        let fx = Fixture::empty();
+        let mut v = fx.view();
+        // Viewport of 3 rows scrolled down by 5, over a 7-entry list.
+        v.suggestions = Some((rect(0, 10, 30, 3), 5, 3, 7));
+
+        assert_eq!(
+            hover_target(&v, 4, 10),
+            Some(HoverTarget::SuggestionItem(5))
+        );
+        assert_eq!(
+            hover_target(&v, 4, 11),
+            Some(HoverTarget::SuggestionItem(6))
+        );
+        // Row 12 would be index 7 — past the 7 entries, so nothing.
+        assert_eq!(hover_target(&v, 4, 12), None);
+    }
+
+    /// The topmost popup wins where two overlap (the stack is walked in
+    /// reverse, because the last one drawn is on top).
+    #[test]
+    fn topmost_popup_wins_when_popups_overlap() {
+        let mut fx = Fixture::empty();
+        let area = rect(0, 0, 20, 4);
+        fx.popups.push((0, area, area, 0, 4, None, 0));
+        fx.popups.push((1, area, area, 0, 4, None, 0));
+
+        assert_eq!(
+            hover_target(&fx.view(), 3, 2),
+            Some(HoverTarget::PopupListItem(1, 2)),
+            "the later (topmost) popup owns the cell"
+        );
+    }
+
+    /// Within the explorer the close button is checked before the resize
+    /// border, and the border is the rightmost *drawn* column.
+    #[test]
+    fn explorer_close_button_beats_border_and_border_is_last_column() {
+        let fx = Fixture::empty();
+        let mut v = fx.view();
+        v.file_explorer_area = Some(rect(0, 0, 30, 10));
+
+        // Close button occupies the last 3 columns of the title row.
+        assert_eq!(
+            hover_target(&v, 28, 0),
+            Some(HoverTarget::FileExplorerCloseButton)
+        );
+        // The border is column 29 (x + width - 1) on a non-title row.
+        assert_eq!(
+            hover_target(&v, 29, 5),
+            Some(HoverTarget::FileExplorerBorder)
+        );
+        // One past the panel is outside it entirely.
+        assert_eq!(hover_target(&v, 30, 5), None);
+    }
+
+    /// The pre-resolved explorer status indicator sits between the close
+    /// button and the border — the shell computes its geometry, but this
+    /// ladder owns where it ranks.
+    #[test]
+    fn explorer_status_indicator_ranks_between_close_button_and_border() {
+        let fx = Fixture::empty();
+        let indicator = HoverTarget::FileExplorerStatusIndicator("/x".into());
+        let mut v = fx.view();
+        v.file_explorer_area = Some(rect(0, 0, 30, 10));
+        v.explorer_status_indicator = Some(indicator.clone());
+
+        // It beats the border…
+        assert_eq!(hover_target(&v, 29, 5), Some(indicator));
+        // …but not the close button.
+        assert_eq!(
+            hover_target(&v, 28, 0),
+            Some(HoverTarget::FileExplorerCloseButton)
+        );
+    }
+
+    /// Split control buttons are drawn over the tab row, so they win
+    /// against a tab occupying the same cell.
+    #[test]
+    fn split_controls_are_hit_on_the_tab_row() {
+        let mut fx = Fixture::empty();
+        fx.close_split_buttons.push((leaf(2), 0, 70, 73));
+        fx.maximize_split_buttons.push((leaf(2), 0, 74, 77));
+
+        let v = fx.view();
+        assert_eq!(
+            hover_target(&v, 71, 0),
+            Some(HoverTarget::CloseSplitButton(leaf(2)))
+        );
+        assert_eq!(
+            hover_target(&v, 75, 0),
+            Some(HoverTarget::MaximizeSplitButton(leaf(2)))
+        );
+        // The gap between the two buttons belongs to neither.
+        assert_eq!(hover_target(&v, 73, 0), None);
+    }
+
+    /// A vertical scrollbar distinguishes thumb from track, and the track
+    /// carries the row offset the click-to-jump math needs.
+    #[test]
+    fn scrollbar_thumb_and_track_are_distinguished() {
+        let mut fx = Fixture::empty();
+        fx.split_scrollbars.push((
+            leaf(3),
+            BufferId(0),
+            rect(0, 1, 79, 20),
+            rect(79, 1, 1, 20),
+            5,
+            9,
+        ));
+
+        let v = fx.view();
+        // Screen row 7 is relative row 6 — inside the thumb's 5..9.
+        assert_eq!(
+            hover_target(&v, 79, 7),
+            Some(HoverTarget::ScrollbarThumb(leaf(3)))
+        );
+        // Screen row 2 is relative row 1 — above the thumb, so track.
+        assert_eq!(
+            hover_target(&v, 79, 2),
+            Some(HoverTarget::ScrollbarTrack(leaf(3), 1))
+        );
+    }
+
+    /// Separators are one cell thick along their length; the direction
+    /// decides which axis is pinned.
+    #[test]
+    fn separator_orientation_decides_the_pinned_axis() {
+        let mut fx = Fixture::empty();
+        let container = ContainerId(SplitId(9));
+        fx.separators
+            .push((container, SplitDirection::Vertical, 40, 2, 10));
+
+        let v = fx.view();
+        // Vertical separator: fixed column 40, rows 2..12.
+        assert_eq!(
+            hover_target(&v, 40, 6),
+            Some(HoverTarget::SplitSeparator(
+                container,
+                SplitDirection::Vertical
+            ))
+        );
+        assert_eq!(
+            hover_target(&v, 41, 6),
+            None,
+            "one column over is not the separator"
+        );
+        assert_eq!(
+            hover_target(&v, 40, 12),
+            None,
+            "past the separator's length"
+        );
+    }
+
+    /// Status-bar segments only match on their own row and column span.
+    #[test]
+    fn status_bar_segment_matches_its_own_span() {
+        let mut fx = Fixture::empty();
+        fx.status_bar_clickable
+            .push((StatusBarClickable::Encoding, 23, 10, 18));
+
+        let mut v = fx.view();
+        v.status_bar_row = Some(23);
+
+        assert_eq!(
+            hover_target(&v, 12, 23),
+            Some(HoverTarget::StatusBarClickable(
+                StatusBarClickable::Encoding
+            ))
+        );
+        assert_eq!(hover_target(&v, 18, 23), None, "end column is exclusive");
+        assert_eq!(hover_target(&v, 12, 22), None, "wrong row");
+    }
+
+    /// Nothing under the pointer means nothing claimed — the caller then
+    /// treats the cell as buffer content.
+    #[test]
+    fn empty_layout_claims_nothing() {
+        let fx = Fixture::empty();
+        assert_eq!(hover_target(&fx.view(), 5, 5), None);
+    }
+}

--- a/crates/fresh-editor/src/app/menu_actions.rs
+++ b/crates/fresh-editor/src/app/menu_actions.rs
@@ -3,7 +3,6 @@
 //! This module contains handlers for menu navigation, execution, and mouse interaction.
 
 use super::Editor;
-use crate::app::types::HoverTarget;
 use crate::config::{generate_dynamic_items, Menu, MenuExt, MenuItem};
 use crate::input::keybindings::Action;
 use anyhow::Result as AnyhowResult;
@@ -178,29 +177,6 @@ impl Editor {
                 break;
             }
         }
-    }
-
-    /// Compute hover target for menu dropdown chain (main dropdown and submenus).
-    /// Uses the cached menu layout from the previous render frame.
-    pub(crate) fn compute_menu_dropdown_hover(
-        &self,
-        col: u16,
-        row: u16,
-        menu_index: usize,
-    ) -> Option<HoverTarget> {
-        let menu_layout = self.active_chrome().menu_layout.as_ref()?;
-
-        // Check submenu items first (they're rendered on top)
-        if let Some((depth, item_idx)) = menu_layout.submenu_item_at(col, row) {
-            return Some(HoverTarget::SubmenuItem(depth, item_idx));
-        }
-
-        // Check main dropdown items
-        if let Some(item_idx) = menu_layout.item_at(col, row) {
-            return Some(HoverTarget::MenuDropdownItem(menu_index, item_idx));
-        }
-
-        None
     }
 
     /// Handle click on menu dropdown chain (main dropdown and any open submenus).

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -34,6 +34,7 @@ mod file_operations;
 mod git_index;
 mod help;
 mod help_actions;
+mod hit_test;
 mod hover;
 mod input;
 mod input_dispatch;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1112,7 +1112,7 @@ impl Editor {
                 .flatten(),
             open_menu: self.menu_state.active_menu.zip(menu_layout),
             file_explorer_area: layout.file_explorer_area,
-            explorer_status_indicator: self.explorer_status_indicator_at(col, row),
+            explorer_status_indicator: &|| self.explorer_status_indicator_at(col, row),
             separators: &layout.separator_areas,
             close_split_buttons: &layout.close_split_areas,
             maximize_split_buttons: &layout.maximize_split_areas,

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1060,279 +1060,142 @@ impl Editor {
     // `self.active_window().split_at_position(col, row)`.
 
     /// Compute what hover target is at the given position
+    /// The UI target under `(col, row)`.
+    ///
+    /// The ladder itself — which layer wins where they overlap — is
+    /// [`super::hit_test::hover_target`], a pure function over the layout
+    /// the last render recorded. This shell only gathers that layout and
+    /// resolves the one probe the pure layer cannot do (the explorer
+    /// status indicator, whose column depends on the theme and the
+    /// explorer renderer's slot layout).
     fn compute_hover_target(&self, col: u16, row: u16) -> Option<HoverTarget> {
-        self.hover_target_in_floating_overlays(col, row)
-            .or_else(|| self.hover_target_in_chrome(col, row))
+        let file_browser = self.is_file_open_active().then(|| {
+            self.active_window()
+                .file_browser_layout
+                .as_ref()
+                .map(|layout| super::hit_test::FileBrowserHit {
+                    layout,
+                    scroll_offset: self
+                        .active_window()
+                        .file_open_state
+                        .as_ref()
+                        .map(|s| s.scroll_offset)
+                        .unwrap_or(0),
+                    entry_count: self
+                        .active_window()
+                        .file_open_state
+                        .as_ref()
+                        .map(|s| s.entries.len())
+                        .unwrap_or(0),
+                })
+        });
+        let layout = self.active_layout();
+        let chrome = self.active_chrome();
+        let menu_layout = chrome.menu_layout.as_ref();
+        let view = super::hit_test::HoverHitView {
+            context_menu: self.active_window().context_menu_core().map(|core| {
+                (
+                    core,
+                    super::hit_test::FrameSize {
+                        width: chrome.last_frame.width,
+                        height: chrome.last_frame.height,
+                    },
+                )
+            }),
+            suggestions: chrome.suggestions_area,
+            popups: &chrome.popup_areas,
+            file_browser: file_browser.flatten(),
+            menu_bar: self
+                .active_window()
+                .menu_bar_visible
+                .then_some(menu_layout)
+                .flatten(),
+            open_menu: self.menu_state.active_menu.zip(menu_layout),
+            file_explorer_area: layout.file_explorer_area,
+            explorer_status_indicator: self.explorer_status_indicator_at(col, row),
+            separators: &layout.separator_areas,
+            close_split_buttons: &layout.close_split_areas,
+            maximize_split_buttons: &layout.maximize_split_areas,
+            tabs: &layout.tab_layouts,
+            split_scrollbars: &layout.split_areas,
+            status_bar_row: chrome.status_bar.area.map(|(row, _, _)| row),
+            status_bar_clickable: &chrome.status_bar.clickable,
+            search_options: chrome.search_options_layout.as_ref(),
+        };
+        super::hit_test::hover_target(&view, col, row)
     }
 
-    /// Hit-test floating overlay layers: context menus, command palette,
-    /// popup lists, and the file-browser dialog. These always render on
-    /// top of the chrome and must be checked first.
-    fn hover_target_in_floating_overlays(&self, col: u16, row: u16) -> Option<HoverTarget> {
-        // The native context menus (tab / "+" new-tab / file-explorer) all
-        // render on top and share one geometry core, so a single hit-test
-        // over the open menu covers all three. An interior (item) row yields
-        // a hover target; border rows and outside positions fall through to
-        // the chrome below.
-        if let Some(core) = self.active_window().context_menu_core() {
-            if let super::types::ContextMenuHit::Item(item_idx) = core.hit(
-                col,
-                row,
-                self.active_chrome().last_frame.width,
-                self.active_chrome().last_frame.height,
-            ) {
-                return Some(HoverTarget::ContextMenuItem(item_idx));
-            }
+    /// The file-explorer status-indicator slot under `(col, row)`, if any.
+    ///
+    /// Kept on `Editor` because it is the one hit-test that is not pure
+    /// geometry over recorded layout: the indicator's screen columns come
+    /// from the explorer renderer's slot resolution, which reads the
+    /// theme, the plugin decoration/slot caches and the tree-indicator
+    /// config. `hit_test::chrome_target` calls the result at the right
+    /// point in the ladder.
+    fn explorer_status_indicator_at(&self, col: u16, row: u16) -> Option<HoverTarget> {
+        let explorer_area = self.active_layout().file_explorer_area?;
+        let content_start_y = explorer_area.y + 1; // +1 for title bar
+        let content_end_y = explorer_area.y + explorer_area.height.saturating_sub(1);
+        let content_width = explorer_area.width.saturating_sub(3) as usize;
+        if row < content_start_y || row >= content_end_y {
+            return None;
         }
-
-        // Check suggestions area first (command palette, autocomplete)
-        if let Some((inner_rect, start_idx, _visible_count, total_count)) =
-            &self.active_chrome().suggestions_area
+        let explorer = self.file_explorer();
+        let explorer = explorer.as_ref()?;
+        let relative_row = row.saturating_sub(content_start_y) as usize;
+        let (node_id, indent) = explorer.get_display_node_at_viewport_row(relative_row)?;
+        let node = explorer.tree().get_node(node_id)?;
+        let theme = self.theme.read().unwrap();
+        let neutral_fg = if node
+            .entry
+            .metadata
+            .as_ref()
+            .map(|m| m.is_hidden)
+            .unwrap_or(false)
         {
-            if in_rect(col, row, *inner_rect) {
-                let relative_row = (row - inner_rect.y) as usize;
-                let item_idx = start_idx + relative_row;
-
-                if item_idx < *total_count {
-                    return Some(HoverTarget::SuggestionItem(item_idx));
-                }
-            }
-        }
-
-        // Check popups (they're rendered on top)
-        // Check from top to bottom (reverse order since last popup is on top)
-        for (popup_idx, _popup_rect, inner_rect, scroll_offset, num_items, _, _) in
-            self.active_chrome().popup_areas.iter().rev()
-        {
-            if in_rect(col, row, *inner_rect) && *num_items > 0 {
-                // Calculate which item is being hovered
-                let relative_row = (row - inner_rect.y) as usize;
-                let item_idx = scroll_offset + relative_row;
-
-                if item_idx < *num_items {
-                    return Some(HoverTarget::PopupListItem(*popup_idx, item_idx));
-                }
-            }
-        }
-
-        // Check file browser popup
-        if self.is_file_open_active() {
-            if let Some(hover) = self.compute_file_browser_hover(col, row) {
-                return Some(hover);
-            }
-        }
-
-        None
-    }
-
-    /// Hit-test the permanent chrome: menu bar, file explorer panel,
-    /// split separators, tabs, scrollbars, status bar, and search
-    /// options. Called only after floating overlays have been ruled out.
-    fn hover_target_in_chrome(&self, col: u16, row: u16) -> Option<HoverTarget> {
-        // Check menu bar (row 0, only when visible)
-        // Check menu bar using cached layout from previous render
-        if self.active_window().menu_bar_visible {
-            if let Some(ref menu_layout) = self.active_chrome().menu_layout {
-                if let Some(menu_idx) = menu_layout.menu_at(col, row) {
-                    return Some(HoverTarget::MenuBarItem(menu_idx));
-                }
-            }
-        }
-
-        // Check menu dropdown items if a menu is open (including submenus)
-        if let Some(active_idx) = self.menu_state.active_menu {
-            if let Some(hover) = self.compute_menu_dropdown_hover(col, row, active_idx) {
-                return Some(hover);
-            }
-        }
-
-        // Check file explorer close button and border (for resize)
-        if let Some(explorer_area) = self.active_layout().file_explorer_area {
-            // Close button is at position: explorer_area.x + explorer_area.width - 3 to -1
-            let close_button_x = explorer_area.x + explorer_area.width.saturating_sub(3);
-            if row == explorer_area.y
-                && col >= close_button_x
-                && col < explorer_area.x + explorer_area.width
-            {
-                return Some(HoverTarget::FileExplorerCloseButton);
-            }
-
-            // Check if hovering over a status indicator in the file explorer content area
-            let content_start_y = explorer_area.y + 1; // +1 for title bar
-            let content_end_y = explorer_area.y + explorer_area.height.saturating_sub(1); // -1 for bottom border
-            let content_width = explorer_area.width.saturating_sub(3) as usize;
-
-            if row >= content_start_y && row < content_end_y {
-                // Determine which item is at this row
-                if let Some(explorer) = self.file_explorer().as_ref() {
-                    let relative_row = row.saturating_sub(content_start_y) as usize;
-                    if let Some((node_id, indent)) =
-                        explorer.get_display_node_at_viewport_row(relative_row)
-                    {
-                        if let Some(node) = explorer.tree().get_node(node_id) {
-                            let theme = self.theme.read().unwrap();
-                            let neutral_fg = if node
-                                .entry
-                                .metadata
-                                .as_ref()
-                                .map(|m| m.is_hidden)
-                                .unwrap_or(false)
-                            {
-                                theme.line_number_fg
-                            } else if node.entry.is_symlink() {
-                                theme.syntax_type
-                            } else if node.is_dir() {
-                                theme.syntax_keyword
-                            } else {
-                                theme.editor_fg
-                            };
-                            let slot_resolver = self.file_explorer_slot_resolver();
-                            let slot_context = crate::view::file_tree::ExplorerSlotContext {
-                                path: &node.entry.path,
-                                is_dir: node.is_dir(),
-                                has_unsaved: self.file_explorer_node_has_unsaved_changes(
-                                    &node.entry.path,
-                                    node.is_dir(),
-                                ),
-                                is_symlink: node.entry.is_symlink(),
-                                is_hidden: node
-                                    .entry
-                                    .metadata
-                                    .as_ref()
-                                    .map(|m| m.is_hidden)
-                                    .unwrap_or(false),
-                                decorations: &self.active_window().file_explorer_decoration_cache,
-                                slot_overrides: &self
-                                    .active_window()
-                                    .file_explorer_slot_override_cache,
-                                theme: &theme,
-                                neutral_fg,
-                            };
-                            let slot_resolution = slot_resolver.resolve(&slot_context);
-                            if let Some((slot_start, slot_end)) = crate::view::ui::file_explorer::FileExplorerRenderer::trailing_slot_screen_bounds(
-                                crate::view::ui::file_explorer::TrailingSlotBoundsCtx {
-                                    view: explorer,
-                                    node_id,
-                                    indent,
-                                    content_width,
-                                    slot_resolution: &slot_resolution,
-                                    tree_indicator_collapsed: &self.config.file_explorer.tree_indicator_collapsed,
-                                    tree_indicator_expanded: &self.config.file_explorer.tree_indicator_expanded,
-                                    explorer_area,
-                                },
-                            ) {
-                                if col >= slot_start && col < slot_end {
-                                    return Some(HoverTarget::FileExplorerStatusIndicator(
-                                        node.entry.path.clone(),
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // The border is at the rightmost column of the file explorer area
-            // (the drawn border character), not one past it.
-            let border_x = explorer_area.x + explorer_area.width.saturating_sub(1);
-            if col == border_x
-                && row >= explorer_area.y
-                && row < explorer_area.y + explorer_area.height
-            {
-                return Some(HoverTarget::FileExplorerBorder);
-            }
-        }
-
-        // Check split separators
-        for (split_id, direction, sep_x, sep_y, sep_length) in &self.active_layout().separator_areas
-        {
-            let is_on_separator = match direction {
-                SplitDirection::Horizontal => {
-                    row == *sep_y && col >= *sep_x && col < sep_x + sep_length
-                }
-                SplitDirection::Vertical => {
-                    col == *sep_x && row >= *sep_y && row < sep_y + sep_length
-                }
-            };
-
-            if is_on_separator {
-                return Some(HoverTarget::SplitSeparator(*split_id, *direction));
-            }
-        }
-
-        // Check tab areas using cached hit regions (computed during rendering)
-        // Check split control buttons first (they're on top of the tab row)
-        for (split_id, btn_row, start_col, end_col) in &self.active_layout().close_split_areas {
-            if row == *btn_row && col >= *start_col && col < *end_col {
-                return Some(HoverTarget::CloseSplitButton(*split_id));
-            }
-        }
-
-        for (split_id, btn_row, start_col, end_col) in &self.active_layout().maximize_split_areas {
-            if row == *btn_row && col >= *start_col && col < *end_col {
-                return Some(HoverTarget::MaximizeSplitButton(*split_id));
-            }
-        }
-
-        for (split_id, tab_layout) in &self.active_layout().tab_layouts {
-            match tab_layout.hit_test(col, row) {
-                Some(TabHit::CloseButton(target)) => {
-                    return Some(HoverTarget::TabCloseButton(target, *split_id));
-                }
-                Some(TabHit::TabName(target)) => {
-                    return Some(HoverTarget::TabName(target, *split_id));
-                }
-                Some(TabHit::ScrollLeft)
-                | Some(TabHit::ScrollRight)
-                | Some(TabHit::BarBackground)
-                | Some(TabHit::NewTabButton)
-                | None => {}
-            }
-        }
-
-        // Check scrollbars
-        for (split_id, _buffer_id, _content_rect, scrollbar_rect, thumb_start, thumb_end) in
-            &self.active_layout().split_areas
-        {
-            if in_rect(col, row, *scrollbar_rect) {
-                let relative_row = row.saturating_sub(scrollbar_rect.y) as usize;
-                let is_on_thumb = relative_row >= *thumb_start && relative_row < *thumb_end;
-
-                if is_on_thumb {
-                    return Some(HoverTarget::ScrollbarThumb(*split_id));
-                } else {
-                    return Some(HoverTarget::ScrollbarTrack(*split_id, relative_row as u16));
-                }
-            }
-        }
-
-        // Check status bar indicators — one generic hit-test over every
-        // clickable segment recorded last frame (encoding, LSP, remote, …).
-        if let Some((status_row, _status_x, _status_width)) = self.active_chrome().status_bar.area {
-            if row == status_row {
-                for (id, indicator_row, start, end) in &self.active_chrome().status_bar.clickable {
-                    if row == *indicator_row && col >= *start && col < *end {
-                        return Some(HoverTarget::StatusBarClickable(*id));
-                    }
-                }
-            }
-        }
-
-        // Check search options bar checkboxes
-        if let Some(ref layout) = self.active_chrome().search_options_layout {
-            use crate::view::ui::status_bar::SearchOptionsHover;
-            if let Some(hover) = layout.checkbox_at(col, row) {
-                return Some(match hover {
-                    SearchOptionsHover::CaseSensitive => HoverTarget::SearchOptionCaseSensitive,
-                    SearchOptionsHover::WholeWord => HoverTarget::SearchOptionWholeWord,
-                    SearchOptionsHover::Regex => HoverTarget::SearchOptionRegex,
-                    SearchOptionsHover::ConfirmEach => HoverTarget::SearchOptionConfirmEach,
-                    SearchOptionsHover::None => return None,
-                });
-            }
-        }
-
-        None
+            theme.line_number_fg
+        } else if node.entry.is_symlink() {
+            theme.syntax_type
+        } else if node.is_dir() {
+            theme.syntax_keyword
+        } else {
+            theme.editor_fg
+        };
+        let slot_resolver = self.file_explorer_slot_resolver();
+        let slot_context = crate::view::file_tree::ExplorerSlotContext {
+            path: &node.entry.path,
+            is_dir: node.is_dir(),
+            has_unsaved: self
+                .file_explorer_node_has_unsaved_changes(&node.entry.path, node.is_dir()),
+            is_symlink: node.entry.is_symlink(),
+            is_hidden: node
+                .entry
+                .metadata
+                .as_ref()
+                .map(|m| m.is_hidden)
+                .unwrap_or(false),
+            decorations: &self.active_window().file_explorer_decoration_cache,
+            slot_overrides: &self.active_window().file_explorer_slot_override_cache,
+            theme: &theme,
+            neutral_fg,
+        };
+        let slot_resolution = slot_resolver.resolve(&slot_context);
+        let (slot_start, slot_end) =
+            crate::view::ui::file_explorer::FileExplorerRenderer::trailing_slot_screen_bounds(
+                crate::view::ui::file_explorer::TrailingSlotBoundsCtx {
+                    view: explorer,
+                    node_id,
+                    indent,
+                    content_width,
+                    slot_resolution: &slot_resolution,
+                    tree_indicator_collapsed: &self.config.file_explorer.tree_indicator_collapsed,
+                    tree_indicator_expanded: &self.config.file_explorer.tree_indicator_expanded,
+                    explorer_area,
+                },
+            )?;
+        (col >= slot_start && col < slot_end)
+            .then(|| HoverTarget::FileExplorerStatusIndicator(node.entry.path.clone()))
     }
 
     /// Handle mouse double click (down event)

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -35,6 +35,7 @@ pub use drag::{TabDragState, TabDropZone};
 pub use hover::HoverTarget;
 
 // layout re-exports
+pub(crate) use layout::PopupAreaLayout;
 pub(crate) use layout::{ChromeLayout, WindowLayoutCache};
 pub use layout::{OverlayPreviewState, ViewLineMapping};
 


### PR DESCRIPTION
Follow-on to #2943, applying the same decision-core/imperative-shell split to the mouse side.

## The problem

`mouse_input.rs` carried the "what is under the pointer?" ladder as `impl Editor` methods reading `self.active_layout()` / `self.active_chrome()` directly. The precedence rules — which overlay wins where two of them cover the same cell — could only be exercised by constructing a whole editor, so they never were. These are the rules that surface to users as "the button doesn't work".

There were also **two implementations of the same probes**: `compute_menu_dropdown_hover` (menu_actions.rs) and `compute_file_browser_hover` (file_open_input.rs) each duplicated hit-tests the hover ladder also performed.

## The change

`app/hit_test.rs` (new, no `impl Editor`) holds the ladder as free functions:

- `hover_target` = `floating_overlay_target` (context menus → suggestions → popups → file browser) then `chrome_target` (menu bar → open dropdown → explorer → separators → split controls → tabs → scrollbars → status bar → search options).
- `menu_dropdown_target` and `file_browser_target` live here too; their former `impl Editor` wrappers now delegate, so each probe has **one** implementation instead of two.

The view borrows **exactly** the rects and slices the decision reads — deliberately not the layout caches themselves. Naming each field means the shell has to state what it hands over, a newly-added layout field cannot silently drift into the hit-test, and tests construct precise values rather than blanking a cache and trusting that the zeros are meaningful.

One probe cannot be pure: the file-explorer **status indicator** resolves its columns through the theme, the plugin decoration/slot caches and the explorer renderer's slot layout. It stays on `Editor` as `explorer_status_indicator_at` and is passed in pre-resolved — so the *ordering* still lives in the ladder even though that probe's geometry does not.

## Notes for review

- Behaviour-preserving: the ladder is the same sequence of the same comparisons, in the same order.
- `mouse_input.rs` drops ~400 lines net; `PopupAreaLayout` is re-exported `pub(crate)` for the view's popup slice.
- **10 new unit tests** cover precedence rules that had no coverage at all before, because reaching them previously required a whole editor: overlay-beats-chrome-underneath, topmost-popup-wins, scroll-offset suggestion rows (and past-the-end fall-through), explorer close button vs status indicator vs resize border, split controls on the tab row, scrollbar thumb vs track, separator orientation, status-bar segment span.

## Still ahead (not in this PR)

`handle_mouse_click` is a **second ~1,100-line ladder over the same geometry** — menu bar, tabs, scrollbars, status bar, explorer, split controls — with hit-test and effect fused together. Two hand-maintained ladders over identical rects is the drift risk the overlay `Layer` work was created to eliminate. With the pure ladder in place, the click path can become *resolve target → match → apply effect*, the same shape `handle_key` now has.

## Testing

- `cargo check` / `cargo clippy --all-targets` / `cargo fmt --check` (`--all-features`) clean — no warnings in touched files
- `cargo test --all-features --lib` — **3,313 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cyMxXzFLeS94CrnXuXbJf

---
_Generated by [Claude Code](https://claude.ai/code/session_014cyMxXzFLeS94CrnXuXbJf)_