### PR TITLE
fix(explorer): stop the sidebar caret blinking through modals

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -228,9 +228,12 @@ impl Editor {
         // separate, composable step that draws only into the returned rect.
         let (editor_content_area, file_explorer_area) =
             self.split_file_explorer_area(main_content_area);
-        if let Some(file_explorer_area) = file_explorer_area {
-            self.render_file_explorer(frame, file_explorer_area);
-        }
+        // Where the sidebar wants the hardware caret (its selected row) when
+        // it owns the keyboard. Committed at the very end of this draw, with
+        // the editor's caret, so overlays painted after the sidebar can
+        // suppress it instead of having it blink through them.
+        let explorer_hardware_cursor = file_explorer_area
+            .and_then(|file_explorer_area| self.render_file_explorer(frame, file_explorer_area));
 
         // Note: Tabs are now rendered within each split by SplitRenderer
 
@@ -903,7 +906,19 @@ impl Editor {
         // When a prompt is active the prompt renderer already placed the
         // caret on the prompt line via `frame.set_cursor_position`; don't
         // override it with the (now-irrelevant) buffer cursor.
-        if let Some((cx, cy)) = pending_hardware_cursor {
+        //
+        // The focused file explorer's caret rides the same path: the sidebar
+        // paints at the top of the draw, so it can only defer the decision to
+        // here. It additionally drops the caret when a late overlay (menu,
+        // settings, another full-screen modal) owns the screen — those paint
+        // after this point or record no popup rect, so
+        // `cursor_obscured_by_overlay` cannot see them. The editor's own
+        // caret needs no such check: `hide_cursor` above already suppressed
+        // it for every one of those states.
+        let hardware_cursor = pending_hardware_cursor.or_else(|| {
+            explorer_hardware_cursor.filter(|_| !self.cursor_suppressed_by_late_overlay())
+        });
+        if let Some((cx, cy)) = hardware_cursor {
             if self.active_window().prompt.is_none() && !self.cursor_obscured_by_overlay(cx, cy) {
                 frame.set_cursor_position((cx, cy));
             }
@@ -1635,7 +1650,14 @@ impl Editor {
         );
     }
 
-    fn render_file_explorer(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
+    /// Returns the cell the sidebar wants the hardware caret parked on (its
+    /// selected row) when it owns the keyboard, for the caller to commit at
+    /// the end of the draw. See [`FileExplorerRenderer::render`].
+    fn render_file_explorer(
+        &mut self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+    ) -> Option<(u16, u16)> {
         // Get connection string before mutable borrow of file_explorer.
         let remote_connection = self.connection_display_string();
 
@@ -1672,6 +1694,9 @@ impl Editor {
             .get_mut(&active_id)
             .expect("active window must exist");
         let __buffers_ref: &crate::app::window::WindowBuffers = &__win.buffers;
+        // Set by the materialised panel below; the loading placeholder has no
+        // selected row and so never asks for the caret.
+        let mut explorer_cursor = None;
         if let Some(explorer) = __win.file_explorer.as_mut() {
             // Build set of files with unsaved changes
             let mut files_with_unsaved_changes = std::collections::HashSet::new();
@@ -1698,7 +1723,7 @@ impl Editor {
                 decorations: &__win.file_explorer_decoration_cache,
                 slot_overrides: &__win.file_explorer_slot_override_cache,
             };
-            FileExplorerRenderer::render(
+            explorer_cursor = FileExplorerRenderer::render(
                 explorer,
                 frame,
                 area,
@@ -1738,6 +1763,7 @@ impl Editor {
             );
         }
         self.active_chrome_mut().apply_theme_runs(&fe_runs);
+        explorer_cursor
     }
 
     /// Render the status bar into `area`, unless it's toggled off or a
@@ -2407,6 +2433,34 @@ impl Editor {
             }
         }
         false
+    }
+
+    /// Returns true when a layer that [`Self::cursor_obscured_by_overlay`]
+    /// cannot account for owns the screen: menus and context menus (they
+    /// record menu layouts, not popup rects) and the full-screen modals —
+    /// settings, keybinding editor, calibration wizard, event debug, a
+    /// floating panel, the workspace-trust prompt — which all paint *after*
+    /// the hardware cursor is committed, on a dimmed backdrop.
+    ///
+    /// A hardware caret committed underneath one of these blinks straight
+    /// through it, since the terminal draws the caret on top of every cell.
+    /// The editor's caret is already suppressed for these states via
+    /// `hide_cursor`; this is the equivalent gate for chrome carets that are
+    /// painted before the overlays exist (today: the file explorer's).
+    fn cursor_suppressed_by_late_overlay(&self) -> bool {
+        self.menu_state.active_menu.is_some()
+            || self.active_window().open_context_menu().is_some()
+            || self.settings_state.as_ref().is_some_and(|s| s.visible)
+            || self.keybinding_editor.is_some()
+            || self.calibration_wizard.is_some()
+            || self.active_window().event_debug.is_some()
+            || self.floating_widget_panel.is_some()
+            || self.global_popups.top().is_some_and(|p| {
+                matches!(
+                    p.resolver,
+                    crate::view::popup::PopupResolver::WorkspaceTrust
+                )
+            })
     }
 
     /// Render the Quick Open hints line showing available mode prefixes

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -184,7 +184,15 @@ impl FileExplorerRenderer {
         false
     }
 
-    /// Render the file explorer in the given frame area
+    /// Render the file explorer in the given frame area.
+    ///
+    /// Returns the cell where the hardware caret should sit (the selected
+    /// row's left edge) when the panel owns the keyboard, or `None`. The
+    /// caret is deliberately *not* committed here: the sidebar paints early
+    /// in the frame, and ratatui draws the hardware caret on top of every
+    /// cell, so a caret set here would blink through any overlay painted
+    /// later (popups, menus, the settings modal). The caller commits it at
+    /// the end of the draw, once it knows what ended up covering that cell.
     #[allow(clippy::too_many_arguments)]
     pub fn render(
         view: &mut FileTreeView,
@@ -209,13 +217,13 @@ impl FileExplorerRenderer {
         // cells — the frontend renders the sidebar natively from
         // `Editor::file_explorer_view`. The TUI always passes `true`.
         draw: bool,
-    ) {
+    ) -> Option<(u16, u16)> {
         // Viewport height drives scrolling math AND the web projection's visible
         // window, so it must be set on every render regardless of `draw`.
         let viewport_height_pre = area.height.saturating_sub(2) as usize;
         view.set_viewport_height(viewport_height_pre);
         if !draw {
-            return;
+            return None;
         }
         let search_active = view.is_search_active();
         // The tree-indicator glyphs are the only config the inner renderers
@@ -349,9 +357,12 @@ impl FileExplorerRenderer {
         // Render close button "×" at the right side of the title bar
         Self::render_close_button(frame, area, theme, close_button_hovered);
 
-        // When focused, show a blinking cursor indicator at the selected row
-        // We render a cursor indicator character and position the hardware cursor there
-        // The hardware cursor provides efficient terminal-native blinking
+        // When focused, show a blinking cursor indicator at the selected row.
+        // We paint the indicator glyph here and hand the cell back to the
+        // caller, which parks the hardware cursor on it at the end of the
+        // draw — the hardware cursor provides efficient terminal-native
+        // blinking, but only the caller knows whether an overlay has since
+        // covered the cell.
         if is_focused {
             if let Some(selected) = selected_viewport_index {
                 // Position at the left edge of the selected row (after border)
@@ -364,10 +375,10 @@ impl FileExplorerRenderer {
                 let cursor_area = ratatui::layout::Rect::new(cursor_x, cursor_y, 1, 1);
                 frame.render_widget(cursor_indicator, cursor_area);
 
-                // Position hardware cursor here for blinking effect
-                frame.set_cursor_position((cursor_x, cursor_y));
+                return Some((cursor_x, cursor_y));
             }
         }
+        None
     }
 
     /// Render a single tree node as a ListItem

--- a/crates/fresh-editor/tests/e2e/file_explorer_cursor_under_modal.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer_cursor_under_modal.rs
@@ -1,0 +1,51 @@
+//! Regression: the focused file explorer's hardware caret must not blink
+//! through a modal drawn over the sidebar.
+//!
+//! The explorer paints at the top of the frame and parks the terminal's
+//! hardware cursor on its selected row for terminal-native blinking. The
+//! terminal draws that caret on top of *every* cell, so a modal painted
+//! later in the same frame (the settings dialog, which dims the whole UI
+//! behind it) cannot cover it by painting cells — the caret has to be
+//! withheld for the frame instead. Before the fix the caret stayed on the
+//! sidebar row and showed through the settings dialog.
+
+use crate::common::harness::EditorTestHarness;
+
+/// The explorer owns the caret while it's focused, and gives it up while the
+/// settings modal is open.
+#[test]
+fn test_explorer_caret_hidden_while_settings_modal_is_open() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    std::fs::write(project_root.join("a.txt"), "hello").unwrap();
+
+    // Open and focus the file explorer.
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("a.txt").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File explorer"))
+        .unwrap();
+
+    // Baseline: the focused explorer parks the caret on its selected row.
+    // Without this the assertion below would pass vacuously.
+    let caret = harness
+        .render_observing_cursor()
+        .unwrap()
+        .expect("focused file explorer should own the hardware caret");
+
+    // Open settings over it. The explorer stays focused underneath (settings
+    // is a modal; it doesn't change the window's key context), so the caret
+    // has to be suppressed on account of the modal itself. The selected row
+    // doesn't move while settings is up, so the explorer's caret cell is
+    // still `caret` — the frame must not put the hardware cursor there.
+    harness.open_settings().unwrap();
+
+    let caret_with_settings = harness.render_observing_cursor().unwrap();
+    assert_ne!(
+        caret_with_settings,
+        Some(caret),
+        "the file explorer's caret is still parked on its selected row \
+         {caret:?} with the settings modal open — it blinks through the dialog"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -47,6 +47,7 @@ pub mod extract_tab_to_workspace;
 pub mod file_browser;
 pub mod file_explorer;
 pub mod file_explorer_compact_chain;
+pub mod file_explorer_cursor_under_modal;
 pub mod file_explorer_open_focus;
 pub mod file_explorer_session_persist;
 pub mod file_permissions;


### PR DESCRIPTION
## Problem

With the file explorer focused, the hardware caret parked on its selected row blinks *through* the settings dialog opened over it.

`FileExplorerRenderer::render` called `frame.set_cursor_position(...)` during the sidebar's own paint — which happens at the very top of the frame (`render.rs:232`). Ratatui commits that position at the end of `Terminal::draw`, and the terminal paints the hardware caret on top of *every* cell, so the settings modal — drawn much later, in `render_panels_and_modals` — can't hide it by painting cells. The only way to hide the caret is to not set it for that frame.

The editor's own caret never had this problem: it's deferred into `pending_hardware_cursor` and committed at the end of the draw, gated by `hide_cursor` (which already covers `settings_visible`) and `cursor_obscured_by_overlay`.

## Change

- `FileExplorerRenderer::render` now **returns** the cell it wants the caret on instead of committing it. The `▌` indicator glyph is still painted there, so it dims with the rest of the backdrop like any other cell.
- `render_file_explorer` passes that up to the draw, which commits it alongside the editor's caret at the end of the frame — so the existing prompt and popup-overlap guards now apply to the sidebar caret too.
- Added `cursor_suppressed_by_late_overlay()` for the layers `cursor_obscured_by_overlay` can't account for, because they paint after the commit point or record no popup rect: menus and context menus, settings, the keybinding editor, the calibration wizard, the event-debug dialog, a floating panel, and the workspace-trust prompt. The editor's caret needs no such check — `hide_cursor` already suppresses it for every one of those states.

## Test

`tests/e2e/file_explorer_cursor_under_modal.rs`: focus the explorer, record the caret cell, open settings, assert the caret is no longer parked there. Verified it fails with the suppression stubbed out and passes with it.

Also ran the explorer and cursor e2e subsets locally (309 tests, all green); the rest is left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnV2QcS9cMresCsHNxV1aG)_