### PR TITLE
fix(render): stop the 256-color contrast pass from stalling large windows

### DIFF
--- a/crates/fresh-editor/src/view/color_support.rs
+++ b/crates/fresh-editor/src/view/color_support.rs
@@ -14,6 +14,7 @@
 //! The Editor will automatically convert colors during rendering based on the capability.
 
 use ratatui::style::Color;
+use std::sync::LazyLock;
 
 /// Terminal color capability levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -339,14 +340,36 @@ const MIN_CONTRAST_RATIO: f64 = 3.0;
 /// The 6 discrete values used in the 256-color cube (indices 16-231)
 const CUBE_VALUES: [u8; 6] = [0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff];
 
+/// sRGB -> linear for every possible channel value.
+///
+/// The conversion is a `powf` per channel and luminance needs three of them, so
+/// a contrast comparison costs six. The input is a `u8`, so the entire domain
+/// fits in a 256-entry table and the `powf` calls disappear from the render
+/// path entirely.
+static LINEAR_CHANNEL: LazyLock<[f64; 256]> = LazyLock::new(|| {
+    std::array::from_fn(|c| {
+        let s = c as f64 / 255.0;
+        if s <= 0.04045 {
+            s / 12.92
+        } else {
+            ((s + 0.055) / 1.055).powf(2.4)
+        }
+    })
+});
+
+/// Relative luminance of every 256-color palette entry, so the candidate scan
+/// in `find_readable_256_color` is table lookups rather than recomputed
+/// luminance for all 240 candidates.
+static PALETTE_LUMINANCE: LazyLock<[f64; 256]> = LazyLock::new(|| {
+    std::array::from_fn(|idx| {
+        let (r, g, b) = idx_to_rgb(idx as u8);
+        relative_luminance(r, g, b)
+    })
+});
+
 /// Convert a sRGB component to linear for luminance calculation
 fn srgb_to_linear(c: u8) -> f64 {
-    let s = c as f64 / 255.0;
-    if s <= 0.04045 {
-        s / 12.92
-    } else {
-        ((s + 0.055) / 1.055).powf(2.4)
-    }
+    LINEAR_CHANNEL[c as usize]
 }
 
 /// Compute relative luminance per WCAG 2.x
@@ -450,7 +473,7 @@ fn find_readable_256_color(fg_idx: u8, bg_rgb: (u8, u8, u8)) -> u8 {
     // Search color cube (16-231) and grayscale ramp (232-255)
     for candidate in 16..=255u8 {
         let c_rgb = idx_to_rgb(candidate);
-        let c_lum = relative_luminance(c_rgb.0, c_rgb.1, c_rgb.2);
+        let c_lum = PALETTE_LUMINANCE[candidate as usize];
 
         // Skip candidates in the wrong direction (optimization)
         if need_lighter && c_lum <= bg_lum {

--- a/crates/fresh-editor/src/view/color_support.rs
+++ b/crates/fresh-editor/src/view/color_support.rs
@@ -14,7 +14,7 @@
 //! The Editor will automatically convert colors during rendering based on the capability.
 
 use ratatui::style::Color;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 /// Terminal color capability levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -424,29 +424,52 @@ fn idx_to_rgb(idx: u8) -> (u8, u8, u8) {
     }
 }
 
+/// Resolve any Color to its 256-color palette index.
+///
+/// Every color we can reason about has an exact index: the named ANSI colors
+/// *are* palette entries 0-15 (`ANSI_COLORS` is the leading slice of
+/// `idx_to_rgb`), and RGB quantizes through `rgb_to_256`. Returns None for
+/// `Reset`, whose appearance belongs to the terminal.
+///
+/// This is what reduces the contrast fixup to a two-`u8` lookup — see
+/// `readable_fg_row`.
+fn color_to_palette_index(color: Color) -> Option<u8> {
+    Some(match color {
+        Color::Indexed(idx) => idx,
+        Color::Rgb(r, g, b) => rgb_to_256(r, g, b),
+        Color::Black => 0,
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Yellow => 3,
+        Color::Blue => 4,
+        Color::Magenta => 5,
+        Color::Cyan => 6,
+        Color::Gray => 7,
+        Color::DarkGray => 8,
+        Color::LightRed => 9,
+        Color::LightGreen => 10,
+        Color::LightYellow => 11,
+        Color::LightBlue => 12,
+        Color::LightMagenta => 13,
+        Color::LightCyan => 14,
+        Color::White => 15,
+        _ => return None, // Reset or other variants we can't resolve
+    })
+}
+
 /// Resolve any Color to an RGB tuple for contrast computation.
 /// Returns None for Reset/default colors (which we can't reason about).
+///
+/// RGB colors keep their exact channels; everything else resolves through its
+/// palette index, so the named-color mapping lives in exactly one place.
+///
+/// The render path works in palette indices and reaches for `idx_to_rgb`
+/// directly, so this now only backs the tests that assert the two agree.
+#[cfg(test)]
 fn color_to_rgb(color: Color) -> Option<(u8, u8, u8)> {
     match color {
         Color::Rgb(r, g, b) => Some((r, g, b)),
-        Color::Indexed(idx) => Some(idx_to_rgb(idx)),
-        Color::Black => Some((0, 0, 0)),
-        Color::Red => Some((128, 0, 0)),
-        Color::Green => Some((0, 128, 0)),
-        Color::Yellow => Some((128, 128, 0)),
-        Color::Blue => Some((0, 0, 128)),
-        Color::Magenta => Some((128, 0, 128)),
-        Color::Cyan => Some((0, 128, 128)),
-        Color::Gray => Some((192, 192, 192)),
-        Color::DarkGray => Some((128, 128, 128)),
-        Color::LightRed => Some((255, 0, 0)),
-        Color::LightGreen => Some((0, 255, 0)),
-        Color::LightYellow => Some((255, 255, 0)),
-        Color::LightBlue => Some((0, 0, 255)),
-        Color::LightMagenta => Some((255, 0, 255)),
-        Color::LightCyan => Some((0, 255, 255)),
-        Color::White => Some((255, 255, 255)),
-        _ => None, // Reset or other variants we can't resolve
+        other => Some(idx_to_rgb(color_to_palette_index(other)?)),
     }
 }
 
@@ -531,37 +554,54 @@ pub fn convert_buffer_colors(buffer: &mut ratatui::buffer::Buffer, capability: C
     }
 }
 
+/// Readable-foreground answers for a single background, indexed by foreground.
+type ReadableRow = [u8; 256];
+
+/// `(foreground, background) -> readable foreground` is a pure function of two
+/// palette indices, so it is a lookup table rather than something to recompute
+/// per cell. One row per background, filled on first use: a session paints only
+/// a handful of distinct backgrounds, and a row is built once and then amortized
+/// over every frame for the rest of the process.
+///
+/// This is what keeps the pass proportional to the number of cells instead of
+/// cells x 240 palette candidates (issue #2982). The per-cell search cost ~12.7us
+/// for every cell falling short of the threshold, and on a dimmed full-screen
+/// modal that is every cell on screen, on every frame.
+static READABLE_FG: [OnceLock<ReadableRow>; 256] = [const { OnceLock::new() }; 256];
+
+/// The readable-foreground row for `bg_idx`, computing it on first use.
+fn readable_fg_row(bg_idx: u8) -> &'static ReadableRow {
+    READABLE_FG[bg_idx as usize].get_or_init(|| {
+        let bg_rgb = idx_to_rgb(bg_idx);
+        std::array::from_fn(|fg_idx| find_readable_256_color(fg_idx as u8, bg_rgb))
+    })
+}
+
+/// The foreground to actually paint for `fg` on `bg`.
+///
+/// Returns `fg` untouched when the pair already clears `MIN_CONTRAST_RATIO`, or
+/// when either color is the terminal default. Leaving readable colors alone
+/// matters beyond tidiness: rewriting a named color to `Indexed` would emit a
+/// longer escape sequence for no visual difference.
+fn readable_fg(fg: Color, bg: Color) -> Color {
+    let (Some(fg_idx), Some(bg_idx)) = (color_to_palette_index(fg), color_to_palette_index(bg))
+    else {
+        return fg; // Can't enforce contrast against the terminal default
+    };
+
+    let readable = readable_fg_row(bg_idx)[fg_idx as usize];
+    if readable == fg_idx {
+        fg
+    } else {
+        Color::Indexed(readable)
+    }
+}
+
 /// Post-conversion pass: ensure every fg/bg pair in the buffer has sufficient
 /// WCAG contrast ratio. Adjusts fg colors when contrast is too low.
 fn enforce_minimum_contrast(buffer: &mut ratatui::buffer::Buffer) {
     for cell in buffer.content.iter_mut() {
-        let bg_rgb = match color_to_rgb(cell.bg) {
-            Some(rgb) => rgb,
-            None => continue, // Can't enforce contrast on unknown bg
-        };
-        let fg_rgb = match color_to_rgb(cell.fg) {
-            Some(rgb) => rgb,
-            None => continue,
-        };
-
-        if contrast_ratio(fg_rgb, bg_rgb) >= MIN_CONTRAST_RATIO {
-            continue;
-        }
-
-        // Try to fix the foreground color
-        match cell.fg {
-            Color::Indexed(idx) => {
-                cell.fg = Color::Indexed(find_readable_256_color(idx, bg_rgb));
-            }
-            _ => {
-                // For named ANSI colors that somehow have low contrast,
-                // convert to indexed and fix
-                if let Some((r, g, b)) = color_to_rgb(cell.fg) {
-                    let idx = rgb_to_256(r, g, b);
-                    cell.fg = Color::Indexed(find_readable_256_color(idx, bg_rgb));
-                }
-            }
-        }
+        cell.fg = readable_fg(cell.fg, cell.bg);
     }
 }
 
@@ -806,6 +846,75 @@ mod tests {
         assert!(solarized_bg <= 17, "solarized bg={}", solarized_bg);
         assert!(nord_bg <= 17, "nord bg={}", nord_bg);
         assert!(dracula_bg <= 17, "dracula bg={}", dracula_bg);
+    }
+
+    /// The lookup table must agree with the search it replaced, for every
+    /// foreground/background pair that exists.
+    #[test]
+    fn readable_fg_agrees_with_direct_search_for_every_pair() {
+        for bg_idx in 0..=255u8 {
+            let bg_rgb = idx_to_rgb(bg_idx);
+            for fg_idx in 0..=255u8 {
+                let expected = find_readable_256_color(fg_idx, bg_rgb);
+                assert_eq!(
+                    readable_fg(Color::Indexed(fg_idx), Color::Indexed(bg_idx)),
+                    Color::Indexed(expected),
+                    "fg {} on bg {}",
+                    fg_idx,
+                    bg_idx
+                );
+            }
+        }
+    }
+
+    /// The named ANSI colors are palette entries 0-15, so routing them through
+    /// an index must not change the color they resolve to.
+    #[test]
+    fn named_colors_resolve_to_their_palette_entry() {
+        for color in [
+            Color::Black,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::Blue,
+            Color::Magenta,
+            Color::Cyan,
+            Color::Gray,
+            Color::DarkGray,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::LightYellow,
+            Color::LightBlue,
+            Color::LightMagenta,
+            Color::LightCyan,
+            Color::White,
+        ] {
+            let idx = color_to_palette_index(color).expect("named colors have an index");
+            assert_eq!(
+                color_to_rgb(color),
+                Some(idx_to_rgb(idx)),
+                "{:?} must resolve to palette entry {}",
+                color,
+                idx
+            );
+        }
+    }
+
+    /// A foreground that is already readable keeps its exact representation —
+    /// rewriting it to `Indexed` would emit a longer escape sequence for no
+    /// visual difference.
+    #[test]
+    fn readable_fg_leaves_readable_named_colors_alone() {
+        assert_eq!(readable_fg(Color::White, Color::Black), Color::White);
+    }
+
+    /// Terminal-default colors are the `terminal` theme's whole basis, and the
+    /// early-out for them is what keeps that theme cheap to render.
+    #[test]
+    fn readable_fg_ignores_terminal_defaults() {
+        assert_eq!(readable_fg(Color::Reset, Color::Reset), Color::Reset);
+        assert_eq!(readable_fg(Color::White, Color::Reset), Color::White);
+        assert_eq!(readable_fg(Color::Reset, Color::Black), Color::Reset);
     }
 
     /// Verify that contrast enforcement works end-to-end via convert_buffer_colors

--- a/crates/fresh-editor/src/view/dimming.rs
+++ b/crates/fresh-editor/src/view/dimming.rs
@@ -4,12 +4,21 @@
 //! that focus is on a modal dialog layer above the dimmed content.
 
 use ratatui::layout::Rect;
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier};
 use ratatui::Frame;
 
 /// Dims a color by reducing its brightness by ~60%
-fn dim_color(color: Color) -> Color {
-    match color {
+///
+/// Returns `None` for `Color::Reset`, whose on-screen appearance belongs to the
+/// terminal: the user's default background is as likely to be light as dark, so
+/// there is no honest RGB value to substitute. Replacing it with a fixed dark
+/// gray is what made modals look like they had their own theme regardless of
+/// the configured one, and it also destroyed the `Reset` that the `terminal`
+/// theme relies on (issue #2982). Those cells are dimmed with `Modifier::DIM`
+/// instead — see `apply_dimming_excluding`.
+fn dim_color(color: Color) -> Option<Color> {
+    Some(match color {
+        Color::Reset => return None,
         Color::Rgb(r, g, b) => Color::Rgb(r / 3, g / 3, b / 3),
         Color::Indexed(idx) => {
             if idx == 0 {
@@ -34,8 +43,7 @@ fn dim_color(color: Color) -> Color {
         Color::LightBlue => Color::Rgb(30, 30, 80),
         Color::LightMagenta => Color::Rgb(80, 30, 80),
         Color::LightCyan => Color::Rgb(30, 80, 80),
-        Color::Reset => Color::Rgb(30, 30, 30),
-    }
+    })
 }
 
 /// Apply dimming effect to all cells in an area
@@ -45,8 +53,12 @@ pub fn apply_dimming(frame: &mut Frame, area: Rect) {
 
 /// Apply dimming effect to an area, optionally excluding a sub-area
 pub fn apply_dimming_excluding(frame: &mut Frame, area: Rect, exclude: Option<Rect>) {
-    let buf = frame.buffer_mut();
+    dim_buffer(frame.buffer_mut(), area, exclude);
+}
 
+/// Buffer-level dimming, split out from the `Frame` wrapper so it can be
+/// exercised directly by tests.
+fn dim_buffer(buf: &mut ratatui::buffer::Buffer, area: Rect, exclude: Option<Rect>) {
     for y in area.y..area.y.saturating_add(area.height) {
         for x in area.x..area.x.saturating_add(area.width) {
             // Skip cells inside the excluded area (if any)
@@ -57,12 +69,127 @@ pub fn apply_dimming_excluding(frame: &mut Frame, area: Rect, exclude: Option<Re
             }
 
             if let Some(cell) = buf.cell_mut((x, y)) {
-                let style = cell.style();
-                let new_fg = style.fg.map(dim_color).unwrap_or(Color::Rgb(40, 40, 40));
-                let new_bg = style.bg.map(dim_color).unwrap_or(Color::Rgb(15, 15, 15));
-                cell.set_fg(new_fg);
-                cell.set_bg(new_bg);
+                if let Some(bg) = dim_color(cell.bg) {
+                    cell.bg = bg;
+                }
+                match dim_color(cell.fg) {
+                    Some(fg) => cell.fg = fg,
+                    // Terminal default foreground: let the terminal dim its own
+                    // color rather than inventing one that could come out
+                    // brighter than what it replaced.
+                    None => cell.modifier |= Modifier::DIM,
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::view::color_support::{convert_buffer_colors, ColorCapability};
+    use ratatui::buffer::Buffer;
+
+    /// Build a 4x2 buffer with every cell set to `fg` on `bg`.
+    fn buffer_of(fg: Color, bg: Color) -> Buffer {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
+        for cell in buffer.content.iter_mut() {
+            cell.fg = fg;
+            cell.bg = bg;
+        }
+        buffer
+    }
+
+    /// Issue #2982: under the `terminal` theme every color is `Color::Reset`,
+    /// so a modal backdrop must stay on the terminal's own colors. Substituting
+    /// a fixed dark gray gave modals a theme of their own, and inverted on a
+    /// light terminal background.
+    #[test]
+    fn terminal_default_colors_survive_dimming() {
+        let mut buffer = buffer_of(Color::Reset, Color::Reset);
+        let area = buffer.area;
+
+        dim_buffer(&mut buffer, area, None);
+
+        for cell in buffer.content.iter() {
+            assert_eq!(
+                cell.bg,
+                Color::Reset,
+                "terminal default background must be left to the terminal"
+            );
+            assert_eq!(
+                cell.fg,
+                Color::Reset,
+                "terminal default foreground must be left to the terminal"
+            );
+            assert!(
+                cell.modifier.contains(Modifier::DIM),
+                "a cell we cannot dim numerically must be dimmed by the terminal"
+            );
+        }
+    }
+
+    /// The other half of issue #2982: because dimming used to replace `Reset`
+    /// with RGB, the 256-color contrast pass could no longer skip those cells
+    /// and ran its palette search over the whole screen every frame. Preserving
+    /// `Reset` restores the early-out.
+    #[test]
+    fn dimmed_terminal_theme_cells_stay_transparent_to_contrast_enforcement() {
+        let mut buffer = buffer_of(Color::Reset, Color::Reset);
+        let area = buffer.area;
+
+        dim_buffer(&mut buffer, area, None);
+        convert_buffer_colors(&mut buffer, ColorCapability::Color256);
+
+        for cell in buffer.content.iter() {
+            assert_eq!(cell.fg, Color::Reset);
+            assert_eq!(cell.bg, Color::Reset);
+        }
+    }
+
+    /// Themes that define real colors must dim exactly as before — this fix is
+    /// only about colors we cannot resolve.
+    #[test]
+    fn rgb_colors_still_dim_numerically() {
+        let mut buffer = buffer_of(Color::Rgb(212, 212, 212), Color::Rgb(30, 30, 30));
+        let area = buffer.area;
+
+        dim_buffer(&mut buffer, area, None);
+
+        for cell in buffer.content.iter() {
+            assert_eq!(cell.fg, Color::Rgb(70, 70, 70));
+            assert_eq!(cell.bg, Color::Rgb(10, 10, 10));
+            assert!(
+                !cell.modifier.contains(Modifier::DIM),
+                "colors we dimmed ourselves need no help from the terminal"
+            );
+        }
+    }
+
+    /// A `Reset` foreground over a themed background keeps its own handling:
+    /// the background still dims, the foreground defers to the terminal.
+    #[test]
+    fn mixed_default_and_themed_colors_are_handled_independently() {
+        let mut buffer = buffer_of(Color::Reset, Color::Rgb(30, 30, 30));
+        let area = buffer.area;
+
+        dim_buffer(&mut buffer, area, None);
+
+        for cell in buffer.content.iter() {
+            assert_eq!(cell.fg, Color::Reset);
+            assert_eq!(cell.bg, Color::Rgb(10, 10, 10));
+            assert!(cell.modifier.contains(Modifier::DIM));
+        }
+    }
+
+    #[test]
+    fn excluded_area_is_left_untouched() {
+        let mut buffer = buffer_of(Color::Rgb(212, 212, 212), Color::Rgb(30, 30, 30));
+        let area = buffer.area;
+
+        dim_buffer(&mut buffer, area, Some(Rect::new(0, 0, 2, 1)));
+
+        assert_eq!(buffer[(0, 0)].bg, Color::Rgb(30, 30, 30), "excluded");
+        assert_eq!(buffer[(2, 0)].bg, Color::Rgb(10, 10, 10), "dimmed");
     }
 }


### PR DESCRIPTION
Fixes the rendering stall analysed in #2982 (reported on Discord: sluggish once the terminal window is large, switching to the `terminal` theme fixes it, but the settings dialog stays slow and "looks like it has its own theme regardless of the main theme setting").

Both symptoms come from `convert_buffer_colors`, which walks every cell of the frame buffer on every render and is skipped only when the terminal is detected as truecolor. WSL2 (no `COLORTERM`, no `WT_SESSION`, `TERM=xterm-256color`) and a Windows console that isn't Windows Terminal both fall through to the `Color256` default, so both take the slow path.

The default theme is untouched; the only visible change is the modal-dimming fix below.

## The cost — `color_support.rs`

Two changes, both turning recomputation into precomputation.

**Luminance was `powf`.** Every cell computed WCAG luminance with `powf` (six per contrast comparison), and every cell falling short then scanned up to 240 palette candidates with three more `powf` each. Both inputs are `u8`, so the whole domain fits in two 256-entry tables built once — `LINEAR_CHANNEL` (sRGB→linear per channel value) and `PALETTE_LUMINANCE` (luminance per palette entry).

**The fixup was a per-cell search.** Once `convert_color` has run, every color the pass can reason about resolves to an exact palette index — the named ANSI colors *are* entries 0–15, and RGB has already been quantized. So `(fg, bg) → readable fg` is a pure function of two `u8`s, i.e. a lookup table:

```rust
static READABLE_FG: [OnceLock<ReadableRow>; 256] = [const { OnceLock::new() }; 256];
```

One row per background, filled on first use, then amortized over every frame for the rest of the process. No per-frame state, no allocation, and nothing to invalidate — the palette is fixed, so an answer stays correct for the life of the process. Two array indexes per cell.

## The theme bug — `dimming.rs`

`dim_color` mapped `Color::Reset` to a hardcoded `Rgb(30, 30, 30)` (and unset to `Rgb(15, 15, 15)`). `Reset` means *whatever the terminal draws by default*, which we can't know — on a light terminal background that substitution is an inversion, not a dim. That's why modals looked like they had a theme of their own, and under the `terminal` theme (where nearly every key is `Default`) it repainted the whole backdrop in fixed dark gray.

Colors we can reason about still dim numerically exactly as before, so themes defining real colors are visually unaffected. For the terminal's own colors we now ask the terminal to dim via `Modifier::DIM` instead of inventing a value — a weaker effect, consistent with the note at `render.rs:3327`, but a weak dim beats the wrong color when the background is unknown.

This also restores the early-out in `enforce_minimum_contrast`, which skips colors it can't resolve. That early-out is exactly why the `terminal` theme was fast, and destroying it is why the settings dialog stayed slow even under it.

## Measurements

Extracted copy of the pass, `rustc -O`, per frame against the 16 ms budget (`FRAME_DURATION`), at 400×100 = 40k cells:

| Scenario | Before | Luminance tables | + fixup table |
|---|---|---|---|
| Normal editing, RGB theme | 4.76 ms | 0.14 ms | **0.14 ms** |
| Settings dialog, `terminal` theme | 509 ms | 0.01 ms | **0.01 ms** (early-out restored) |
| Settings dialog, RGB theme | 509 ms | 47 ms | **0.095 ms** |

## Testing

**`color_support`** — the headline test asserts the lookup table agrees with the search it replaces across all 65,536 `(fg, bg)` pairs. Plus: named colors resolve to their palette entry, already-readable foregrounds keep their exact representation (rewriting a named color to `Indexed` would emit a longer escape sequence for no visual gain), and terminal defaults pass through untouched. The six pre-existing #1239 contrast tests are unmodified and still pass, which is what pins the luminance tables as numerically equivalent.

**`dimming`** — five unit tests. Verified they fail without the change: the three `Reset` tests fail (`left: Rgb(30, 30, 30), right: Reset`) while the two regression guards — RGB themes dim identically, exclusion rect respected — pass either way. One covers the chain end to end: dim a `Reset` buffer, run `convert_buffer_colors` at `Color256`, assert the cells are still `Reset`; before the fix they come out as `Indexed(28)`. The buffer walk is split out of the `Frame` wrapper as `dim_buffer` so this is testable without constructing a `Frame`.

Ran locally: `cargo check`, `cargo clippy` (no warnings in either changed file), `cargo fmt --check`, and the `view::dimming` + `view::color_support` unit tests. **The e2e suite was not run locally** — the sandbox ran out of disk building the test binaries — so CI is its first real run.

## Follow-up, not fixed here

On dimmed cells the contrast pass raises foreground luminance ~1.9× above the intended dim level, so in 256-color mode the modal backdrop is partly un-dimmed by the pass. Enforcing readability on a deliberately-unreadable decorative backdrop is arguably wrong regardless of cost, but fixing it needs a way to mark those cells — `Modifier::DIM` can't serve, since it's already used for ordinary content (suggestions, ghost text, file browser) and hijacking it would silently undo #1239's readability fixes. Now that the fixup is a table this is a correctness question rather than a performance one.

Closes #2982