### PR TITLE
fix(mouse): route wheel events to what the pointer is over, not to the focused pane

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -595,6 +595,13 @@ impl Editor {
             // its column (never leaks to the window beneath).
         } else if self.handle_split_widget_panel_wheel(col, row, delta) {
             // a mounted widget panel consumed the scroll
+        } else if self.active_window().wheel_surface_at(col, row).is_none() {
+            // Chrome that owns no scrollable content — menu bar, tab bars,
+            // status bar, split separators. The wheel is dropped here rather
+            // than falling through to the focused pane, which used to scroll a
+            // focused terminal's scrollback from a pointer sitting on the
+            // status bar (sinelaw/fresh#2969). Gating at this fork also keeps
+            // the focused terminal out of read-only scrollback below.
         } else {
             if self.active_window().focused_terminal_live() {
                 // Scrolling up drops the focused split into read-only scrollback

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -7,6 +7,7 @@
 //! - Split separator dragging
 //! - Text selection via mouse
 
+use super::scrollbar_input::WheelSurface;
 use super::*;
 use crate::input::keybindings::Action;
 use crate::model::event::{ContainerId, CursorId, LeafId, SplitDirection};
@@ -595,32 +596,41 @@ impl Editor {
             // its column (never leaks to the window beneath).
         } else if self.handle_split_widget_panel_wheel(col, row, delta) {
             // a mounted widget panel consumed the scroll
-        } else if self.active_window().wheel_surface_at(col, row).is_none() {
-            // Chrome that owns no scrollable content — menu bar, tab bars,
-            // status bar, split separators. The wheel is dropped here rather
-            // than falling through to the focused pane, which used to scroll a
-            // focused terminal's scrollback from a pointer sitting on the
-            // status bar (sinelaw/fresh#2969). Gating at this fork also keeps
-            // the focused terminal out of read-only scrollback below.
         } else {
-            if self.active_window().focused_terminal_live() {
-                // Scrolling up drops the focused split into read-only scrollback
-                // (recorded per-split, so re-focusing keeps it there).
-                self.enter_terminal_scrollback();
-            } else if let Some((split_id, buffer_id)) =
-                self.active_window().split_at_position(col, row)
-            {
-                // Scrolling a terminal split that a drag parked in implicit
-                // scrollback means the user is now *reading* the scrollback:
-                // convert the visit to an explicit one, so copy / click-away
-                // no longer auto-resume the live grid (no-op for everything
-                // else).
-                self.active_window_mut()
-                    .set_split_terminal_drag_scrollback(split_id, buffer_id, false);
+            // Nothing above claimed the wheel, so it belongs to whatever the
+            // pointer is over in the permanent layout: a pane, the file
+            // explorer, a tab strip — or nothing at all, on chrome that owns
+            // no content (the menu bar, the status bar, a split separator).
+            // Before this fork existed the miss fell through to the *focused*
+            // pane, so resting the pointer on the status bar scrolled a
+            // focused terminal's scrollback (sinelaw/fresh#2969).
+            match self.active_window().wheel_surface_at(col, row) {
+                None => {}
+                Some(surface) => {
+                    // Only a wheel over a pane changes that terminal's
+                    // live/scrollback state; panning the tab strip or the
+                    // explorer leaves a live terminal streaming.
+                    if let WheelSurface::Split(split_id, buffer_id) = surface {
+                        if self.active_window().focused_terminal_live() {
+                            // Scrolling up drops the focused split into read-only
+                            // scrollback (recorded per-split, so re-focusing keeps
+                            // it there).
+                            self.enter_terminal_scrollback();
+                        } else {
+                            // Scrolling a terminal split that a drag parked in
+                            // implicit scrollback means the user is now *reading*
+                            // the scrollback: convert the visit to an explicit
+                            // one, so copy / click-away no longer auto-resume the
+                            // live grid (no-op for everything else).
+                            self.active_window_mut()
+                                .set_split_terminal_drag_scrollback(split_id, buffer_id, false);
+                        }
+                    }
+                    self.dismiss_transient_popups();
+                    self.active_window_mut()
+                        .handle_mouse_scroll(col, row, delta)?;
+                }
             }
-            self.dismiss_transient_popups();
-            self.active_window_mut()
-                .handle_mouse_scroll(col, row, delta)?;
         }
         Ok(())
     }
@@ -2779,30 +2789,17 @@ impl Editor {
                 }
                 Some(Ok(()))
             }
+            // The indicators and the wheel nudge the strip through one shared
+            // helper, so a click and a wheel notch move it by the same step
+            // and both stop at the last tab.
             TabHit::ScrollLeft => {
                 self.set_status_message("ScrollLeft clicked!".to_string());
-                if let Some(vs) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
-                    .expect("active window must have a populated split layout")
-                    .get_mut(&split_id)
-                {
-                    vs.tab_scroll_offset = vs.tab_scroll_offset.saturating_sub(10);
-                }
+                self.active_window_mut().scroll_tab_strip(split_id, -1);
                 Some(Ok(()))
             }
             TabHit::ScrollRight => {
                 self.set_status_message("ScrollRight clicked!".to_string());
-                if let Some(vs) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
-                    .expect("active window must have a populated split layout")
-                    .get_mut(&split_id)
-                {
-                    vs.tab_scroll_offset = vs.tab_scroll_offset.saturating_add(10);
-                }
+                self.active_window_mut().scroll_tab_strip(split_id, 1);
                 Some(Ok(()))
             }
             TabHit::NewTabButton => {

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -10,7 +10,44 @@ use anyhow::Result as AnyhowResult;
 
 use crate::model::event::{BufferId, LeafId};
 
+/// The scrollable surface a wheel event lands on.
+///
+/// There is deliberately no "whatever has focus" variant: chrome that owns no
+/// scrollable content of its own — the menu bar, the tab bars, the status bar,
+/// split separators — hit-tests to `None`, and the wheel is dropped there
+/// instead of being handed to the focused pane (sinelaw/fresh#2969).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WheelSurface {
+    /// The file explorer panel, which scrolls its own viewport rather than a
+    /// split's.
+    FileExplorer,
+    /// An editor/terminal split, hit either in its content rect or in its
+    /// scrollbar gutter.
+    Split(LeafId, BufferId),
+}
+
 impl crate::app::window::Window {
+    /// Hit-test the scrollable surface under a screen cell for wheel routing.
+    ///
+    /// This is the single fork every wheel path shares, so "the pointer is
+    /// over nothing scrollable" is decided in one place rather than per call
+    /// site. Overlays and mounted widget panels are resolved *before* this by
+    /// [`Editor::handle_vertical_scroll`]; what reaches here is the permanent
+    /// layout.
+    pub(crate) fn wheel_surface_at(&self, col: u16, row: u16) -> Option<WheelSurface> {
+        if let Some(explorer_area) = self.layout_cache.file_explorer_area {
+            if col >= explorer_area.x
+                && col < explorer_area.x + explorer_area.width
+                && row >= explorer_area.y
+                && row < explorer_area.y + explorer_area.height
+            {
+                return Some(WheelSurface::FileExplorer);
+            }
+        }
+        self.split_at_position(col, row)
+            .map(|(split_id, buffer_id)| WheelSurface::Split(split_id, buffer_id))
+    }
+
     /// Handle mouse wheel scroll event
     pub(super) fn handle_mouse_scroll(
         &mut self,
@@ -30,13 +67,10 @@ impl crate::app::window::Window {
             },
         );
 
-        // Check if scroll is over the file explorer
-        if let Some(explorer_area) = self.layout_cache.file_explorer_area {
-            if col >= explorer_area.x
-                && col < explorer_area.x + explorer_area.width
-                && row >= explorer_area.y
-                && row < explorer_area.y + explorer_area.height
-            {
+        // Scroll the surface under the mouse pointer — not necessarily the
+        // focused one, and nothing at all when the pointer is over chrome.
+        let (target_split, buffer_id) = match self.wheel_surface_at(col, row) {
+            Some(WheelSurface::FileExplorer) => {
                 // Scroll the file explorer's viewport. The wheel moves the
                 // view, not the selection — moving the selected entry (and
                 // letting it drag the viewport) is jumpy and surprising.
@@ -57,20 +91,9 @@ impl crate::app::window::Window {
                 }
                 return Ok(());
             }
-        }
-
-        // Scroll the split under the mouse pointer (not necessarily the focused split).
-        // Fall back to the active split if the pointer isn't over any split area.
-        let (target_split, buffer_id) = self.split_at_position(col, row).unwrap_or_else(|| {
-            (
-                self.buffers
-                    .splits()
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .active_split(),
-                self.active_buffer(),
-            )
-        });
+            Some(WheelSurface::Split(split_id, buffer_id)) => (split_id, buffer_id),
+            None => return Ok(()),
+        };
 
         // Panels marked non-scrollable (buffer-group toolbars/headers/footers
         // default to this) swallow the wheel event — their content is pinned
@@ -112,16 +135,13 @@ impl crate::app::window::Window {
         row: u16,
         delta: i32,
     ) -> AnyhowResult<()> {
-        let (target_split, buffer_id) = self.split_at_position(col, row).unwrap_or_else(|| {
-            (
-                self.buffers
-                    .splits()
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .active_split(),
-                self.active_buffer(),
-            )
-        });
+        // Same fork as the vertical wheel: pan the split under the pointer,
+        // and pan nothing when the pointer is over chrome or over the file
+        // explorer (which has no horizontal viewport of its own).
+        let Some(WheelSurface::Split(target_split, buffer_id)) = self.wheel_surface_at(col, row)
+        else {
+            return Ok(());
+        };
 
         if self.is_non_scrollable_buffer(buffer_id) {
             return Ok(());

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -10,17 +10,25 @@ use anyhow::Result as AnyhowResult;
 
 use crate::model::event::{BufferId, LeafId};
 
+/// Columns a single scroll step moves a split's tab strip, shared by the
+/// wheel and by a click on the bar's `<` / `>` indicators so both nudge the
+/// strip by the same amount.
+pub(crate) const TAB_SCROLL_STEP_COLUMNS: usize = 10;
+
 /// The scrollable surface a wheel event lands on.
 ///
-/// There is deliberately no "whatever has focus" variant: chrome that owns no
-/// scrollable content of its own — the menu bar, the tab bars, the status bar,
-/// split separators — hit-tests to `None`, and the wheel is dropped there
-/// instead of being handed to the focused pane (sinelaw/fresh#2969).
+/// There is deliberately no "whatever has focus" variant: the wheel moves what
+/// the pointer is over. Chrome that owns no scrollable content of its own —
+/// the menu bar, the status bar, split separators — hit-tests to `None` and
+/// the wheel is dropped there rather than being handed to the focused pane
+/// (sinelaw/fresh#2969).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WheelSurface {
     /// The file explorer panel, which scrolls its own viewport rather than a
     /// split's.
     FileExplorer,
+    /// A split's tab strip, which pans horizontally through its tabs.
+    TabBar(LeafId),
     /// An editor/terminal split, hit either in its content rect or in its
     /// scrollbar gutter.
     Split(LeafId, BufferId),
@@ -29,9 +37,9 @@ pub(crate) enum WheelSurface {
 impl crate::app::window::Window {
     /// Hit-test the scrollable surface under a screen cell for wheel routing.
     ///
-    /// This is the single fork every wheel path shares, so "the pointer is
-    /// over nothing scrollable" is decided in one place rather than per call
-    /// site. Overlays and mounted widget panels are resolved *before* this by
+    /// This is the single fork every wheel path shares, so "what is under the
+    /// pointer" is decided in one place rather than per call site. Overlays
+    /// and mounted widget panels are resolved *before* this by
     /// [`Editor::handle_vertical_scroll`]; what reaches here is the permanent
     /// layout.
     pub(crate) fn wheel_surface_at(&self, col: u16, row: u16) -> Option<WheelSurface> {
@@ -44,8 +52,59 @@ impl crate::app::window::Window {
                 return Some(WheelSurface::FileExplorer);
             }
         }
-        self.split_at_position(col, row)
-            .map(|(split_id, buffer_id)| WheelSurface::Split(split_id, buffer_id))
+        if let Some((split_id, buffer_id)) = self.split_at_position(col, row) {
+            return Some(WheelSurface::Split(split_id, buffer_id));
+        }
+        // The tab strip is chrome, but chrome with content of its own: when
+        // the tabs overflow their bar it scrolls, so the wheel pans it instead
+        // of doing nothing. Checked after the splits because a split's content
+        // rect never overlaps its bar, so the order only decides which
+        // comparison runs first.
+        self.layout_cache
+            .tab_layouts
+            .iter()
+            .find(|(_, layout)| {
+                let bar = layout.bar_area;
+                col >= bar.x && col < bar.x + bar.width && row >= bar.y && row < bar.y + bar.height
+            })
+            .map(|(split_id, _)| WheelSurface::TabBar(*split_id))
+    }
+
+    /// Pan a split's tab strip by one scroll step: negative moves toward the
+    /// first tab, positive toward the last.
+    ///
+    /// Scrolling right stops at the last tab — `right_overflow` is the
+    /// renderer's own record of whether anything is still hidden off the right
+    /// edge, so the offset can't run out into empty space and leave the user
+    /// wheeling back through nothing. Which tab is *active* never changes: the
+    /// wheel moves the view, like every other wheel surface in the editor.
+    pub(crate) fn scroll_tab_strip(&mut self, split_id: LeafId, delta: i32) {
+        if delta == 0 {
+            return;
+        }
+        let overflows_right = self
+            .layout_cache
+            .tab_layouts
+            .get(&split_id)
+            .is_some_and(|layout| layout.right_overflow);
+        if delta > 0 && !overflows_right {
+            return;
+        }
+        if let Some(view_state) = self
+            .split_view_states_mut()
+            .expect("active window must have a populated split layout")
+            .get_mut(&split_id)
+        {
+            view_state.tab_scroll_offset = if delta < 0 {
+                view_state
+                    .tab_scroll_offset
+                    .saturating_sub(TAB_SCROLL_STEP_COLUMNS)
+            } else {
+                view_state
+                    .tab_scroll_offset
+                    .saturating_add(TAB_SCROLL_STEP_COLUMNS)
+            };
+        }
     }
 
     /// Handle mouse wheel scroll event
@@ -89,6 +148,12 @@ impl crate::app::window::Window {
                     };
                     explorer.set_scroll_offset(new_offset);
                 }
+                return Ok(());
+            }
+            Some(WheelSurface::TabBar(split_id)) => {
+                // A vertical wheel over a horizontal strip pans it: up walks
+                // toward the first tab, down toward the last.
+                self.scroll_tab_strip(split_id, delta);
                 return Ok(());
             }
             Some(WheelSurface::Split(split_id, buffer_id)) => (split_id, buffer_id),
@@ -135,12 +200,16 @@ impl crate::app::window::Window {
         row: u16,
         delta: i32,
     ) -> AnyhowResult<()> {
-        // Same fork as the vertical wheel: pan the split under the pointer,
-        // and pan nothing when the pointer is over chrome or over the file
-        // explorer (which has no horizontal viewport of its own).
-        let Some(WheelSurface::Split(target_split, buffer_id)) = self.wheel_surface_at(col, row)
-        else {
-            return Ok(());
+        // Same fork as the vertical wheel: pan whatever is under the pointer.
+        // The file explorer has no horizontal viewport of its own, and chrome
+        // with no content stays put.
+        let (target_split, buffer_id) = match self.wheel_surface_at(col, row) {
+            Some(WheelSurface::TabBar(split_id)) => {
+                self.scroll_tab_strip(split_id, delta);
+                return Ok(());
+            }
+            Some(WheelSurface::Split(split_id, buffer_id)) => (split_id, buffer_id),
+            Some(WheelSurface::FileExplorer) | None => return Ok(()),
         };
 
         if self.is_non_scrollable_buffer(buffer_id) {

--- a/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
@@ -1,0 +1,201 @@
+//! Regression tests for issue #2969 (defect 1): a mouse wheel over UI chrome
+//! — the menu bar, a tab bar, the status bar — was routed to whatever pane
+//! held *focus* instead of being ignored, because the wheel router fell back
+//! to the active split whenever the pointer hit-tested to no split at all.
+//!
+//! The user-visible damage was worst with a focused terminal: its scrollback
+//! scrolled while the pointer sat on the status bar, nowhere near the terminal
+//! pane. The same fall-through moved a focused *editor* the same way, which is
+//! what the first test drives (no PTY required, so it covers the fix
+//! everywhere).
+//!
+//! Both tests assert only on rendered output (CONTRIBUTING.md Testing §2): the
+//! window of `LINE n` markers on screen *is* the scroll position, so "the pane
+//! did not move" and "the pane did move" are both read off the screen. Each
+//! also wheels over the real pane afterwards, so a fix that simply swallowed
+//! every wheel event could not pass.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use portable_pty::{native_pty_system, PtySize};
+
+/// Wheel notches sent per target, matching the issue's measurements.
+const NOTCHES: usize = 5;
+
+/// Every `LINE n` marker visible on screen, in reading order.
+///
+/// This is the rendered scroll position of whichever pane owns the markers:
+/// the list shifts as soon as the pane moves by a single line, and is
+/// identical frame-to-frame while it stays put. The shell's echoed command
+/// (`... echo "LINE $i" ...`) carries no digits after the marker, so it never
+/// contributes an entry.
+fn line_markers(screen: &str) -> Vec<u32> {
+    screen
+        .lines()
+        .flat_map(|line| line.split("LINE ").skip(1))
+        .filter_map(|rest| {
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            digits.parse::<u32>().ok()
+        })
+        .collect()
+}
+
+/// The chrome rows of a rendered screen: the menu bar, the tab bar, and the
+/// status bar — named by what is actually drawn on them, so the coordinates
+/// the wheel is aimed at are verified against the frame rather than assumed.
+fn chrome_rows(screen: &str) -> Vec<(&'static str, u16)> {
+    let row_with = |label: &str, needle: &str| -> u16 {
+        screen
+            .lines()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("no {label} row ({needle:?}) on screen:\n{screen}"))
+            as u16
+    };
+    vec![
+        // The menu bar's own labels, the tab bar's close button, and the
+        // status bar's palette hint — each row located by what it draws, so
+        // the wheel targets follow the frame instead of hard-coded rows.
+        ("menu bar", row_with("menu bar", "File   Edit")),
+        ("tab bar", row_with("tab bar", "×")),
+        ("status bar", row_with("status bar", "Palette: Ctrl+P")),
+    ]
+}
+
+/// A wheel over the menu bar, the tab bar or the status bar must leave the
+/// focused editor where it is — while a wheel over the editor pane itself
+/// still scrolls it.
+///
+/// Before the fix the chrome wheel fell through to the focused split, so all
+/// three chrome targets scrolled the editor exactly as if the pointer had been
+/// over its text (issue #2969: "with the editor focused, wheel over the status
+/// bar scrolls the editor, top line 9 → 1").
+#[test]
+fn wheel_over_chrome_does_not_scroll_the_focused_editor() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+
+    let content: Vec<String> = (1..=200).map(|i| format!("LINE {i}")).collect();
+    let _fixture = harness.load_buffer_from_text(&content.join("\n")).unwrap();
+
+    // Park the viewport in the middle of the file so a wheel-up has somewhere
+    // to go in either direction.
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let baseline = line_markers(&harness.screen_to_string());
+    assert!(
+        !baseline.is_empty(),
+        "the editor should be showing numbered lines. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    for (label, row) in chrome_rows(&harness.screen_to_string()) {
+        for _ in 0..NOTCHES {
+            harness.mouse_scroll_up(30, row).unwrap();
+        }
+        assert_eq!(
+            line_markers(&harness.screen_to_string()),
+            baseline,
+            "a wheel over the {label} (row {row}) must not scroll the focused editor. Screen:\n{}",
+            harness.screen_to_string()
+        );
+    }
+
+    // Guard against over-fixing: the wheel still works where a real pane is
+    // under the pointer.
+    for _ in 0..NOTCHES {
+        harness.mouse_scroll_up(30, 10).unwrap();
+    }
+    let scrolled = line_markers(&harness.screen_to_string());
+    assert!(
+        scrolled.first() < baseline.first(),
+        "a wheel over the editor pane should still scroll it up (was {:?}, now {:?}). Screen:\n{}",
+        baseline.first(),
+        scrolled.first(),
+        harness.screen_to_string()
+    );
+}
+
+/// The issue's own repro: an editor pane on the left, a focused terminal on
+/// the right, and the wheel aimed at chrome above/below the *editor*. The
+/// terminal's scrollback must not move — before the fix it scrolled on every
+/// one of the three chrome targets (top line 264 → 249 → 234 → 219).
+///
+/// Requires a PTY; skipped where one cannot be opened, like the other terminal
+/// e2e tests.
+#[test]
+#[cfg(not(windows))] // Uses a Unix shell to produce scrollback
+fn wheel_over_chrome_does_not_scroll_the_focused_terminal() {
+    if native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_err()
+    {
+        eprintln!("Skipping terminal test: PTY not available in this environment");
+        return;
+    }
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+
+    // Editor on the left with locatable content, terminal on the right. The
+    // terminal takes focus, so it is what the old fall-through would scroll.
+    harness.type_text("EDITORPANE").unwrap();
+    harness.render().unwrap();
+    harness
+        .run_palette_command("Open Terminal to the Right")
+        .unwrap();
+    harness.render().unwrap();
+
+    // Fill the terminal with numbered lines so its scrollback has somewhere to
+    // move, then let the shell go quiet: `wait_until_stable` returns only once
+    // the prompt has been drawn and the frame stops changing, so nothing the
+    // shell emits can be mistaken for a wheel-driven scroll below.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"for i in $(seq 1 200); do echo \"LINE $i\"; done\n");
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("LINE 200"))
+        .unwrap();
+
+    let baseline = line_markers(&harness.screen_to_string());
+    assert!(
+        !baseline.is_empty(),
+        "the terminal should be showing numbered lines. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Column 30 is over the *editor* half of the 120-column window, exactly as
+    // in the issue: these rows belong to no pane at all.
+    for (label, row) in chrome_rows(&harness.screen_to_string()) {
+        for _ in 0..NOTCHES {
+            harness.mouse_scroll_up(30, row).unwrap();
+        }
+        assert_eq!(
+            line_markers(&harness.screen_to_string()),
+            baseline,
+            "a wheel over the {label} (row {row}) must not scroll the focused terminal's \
+             scrollback. Screen:\n{}",
+            harness.screen_to_string()
+        );
+    }
+
+    // Guard against over-fixing: over the terminal pane the wheel still walks
+    // back into the scrollback.
+    for _ in 0..NOTCHES {
+        harness.mouse_scroll_up(100, 10).unwrap();
+    }
+    let scrolled = line_markers(&harness.screen_to_string());
+    assert!(
+        scrolled.first() < baseline.first(),
+        "a wheel over the terminal pane should still scroll its scrollback up (was {:?}, now \
+         {:?}). Screen:\n{}",
+        baseline.first(),
+        scrolled.first(),
+        harness.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
@@ -17,7 +17,6 @@
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
-use portable_pty::{native_pty_system, PtySize};
 
 /// Wheel notches sent per target, matching the issue's measurements.
 const NOTCHES: usize = 5;
@@ -127,6 +126,10 @@ fn wheel_over_chrome_does_not_scroll_the_focused_editor() {
 #[test]
 #[cfg(not(windows))] // Uses a Unix shell to produce scrollback
 fn wheel_over_chrome_does_not_scroll_the_focused_terminal() {
+    // Imported here rather than at module scope so the Windows build, which
+    // cfg's this test out, doesn't carry an unused import.
+    use portable_pty::{native_pty_system, PtySize};
+
     if native_pty_system()
         .openpty(PtySize {
             rows: 1,

--- a/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs
@@ -1,7 +1,7 @@
 //! Regression tests for issue #2969 (defect 1): a mouse wheel over UI chrome
 //! — the menu bar, a tab bar, the status bar — was routed to whatever pane
-//! held *focus* instead of being ignored, because the wheel router fell back
-//! to the active split whenever the pointer hit-tested to no split at all.
+//! held *focus*, because the wheel router fell back to the active split
+//! whenever the pointer hit-tested to no split at all.
 //!
 //! The user-visible damage was worst with a focused terminal: its scrollback
 //! scrolled while the pointer sat on the status bar, nowhere near the terminal
@@ -9,11 +9,16 @@
 //! what the first test drives (no PTY required, so it covers the fix
 //! everywhere).
 //!
-//! Both tests assert only on rendered output (CONTRIBUTING.md Testing §2): the
+//! The rule the fix enforces is that the wheel moves what the pointer is over,
+//! so the third test covers the other half of it: the tab strip *does* own
+//! scrollable content, and a wheel over it pans the tabs rather than doing
+//! nothing.
+//!
+//! All three assert only on rendered output (CONTRIBUTING.md Testing §2): the
 //! window of `LINE n` markers on screen *is* the scroll position, so "the pane
 //! did not move" and "the pane did move" are both read off the screen. Each
-//! also wheels over the real pane afterwards, so a fix that simply swallowed
-//! every wheel event could not pass.
+//! also wheels over a surface that should respond, so a fix that simply
+//! swallowed every wheel event could not pass.
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -58,6 +63,15 @@ fn chrome_rows(screen: &str) -> Vec<(&'static str, u16)> {
         ("tab bar", row_with("tab bar", "×")),
         ("status bar", row_with("status bar", "Palette: Ctrl+P")),
     ]
+}
+
+/// The text of the tab row (the row carrying a tab's close button).
+fn tab_bar_text(screen: &str) -> String {
+    screen
+        .lines()
+        .find(|line| line.contains('×'))
+        .unwrap_or_else(|| panic!("no tab row on screen:\n{screen}"))
+        .to_string()
 }
 
 /// A wheel over the menu bar, the tab bar or the status bar must leave the
@@ -199,6 +213,91 @@ fn wheel_over_chrome_does_not_scroll_the_focused_terminal() {
          {:?}). Screen:\n{}",
         baseline.first(),
         scrolled.first(),
+        harness.screen_to_string()
+    );
+}
+
+/// The tab strip is chrome, but chrome that owns content: when the tabs
+/// overflow their bar it scrolls, so a wheel over it pans the strip rather
+/// than doing nothing. That is the same rule as everywhere else — the wheel
+/// moves what the pointer is over — and it moves the *view*, not the
+/// selection: the active tab and the editor beneath both stay put.
+#[test]
+fn wheel_over_the_tab_bar_pans_the_tab_strip() {
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+
+    // Enough long-named tabs to overflow a 100-column bar. Each fixture has to
+    // outlive the test, so they are all bound.
+    let _fixtures: Vec<_> = [
+        "tab_alpha",
+        "tab_bravo",
+        "tab_charlie",
+        "tab_delta",
+        "tab_foxtrot",
+        "tab_golf",
+        "tab_hotel",
+    ]
+    .iter()
+    .map(|name| {
+        harness
+            .load_buffer_from_text_named(&format!("{name}.txt"), "PAD")
+            .unwrap()
+    })
+    .collect();
+    // The last-opened file is the active tab and carries the numbered content,
+    // so the `LINE n` window doubles as proof the editor never moved while the
+    // strip did.
+    let content: Vec<String> = (1..=200).map(|i| format!("LINE {i}")).collect();
+    let _active = harness
+        .load_buffer_from_text_named("tab_echo.txt", &content.join("\n"))
+        .unwrap();
+    harness.render().unwrap();
+
+    let tab_row = chrome_rows(&harness.screen_to_string())
+        .into_iter()
+        .find(|(label, _)| *label == "tab bar")
+        .expect("the tab bar is one of the chrome rows")
+        .1;
+    let baseline_tabs = tab_bar_text(&harness.screen_to_string());
+    let baseline_lines = line_markers(&harness.screen_to_string());
+    assert!(
+        baseline_tabs.contains("tab_echo") && !baseline_tabs.contains("tab_alpha"),
+        "the strip should be scrolled to the active tab with earlier tabs off the left edge — \
+         otherwise there is nothing to pan. Tab row: {baseline_tabs:?}"
+    );
+
+    // Wheel up over the bar walks the strip back toward the first tab.
+    for _ in 0..NOTCHES {
+        harness.mouse_scroll_up(30, tab_row).unwrap();
+    }
+    let panned = tab_bar_text(&harness.screen_to_string());
+    assert!(
+        panned.contains("tab_alpha"),
+        "a wheel over the tab bar should pan the strip toward the first tab (was {baseline_tabs:?}, \
+         now {panned:?})"
+    );
+    assert_eq!(
+        line_markers(&harness.screen_to_string()),
+        baseline_lines,
+        "panning the tab strip must not scroll the editor beneath it. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // ...and wheel down walks it forward again, stopping at the last tab
+    // rather than running off into empty space.
+    for _ in 0..NOTCHES * 2 {
+        harness.mouse_scroll_down(30, tab_row).unwrap();
+    }
+    let returned = tab_bar_text(&harness.screen_to_string());
+    assert!(
+        returned.contains("tab_echo"),
+        "a wheel down over the tab bar should pan back to the last tab and stop there, \
+         got {returned:?}"
+    );
+    assert_eq!(
+        line_markers(&harness.screen_to_string()),
+        baseline_lines,
+        "panning the tab strip must not scroll the editor beneath it. Screen:\n{}",
         harness.screen_to_string()
     );
 }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -105,6 +105,7 @@ pub mod issue_2843_single_line_viewport;
 pub mod issue_2876_prompt_input_hscroll;
 pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
+pub mod issue_2969_wheel_over_chrome;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
Fixes defect **1** of #2969 ("Mouse wheel over UI chrome scrolls the focused terminal's scrollback"). The other four defects in that issue are untouched.

## The bug

Both wheel routers hit-tested the pointer and then fell back to the **active split** when it matched nothing:

```rust
let (target_split, buffer_id) = self.split_at_position(col, row).unwrap_or_else(|| {
    (…active_split(), self.active_buffer())
});
```

So a wheel notch over the menu bar, a tab bar or the status bar scrolled whatever held focus. Reproduced against `4aa2f1a` under tmux with the issue's own steps (`fresh README.md` in 140x42 → `Open Terminal to the Right` → `seq 1 300` → wheel-up at col 30), watching the terminal's top visible line:

| wheel target | before | after |
|---|---|---|
| baseline | 264 | 264 |
| menu bar (row 1) | 249 | 264 |
| tab bar (row 2) | 234 | 264 (tabs pan instead) |
| status bar (row 42) | 219 | 264 |
| **over the terminal pane** | 234 → 219 | **264 → 249** (still scrolls) |

The editor-focused asymmetry the issue describes reproduced too: with the editor focused, a status-bar wheel moved its top line 16 → 9. After the fix it stays put, while a wheel over the editor pane still scrolls it (1 → 9) and leaves the terminal alone.

## The fix

The rule is **the wheel moves what the pointer is over**. One shared hit-test, `Window::wheel_surface_at`, resolves a screen cell to the file explorer, a split, a tab strip, or nothing — and every wheel path routes through it. CONTRIBUTING.md §12: the gate belongs at a single fork rather than as another per-site guard. Four fall-throughs collapse into it:

- `handle_mouse_scroll` (vertical) — its explorer check and its focused-split fallback become arms of the same match.
- `handle_horizontal_scroll` — had drifted into the identical fallback, so Shift+wheel and native `ScrollLeft`/`ScrollRight` over chrome panned the focused split.
- `handle_vertical_scroll`'s terminal branch — consulted `focused_terminal_live()` before any hit-test, so a wheel that never touched a pane (chrome, the tab strip, the explorer) still dropped a focused live terminal into read-only scrollback. It is now scoped to a wheel over a pane.
- The tab bar's `<` / `>` click handlers now nudge the strip through the same helper as the wheel, so a click and a notch move it by the same step and both stop at the last tab (the click path previously incremented the offset without any bound).

Everything upstream of that fork is unchanged: mouse-modal overlays, prompt dropdowns, the popup stack, the orchestrator dock and mounted widget panels all still consume the wheel before the permanent layout is consulted.

### What each region does now

| region under the pointer | wheel |
|---|---|
| editor / terminal split | scrolls that pane (focused or not) — unchanged |
| file explorer | scrolls its viewport — unchanged |
| **tab strip** | **pans the tabs** (new) |
| menu bar, status bar, split separators | nothing |

The **tab strip** is chrome, but chrome that owns scrollable content: it has a per-split `tab_scroll_offset` and `<` / `>` indicators, so under the pointer-wins rule the wheel belongs to it. Wheel up walks toward the first tab, wheel down toward the last, and the **active tab never changes** — the wheel moves the view, matching every other wheel surface in the editor. Scrolling right stops once the renderer reports no remaining right overflow, so the offset can't run off past the last tab and leave you wheeling back through empty space.

The **menu bar**, **status bar** and **split separators** stay inert — not as a policy about chrome, but because nothing scrollable is under the pointer there. Menu dropdowns have no scroll state either, so there is nothing to route to them.

## Tests

`crates/fresh-editor/tests/e2e/issue_2969_wheel_over_chrome.rs` — three e2e tests driving real wheel events, asserting only on rendered output (CONTRIBUTING.md Testing §2): the window of `LINE n` markers on screen *is* the scroll position, and the tab row's text *is* the strip's position.

1. `wheel_over_chrome_does_not_scroll_the_focused_editor` — no PTY needed, so it covers the fix on every runner.
2. `wheel_over_chrome_does_not_scroll_the_focused_terminal` — the issue's exact setup (editor left, focused terminal right, wheel at col 30 over the editor's chrome); skips where no PTY can be opened, like the other terminal e2e tests.
3. `wheel_over_the_tab_bar_pans_the_tab_strip` — enough tabs to overflow the bar; a wheel brings earlier tabs into view, the wheel back stops at the last tab, and the editor beneath does not move.

Chrome rows are located by what they render rather than hard-coded, and each test also wheels over a surface that *should* respond — so a "fix" that swallowed every wheel event fails them. All three fail without the corresponding change (1 and 2 on master: `assertion left == right failed: a wheel over the menu bar (row 0) must not scroll the focused editor`, the pane having jumped 15 lines; 3 without the tab routing: the strip sits still). No timeouts: the terminal test waits on `wait_until_stable` for the shell to go quiet, and every test runs under the harness's per-test temp workdir.

## Checks

`cargo fmt --check`, `cargo clippy --all-features --all-targets`, `cargo check --all-targets`, and `cargo check --all-targets --features gui` all clean (no new warnings in the touched files). Ran the tab/mouse/scroll/terminal/explorer/dock/split/diff e2e slices — 686 + 591 tests, 0 failures — including the pre-existing wheel-routing suites (`issue_2119_wheel_scroll`, `split_view_expectations::test_scroll_wheel_targets_viewport_under_pointer`, `code_tour_dock::test_wheel_scrolls_the_hovered_list`). Also re-verified the whole matrix by hand in tmux: pane scrolls, tab strip pans both ways and stops at the ends, menu bar and status bar inert.