### PR TITLE
fix(widgets): keep the section border under a panel scrollbar

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4436,7 +4436,9 @@ impl Editor {
     /// nothing about widget geometry, so without this pass their
     /// overflowing lists show no scrollbar at all.
     fn render_split_widget_panel_scrollbars(&mut self, frame: &mut Frame) {
-        use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
+        use crate::view::ui::scrollbar::{
+            render_scrollbar_over_chrome, ScrollbarColors, ScrollbarState,
+        };
 
         // Collect paint jobs first so the layout/registry borrows end
         // before the frame is written.
@@ -4519,7 +4521,9 @@ impl Editor {
             ScrollbarColors::from_theme(&theme)
         };
         for (rect, state) in jobs {
-            render_scrollbar(frame, rect, &state, &colors);
+            // The region reaches onto the panel's own `LabeledSection`
+            // border, so the bar has to tint that border, not blank it out.
+            render_scrollbar_over_chrome(frame, rect, &state, &colors, false);
         }
     }
 
@@ -4846,7 +4850,9 @@ impl Editor {
             scrollbar_flash_until.is_some_and(|until| self.time_source().now() < until);
         let mut scrollbar_hover_zones: Vec<ratatui::layout::Rect> = Vec::new();
         {
-            use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
+            use crate::view::ui::scrollbar::{
+                render_scrollbar_over_chrome, ScrollbarColors, ScrollbarState,
+            };
             let colors = ScrollbarColors::from_theme(&theme);
             for region in &scroll_regions {
                 // Regions are emitted for every keyed list (wheel routing
@@ -4906,7 +4912,9 @@ impl Editor {
                     continue;
                 }
                 let state = ScrollbarState::new(region.total, region.visible, region.scroll);
-                render_scrollbar(frame, sb_rect, &state, &colors);
+                // Same as the split-mounted panels: the region reaches onto
+                // the section border, which must stay drawn under the bar.
+                render_scrollbar_over_chrome(frame, sb_rect, &state, &colors, false);
                 scrollbar_tracks.push(super::WidgetScrollbarTrack {
                     list_key: region.list_key.clone(),
                     rect: sb_rect,

--- a/crates/fresh-editor/src/view/ui/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/scrollbar.rs
@@ -345,6 +345,59 @@ pub fn render_scrollbar(
     (thumb_start, thumb_end)
 }
 
+/// Render a vertical scrollbar over a column whose glyph has to survive.
+///
+/// [`render_scrollbar`] paints a blank cell per row. That is right over a
+/// list's own padding, but it *erases* whatever it lands on — and a widget
+/// panel's scroll region is deliberately extended two columns, through the
+/// right padding and onto the wrapping `LabeledSection`'s `│` border, so the
+/// bar hugs the section edge instead of floating a column inboard. The blank
+/// fill therefore rubbed out the box's right border on every row the bar
+/// covered, which is why the code tour's explanation box lost its right edge
+/// as soon as its prose overflowed (a short dock, mostly).
+///
+/// This keeps the glyph that is already in the column and re-styles only its
+/// background, so the box stays closed and the bar still reads as a bar.
+/// Over a list row the cell underneath is a space, so it paints identically
+/// to [`render_scrollbar`].
+///
+/// # Returns
+/// (thumb_start, thumb_end) in row coordinates relative to the area
+pub fn render_scrollbar_over_chrome(
+    frame: &mut Frame,
+    area: Rect,
+    state: &ScrollbarState,
+    colors: &ScrollbarColors,
+    thumb_hovered: bool,
+) -> (usize, usize) {
+    let height = area.height as usize;
+    if height == 0 || area.width == 0 {
+        return (0, 0);
+    }
+
+    let (thumb_start, thumb_size) = state.thumb_geometry(height);
+    let thumb_end = thumb_start + thumb_size;
+    let thumb_color = if thumb_hovered {
+        Color::White
+    } else {
+        colors.thumb
+    };
+
+    let buffer = frame.buffer_mut();
+    for row in 0..height {
+        let bg = if row >= thumb_start && row < thumb_end {
+            thumb_color
+        } else {
+            colors.track
+        };
+        if let Some(cell) = buffer.cell_mut((area.x, area.y + row as u16)) {
+            cell.set_bg(bg);
+        }
+    }
+
+    (thumb_start, thumb_end)
+}
+
 /// Render a scrollbar with mouse hover highlight
 ///
 /// Same as `render_scrollbar` but highlights the thumb if hovered

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -986,6 +986,64 @@ fn test_overflowing_lists_show_scrollbars() {
     }
 }
 
+/// An overflowing list must not cost the section its right border.
+///
+/// The panel's scroll region deliberately reaches through the right padding
+/// onto the wrapping section's `│` border, so the bar hugs the box edge. The
+/// bar was painted as a blank cell per row, though, which rubbed the border
+/// out: as soon as the prose was taller than its window — any dock short
+/// enough, which includes a tour opened into an already-open bottom dock —
+/// the explanation box rendered with a top and a bottom border and no right
+/// edge at all on the rows between them.
+#[test]
+fn test_overflowing_lists_keep_the_section_border() {
+    let (_temp, project_root) = setup_tour_project();
+    let mut harness = harness_in(&project_root, 160, 40);
+    let first_row = load_overflow_tour(&mut harness, &project_root);
+
+    // The sections' shared top-border row carries one `╮` per box; those are
+    // the columns the two scrollbars paint on. Every glyph on the row is
+    // single-width, so char index == screen column.
+    let border_row = first_row - 1;
+    let screen = harness.screen_to_string();
+    let line = screen.lines().nth(border_row).expect("border row");
+    let closes: Vec<u16> = line
+        .chars()
+        .enumerate()
+        .filter(|(_, c)| *c == '╮')
+        .map(|(i, _)| i as u16)
+        .collect();
+    assert_eq!(closes.len(), 2, "expected both section borders\n{line}");
+    // The body's last row is the one above the sections' bottom border.
+    let bottom_row = screen
+        .lines()
+        .skip(border_row)
+        .position(|l| l.contains('╰'))
+        .map(|offset| border_row + offset)
+        .unwrap_or_else(|| panic!("expected the sections' bottom border\nScreen:\n{screen}"));
+    assert!(
+        bottom_row > first_row,
+        "expected content rows between the borders\nScreen:\n{screen}"
+    );
+
+    for col in closes {
+        // The bar is still there — this is not "no scrollbar, no problem".
+        assert!(
+            harness.is_scrollbar_thumb_at(col, first_row as u16)
+                || harness.is_scrollbar_track_at(col, first_row as u16),
+            "expected a scrollbar cell on the border col {col} row {first_row}\nScreen:\n{screen}"
+        );
+        for row in first_row..bottom_row {
+            assert_eq!(
+                harness.get_cell(col, row as u16).as_deref(),
+                Some("│"),
+                "the section's right border must survive the scrollbar at \
+                 col {col} row {row}\nScreen:\n{screen}"
+            );
+        }
+    }
+}
+
 /// The selected rows' highlight stays inside the panel. Before the fix,
 /// the selection band's `extend_to_line_end` survived the row zipper and
 /// the painter flooded every cell right of the panel border — a stray


### PR DESCRIPTION
Fixes **sub-issue 3b** of #2969 — "Tour explanation box loses its right border at short dock heights".

## What was wrong

`collect_labeled_section` widens a child's scroll region by two columns on purpose, so the bar lands *on* the section's `│` border rather than floating a column inboard (and so a wheel over the border still scrolls the list). `render_scrollbar` then paints one **blank cell** per row — correct over a list's own padding, destructive over a border. Every row the bar covered lost the box's right edge.

That is the whole of 3b: the border is not "missing", it is overwritten by a space. Reading the same frame with colours shows it — the last column of each content row is a space carrying the scrollbar's thumb/track background:

```
lines 1–88                        ^[[38;5;170m^[[48;5;226m ^[[39m   <- thumb, was `│`
                                  ^[[48;5;238m ^[[39m                <- track, was `│`
```

Which explains the height threshold in the issue (140x45/44/42 fine, 40 and below broken) and why width is irrelevant: a shorter dock is simply what makes the prose overflow its window and earn a scrollbar. Same for "opening the tour into an already-open bottom dock renders borderless immediately" — that dock is shorter from the start.

## The fix

`render_scrollbar_over_chrome` paints the same track/thumb colours but keeps whatever glyph is already in the column, re-styling only its background. Used at the two widget-panel paint sites (split-mounted panels, floating panels), which are exactly the bars whose regions were extended onto the section border. Every other scrollbar in the editor — file browser, settings, keybinding editor, prompt suggestions, buffer scrollbars — is untouched.

The box stays closed, the bar still reads as a bar (border glyph in thumb/track colours), and over an ordinary list row — a space — it paints identically to before, so `is_scrollbar_thumb_at` / `is_scrollbar_track_at` and the existing drag/hit-test behaviour are unaffected.

Verified by hand under tmux at 140x36: content rows are back to 137 columns ending in `│`, with the scrollbar's background still on that column.

## Test

`test_overflowing_lists_keep_the_section_border` in `crates/fresh-editor/tests/e2e/code_tour_dock.rs` loads the existing overflow-tour fixture (both the Steps rail and the prose overflow), then asserts on rendered output only: on each of the two `╮` columns, the bar is present (a thumb or track cell — this must not pass by having no scrollbar at all) **and** every content row between the top and bottom borders still carries `│`.

Without the fix: `left: Some(" "), right: Some("│")` at the first content row. With it, it passes.

## Checks

- `cargo fmt`, `cargo clippy`, `cargo check --all-targets`
- e2e modules most exposed to the change, run before the final commit: `code_tour` (34), `dock` (145), `orchestrator` (145), `scrollbar` (82) — all pass. The rest is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LV5WvsL3drUfQmFRMe4kP

---
_Generated by [Claude Code](https://claude.ai/code/session_013LV5WvsL3drUfQmFRMe4kP)_