### PR TITLE
fix(plugins): reflow layout when a plugin panel creates a split

### DIFF
--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -384,6 +384,25 @@ impl Editor {
     /// plugin hook is signature-deduped, so callers never need to decide
     /// "did this actually change the layout?" — they just call `relayout`.
     pub fn relayout(&mut self) {
+        self.push_layout_geometry();
+        self.notify_layout_changed();
+    }
+
+    /// The geometry half of [`Editor::relayout`]: derive the authoritative
+    /// dimensions and push them down to every window's viewports and
+    /// terminal PTYs, *without* notifying plugins.
+    ///
+    /// Callers that are themselves running inside a plugin command must use
+    /// this rather than `relayout`. The notify half fires the `resize` hook
+    /// re-entrantly into the plugin thread, and a plugin part-way through its
+    /// own command — still awaiting the callback that hands it the buffer id
+    /// it just asked the host to create — will service that hook against its
+    /// pre-await state. `search_replace.ts` does exactly this: its `resize`
+    /// handler re-renders the panel through `panel.resultsBufferId`, which is
+    /// still its initial `0` until `createVirtualBufferInSplit` resolves, so
+    /// the panel mounts into `BufferId(0)` ("Buffer not found") and its body
+    /// never paints. Everything the terminals need lives in this half.
+    pub(crate) fn push_layout_geometry(&mut self) {
         // Derive the dock width from its placement (the source of truth),
         // exactly as the renderer's `compute_dock_split` does, so the
         // geometry we push down matches what gets painted.
@@ -397,8 +416,6 @@ impl Editor {
         for window in self.windows.values_mut() {
             window.apply_layout(width, height, dock_cols);
         }
-
-        self.notify_layout_changed();
     }
 
     /// Effective width (cols) the left dock currently claims, or `0` when

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3839,6 +3839,19 @@ impl Editor {
             }
         };
 
+        // A plugin-created split changes every sibling pane's geometry — most
+        // visibly for `role = "utility_dock"`, which splits at the *root* and
+        // so takes rows from every pane above it. Reflow through the single
+        // layout funnel here, the one fork both split shapes pass through, so
+        // an existing terminal's PTY is SIGWINCHed to its new pane instead of
+        // keeping the rows it had before the dock appeared. Without this a
+        // terminal kept writing below the pane's new bottom edge — the shell
+        // prompt and everything after it landed in grid rows that are never
+        // drawn (issue #2969 item 5). `relayout` is explicitly cheap to call
+        // redundantly, so the failed-split branch runs it too, exactly as
+        // `Editor::split_current` and the tab-drag drop fork do.
+        self.relayout();
+
         if let Some(req_id) = request_id {
             tracing::trace!(
                 "CreateVirtualBufferInSplit: resolving callback for request_id={}, \

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3841,16 +3841,26 @@ impl Editor {
 
         // A plugin-created split changes every sibling pane's geometry — most
         // visibly for `role = "utility_dock"`, which splits at the *root* and
-        // so takes rows from every pane above it. Reflow through the single
-        // layout funnel here, the one fork both split shapes pass through, so
-        // an existing terminal's PTY is SIGWINCHed to its new pane instead of
-        // keeping the rows it had before the dock appeared. Without this a
-        // terminal kept writing below the pane's new bottom edge — the shell
-        // prompt and everything after it landed in grid rows that are never
-        // drawn (issue #2969 item 5). `relayout` is explicitly cheap to call
-        // redundantly, so the failed-split branch runs it too, exactly as
-        // `Editor::split_current` and the tab-drag drop fork do.
-        self.relayout();
+        // so takes rows from every pane above it. Push the new geometry down
+        // here, at the one fork both split shapes pass through, so an existing
+        // terminal's PTY is SIGWINCHed to its new pane instead of keeping the
+        // rows it had before the dock appeared. Without this a terminal kept
+        // writing below the pane's new bottom edge — the shell prompt and
+        // everything after it landed in grid rows that are never drawn
+        // (issue #2969 item 5).
+        //
+        // The geometry half only, *not* `relayout`: we are inside a plugin
+        // command whose callback has not been resolved yet (see below), so
+        // firing the `resize` hook from here re-enters the calling plugin
+        // before it knows its own buffer id. That is not hypothetical —
+        // `search_replace.ts` renders its panel through a `resultsBufferId`
+        // that is still `0` until this very callback resolves, so the hook
+        // mounted its panel into `BufferId(0)` and the panel came up blank.
+        // Terminals need nothing from the notify half.
+        //
+        // Cheap to call redundantly (PTY resizes are idempotent), so the
+        // failed-split branch runs it too, matching `Editor::split_current`.
+        self.push_layout_geometry();
 
         if let Some(req_id) = request_id {
             tracing::trace!(

--- a/crates/fresh-editor/tests/e2e/dock_create_terminal_resize.rs
+++ b/crates/fresh-editor/tests/e2e/dock_create_terminal_resize.rs
@@ -1,0 +1,224 @@
+//! E2E coverage for issue #2969 item 5: a plugin panel that *creates* the
+//! bottom utility dock takes rows away from the panes above it, and an
+//! already-running terminal in one of those panes has to be told about it.
+//!
+//! Before the fix the dock-creating path (`CreateVirtualBufferInSplit` with
+//! `role = "utility_dock"`, which the code-tour plugin uses) never ran the
+//! layout funnel, so the PTY kept the row count it had before the dock
+//! appeared. The shell went on writing below the pane's new bottom edge and
+//! everything it wrote there — including its prompt — landed in grid rows
+//! that are never drawn.
+//!
+//! Per CONTRIBUTING.md §2 the assertion is on rendered output only: the shell
+//! itself decides where "the last row of the screen" is (it asks the kernel
+//! via `stty size`) and writes a marker there. Whether that marker is on
+//! screen is exactly the user-visible consequence of the PTY size — at the
+//! correct size it is the bottom row of the pane, at the stale size it is
+//! well past it and invisible.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use portable_pty::{native_pty_system, PtySize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MAIN_RS: &str = "fn main() {\n    let l = listen();\n}\n\nfn handle() {\n    todo!()\n}\n";
+
+/// The tour step's file. Its contents are the test's evidence that the step
+/// actually opened, and its name is deliberately absent from `main.rs`.
+const HANDLER_RS: &str = "fn handler() {\n    // STEP_TARGET_CONTENT\n}\n";
+
+/// A path as a JSON string literal — quotes and escapes included. A Windows
+/// path interpolated raw is not valid JSON (`C:\Users\…` carries `\U`), which
+/// makes the plugin's parse throw so no panel ever mounts.
+fn json_path(path: &Path) -> String {
+    serde_json::to_string(&path.display().to_string()).expect("path is UTF-8")
+}
+
+fn tour_json(root: &Path) -> String {
+    let handler_rs = json_path(&root.join("src/handler.rs"));
+    format!(
+        r###"{{
+  "title": "Pipeline Tour",
+  "description": "How a request reaches the handler",
+  "schema_version": "1.0",
+  "steps": [
+    {{
+      "step_id": 1,
+      "title": "The handler",
+      "file_path": {handler_rs},
+      "lines": [1, 3],
+      "explanation": "## Where it lands\n\nEach connection is dispatched here."
+    }}
+  ]
+}}"###
+    )
+}
+
+/// Project with the code-tour plugin and a tour manifest at the root, under a
+/// per-test temp dir (CONTRIBUTING.md §4).
+fn setup_tour_project() -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    // Canonicalize before it reaches the manifest: on macOS a tempdir is
+    // `/var/folders/…`, a symlink to `/private/var/…`, and the editor stores
+    // the resolved path on the buffer, so an unresolved manifest path never
+    // matches and no step finds its file.
+    let project_root = fs::canonicalize(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "code-tour");
+
+    fs::create_dir(project_root.join("src")).unwrap();
+    fs::write(project_root.join("src/main.rs"), MAIN_RS).unwrap();
+    fs::write(project_root.join("src/handler.rs"), HANDLER_RS).unwrap();
+    fs::write(
+        project_root.join(".fresh-tour.json"),
+        tour_json(&project_root),
+    )
+    .unwrap();
+
+    (temp_dir, project_root)
+}
+
+/// Shell input that asks the kernel how tall the terminal is and writes a
+/// marker on that last row, then a second marker on the first row.
+///
+/// The row-1 marker is the test's sync point: it is written *after* the
+/// bottom one and lands in a grid row that is on screen under either PTY
+/// size, so seeing it proves the bottom marker has already been processed.
+/// That is what makes the assertion below a real failure rather than a hang.
+///
+/// `B` and `T` are emitted as octal escapes so the marker text never appears
+/// in the terminal's echo of the command line itself — finding `BOTMARK_…`
+/// on screen can only mean the *output* row was rendered. Octal rather than
+/// `\x` because hex escapes in `printf` are a GNU extension.
+fn bottom_row_probe(tag: &str) -> Vec<u8> {
+    format!(
+        "printf '\\033[2J\\033[H'; \
+         R=$(stty size | cut -d' ' -f1); \
+         printf '\\033[%d;1H\\102OTMARK_{tag}' \"$R\"; \
+         printf '\\033[1;1H\\124OPMARK_{tag}'\n"
+    )
+    .into_bytes()
+}
+
+/// Run the probe and block until its rendered end state is on screen.
+fn run_bottom_row_probe(harness: &mut EditorTestHarness, tag: &str) {
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(&bottom_row_probe(tag));
+    let top = format!("TOPMARK_{tag}");
+    harness
+        .wait_until(|h| h.screen_to_string().contains(&top))
+        .unwrap();
+}
+
+/// A terminal open in a vertical split keeps writing where the user can see
+/// it after the code tour opens the bottom dock beneath it.
+///
+/// Fails without the fix: the second probe's bottom marker is written well
+/// below the pane's new bottom edge and never renders.
+#[test]
+#[cfg(not(windows))] // drives a Unix shell (`stty`, `cut`, POSIX `printf`)
+fn tour_creating_the_dock_resizes_an_open_terminal() {
+    if native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_err()
+    {
+        eprintln!("Skipping: PTY not available in this environment");
+        return;
+    }
+
+    let (_temp, project_root) = setup_tour_project();
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness
+        .open_file(&project_root.join("src/main.rs"))
+        .unwrap();
+    harness.render().unwrap();
+
+    // A terminal in a vertical split to the right, full height for now. It
+    // takes focus, so the probe below reaches its PTY.
+    harness
+        .run_palette_command("Open Terminal to the Right")
+        .unwrap();
+
+    // Baseline: the shell's idea of the bottom row is on screen. Without it
+    // the post-tour assertion could pass vacuously against a probe that never
+    // worked in the first place (CONTRIBUTING.md §16).
+    run_bottom_row_probe(&mut harness, "PRE");
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("BOTMARK_PRE"),
+        "before the dock exists the terminal's last row must be on screen; \
+         if this fails the probe itself is broken.\nScreen:\n{screen}"
+    );
+
+    // Focus the editor split, so the tour opens its step there and the
+    // palette keystrokes are not swallowed by the PTY.
+    harness.mouse_click(20, 10).unwrap();
+    harness.render().unwrap();
+
+    // Load the tour: this is the path that creates the bottom dock.
+    harness
+        .run_palette_command("Tour: Load Definition")
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("tour file path"))
+        .unwrap();
+    harness
+        .type_text(&project_root.join(".fresh-tour.json").display().to_string())
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Opening a step is an async chain: mount the panel, open the step's file
+    // (focus → editor split), then hand focus back to the panel. The panel is
+    // focused *transiently* at the start too, so panel focus alone is not a
+    // sound wait — a key sent then would race the rest of the chain. The
+    // step's file is only open once `revealStep` has run, so "its tab is on
+    // the tab bar" ∧ "the read-only panel holds focus" is first true when the
+    // chain is finished.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("*Tour: Pipeline Tour*")
+                && screen.contains("Jump to code")
+                && screen.contains("handler.rs")
+                && h.get_status_bar().contains("[RO]")
+        })
+        .unwrap();
+
+    // Back into the terminal pane. Column 120 is inside the right split at
+    // this width, row 5 inside the (now shorter) terminal pane. The status
+    // bar drops the panel's `[RO]` once focus has actually landed there.
+    harness.mouse_click(120, 5).unwrap();
+    harness
+        .wait_until(|h| !h.get_status_bar().contains("[RO]"))
+        .unwrap();
+
+    run_bottom_row_probe(&mut harness, "POST");
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("BOTMARK_POST"),
+        "after the tour created the bottom dock the terminal's own last row \
+         must still be on screen — a stale PTY row count puts the shell's \
+         output, and its prompt, below the pane's visible bottom edge.\n\
+         Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -27,6 +27,7 @@ pub mod csi_u_session_input;
 pub mod ctrl_slash_legacy_terminal;
 pub mod cursor_style_rendering;
 pub mod dabbrev_completion;
+pub mod dock_create_terminal_resize;
 #[cfg(feature = "plugins")]
 pub mod dock_dropdown_mouse;
 #[cfg(feature = "plugins")]


### PR DESCRIPTION
Fixes sub-issue **5** of #2969 — *"Opening the code tour does not resize existing terminals"*.

## The defect

Opening the code tour when the bottom dock does not exist yet creates it, taking rows from the panes above — but the existing terminal's PTY was never resized. The shell kept writing below the pane's new bottom edge, into grid rows that are never drawn, so its output and its prompt silently vanished.

Reproduced manually under tmux exactly as the issue describes (`fresh README.md` at 160x45 → `Open Terminal to the Right` → `Tour: Load Definition...`), measuring with `stty size` / `tput lines` against the pane's visible row count from `tmux capture-pane`:

| | before tour | after tour opens the dock |
|---|---|---|
| pane rows (rendered) | 41 | 26 |
| `tput lines` / `stty size` on `master` | 41 ✓ | **41 ✗** |
| same, with this branch | 41 ✓ | 25 ✓ |

The visible consequence, same A/B: a marker the shell writes on what it believes is the last row renders at the bottom of the pane with the fix, and is nowhere on screen without it.

## Cause

The tour mounts its panel through `CreateVirtualBufferInSplit` with `role = "utility_dock"`, which splits at the **root** so the dock spans the full width. That path was the only geometry-changing split creation that never pushed the new geometry down. Every neighbouring path already does — `split_current`, the tab-drag drop fork, `handle_open_terminal_in_dock`, `handle_close_split` — which is exactly why the file explorer, the orchestrator dock, an outer window resize and the ``Alt+` `` utility terminal all propagate correctly and only the tour did not.

## The fix, and the correction in the second commit

`Editor::relayout` is two things: a **geometry half** that derives the new dimensions and pushes them to window viewports and terminal PTYs, and a **notify half** that fires the plugin `resize` hook and re-renders mounted widget panels.

The first commit called `relayout` at that fork. That fixed the terminal but **broke 49 e2e tests** across `search_replace`, `dock_panel_routing`, `issue_2572_hover_through_panel` and `issue_2810_session_escape_flush` — see the first CI run on this branch. The second commit fixes that, and the reasoning is worth recording because the first commit's PR description asserted the opposite:

> ~~Creating a split changes none of the four values in the dedupe signature, so the hook and the panel rerender stay quiet.~~

That was wrong. The hook demonstrably ran. Evidence gathered rather than assumed:

1. **Not a deadlock.** `gdb -p <hung test> -ex "thread apply all bt"`: the test thread sits in `wait_until`'s normal poll loop, every other thread parked idle in tokio.
2. **Driven by hand in tmux** (`Alt+A`, 120x32): the Search/Replace split and tab are created, the body is empty — no `Search:`/`Replace:` fields, no buttons — and the status bar shows a `[⚠ 2]` warning badge.
3. **The warning log** (`~/.local/state/fresh/logs/warnings-*.log`) says exactly what happened:
   ```
   ERROR fresh::app::plugin_dispatch: Failed to render mounted widget panel
         search_replace:1 into BufferId(0): Buffer not found
   ERROR fresh::app::plugin_dispatch: Failed to render updated widget panel
         search_replace:1: Buffer not found
   ```
4. **`BufferId(0)` matches the plugin exactly.** `search_replace.ts` sets `resultsBufferId: 0` (L1441) *before* `await editor.createVirtualBufferInSplit(…)` (L1472) and assigns the real id *after* it (L1493); its `resize` handler (L2235) re-renders through that field. The fork runs before `resolve_callback`, so the hook reached the plugin mid-await and mounted the panel into buffer 0.
5. **Bisected.** Swapping `relayout` for the geometry push-down alone makes both `search_replace::test_search_replace_shows_results_panel` and the new terminal test pass.

So the fix is to push geometry only from inside a plugin command. `relayout` is split into `push_layout_geometry()` + `notify_layout_changed()`; this fork calls the former. Resizing PTYs lives entirely in the geometry half, so the terminal fix is unaffected, and the plugin thread is left alone. The seam is named and documented at both ends so the next caller in plugin dispatch has to choose deliberately instead of reaching for the funnel and rediscovering this.

### Cross-cutting state (CONTRIBUTING.md §8)

`push_layout_geometry` covers every consumer of the geometry itself: each window's cached screen/dock dimensions, the split viewports, the visible terminal PTYs **across all windows**, and the per-split tab-scroll offsets. The consumers left out are the plugin-facing ones — the `resize` hook and mounted widget panels — which are deliberately not notified here, for the reason above.

## Test

`crates/fresh-editor/tests/e2e/dock_create_terminal_resize.rs` drives the command palette and the mouse and asserts **only on rendered output** (CONTRIBUTING.md §2). The invariant "PTY rows == pane rows" is made visible rather than inspected: the shell asks the kernel how tall its terminal is (`stty size`) and writes a marker on that row. At the correct size that row is the bottom of the pane; at the stale size it is well past it.

- A **pre-dock probe** runs first and asserts the marker is visible, so the post-dock assertion cannot pass vacuously (§16).
- A second marker written on row 1 *after* the bottom one is the sync point — it is on screen under either PTY size, so the broken case **fails outright rather than hanging**. No timeouts or time-based waits anywhere; all waits are semantic (§3).
- Markers are emitted via octal `printf` escapes so the literal text never appears in the terminal's echo of the command line — finding it on screen can only mean the output row was rendered.
- Per-test `tempfile::TempDir` workdir, PTY-availability skip, and `#[cfg(not(windows))]` for the Unix shell (§4).

Verified both directions on the first commit:

```
with the fix:     test result: ok.     1 passed; 0 failed   (0.89s)
fix reverted:     test result: FAILED. 0 passed; 1 failed   (1.51s, assertion — not a hang)
```

## Checks

`cargo check --all-targets`, `cargo check --all-targets --features gui`, `cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean on both commits. The e2e suite for the second commit is being verified by CI on this push rather than locally.