### PR TITLE
fix(input): keep the file explorer's keys and the terminal's keys apart

### DIFF
--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -83,9 +83,20 @@ impl Editor {
 
         // Check for keys that should re-enter terminal mode from scrollback view.
         // Any plain character key exits scrollback and is forwarded to the terminal.
-        if self
-            .active_window()
-            .is_terminal_buffer(self.active_buffer())
+        //
+        // Gated on the editor pane owning the keyboard, for the same reason the
+        // live branch above is: the active buffer is still the terminal while
+        // the user is off in the file explorer, so "the active buffer is a
+        // terminal" alone would forward the explorer's own keys to the PTY.
+        // That is exactly what happened to Enter — it dived into the shell,
+        // which then took focus back, instead of opening the selected entry —
+        // and to Tab, Backspace and every plain character. `focused_terminal_live`
+        // fixed the same class for the live branch (issue #2029); this is the
+        // scroll-back branch, which the gate never reached.
+        if self.active_window().editor_pane_owns_keyboard()
+            && self
+                .active_window()
+                .is_terminal_buffer(self.active_buffer())
             && should_enter_terminal_mode(event)
         {
             self.enter_terminal_mode();

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -83,16 +83,10 @@ impl Editor {
 
         // Check for keys that should re-enter terminal mode from scrollback view.
         // Any plain character key exits scrollback and is forwarded to the terminal.
-        //
-        // Gated on the editor pane owning the keyboard, for the same reason the
-        // live branch above is: the active buffer is still the terminal while
-        // the user is off in the file explorer, so "the active buffer is a
-        // terminal" alone would forward the explorer's own keys to the PTY.
-        // That is exactly what happened to Enter — it dived into the shell,
-        // which then took focus back, instead of opening the selected entry —
-        // and to Tab, Backspace and every plain character. `focused_terminal_live`
-        // fixed the same class for the live branch (issue #2029); this is the
-        // scroll-back branch, which the gate never reached.
+        // The focus gate matters because the active buffer is still the
+        // terminal while the user is off in the file explorer — without it
+        // Enter and every other plain key went to the PTY from under the
+        // explorer. Issue #2029 was the same class, on the live branch above.
         if self.active_window().editor_pane_owns_keyboard()
             && self
                 .active_window()

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2906,21 +2906,9 @@ impl Window {
         self.key_context == crate::input::keybindings::KeyContext::Terminal
     }
 
-    /// Whether the **editor pane** owns the keyboard, as opposed to a
-    /// persistent chrome region beside it (the file explorer) or a plugin
-    /// panel that has claimed keys through a `Mode` context.
-    ///
-    /// The distinction matters for anything that reaches for the active
-    /// buffer to decide where a keystroke goes: the active buffer stays the
-    /// terminal while the user is off in the explorer, so "the active buffer
-    /// is a terminal" on its own is never enough to justify sending a key to
-    /// its PTY. [`Window::focused_terminal_live`] is the narrower "…and it is
-    /// live" case; this is the wider gate every other terminal-input path
-    /// needs (issues #2029 and the Enter-into-the-shell follow-up).
-    ///
-    /// Overlays that own the keyboard (prompts, popups, menus, the dock,
-    /// modals) never reach these paths — `presents_blocking_overlay` stops
-    /// them earlier — so the editor-pane contexts are the whole allowlist.
+    /// Whether the editor pane owns the keyboard, rather than the file
+    /// explorer or a plugin panel beside it. Keyboard-owning overlays are
+    /// turned away before the callers of this, so these two are the whole set.
     pub fn editor_pane_owns_keyboard(&self) -> bool {
         use crate::input::keybindings::KeyContext;
         matches!(self.key_context, KeyContext::Normal | KeyContext::Terminal)

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2906,6 +2906,26 @@ impl Window {
         self.key_context == crate::input::keybindings::KeyContext::Terminal
     }
 
+    /// Whether the **editor pane** owns the keyboard, as opposed to a
+    /// persistent chrome region beside it (the file explorer) or a plugin
+    /// panel that has claimed keys through a `Mode` context.
+    ///
+    /// The distinction matters for anything that reaches for the active
+    /// buffer to decide where a keystroke goes: the active buffer stays the
+    /// terminal while the user is off in the explorer, so "the active buffer
+    /// is a terminal" on its own is never enough to justify sending a key to
+    /// its PTY. [`Window::focused_terminal_live`] is the narrower "…and it is
+    /// live" case; this is the wider gate every other terminal-input path
+    /// needs (issues #2029 and the Enter-into-the-shell follow-up).
+    ///
+    /// Overlays that own the keyboard (prompts, popups, menus, the dock,
+    /// modals) never reach these paths — `presents_blocking_overlay` stops
+    /// them earlier — so the editor-pane contexts are the whole allowlist.
+    pub fn editor_pane_owns_keyboard(&self) -> bool {
+        use crate::input::keybindings::KeyContext;
+        matches!(self.key_context, KeyContext::Normal | KeyContext::Terminal)
+    }
+
     /// Clear the visual search overlays for the active buffer,
     /// preserving search state so F3/Shift+F3 still work.
     pub fn clear_search_overlays(&mut self) {

--- a/crates/fresh-editor/src/input/command_registry.rs
+++ b/crates/fresh-editor/src/input/command_registry.rs
@@ -265,9 +265,10 @@ impl CommandRegistry {
             }
 
             // Focus-independent actions stay available even when the keyboard
-            // is owned by a non-editing surface. A terminal (or the explorer /
-            // dock / a plugin mode) still lets these actions run from their
-            // keybinding — `is_terminal_ui_action` is exactly that allowlist.
+            // is owned by a non-editing surface. The wider allowlist is
+            // deliberate: the palette runs the action itself instead of routing
+            // a key through that surface, so even the explorer commands a
+            // focused terminal keeps for the shell are runnable here.
             // Greying the same command out in the palette contradicted the
             // keymap: Alt+` opened a dock terminal from a focused terminal
             // while the palette refused "Open Terminal in Utility Dock".
@@ -283,7 +284,7 @@ impl CommandRegistry {
                 && (matches!(current_context, KeyContext::Terminal)
                     || current_context.allows_ui_fallthrough())
             {
-                return crate::input::keybindings::KeybindingResolver::is_terminal_ui_action(
+                return crate::input::keybindings::KeybindingResolver::is_ui_fallthrough_action(
                     &cmd.action,
                 );
             }

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -281,7 +281,7 @@ impl KeyContext {
 
     /// Whether this context should allow Normal-context bindings to fall
     /// through when the action is in the curated UI / navigation set
-    /// (`is_terminal_ui_action`): tab/buffer switching, split navigation,
+    /// (`is_ui_fallthrough_action`): tab/buffer switching, split navigation,
     /// palette, settings, etc. These actions don't depend on a text cursor
     /// and naturally apply to whichever buffer is currently active, so
     /// users expect them to work even when keyboard focus is elsewhere
@@ -289,7 +289,7 @@ impl KeyContext {
     ///
     /// Also true for plugin `Mode(_)` contexts so that focus inside a
     /// panel (search/replace, dashboard, git log, …) doesn't swallow
-    /// global navigation keys. `is_terminal_ui_action` is the curated
+    /// global navigation keys. `is_ui_fallthrough_action` is the curated
     /// whitelist (split nav, palette, save, quit, help, …) — none of
     /// which a sensible plugin mode would want to suppress. See §18 of
     /// `docs/internal/search-replace-scope-replan-on-widgets.md`.
@@ -1967,64 +1967,88 @@ impl KeybindingResolver {
         )
     }
 
-    /// Check if an action is a UI action that should work in terminal mode
-    /// (without keyboard capture). These are general navigation and UI actions
-    /// that don't involve text editing.
-    pub fn is_terminal_ui_action(action: &Action) -> bool {
+    fn is_global_ui_action(action: &Action) -> bool {
         matches!(
             action,
-            // Global UI actions
             Action::CommandPalette
                 | Action::QuickOpen
                 | Action::QuickOpenBuffers
                 | Action::QuickOpenFiles
                 | Action::OpenLiveGrep
                 | Action::ResumeLiveGrep
+                | Action::CycleLiveGrepProvider
                 | Action::ToggleUtilityDock
                 | Action::OpenTerminalInDock
                 | Action::ToggleDockFocus
-                | Action::CycleLiveGrepProvider
                 | Action::OpenSettings
                 | Action::MenuActivate
                 | Action::MenuOpen(_)
+                | Action::ToggleMenuBar
                 | Action::ShowHelp
                 | Action::ShowKeyboardShortcuts
                 | Action::Quit
                 | Action::ForceQuit
-                // Split navigation
-                | Action::NextSplit
+        )
+    }
+
+    fn is_layout_navigation_action(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::NextSplit
                 | Action::PrevSplit
-                // Pane navigation (cycle through all splits + tabs)
                 | Action::NextPane
                 | Action::PrevPane
-                // Window navigation
                 | Action::NextWindow
                 | Action::PrevWindow
                 | Action::SplitHorizontal
                 | Action::SplitVertical
                 | Action::CloseSplit
                 | Action::ToggleMaximizeSplit
-                // Tab/buffer navigation
                 | Action::NextBuffer
                 | Action::PrevBuffer
                 | Action::Close
                 | Action::CloseTab
                 | Action::ScrollTabsLeft
                 | Action::ScrollTabsRight
-                // Terminal control
-                | Action::TerminalEscape
+        )
+    }
+
+    fn is_terminal_control_action(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::TerminalEscape
                 | Action::ToggleKeyboardCapture
                 | Action::OpenTerminal
                 | Action::OpenTerminalRight
                 | Action::OpenTerminalBelow
                 | Action::CloseTerminal
                 | Action::TerminalPaste
-                // File explorer
-                | Action::ToggleFileExplorer
-                | Action::ToggleFileExplorerSide
-                // Menu bar
-                | Action::ToggleMenuBar
         )
+    }
+
+    /// Its own group because its default keys are readline's: Ctrl+B is
+    /// backward-char, Ctrl+E is end-of-line.
+    fn is_file_explorer_ui_action(action: &Action) -> bool {
+        matches!(
+            action,
+            Action::ToggleFileExplorer | Action::ToggleFileExplorerSide
+        )
+    }
+
+    /// UI actions a focused terminal yields to the editor instead of sending to
+    /// the PTY. `terminal_escape` is among them, so what is left out stays one
+    /// keystroke away rather than unreachable.
+    fn is_terminal_ui_action(action: &Action) -> bool {
+        Self::is_global_ui_action(action)
+            || Self::is_layout_navigation_action(action)
+            || Self::is_terminal_control_action(action)
+    }
+
+    /// Adds the explorer's keys back, for contexts the user looks at rather
+    /// than types into ([`KeyContext::allows_ui_fallthrough`] and the lookups
+    /// that draw keybinding hints).
+    pub fn is_ui_fallthrough_action(action: &Action) -> bool {
+        Self::is_terminal_ui_action(action) || Self::is_file_explorer_ui_action(action)
     }
 
     /// The context chain for a lookup: the context itself, its ancestors
@@ -2247,7 +2271,7 @@ impl KeybindingResolver {
                 if let Some(action) = normal_bindings.get(norm) {
                     if full_fallthrough
                         || Self::is_application_wide_action(action)
-                        || (ui_fallthrough && Self::is_terminal_ui_action(action))
+                        || (ui_fallthrough && Self::is_ui_fallthrough_action(action))
                     {
                         tracing::trace!(
                             "  -> Found action in custom normal bindings (fallthrough): {:?}",
@@ -2263,7 +2287,7 @@ impl KeybindingResolver {
                     if let Some(action) = normal_bindings.get(norm) {
                         if full_fallthrough
                             || Self::is_application_wide_action(action)
-                            || (ui_fallthrough && Self::is_terminal_ui_action(action))
+                            || (ui_fallthrough && Self::is_ui_fallthrough_action(action))
                         {
                             tracing::trace!(
                                 "  -> Found action in default normal bindings (fallthrough): {:?}",
@@ -2340,8 +2364,9 @@ impl KeybindingResolver {
     }
 
     /// Resolve a key event to a UI action for terminal mode.
-    /// Only returns actions that are classified as UI actions (is_terminal_ui_action).
-    /// Returns Action::None if the key doesn't map to a UI action.
+    /// Only returns actions the terminal yields to the editor
+    /// ([`Self::is_terminal_ui_action`]).
+    /// Returns Action::None if the key doesn't map to such an action.
     pub fn resolve_terminal_ui_action(&self, event: &KeyEvent) -> Action {
         let norm = normalize_key(event.code, event.modifiers);
         tracing::trace!(
@@ -3137,7 +3162,7 @@ impl KeybindingResolver {
         if context != KeyContext::Normal
             && (context.allows_normal_fallthrough()
                 || Self::is_application_wide_action(action)
-                || (context.allows_ui_fallthrough() && Self::is_terminal_ui_action(action)))
+                || (context.allows_ui_fallthrough() && Self::is_ui_fallthrough_action(action)))
         {
             // Check custom normal bindings
             if let Some(normal_bindings) = self.bindings.get(&KeyContext::Normal) {
@@ -3445,7 +3470,7 @@ mod tests {
         );
 
         // Ctrl+S is application-wide (covered by `is_application_wide_action`),
-        // but also `is_terminal_ui_action`-true — verify the UI fallthrough
+        // but also `is_ui_fallthrough_action`-true — verify the UI fallthrough
         // path doesn't accidentally exclude it.
         let ctrl_s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
         assert_eq!(
@@ -3456,7 +3481,7 @@ mod tests {
 
         // Editing actions on the source buffer must NOT pass through.
         // Ctrl+D (add cursor next match) is editor-only and absent from
-        // `is_terminal_ui_action`.
+        // `is_ui_fallthrough_action`.
         let ctrl_d = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL);
         assert_ne!(
             resolver.resolve(&ctrl_d, mode_ctx),

--- a/crates/fresh-editor/tests/e2e/explorer_focus_terminal_keys.rs
+++ b/crates/fresh-editor/tests/e2e/explorer_focus_terminal_keys.rs
@@ -1,16 +1,6 @@
-//! The file explorer keeps its keys when a terminal is the active buffer.
+//! The file explorer and a focused terminal each keep their own keys.
 //!
-//! `dispatch_terminal_input`'s scroll-back branch used to forward any plain
-//! key — Enter, Tab, Backspace, every character — to the PTY whenever the
-//! *active buffer* was a terminal, without asking who actually owns the
-//! keyboard. The active buffer stays the terminal while the user is off in
-//! the file explorer, so pressing Enter there dived into the shell (which
-//! then took focus back) instead of acting on the selected entry. Issue #2029
-//! fixed the same class for the *live* branch of that dispatch; this is the
-//! scroll-back branch, which the gate never reached.
-//!
-//! Per CONTRIBUTING.md §2 every assertion is on rendered output: the menu bar,
-//! the explorer's selection glyph, its expand/collapse arrows, and the tree.
+//! Assertions are on rendered output only (CONTRIBUTING.md §2).
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -18,10 +8,8 @@ use portable_pty::{native_pty_system, PtySize};
 use std::fs;
 use std::path::PathBuf;
 
-/// How many columns the explorer panel occupies at the width these tests use.
-/// Screen rows are truncated to this before being searched, so only the
-/// explorer's own cells can match — the editor and terminal panes beside it
-/// draw block glyphs and file names of their own.
+/// Rows are cropped to this before searching, so the panes beside the
+/// explorer cannot match.
 const EXPLORER_COLS: usize = 40;
 
 fn pty_available() -> bool {
@@ -35,18 +23,13 @@ fn pty_available() -> bool {
         .is_ok()
 }
 
-/// Whether the file explorer owns the keyboard, read off the menu bar: the
-/// `Explorer` menu is offered only while it does.
-///
-/// The explorer's selection glyph is deliberately *not* the signal here — it
-/// is a block character a shell cursor also paints, so a whole-screen search
-/// for it can match the terminal pane instead.
+/// The `Explorer` menu is offered only while the explorer owns the keyboard.
+/// Its selection glyph is not usable for this — a shell cursor paints the same
+/// block character.
 fn explorer_has_focus(harness: &EditorTestHarness) -> bool {
     harness.get_menu_bar().contains("Explorer")
 }
 
-/// Everything the explorer panel itself has drawn, with the panes beside it
-/// cropped away.
 fn explorer_text(harness: &EditorTestHarness) -> String {
     harness
         .screen_to_string()
@@ -56,7 +39,6 @@ fn explorer_text(harness: &EditorTestHarness) -> String {
         .join("\n")
 }
 
-/// The explorer's selected row — the one carrying its selection glyph.
 fn selected_explorer_row(harness: &EditorTestHarness) -> Option<String> {
     explorer_text(harness)
         .lines()
@@ -64,13 +46,10 @@ fn selected_explorer_row(harness: &EditorTestHarness) -> Option<String> {
         .map(|left| left.to_string())
 }
 
-/// A project whose root holds a directory (`nested`, itself holding
-/// `inner_file.txt`) and a loose file, under a per-test temp workdir
-/// (CONTRIBUTING.md §4).
 fn setup_project() -> (tempfile::TempDir, PathBuf) {
     let temp = tempfile::TempDir::new().unwrap();
-    // Canonicalize: on macOS a tempdir is a symlink into `/private/var`, and
-    // the editor stores the resolved path.
+    // On macOS a tempdir is a symlink into `/private/var`; the editor stores
+    // the resolved path.
     let root = fs::canonicalize(temp.path()).unwrap();
     fs::create_dir(root.join("nested")).unwrap();
     fs::write(root.join("nested/inner_file.txt"), "inner\n").unwrap();
@@ -78,12 +57,8 @@ fn setup_project() -> (tempfile::TempDir, PathBuf) {
     (temp, root)
 }
 
-/// Open the explorer, then a terminal to the right of it. Leaves the terminal
-/// focused with the terminal buffer active, which is the state both tests
-/// start their real work from.
-///
-/// No file is opened, so the explorer's selection sits where it starts: on
-/// the project root, the top row, with `nested` directly below it.
+/// Leaves the terminal focused, with no file open so the explorer's selection
+/// starts on the root row and `nested` sits directly below it.
 fn harness_with_explorer_and_terminal(root: &PathBuf) -> EditorTestHarness {
     let mut harness = EditorTestHarness::with_working_dir(140, 36, root.clone()).unwrap();
     harness.render().unwrap();
@@ -93,41 +68,23 @@ fn harness_with_explorer_and_terminal(root: &PathBuf) -> EditorTestHarness {
         .unwrap();
     harness.wait_for_file_explorer_item("nested").unwrap();
 
-    // The terminal takes focus, so from here on the active buffer is a
-    // terminal even once focus moves elsewhere — the whole point of these
-    // regressions. Losing the `Explorer` menu is the rendered signal that the
-    // handover happened.
     harness
         .run_palette_command("Open Terminal to the Right")
         .unwrap();
-    // Settle, not just observe: the shell's first prompt and the split's
-    // first paints land asynchronously after the palette command returns, and
-    // a focus handover racing them was enough to pull the keyboard back off
-    // the explorer mid-test. Waiting for the screen to stop changing as well
-    // as for the handover makes the tests' starting state deterministic.
+    // Stable, not just observed: the shell's first prompt lands after the
+    // command returns, and a focus handover racing it pulled the keyboard back
+    // off the explorer mid-test.
     harness
         .wait_until_stable(|h| !explorer_has_focus(h))
         .unwrap();
     harness
 }
 
-/// With the explorer focused, step the selection onto the collapsed `nested`
-/// directory and press Enter: the explorer must expand it.
-///
-/// Both steps are checked on the frame they happen in, with no waiting, so
-/// the broken case fails outright instead of blocking:
-///
-/// * The Down step doubles as the focus check. The explorer only moves its
-///   selection while it owns the keyboard, so a rendered selection on
-///   `nested` proves focus is there — and Down is not a key either bug
-///   affects (neither is "plain"), so it cannot mask what Enter does next.
-/// * Expanding is synchronous, so `inner_file.txt` is on screen in the same
-///   frame as the Enter. If the key had gone to the shell, `nested` would
-///   still be collapsed.
-///
-/// Focus is deliberately not asserted *after* Enter: acting on a directory
-/// row hands the keyboard back to the editor either way, which is existing
-/// behaviour and says nothing about where the key went.
+/// Down doubles as the focus check — the explorer only moves its selection
+/// while it owns the keyboard, and arrow keys are unaffected by the bug.
+/// Expanding is synchronous, so neither step waits and the broken case fails
+/// rather than blocking. Focus after Enter proves nothing: acting on a
+/// directory row hands the keyboard back either way.
 fn assert_enter_expands_nested(harness: &mut EditorTestHarness) {
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
@@ -158,11 +115,8 @@ fn assert_enter_expands_nested(harness: &mut EditorTestHarness) {
     );
 }
 
-/// Enter in a focused file explorer acts on the explorer, even when the buffer
-/// behind it is a live terminal. Focus is handed back with the mouse here.
-///
-/// Fails without the dispatch gate: Enter reaches the shell instead, the
-/// explorer loses focus in the same frame, and `nested` stays collapsed.
+/// Without the dispatch gate, Enter reaches the shell and `nested` stays
+/// collapsed.
 #[test]
 #[cfg(not(windows))] // spawns a PTY-backed shell
 fn enter_acts_on_the_explorer_after_clicking_back_into_it() {
@@ -173,10 +127,87 @@ fn enter_acts_on_the_explorer_after_clicking_back_into_it() {
     let (_temp, root) = setup_project();
     let mut harness = harness_with_explorer_and_terminal(&root);
 
-    // Hand focus back to the explorer with the mouse, clicking empty space
-    // below the tree so the click itself activates nothing.
+    // Empty space below the tree, so the click itself activates nothing.
     harness.mouse_click(20, 12).unwrap();
     harness.wait_until(explorer_has_focus).unwrap();
 
     assert_enter_expands_nested(&mut harness);
+}
+
+/// `/bin/cat` as the shell keeps this off the platform's line editor: with no
+/// readline in the way the tty echoes the control bytes as `^B` / `^E`, which
+/// is what proves they reached the PTY.
+///
+/// Only the Ctrl+B half fails without the fix; Ctrl+E is asserted as a guard
+/// against putting `FocusFileExplorer` back on the terminal's allowlist.
+#[test]
+#[cfg(not(windows))] // spawns a PTY and asserts on tty control-char echo
+fn ctrl_b_and_ctrl_e_reach_the_shell_when_the_terminal_is_focused() {
+    if !pty_available() {
+        eprintln!("Skipping: PTY not available in this environment");
+        return;
+    }
+    let shell = "/bin/cat";
+    if !std::path::Path::new(shell).exists() {
+        eprintln!("Skipping: {shell} not available");
+        return;
+    }
+
+    let (_temp, root) = setup_project();
+    let mut config = fresh::config::Config::default();
+    config.terminal.shell = Some(fresh::config::TerminalShellConfig {
+        command: shell.to_string(),
+        args: Vec::new(),
+    });
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(140, 36, config, root.clone()).unwrap();
+    harness.render().unwrap();
+
+    // The explorer stays closed, so its panel appearing means a key was stolen.
+    harness
+        .run_palette_command("Open Terminal to the Right")
+        .unwrap();
+    harness.type_text("abc").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("abc"))
+        .unwrap();
+
+    harness
+        .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+    // Resolves under either behaviour, so it gates rather than only ending
+    // when the test passes.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("^B") || screen.contains("File Explorer")
+        })
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("File Explorer"),
+        "Ctrl+B must not open the file explorer while a terminal is focused — \
+         it is the shell's backward-char.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("^B"),
+        "Ctrl+B must reach the terminal's PTY.\nScreen:\n{screen}"
+    );
+
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("^E") || explorer_has_focus(h))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !explorer_has_focus(&harness),
+        "Ctrl+E must not move focus to the file explorer while a terminal is \
+         focused — it is the shell's end-of-line.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("^E"),
+        "Ctrl+E must reach the terminal's PTY.\nScreen:\n{screen}"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/explorer_focus_terminal_keys.rs
+++ b/crates/fresh-editor/tests/e2e/explorer_focus_terminal_keys.rs
@@ -1,0 +1,182 @@
+//! The file explorer keeps its keys when a terminal is the active buffer.
+//!
+//! `dispatch_terminal_input`'s scroll-back branch used to forward any plain
+//! key — Enter, Tab, Backspace, every character — to the PTY whenever the
+//! *active buffer* was a terminal, without asking who actually owns the
+//! keyboard. The active buffer stays the terminal while the user is off in
+//! the file explorer, so pressing Enter there dived into the shell (which
+//! then took focus back) instead of acting on the selected entry. Issue #2029
+//! fixed the same class for the *live* branch of that dispatch; this is the
+//! scroll-back branch, which the gate never reached.
+//!
+//! Per CONTRIBUTING.md §2 every assertion is on rendered output: the menu bar,
+//! the explorer's selection glyph, its expand/collapse arrows, and the tree.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use portable_pty::{native_pty_system, PtySize};
+use std::fs;
+use std::path::PathBuf;
+
+/// How many columns the explorer panel occupies at the width these tests use.
+/// Screen rows are truncated to this before being searched, so only the
+/// explorer's own cells can match — the editor and terminal panes beside it
+/// draw block glyphs and file names of their own.
+const EXPLORER_COLS: usize = 40;
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// Whether the file explorer owns the keyboard, read off the menu bar: the
+/// `Explorer` menu is offered only while it does.
+///
+/// The explorer's selection glyph is deliberately *not* the signal here — it
+/// is a block character a shell cursor also paints, so a whole-screen search
+/// for it can match the terminal pane instead.
+fn explorer_has_focus(harness: &EditorTestHarness) -> bool {
+    harness.get_menu_bar().contains("Explorer")
+}
+
+/// Everything the explorer panel itself has drawn, with the panes beside it
+/// cropped away.
+fn explorer_text(harness: &EditorTestHarness) -> String {
+    harness
+        .screen_to_string()
+        .lines()
+        .map(|line| line.chars().take(EXPLORER_COLS).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The explorer's selected row — the one carrying its selection glyph.
+fn selected_explorer_row(harness: &EditorTestHarness) -> Option<String> {
+    explorer_text(harness)
+        .lines()
+        .find(|left| left.contains('▌'))
+        .map(|left| left.to_string())
+}
+
+/// A project whose root holds a directory (`nested`, itself holding
+/// `inner_file.txt`) and a loose file, under a per-test temp workdir
+/// (CONTRIBUTING.md §4).
+fn setup_project() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::TempDir::new().unwrap();
+    // Canonicalize: on macOS a tempdir is a symlink into `/private/var`, and
+    // the editor stores the resolved path.
+    let root = fs::canonicalize(temp.path()).unwrap();
+    fs::create_dir(root.join("nested")).unwrap();
+    fs::write(root.join("nested/inner_file.txt"), "inner\n").unwrap();
+    fs::write(root.join("alpha.txt"), "alpha\n").unwrap();
+    (temp, root)
+}
+
+/// Open the explorer, then a terminal to the right of it. Leaves the terminal
+/// focused with the terminal buffer active, which is the state both tests
+/// start their real work from.
+///
+/// No file is opened, so the explorer's selection sits where it starts: on
+/// the project root, the top row, with `nested` directly below it.
+fn harness_with_explorer_and_terminal(root: &PathBuf) -> EditorTestHarness {
+    let mut harness = EditorTestHarness::with_working_dir(140, 36, root.clone()).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_file_explorer_item("nested").unwrap();
+
+    // The terminal takes focus, so from here on the active buffer is a
+    // terminal even once focus moves elsewhere — the whole point of these
+    // regressions. Losing the `Explorer` menu is the rendered signal that the
+    // handover happened.
+    harness
+        .run_palette_command("Open Terminal to the Right")
+        .unwrap();
+    // Settle, not just observe: the shell's first prompt and the split's
+    // first paints land asynchronously after the palette command returns, and
+    // a focus handover racing them was enough to pull the keyboard back off
+    // the explorer mid-test. Waiting for the screen to stop changing as well
+    // as for the handover makes the tests' starting state deterministic.
+    harness
+        .wait_until_stable(|h| !explorer_has_focus(h))
+        .unwrap();
+    harness
+}
+
+/// With the explorer focused, step the selection onto the collapsed `nested`
+/// directory and press Enter: the explorer must expand it.
+///
+/// Both steps are checked on the frame they happen in, with no waiting, so
+/// the broken case fails outright instead of blocking:
+///
+/// * The Down step doubles as the focus check. The explorer only moves its
+///   selection while it owns the keyboard, so a rendered selection on
+///   `nested` proves focus is there — and Down is not a key either bug
+///   affects (neither is "plain"), so it cannot mask what Enter does next.
+/// * Expanding is synchronous, so `inner_file.txt` is on screen in the same
+///   frame as the Enter. If the key had gone to the shell, `nested` would
+///   still be collapsed.
+///
+/// Focus is deliberately not asserted *after* Enter: acting on a directory
+/// row hands the keyboard back to the editor either way, which is existing
+/// behaviour and says nothing about where the key went.
+fn assert_enter_expands_nested(harness: &mut EditorTestHarness) {
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let before = selected_explorer_row(harness).unwrap_or_else(|| {
+        panic!(
+            "the explorer should have moved its selection down onto `nested`, \
+             which it only does while it owns the keyboard.\nExplorer:\n{}",
+            explorer_text(harness)
+        )
+    });
+    assert!(
+        before.contains("nested") && before.contains('>'),
+        "expected the selection on a collapsed `nested`.\nRow: {before:?}\nExplorer:\n{}",
+        explorer_text(harness)
+    );
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        explorer_text(harness).contains("inner_file.txt"),
+        "Enter must reach the file explorer and expand `nested` — a terminal \
+         being the active buffer behind the explorer is not a reason to send \
+         the explorer's keys to the shell.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Enter in a focused file explorer acts on the explorer, even when the buffer
+/// behind it is a live terminal. Focus is handed back with the mouse here.
+///
+/// Fails without the dispatch gate: Enter reaches the shell instead, the
+/// explorer loses focus in the same frame, and `nested` stays collapsed.
+#[test]
+#[cfg(not(windows))] // spawns a PTY-backed shell
+fn enter_acts_on_the_explorer_after_clicking_back_into_it() {
+    if !pty_available() {
+        eprintln!("Skipping: PTY not available in this environment");
+        return;
+    }
+    let (_temp, root) = setup_project();
+    let mut harness = harness_with_explorer_and_terminal(&root);
+
+    // Hand focus back to the explorer with the mouse, clicking empty space
+    // below the tree so the click itself activates nothing.
+    harness.mouse_click(20, 12).unwrap();
+    harness.wait_until(explorer_has_focus).unwrap();
+
+    assert_enter_expands_nested(&mut harness);
+}

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -366,7 +366,7 @@ fn test_palette_runs_focus_independent_command_while_explorer_focused() {
     );
 
     // And a command whose keybinding already falls through to the explorer
-    // (`is_terminal_ui_action`) is no longer greyed out in the palette either.
+    // (`is_ui_fallthrough_action`) is no longer greyed out in the palette either.
     let screen = run_from_palette(&mut harness, "Toggle Utility Dock");
     assert!(
         screen.contains("No Utility Dock open"),

--- a/crates/fresh-editor/tests/e2e/issue_2029_file_explorer_terminal_focus.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2029_file_explorer_terminal_focus.rs
@@ -123,20 +123,18 @@ fn click_in_explorer_while_terminal_active_keeps_focus_on_explorer() {
     fs::write(project.join("alpha.txt"), "ALPHA_FILE_CONTENT\n").unwrap();
     fs::write(project.join("beta.txt"), "BETA_FILE_CONTENT\n").unwrap();
 
-    // Wait for the terminal tab to render before sending any keys —
-    // without this gate, on heavily-loaded CI the Ctrl+B can race
-    // ahead of the terminal's async setup.
-    harness.editor_mut().open_terminal();
-    harness.wait_for_screen_contains("*Terminal 0*").unwrap();
-
-    // Open the file explorer and wait for both target files to
-    // render so the click lands against a settled tree.
+    // Explorer first: Ctrl+B belongs to the shell once a terminal has focus,
+    // so it cannot be used to open the explorer from one. Wait for both target
+    // files so the click later lands against a settled tree.
     harness
         .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
         .unwrap();
     harness.wait_for_file_explorer().unwrap();
     harness.wait_for_file_explorer_item("alpha.txt").unwrap();
     harness.wait_for_file_explorer_item("beta.txt").unwrap();
+
+    harness.editor_mut().open_terminal();
+    harness.wait_for_screen_contains("*Terminal 0*").unwrap();
 
     // Single-click alpha.txt. Wait for the preview to render so the
     // next keypress is observed against a settled UI.

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -39,6 +39,7 @@ pub mod emacs_actions;
 pub mod encoding;
 pub mod explorer_bugs;
 pub mod explorer_context_menu;
+pub mod explorer_focus_terminal_keys;
 pub mod explorer_menu;
 pub mod external_file_save_as_tab;
 pub mod extract_tab_to_workspace;


### PR DESCRIPTION
Two directions of the same confusion between the file explorer and a terminal, each reproduced by hand under tmux before and after the fix.

> **Edit:** an earlier revision of the second commit did the opposite of what it does now — it made `Ctrl+E` reach the *explorer* from a live terminal. That was wrong: `Ctrl+B` and `Ctrl+E` are readline keys and belong to the shell. It has been replaced, along with the explorer title-hint change that only existed as its fallout.

## 1. The explorer's keys were typed into the shell

With a terminal open beside the editor: click into the explorer, select a collapsed directory, press Enter. The directory stayed collapsed, the explorer's focus marker vanished, and a **second shell prompt** appeared — the Enter had been typed into the shell, which then took focus back. Arrow keys worked, so the explorer could be navigated but never used.

`dispatch_terminal_input` has two branches:

| branch | purpose | focus gate |
|---|---|---|
| live terminal | forward keys to the PTY | `focused_terminal_live()` — false in any non-editor context (issue #2029) |
| scroll-back re-entry | a plain key dives back into a terminal showing read-only scroll-back | **none** — only "is the active buffer a terminal?" |

Focus moving to the explorer does not change the active buffer, so the second branch forwarded everything `should_enter_terminal_mode` calls plain — Enter, Tab, Backspace and every character — from under the explorer's feet. Same class as #2029, one branch over.

The gate is the missing half of a pair rather than a new condition, so it sits next to its sibling as `Window::editor_pane_owns_keyboard()`. Overlays that own the keyboard are already turned away by `presents_blocking_overlay` before either branch runs, so the editor-pane contexts are the whole allowlist and the predicate stays positive rather than naming the file explorer as an exception (CONTRIBUTING.md §9).

## 2. The shell's keys were taken by the explorer

The other direction, and the worse of the two. In a focused terminal, typing `abc` then `Ctrl+B` then `X` should leave `abXc` — `Ctrl+B` is backward-char. Instead it **opened the file explorer**. `Ctrl+E` (end-of-line) **focused** it, after which the next character typed went into the explorer's *search box*:

```
before:  ┌ /Z ────────────────────×─┐      ← `Z` landed in the explorer's search
after:   root@vm:/tmp/proj# abXcZ          ← both keys reached the shell
```

`is_terminal_ui_action` named one list serving two different questions. The terminal asked it "which keys do I give up?", but so did the `FileExplorer` / `Dock` / plugin-`Mode` fallthrough in `resolve`, the keybinding lookups that draw hints, and the palette's enablement check. Those contexts are chrome the user is looking at rather than typing into, so a UI key belongs to the editor there — including the explorer's own. Only the terminal needs a narrower answer.

So the list is split into the groups its comments already described, and the two questions get a name each — composed from those groups rather than expressed as "the other one minus some exceptions":

```rust
is_terminal_ui_action    = global_ui + layout_navigation + terminal_control
is_ui_fallthrough_action = is_terminal_ui_action + file_explorer_ui
```

`is_terminal_ui_action` keeps its name and now means what it says, since `resolve_terminal_ui_action` is its only caller. Everyone else moves to `is_ui_fallthrough_action`, named for the thing it gates (`KeyContext::allows_ui_fallthrough`). Adding an action means putting it in the group it belongs to instead of remembering to subtract it somewhere. The split is behaviour-preserving by construction — the four groups' union is the identical 43-action set, checked mechanically rather than by eye.

The palette keeps the wider set deliberately: it runs the action itself rather than routing a key through the focused surface, so the explorer commands stay runnable — and un-greyed — from a focused terminal.

Nothing becomes unreachable by key either: `terminal_escape` is in the terminal-control group, so `Ctrl+Space` still leaves terminal mode, after which both keys work as before. Closing the explorer with `Ctrl+B` while it is *focused* is unaffected too — that path has its own explicit binding in the `file_explorer` context rather than relying on the fallthrough.

### One existing test changed with it

`issue_2029_file_explorer_terminal_focus::click_in_explorer_while_terminal_active_keeps_focus_on_explorer` opened a terminal and then used `Ctrl+B` to open the explorer *from* it — the behaviour this commit removes — so it hung waiting for a panel that never appeared. Its setup now opens the explorer first and the terminal second, which leaves what it actually tests (clicking a file in the explorer while a terminal is the active buffer) untouched. It was the only one of the 30 `Ctrl+B` / `Ctrl+E` presses in the suite with a terminal focused; the rest are in `Normal` context.

## Tests

`crates/fresh-editor/tests/e2e/explorer_focus_terminal_keys.rs`, driving keyboard and mouse and asserting **only on rendered output** (CONTRIBUTING.md §2).

- `enter_acts_on_the_explorer_after_clicking_back_into_it` — covers 1. The `Down` step doubles as the focus check (the explorer only moves its selection while it owns the keyboard, and arrow keys are affected by neither bug), and expansion is synchronous, so `inner_file.txt` is on screen in the same frame as the Enter.
- `ctrl_b_and_ctrl_e_reach_the_shell_when_the_terminal_is_focused` — covers 2. The shell is overridden to `/bin/cat` so the assertion does not depend on which line editor the platform's login shell uses: with no readline in the way, the tty's own echo renders the control bytes as `^B` and `^E`, direct evidence they reached the PTY. Its waits resolve under *either* behaviour — the echo if the byte reached the PTY, the explorer panel if the editor claimed the key — so they gate rather than only ending when the test passes.

No timeouts or time-based waits (§3); per-test `tempfile::TempDir` workdir, PTY-availability skip and `#[cfg(not(windows))]` for the PTY-backed shell (§4).

**Verified in both directions** (CONTRIBUTING.md §1), reverting one fix at a time:

| build | `enter_acts_…` | `ctrl_b_and_ctrl_e_…` |
|---|---|---|
| both fixes | pass | pass |
| dispatch gate reverted | **fail** | pass |
| terminal-yields fix reverted | pass | **fail** (`Ctrl+B must not open the file explorer…`) |

Only the `Ctrl+B` half of the second test fails without its fix — `Ctrl+E` is already forwarded on `master`. It is asserted anyway because putting `FocusFileExplorer` on the terminal's allowlist is a specific mistake worth a guard; an earlier revision of this PR made exactly that mistake.

Also green locally: `issue_2029`, `issue_1569`, `file_explorer` (78 tests) and this module, plus the 397 input/keybinding unit tests.

## Checks

`cargo check --all-targets`, `cargo fmt --all -- --check` and `cargo clippy --all-targets` clean on both commits.