### PR TITLE
fix(layout): push down geometry that matches the cells actually painted

### DIFF
--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -491,20 +491,56 @@ impl Editor {
 impl crate::app::window::Window {
     /// Adopt the geometry handed down by [`Editor::relayout`]: cache the
     /// screen dimensions and the editor-global dock width, reseed every
-    /// split viewport against the post-dock editor width, and resize the
-    /// visible terminal PTYs. Per-split viewport dimensions are refined
-    /// again at paint time by `sync_viewport_to_content`; terminals have
-    /// no such paint-time sync, which is why their PTY size must be pushed
-    /// here.
+    /// split viewport against the pane rect that split will actually be
+    /// painted into, and resize the visible terminal PTYs. Per-split
+    /// viewport dimensions are refined again at paint time by
+    /// `sync_viewport_to_content` (which subtracts each pane's own chrome —
+    /// gutter, tab bar, scrollbars); terminals have no such paint-time sync,
+    /// which is why their PTY size must be pushed here.
     pub fn apply_layout(&mut self, width: u16, height: u16, dock_cols: u16) {
         self.terminal_width = width;
         self.terminal_height = height;
         self.dock_cols = dock_cols;
 
-        let editor_width = width.saturating_sub(dock_cols);
+        // Per-split pane rects, derived from the same content area the
+        // renderer and `resize_visible_terminals` lay out against — so the
+        // file explorer's columns (and a sibling split's) are already carved
+        // out of them.
+        let visible: Vec<(
+            crate::model::event::LeafId,
+            crate::model::event::BufferId,
+            ratatui::layout::Rect,
+        )> = match self.buffers.splits() {
+            Some((mgr, _)) => mgr.get_visible_buffers(self.editor_content_area()),
+            None => Vec::new(),
+        };
+
+        // Seed each visible split's viewport from its own pane rect. Seeding
+        // every split with the whole post-dock editor width instead — which is
+        // what this did — ignored the file explorer entirely, so toggling it
+        // changed no viewport here at all. Nothing downstream noticed the
+        // narrower panes until the *next* paint corrected them, and by then
+        // `notify_layout_changed` had already refreshed the plugin-facing
+        // snapshot and fired its hooks off the stale, too-wide geometry: a
+        // plugin panel that re-lays itself out in reaction (the code tour's
+        // dock panel) saw no width change, kept its old layout, and spilled
+        // out of the region it had been given until something else forced a
+        // re-layout. Toggling the *dock* never had that problem, because
+        // `dock_cols` was the one piece of chrome this did subtract.
+        //
+        // Splits that aren't on screen keep the coarse full-content-width
+        // seed; they have no rect of their own until they are laid out.
+        let content_width = self.editor_content_area().width;
+        let visible_rects: std::collections::HashMap<_, _> = visible
+            .iter()
+            .map(|(split_id, _, area)| (*split_id, *area))
+            .collect();
         if let Some(view_states) = self.split_view_states_mut() {
-            for view_state in view_states.values_mut() {
-                view_state.viewport.resize(editor_width, height);
+            for (split_id, view_state) in view_states.iter_mut() {
+                match visible_rects.get(split_id) {
+                    Some(area) => view_state.viewport.resize(area.width, area.height),
+                    None => view_state.viewport.resize(content_width, height),
+                }
             }
         }
 
@@ -517,20 +553,8 @@ impl crate::app::window::Window {
         // tab-scroll offset is never revisited. Use each split's real area
         // width (dock/explorer/split-aware), not the whole-window width, so
         // a half-width vertical split scrolls correctly too.
-        let visible: Vec<(
-            crate::model::event::LeafId,
-            crate::model::event::BufferId,
-            u16,
-        )> = match self.buffers.splits() {
-            Some((mgr, _)) => mgr
-                .get_visible_buffers(self.editor_content_area())
-                .into_iter()
-                .map(|(split_id, buffer_id, area)| (split_id, buffer_id, area.width))
-                .collect(),
-            None => Vec::new(),
-        };
-        for (split_id, buffer_id, tab_width) in visible {
-            self.ensure_active_tab_visible(split_id, buffer_id, tab_width);
+        for (split_id, buffer_id, area) in visible {
+            self.ensure_active_tab_visible(split_id, buffer_id, area.width);
         }
     }
 }

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -2227,7 +2227,18 @@ impl Window {
     /// Computing the file-explorer width against the post-dock chrome
     /// width (not the full screen) matches the renderer exactly, so split
     /// geometry derived from this lines up with the cells actually drawn.
+    ///
+    /// The vertical bands come from the same toggles the renderer lays out
+    /// against. Hard-coding "menu bar + status bar" instead over-reported the
+    /// height by a row whenever the prompt line was shown — panes are one row
+    /// shorter than that, so a panel that sizes itself to the pane it is told
+    /// it has (the code tour's dock panel) emitted one row too many and its
+    /// hint bar fell off the bottom of the dock — and under-reported it with
+    /// the menu or status bar hidden.
     pub(crate) fn editor_content_area(&self) -> ratatui::layout::Rect {
+        let menu_rows = u16::from(self.menu_bar_visible);
+        let status_rows = u16::from(self.status_bar_visible);
+        let prompt_rows = u16::from(self.prompt_line_visible);
         let chrome_width = self.terminal_width.saturating_sub(self.dock_cols);
         let file_explorer_width = if self.file_explorer_visible {
             self.file_explorer_width.to_cols(chrome_width)
@@ -2243,9 +2254,10 @@ impl Window {
         let editor_width = chrome_width.saturating_sub(file_explorer_width);
         ratatui::layout::Rect::new(
             editor_x,
-            1, // menu bar
+            menu_rows,
             editor_width,
-            self.terminal_height.saturating_sub(2), // menu bar + status bar
+            self.terminal_height
+                .saturating_sub(menu_rows + status_rows + prompt_rows),
         )
     }
 

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -2014,6 +2014,76 @@ fn test_load_definition_picker_reaches_hidden_tour_files() {
     wait_for_step_settled(&mut harness);
 }
 
+/// A dock panel has to fit the dock it is actually painted into.
+///
+/// The editor's content area was derived as "screen height minus the menu bar
+/// and the status bar", which is one row too many whenever the prompt line is
+/// shown — and one row too few with the menu or status bar hidden. Panes are
+/// laid out inside that area, so the pane geometry every consumer reads (the
+/// `describeWorkspace` / `listSplits` snapshots, terminal PTY sizes) claimed a
+/// row that was not there. A panel that sizes its bands to the pane it is told
+/// it has then emits one row too many: the tour's hint bar, its last band,
+/// was pushed out of the dock entirely and nothing on screen said why.
+#[test]
+fn test_tour_panel_fits_the_dock_when_the_prompt_line_is_shown() {
+    let (_temp, project_root) = setup_tour_project();
+    let mut harness = harness_in(&project_root, 200, 45);
+
+    // Precondition, read off the screen: the prompt line occupies the bottom
+    // row (it is blank until a prompt is open), so the status bar is *not*
+    // the last row and the editor area is three bands shorter than the
+    // screen, not two.
+    let screen = harness.screen_to_string();
+    let rows: Vec<&str> = screen.lines().collect();
+    assert!(
+        rows.last().is_some_and(|r| r.trim().is_empty()),
+        "expected the prompt line on the bottom row\nScreen:\n{screen}"
+    );
+    assert!(
+        rows.iter()
+            .nth_back(1)
+            .is_some_and(|r| r.contains("Trusted")),
+        "expected the status bar directly above the prompt line\nScreen:\n{screen}"
+    );
+
+    let manifest = project_root.join(".fresh-tour.json");
+    run_command(&mut harness, "Tour: Load Definition");
+    harness
+        .wait_until(|h| h.screen_to_string().contains("tour file path"))
+        .unwrap();
+    harness.type_text(&manifest.display().to_string()).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Wait for the panel's *body* and then for the frame to settle —
+    // deliberately not for the hint bar, which is the thing under test.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("╭─ Steps"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let bottom_border = screen
+        .lines()
+        .position(|l| l.contains('╰'))
+        .unwrap_or_else(|| panic!("expected the body's bottom border\nScreen:\n{screen}"));
+    // The hint bar is the panel's last band. Lower-case "jump to code" is the
+    // hint's wording; the header's button reads "[ Jump to code ⏎ ]".
+    let hints = screen
+        .lines()
+        .position(|l| l.contains("jump to code"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the hint bar must still be inside the dock — the panel sized \
+                 itself to a dock one row taller than it was given\nScreen:\n{screen}"
+            )
+        });
+    assert!(
+        hints > bottom_border,
+        "the hint bar belongs below the body, inside the dock \
+         (hints={hints}, bottom_border={bottom_border})\nScreen:\n{screen}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // The panel re-lays out when a sibling panel takes its width
 // ---------------------------------------------------------------------------

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -2013,3 +2013,93 @@ fn test_load_definition_picker_reaches_hidden_tour_files() {
         .unwrap();
     wait_for_step_settled(&mut harness);
 }
+
+// ---------------------------------------------------------------------------
+// The panel re-lays out when a sibling panel takes its width
+// ---------------------------------------------------------------------------
+
+/// The screen row the tour's body opens its two boxes on — the rail's
+/// `╭─ Steps ─…` and the prose section's `╭─ 1/2 · … ─…` — together with the
+/// number of box corners that close on it. A body laid out wider than the
+/// dock spills its corners onto the following row, so a count below two says
+/// the panel overflowed its region.
+fn body_box_top_row(harness: &EditorTestHarness) -> Option<(String, usize)> {
+    harness
+        .screen_to_string()
+        .lines()
+        .find(|l| l.contains("╭─ Steps"))
+        .map(|l| (l.to_string(), l.chars().filter(|c| *c == '╮').count()))
+}
+
+/// Opening the file explorer takes columns away from the tour's dock without
+/// any window resize. The panel must re-lay out into the region it now has.
+///
+/// It used not to: the layout funnel reseeded every split viewport from the
+/// post-dock *window* width, which never accounted for the file explorer, so
+/// toggling the explorer moved no viewport the panel could observe. The panel
+/// kept its previous, wider layout and overflowed — the box's top border
+/// spilled onto a second screen row, every content row was followed by a
+/// stray line carrying the right border that no longer fit, and the hint bar
+/// was pushed out of the dock entirely. It stayed that way until a step
+/// change or a window resize forced a re-layout.
+#[test]
+fn test_tour_panel_relayouts_when_the_explorer_narrows_the_dock() {
+    let (_temp, project_root) = setup_tour_project();
+    let mut harness = harness_in(&project_root, 160, 40);
+
+    let manifest = project_root.join(".fresh-tour.json");
+    load_tour(
+        &mut harness,
+        &manifest.display().to_string(),
+        "*Tour: Pipeline Tour*",
+    );
+
+    // Baseline: the rail's box opens and closes on one screen row, and the
+    // hint bar is on screen below it.
+    let (before, before_closes) = body_box_top_row(&harness).unwrap_or_else(|| {
+        panic!(
+            "expected the Steps rail box before the explorer opens\nScreen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    assert_eq!(
+        before_closes, 2,
+        "baseline: both body boxes must open and close on one screen row\nRow: {before}"
+    );
+
+    // Read the code, then open the explorer beside it — the panel's own mode
+    // owns the keyboard while the panel holds focus, so click into the editor
+    // split first, exactly as a reader would.
+    harness.mouse_click(10, 3).unwrap();
+    harness
+        .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+    // The explorer's panel and the tour's re-layout are both async; wait for
+    // the sidebar to paint and then for the frame to stop changing, so the
+    // assertions below read a settled screen either way. The sidebar draws a
+    // bordered box whose top-left corner sits at column 0 — nothing else
+    // paints a `┌` at the start of a line, so it is a locale-independent
+    // "the sidebar is on screen" signal.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().lines().any(|l| l.starts_with('┌')))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let (after, after_closes) = body_box_top_row(&harness).unwrap_or_else(|| {
+        panic!("expected the Steps rail box to still be drawn\nScreen:\n{screen}")
+    });
+    assert_eq!(
+        after_closes, 2,
+        "the panel must re-lay out into the narrower dock: both body boxes \
+         have to open and close on the same screen row, not spill their \
+         right-hand corners onto the next one\nRow: {after}\nScreen:\n{screen}"
+    );
+    // A panel laid out too wide pushes its own tail off the bottom of the
+    // dock; the hint bar is the last band, so its presence says the whole
+    // panel still fits the rows it has.
+    assert!(
+        screen.contains("jump to code"),
+        "the hint bar must still be inside the dock after the explorer opens\
+         \nScreen:\n{screen}"
+    );
+}


### PR DESCRIPTION
Fixes **sub-issue 3** of #2969 — "Tour panel does not re-layout when its available width changes" — plus a second defect of the same shape found while testing it (see part 2).

Two commits, one per axis. Both are the same class of bug: the geometry the layout funnel derives and pushes down disagreed with the geometry the renderer paints, and the consumers that trust it — the plugin-facing `describeWorkspace` / `listSplits` snapshots, terminal PTY sizes, split viewports — were wrong until something forced a recompute.

---

## Part 1 — width: the funnel ignored the file explorer

`Window::apply_layout` reseeded *every* split viewport with `terminal_width - dock_cols`. That subtracts the orchestrator dock but never the file explorer, so toggling the explorer changed no viewport at all. The panes really did narrow; nothing downstream could see it until the *next* paint recomputed each pane's content rect, and by then `notify_layout_changed` had already refreshed the plugin-facing snapshot and fired the `resize` hook off the stale, pre-explorer width.

So a plugin that re-lays itself out in reaction never saw a change. That matches the issue's scoping clue exactly: `Alt+O` re-lays out correctly because `dock_cols` was the one piece of chrome the seed did subtract; `Ctrl+B` does not.

Confirmed by instrumenting the plugin against a debug build under tmux. The `viewport_changed` hook fires with the correct new width; the snapshot the plugin reads back does not:

```
PROBE hook w=140 snapW=200 snapPaneW=140 cachedW=200
```

`w` (hook payload, post-paint) and `snapPaneW` (the pane rect) are the new 140; `snapW` — `listSplits()[…].viewport.width`, which is what the panel sizes itself from — is still 200. The panel concludes nothing changed and keeps its old layout.

**Fix:** seed each visible split from its own pane rect, taken from `mgr.get_visible_buffers(self.editor_content_area())` — the same rects the renderer and `resize_visible_terminals` already lay out against. `apply_layout` already computed those rects for tab re-pinning; they are now computed once and used for both. Splits that are not on screen keep the coarse full-content-width seed — they have no rect of their own until they are laid out.

### Before (200x50, `Ctrl+B` with a tour open)

```
│                                                          │ Fresh Plugin System Tour            Step 1 of 4  ▰▱▱▱  [ Jump to
│                                                          │ code ⏎ ] [ Re-highlight ] [ ◀ Prev ] [ Next ▶ ] [ ✕ Exit ]
│                                                          │╭─ Steps ─────────────────────────────────────────╮╭─ 1/4 · Plugin API Overview
│                                                          │──────────────────────────────────────────────────────────────╮
│                                                          ││  ▸ 1  Plugin API Overview                       ││ crates/…/quickjs_backend.rs   lines 1–88
│                                                          │                                                         │
```

After, the same steps re-lay out into the 141-column region: borders on every row, hint bar still in the dock. `Alt+O`, closing the explorer again, and a window resize all still re-lay out correctly.

---

## Part 2 — height: the content area ignored the prompt line

Found while writing the test above, which hung at 200x45 for a reason that had nothing to do with width.

`Window::editor_content_area` hard-coded its vertical bands as "menu bar + status bar": origin row 1, height `terminal_height - 2`. The renderer lays the screen out from the toggles — menu bar, status bar **and prompt line** — so the two disagree the moment any of them is flipped from its assumed state. With the prompt line shown the area claims a row that is not there; with the menu or status bar hidden it gives up a row that is.

Every pane is laid out inside that area, so the error reaches everything that reads pane geometry. The visible symptom is the tour panel sizing its bands to a dock one row taller than it was given, and its last band — the hint bar — falling off the bottom with nothing on screen to explain it. Reproduced in the real editor at 200x45: palette → `Toggle Prompt Line` → load a tour:

```
41 '│                                                 ││        '
42 '╰─────────────────────────────────────────────────╯╰────────'
43 ' Trusted  Local                                             '     <- hint bar gone
44 ''                                                                 <- prompt line
```

**Fix:** derive the bands from the same toggles the renderer uses. After it, at the same size: body ends at 41, hint bar at 42, status bar 43, prompt line 44.

This is not only the tour: terminal PTY rows and every plugin reading `listSplits()` were off by the same row whenever the prompt line was shown.

---

## Tests

Both in `crates/fresh-editor/tests/e2e/code_tour_dock.rs`, asserting on rendered output only, no timeouts — each waits for a settled frame and then reads it.

- `test_tour_panel_relayouts_when_the_explorer_narrows_the_dock` — loads a tour, clicks into the editor split, opens the explorer with `Ctrl+B`; both body boxes must open **and close** on the same screen row, and the hint bar must still be inside the dock. Without part 1: `left: 1, right: 2` (the prose box's closing corner has spilled onto the next row).
- `test_tour_panel_fits_the_dock_when_the_prompt_line_is_shown` — asserts the precondition off the screen (prompt line on the bottom row, status bar directly above it), loads a tour at 200x45, and requires the hint bar below the body's bottom border. It deliberately waits for the panel *body*, not the hint bar, so the buggy build reaches the assertion instead of hanging. Without part 2: `the hint bar must still be inside the dock`.

## Checks

- `cargo fmt`, `cargo clippy` (clean on the touched files), `cargo check --all-targets`
- `cargo test -p fresh-editor --lib` — 3300 passed
- e2e modules most exposed to the change: `code_tour` (35), `terminal` (148), `split` (133), `file_explorer` (100), `dock` (146) — all pass. The rest is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LV5WvsL3drUfQmFRMe4kP