### PR TITLE
Settings: the mouse wheel scrolls the search results without moving the selection

### DIFF
--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -1535,14 +1535,25 @@ impl SettingsState {
         self.search_input.move_end();
     }
 
+    /// Scroll the search-result viewport just enough to show the selected
+    /// result. Only *selection* moves (keyboard, click) may call this — a
+    /// view scroll must never drag the selection along, and equally must
+    /// never be undone behind the user's back.
+    fn ensure_search_selection_visible(&mut self) {
+        if self.selected_search_result < self.search_scroll_offset {
+            self.search_scroll_offset = self.selected_search_result;
+        } else if self.selected_search_result >= self.search_scroll_offset + self.search_max_visible
+        {
+            self.search_scroll_offset =
+                self.selected_search_result + 1 - self.search_max_visible.max(1);
+        }
+    }
+
     /// Navigate to previous search result
     pub fn search_prev(&mut self) {
         if !self.search_results.is_empty() && self.selected_search_result > 0 {
             self.selected_search_result -= 1;
-            // Scroll up if selection moved above visible area
-            if self.selected_search_result < self.search_scroll_offset {
-                self.search_scroll_offset = self.selected_search_result;
-            }
+            self.ensure_search_selection_visible();
         }
     }
 
@@ -1552,38 +1563,30 @@ impl SettingsState {
             && self.selected_search_result + 1 < self.search_results.len()
         {
             self.selected_search_result += 1;
-            // Scroll down if selection moved below visible area
-            if self.selected_search_result >= self.search_scroll_offset + self.search_max_visible {
-                self.search_scroll_offset =
-                    self.selected_search_result - self.search_max_visible + 1;
-            }
+            self.ensure_search_selection_visible();
         }
     }
 
-    /// Scroll search results up by delta items
+    /// Scroll search results up by delta items.
+    ///
+    /// Scrolling moves the VIEW ONLY: the selected result never moves, even
+    /// when it scrolls out of sight. Selection belongs to the keyboard and
+    /// to clicks. (This supersedes the wheel-moves-selection behaviour that
+    /// was added here for the second half of #2860.)
     pub fn search_scroll_up(&mut self, delta: usize) -> bool {
-        if self.search_results.is_empty() {
+        if self.search_results.is_empty() || self.search_scroll_offset == 0 {
             return false;
         }
-        if self.search_scroll_offset == 0 {
-            // Viewport already at the top: keep walking the selection up so
-            // the wheel can reach (and select) the first result, matching
-            // keyboard navigation (#2860).
-            if self.selected_search_result == 0 {
-                return false;
-            }
-            self.selected_search_result = self.selected_search_result.saturating_sub(delta);
-            return true;
-        }
         self.search_scroll_offset = self.search_scroll_offset.saturating_sub(delta);
-        // Keep selection visible
-        if self.selected_search_result >= self.search_scroll_offset + self.search_max_visible {
-            self.selected_search_result = self.search_scroll_offset + self.search_max_visible - 1;
-        }
         true
     }
 
-    /// Scroll search results down by delta items
+    /// Scroll search results down by delta items. View-only, as
+    /// [`Self::search_scroll_up`].
+    ///
+    /// The bottom stop is `len - max_visible`, so scrolling to the end does
+    /// bring the *last result* on screen — which is what #2860 asked for;
+    /// the selection just stays where the user left it.
     pub fn search_scroll_down(&mut self, delta: usize) -> bool {
         if self.search_results.is_empty() {
             return false;
@@ -1593,25 +1596,14 @@ impl SettingsState {
             .len()
             .saturating_sub(self.search_max_visible);
         if self.search_scroll_offset >= max_offset {
-            // Viewport already at the bottom: keep walking the selection down
-            // so the wheel can reach (and select) the last result, matching
-            // keyboard navigation (#2860).
-            let last = self.search_results.len() - 1;
-            if self.selected_search_result >= last {
-                return false;
-            }
-            self.selected_search_result = (self.selected_search_result + delta).min(last);
-            return true;
+            return false;
         }
         self.search_scroll_offset = (self.search_scroll_offset + delta).min(max_offset);
-        // Keep selection visible
-        if self.selected_search_result < self.search_scroll_offset {
-            self.selected_search_result = self.search_scroll_offset;
-        }
         true
     }
 
-    /// Scroll search results to a ratio (0.0 = top, 1.0 = bottom)
+    /// Scroll search results to a ratio (0.0 = top, 1.0 = bottom). Driven by
+    /// the scrollbar, and view-only for the same reason as the wheel.
     pub fn search_scroll_to_ratio(&mut self, ratio: f32) -> bool {
         if self.search_results.is_empty() {
             return false;
@@ -1623,15 +1615,6 @@ impl SettingsState {
         let new_offset = (ratio * max_offset as f32) as usize;
         if new_offset != self.search_scroll_offset {
             self.search_scroll_offset = new_offset.min(max_offset);
-            // Keep selection visible
-            if self.selected_search_result < self.search_scroll_offset {
-                self.selected_search_result = self.search_scroll_offset;
-            } else if self.selected_search_result
-                >= self.search_scroll_offset + self.search_max_visible
-            {
-                self.selected_search_result =
-                    self.search_scroll_offset + self.search_max_visible - 1;
-            }
             return true;
         }
         false
@@ -4291,51 +4274,111 @@ mod tests {
         state
     }
 
-    /// Reproducer for issue #2860 (wheel can't reach the last result):
-    /// wheel-down used to clamp the scroll offset at `len - max_visible` and
-    /// pin the selection to the viewport top, so the selection could never
-    /// land on the last result. Once the viewport is at the bottom, further
-    /// wheel-downs must keep advancing the selection — matching keyboard
-    /// navigation, which reaches the last item fine.
+    /// The wheel scrolls the VIEW only. Wheeling down must walk the viewport
+    /// all the way to the end of the list — so the last result really does
+    /// become visible, which is what #2860 complained about — while leaving
+    /// the selected result exactly where the user left it, even though that
+    /// scrolls it off screen.
     #[test]
-    fn test_search_wheel_down_reaches_last_result() {
+    fn test_search_wheel_down_reveals_last_result_without_moving_selection() {
         let mut state = search_scroll_state();
-        let last = state.search_results.len() - 1;
+        let len = state.search_results.len();
+        state.selected_search_result = 1;
 
         // Wheel down more than enough notches to pass the end of the list.
-        for _ in 0..(2 * state.search_results.len()) {
+        for _ in 0..(2 * len) {
             state.search_scroll_down(1);
         }
 
         assert_eq!(
-            state.selected_search_result, last,
-            "wheel-down must be able to select the last search result"
+            state.search_scroll_offset + state.search_max_visible,
+            len,
+            "wheel-down must scroll the view until the last result is visible"
         );
-        // One more wheel-down at the very end is a no-op.
+        assert_eq!(
+            state.selected_search_result, 1,
+            "the wheel must never move the selection"
+        );
+        // Once the last result is on screen there is nothing left to scroll.
         assert!(!state.search_scroll_down(1));
-        assert_eq!(state.selected_search_result, last);
+        assert_eq!(state.selected_search_result, 1);
     }
 
-    /// Symmetric to `test_search_wheel_down_reaches_last_result`: once the
-    /// viewport is back at the top, further wheel-ups keep moving the
-    /// selection until it reaches the first result.
+    /// Symmetric to `test_search_wheel_down_reveals_last_result_without_moving_selection`:
+    /// wheeling back up returns the view to the first result and still
+    /// leaves the selection untouched.
     #[test]
-    fn test_search_wheel_up_reaches_first_result() {
+    fn test_search_wheel_up_reveals_first_result_without_moving_selection() {
         let mut state = search_scroll_state();
+        let len = state.search_results.len();
+        // Select the last result (as a click would), then wheel around.
+        state.selected_search_result = len - 1;
 
-        // Go all the way down first, then all the way back up.
-        for _ in 0..(2 * state.search_results.len()) {
+        for _ in 0..(2 * len) {
             state.search_scroll_down(1);
         }
-        for _ in 0..(2 * state.search_results.len()) {
+        for _ in 0..(2 * len) {
             state.search_scroll_up(1);
         }
 
-        assert_eq!(state.search_scroll_offset, 0);
         assert_eq!(
-            state.selected_search_result, 0,
-            "wheel-up must be able to select the first search result"
+            state.search_scroll_offset, 0,
+            "wheel-up must scroll the view back to the first result"
+        );
+        assert_eq!(
+            state.selected_search_result,
+            len - 1,
+            "the wheel must never move the selection"
         );
         assert!(!state.search_scroll_up(1));
+    }
+
+    /// Dragging/clicking the search scrollbar is a view gesture too, so it
+    /// must not drag the selection along either.
+    #[test]
+    fn test_search_scrollbar_ratio_does_not_move_selection() {
+        let mut state = search_scroll_state();
+        state.selected_search_result = 0;
+
+        assert!(state.search_scroll_to_ratio(1.0));
+        assert_eq!(
+            state.search_scroll_offset,
+            state.search_results.len() - state.search_max_visible
+        );
+        assert_eq!(state.selected_search_result, 0);
+    }
+
+    /// Keyboard navigation is the other half of the contract: once the wheel
+    /// has scrolled the selection out of sight, pressing Down/Up must bring
+    /// it back into view (in both directions).
+    #[test]
+    fn test_search_keyboard_nav_rescrolls_to_selection_after_wheel() {
+        let mut state = search_scroll_state();
+        let len = state.search_results.len();
+
+        // Wheel to the bottom with the selection on result 0.
+        for _ in 0..(2 * len) {
+            state.search_scroll_down(1);
+        }
+        assert!(state.search_scroll_offset > 0);
+
+        // Down: selection 0 -> 1, which is above the viewport, so the view
+        // follows the selection back up.
+        state.search_next();
+        assert_eq!(state.selected_search_result, 1);
+        assert_eq!(state.search_scroll_offset, 1);
+
+        // And the other direction: wheel back to the top, then Up.
+        state.selected_search_result = len - 1;
+        for _ in 0..(2 * len) {
+            state.search_scroll_up(1);
+        }
+        assert_eq!(state.search_scroll_offset, 0);
+        state.search_prev();
+        assert_eq!(state.selected_search_result, len - 2);
+        assert_eq!(
+            state.search_scroll_offset,
+            len - 2 + 1 - state.search_max_visible
+        );
     }
 }

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1105,17 +1105,19 @@ fn test_settings_search_result_click_after_wheel_scroll() {
         .find_text_on_screen("▸ ")
         .expect("selected search result marker visible");
     let name_col = marker_col + 2;
-    // Extract the top slot's result name from its row text. Anchor on the
-    // "▸" marker char itself (char indices in `screen_row_text` can drift
-    // from screen columns), and cut at the first double-space run.
+    // Extract the top slot's result name from its row text. Char indices in
+    // `screen_row_text` can drift from screen columns, so cut the row on the
+    // panel borders instead of counting: the results column is the third
+    // `│`-delimited segment. Drop the 2-cell selection indicator (either
+    // "▸ " or blanks — the wheel does not move the selection, so the top row
+    // is usually *not* the selected one) and cut at the first double space.
     let name_of_top_slot = |harness: &EditorTestHarness| -> String {
         let row_text = harness.screen_row_text(top_row);
-        let idx = match row_text.find('▸') {
-            Some(i) => i + '▸'.len_utf8(),
-            None => return String::new(),
+        let Some(segment) = row_text.split('│').nth(2) else {
+            return String::new();
         };
-        row_text[idx..]
-            .trim_start()
+        segment
+            .trim_start_matches([' ', '▸'])
             .split("  ")
             .next()
             .unwrap_or("")
@@ -1152,13 +1154,47 @@ fn test_settings_search_result_click_after_wheel_scroll() {
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
 }
 
-/// Reproducer for issue #2860 (wheel cannot select the last result): at the
-/// end of the list further wheel-downs were no-ops while the selection was
-/// pinned to the first visible row, so the last result was unreachable by
-/// mouse. Wheel-downs past the end must keep advancing the selection until
-/// the bottom-most visible row is the selected one (matching keyboard).
+/// Parse the search header's `(first-last of total)` position readout off
+/// the rendered screen. Picks the first line whose parenthesised group parses
+/// as three numbers, so a description containing " of " can't fool it.
+fn search_result_range(harness: &EditorTestHarness) -> (usize, usize, usize) {
+    let screen = harness.screen_to_string();
+    for line in screen.lines() {
+        let Some(mid) = line.find(" of ") else {
+            continue;
+        };
+        let Some(open) = line[..mid].rfind('(') else {
+            continue;
+        };
+        let Some(close) = line[mid..].find(')').map(|i| i + mid) else {
+            continue;
+        };
+        let inner = &line[open + 1..close];
+        let Some((range, total)) = inner.split_once(" of ") else {
+            continue;
+        };
+        let Some((first, last)) = range.split_once('-') else {
+            continue;
+        };
+        if let (Ok(f), Ok(l), Ok(t)) = (
+            first.trim().parse::<usize>(),
+            last.trim().parse::<usize>(),
+            total.trim().parse::<usize>(),
+        ) {
+            return (f, l, t);
+        }
+    }
+    panic!("search header position readout not on screen:\n{screen}");
+}
+
+/// The mouse wheel scrolls the VIEW ONLY in the settings search results — it
+/// must never move the selection (this revises the wheel-moves-selection
+/// behaviour that had been added for the second half of #2860). Wheeling to
+/// the bottom must still bring the *last* result on screen (the symptom
+/// #2860 reported), while the selection marker stays on the entry the user
+/// left it on and simply scrolls out of sight and back.
 #[test]
-fn test_settings_search_wheel_selects_last_result() {
+fn test_settings_search_wheel_scrolls_view_without_moving_selection() {
     let mut harness = EditorTestHarness::new(120, 40).unwrap();
     harness.open_settings().unwrap();
 
@@ -1172,35 +1208,91 @@ fn test_settings_search_wheel_selects_last_result() {
     }
     harness.render().unwrap();
 
+    // The selected result carries the "▸ " marker; initially that is the
+    // first result, at the top of the list.
     let (marker_col, top_row) = harness
         .find_text_on_screen("▸ ")
         .expect("selected search result marker visible");
+    // Name of the entry the "▸ " marker sits on in `row`, or "" when that
+    // row is not the selected one. Char indices in `screen_row_text` can
+    // drift from screen columns, so cut the row on the panel borders (the
+    // results column is the third `│`-delimited segment) rather than
+    // counting columns, then cut the name at the first double space.
+    let selected_entry_in_row = |harness: &EditorTestHarness, row: u16| -> String {
+        let row_text = harness.screen_row_text(row);
+        let Some(segment) = row_text.split('│').nth(2) else {
+            return String::new();
+        };
+        let Some(idx) = segment.find('▸') else {
+            return String::new();
+        };
+        segment[idx + '▸'.len_utf8()..]
+            .split("  ")
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+    let selected_entry = selected_entry_in_row(&harness, top_row);
+    assert!(!selected_entry.is_empty());
 
-    // Wheel down until the screen stops changing (bottom of the list plus
-    // the selection walk to the last item). Bounded by twice the notch count
-    // any realistic result list needs, and exits early once stable.
-    let mut prev_screen = harness.screen_to_string();
+    let (first, _, total) = search_result_range(&harness);
+    assert_eq!(first, 1, "list starts at the top");
+    assert!(total > 1, "need a scrollable result list, got {total}");
+
+    let wheel_col = marker_col + 5;
+    let wheel_row = top_row + 4;
+
+    // Wheel down until the view stops moving.
+    let mut prev = harness.screen_to_string();
     for _ in 0..300 {
-        harness
-            .mouse_scroll_down(marker_col + 5, top_row + 4)
-            .unwrap();
+        harness.mouse_scroll_down(wheel_col, wheel_row).unwrap();
         harness.render().unwrap();
         let screen = harness.screen_to_string();
-        if screen == prev_screen {
+        if screen == prev {
             break;
         }
-        prev_screen = screen;
+        prev = screen;
     }
 
-    // The selection marker must have walked below the first visible row —
-    // onto the last result — instead of staying pinned to the viewport top.
-    let (_, marker_row_after) = harness
-        .find_text_on_screen("▸ ")
-        .expect("selected search result marker still visible");
+    // The view reached the very end: the last result is on screen.
+    let (_, last_visible, total_after) = search_result_range(&harness);
+    assert_eq!(total_after, total);
+    assert_eq!(
+        last_visible, total,
+        "wheeling down must scroll the view far enough to show the last result"
+    );
+
+    // ...and the selection did not come along for the ride: it is still on
+    // the first result, which is now scrolled off the top of the viewport,
+    // so no row on screen carries the selection marker.
+    let screen = harness.screen_to_string();
     assert!(
-        marker_row_after >= top_row + 3,
-        "selection must reach past the first visible row at the end of the \
-         list (marker at row {marker_row_after}, results start at {top_row})"
+        !screen.contains('▸'),
+        "the wheel must not move the selection onto a visible row; screen:\n{screen}"
+    );
+
+    // Wheel back up: the same entry is selected as before any scrolling.
+    let mut prev = harness.screen_to_string();
+    for _ in 0..300 {
+        harness.mouse_scroll_up(wheel_col, wheel_row).unwrap();
+        harness.render().unwrap();
+        let screen = harness.screen_to_string();
+        if screen == prev {
+            break;
+        }
+        prev = screen;
+    }
+
+    let (first_again, _, _) = search_result_range(&harness);
+    assert_eq!(first_again, 1, "wheeling up returns the view to the top");
+    let (_, marker_row_back) = harness
+        .find_text_on_screen("▸ ")
+        .expect("selection marker back in view at the top of the list");
+    assert_eq!(
+        selected_entry_in_row(&harness, marker_row_back),
+        selected_entry,
+        "the wheel must leave the selection on the entry it started on"
     );
 
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();


### PR DESCRIPTION
## Motivation

The maintainer's rule: **the mouse wheel scrolls the view only and must never move the selection.** In the Settings search results the two were coupled, so a wheel notch silently re-selected a setting the user never pointed at (and Enter then jumped there).

This **revises part of #2950 at the maintainer's direction**. That PR fixed #2860's hit-testing desync (kept intact here) and, for the second half of #2860 — "the wheel can never reach/select the last result" — made `search_scroll_down`/`search_scroll_up` keep *advancing the selection* once the viewport hit an end, explicitly "matching keyboard navigation". Under the rule above that is wrong.

The correct reading of #2860's report is that the *view* could not be scrolled far enough to bring the last entries on screen. That symptom stays fixed: the view scrolls freely to the very end (bottom stop is `len - max_visible`, so the last result is visible), and the selection simply stays where the user left it — possibly scrolled out of sight.

`Refs #2860` (already closed by #2950 — this does not re-fix it).

## The change

`crates/fresh-editor/src/view/settings/state.rs`:

- `search_scroll_up` / `search_scroll_down`: pure viewport moves. No selection walk at the ends, no "keep selection visible" clamping.
- `search_scroll_to_ratio` (search scrollbar click/drag): same — dragging a scrollbar is a view gesture too.
- `search_next` / `search_prev`: share a new `ensure_search_selection_visible` helper that scrolls the selection back into view in **both** directions. Previously `search_next` only handled a selection below the viewport; now that the wheel can leave the selection above it, keyboard nav re-reveals it either way.

Nothing else in `view/settings/**` needed changing (audit below).

## Audit of the other scroll paths in settings

| Path | Verdict |
|---|---|
| `mouse.rs` wheel over the search results | fixed (routes to `search_scroll_up/down`) |
| `mouse.rs` search scrollbar click/drag → `search_scroll_to_ratio` | fixed |
| `mouse.rs` wheel over the categories panel → `categories_scroll.scroll.scroll_by` | already view-only |
| `mouse.rs` wheel over an open dropdown → `Dropdown::scroll_by` | already view-only |
| Entry-dialog wheel/scrollbar (`entry_dialog.rs`) | already view-only |
| Keybinding editor | no scroll state of its own; it scrolls with the settings body |
| Plain-view body wheel → `scroll_up`/`scroll_down` | does **not** move the item selection. It does call `sync_tree_cursor_to_body_scroll`, which moves the *left-panel tree cursor* to track the section you are looking at — see below |

**Left for the maintainer to rule on:** `sync_tree_cursor_to_body_scroll` makes the categories-tree highlight follow the body scroll (wheel *and* keyboard, via `ensure_visible`). That is a separate, deliberately-added feature with its own e2e coverage (`e2e::settings_tree_view::body_wheel_scroll_updates_tree_highlight_both_directions`, `keyboard_up_after_body_scroll_starts_from_synced_section`, …). It is a sidebar navigation cursor rather than the settings selection, and reverting it would undo merged intent, so it is untouched here. Say the word if the rule is meant to cover it too.

## Tests

Rewritten (not deleted) to assert the correct property — the view reaches the end of the list while the selection index stays put:

- `view::settings::state::tests::test_search_wheel_down_reaches_last_result` → `…::test_search_wheel_down_reveals_last_result_without_moving_selection`
- `view::settings::state::tests::test_search_wheel_up_reaches_first_result` → `…::test_search_wheel_up_reveals_first_result_without_moving_selection`
- e2e `test_settings_search_wheel_selects_last_result` → `test_settings_search_wheel_scrolls_view_without_moving_selection`: drives real wheel events and asserts only on rendered output — the header's `(first-last of total)` readout reaches `… of total` (the last result is on screen), no row carries the `▸` selection marker while scrolled (the selection did not follow), and wheeling back up puts the marker on the same entry it started on.

Added:

- `test_search_scrollbar_ratio_does_not_move_selection`
- `test_search_keyboard_nav_rescrolls_to_selection_after_wheel` (Down/Up bring an off-screen selection back into view)

Kept intact (#2860 hit-testing, unrelated and correct): `test_hit_test_search_result_scrolled_uses_absolute_index` and e2e `test_settings_search_result_click_after_wheel_scroll`. The latter needed one mechanical fix: it located the top visible row's name by anchoring on the `▸` marker, which only worked because the wheel used to drag the selection to the top row. It now cuts the row on the panel borders instead, so it no longer depends on where the selection is; its assertion (clicking the row showing X selects X) is unchanged.

All four rewritten/added unit tests and the e2e test were verified to **fail** with the production change reverted and **pass** with it.

Ran (after `cargo clean -p fresh-editor`, binary identity confirmed via `--list`):

- `cargo test -p fresh-editor --lib` — the 4 state tests above + `test_hit_test_search_result_scrolled_uses_absolute_index` → 5 passed
- e2e `test_settings_search_wheel_scrolls_view_without_moving_selection`, `test_settings_search_result_click_after_wheel_scroll`, `test_settings_search_results_scroll`, `test_settings_search_jump_scrolls`, `test_settings_search`, `test_settings_search_result_click_navigates` → 6 passed
- e2e `settings_tree_view` (14) and `settings_scrolled_list_click` (1) → 15 passed, confirming the untouched body/tree scroll behaviour is unaffected
- `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6SkGXXTcJsytTjF1TBf8Y)_