### PR TITLE
fix(code-tour): open every step into one target pane

### DIFF
--- a/crates/fresh-editor/plugins/code-tour.ts
+++ b/crates/fresh-editor/plugins/code-tour.ts
@@ -112,6 +112,10 @@ interface TourInstance {
   visited: Set<number>;
   bufferId: number;
   splitId: number;
+  /** The editor pane this tour opens its steps into — see `targetSplit`.
+   * Seeded with the split the tour was launched from and re-pinned to
+   * wherever a step actually landed, so it survives splits being closed. */
+  targetSplitId: number;
   panel: WidgetPanel;
   /** Per-tour overlay namespace, so one tour's teardown cannot clear another's
    * highlight and two tours may highlight the same buffer at once. */
@@ -830,6 +834,10 @@ async function openTour(
   const drift = await commitDrift(manifest);
 
   const name = tabName(manifest.title);
+  // The pane the reader was in when they started the tour is where its code
+  // belongs. Read before the dock panel is mounted — mounting makes the dock
+  // the active split, and after that there is nothing left to remember.
+  const launchedFrom = editor.getActiveSplitId();
   let bufferId = 0;
   let splitId = 0;
   try {
@@ -866,6 +874,7 @@ async function openTour(
     visited: new Set(options.visited ?? [step]),
     bufferId,
     splitId,
+    targetSplitId: launchedFrom,
     panel: new WidgetPanel(bufferId),
     namespace: `code-tour:${manifestPath}`,
     railOpen: options.railOpen !== false,
@@ -923,7 +932,67 @@ function clampStep(step: number, total: number): number {
   return Math.min(Math.max(Math.floor(step), 0), total - 1);
 }
 
-/** Open the step's file in the editor split, centre it, and paint the
+/** The editor pane this tour opens its steps into, or `null` when the
+ * workspace has none to offer.
+ *
+ * A tour is a reading flow: the code it is talking about belongs in one
+ * predictable pane, not wherever focus happened to be when the step changed.
+ * `openFile` lands in the *active* split, so stepping through a tour while
+ * clicking between splits scattered its files across all of them — step 2 in
+ * the left split, step 3 in the right, step 4 back in the left.
+ *
+ * The pane is the one the tour was launched from, but it is re-resolved on
+ * every step rather than trusted: splits close, and a pane that has since
+ * become a terminal or a plugin panel cannot hold the step's source. When the
+ * remembered pane is no longer usable the left-most/top-most file pane takes
+ * over and is remembered in its place. `t.splitId` — the tour's own dock leaf,
+ * which every Utility Dock panel shares — is never a candidate, so a step's
+ * file cannot land beside the panels.
+ */
+function targetSplit(t: TourInstance): number | null {
+  const panes = editor.describeWorkspace().panes;
+  const usable = (splitId: number, kind: string) =>
+    kind === "file" && splitId !== t.splitId &&
+    ![...tours.values()].some((other) => other.splitId === splitId);
+  const remembered = panes.find((p) => p.splitId === t.targetSplitId);
+  if (remembered && usable(remembered.splitId, remembered.kind)) return remembered.splitId;
+  const fallback = panes.find((p) => usable(p.splitId, p.kind));
+  if (!fallback) return null;
+  t.targetSplitId = fallback.splitId;
+  return fallback.splitId;
+}
+
+/** Open a step's file in the tour's target pane.
+ *
+ * Falls back to `openFile` when no pane qualifies (a workspace showing only
+ * terminals and panels, say): the host's own file-open path redirects the
+ * active split away from the Utility Dock, so the file still does not become
+ * a tab in the dock even though the tour panel holds focus. */
+function openStepFile(t: TourInstance, stepPath: string, line: number): void {
+  const target = targetSplit(t);
+  if (target === null) {
+    editor.openFile(stepPath, line, 1);
+    return;
+  }
+  editor.openFileInSplit(target, stepPath, line, 1);
+}
+
+/** Pin the tour to the pane its step actually landed in.
+ *
+ * The fallback path above lets the host choose, and even the targeted path can
+ * be redirected. Reading the result back means the *next* step joins this one
+ * instead of starting the hunt over — which is the whole point: one pane, all
+ * the way through. Callers must `flush` first; `describeWorkspace` reads the
+ * plugin-state snapshot, which still describes the pre-open layout until the
+ * host has drained the queued command. */
+function rememberTargetSplit(t: TourInstance, bufferId: number): void {
+  const pane = editor
+    .describeWorkspace()
+    .panes.find((p) => p.bufferId === bufferId && p.splitId !== t.splitId);
+  if (pane) t.targetSplitId = pane.splitId;
+}
+
+/** Open the step's file in the tour's target pane, centre it, and paint the
  * highlight. Never moves keyboard focus out of the panel. */
 async function revealStep(t: TourInstance): Promise<void> {
   const step = currentStep(t);
@@ -946,12 +1015,7 @@ async function revealStep(t: TourInstance): Promise<void> {
     return;
   }
 
-  // `openFile` — not `openFileInSplit`. The host's file-open path already
-  // redirects the active split away from the Utility Dock, so a file never
-  // becomes a tab in the dock even though the tour panel is what holds focus.
-  // Naming a split explicitly would bypass that guard and let the step's
-  // source land beside the panels.
-  editor.openFile(stepPath, step.lines[0], 1);
+  openStepFile(t, stepPath, step.lines[0]);
   // Hand the keyboard straight back. Both calls are FIFO commands, so
   // queueing the focus restore in the same turn leaves no window where
   // a key typed at the panel lands in the source file instead — parking
@@ -967,6 +1031,7 @@ async function revealStep(t: TourInstance): Promise<void> {
 
   const bufferId = stepBufferId(stepPath);
   if (bufferId) {
+    rememberTargetSplit(t, bufferId);
     // Centre the range — but never at the cost of its first line. The
     // host parks the passed line a third of the viewport from the top,
     // so clamp the target: a range taller than the pane keeps its top
@@ -1163,9 +1228,9 @@ function jumpToCode(t: TourInstance): void {
     return;
   }
   // Deliberately no `focusSplit` back to the panel afterwards: this is the
-  // explicit "put me in the code" gesture, so focus stays where `openFile`
-  // left it.
-  editor.openFile(resolveStepPath(t.manifestPath, step.file_path), step.lines[0], 1);
+  // explicit "put me in the code" gesture, so focus stays in the pane the
+  // step opened into — the same pane every other step uses.
+  openStepFile(t, resolveStepPath(t.manifestPath, step.file_path), step.lines[0]);
   editor.setStatus(
     editor.t("status.jumped", { file: step.file_path, line: String(step.lines[0]) }),
   );

--- a/crates/fresh-editor/tests/e2e/code_tour_dock.rs
+++ b/crates/fresh-editor/tests/e2e/code_tour_dock.rs
@@ -986,6 +986,83 @@ fn test_overflowing_lists_show_scrollbars() {
     }
 }
 
+/// The two editor splits' tab strips, taken from the tab-bar row and split
+/// at the vertical separator between the panes.
+fn tab_bar_halves(harness: &EditorTestHarness) -> (String, String) {
+    let screen = harness.screen_to_string();
+    let row = screen
+        .lines()
+        .nth(1)
+        .unwrap_or_else(|| panic!("expected a tab-bar row\nScreen:\n{screen}"));
+    row.split_once('\u{2502}')
+        .map(|(left, right)| (left.to_string(), right.to_string()))
+        .unwrap_or_else(|| {
+            panic!("expected two side-by-side tab strips\nRow: {row}\nScreen:\n{screen}")
+        })
+}
+
+/// Every step opens into the same pane — the one the tour was launched from —
+/// no matter which split has focus when the step changes.
+///
+/// Each step used to open into whichever split was active, so reading the code
+/// in one pane and then stepping scattered the tour's files across all of
+/// them: step 2 in the left split, step 3 in the right, step 4 back in the
+/// left, with no way to predict where the next one would land.
+#[test]
+fn test_tour_opens_every_step_in_its_target_panel() {
+    let (_temp, project_root) = setup_tour_project();
+    let mut harness = harness_in(&project_root, 160, 40);
+
+    run_command(&mut harness, "Split Vertical");
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .lines()
+                .nth(1)
+                .is_some_and(|r| r.contains('\u{2502}'))
+        })
+        .unwrap();
+
+    // Launch the tour from the left split: that is the pane its code belongs
+    // in for the rest of the tour.
+    harness.mouse_click(10, 3).unwrap();
+    let manifest = project_root.join(".fresh-tour.json");
+    load_tour(
+        &mut harness,
+        &manifest.display().to_string(),
+        "*Tour: Pipeline Tour*",
+    );
+
+    // Read the code in the *other* split, then step the tour from there.
+    harness.mouse_click(120, 3).unwrap();
+    run_command(&mut harness, "Tour: Next Step");
+    // Wait for the step to have landed *somewhere* — the panel counter plus
+    // the new file's tab — and then for the frame to settle. Deliberately not
+    // `wait_for_step_settled`: that watches for the highlight at a column
+    // inside the left split, which is the very thing under test.
+    harness
+        .wait_until_stable(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("Step 2 of 2")
+                && screen.lines().nth(1).is_some_and(|r| r.contains("wide.rs"))
+        })
+        .unwrap();
+
+    let (left, right) = tab_bar_halves(&harness);
+    assert!(
+        left.contains("wide.rs"),
+        "step 2's file must open in the pane the tour was launched from\n\
+         left strip: {left}\nright strip: {right}\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        !right.contains("wide.rs"),
+        "step 2's file must not follow the focused split\n\
+         left strip: {left}\nright strip: {right}\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
 /// The selected rows' highlight stays inside the panel. Before the fix,
 /// the selection band's `extend_to_line_end` survived the row zipper and
 /// the painter flooded every cell right of the panel border — a stray


### PR DESCRIPTION
Fixes **sub-issue 2** of #2969 — "Code tour opens each step into the last-focused split instead of one target panel".

## What was wrong

`revealStep` opened each step with `editor.openFile`, which lands in whichever split is *active*. So reading a step's code in one pane and then stepping put the next step's file in that pane, and stepping through a tour while clicking between splits scattered its files across all of them.

## How the target pane is chosen

The issue leaves this to judgement; here is what I picked and why.

- **The pane the tour was launched from.** That is the pane the reader was already using, and it is what "the tour's code lives here" means without asking them to nominate one. It is captured *before* the dock panel is mounted — mounting makes the dock the active split, after which there is nothing left to remember.
- **Re-resolved on every step, not trusted.** Splits close, and a pane that has since become a terminal or another plugin's panel cannot hold the step's source. When the remembered pane is no longer usable, the left-most/top-most file pane takes over and is remembered in its place.
- **The dock is never a candidate.** `t.splitId` — the tour's own Utility Dock leaf, which every dock panel shares — is excluded explicitly. That is the guarantee the old `openFile` comment was leaning on the host's dock redirect for; naming a split now means naming it ourselves, so the exclusion is ours to make.
- **Whatever happens, pin to where the file actually landed.** After the open is flushed, the pane showing the step's buffer is read back and remembered. So even the fallback path (`openFile`, used when no pane qualifies at all — a workspace of nothing but terminals and panels) converges on one pane from the second step onwards.
- **`Jump to code` uses the same pane**, which also gives that gesture a predictable destination for focus.

Nothing is persisted: split ids do not survive a restart, and a restored tour re-resolves on its first step anyway.

## Reproduction (manual, before the fix)

`fresh` with two vertical splits, tour loaded, then click the right split → `[ Next ▶ ]` → the step's file opens in the **right** split; click the left split → `[ Next ▶ ]` → the next one opens in the **left**. After the fix, the same clicking leaves every step in the launch pane:

```
 main.rs ×   gamma.rs ×   beta.rs ×   +          □× │ main.rs ×   +          □×
```

(both steps taken with focus in the right split — one Next, one Prev.)

## Test

`test_tour_opens_every_step_in_its_target_panel` in `crates/fresh-editor/tests/e2e/code_tour_dock.rs`: split vertically, click into the left split, load the tour there, then click into the right split and advance the tour from the palette. It asserts on rendered output only — step 2's file must appear in the left split's tab strip and must **not** appear in the right one.

The wait is deliberately not `wait_for_step_settled`: that watches for the step highlight at a column inside the left split, which is the very thing under test. It waits for the step counter plus the new file's tab (wherever it landed) and then for the frame to settle, so the buggy build reaches the assertion and fails there rather than hanging.

Without the fix: `step 2's file must open in the pane the tour was launched from`. With it, it passes.

## Checks

- `cargo fmt`, `cargo check --all-targets`, `plugins/check-types.sh` (no errors in `code-tour.ts`; the pre-existing `lib/widgets.ts` ones are untouched)
- `code_tour` e2e module: 34 passed. The rest is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LV5WvsL3drUfQmFRMe4kP

---
_Generated by [Claude Code](https://claude.ai/code/session_013LV5WvsL3drUfQmFRMe4kP)_