### PR TITLE
fix(orchestrator): make the dock's highlight span the row it highlights

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2218,6 +2218,27 @@ pub enum WidgetSpec {
         /// button looks under the pointer.
         #[serde(default)]
         bare: bool,
+        /// Stretch the button across the full width it is laid out in
+        /// (the panel's content width, or its share of an enclosing
+        /// `Row`), padding the label with spaces — and truncating it
+        /// with an `…` when the width can't hold it.
+        ///
+        /// This exists because focus / hover paint the button's *own*
+        /// cells: a natural-width button leaves the rest of its row
+        /// unhighlighted even when the surrounding container pads the
+        /// row out (a `LabeledSection` pads every child to its inner
+        /// width). Dropdown and context-menu entries are rows of a
+        /// menu, not free-standing actions, so their highlight has to
+        /// span the row — set this on them and the host fills the row
+        /// at the width it actually rendered, with no plugin-side
+        /// width guess to drift on a resize or a dock drag.
+        ///
+        /// Leave it off for a free-standing action, and off for
+        /// anything inside an anchored popup that sizes itself to its
+        /// content — filling there stretches the popup to the whole
+        /// panel width.
+        #[serde(default)]
+        full_width: bool,
         /// Style applied while the pointer is over this button. `None`
         /// (the default) leaves it looking the same hovered as not.
         ///

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1687,6 +1687,28 @@ type WidgetSpec = {
 	*/
 	bare: boolean;
 	/**
+	* Stretch the button across the full width it is laid out in
+	* (the panel's content width, or its share of an enclosing
+	* `Row`), padding the label with spaces — and truncating it
+	* with an `…` when the width can't hold it.
+	*
+	* This exists because focus / hover paint the button's *own*
+	* cells: a natural-width button leaves the rest of its row
+	* unhighlighted even when the surrounding container pads the
+	* row out (a `LabeledSection` pads every child to its inner
+	* width). Dropdown and context-menu entries are rows of a
+	* menu, not free-standing actions, so their highlight has to
+	* span the row — set this on them and the host fills the row
+	* at the width it actually rendered, with no plugin-side
+	* width guess to drift on a resize or a dock drag.
+	*
+	* Leave it off for a free-standing action, and off for
+	* anything inside an anchored popup that sizes itself to its
+	* content — filling there stretches the popup to the whole
+	* panel width.
+	*/
+	fullWidth: boolean;
+	/**
 	* Style applied while the pointer is over this button. `None`
 	* (the default) leaves it looking the same hovered as not.
 	*

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -310,6 +310,23 @@ export function button(
      * anything with a word on it. Layout only — `hoverStyle` decides
      * how it looks under the pointer. */
     bare?: boolean;
+    /** Stretch the button across the full width it is laid out in (the
+     * panel's content width, or its share of an enclosing `row`),
+     * padding the label out — and `…`-truncating it when the width
+     * can't hold it.
+     *
+     * Focus and hover paint the button's *own* cells, so a
+     * natural-width button leaves the rest of its row unhighlighted
+     * even where the container pads the row out around it (a
+     * `labeledSection` pads every child to its inner width). Menu
+     * entries are rows of a menu rather than free-standing actions, so
+     * set this on them and the highlight spans the row — at the width
+     * the host actually rendered, with no plugin-side width guess to
+     * drift on a resize or a dock drag.
+     *
+     * Leave it off inside an anchored popup that sizes itself to its
+     * content: filling there stretches the popup to the panel width. */
+    fullWidth?: boolean;
     /** How the button looks while the pointer is over it. Omit to
      * leave it looking the same hovered as not.
      *
@@ -332,6 +349,7 @@ export function button(
     disabled: options?.disabled ?? false,
     focusable: options?.focusable ?? true,
     bare: options?.bare ?? false,
+    fullWidth: options?.fullWidth ?? false,
   };
   // Omit rather than pass `undefined`: the plugin bridge turns a
   // present `undefined` into JSON `null`, which fails to deserialize

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4331,6 +4331,9 @@ function dockProjectMenu(): WidgetSpec {
         intent: i === cursor ? ("primary" as const) : undefined,
       };
     }),
+    // Lives inside the dock panel, so the section pads each row to the
+    // dock width — the band has to follow (see `menuRows`).
+    { fill: true },
   );
   return overlay(labeledSection({ label: editor.t("dock.menu_label"), child: col(...rows) }));
 }
@@ -4705,40 +4708,62 @@ function dockMenuOptions(): MenuOption[] {
 // A dropdown/context-menu row. Menu entries are *rows in a list*, not
 // framed actions: a `[ ]` frame around every line turns the popup into a
 // column of ragged brackets and leaves the highlight hugging the label
-// instead of the popup. `bare` drops the frame, and padding every label
-// to the widest one makes the focus/hover band a uniform full-width bar
-// down the menu (`menuRows` measures the set).
+// instead of the popup. `bare` drops the frame; how the row reaches its
+// full width depends on where the menu lives — see `menuRows`.
 function menuItemButton(
   label: string,
   key: string,
-  opts?: { intent?: "primary" | "danger"; disabled?: boolean; width?: number },
+  opts?: {
+    intent?: "primary" | "danger";
+    disabled?: boolean;
+    width?: number;
+    fullWidth?: boolean;
+  },
 ): WidgetSpec {
   const width = opts?.width ?? 0;
   const pad = Math.max(0, width - editor.stringWidth(label));
   return button(" " + label + " ".repeat(pad) + " ", {
     key,
     bare: true,
+    fullWidth: opts?.fullWidth ?? false,
     intent: opts?.intent ?? "normal",
     disabled: opts?.disabled ?? false,
   });
 }
 
-// Lay out a set of menu entries at one shared width, so every row's
-// highlight spans the same columns and the popup sizes to its widest item.
+// Lay out a set of menu entries so every row's focus/hover band spans
+// the whole menu row rather than hugging its label. Which width "the
+// whole row" means depends on the surface, so the caller says:
 //
-// Deliberately no `flexSpacer`: that stretches the row to the *panel*
-// width, which for an anchored popup means half the screen — and it pads
-// with dead space rather than with the row itself, so the highlight would
-// still stop at the label. The shared label width does the aligning.
+// * `fill: false` (the default) — an anchored popup panel the host
+//   sizes to its widest row. Padding every label to the widest one is
+//   what makes the rows uniform *and* what sets the popup's width.
+//   Filling here would stretch the popup to the panel width (~half the
+//   screen), so the shared label width does the aligning.
+// * `fill: true` — a dropdown that lives inside the dock's own panel,
+//   where the enclosing `labeledSection` pads every row out to the dock
+//   width anyway. The widest label is then far short of the row, and
+//   the band stopped there while the row visibly ran on to the border.
+//   `fullWidth` hands the padding to the host, which knows the width it
+//   actually rendered at — including a user-dragged dock.
+//
+// Deliberately no `flexSpacer` in either mode: it pads with dead space
+// beside the row rather than with the row itself, so the highlight
+// would still stop at the label.
 function menuRows(
   items: { label: string; key: string; intent?: "primary" | "danger"; disabled?: boolean }[],
+  opts?: { fill?: boolean },
 ): WidgetSpec[] {
-  const width = items.reduce((w, it) => Math.max(w, editor.stringWidth(it.label)), 0);
+  const fill = opts?.fill ?? false;
+  const width = fill
+    ? 0
+    : items.reduce((w, it) => Math.max(w, editor.stringWidth(it.label)), 0);
   return items.map((it) =>
     menuItemButton(it.label, it.key, {
       intent: it.intent,
       disabled: it.disabled,
       width,
+      fullWidth: fill,
     })
   );
 }
@@ -4750,6 +4775,7 @@ function dockDropdownOverlay(label: string, opts: MenuOption[], cursor: number):
       key: menuPickKey(o.key),
       intent: i === cursor ? ("primary" as const) : undefined,
     })),
+    { fill: true },
   );
   return overlay(labeledSection({ label, child: col(...rows) }));
 }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -5482,6 +5482,27 @@ pub(crate) fn paint_text_property_entry(
         }
     }
 
+    // The row's trailing cells come from the Paragraph's own style, so
+    // that style is where `extend_to_line_end` has to land: an inline
+    // overlay carrying it is asking for a band across the whole row, not
+    // just the cells it covers. The widget renderer sets it on the hover
+    // band, and a row-wide band that stopped at the end of the text —
+    // while the row visibly ran on to the panel edge — is the tell that
+    // the flag was being dropped here. The buffer path honours it via
+    // the `extend_to_line_end` tail-fill; panels honour it here.
+    //
+    // Last writer wins, matching the per-span overlay precedence above.
+    // Note this is the *row's* line end: a container that pads its
+    // children (a `LabeledSection`) clears the flag when it wraps them,
+    // so a band can't flood past the section border.
+    let fill_style = normalized
+        .inline_overlays
+        .iter()
+        .filter(|o| o.style.extend_to_line_end)
+        .filter_map(|o| Editor::resolve_overlay_style(&o.style, theme).bg)
+        .next_back()
+        .map_or(base_style, |bg| base_style.bg(bg));
+
     let line = Line::from(spans);
     let rect = ratatui::layout::Rect {
         x,
@@ -5489,7 +5510,7 @@ pub(crate) fn paint_text_property_entry(
         width,
         height: 1,
     };
-    frame.render_widget(Paragraph::new(line).style(base_style), rect);
+    frame.render_widget(Paragraph::new(line).style(fill_style), rect);
 }
 
 /// Record `[start_col, start_col+span_w)` of screen row `row` into the

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -79,6 +79,13 @@ const FOCUS_MARKER: &str = "▸ ";
 // two display columns the marker occupies, so reserving the gutter
 // keeps control widths identical whether or not they're focused.
 const FOCUS_GUTTER_BLANK: &str = "  ";
+// Display columns the focus-marker gutter occupies (`FOCUS_MARKER` /
+// `FOCUS_GUTTER_BLANK`) and the columns a framed button spends on its
+// own `[ ` / ` ]` chrome. Both are reserved when stretching a
+// `full_width` button so the finished control lands on the panel width
+// exactly.
+const FOCUS_GUTTER_COLS: usize = 2;
+const FRAMED_BUTTON_CHROME_COLS: usize = 4;
 
 /// The two-column gutter prefix a focusable control leads with when
 /// the render reserves the focus-marker gutter
@@ -819,6 +826,7 @@ fn render_collected(
             key,
             disabled,
             bare,
+            full_width,
             hover_style,
             ..
         } => collect_button(
@@ -828,8 +836,10 @@ fn render_collected(
             key.as_deref(),
             *disabled,
             *bare,
+            *full_width,
             hover_style.as_ref(),
             ctx,
+            panel_width,
         ),
         WidgetSpec::Spacer { cols, .. } => collect_spacer(*cols),
         WidgetSpec::Divider { ch, style, .. } => collect_divider(ch, style.as_ref(), panel_width),
@@ -1644,6 +1654,30 @@ fn collect_dropdown(
     out
 }
 
+/// Pad (or `…`-truncate) a `full_width` button's label so the finished
+/// control spans exactly `panel_width` display columns.
+///
+/// The chrome the renderer is about to add is reserved here rather than
+/// trimmed afterwards, so the band never overshoots the row: a framed
+/// button spends 4 columns on `[ ` / ` ]`, plus 2 more on the
+/// focus-marker gutter when the panel opted into one. A bare button is
+/// all label.
+///
+/// Padding goes through the shared column helper: menu labels carry
+/// `…`, `▾` and box glyphs, and byte-counted padding both misaligns the
+/// row and risks slicing a multi-byte char.
+fn fill_button_label(label: &str, bare: bool, marker_gutter: bool, panel_width: u32) -> String {
+    let chrome = if bare {
+        0
+    } else {
+        FRAMED_BUTTON_CHROME_COLS + if marker_gutter { FOCUS_GUTTER_COLS } else { 0 }
+    };
+    let target = (panel_width as usize).saturating_sub(chrome).max(1);
+    let mut filled = label.to_string();
+    pad_or_truncate_cols(&mut filled, target);
+    filled
+}
+
 #[allow(clippy::too_many_arguments)]
 fn collect_button(
     label: &str,
@@ -1652,8 +1686,10 @@ fn collect_button(
     key: Option<&str>,
     disabled: bool,
     bare: bool,
+    full_width: bool,
     hover_style: Option<&OverlayOptions>,
     ctx: RenderContext<'_>,
+    panel_width: u32,
 ) -> CollectedOutput {
     let mut out = CollectedOutput::default();
     let is_focused = !disabled
@@ -1667,6 +1703,13 @@ fn collect_button(
     // itself as live would lie.
     let hovered = !disabled && ctx.is_hovered(key);
     let hover = hover_style.filter(|_| hovered);
+    // A `full_width` button is stretched by padding its *label*, before
+    // the chrome goes on, so the finished control (frame and all) is
+    // exactly `panel_width` columns — the focus / hover band is painted
+    // over the button's own cells, so filling the label is what makes
+    // the band span the row rather than hugging the word.
+    let filled = full_width.then(|| fill_button_label(label, bare, ctx.marker_gutter, panel_width));
+    let label = filled.as_deref().unwrap_or(label);
     let mut entry = if bare {
         render_bare_button(label, is_focused, intent, disabled, hover, hovered)
     } else {
@@ -4149,9 +4192,15 @@ fn wrap_entry_between(
     // all it could reach is whatever lies past the section's right
     // edge: the split's spare columns, or a sibling column once a Row
     // zips this line. Scope the style to the row's own cells so the
-    // selection can't flood the screen past the panel border.
+    // selection can't flood the screen past the panel border. The same
+    // goes for a row-filling *inline* overlay (the hover band): the
+    // renderers fill a row's tail from either, so both have to be
+    // pinned here or the section leaks.
     if let Some(style) = child.style.as_mut() {
         style.extend_to_line_end = false;
+    }
+    for overlay in child.inline_overlays.iter_mut() {
+        overlay.style.extend_to_line_end = false;
     }
 
     // Compose final text: `<prefix>` + child + `<suffix>\n`.
@@ -7116,6 +7165,7 @@ mod tests {
                     disabled: false,
                     focusable: true,
                     bare: false,
+                    full_width: false,
                     hover_style: None,
                 },
             ],
@@ -7198,6 +7248,7 @@ mod tests {
                     disabled: false,
                     focusable: true,
                     bare: false,
+                    full_width: false,
                     hover_style: None,
                 },
             ],
@@ -7276,6 +7327,7 @@ mod tests {
             disabled: false,
             focusable: true,
             bare: false,
+            full_width: false,
             hover_style: None,
         };
         let (_entries, hits, _state) = render_no_focus(&spec, &HashMap::new());
@@ -7301,6 +7353,7 @@ mod tests {
                     disabled: true,
                     focusable: true,
                     bare: false,
+                    full_width: false,
                     hover_style: None,
                 },
                 WidgetSpec::Button {
@@ -7311,6 +7364,7 @@ mod tests {
                     disabled: false,
                     focusable: true,
                     bare: false,
+                    full_width: false,
                     hover_style: None,
                 },
             ],
@@ -7557,6 +7611,7 @@ mod tests {
                             disabled: false,
                             focusable: true,
                             bare: false,
+                            full_width: false,
                             hover_style: None,
                         },
                     ],

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -4078,3 +4078,261 @@ fn moving_extracted_co_tenant_workspace_to_folder_leaves_original_unfiled() {
          got screen:\n{screen}"
     );
 }
+
+// ---------------------------------------------------------------------
+// Highlight band width.
+//
+// The dock's hover / selection highlight is a background band, so these
+// read cell backgrounds off the rendered screen. None of them names a
+// theme colour: each snapshots a row's backgrounds with the pointer
+// parked elsewhere, drives the pointer (or the keyboard) onto the row,
+// and diffs — the columns that changed ARE the band the user sees,
+// whatever the active theme paints it with.
+// ---------------------------------------------------------------------
+
+/// Background colour of every column on one screen row.
+fn row_bgs(h: &EditorTestHarness, row: u16) -> Vec<Option<ratatui::style::Color>> {
+    let cols = h.screen_row_text(row).chars().count() as u16;
+    (0..cols)
+        .map(|c| h.get_cell_style(c, row).and_then(|s| s.bg))
+        .collect()
+}
+
+/// Inclusive column span whose background differs between two snapshots
+/// of one row — the band the highlight painted. `None` when nothing
+/// changed (no band at all).
+fn band_span(
+    before: &[Option<ratatui::style::Color>],
+    after: &[Option<ratatui::style::Color>],
+) -> Option<(u16, u16)> {
+    let changed: Vec<u16> = before
+        .iter()
+        .zip(after.iter())
+        .enumerate()
+        .filter(|(_, (b, a))| b != a)
+        .map(|(i, _)| i as u16)
+        .collect();
+    Some((*changed.first()?, *changed.last()?))
+}
+
+/// Park the pointer over the editor buffer, far right of the dock, for a
+/// clean un-hovered baseline.
+fn park_pointer(h: &mut EditorTestHarness) {
+    h.mouse_move(110, 20).unwrap();
+}
+
+/// Hover each of `rows` in turn, returning `(row, first, last)` for the
+/// rows that answered the pointer.
+///
+/// The dock's *selected* row keeps its own, stronger highlight and hover
+/// deliberately leaves it alone, so it contributes nothing here. Which
+/// row that is depends on which workspace is active, and the screen is
+/// the only place a test may learn that from — so rather than assume,
+/// sweep both rows and assert on whichever ones lit up.
+fn hover_bands(h: &mut EditorTestHarness, rows: &[u16]) -> Vec<(u16, u16, u16)> {
+    let mut lit = Vec::new();
+    for &row in rows {
+        park_pointer(h);
+        let idle = row_bgs(h, row);
+        // Nothing crosses the plugin bridge on a hover — the host
+        // repaints from its own hover state — so the screen is settled
+        // by the time `mouse_move` returns.
+        h.mouse_move(4, row).unwrap();
+        let hovered = row_bgs(h, row);
+        if let Some((first, last)) = band_span(&idle, &hovered) {
+            lit.push((row, first, last));
+        }
+    }
+    lit
+}
+
+/// The dock's right-edge divider column, found on the toolbar row.
+fn dock_edge_col(h: &EditorTestHarness) -> u16 {
+    let cols = h.screen_row_text(0).chars().count() as u16;
+    (0..cols)
+        .find(|&c| h.get_cell(c, 0).as_deref() == Some("│"))
+        .expect("the dock's right-edge divider should be present on the toolbar row")
+}
+
+/// Columns of the first two `│` glyphs on `row` — the box a dropdown /
+/// card draws around that row.
+fn box_border_cols(h: &EditorTestHarness, row: u16) -> (u16, u16) {
+    let borders: Vec<u16> = (0..h.screen_row_text(row).chars().count() as u16)
+        .filter(|&c| h.get_cell(c, row).as_deref() == Some("│"))
+        .collect();
+    assert!(
+        borders.len() >= 2,
+        "row {row} should be framed by a box, got:\n{}",
+        h.screen_to_string()
+    );
+    (borders[0], borders[1])
+}
+
+/// Open the dock's "New Task… ▾" create dropdown (entries "New Task…"
+/// and "New Folder…") and return the screen row of its second entry.
+fn open_create_dropdown(h: &mut EditorTestHarness) -> u16 {
+    let new_row = row_of(h, "New Task") as u16;
+    h.mouse_click(4, new_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Folder"))
+        .unwrap();
+    row_of(h, "New Folder") as u16
+}
+
+/// A dock dropdown's hover band must span the menu row, not a band sized
+/// to the longest label.
+///
+/// The menu's entries are bare buttons, and hover paints a button's OWN
+/// cells — so the band stopped at the widest label (~15 columns) while
+/// the enclosing section padded every row out to the dock width, leaving
+/// most of the row visibly unhighlighted. Both entries lit exactly the
+/// same 15 columns despite labels of different lengths, which is the
+/// tell: the band tracked the label set, not the row.
+#[test]
+fn dock_dropdown_hover_band_spans_the_menu_row() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // "New Folder…" is the entry to hover: "New Task…" is the keyboard
+    // cursor and already carries the focus band.
+    let menu_row = open_create_dropdown(&mut h);
+    let (left, right) = box_border_cols(&h, menu_row);
+
+    park_pointer(&mut h);
+    let idle = row_bgs(&h, menu_row);
+    h.mouse_move(left + 4, menu_row).unwrap();
+    let hovered = row_bgs(&h, menu_row);
+
+    let (start, end) = band_span(&idle, &hovered).unwrap_or_else(|| {
+        panic!(
+            "hovering a dropdown entry must repaint it; row {menu_row} was unchanged:\n{}",
+            h.screen_to_string()
+        )
+    });
+    // The row runs from just inside the left border to just inside the
+    // right one, the section keeping one column of padding at each end.
+    // Before the fix the band ended ~15 columns in, far short of `right`.
+    assert!(
+        start <= left + 2 && end >= right - 2,
+        "the hover band must span the menu row (borders at cols {left}/{right}), \
+         got cols {start}..{end}:\n{}",
+        h.screen_to_string()
+    );
+}
+
+/// The same band, driven by the keyboard cursor rather than the pointer:
+/// the highlighted entry of an open dropdown must read as a full-width
+/// bar so the menu looks like a menu.
+#[test]
+fn dock_dropdown_cursor_band_spans_the_menu_row() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    let menu_row = open_create_dropdown(&mut h);
+    park_pointer(&mut h);
+    let (left, right) = box_border_cols(&h, menu_row);
+    let idle = row_bgs(&h, menu_row);
+
+    // ↓ moves the dropdown cursor onto "New Folder…".
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| row_bgs(h, menu_row) != idle).unwrap();
+    let selected = row_bgs(&h, menu_row);
+
+    let (start, end) = band_span(&idle, &selected).expect("the cursor row must repaint");
+    assert!(
+        start <= left + 2 && end >= right - 2,
+        "the dropdown cursor band must span the menu row (borders at cols \
+         {left}/{right}), got cols {start}..{end}:\n{}",
+        h.screen_to_string()
+    );
+}
+
+/// A workspace with a sibling, so the dock has one row that is NOT the
+/// selected one and can therefore show a distinct hover state.
+fn dock_with_two_workspaces(config: Config) -> (tempfile::TempDir, EditorTestHarness) {
+    let (tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, config, root.clone()).unwrap();
+    let sibling = root.parent().unwrap().join("zzz_project");
+    fs::create_dir(&sibling).unwrap();
+    h.editor_mut()
+        .create_window_at(sibling, "zzz_project".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("zzz_project"))
+        .unwrap();
+    (tmp, h)
+}
+
+/// Compact workspace rows: hovering one must light the row across the
+/// whole dock, the way the selected row already does.
+///
+/// The hover band declares `extend_to_line_end`, but the panel renderer
+/// filled a row's trailing cells from the row-level style alone and
+/// dropped the flag off inline overlays — so the selection band ran to
+/// the dock edge while the hover band stopped dead at the end of the
+/// workspace name.
+#[test]
+fn dock_compact_row_hover_band_spans_the_dock() {
+    let (_tmp, mut h) = dock_with_two_workspaces(Default::default());
+
+    let edge = dock_edge_col(&h);
+    let rows = [
+        row_of(&h, "alphaproj") as u16,
+        row_of(&h, "zzz_project") as u16,
+    ];
+    let lit = hover_bands(&mut h, &rows);
+
+    assert!(
+        !lit.is_empty(),
+        "hovering a workspace row must repaint it:\n{}",
+        h.screen_to_string()
+    );
+    for (row, start, end) in lit {
+        assert!(
+            start == 0 && end >= edge - 1,
+            "the hover band on row {row} must span the dock (right edge at col \
+             {edge}), got cols {start}..{end}:\n{}",
+            h.screen_to_string()
+        );
+    }
+}
+
+/// Card density: the same row-wide band, this time over a bordered card,
+/// where "the row" is the card and the band has to reach its borders.
+#[test]
+fn dock_card_row_hover_band_spans_the_card() {
+    let (_tmp, mut h) = dock_with_two_workspaces(card_config());
+
+    let rows = [
+        row_of(&h, "alphaproj") as u16,
+        row_of(&h, "zzz_project") as u16,
+    ];
+    let lit = hover_bands(&mut h, &rows);
+
+    assert!(
+        !lit.is_empty(),
+        "hovering a workspace card must repaint it:\n{}",
+        h.screen_to_string()
+    );
+    for (row, start, end) in lit {
+        // Read the card's own borders — the active workspace's card is
+        // drawn as a seamless tab with no right border, so the frame
+        // can't be assumed; only rows that answered the pointer (never
+        // the selected one) are measured.
+        let (left, right) = box_border_cols(&h, row);
+        assert!(
+            start <= left && end >= right,
+            "the hover band on card row {row} must span the card (borders at cols \
+             {left}/{right}), got cols {start}..{end}:\n{}",
+            h.screen_to_string()
+        );
+    }
+}


### PR DESCRIPTION
Fixes item **4** of #2969 ("Orchestrator panel hover highlight is a fixed narrow band, not the panel width").

## Reproduced first

`fresh README.md` at 160x45 → `Alt+O` → click `[ New Task… ▾ ]` → motion events injected as raw SGR over each entry, backgrounds read from `tmux capture-pane -p -e`. Dock at cols 1–38, menu box interior cols 2–37:

| row | state | before | after |
|---|---|---|---|
| `New Task…` | cursor (not hovered) | cols 3–17 `bg 25` | cols **3–36** `bg 25` |
| `New Task…` | hovered | cols 3–17 `bg 236` | cols **3–36** `bg 236` |
| `New Folder…` | hovered | cols 3–17 `bg 236` | cols **3–36** `bg 236` |

Cols 2 and 37 stay unpainted — that is the `LabeledSection`'s own one-column padding, which every child of a section gets; the band now spans the full row *content* width.

## Two causes, both "the band covers the control, not the row"

**1. Menu entries are bare `Button`s.** A button's focus/hover style spans its own label, and `menuRows` padded every label to the widest one — which aligns the entries but lands ~15 columns short inside a section that pads each row out to the dock width. The plugin can't close that gap itself: a plugin-computed width forks the host's authoritative width and drifts on a resize or a dock drag (the same reason `Divider` is host-drawn).

So `Button` gains `full_width`: the host stretches the label at the width it actually rendered, reserving the `[ ]` frame and focus-marker gutter so the finished control lands on the panel width exactly, and padding through the shared column helper (`pad_or_truncate_cols`) — menu labels carry `…`, `▾` and box glyphs, so byte-counted padding both misaligns the row and risks slicing a multi-byte char.

The orchestrator sets it on the two dropdowns that live *inside* the dock panel (create + project). The anchored right-click context menu deliberately does not: it sizes itself to its widest row, and filling there would stretch the popup to the panel width — `menuRows` now takes that as an explicit `fill` choice rather than one shared behaviour.

**2. The hover band already asked to fill the row and was ignored.** `apply_hover_band` sets `extend_to_line_end`, but `paint_text_property_entry` filled a row's trailing cells from the row-level style alone and dropped the flag when it rode on an inline overlay. That is exactly why *selection* ran to the dock edge and *hover* stopped at the project name on the very same compact row. Panels now honour it, the way the buffer path already does via its tail-fill.

Because both renderers can now fill a row's tail from either kind of style, `wrap_entry_between` pins `extend_to_line_end` off inline overlays too — otherwise a band inside a `LabeledSection` (already padded to the inner width) would flood past the section border, the leak the existing row-style guard was written to prevent.

## Surfaces covered

| surface | before | after |
|---|---|---|
| dock create dropdown (`New Task…` / `New Folder…`), hover **and** keyboard cursor | fixed 15-col band | spans the menu row |
| dock project dropdown (`[ All ▾ ]`) | same fixed band | spans the menu row |
| workspace list rows, **compact** — hover | stopped at the project name | spans the dock |
| workspace list rows, **compact** — selection | already spanned the dock | unchanged |
| workspace list rows, **card** — hover | already spanned the card | unchanged |
| workspace list rows, **card** — selection | heavy-border frame, no band | unchanged |
| anchored right-click context menu | already spanned its own row | unchanged (verified: still hugs its content, 17-col rows) |

The compact-hover surface is the one @sinelaw suspected but couldn't observe with a single workspace — it is a distinct bug from the dropdown's, with a distinct fix.

## Tests

Four E2E tests in `orchestrator_dock.rs`, all mouse/keyboard-driven and asserting only on rendered output (CONTRIBUTING §2). None names a theme colour: each snapshots a row's cell backgrounds with the pointer parked over the editor, drives the pointer or the keyboard onto the row, and diffs — the columns that changed *are* the band the user sees. Semantic waits only, per-test `TempDir` workdirs.

* `dock_dropdown_hover_band_spans_the_menu_row` — fails before (band ends ~15 cols in, far short of the box border)
* `dock_dropdown_cursor_band_spans_the_menu_row` — fails before
* `dock_compact_row_hover_band_spans_the_dock` — fails before (band ends at the project name)
* `dock_card_row_hover_band_spans_the_card` — passes before and after; coverage for the surface that was already correct, so it stays that way

Selection is the control in the sweep helpers: hover deliberately leaves the selected row alone, and which workspace that is depends on which window is active — so the tests sweep both rows and assert on whichever answered the pointer, rather than assuming.

`cargo check --all-targets`, `cargo fmt`, `cargo clippy` clean (warning count unchanged vs. `master`); `fresh.d.ts` and the JSON schemas regenerated; `plugins/check-types.sh` shows no new errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LBs83HrsDo3t5rRnXSJrU)_