### PR TITLE
feat(install): integrate the musl archive's desktop entry and icons

### DIFF
--- a/.github/workflows/musl-builds.yml
+++ b/.github/workflows/musl-builds.yml
@@ -67,8 +67,14 @@ jobs:
           ARCHIVE_NAME="fresh-editor-${{ matrix.target }}"
           mkdir -p "${ARCHIVE_NAME}"
           cp target/${{ matrix.target }}/release/fresh "${ARCHIVE_NAME}/"
-          cp README.md LICENSE "${ARCHIVE_NAME}/" 2>/dev/null || true
+          # LICENSE ships because the archive redistributes a binary. README
+          # does not: self-update swaps the binary alone, so a copy in here
+          # would sit frozen at whatever version was first installed.
+          cp LICENSE "${ARCHIVE_NAME}/" 2>/dev/null || true
           # Plugins/themes are embedded in the binary; no on-disk copy needed.
+          # The icon theme and desktop entry are the same files the .deb and
+          # .rpm install; install.sh copies them into the XDG data dirs, which
+          # is the only reason they are worth carrying.
           cp -r docs/icons/linux/hicolor "${ARCHIVE_NAME}/icons" 2>/dev/null || true
           cp crates/fresh-editor/resources/fresh.desktop "${ARCHIVE_NAME}/fresh.desktop" 2>/dev/null || true
 
@@ -104,6 +110,21 @@ jobs:
             || { echo "::error::musl archive receipt is not channel=tarball"; exit 1; }
           echo "$receipt" | grep -q 'self_update = true' \
             || { echo "::error::musl archive receipt is not self_update=true"; exit 1; }
+
+      - name: Verify the archive carries the desktop entry and icons
+        run: |
+          # Every `cp` above is `|| true`, so a rename under docs/icons or
+          # resources/ would drop these silently — and this is now the default
+          # Linux install, the one whose desktop integration install.sh builds
+          # from these files.
+          ARCHIVE_NAME="fresh-editor-${{ matrix.target }}"
+          listing=$(tar -tzf "${ARCHIVE_NAME}.tar.gz")
+          echo "$listing" | grep -q "^${ARCHIVE_NAME}/fresh.desktop\$" \
+            || { echo "::error::musl archive is missing fresh.desktop"; exit 1; }
+          icons=$(echo "$listing" | grep -c "^${ARCHIVE_NAME}/icons/.*/apps/fresh\.png\$" || true)
+          [ "$icons" -ge 9 ] \
+            || { echo "::error::musl archive has $icons icons, expected at least 9"; exit 1; }
+          echo "desktop entry present, $icons icons present"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6

--- a/README.md
+++ b/README.md
@@ -118,9 +118,21 @@ replace itself: `fresh --cmd update` downloads the next release, verifies it
 against both its published checksum and GitHub's release attestation, and swaps
 the binary in place.
 
+The archive also carries the same desktop entry and icon theme the `.deb` and
+`.rpm` install, and the installer copies them into `$XDG_DATA_HOME`
+(`~/.local/share` by default) so Fresh shows up in your application menu. Pass
+`--no-desktop-integration`, or set `FRESH_NO_DESKTOP=1`, to skip that — usually
+what you want on a server or in a container. Every file written outside the
+install directory is listed in
+`~/.local/share/fresh-editor/installed-files.txt`, so re-running the installer
+cleans up after the previous run and uninstalling is `rm` over that list plus
+the install directory and the symlink.
+
 Downloading the archive by hand from the [releases
 page](https://github.com/sinelaw/fresh/releases) works the same way — it ships
-the same install receipt, so a hand-unpacked copy self-updates too.
+the same install receipt, so a hand-unpacked copy self-updates too. Only the
+binary is swapped on update, so the desktop entry and icons are refreshed by
+re-running the installer, not by `fresh --cmd update`.
 
 ### Brew
 

--- a/docs/internal/packaging-self-update.md
+++ b/docs/internal/packaging-self-update.md
@@ -489,6 +489,36 @@ writes the matching receipt (or relies on the package's own packaged receipt).
 Its AppImage branch writes `channel=appimage`, `self_update=true`,
 `install_root=~/.local/share/fresh-editor`.
 
+#### Desktop integration (tarball branch only)
+The musl archive carries `fresh.desktop` and a `hicolor` icon tree — the same
+files `debian/fresh-editor.install` puts in `/usr/share`. Unpacked under
+`INSTALL_DIR` they are inert, because no XDG lookup consults that path, so the
+tarball branch copies them into `$XDG_DATA_HOME/{applications,icons/hicolor}`
+after the move. Three details are load-bearing:
+
+- **`Exec=` is rewritten** to the absolute `$BIN_DIR/fresh`. The shipped entry
+  says `Exec=fresh`, correct for a package that lands in `/usr/bin`; a desktop
+  environment launching the entry frequently does not have `~/.local/bin` on
+  `PATH`.
+- **A manifest** (`$INSTALL_DIR/installed-files.txt`) records every path written
+  outside `INSTALL_DIR`. Everything else the installer creates is one directory
+  plus one symlink; without the manifest these files could not be removed
+  without guessing. The next run prunes what the previous one recorded, and
+  refuses to act on any line that is not one of the two shapes it writes.
+- **Nothing here fails the install.** Missing `$HOME`, an archive built without
+  the assets, an unwritable data dir, absent `update-desktop-database` /
+  `gtk-update-icon-cache`: all warn at most. `--no-desktop-integration` /
+  `FRESH_NO_DESKTOP=1` skips the whole step (still pruning the previous run's
+  files), which is the right default for servers and containers.
+
+Self-update swaps the binary alone (§8), so these files are refreshed by
+re-running `install.sh`, not by `fresh --cmd update`. That is why `README.md` is
+*not* in the archive: it would freeze at the first-installed version. `LICENSE`
+stays, because the archive redistributes a binary.
+
+The AppImage branch deliberately does none of this — its assets live inside the
+extracted AppDir and are its own concern.
+
 ### 7.5 Known limitations
 - **winget / scoop / chocolatey.** These consume the same Windows `.zip` as a
   raw download. winget-pkgs zip installers can't run a post-extract hook, so a

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,19 @@ BIN_NAME="fresh-editor"
 INSTALL_DIR="${FRESH_INSTALL_DIR:-${HOME}/.local/share/fresh-editor}"
 BIN_DIR="${FRESH_BIN_DIR:-${HOME}/.local/bin}"
 
+# 6. Desktop integration for the universal build: the archive ships an icon
+#    theme and a .desktop entry, and unpacking them under INSTALL_DIR puts them
+#    somewhere no XDG lookup consults. Copying them into the XDG data dirs is
+#    what the .deb and .rpm do; set FRESH_NO_DESKTOP=1 (or pass
+#    --no-desktop-integration) to skip it, which is usually what you want on a
+#    server or in a container.
+NO_DESKTOP="${FRESH_NO_DESKTOP:-0}"
+
+# The list of paths written outside INSTALL_DIR, recorded inside it. Without a
+# manifest those files are unremovable without guesswork: everything else the
+# installer creates is one directory plus one symlink.
+MANIFEST_NAME="installed-files.txt"
+
 # ==============================================================================
 #   END CONFIGURATION
 # ==============================================================================
@@ -66,7 +79,7 @@ usage() {
     cat <<EOF
 Fresh Editor installer
 
-Usage: install.sh [--method=METHOD]
+Usage: install.sh [--method=METHOD] [--no-desktop-integration]
 
 Methods:
   auto      (default) universal build on Linux, Homebrew on macOS, Nix on NixOS
@@ -80,15 +93,26 @@ Methods:
   npm       npm install -g
   appimage  AppImage, extracted under ~/.local
 
+Options:
+  --no-desktop-integration
+            do not install the .desktop entry and icon theme into the XDG data
+            dirs (universal build only)
+
 Environment:
   FRESH_INSTALL_METHOD   same as --method
   FRESH_INSTALL_DIR      where the universal build unpacks (default ~/.local/share/fresh-editor)
   FRESH_BIN_DIR          where the 'fresh' symlink goes (default ~/.local/bin)
+  FRESH_NO_DESKTOP       set to 1 for --no-desktop-integration
+  XDG_DATA_HOME          where the desktop entry and icons go (default ~/.local/share)
 
 Notes:
   The universal build updates itself with 'fresh --cmd update'. Distro packages
   delegate updates to the package manager that installed them, which is why
   they are opt-in rather than the default.
+
+  The universal build records every file it writes outside its install
+  directory in <install-dir>/${MANIFEST_NAME}; re-running this script removes
+  what the previous run put there before installing again.
 EOF
 }
 
@@ -100,6 +124,7 @@ for arg in "$@"; do
     case "$arg" in
         --method=*) METHOD="${arg#--method=}" ;;
         --method)   log_error "--method needs a value, e.g. --method=deb" ;;
+        --no-desktop-integration) NO_DESKTOP=1 ;;
         -h|--help)  usage; exit 0 ;;
         *)          log_error "unknown argument: $arg (try --help)" ;;
     esac
@@ -222,6 +247,137 @@ musl_target() {
     esac
 }
 
+xdg_data_home() {
+    if [ -n "${XDG_DATA_HOME:-}" ]; then
+        printf '%s\n' "$XDG_DATA_HOME"
+    elif [ -n "${HOME:-}" ]; then
+        printf '%s\n' "$HOME/.local/share"
+    else
+        return 1
+    fi
+}
+
+# Remove what a previous run of this script installed outside INSTALL_DIR, so a
+# reinstall does not leave an older layout's files orphaned in the XDG tree.
+#
+# Only the two shapes this script writes are honored. A manifest is a plain list
+# of paths in a directory the user owns, so treating it as a list of things to
+# delete unconditionally would turn one bad line — hand-edited, or written by
+# something else that claimed the path — into an arbitrary `rm`. Anything that
+# does not look like a file we placed is skipped and reported.
+prune_recorded_files() {
+    manifest="$INSTALL_DIR/$MANIFEST_NAME"
+    [ -f "$manifest" ] || return 0
+
+    while IFS= read -r recorded; do
+        [ -n "$recorded" ] || continue
+        case "$recorded" in
+            */applications/fresh.desktop)
+                rm -f "$recorded"
+                ;;
+            */icons/hicolor/*/apps/fresh.png)
+                rm -f "$recorded"
+                # Leave no empty size directories behind in a theme tree other
+                # applications share. rmdir refuses a non-empty directory, which
+                # is exactly the check we want.
+                apps_dir=$(dirname "$recorded")
+                if rmdir "$apps_dir" 2>/dev/null; then
+                    rmdir "$(dirname "$apps_dir")" 2>/dev/null || true
+                fi
+                ;;
+            *)
+                log_warn "not removing unexpected entry in $MANIFEST_NAME: $recorded"
+                ;;
+        esac
+    done < "$manifest"
+    return 0
+}
+
+# Copy the archive's .desktop entry and icon theme into the XDG data dirs — the
+# same places the .deb and .rpm install them. Unpacked under INSTALL_DIR they
+# are inert: no desktop environment looks there.
+#
+# Best-effort throughout. A machine with no $HOME, no icons in the archive, or
+# no cache tools installed still gets a working editor, and a failure here must
+# not fail an install that has already succeeded.
+integrate_desktop_files() {
+    if [ "$NO_DESKTOP" = "1" ]; then
+        log_info "Skipping desktop integration (requested)."
+        return 0
+    fi
+
+    DATA_HOME=$(xdg_data_home) || {
+        log_warn "Neither XDG_DATA_HOME nor HOME is set; skipping desktop integration."
+        return 0
+    }
+
+    manifest="$INSTALL_DIR/$MANIFEST_NAME"
+    : > "$manifest" || return 0
+
+    icons_installed=0
+    if [ -d "$INSTALL_DIR/icons" ]; then
+        for size_dir in "$INSTALL_DIR"/icons/*/; do
+            src="${size_dir}apps/fresh.png"
+            [ -f "$src" ] || continue
+            size=$(basename "$size_dir")
+            dest_dir="$DATA_HOME/icons/hicolor/$size/apps"
+            mkdir -p "$dest_dir" 2>/dev/null || continue
+            cp "$src" "$dest_dir/fresh.png" 2>/dev/null || continue
+            printf '%s\n' "$dest_dir/fresh.png" >> "$manifest"
+            icons_installed=$((icons_installed + 1))
+        done
+    fi
+
+    desktop_installed=0
+    if [ -f "$INSTALL_DIR/fresh.desktop" ]; then
+        apps_dir="$DATA_HOME/applications"
+        if mkdir -p "$apps_dir" 2>/dev/null; then
+            # The shipped entry says `Exec=fresh`, which is right for a package
+            # that installs into /usr/bin. Here the binary is reached through a
+            # symlink in ~/.local/bin, and a desktop environment launching the
+            # entry very often does not have that on PATH — so the Exec line is
+            # rewritten to the absolute path we just linked. Arguments after the
+            # program name (the %F field code) are preserved.
+            if FRESH_EXEC_PATH="$BIN_DIR/fresh" awk '
+                /^Exec=/ && !done {
+                    rest = $0
+                    sub(/^Exec=[^ ]*/, "", rest)
+                    print "Exec=" ENVIRON["FRESH_EXEC_PATH"] rest
+                    done = 1
+                    next
+                }
+                { print }
+            ' "$INSTALL_DIR/fresh.desktop" > "$apps_dir/fresh.desktop" 2>/dev/null
+            then
+                printf '%s\n' "$apps_dir/fresh.desktop" >> "$manifest"
+                desktop_installed=1
+            else
+                rm -f "$apps_dir/fresh.desktop"
+                log_warn "Could not write $apps_dir/fresh.desktop."
+            fi
+        fi
+    fi
+
+    # Both caches are optional: a desktop environment reads the directories
+    # directly when they are absent, and neither tool exists on a headless box.
+    if [ "$desktop_installed" -eq 1 ] && check_cmd update-desktop-database; then
+        update-desktop-database "$DATA_HOME/applications" >/dev/null 2>&1 || true
+    fi
+
+    if [ "$icons_installed" -gt 0 ] && check_cmd gtk-update-icon-cache; then
+        gtk-update-icon-cache -q -t -f "$DATA_HOME/icons/hicolor" >/dev/null 2>&1 || true
+    fi
+
+    if [ "$desktop_installed" -eq 1 ] || [ "$icons_installed" -gt 0 ]; then
+        log_success "Desktop entry and $icons_installed icon(s) installed under $DATA_HOME"
+    else
+        # Nothing outside INSTALL_DIR, so nothing to record and nothing for the
+        # next run to clean up.
+        rm -f "$manifest"
+    fi
+    return 0
+}
+
 do_install_tarball() {
     mark_tried tarball
     if [ "$(uname -s)" != "Linux" ]; then
@@ -292,10 +448,14 @@ EOF
 
     log_info "Finalizing installation..."
     mkdir -p "$(dirname "$INSTALL_DIR")" "$BIN_DIR"
+    # Before the manifest goes away with the directory that holds it.
+    prune_recorded_files
     rm -rf "$INSTALL_DIR"
     mv "$STAGED" "$INSTALL_DIR" || log_error "failed to move files to $INSTALL_DIR."
 
     ln -sf "$INSTALL_DIR/fresh" "$BIN_DIR/fresh"
+
+    integrate_desktop_files
 
     case ":$PATH:" in
         *":${BIN_DIR}:"*) ;;


### PR DESCRIPTION
## Why

The musl tarball ships `fresh.desktop` and a `hicolor` icon tree, and `install.sh` unpacked them under `~/.local/share/fresh-editor` — a path no XDG lookup consults. `debian/fresh-editor.install` puts the same files in `/usr/share` and `linux-packages.yml` verifies they landed, so the install we are making the Linux default was the only one carrying desktop assets and then doing nothing with them.

## What changed

### `scripts/install.sh` — tarball branch only

- `integrate_desktop_files()` copies `icons/*/apps/fresh.png` into `$XDG_DATA_HOME/icons/hicolor/<size>/apps/` and `fresh.desktop` into `$XDG_DATA_HOME/applications/`, then refreshes `update-desktop-database` / `gtk-update-icon-cache` when they exist.
- **`Exec=` is rewritten** to the absolute `$BIN_DIR/fresh`. The shipped entry says `Exec=fresh`, correct for a package landing in `/usr/bin`; a desktop environment launching the entry frequently has no `~/.local/bin` on `PATH`. Field codes after the program name (`%F`) are preserved.
- **A manifest** at `<install-dir>/installed-files.txt` records every path written outside `INSTALL_DIR`. `prune_recorded_files()` runs before the `rm -rf` and removes what the previous run recorded, `rmdir`-ing size directories it emptied in a theme tree other applications share. Pruning honors only the two path shapes the script writes; anything else is warned about and left alone, so a hand-edited manifest cannot turn into an arbitrary `rm`.
- **Nothing here can fail the install.** No `$HOME`, no assets in the archive, an unwritable data dir, missing cache tools — all warn at most. `--no-desktop-integration` / `FRESH_NO_DESKTOP=1` skips the copy (still pruning the previous run), which is the right default for servers and containers.

The AppImage branch is deliberately untouched.

### `.github/workflows/musl-builds.yml`

- Dropped `README.md` from the archive: self-update swaps the binary alone, so a copy in there freezes at whatever version was first installed. `LICENSE` stays, since the archive redistributes a binary.
- New step asserting the archive still carries the desktop entry and at least 9 icons. Every `cp` building the archive is `|| true`, so a rename under `docs/icons/` or `resources/` would drop them silently.

### Docs

README install section, and a new §7.4 subsection in `docs/internal/packaging-self-update.md`.

## Consequence worth being explicit about

`fresh --cmd update` replaces only the binary, so the desktop entry and icons are refreshed by re-running `install.sh`, not by updating. Documented in both the README and the internal doc rather than engineered around — these files are near-static, and plumbing archive-wide extraction into the update path buys little.

## Verification

Ran the tarball path end to end against a stub `curl` serving a locally built archive:

| Case | Result |
|---|---|
| Fresh install | 9 icons + entry installed, `Exec=` absolute, 10-line manifest |
| Reinstall w/ stale `1024x1024` icon + bogus manifest line | Stale icon pruned, bogus line refused with a warning, its target file intact |
| Reinstall w/ `--no-desktop-integration` | All 9 icons and the entry removed, emptied dirs cleaned |
| Archive with neither icons nor entry | Clean install, no empty manifest left behind |
| No `HOME`, no `XDG_DATA_HOME` | Warns, installs anyway |

`sh -n` clean. shellcheck is not installed in this environment, so the script itself was not linted — CI's actionlint covers only workflow `run:` blocks, and I checked the new one by running its commands against a real archive.