### PR TITLE
Review Diff: full-width diff, no soft wrap, and panels rebuilt on the widget runtime

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4068,6 +4068,12 @@ pub enum PluginCommand {
     /// Focus a specific panel within a buffer group
     FocusPanel { group_id: usize, panel_name: String },
 
+    /// Switch a virtual buffer's mode, and with it the keybindings that
+    /// apply while it is focused. Lets a panel enter a text-entry mode
+    /// (an in-panel filter field) without the mode's other single-key
+    /// commands eating the typing.
+    SetBufferMode { buffer_id: BufferId, mode: String },
+
     /// Show or hide one panel of a buffer group without tearing the
     /// group down. The panel's buffer and its scroll position survive
     /// while hidden; only the group's split tree changes.

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4068,6 +4068,15 @@ pub enum PluginCommand {
     /// Focus a specific panel within a buffer group
     FocusPanel { group_id: usize, panel_name: String },
 
+    /// Show or hide one panel of a buffer group without tearing the
+    /// group down. The panel's buffer and its scroll position survive
+    /// while hidden; only the group's split tree changes.
+    SetBufferGroupPanelVisible {
+        group_id: usize,
+        panel_name: String,
+        visible: bool,
+    },
+
     /// Define a buffer mode with keybindings
     DefineMode {
         name: String,

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4270,6 +4270,14 @@ pub enum PluginCommand {
     /// Navigate to the previous hunk in a composite buffer
     CompositePrevHunk { buffer_id: BufferId },
 
+    /// Put a composite buffer's cursor on the aligned row that shows
+    /// `line` (0-indexed) of pane `pane`, and scroll it into view.
+    SetCompositeCursorLine {
+        buffer_id: BufferId,
+        pane: usize,
+        line: usize,
+    },
+
     /// Focus a specific split
     FocusSplit { split_id: SplitId },
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1683,6 +1683,29 @@ let toolbarPanel: WidgetPanel | null = null;
 let filesPanel: WidgetPanel | null = null;
 let commentsPanel: WidgetPanel | null = null;
 
+/** Width in columns of a side panel: the host's last reported viewport
+ *  width for it, or the share of the screen `REVIEW_LAYOUT` gives it
+ *  until the first `viewport_changed` for that panel arrives. */
+function panelWidthOf(panel: 'files' | 'comments'): number {
+    const known = state.panelWidths[panel];
+    if (known && known > 0) return known;
+    return Math.max(12, Math.floor(state.viewportWidth * (panel === 'files' ? 0.16 : 0.15)));
+}
+
+/** `text` clipped to `width` columns, dropping characters from the left
+ *  and marking the cut with `…`. Used for paths, where the tail (the
+ *  directory you are in) carries more than the root. */
+function elideLeft(text: string, width: number): string {
+    if (width <= 1) return text.slice(0, Math.max(0, width));
+    return text.length <= width ? text : '…' + text.slice(text.length - (width - 1));
+}
+
+/** `text` clipped to `width` columns, marking the cut with `…`. */
+function elideRight(text: string, width: number): string {
+    if (width <= 1) return text.slice(0, Math.max(0, width));
+    return text.length <= width ? text : text.slice(0, width - 1) + '…';
+}
+
 /** The close button at the right edge of an open side panel's header.
  *  Clicking it hides that panel (same as `F` / `C`). */
 const PANEL_CLOSE_GLYPH = '✕';
@@ -1784,6 +1807,11 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
     const entries: TextPropertyEntry[] = [];
     state.filesPanelByRow = {};
     state.filesPanelDirByRow = {};
+    // Every row is cut to the panel's width. A row wider than the panel
+    // would let the buffer scroll sideways (nothing wraps in a panel), and
+    // that pans the *whole* viewport — header included — the moment the
+    // hidden cursor lands past the right edge.
+    const W = panelWidthOf('files');
 
     if (state.files.length === 0) {
         entries.push({
@@ -1819,7 +1847,7 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
             const display = state.mode === 'range' ? label : label.toUpperCase();
             row1++;
             entries.push({
-                text: ` ${display} (${catCounts[group.category]})\n`,
+                text: `${elideRight(` ${display} (${catCounts[group.category]})`, W)}\n`,
                 style: { fg: STYLE_SECTION_HEADER, bold: true },
                 properties: { type: "files-section" },
             });
@@ -1837,8 +1865,12 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
             ? `  ${dirFiles.length} file${dirFiles.length === 1 ? '' : 's'}` : '';
         row1++;
         state.filesPanelDirByRow[row1] = group.dirKey;
+        // The counts are the part worth keeping when a path is too long,
+        // so the path is what gets elided (from the left — the leaf
+        // directory says more than the repo root).
+        const dirStats = `${countNote}  +${added} -${removed}`;
         entries.push({
-            text: ` ${tri} ${group.dir}${countNote}  +${added} -${removed}\n`,
+            text: ` ${tri} ${elideLeft(group.dir, Math.max(4, W - 3 - dirStats.length))}${dirStats}\n`,
             style: { fg: STYLE_SECTION_HEADER },
             properties: { type: "files-dir", dirKey: group.dirKey },
         });
@@ -1858,7 +1890,7 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
             state.filesPanelByRow[row1] = key;
             // Basename only — the directory header carries the path.
             entries.push({
-                text: `   ${glyph} ${fileBaseOf(file.path)}${stats}\n`,
+                text: `   ${glyph} ${elideRight(fileBaseOf(file.path), Math.max(4, W - 5 - stats.length))}${stats}\n`,
                 style,
                 properties: { type: "file", fileKey: key, filePath: file.path },
             });
@@ -2317,6 +2349,21 @@ function on_review_mouse_click(data: {
     // Clicks on the toolbar's and the panel headers' buttons arrive as
     // `widget_event`, not here.
 
+    // A click is a focus gesture: the panel you clicked takes the keys.
+    // The host moves its own focus to the clicked buffer; mirroring it
+    // here keeps `state.focusPanel` — which decides where ↑↓ / ←→ /
+    // Home / End go — from pointing at the panel you just left.
+    const clickedPanel: 'files' | 'diff' | 'comments' | null =
+        data.buffer_id === state.panelBuffers["files"] ? 'files'
+            : data.buffer_id === commentsId ? 'comments'
+                : (data.buffer_id === diffId || data.buffer_id === stickyId
+                    || (state.centerComposite
+                        && data.buffer_id === state.centerComposite.compositeBufId)) ? 'diff'
+                    : null;
+    if (clickedPanel && clickedPanel !== state.focusPanel && panelVisible(clickedPanel)) {
+        reviewSetFocus(clickedPanel);
+    }
+
     // Click in the diff buffer: section headers and file headers are
     // both interactive — clicking either toggles its fold state.
     if (data.buffer_id === diffId) {
@@ -2411,7 +2458,6 @@ function on_review_mouse_click(data: {
                 } else {
                     jumpToFile(file);
                 }
-                editor.focusBufferGroupPanel(state.groupId, "diff");
             }
         }
         return;
@@ -2425,9 +2471,11 @@ function on_review_mouse_click(data: {
         const targetRow1 = data.buffer_row + 1;
         const commentId = state.commentsByRow[targetRow1];
         if (commentId) {
+            // Clicking a comment moves the diff to it but leaves focus in
+            // the rail — you clicked the rail, so the next arrow key
+            // should step to the next comment, not scroll the diff.
             state.commentsSelectedRow = targetRow1;
             jumpToComment(commentId);
-            editor.focusBufferGroupPanel(state.groupId, "diff");
             renderCommentsPanel();
         }
         return;
@@ -2813,10 +2861,13 @@ function reviewSetFocus(panel: 'files' | 'diff' | 'comments'): void {
     // async, but a key handler firing immediately after must see the new
     // focus to route the next arrow correctly.
     state.focusPanel = panel;
-    // Pin the FILES cursor to the start of the selected row. Without this the
-    // panel keeps whatever column the hidden cursor last had, and focusing it
-    // can scroll the sidebar horizontally to a long path's end-of-line.
-    if (panel === 'files') scrollFilesToSelected();
+    // A freshly focused sidebar needs a selected row for its keys to act
+    // on, and the row scrolled into view.
+    if (panel === 'files') {
+        selectedSidebarFile();
+        renderFilesPanel();
+        scrollFilesToSelected();
+    }
     refreshFocusIndicators();
 }
 
@@ -3195,9 +3246,22 @@ function review_nav_right() {
 }
 registerHandler("review_nav_right", review_nav_right);
 
+/** The file the sidebar points at, falling back to the first visible one.
+ *  In the expanded stream the selection tracks the diff cursor, which sits
+ *  on a section header at startup — with no fallback the sidebar's own keys
+ *  would have nothing to act on until you scrolled into a file. */
+function selectedSidebarFile(): FileEntry | null {
+    const current = state.files.find(f => fileKey(f) === state.filesCurrentKey);
+    if (current) return current;
+    const vis = visibleFiles();
+    if (vis.length === 0) return null;
+    state.filesCurrentKey = fileKey(vis[0]);
+    return vis[0];
+}
+
 /** Collapse or expand the directory group holding the selected file. */
 function setSelectedDirCollapsed(collapsed: boolean): void {
-    const file = state.files.find(f => fileKey(f) === state.filesCurrentKey);
+    const file = selectedSidebarFile();
     if (!file) return;
     const dirKey = `${file.category} ${fileDirOf(file.path)}`;
     const had = state.collapsedDirs.has(dirKey);
@@ -4626,10 +4690,44 @@ function restoreReviewAnchor(anchor: ReviewAnchor): void {
             return;
         }
     }
-    // The line isn't in the stream (a context line outside every hunk, in
-    // a file whose hunks don't cover it) — settle for the file header.
+    // The line isn't in the stream at all. Side-by-side shows the whole
+    // file, so the cursor can sit a long way from any change; unified
+    // only carries the hunks and their context. Land on the change
+    // nearest that line — the one just above it, or the one just below
+    // when there is nothing above — instead of falling back to the file
+    // header, which reads as "jumped somewhere random".
+    const hunkRow = nearestHunkRowToAnchor(anchor);
+    if (hunkRow !== undefined) {
+        jumpDiffCursorToRow(hunkRow);
+        return;
+    }
     const headerRow = state.fileHeaderRows[anchor.fileKey];
     if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+}
+
+/** Row of the hunk closest to `anchor`'s line within its file: the last
+ *  one ending at or before it, else the first one starting after it.
+ *  `undefined` when the file has no hunks in the stream. */
+function nearestHunkRowToAnchor(anchor: ReviewAnchor): number | undefined {
+    const file = state.files.find(f => fileKey(f) === anchor.fileKey);
+    if (!file) return undefined;
+    const line = anchor.lineType === 'remove' ? anchor.oldLine : anchor.newLine;
+    if (line === undefined) return undefined;
+    const useOld = anchor.lineType === 'remove';
+    let before: Hunk | undefined;
+    let after: Hunk | undefined;
+    for (const h of state.hunks) {
+        if (h.file !== file.path || (h.gitStatus || 'unstaged') !== file.category) continue;
+        const start = useOld ? h.oldRange.start : h.range.start;
+        const end = useOld ? h.oldRange.end : h.range.end;
+        if (end <= line) before = h;              // hunks come in file order
+        else if (start >= line && !after) after = h;
+    }
+    const pick = before && after
+        ? ((line - (useOld ? before.oldRange.end : before.range.end))
+            <= ((useOld ? after.oldRange.start : after.range.start) - line) ? before : after)
+        : (before ?? after);
+    return pick ? state.hunkRowByHunkId[pick.id] : undefined;
 }
 
 async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<void> {

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1767,6 +1767,53 @@ interface FilesTree {
 /** Build the sidebar's node list: one row per category, per directory,
  *  and per file, depth-first. The tree draws its own disclosure glyphs
  *  and indents by depth, so the rows carry text only. */
+/** One directory in the sidebar's hierarchy. Built per category from the
+ *  changed files' paths, so the panel shows `crates` → `fresh-editor` →
+ *  `src` as nested rows carrying short names — the file explorer's shape —
+ *  rather than one row repeating the whole path per group. */
+interface DirNode {
+    /** Path segment shown on the row (empty for a category's root). */
+    name: string;
+    /** Full path from the repo root, with a trailing slash. */
+    path: string;
+    children: Map<string, DirNode>;
+    files: FileEntry[];
+    /** Added / removed across everything beneath, so an ancestor row
+     *  totals its subtree the way its own files' rows total themselves. */
+    added: number;
+    removed: number;
+}
+
+function newDirNode(name: string, path: string): DirNode {
+    return { name, path, children: new Map(), files: [], added: 0, removed: 0 };
+}
+
+/** Insert `file` under its directory chain, creating the ancestors it
+ *  needs and adding its counts to each of them. */
+function insertIntoDirTree(root: DirNode, file: FileEntry): void {
+    const counts = fileChangeCounts(file);
+    const dir = fileDirOf(file.path);
+    let node = root;
+    node.added += counts.added;
+    node.removed += counts.removed;
+    if (dir !== './') {
+        let prefix = '';
+        for (const segment of dir.split('/')) {
+            if (segment === '') continue;
+            prefix += `${segment}/`;
+            let child = node.children.get(segment);
+            if (!child) {
+                child = newDirNode(segment, prefix);
+                node.children.set(segment, child);
+            }
+            child.added += counts.added;
+            child.removed += counts.removed;
+            node = child;
+        }
+    }
+    node.files.push(file);
+}
+
 function buildFilesTree(): FilesTree {
     const out: FilesTree = {
         nodes: [], keys: [], fileByNodeKey: {}, indexByFileKey: {}, groupKeys: [],
@@ -1774,76 +1821,93 @@ function buildFilesTree(): FilesTree {
     const commentCounts: Record<string, number> = {};
     for (const c of state.comments) commentCounts[c.file] = (commentCounts[c.file] || 0) + 1;
 
+    // `fileGroups()` stays the ordering authority (category order, then
+    // directory, then file) — this only re-shapes it into a hierarchy.
     const groups = fileGroups();
     const catCounts: Record<string, number> = {};
-    for (const g of groups) catCounts[g.category] = (catCounts[g.category] || 0) + g.files.length;
+    const roots: Array<{ category: string; root: DirNode }> = [];
+    for (const g of groups) {
+        catCounts[g.category] = (catCounts[g.category] || 0) + g.files.length;
+        let entry = roots.find(r => r.category === g.category);
+        if (!entry) {
+            entry = { category: g.category, root: newDirNode('', '') };
+            roots.push(entry);
+        }
+        for (const f of g.files) insertIntoDirTree(entry.root, f);
+    }
     // With one category (the usual worktree review: everything unstaged)
     // a category row would be a header over the whole tree and one wasted
     // indent level in a panel that has ~24 columns to work with.
-    const categories = Object.keys(catCounts);
-    const showCategories = categories.length > 1;
-    const dirDepth = showCategories ? 1 : 0;
-    // Rows are clipped by the host to the panel width; a path clipped from
-    // the right leaves three sibling directories looking identical, so
-    // elide from the left and keep the leaf.
+    const showCategories = roots.length > 1;
+    const baseDepth = showCategories ? 1 : 0;
     const W = panelWidthOf('files');
 
-    let lastCategory: string | undefined;
-    for (const group of groups) {
-        if (showCategories && group.category !== lastCategory) {
-            lastCategory = group.category;
-            let label: string = group.category;
+    const pushDir = (category: string, node: DirNode, depth: number): void => {
+        const key = `dir:${category} ${node.path}`;
+        out.groupKeys.push(key);
+        out.keys.push(key);
+        const stats = `  +${node.added} -${node.removed}`;
+        // The host indents 2 columns per depth level and draws a
+        // disclosure glyph; a segment is short, so this only bites on a
+        // deeply nested path in a narrow panel.
+        const room = Math.max(4, W - depth * 2 - 2 - stats.length);
+        out.nodes.push(treeNode(
+            { text: `${elideRight(node.name, room)}${stats}`, style: { fg: STYLE_SECTION_HEADER } },
+            { depth, hasChildren: true },
+        ));
+    };
+
+    const pushFile = (file: FileEntry, depth: number): void => {
+        const counts = fileChangeCounts(file);
+        const key = fileKey(file);
+        const badge = commentCounts[file.path] ? ` *${commentCounts[file.path]}` : '';
+        const nodeKey = `file:${key}`;
+        out.fileByNodeKey[nodeKey] = key;
+        out.indexByFileKey[key] = out.nodes.length;
+        out.keys.push(nodeKey);
+        const stats = `  +${counts.added} -${counts.removed}${badge}`;
+        const room = Math.max(4, W - depth * 2 - 4 - stats.length);
+        out.nodes.push(treeNode(
+            {
+                text: `${file.status || ' '} ${elideRight(fileBaseOf(file.path), room)}${stats}`,
+                properties: { type: "file", fileKey: key, filePath: file.path },
+            },
+            { depth },
+        ));
+    };
+
+    /** Depth-first: a directory's own rows, then its children, then its
+     *  files — the file explorer's order. */
+    const emit = (category: string, node: DirNode, depth: number): void => {
+        const childNames = [...node.children.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+        for (const name of childNames) {
+            const child = node.children.get(name)!;
+            pushDir(category, child, depth);
+            emit(category, child, depth + 1);
+        }
+        for (const file of node.files) pushFile(file, depth);
+    };
+
+    for (const { category, root } of roots) {
+        if (showCategories) {
+            let label: string = category;
             if (state.mode === 'range' && state.range) label = state.range.label;
-            else if (group.category === 'staged') label = editor.t("section.staged") || "Staged";
-            else if (group.category === 'unstaged') label = editor.t("section.unstaged") || "Changes";
-            else if (group.category === 'untracked') label = editor.t("section.untracked") || "Untracked";
+            else if (category === 'staged') label = editor.t("section.staged") || "Staged";
+            else if (category === 'unstaged') label = editor.t("section.unstaged") || "Changes";
+            else if (category === 'untracked') label = editor.t("section.untracked") || "Untracked";
             const display = state.mode === 'range' ? label : label.toUpperCase();
-            const key = `cat:${group.category}`;
+            const key = `cat:${category}`;
             out.groupKeys.push(key);
             out.keys.push(key);
             out.nodes.push(treeNode(
-                { text: `${display} (${catCounts[group.category]})`, style: { fg: STYLE_SECTION_HEADER, bold: true } },
+                {
+                    text: `${display} (${catCounts[category]})`,
+                    style: { fg: STYLE_SECTION_HEADER, bold: true },
+                },
                 { depth: 0, hasChildren: true },
             ));
         }
-
-        let added = 0, removed = 0;
-        for (const f of group.files) {
-            const c = fileChangeCounts(f);
-            added += c.added; removed += c.removed;
-        }
-        const dirKey = `dir:${group.dirKey}`;
-        out.groupKeys.push(dirKey);
-        out.keys.push(dirKey);
-        const dirStats = `  +${added} -${removed}`;
-        // Indent the host adds: 2 per depth level, plus the disclosure glyph.
-        const dirRoom = Math.max(6, W - dirDepth * 2 - 2 - dirStats.length);
-        out.nodes.push(treeNode(
-            {
-                text: `${elideLeft(group.dir, dirRoom)}${dirStats}`,
-                style: { fg: STYLE_SECTION_HEADER },
-            },
-            { depth: dirDepth, hasChildren: true },
-        ));
-
-        for (const file of group.files) {
-            const counts = fileChangeCounts(file);
-            const key = fileKey(file);
-            const badge = commentCounts[file.path] ? ` *${commentCounts[file.path]}` : '';
-            const nodeKey = `file:${key}`;
-            out.fileByNodeKey[nodeKey] = key;
-            out.indexByFileKey[key] = out.nodes.length;
-            out.keys.push(nodeKey);
-            const stats = `  +${counts.added} -${counts.removed}${badge}`;
-            const nameRoom = Math.max(6, W - (dirDepth + 1) * 2 - 4 - stats.length);
-            out.nodes.push(treeNode(
-                {
-                    text: `${file.status || ' '} ${elideRight(fileBaseOf(file.path), nameRoom)}${stats}`,
-                    properties: { type: "file", fileKey: key, filePath: file.path },
-                },
-                { depth: dirDepth + 1 },
-            ));
-        }
+        emit(category, root, baseDepth);
     }
     return out;
 }
@@ -1871,9 +1935,17 @@ function panelListRows(panel: 'files' | 'comments'): number {
  *  the file tree. */
 function buildFilesPanelSpec(): WidgetSpec {
     filesTree = buildFilesTree();
-    const selected = state.filesCurrentKey !== null
-        ? (filesTree.indexByFileKey[state.filesCurrentKey] ?? -1)
-        : -1;
+    // The spec's `selectedIndex` is authoritative on every render, so it
+    // has to agree with where the host's own navigation left the
+    // selection — otherwise each repaint drags the selection back to the
+    // current file and folding a directory (which selects a directory
+    // row first) never gets to happen.
+    const fileNodeKey = state.filesCurrentKey !== null ? `file:${state.filesCurrentKey}` : "";
+    const trackedKey = filesSelectedNodeKey.startsWith("file:")
+        ? fileNodeKey                       // a file row: the review's current file wins
+        : filesSelectedNodeKey;             // a directory / category row: keep it
+    let selected = trackedKey ? filesTree.keys.indexOf(trackedKey) : -1;
+    if (selected < 0 && fileNodeKey) selected = filesTree.keys.indexOf(fileNodeKey);
     const parts: WidgetSpec[] = [
         panelHeaderSpec('files', filesHeaderLabel()),
         // Always present, whether or not it holds focus: a filter you

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -5109,9 +5109,11 @@ function review_filter_text_input(args: { text: string }): void {
     if (!filterEditing || filesPanel === null || !args?.text) return;
     filesPanel.command(textInputChar(args.text));
 }
-// The host dispatches unbound printable keys in an `allowTextInput`
-// mode as the `mode_text_input` action; the `filterEditing` guard keeps
-// this a no-op everywhere else (other plugins register it too).
+// The host dispatches unbound printable keys in an `allowTextInput` mode
+// as the `mode_text_input` action, qualified by the mode name so it
+// reaches the plugin that defined the mode — here, only while
+// `REVIEW_FILTER_MODE` is active. The `filterEditing` guard covers the
+// unqualified legacy dispatch, which other plugins also answer to.
 registerHandler("mode_text_input", review_filter_text_input);
 
 /** Editing keys (Backspace, arrows, …) and the tree-walking keys, both

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2244,16 +2244,18 @@ function refreshStickyHeader(topVisibleRow: number): void {
         properties: { type: "sticky-header" },
     }]);
 
-    // Legacy multi-file-stream mode only: keep the sidebar's highlighted
-    // file in sync with the diff's top file. In focus mode the current file
-    // is driven by explicit navigation, so we must NOT re-derive it here.
+    // Expanded (multi-file) stream: the sidebar highlight follows the
+    // *cursor's* file, not the top-visible one. Deriving it from the scroll
+    // fought navigation — `.` jumped the cursor into the next file, the
+    // resulting scroll put a different file at the top, and the highlight
+    // (and with it the next `.`) snapped back to that one. In focus mode
+    // the current file is explicit navigation, so it isn't re-derived at all.
     if (!state.focusOnly) {
-        const curKey = bestFile ? fileKey(bestFile) : null;
+        const cursorFile = currentFileFromCursor();
+        const curKey = cursorFile ? fileKey(cursorFile) : state.filesCurrentKey;
         if (curKey !== state.filesCurrentKey) {
             state.filesCurrentKey = curKey;
-            if (state.panelBuffers["files"] !== undefined) {
-                renderFilesPanel();
-            }
+            renderFilesPanel();
         }
     }
 }
@@ -2977,6 +2979,19 @@ function review_comments_select_prev() {
 }
 registerHandler("review_comments_select_prev", review_comments_select_prev);
 
+/** Home / End in the COMMENTS rail: first / last comment. */
+function review_comments_select_first() {
+    if (state.groupId === null || state.comments.length === 0) return;
+    state.commentsSelectedRow = 2;
+    renderCommentsPanel();
+}
+
+function review_comments_select_last() {
+    if (state.groupId === null || state.comments.length === 0) return;
+    state.commentsSelectedRow = state.comments.length + 1;
+    renderCommentsPanel();
+}
+
 /**
  * Visual line-selection mode. Activates a multi-row selection rooted
  * at the cursor's hunk; j/k extend it; Esc cancels. The selection is
@@ -3161,6 +3176,52 @@ function review_nav_down() {
     }
 }
 registerHandler("review_nav_down", review_nav_down);
+
+/** Left / Right belong to whichever panel has focus. In the diff they pan
+ *  the (unwrapped) stream horizontally; in the FILES sidebar they fold and
+ *  unfold the selected file's directory group — a sidebar keystroke must
+ *  never reach through and scroll the diff behind it. */
+function review_nav_left() {
+    if (state.focusPanel === 'files') { setSelectedDirCollapsed(true); return; }
+    if (state.focusPanel === 'comments') return;
+    editor.executeAction("move_left");
+}
+registerHandler("review_nav_left", review_nav_left);
+
+function review_nav_right() {
+    if (state.focusPanel === 'files') { setSelectedDirCollapsed(false); return; }
+    if (state.focusPanel === 'comments') return;
+    editor.executeAction("move_right");
+}
+registerHandler("review_nav_right", review_nav_right);
+
+/** Collapse or expand the directory group holding the selected file. */
+function setSelectedDirCollapsed(collapsed: boolean): void {
+    const file = state.files.find(f => fileKey(f) === state.filesCurrentKey);
+    if (!file) return;
+    const dirKey = `${file.category} ${fileDirOf(file.path)}`;
+    const had = state.collapsedDirs.has(dirKey);
+    if (collapsed === had) return;
+    if (collapsed) state.collapsedDirs.add(dirKey);
+    else state.collapsedDirs.delete(dirKey);
+    renderFilesPanel();
+}
+
+/** Home / End in a side panel jump to its first / last row; in the diff
+ *  they keep the editor's start-of-line / end-of-line meaning. */
+function review_nav_home() {
+    if (state.focusPanel === 'files') { review_goto_file(-state.files.length); return; }
+    if (state.focusPanel === 'comments') { review_comments_select_first(); return; }
+    editor.executeAction("move_line_start");
+}
+registerHandler("review_nav_home", review_nav_home);
+
+function review_nav_end() {
+    if (state.focusPanel === 'files') { review_goto_file(state.files.length); return; }
+    if (state.focusPanel === 'comments') { review_comments_select_last(); return; }
+    editor.executeAction("move_line_end");
+}
+registerHandler("review_nav_end", review_nav_end);
 
 function review_page_up() {
     if (state.focusPanel === 'comments') { review_comments_select_prev(); return; }
@@ -4493,22 +4554,104 @@ registerHandler("review_drill_down", review_drill_down);
 // See docs/internal/REVIEW_DIFF_HUNK_PARITY_UX_DESIGN.md §5.1.
 const AUTO_SPLIT_MIN_WIDTH = 140;
 
-function review_set_layout(layout: 'unified' | 'side-by-side'): void {
+/** Where the reader is: the file and the file-line under the cursor, in
+ *  whichever layout is showing. Carried across a layout switch so the
+ *  other view opens on the same line rather than at the top of the file. */
+interface ReviewAnchor {
+    fileKey: string;
+    lineType: 'add' | 'remove' | 'context';
+    oldLine?: number;
+    newLine?: number;
+}
+
+/** The anchor for the current cursor position. Reads the composite's
+ *  cursor in side-by-side and the unified stream's row properties
+ *  otherwise. */
+async function currentReviewAnchor(): Promise<ReviewAnchor | null> {
+    const info = state.centerComposite
+        ? await getCompositeLineInfo()
+        : getCurrentLineInfo();
+    if (!info || !info.lineType) return null;
+    const file = state.files.find(f => f.path === info.file);
+    if (!file) return null;
+    return {
+        fileKey: fileKey(file),
+        lineType: info.lineType,
+        oldLine: info.oldLine,
+        newLine: info.newLine,
+    };
+}
+
+/** Index, within its file's hunks, of the hunk holding the anchor's line —
+ *  what `buildCenterComposite` wants as its initial focus. 0 when the line
+ *  sits outside every hunk. */
+function anchorHunkIndex(anchor: ReviewAnchor): number {
+    const file = state.files.find(f => fileKey(f) === anchor.fileKey);
+    if (!file) return 0;
+    const fileHunks = state.hunks.filter(
+        h => h.file === file.path && (h.gitStatus || 'unstaged') === file.category
+    );
+    const idx = fileHunks.findIndex(h =>
+        (anchor.newLine !== undefined
+            && anchor.newLine >= h.range.start && anchor.newLine <= h.range.end)
+        || (anchor.oldLine !== undefined
+            && anchor.oldLine >= h.oldRange.start && anchor.oldLine <= h.oldRange.end)
+    );
+    return idx < 0 ? 0 : idx;
+}
+
+/** Put the freshly-built center on `anchor`. In unified that is the stream
+ *  row carrying the same file + line; in side-by-side it is the composite
+ *  row showing that line of OLD (pane 0) or NEW (pane 1). */
+function restoreReviewAnchor(anchor: ReviewAnchor): void {
+    if (state.reviewLayout === 'side-by-side') {
+        const cc = state.centerComposite;
+        if (!cc) return;
+        const pane = anchor.lineType === 'remove' ? 0 : 1;
+        const line = anchor.lineType === 'remove' ? anchor.oldLine : anchor.newLine;
+        if (line === undefined) return;
+        editor.setCompositeCursorLine(cc.compositeBufId, pane, line - 1);
+        return;
+    }
+    for (const rowStr of Object.keys(state.entryPropsByRow)) {
+        const row = Number(rowStr);
+        const props = state.entryPropsByRow[row];
+        if (props["type"] !== anchor.lineType) continue;
+        if (props["file"] !== state.files.find(f => fileKey(f) === anchor.fileKey)?.path) continue;
+        const matches = anchor.lineType === 'remove'
+            ? props["oldLine"] === anchor.oldLine
+            : props["newLine"] === anchor.newLine;
+        if (matches) {
+            jumpDiffCursorToRow(row);
+            return;
+        }
+    }
+    // The line isn't in the stream (a context line outside every hunk, in
+    // a file whose hunks don't cover it) — settle for the file header.
+    const headerRow = state.fileHeaderRows[anchor.fileKey];
+    if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+}
+
+async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<void> {
     if (state.reviewLayout !== layout) {
+        // Read where the reader is *before* the center is rebuilt.
+        const anchor = await currentReviewAnchor();
         state.reviewLayout = layout;
         // Unified expands every file, side-by-side renders one — the
         // center rebuild below has to see the new mode.
         syncFocusMode();
-        // Side-by-side has nowhere to draw an inline comment box: the
-        // center is two real file buffers. The NEW pane's label says how
-        // many the file carries and the rail carries the text (Enter on a
-        // row jumps the composite to it), so open it on the way in rather
-        // than leaving the comments written but unreadable.
-        if (layout === 'side-by-side' && state.comments.length > 0) {
-            setReviewPanelVisible('comments', true);
+        if (anchor) state.filesCurrentKey = anchor.fileKey;
+        if (layout === 'side-by-side') {
+            // Await the build (renderCenter fires it off unawaited) so the
+            // composite exists before the cursor is placed on it, and open
+            // it on the anchor's hunk so the exact-line move below is a
+            // nudge rather than a jump.
+            await buildCenterComposite(anchor ? anchorHunkIndex(anchor) : 0);
+        } else {
+            renderCenter();
         }
-        renderCenter();
-        refreshStickyHeader(state.diffViewportTopRow);
+        if (anchor) restoreReviewAnchor(anchor);
+        else refreshStickyHeader(state.diffViewportTopRow);
     }
     editor.setStatus(
         layout === 'side-by-side'
@@ -4516,10 +4659,10 @@ function review_set_layout(layout: 'unified' | 'side-by-side'): void {
             : (editor.t("status.unified_view") || "Unified view")
     );
 }
-function review_layout_split() { review_set_layout('side-by-side'); }
+async function review_layout_split() { await review_set_layout('side-by-side'); }
 registerHandler("review_layout_split", review_layout_split);
 
-function review_layout_stack() { review_set_layout('unified'); }
+async function review_layout_stack() { await review_set_layout('unified'); }
 registerHandler("review_layout_stack", review_layout_stack);
 
 function review_layout_auto() {
@@ -4549,6 +4692,8 @@ async function review_help() {
         "",
         " Focus       Tab / S-Tab cycle focus: files → diff → comments",
         "             ↑ ↓        move within the focused panel (j / k too)",
+        "             ← →        pan the diff / fold a directory in FILES",
+        "             Home End   line ends in the diff, first / last row in a panel",
         " Navigate    n / p      next / prev hunk",
         "             , / .      prev / next file",
         "             ] / [      next / prev comment",
@@ -4637,8 +4782,10 @@ function review_goto_file(delta: number) {
     if (vis.length === 0) return;
     let idx = vis.findIndex(f => fileKey(f) === state.filesCurrentKey);
     if (idx < 0) idx = 0;
-    const next = idx + delta;
-    if (next < 0 || next >= vis.length) return;
+    // Clamped, not bailed: `,`/`.` still stop at the ends, and Home / End
+    // can ask for "as far as it goes" with one big delta.
+    const next = Math.max(0, Math.min(vis.length - 1, idx + delta));
+    if (next === idx) return;
     state.filesCurrentKey = fileKey(vis[next]);
     // Light refresh: only the center + sidebar highlight + sticky change on a
     // file switch — rebuilding the toolbar/comments panels too would add
@@ -6950,16 +7097,16 @@ editor.defineMode("review-mode", [
     ["Up", "review_nav_up"], ["Down", "review_nav_down"],
     ["k", "review_nav_up"], ["j", "review_nav_down"],
     ["PageUp", "review_page_up"], ["PageDown", "review_page_down"],
-    // Home / End — match the editor's normal-mode defaults so users
-    // get the same start-of-line / end-of-line behavior they're used
-    // to. Mode bindings replace globals, so we must bind these
-    // explicitly even though the actions are built-in.
-    ["Home", "move_line_start"], ["End", "move_line_end"],
+    // Home / End — start / end of line in the diff (the editor's normal
+    // meaning), first / last row in a focused side panel. Mode bindings
+    // replace globals, so these are bound explicitly.
+    ["Home", "review_nav_home"], ["End", "review_nav_end"],
     // Left / Right pan the unified stream horizontally. Nothing wraps
     // in the diff panel, so a long line runs past the right edge; the
     // cursor walking off it is what scrolls the viewport across, the
-    // same way it does in a normal buffer (Shift+wheel pans too).
-    ["Left", "move_left"], ["Right", "move_right"],
+    // same way it does in a normal buffer (Shift+wheel pans too). In the
+    // FILES sidebar they fold / unfold the selected directory instead.
+    ["Left", "review_nav_left"], ["Right", "review_nav_right"],
     // Hunk navigation across the unified stream.
     ["n", "review_next_hunk"], ["p", "review_prev_hunk"],
     // File navigation (hunk-style): focus the prev / next file.

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1777,10 +1777,20 @@ function buildFilesTree(): FilesTree {
     const groups = fileGroups();
     const catCounts: Record<string, number> = {};
     for (const g of groups) catCounts[g.category] = (catCounts[g.category] || 0) + g.files.length;
+    // With one category (the usual worktree review: everything unstaged)
+    // a category row would be a header over the whole tree and one wasted
+    // indent level in a panel that has ~24 columns to work with.
+    const categories = Object.keys(catCounts);
+    const showCategories = categories.length > 1;
+    const dirDepth = showCategories ? 1 : 0;
+    // Rows are clipped by the host to the panel width; a path clipped from
+    // the right leaves three sibling directories looking identical, so
+    // elide from the left and keep the leaf.
+    const W = panelWidthOf('files');
 
     let lastCategory: string | undefined;
     for (const group of groups) {
-        if (group.category !== lastCategory) {
+        if (showCategories && group.category !== lastCategory) {
             lastCategory = group.category;
             let label: string = group.category;
             if (state.mode === 'range' && state.range) label = state.range.label;
@@ -1805,9 +1815,15 @@ function buildFilesTree(): FilesTree {
         const dirKey = `dir:${group.dirKey}`;
         out.groupKeys.push(dirKey);
         out.keys.push(dirKey);
+        const dirStats = `  +${added} -${removed}`;
+        // Indent the host adds: 2 per depth level, plus the disclosure glyph.
+        const dirRoom = Math.max(6, W - dirDepth * 2 - 2 - dirStats.length);
         out.nodes.push(treeNode(
-            { text: `${group.dir}  +${added} -${removed}`, style: { fg: STYLE_SECTION_HEADER } },
-            { depth: 1, hasChildren: true },
+            {
+                text: `${elideLeft(group.dir, dirRoom)}${dirStats}`,
+                style: { fg: STYLE_SECTION_HEADER },
+            },
+            { depth: dirDepth, hasChildren: true },
         ));
 
         for (const file of group.files) {
@@ -1818,17 +1834,24 @@ function buildFilesTree(): FilesTree {
             out.fileByNodeKey[nodeKey] = key;
             out.indexByFileKey[key] = out.nodes.length;
             out.keys.push(nodeKey);
+            const stats = `  +${counts.added} -${counts.removed}${badge}`;
+            const nameRoom = Math.max(6, W - (dirDepth + 1) * 2 - 4 - stats.length);
             out.nodes.push(treeNode(
                 {
-                    text: `${file.status || ' '} ${fileBaseOf(file.path)}  +${counts.added} -${counts.removed}${badge}`,
+                    text: `${file.status || ' '} ${elideRight(fileBaseOf(file.path), nameRoom)}${stats}`,
                     properties: { type: "file", fileKey: key, filePath: file.path },
                 },
-                { depth: 2 },
+                { depth: dirDepth + 1 },
             ));
         }
     }
     return out;
 }
+
+/** The node the sidebar tree has selected — `file:…`, `dir:…` or
+ *  `cat:…`. Mirrored from the host's `select` events so Enter knows what
+ *  it is acting on. */
+let filesSelectedNodeKey = "";
 
 /** The sidebar tree as last built — the map from a `select` event's node
  *  key back to a file. */
@@ -1840,7 +1863,7 @@ let filesTree: FilesTree = {
  *  (and the filter field when it is showing). */
 function panelListRows(panel: 'files' | 'comments'): number {
     const height = state.panelHeights[panel] ?? Math.max(8, state.viewportHeight - 6);
-    const chrome = 1 + (panel === 'files' && filterEditing ? 1 : 0);
+    const chrome = 1 + (panel === 'files' ? 1 : 0); // header (+ filter field)
     return Math.max(1, height - chrome);
 }
 
@@ -1851,16 +1874,19 @@ function buildFilesPanelSpec(): WidgetSpec {
     const selected = state.filesCurrentKey !== null
         ? (filesTree.indexByFileKey[state.filesCurrentKey] ?? -1)
         : -1;
-    const parts: WidgetSpec[] = [panelHeaderSpec('files', filesHeaderLabel())];
-    if (filterEditing) {
-        parts.push(text({
+    const parts: WidgetSpec[] = [
+        panelHeaderSpec('files', filesHeaderLabel()),
+        // Always present, whether or not it holds focus: a filter you
+        // cannot see is a filter you forget is on. `/` focuses it, and so
+        // does clicking it.
+        text({
             value: state.fileFilter,
             cursorByte: filterCursor,
             placeholder: editor.t("prompt.filter_files") || "Filter files",
             fullWidth: true,
             key: FILES_FILTER_KEY,
-        }));
-    }
+        }),
+    ];
     if (filesTree.nodes.length === 0) {
         parts.push(raw([{
             text: ` ${(state.fileFilter
@@ -2034,7 +2060,6 @@ function panelVisible(panel: 'files' | 'diff' | 'comments'): boolean {
 function renderFilesPanel(): void {
     if (filesPanel === null || !panelVisible('files')) return;
     filesPanel.set(buildFilesPanelSpec());
-    filesPanel.setFocusKey(filterEditing ? FILES_FILTER_KEY : FILES_TREE_KEY);
 }
 
 /** Repaint the COMMENTS rail, if it is on screen. */
@@ -2069,6 +2094,8 @@ function setReviewPanelVisible(panel: 'files' | 'comments', visible: boolean): v
         } else {
             renderCommentsPanel();
         }
+        // You asked for the panel; the keys go there.
+        reviewSetFocus(panel);
     } else if (state.focusPanel === panel) {
         // Focus cannot stay on a panel that is no longer drawn.
         reviewSetFocus('diff');
@@ -2096,20 +2123,33 @@ editor.on("widget_event", (data) => {
 
     // --- FILES tree: selection, activation, and the filter field --------
     if (data.widget_key === FILES_TREE_KEY) {
+        // Focus moved off the field and onto the tree — back to the
+        // panel's command keys.
+        if (data.event_type === "focus") {
+            leaveFilterMode();
+            return;
+        }
         const nodeKey = String((data.payload as Record<string, unknown>)?.["key"] ?? "");
         if (data.event_type === "select") {
             onFilesTreeSelect(nodeKey);
             return;
         }
         if (data.event_type === "activate") {
-            // Enter on a file opens it the way Enter in the diff does;
-            // on a folder the host has already toggled the fold.
-            if (nodeKey.startsWith("file:")) void review_drill_down();
+            // Double-click on a file row: same as Enter — go to it.
+            if (nodeKey.startsWith("file:")) {
+                filesSelectedNodeKey = nodeKey;
+                onFilesTreeSelect(nodeKey);
+                reviewSetFocus('diff');
+            }
             return;
         }
         return; // `expand` is host-owned; nothing to mirror.
     }
     if (data.widget_key === FILES_FILTER_KEY) {
+        if (data.event_type === "focus") {
+            enterFilterMode();
+            return;
+        }
         if (data.event_type === "change") {
             const payload = (data.payload ?? {}) as Record<string, unknown>;
             if (typeof payload["value"] === "string") state.fileFilter = payload["value"];
@@ -2163,6 +2203,7 @@ editor.on("widget_event", (data) => {
  *  Selecting a file moves the review to it; selecting a category or
  *  directory row is just navigation. */
 function onFilesTreeSelect(nodeKey: string): void {
+    filesSelectedNodeKey = nodeKey;
     const key = filesTree.fileByNodeKey[nodeKey];
     if (key === undefined || key === state.filesCurrentKey) return;
     state.filesCurrentKey = key;
@@ -2862,6 +2903,9 @@ function reviewSetFocus(panel: 'files' | 'diff' | 'comments'): void {
     if (panel === 'files') {
         selectedSidebarFile();
         renderFilesPanel();
+        if (filesPanel !== null) {
+            filesPanel.setFocusKey(filterEditing ? FILES_FILTER_KEY : FILES_TREE_KEY);
+        }
     }
     refreshFocusIndicators();
 }
@@ -2935,6 +2979,16 @@ registerHandler("review_comments_select_next", review_comments_select_next);
 function review_enter_dispatch() {
     if (state.focusPanel === 'comments') {
         review_open_selected_comment();
+        return;
+    }
+    // FILES: Enter is "take me there". The selection already moved the
+    // diff to that file, so Enter hands focus to it — the same place Tab
+    // would put you, without the keystroke reaching the diff buffer (where
+    // it used to land on the file header and fold it). On a directory row
+    // it goes to the tree, which folds or unfolds it.
+    if (state.focusPanel === 'files') {
+        if (filesSelectedNodeKey.startsWith("file:")) reviewSetFocus('diff');
+        else filesKey("Enter");
         return;
     }
     // Side-by-side center: Enter opens the file version under the cursor
@@ -4746,7 +4800,9 @@ async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<vo
             renderCenter();
         }
         if (anchor) restoreReviewAnchor(anchor);
-        else refreshStickyHeader(state.diffViewportTopRow);
+        // The sticky names the current file in side-by-side and the
+        // top-of-view file in unified — either way it has just changed.
+        refreshStickyHeader(state.diffViewportTopRow);
     }
     editor.setStatus(
         layout === 'side-by-side'
@@ -4911,18 +4967,32 @@ let filterBeforeEdit = "";
 
 const REVIEW_FILTER_MODE = "review-filter";
 
+/** Put the panel into text-entry mode: while the filter field holds
+ *  focus its single-key commands (`s`, `c`, `n`, …) are letters, not
+ *  commands, so the FILES buffer switches to a mode that says so. */
+function enterFilterMode(): void {
+    if (filterEditing) return;
+    filterEditing = true;
+    filterBeforeEdit = state.fileFilter;
+    const filesBuf = state.panelBuffers["files"];
+    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, REVIEW_FILTER_MODE);
+}
+
+/** Focus has left the field — the panel's command keys are back. */
+function leaveFilterMode(): void {
+    if (!filterEditing) return;
+    filterEditing = false;
+    const filesBuf = state.panelBuffers["files"];
+    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, "review-mode");
+}
+
 function review_filter_files() {
     if (state.groupId === null) return;
     setReviewPanelVisible('files', true);
-    filterBeforeEdit = state.fileFilter;
     filterCursor = getByteLength(state.fileFilter);
-    filterEditing = true;
-    const filesBuf = state.panelBuffers["files"];
-    // While the field is open the panel's single-key commands (`s`, `c`,
-    // `n`, …) must not fire — they are letters the user is typing.
-    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, REVIEW_FILTER_MODE);
+    enterFilterMode();
     reviewSetFocus('files');
-    renderFilesPanel();
+    if (filesPanel !== null) filesPanel.setFocusKey(FILES_FILTER_KEY);
 }
 registerHandler("review_filter_files", review_filter_files);
 
@@ -4945,13 +5015,13 @@ function applyFileFilter(): void {
  *  field opened (Esc); otherwise the typed query stands (Enter). */
 function closeFileFilter(revert: boolean): void {
     if (!filterEditing) return;
-    filterEditing = false;
     if (revert && state.fileFilter !== filterBeforeEdit) {
         state.fileFilter = filterBeforeEdit;
         applyFileFilter();
     }
-    const filesBuf = state.panelBuffers["files"];
-    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, "review-mode");
+    leaveFilterMode();
+    // Focus lands on the tree — you filtered to pick a file.
+    if (filesPanel !== null) filesPanel.setFocusKey(FILES_TREE_KEY);
     renderFilesPanel();
 }
 
@@ -4982,8 +5052,16 @@ function review_filter_key(name: string): void {
 }
 registerHandler("review_filter_backspace", () => review_filter_key("Backspace"));
 registerHandler("review_filter_delete", () => review_filter_key("Delete"));
-registerHandler("review_filter_up", () => review_filter_key("Up"));
-registerHandler("review_filter_down", () => review_filter_key("Down"));
+/** ↑ / ↓ from the field step into the results: focus moves to the tree
+ *  (which puts the panel back in command mode) and the key walks it. */
+function review_filter_step(name: "Up" | "Down"): void {
+    if (filesPanel === null) return;
+    filesPanel.setFocusKey(FILES_TREE_KEY);
+    leaveFilterMode();
+    filesPanel.command(key(name));
+}
+registerHandler("review_filter_up", () => review_filter_step("Up"));
+registerHandler("review_filter_down", () => review_filter_step("Down"));
 registerHandler("review_filter_left", () => review_filter_key("Left"));
 registerHandler("review_filter_right", () => review_filter_key("Right"));
 
@@ -5072,7 +5150,9 @@ function jumpDiffCursorToRow(row: number, options?: { recenter?: boolean }): voi
     }
     state.diffCursorRow = row;
     applyCursorLineOverlay('diff');
-    refreshStickyHeader(idx);
+    // The scroll this jump triggers reports back through
+    // `viewport_changed`, which is what re-derives the sticky header.
+    refreshStickyHeader(state.diffViewportTopRow);
     updateReviewStatus();
 }
 
@@ -6414,8 +6494,11 @@ function refreshFocusIndicators(): void {
     if (state.panelBuffers["comments"] !== undefined) {
         renderCommentsPanel();
     }
-    // The diff's "header" is the sticky bar; refresh it in place.
-    refreshStickyHeader(Math.max(0, state.diffCursorRow - 1));
+    // The diff's "header" is the sticky bar; refresh it in place. It
+    // names what sits at the *top of the view*, so it is driven by the
+    // viewport, never by the cursor — feeding it the cursor row made it
+    // name a file that wasn't on screen.
+    refreshStickyHeader(state.diffViewportTopRow);
 }
 
 /**

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1814,6 +1814,36 @@ function insertIntoDirTree(root: DirNode, file: FileEntry): void {
     node.files.push(file);
 }
 
+/**
+ * Collapse runs of directories that only ever contain one another into a
+ * single row, the way the file explorer does: `crates/fresh-editor/src/app`
+ * is one row rather than four, because none of the intermediate levels has
+ * a file or a second child of its own to show. A level earns its own row as
+ * soon as it holds a file or branches.
+ *
+ * Counts need no fixing up — every level of a chain totals the same
+ * subtree — and the surviving node keeps the deepest `path`, so its key and
+ * its expand state stay stable as long as the chain does.
+ */
+function compressDirChains(node: DirNode): void {
+    for (const [key, child] of [...node.children]) {
+        let merged = child;
+        while (merged.files.length === 0 && merged.children.size === 1) {
+            const only = [...merged.children.values()][0];
+            merged = {
+                name: `${merged.name}/${only.name}`,
+                path: only.path,
+                children: only.children,
+                files: only.files,
+                added: only.added,
+                removed: only.removed,
+            };
+        }
+        if (merged !== child) node.children.set(key, merged);
+        compressDirChains(merged);
+    }
+}
+
 function buildFilesTree(): FilesTree {
     const out: FilesTree = {
         nodes: [], keys: [], fileByNodeKey: {}, indexByFileKey: {}, groupKeys: [],
@@ -1835,6 +1865,7 @@ function buildFilesTree(): FilesTree {
         }
         for (const f of g.files) insertIntoDirTree(entry.root, f);
     }
+    for (const r of roots) compressDirChains(r.root);
     // With one category (the usual worktree review: everything unstaged)
     // a category row would be a header over the whole tree and one wasted
     // indent level in a panel that has ~24 columns to work with.
@@ -5089,7 +5120,13 @@ function closeFileFilter(revert: boolean): void {
     if (!filterEditing) return;
     if (revert && state.fileFilter !== filterBeforeEdit) {
         state.fileFilter = filterBeforeEdit;
+        filterCursor = filterBeforeEdit.length;
         applyFileFilter();
+        // The host owns the field's text, and a plain re-render carries the
+        // widget's own value forward — so the restored query has to be
+        // pushed back explicitly, or Esc leaves the box reading the
+        // abandoned text over a tree that already reverted.
+        filesPanel?.setValue(FILES_FILTER_KEY, filterBeforeEdit, filterCursor);
     }
     leaveFilterMode();
     // Focus lands on the tree — you filtered to pick a file.

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -397,6 +397,16 @@ const STYLE_LINE_NUM_FG: OverlayColorSpec = "editor.line_number_fg";
 // gutter (extremely rare in review-diff context).
 const LINE_NUM_W = 4;
 
+/** Disclosure triangles for collapsible headers (sections, files,
+ *  hunks). The buffer text always carries `GLYPH_EXPANDED`; `applyFolds`
+ *  overlays `GLYPH_COLLAPSED` as a replacement conceal while the body is
+ *  folded, so collapsing never rewrites the buffer. Both are one column
+ *  and the same length in bytes — `TRIANGLE_BYTES` — which is what lets
+ *  the conceal target a fixed range after the header's leading space. */
+const GLYPH_EXPANDED = '▾';
+const GLYPH_COLLAPSED = '▸';
+const TRIANGLE_BYTES = getByteLength(GLYPH_EXPANDED);
+
 /** Format the per-row "OLD  NEW " prefix (with trailing space). Either
  *  side passes `undefined` for blank — removed lines blank the new
  *  column, added lines blank the old column. */
@@ -1110,16 +1120,16 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
             else if (file.category === 'unstaged') label = editor.t("section.unstaged") || "Unstaged";
             else if (file.category === 'untracked') label = editor.t("section.untracked") || "Untracked";
             const sectionCount = state.files.filter(f => f.category === file.category && fileMatchesFilter(f)).length;
-            // Always render expanded triangle (▾). Collapse state is
+            // Always render the expanded triangle. Collapse state is
             // shown by overlaying a `▸` replacement-conceal on the
-            // triangle byte range — the buffer text never changes, so
-            // toggling collapse never has to rebuild.
+            // triangle byte range (see `applyFolds`) — the buffer text
+            // never changes, so toggling collapse never has to rebuild.
             // Range labels (e.g. `main..HEAD`) carry case already — don't
             // mangle them with the section uppercase; worktree category
             // names are lowercase words and need the uppercase.
             const displayLabel = state.mode === 'range' ? label : label.toUpperCase();
             lines.push({
-                text: ` ▾ ${displayLabel}  (${sectionCount})`,
+                text: ` ${GLYPH_EXPANDED} ${displayLabel}  (${sectionCount})`,
                 type: 'section-header',
                 file: file.category, // store category in 'file' field for reuse
                 filePath: file.category,
@@ -1132,12 +1142,12 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
             });
         }
 
-        // File header — always emit the expanded triangle; conceal
-        // overlays handle the collapsed view.
+        // File header — always emit the expanded triangle; the
+        // conceal in `applyFolds` shows the collapsed view.
         const counts = fileChangeCounts(file);
         const key = fileKey(file);
         const filename = file.origPath ? `${file.origPath} → ${file.path}` : file.path;
-        const headerText = ` ▾ ${filename}   +${counts.added} / -${counts.removed}`;
+        const headerText = ` ${GLYPH_EXPANDED} ${filename}   +${counts.added} / -${counts.removed}`;
         lines.push({
             text: headerText,
             type: 'file-header',
@@ -1184,12 +1194,12 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
         }
 
         for (const hunk of fileHunks) {
-        // Hunk header — always emit expanded triangle; collapse
-        // overlays a `▸` replacement-conceal.
+        // Hunk header — always emit the expanded triangle; collapse
+        // overlays a `▸` replacement-conceal (see `applyFolds`).
         const headerInner = hunk.contextHeader
             ? `@@ ${hunk.contextHeader} @@`
             : `@@ -${hunk.oldRange.start} +${hunk.range.start} @@`;
-        const header = ` ▾ ${headerInner}`;
+        const header = ` ${GLYPH_EXPANDED} ${headerInner}`;
 
         lines.push({
             text: header,
@@ -1896,11 +1906,20 @@ function buildFilesTree(): FilesTree {
         out.fileByNodeKey[nodeKey] = key;
         out.indexByFileKey[key] = out.nodes.length;
         out.keys.push(nodeKey);
-        const stats = `  +${counts.added} -${counts.removed}${badge}`;
-        const room = Math.max(4, W - depth * 2 - 4 - stats.length);
+        // The status letter rides on the right with the counts, not in
+        // front of the name. The host already aligns a leaf's text with
+        // its sibling directories' *names* (a leaf gets two spaces where
+        // the disclosure glyph would be), so a leading `M ` pushed every
+        // filename two columns past its siblings — and a file following a
+        // collapsed directory then read as that directory's contents. The
+        // file explorer this sidebar mirrors right-aligns status for the
+        // same reason.
+        const status = file.status ? ` ${file.status}` : '';
+        const stats = `  +${counts.added} -${counts.removed}${badge}${status}`;
+        const room = Math.max(4, W - depth * 2 - 2 - stats.length);
         out.nodes.push(treeNode(
             {
-                text: `${file.status || ' '} ${elideRight(fileBaseOf(file.path), room)}${stats}`,
+                text: `${elideRight(fileBaseOf(file.path), room)}${stats}`,
                 properties: { type: "file", fileKey: key, filePath: file.path },
             },
             { depth },
@@ -2339,35 +2358,67 @@ function updateMagitDisplay(): void {
     refreshStickyHeader(0);
 }
 
+/** Conceal namespace owning the collapsed-header triangles, so
+ *  `applyFolds` can drop the whole set in one host call. */
+const NS_COLLAPSE_TRIANGLE = "review-collapse-triangle";
+
+/** Byte range of the `▾` in a header row, given its 1-indexed row.
+ *  Every collapsible header is emitted as `" ▾ …"`, so the glyph is the
+ *  `TRIANGLE_BYTES` bytes after the leading space. Returns null when the
+ *  row index has no recorded offset (stale state between rebuilds). */
+function headerTriangleRange(row1: number | undefined): { start: number; end: number } | null {
+    if (row1 === undefined) return null;
+    const start = state.diffLineByteOffsets[row1 - 1];
+    if (start === undefined) return null;
+    return { start: start + 1, end: start + 1 + TRIANGLE_BYTES };
+}
+
 /**
  * Apply collapse state via the host's folding infrastructure. Folds
  * are designed exactly for "header line stays visible, body lines
  * skipped by the renderer". A fold range covers `[bodyStart, bodyEnd)`
  * — the line containing `bodyStart - 1` (the header) stays visible,
- * everything inside the range gets elided. The host renders its own
- * "..." indicator on the collapsed header line, which is sufficient
- * visual feedback (no need for a triangle swap).
+ * everything inside the range gets elided.
  *
- * Toggling collapse on a 5000-line diff is now O(collapsed_set_size)
- * `addFold` calls. `clearFolds` drops the entire set in one host call
- * so re-applying after a state change is also cheap.
+ * The header keeps its `▾` in the buffer text and a replacement conceal
+ * turns it into `▸` while collapsed, so the triangle agrees with the
+ * fold instead of pointing open over a closed body — the sidebar's
+ * directory rows rotate theirs, and a row that says "expanded" while
+ * showing nothing is a contradiction the host's `…` marker doesn't
+ * resolve. Conceals are rendering-only: the buffer text never changes,
+ * so this keeps collapse a rebuild-free operation.
+ *
+ * Toggling collapse on a 5000-line diff is O(collapsed_set_size)
+ * `addFold` + `addConceal` calls. `clearFolds` /
+ * `clearConcealNamespace` each drop the whole set in one host call so
+ * re-applying after a state change is also cheap.
  */
 function applyFolds(): void {
     if (state.groupId === null) return;
     const diffId = state.panelBuffers["diff"];
     if (diffId === undefined) return;
     editor.clearFolds(diffId);
+    editor.clearConcealNamespace(diffId, NS_COLLAPSE_TRIANGLE);
+    const collapseTriangle = (row1: number | undefined): void => {
+        const range = headerTriangleRange(row1);
+        if (range) {
+            editor.addConceal(diffId, NS_COLLAPSE_TRIANGLE, range.start, range.end, GLYPH_COLLAPSED);
+        }
+    };
     for (const cat of state.collapsedSections) {
         const body = state.sectionBodyRange[cat];
         if (body && body.end > body.start) editor.addFold(diffId, body.start, body.end);
+        collapseTriangle(state.sectionHeaderRows[cat]);
     }
     for (const key of state.collapsedFiles) {
         const body = state.fileBodyRange[key];
         if (body && body.end > body.start) editor.addFold(diffId, body.start, body.end);
+        collapseTriangle(state.fileHeaderRows[key]);
     }
     for (const id of state.collapsedHunks) {
         const body = state.hunkBodyRange[id];
         if (body && body.end > body.start) editor.addFold(diffId, body.start, body.end);
+        collapseTriangle(state.hunkRowByHunkId[id]);
     }
 }
 
@@ -2382,7 +2433,10 @@ function refreshStickyHeader(topVisibleRow: number): void {
     const stickyId = state.panelBuffers["sticky"];
     if (stickyId === undefined) return;
 
-    const W = state.viewportWidth;
+    // The sticky row spans the diff pane, so it is clipped to the diff
+    // pane's width — not the review's overall viewport, which is the
+    // focused split's and may be a side panel.
+    const W = diffPanelWidth();
     let text: string;
     let style: Partial<OverlayOptions> = { fg: STYLE_HEADER, bold: true };
 
@@ -2721,6 +2775,10 @@ function on_review_viewport_changed(data: { split_id: number; buffer_id: number;
     // Inline comment boxes are laid out to this width (see
     // `diffPanelWidth`); the next center rebuild picks up a change.
     state.panelWidths["diff"] = data.width;
+    // Height too, so `refreshViewportDimensions` has an authoritative
+    // size for the diff pane and never has to trust whichever split
+    // happens to hold focus.
+    state.panelHeights["diff"] = data.height;
     // Prefer top_line when the host provides it. Virtual buffers may not
     // have line metadata, in which case top_line is null — fall back to
     // converting top_byte using our own row-byte index.
@@ -3878,7 +3936,19 @@ function restoreCursorAfterRebuild() {
  * unlike the terminal-level resize event which reports full terminal size.
  */
 function refreshViewportDimensions(): boolean {
-    const viewport = editor.getViewport();
+    // `getViewport()` reports the *focused* split only. With a side panel
+    // focused — which is exactly where `r` leaves you after picking a file
+    // — that is the sidebar's geometry, and recording it as the review's
+    // viewport shrinks everything laid out against `viewportWidth` (the
+    // sticky header was being sliced to the sidebar's width). The host
+    // reports each panel's real rect through `on_review_viewport_changed`,
+    // so prefer the diff pane's own recorded size and fall back to the
+    // focused split only before the group has been laid out once.
+    const width = state.panelWidths["diff"];
+    const height = state.panelHeights["diff"];
+    const viewport = width && height && width > 0 && height > 0
+        ? { width, height }
+        : editor.getViewport();
     if (viewport) {
         const changed = viewport.width !== state.viewportWidth || viewport.height !== state.viewportHeight;
         state.viewportWidth = viewport.width;

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -18,6 +18,16 @@ import {
   fetchGitLog,
 } from "./lib/git_history.ts";
 import { type GitRepo, resolveGitRepo } from "./lib/git_repo.ts";
+import {
+  WidgetPanel,
+  button,
+  col,
+  flexSpacer,
+  raw,
+  row,
+  spacer,
+  styledRow,
+} from "./lib/widgets.ts";
 const VirtualBufferFactory = createVirtualBufferFactory(editor);
 
 
@@ -206,9 +216,6 @@ interface ReviewState {
   // Maps a sidebar row to a directory-group key (`${category} ${dir}`) so
   // clicking a directory header toggles its collapse.
   filesPanelDirByRow: Record<number, string>;
-  // Byte offset of each file's row in the files panel buffer, so the panel
-  // can be scrolled to keep the selected file visible (B2).
-  filesPanelByteByKey: Record<string, number>;
   // File key currently highlighted in the sidebar (tracks the diff
   // viewport's top file). Lets the scroll handler skip a sidebar repaint
   // when the current file hasn't changed.
@@ -219,15 +226,27 @@ interface ReviewState {
   showComments: boolean;
   // Active file-filter query (the `/` filter). Empty = show all files.
   fileFilter: string;
-  // When true (default), the center panel renders only the focused file
-  // (`filesCurrentKey`) instead of every file's hunks. The sidebar is the
-  // multi-file navigator; this keeps the center buffer small and fast even
-  // on huge changesets. `,`/`.` move the focus between files.
+  // When true, the center panel renders only the focused file
+  // (`filesCurrentKey`) instead of every file's hunks. Derived, not a
+  // user setting — see `syncFocusMode`: the unified stream expands every
+  // file so the mouse wheel walks the whole review, and only falls back
+  // to one-file-at-a-time for the side-by-side composite (which is
+  // per-file by construction) or a changeset too big to lay out at once.
   focusOnly: boolean;
   // When true, the focused file renders as a two-column side-by-side
   // (OLD | NEW) in the center panel instead of the unified stream. The
   // `1`/`2` keys toggle it; the sidebar and other panels stay put.
   splitView: boolean;
+  // Which of the two optional side panels are on screen. Both start
+  // hidden so the diff owns the full width — the reading surface is what
+  // a review is about. `F` / `C` (or the toolbar buttons, or the `✕` in a
+  // panel header) toggle them; the choice sticks for the editor session.
+  panelsVisible: { files: boolean; comments: boolean };
+  // Last width in columns the host reported for each panel, keyed by
+  // panel name. Used to right-align the `✕` close button in a panel
+  // header; falls back to a ratio-derived estimate until the first
+  // viewport_changed for that panel arrives.
+  panelWidths: Record<string, number>;
   // Current selection in the comments panel (1-indexed row, 0 means none)
   commentsSelectedRow: number;
   // Comment-id the diff cursor is sitting on / attached to. Drives the
@@ -298,10 +317,11 @@ const state: ReviewState = {
   commentsByRow: {},
   filesPanelByRow: {},
   filesPanelDirByRow: {},
-  filesPanelByteByKey: {},
   filesCurrentKey: null,
   showComments: true,
   fileFilter: "",
+  panelsVisible: { files: false, comments: false },
+  panelWidths: {},
   focusOnly: true,
   splitView: false,
   commentsSelectedRow: 0,
@@ -879,6 +899,14 @@ function wrapText(text: string, width: number): string[] {
     return out.length > 0 ? out : [''];
 }
 
+/** Width in columns of the center diff panel — the host's last reported
+ *  viewport width for it, falling back to the terminal width before the
+ *  first `viewport_changed` arrives. */
+function diffPanelWidth(): number {
+    const known = state.panelWidths["diff"];
+    return known && known > 0 ? known : state.viewportWidth;
+}
+
 /**
  * Push inline comment box rows for a given diff line into the lines array.
  * Each comment becomes a bordered, word-wrapped callout whose border title
@@ -902,10 +930,13 @@ function pushLineComments(
     // Indent the box so its left border aligns with the diff content
     // column (just past the OLD/NEW number gutter and the +/- indicator).
     const commentIndent = ' '.repeat(LINE_NUM_W + 1 + LINE_NUM_W + 1 + 1 + 1);
-    // Box outer width, clamped to the visible content area.
+    // Box outer width, clamped to the visible content area. The diff
+    // panel's own width (not the terminal's) is what the box has to fit
+    // in — with a side panel open they differ, and nothing soft-wraps a
+    // box that overshoots any more; it just gets clipped.
     const boxW = Math.max(
         COMMENT_BOX_MIN_W,
-        Math.min(COMMENT_BOX_MAX_W, state.viewportWidth - commentIndent.length - 1)
+        Math.min(COMMENT_BOX_MAX_W, diffPanelWidth() - commentIndent.length - 1)
     );
     const innerW = boxW - 4; // "| " + content + " |"
     for (const comment of lineComments) {
@@ -1438,9 +1469,52 @@ function buildToolbar(W: number): TextPropertyEntry[] {
 
 // --- Buffer Group panel content builders ---
 
-function buildToolbarPanelEntries(): TextPropertyEntry[] {
-    // Two-row toolbar: navigation hints on row 1, actions on row 2.
-    return buildToolbar(state.viewportWidth);
+// The toolbar is a widget panel: two hint rows (still built as styled
+// text entries and wrapped in `raw`) plus the two panel buttons pinned to
+// the right of the second row by a `flexSpacer`. The buttons are real
+// `Button` widgets, so the host owns their hit-testing, hover styling and
+// keyboard activation and the plugin only handles `widget_event`.
+const PANEL_BUTTON_KEYS = {
+    files: "toolbar.files",
+    comments: "toolbar.comments",
+} as const;
+
+/** Columns the two toolbar buttons take, including the gap between them
+ *  and the `[ ]` frames the host draws — the budget the hint text has to
+ *  leave free. Used only to size the *text*; where the buttons actually
+ *  land is the host's layout, not ours. */
+function toolbarButtonsWidth(): number {
+    return panelButtonLabel('files').length
+        + panelButtonLabel('comments').length
+        + 10; // two `[ ]` frames + the gap between the buttons
+}
+
+function panelButtonLabel(panel: 'files' | 'comments'): string {
+    const name = panel === 'files'
+        ? (editor.t("panel.files") || "Files")
+        : (editor.t("panel.comments") || "Comments");
+    return `${state.panelsVisible[panel] ? '▾' : '▸'} ${name}`;
+}
+
+function panelButton(panel: 'files' | 'comments'): WidgetSpec {
+    return button(panelButtonLabel(panel), {
+        key: PANEL_BUTTON_KEYS[panel],
+        // Mouse-first affordance: the review mode's Tab cycle belongs to
+        // the three content panels, and `F` / `C` already drive these
+        // from the keyboard.
+        focusable: false,
+    });
+}
+
+/** Render the toolbar panel: hint rows plus the panel buttons. */
+function renderToolbar(): void {
+    if (toolbarPanel === null) return;
+    const W = state.viewportWidth;
+    const rows = buildToolbar(Math.max(20, W - toolbarButtonsWidth()));
+    toolbarPanel.set(col(
+        raw([rows[0]]),
+        row(raw([rows[1]]), flexSpacer(), panelButton('files'), spacer(1), panelButton('comments')),
+    ));
 }
 
 /**
@@ -1601,6 +1675,52 @@ function focusMark(panel: 'files' | 'diff' | 'comments'): string {
     return state.focusPanel === panel ? '▸' : ' ';
 }
 
+// The toolbar and the two side panels are widget panels: the host owns
+// their buttons' hit-testing, hover styling and activation, and the
+// plugin only reacts to `widget_event`. Their bodies are still
+// entry-based text, wrapped in `raw`.
+let toolbarPanel: WidgetPanel | null = null;
+let filesPanel: WidgetPanel | null = null;
+let commentsPanel: WidgetPanel | null = null;
+
+/** The close button at the right edge of an open side panel's header.
+ *  Clicking it hides that panel (same as `F` / `C`). */
+const PANEL_CLOSE_GLYPH = '✕';
+
+const PANEL_CLOSE_KEYS = {
+    files: "files.close",
+    comments: "comments.close",
+} as const;
+
+/**
+ * Header row for a side panel: the focus marker and label on the left, a
+ * `✕` hard against the right edge. A `flexSpacer` between them is sized
+ * by the host against the panel's real width, so the button stays pinned
+ * to the edge without the plugin measuring anything — and the `✕` is a
+ * real `Button`, so the host owns its hit-testing and hover styling.
+ */
+function panelHeaderSpec(panel: 'files' | 'comments', label: string): WidgetSpec {
+    const base: Partial<OverlayOptions> = {
+        fg: STYLE_INVERSE_FG,
+        bg: STYLE_INVERSE_BG,
+        bold: true,
+        extendToLineEnd: true,
+    };
+    return row(
+        raw([styledRow([{ text: `${focusMark(panel)}${label}`, style: base }], { style: base })]),
+        flexSpacer(),
+        button(PANEL_CLOSE_GLYPH, {
+            key: PANEL_CLOSE_KEYS[panel],
+            // Mouse-only, like the file explorer's and the orchestrator
+            // dock's `✕`: the keyboard has `F` / `C`, and this panel's Tab
+            // stop belongs to its list.
+            focusable: false,
+            bare: true,
+            hoverStyle: { fg: "ui.tab_close_hover_fg" },
+        }),
+    );
+}
+
 /** Parent directory of a path (with trailing slash; `./` for repo root). */
 function fileDirOf(p: string): string {
     const i = p.lastIndexOf('/');
@@ -1651,18 +1771,19 @@ function fileGroups(): FileGroup[] {
     return groups;
 }
 
+/** The FILES panel's header label (the panel's `✕` and the focus marker
+ *  are drawn by `panelHeaderSpec`). */
+function filesHeaderLabel(): string {
+    return (editor.t("panel.files") || "Files").toUpperCase()
+        + (state.fileFilter ? `  /${state.fileFilter}` : "");
+}
+
+/** The FILES panel body, one entry per row *below* the header row that
+ *  `panelHeaderSpec` occupies — hence the row counter starting at 1. */
 function buildFilesPanelEntries(): TextPropertyEntry[] {
     const entries: TextPropertyEntry[] = [];
     state.filesPanelByRow = {};
     state.filesPanelDirByRow = {};
-
-    const headerLabel = (editor.t("panel.files") || "Files").toUpperCase()
-        + (state.fileFilter ? `  /${state.fileFilter}` : "");
-    entries.push({
-        text: `${focusMark('files')}${headerLabel}\n`,
-        style: { fg: STYLE_INVERSE_FG, bg: STYLE_INVERSE_BG, bold: true, extendToLineEnd: true },
-        properties: { type: "header" },
-    });
 
     if (state.files.length === 0) {
         entries.push({
@@ -1750,45 +1871,35 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
             properties: { type: "empty" },
         });
     }
-    // Record each file row's byte offset so the panel can be scrolled to keep
-    // the selected file visible (B2).
-    state.filesPanelByteByKey = {};
-    let acc = 0;
-    for (const e of entries) {
-        const fk = e.properties && (e.properties as Record<string, unknown>)["fileKey"];
-        if (typeof fk === 'string') state.filesPanelByteByKey[fk] = acc;
-        acc += getByteLength(e.text);
-    }
     return entries;
 }
 
 /** Scroll the FILES panel so the currently-selected file row stays visible.
- *  Uses setBufferCursor (which runs ensure_cursor_visible) so the panel only
- *  scrolls when the selection would otherwise be off-screen — no jumpy
- *  re-centering when it is already in view. */
+ *  The panel's selection is plugin state, not a buffer cursor, so the host
+ *  needs telling which row to keep in view — `scrollBufferToLine` is the
+ *  buffer-group panel's version of "ensure this row is visible", and it
+ *  leaves the viewport alone when the row already is. */
 function scrollFilesToSelected(): void {
     if (state.groupId === null || !state.filesCurrentKey) return;
     const filesId = state.panelBuffers["files"];
     if (filesId === undefined) return;
-    const byte = state.filesPanelByteByKey[state.filesCurrentKey];
-    if (byte !== undefined) editor.setBufferCursor(filesId, byte);
+    for (const rowStr of Object.keys(state.filesPanelByRow)) {
+        if (state.filesPanelByRow[Number(rowStr)] === state.filesCurrentKey) {
+            editor.scrollBufferToLine(filesId, Number(rowStr) - 1);
+            return;
+        }
+    }
 }
 
+/** The COMMENTS panel's header label. */
+function commentsHeaderLabel(): string {
+    return (editor.t("panel.comments") || "Comments").toUpperCase();
+}
+
+/** The COMMENTS panel body, one entry per row below the header row. */
 function buildCommentsPanelEntries(): TextPropertyEntry[] {
     const entries: TextPropertyEntry[] = [];
     state.commentsByRow = {};
-
-    const headerLabel = (editor.t("panel.comments") || "Comments").toUpperCase();
-    entries.push({
-        text: `${focusMark('comments')}${headerLabel}\n`,
-        style: {
-            fg: STYLE_INVERSE_FG,
-            bg: STYLE_INVERSE_BG,
-            bold: true,
-            extendToLineEnd: true,
-        },
-        properties: { type: "header" },
-    });
 
     if (state.comments.length === 0) {
         entries.push({
@@ -1867,6 +1978,137 @@ function buildCommentsPanelEntries(): TextPropertyEntry[] {
     return entries;
 }
 
+/** Total number of raw diff lines across every hunk that passes the
+ *  active `/` filter — the cost of laying the whole review out at once. */
+function totalVisibleDiffLines(): number {
+    let n = 0;
+    if (!state.fileFilter) {
+        for (const h of state.hunks) n += h.lines.length;
+        return n;
+    }
+    const keys = new Set<string>();
+    for (const f of state.files) {
+        if (fileMatchesFilter(f)) keys.add(fileKey(f));
+    }
+    for (const h of state.hunks) {
+        if (keys.has(fileKeyOf(h.file, h.gitStatus || 'unstaged'))) n += h.lines.length;
+    }
+    return n;
+}
+
+/** Above this many diff lines the unified stream keeps rendering one file
+ *  at a time. Laying out every hunk of a changeset that size costs more
+ *  than the scrolling it buys, and the FILES sidebar is still the way
+ *  across such a review. */
+const EXPAND_ALL_MAX_DIFF_LINES = 20000;
+
+/**
+ * Decide whether the center renders every file or just the focused one.
+ *
+ * Unified is a single scrollable stream, so it expands everything: the
+ * mouse wheel is the primary way through a review and it must reach the
+ * whole diff, not stop at the first file's last hunk. Side-by-side builds
+ * a composite of one file's OLD/NEW buffers and is per-file by
+ * construction, so it stays focused. Oversized changesets stay focused
+ * too — see `EXPAND_ALL_MAX_DIFF_LINES`.
+ */
+function syncFocusMode(): void {
+    state.focusOnly = state.reviewLayout === 'side-by-side'
+        || totalVisibleDiffLines() > EXPAND_ALL_MAX_DIFF_LINES;
+}
+
+/** Whether `panel` is currently on screen. The diff and its sticky header
+ *  are never hidden; the two side panels are. */
+function panelVisible(panel: 'files' | 'diff' | 'comments'): boolean {
+    if (panel === 'diff') return true;
+    return state.panelsVisible[panel];
+}
+
+/** Repaint the FILES sidebar, if it is on screen. Hidden panels are not
+ *  rendered, so rebuilding their content is work nobody sees —
+ *  `setReviewPanelVisible` repaints on the way back in. */
+function renderFilesPanel(): void {
+    if (filesPanel === null || !panelVisible('files')) return;
+    filesPanel.set(col(
+        panelHeaderSpec('files', filesHeaderLabel()),
+        raw(buildFilesPanelEntries()),
+    ));
+}
+
+/** Repaint the COMMENTS rail, if it is on screen. */
+function renderCommentsPanel(): void {
+    if (commentsPanel === null || !panelVisible('comments')) return;
+    commentsPanel.set(col(
+        panelHeaderSpec('comments', commentsHeaderLabel()),
+        raw(buildCommentsPanelEntries()),
+    ));
+}
+
+/** Push the plugin's visibility state into the host's group layout. */
+function applyPanelVisibility(): void {
+    if (state.groupId === null) return;
+    for (const panel of ['files', 'comments'] as const) {
+        editor.setBufferGroupPanelVisible(state.groupId, panel, state.panelsVisible[panel]);
+    }
+}
+
+/**
+ * Show or hide one of the side panels. Hiding the panel that holds
+ * keyboard focus hands focus back to the diff (the host refuses to focus
+ * an unrendered panel, so leaving `focusPanel` pointing at it would
+ * strand the arrow keys).
+ */
+function setReviewPanelVisible(panel: 'files' | 'comments', visible: boolean): void {
+    if (state.groupId === null) return;
+    if (state.panelsVisible[panel] === visible) return;
+    state.panelsVisible[panel] = visible;
+    editor.setBufferGroupPanelVisible(state.groupId, panel, visible);
+    if (visible) {
+        if (panel === 'files') {
+            renderFilesPanel();
+            scrollFilesToSelected();
+        } else {
+            renderCommentsPanel();
+        }
+    } else if (state.focusPanel === panel) {
+        reviewSetFocus('diff');
+    }
+    // The panel appearing or vanishing is its own feedback — no status
+    // message — but the toolbar button carries the open/closed marker.
+    renderToolbar();
+}
+
+function review_toggle_files_panel(): void {
+    setReviewPanelVisible('files', !state.panelsVisible.files);
+}
+registerHandler("review_toggle_files_panel", review_toggle_files_panel);
+
+function review_toggle_comments_panel(): void {
+    setReviewPanelVisible('comments', !state.panelsVisible.comments);
+}
+registerHandler("review_toggle_comments_panel", review_toggle_comments_panel);
+
+/** Buttons in the toolbar and in the two panel headers. The host does the
+ *  hit-testing and hands us the widget key. */
+editor.on("widget_event", (data) => {
+    if (state.groupId === null) return;
+    if (data.event_type !== "activate") return;
+    switch (data.widget_key) {
+        case PANEL_BUTTON_KEYS.files:
+            review_toggle_files_panel();
+            return;
+        case PANEL_BUTTON_KEYS.comments:
+            review_toggle_comments_panel();
+            return;
+        case PANEL_CLOSE_KEYS.files:
+            setReviewPanelVisible('files', false);
+            return;
+        case PANEL_CLOSE_KEYS.comments:
+            setReviewPanelVisible('comments', false);
+            return;
+    }
+});
+
 /**
  * Full refresh — rebuild all three panels. Called on data changes
  * (refreshMagitData, comment add/edit, note edit, resize). NOT called on
@@ -1875,13 +2117,12 @@ function buildCommentsPanelEntries(): TextPropertyEntry[] {
 function updateMagitDisplay(): void {
     refreshViewportDimensions();
     if (state.groupId === null) return;
+    syncFocusMode();
     ensureFocusFile();
-    editor.setPanelContent(state.groupId, "toolbar", buildToolbarPanelEntries());
+    renderToolbar();
     renderCenter();
-    editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
-    if (state.panelBuffers["files"] !== undefined) {
-        editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
-    }
+    renderCommentsPanel();
+    renderFilesPanel();
     refreshStickyHeader(0);
 }
 
@@ -2009,7 +2250,7 @@ function refreshStickyHeader(topVisibleRow: number): void {
         if (curKey !== state.filesCurrentKey) {
             state.filesCurrentKey = curKey;
             if (state.panelBuffers["files"] !== undefined) {
-                editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+                renderFilesPanel();
             }
         }
     }
@@ -2068,6 +2309,9 @@ function on_review_mouse_click(data: {
     const diffId = state.panelBuffers["diff"];
     const stickyId = state.panelBuffers["sticky"];
     const commentsId = state.panelBuffers["comments"];
+
+    // Clicks on the toolbar's and the panel headers' buttons arrive as
+    // `widget_event`, not here.
 
     // Click in the diff buffer: section headers and file headers are
     // both interactive — clicking either toggles its fold state.
@@ -2140,12 +2384,15 @@ function on_review_mouse_click(data: {
     // Click in the file sidebar: jump to that file and hand focus to the
     // diff so the user can immediately keep navigating.
     if (data.buffer_id === state.panelBuffers["files"]) {
+        // Row 0 is the widget header (label + `✕`); its button reports
+        // through `widget_event`, and the rest of the row is inert.
+        if (data.buffer_row === 0) return;
         // Directory header click: toggle that group's collapse.
         const dirKey = state.filesPanelDirByRow[data.buffer_row + 1];
         if (dirKey) {
             if (state.collapsedDirs.has(dirKey)) state.collapsedDirs.delete(dirKey);
             else state.collapsedDirs.add(dirKey);
-            editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+            renderFilesPanel();
             return;
         }
         const key = state.filesPanelByRow[data.buffer_row + 1];
@@ -2169,13 +2416,15 @@ function on_review_mouse_click(data: {
     // Click in the comments panel: jump to the comment's location and
     // hand focus to the diff so the user can immediately keep navigating.
     if (data.buffer_id === commentsId) {
+        // Row 0 is the widget header — see the FILES panel above.
+        if (data.buffer_row === 0) return;
         const targetRow1 = data.buffer_row + 1;
         const commentId = state.commentsByRow[targetRow1];
         if (commentId) {
             state.commentsSelectedRow = targetRow1;
             jumpToComment(commentId);
             editor.focusBufferGroupPanel(state.groupId, "diff");
-            editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+            renderCommentsPanel();
         }
         return;
     }
@@ -2206,11 +2455,11 @@ function jumpToComment(commentId: string): void {
         void (async () => {
             await buildCenterComposite(idx);
             if (state.groupId !== null && state.panelBuffers["files"] !== undefined) {
-                editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+                renderFilesPanel();
                 scrollFilesToSelected();
             }
             if (state.groupId !== null) {
-                editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+                renderCommentsPanel();
             }
             refreshStickyHeader(0);
         })();
@@ -2250,7 +2499,7 @@ function jumpToComment(commentId: string): void {
     const prevHighlight = state.commentsHighlightId;
     state.commentsHighlightId = commentId;
     if (state.groupId !== null && prevHighlight !== commentId) {
-        editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+        renderCommentsPanel();
     }
     // Prefer the diff line the comment is anchored to (line-based);
     // fall back to the hunk header if the lookup hasn't seen the
@@ -2263,7 +2512,21 @@ function jumpToComment(commentId: string): void {
 
 function on_review_viewport_changed(data: { split_id: number; buffer_id: number; top_byte: number; top_line: number | null; width: number; height: number }): void {
     if (state.groupId === null) return;
+    // Side panels: remember how wide the host actually made them, and
+    // repaint once when that changes so the header's `✕` lands on the
+    // right edge instead of a guessed column.
+    for (const panel of ['files', 'comments'] as const) {
+        if (data.buffer_id !== state.panelBuffers[panel]) continue;
+        if (state.panelWidths[panel] === data.width) return;
+        state.panelWidths[panel] = data.width;
+        if (panel === 'files') renderFilesPanel();
+        else renderCommentsPanel();
+        return;
+    }
     if (data.buffer_id !== state.panelBuffers["diff"]) return;
+    // Inline comment boxes are laid out to this width (see
+    // `diffPanelWidth`); the next center rebuild picks up a change.
+    state.panelWidths["diff"] = data.width;
     // Prefer top_line when the host provides it. Virtual buffers may not
     // have line metadata, in which case top_line is null — fall back to
     // converting top_byte using our own row-byte index.
@@ -2475,7 +2738,7 @@ function selectAndJumpToComment(c: ReviewComment) {
     const idx = sorted.findIndex(x => x.id === c.id);
     if (idx >= 0) {
         state.commentsSelectedRow = idx + 2;
-        editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+        renderCommentsPanel();
     }
 }
 
@@ -2514,20 +2777,26 @@ registerHandler("review_prev_comment", review_prev_comment);
  */
 function review_focus_comments() {
     if (state.groupId === null) return;
+    // Asking for the comments panel is asking to see it.
+    setReviewPanelVisible('comments', true);
     reviewSetFocus('comments');
     // Ensure the selection highlight shows immediately.
     if (state.commentsSelectedRow < 2 && state.comments.length > 0) {
         state.commentsSelectedRow = 2;
     }
-    editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+    renderCommentsPanel();
 }
 registerHandler("review_focus_comments", review_focus_comments);
 
 /** The Tab/BackTab focus ring: file list → diff → comments → (wrap).
- *  Comments join the ring only when there are comments to step through. */
+ *  A hidden panel is not in the ring — there is nothing on screen to move
+ *  a cursor into. Comments join it only when there are comments to step
+ *  through. */
 function reviewFocusOrder(): Array<'files' | 'diff' | 'comments'> {
-    const order: Array<'files' | 'diff' | 'comments'> = ['files', 'diff'];
-    if (state.comments.length > 0) order.push('comments');
+    const order: Array<'files' | 'diff' | 'comments'> = [];
+    if (panelVisible('files')) order.push('files');
+    order.push('diff');
+    if (panelVisible('comments') && state.comments.length > 0) order.push('comments');
     return order;
 }
 
@@ -2613,7 +2882,7 @@ function review_comments_select_next() {
     const currentIdx = Math.max(0, state.commentsSelectedRow - 2);
     const nextIdx = Math.min(total - 1, currentIdx + 1);
     state.commentsSelectedRow = nextIdx + 2;
-    editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+    renderCommentsPanel();
 }
 registerHandler("review_comments_select_next", review_comments_select_next);
 
@@ -2702,7 +2971,7 @@ function review_comments_select_prev() {
     const currentIdx = Math.max(0, state.commentsSelectedRow - 2);
     const prevIdx = Math.max(0, currentIdx - 1);
     state.commentsSelectedRow = prevIdx + 2;
-    editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+    renderCommentsPanel();
 }
 registerHandler("review_comments_select_prev", review_comments_select_prev);
 
@@ -3954,6 +4223,7 @@ async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
  *  composite is showing). */
 function renderCenter(): void {
     if (state.groupId === null) return;
+    syncFocusMode();
     if (state.reviewLayout === 'side-by-side') {
         void buildCenterComposite();
         return;
@@ -3984,7 +4254,7 @@ function refreshFocusedFile(): void {
     const keepFocus = state.focusPanel;
     renderCenter();
     if (state.panelBuffers["files"] !== undefined) {
-        editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+        renderFilesPanel();
         scrollFilesToSelected();
     }
     // Unified: scroll the newly-focused file into position and put the cursor
@@ -4200,7 +4470,11 @@ const AUTO_SPLIT_MIN_WIDTH = 140;
 function review_set_layout(layout: 'unified' | 'side-by-side'): void {
     if (state.reviewLayout !== layout) {
         state.reviewLayout = layout;
+        // Unified expands every file, side-by-side renders one — the
+        // center rebuild below has to see the new mode.
+        syncFocusMode();
         renderCenter();
+        refreshStickyHeader(state.diffViewportTopRow);
     }
     editor.setStatus(
         layout === 'side-by-side'
@@ -4246,6 +4520,8 @@ async function review_help() {
         "             ] / [      next / prev comment",
         "             z a / z r  fold all / unfold all (Enter folds one)",
         " Layout      1 / 2 / 0  split (side-by-side) / stack (unified) / auto",
+        " Panels      F / C      show / hide the files sidebar / comments rail",
+        "                        (both start hidden; ✕ in a header closes it)",
         " View        a          show / hide inline notes",
         "             /          filter files (empty to clear)",
         "             W          watch: auto-reload when a file is saved",
@@ -4804,7 +5080,7 @@ async function compositeHunkNav(dir: 1 | -1): Promise<void> {
     state.filesCurrentKey = fileKey(vis[next]);
     await buildCenterComposite(); // rebuilds the composite, resets compositeHunkIdx = 0
     if (state.groupId !== null && state.panelBuffers["files"] !== undefined) {
-        editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+        renderFilesPanel();
         scrollFilesToSelected();
     }
     refreshStickyHeader(0);
@@ -5394,6 +5670,21 @@ async function openReviewPanels(groupName: string): Promise<boolean> {
         (editor as any).setBufferShowCursors(state.panelBuffers["diff"], true);
     }
 
+    // Mount the widget panels over the group's toolbar / sidebar / rail
+    // buffers. Everything with a button on it goes through the widget
+    // runtime; the diff and its sticky header stay plain text panels.
+    toolbarPanel = state.panelBuffers["toolbar"] !== undefined
+        ? new WidgetPanel(state.panelBuffers["toolbar"]) : null;
+    filesPanel = state.panelBuffers["files"] !== undefined
+        ? new WidgetPanel(state.panelBuffers["files"]) : null;
+    commentsPanel = state.panelBuffers["comments"] !== undefined
+        ? new WidgetPanel(state.panelBuffers["comments"]) : null;
+
+    // The group is created with every panel in its layout; the two side
+    // panels are then hidden (the session default) before anything is
+    // drawn, so the diff opens at full width without a visible reflow.
+    applyPanelVisibility();
+
     updateMagitDisplay();
 
     editor.focusBufferGroupPanel(state.groupId!, "diff");
@@ -5477,6 +5768,12 @@ registerHandler("start_review_diff", start_review_diff);
 
 function stop_review_diff() {
     teardownCenterComposite();
+    // Unmount before the buffers go away, so the host drops the panels'
+    // widget state instead of holding it against dead buffer ids.
+    for (const panel of [toolbarPanel, filesPanel, commentsPanel]) panel?.unmount();
+    toolbarPanel = null;
+    filesPanel = null;
+    commentsPanel = null;
     if (state.groupId !== null) {
         editor.closeBufferGroup(state.groupId);
         state.groupId = null;
@@ -5754,10 +6051,10 @@ registerHandler("on_review_buffer_activated", on_review_buffer_activated);
 function refreshFocusIndicators(): void {
     if (state.groupId === null) return;
     if (state.panelBuffers["files"] !== undefined) {
-        editor.setPanelContent(state.groupId, "files", buildFilesPanelEntries());
+        renderFilesPanel();
     }
     if (state.panelBuffers["comments"] !== undefined) {
-        editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+        renderCommentsPanel();
     }
     // The diff's "header" is the sticky bar; refresh it in place.
     refreshStickyHeader(Math.max(0, state.diffCursorRow - 1));
@@ -5835,7 +6132,7 @@ function on_review_cursor_moved(data: {
         const newHighlight = currentCommentIdAtCursor();
         if (newHighlight !== prevHighlight) {
             state.commentsHighlightId = newHighlight;
-            editor.setPanelContent(state.groupId, "comments", buildCommentsPanelEntries());
+            renderCommentsPanel();
         }
         return;
     }
@@ -6629,6 +6926,10 @@ editor.defineMode("review-mode", [
     ["1", "review_layout_split"],
     ["2", "review_layout_stack"],
     ["0", "review_layout_auto"],
+    // Show / hide the two side panels (both start hidden, so the diff
+    // gets the full width until you ask for them).
+    ["F", "review_toggle_files_panel"],
+    ["C", "review_toggle_comments_panel"],
     // Toggle inline review-note visibility; filter files; watch; help.
     ["a", "review_toggle_agent_notes"],
     ["/", "review_filter_files"],

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -18,15 +18,24 @@ import {
   fetchGitLog,
 } from "./lib/git_history.ts";
 import { type GitRepo, resolveGitRepo } from "./lib/git_repo.ts";
+import type { HintEntry, TreeNode, WidgetSpec } from "./lib/widgets.ts";
 import {
   WidgetPanel,
   button,
   col,
   flexSpacer,
+  hintBar,
+  key,
+  list,
   raw,
   row,
   spacer,
   styledRow,
+  text,
+  textInputChar,
+  textInputKey,
+  tree,
+  treeNode,
 } from "./lib/widgets.ts";
 const VirtualBufferFactory = createVirtualBufferFactory(editor);
 
@@ -208,8 +217,6 @@ interface ReviewState {
   // Maps a category name (`'staged'` etc.) -> 1-indexed row of its
   // section-header row in the unified stream. Used by Tab toggle.
   sectionHeaderRows: Record<string, number>;
-  // Maps a 1-indexed row in the comments panel -> comment id
-  commentsByRow: Record<number, string>;
   // Maps a 1-indexed row in the files sidebar -> file key. Lets clicks in
   // the sidebar resolve back to a FileEntry.
   filesPanelByRow: Record<number, string>;
@@ -247,8 +254,13 @@ interface ReviewState {
   // header; falls back to a ratio-derived estimate until the first
   // viewport_changed for that panel arrives.
   panelWidths: Record<string, number>;
-  // Current selection in the comments panel (1-indexed row, 0 means none)
-  commentsSelectedRow: number;
+  // Last height in rows the host reported for each panel. The tree and
+  // list widgets need a row budget (`visibleRows`) to scroll within.
+  panelHeights: Record<string, number>;
+  // Which comment the rail has selected (null = none). The rail is a
+  // List widget: the host owns the selected *row*, the plugin owns which
+  // comment that row belongs to.
+  commentsSelectedId: string | null;
   // Comment-id the diff cursor is sitting on / attached to. Drives the
   // `>` follow-cursor marker in the comments panel.
   commentsHighlightId: string | null;
@@ -314,7 +326,6 @@ const state: ReviewState = {
   fileBodyRange: {},
   hunkBodyRange: {},
   sectionHeaderRows: {},
-  commentsByRow: {},
   filesPanelByRow: {},
   filesPanelDirByRow: {},
   filesCurrentKey: null,
@@ -322,9 +333,10 @@ const state: ReviewState = {
   fileFilter: "",
   panelsVisible: { files: false, comments: false },
   panelWidths: {},
+  panelHeights: {},
   focusOnly: true,
   splitView: false,
-  commentsSelectedRow: 0,
+  commentsSelectedId: null,
   commentsHighlightId: null,
   stickyCurrentFile: null,
   diffViewportTopRow: 0,
@@ -1368,74 +1380,11 @@ interface HintItem {
 }
 
 /**
- * Build a styled toolbar entry with highlighted key hints.
- * Keys get bold + keyword color; labels get dim text; groups separated by │.
- */
-function buildToolbarRow(W: number, groups: HintItem[][]): TextPropertyEntry {
-    const overlays: InlineOverlay[] = [];
-    let text = " ";
-    let bytePos = getByteLength(" ");
-    let done = false;
-
-    for (let g = 0; g < groups.length && !done; g++) {
-        if (g > 0) {
-            const sep = " │ ";
-            if (text.length + sep.length > W) { done = true; break; }
-            overlays.push({ start: bytePos, end: bytePos + getByteLength(sep), style: { fg: STYLE_TOOLBAR_SEP } });
-            text += sep;
-            bytePos += getByteLength(sep);
-        }
-        for (let h = 0; h < groups[g].length && !done; h++) {
-            const item = groups[g][h];
-            const gap = h > 0 ? "  " : "";
-            // Bracket-style key hint: "[key] label" — the brackets make
-            // the keys legible without a saturated bg, which works in
-            // every theme (no Dracula hot-pink toolbar problem). When
-            // the key itself is `[` or `]`, drop the brackets so we
-            // don't render `[[]` / `[]]`.
-            const isBracket = item.key === '[' || item.key === ']';
-            const keyDisplay = isBracket ? item.key : `[${item.key}]`;
-            const fullLen = gap.length + keyDisplay.length + 1 + item.label.length;
-            const keyOnlyLen = gap.length + keyDisplay.length;
-
-            if (text.length + fullLen <= W) {
-                if (gap) { text += gap; bytePos += getByteLength(gap); }
-                const keyLen = getByteLength(keyDisplay);
-                overlays.push({ start: bytePos, end: bytePos + keyLen, style: { fg: STYLE_KEY_FG, bold: true } });
-                text += keyDisplay;
-                bytePos += keyLen;
-                const labelText = " " + item.label;
-                const labelLen = getByteLength(labelText);
-                overlays.push({ start: bytePos, end: bytePos + labelLen, style: { fg: STYLE_HINT_FG } });
-                text += labelText;
-                bytePos += labelLen;
-            } else if (text.length + keyOnlyLen <= W) {
-                if (gap) { text += gap; bytePos += getByteLength(gap); }
-                const keyLen = getByteLength(keyDisplay);
-                overlays.push({ start: bytePos, end: bytePos + keyLen, style: { fg: STYLE_KEY_FG, bold: true } });
-                text += keyDisplay;
-                bytePos += keyLen;
-            } else {
-                done = true;
-            }
-        }
-    }
-
-    const padded = text.padEnd(W) + "\n";
-    return {
-        text: padded,
-        properties: { type: "toolbar" },
-        style: { bg: STYLE_TOOLBAR_BG, extendToLineEnd: true },
-        inlineOverlays: overlays,
-    };
-}
-
-/**
  * Build the (two-row) toolbar with all review-diff shortcuts.
  * Row 1 — navigation; row 2 — actions. Identical regardless of which
  * panel currently has focus (no more files-pane vs diff-pane variants).
  */
-function buildToolbar(W: number): TextPropertyEntry[] {
+function buildToolbar(): HintEntry[][] {
     // In range mode, stage / unstage / discard are meaningless (there is
     // no working tree to mutate), so hide them from the hint bar to keep
     // the toolbar honest. The key-bindings themselves are harmless if
@@ -1464,7 +1413,9 @@ function buildToolbar(W: number): TextPropertyEntry[] {
             : [{ key: "S U D", label: "file-level" }, { key: "/", label: "filter" },
                { key: "?", label: "help" }, { key: "q", label: "close" }],
     ];
-    return [buildToolbarRow(W, row1), buildToolbarRow(W, row2)];
+    return [row1, row2].map(groups => groups.flat().map(
+        (item): HintEntry => ({ keys: item.key, label: item.label }),
+    ));
 }
 
 // --- Buffer Group panel content builders ---
@@ -1478,16 +1429,6 @@ const PANEL_BUTTON_KEYS = {
     files: "toolbar.files",
     comments: "toolbar.comments",
 } as const;
-
-/** Columns the two toolbar buttons take, including the gap between them
- *  and the `[ ]` frames the host draws — the budget the hint text has to
- *  leave free. Used only to size the *text*; where the buttons actually
- *  land is the host's layout, not ours. */
-function toolbarButtonsWidth(): number {
-    return panelButtonLabel('files').length
-        + panelButtonLabel('comments').length
-        + 10; // two `[ ]` frames + the gap between the buttons
-}
 
 function panelButtonLabel(panel: 'files' | 'comments'): string {
     const name = panel === 'files'
@@ -1509,11 +1450,10 @@ function panelButton(panel: 'files' | 'comments'): WidgetSpec {
 /** Render the toolbar panel: hint rows plus the panel buttons. */
 function renderToolbar(): void {
     if (toolbarPanel === null) return;
-    const W = state.viewportWidth;
-    const rows = buildToolbar(Math.max(20, W - toolbarButtonsWidth()));
+    const rows = buildToolbar();
     toolbarPanel.set(col(
-        raw([rows[0]]),
-        row(raw([rows[1]]), flexSpacer(), panelButton('files'), spacer(1), panelButton('comments')),
+        hintBar(rows[0]),
+        row(hintBar(rows[1]), flexSpacer(), panelButton('files'), spacer(1), panelButton('comments')),
     ));
 }
 
@@ -1797,46 +1737,49 @@ function fileGroups(): FileGroup[] {
 /** The FILES panel's header label (the panel's `✕` and the focus marker
  *  are drawn by `panelHeaderSpec`). */
 function filesHeaderLabel(): string {
-    return (editor.t("panel.files") || "Files").toUpperCase()
-        + (state.fileFilter ? `  /${state.fileFilter}` : "");
+    return (editor.t("panel.files") || "Files").toUpperCase();
 }
 
-/** The FILES panel body, one entry per row *below* the header row that
- *  `panelHeaderSpec` occupies — hence the row counter starting at 1. */
-function buildFilesPanelEntries(): TextPropertyEntry[] {
-    const entries: TextPropertyEntry[] = [];
-    state.filesPanelByRow = {};
-    state.filesPanelDirByRow = {};
-    // Every row is cut to the panel's width. A row wider than the panel
-    // would let the buffer scroll sideways (nothing wraps in a panel), and
-    // that pans the *whole* viewport — header included — the moment the
-    // hidden cursor lands past the right edge.
-    const W = panelWidthOf('files');
+// --- FILES sidebar: a host-owned Tree -------------------------------------
+//
+// The sidebar is a `Tree` widget, not plugin-drawn rows. The host owns
+// what a file list keeps getting wrong when a plugin hand-rolls it:
+// selection, expand/collapse, scrolling the selection into view, clipping
+// rows to the panel, and routing clicks. The plugin's job is to emit the
+// hierarchy (category → directory → file) and to react to `select` /
+// `activate` / `expand` events.
 
-    if (state.files.length === 0) {
-        entries.push({
-            text: ` ${editor.t("panel.no_changes") || "No changes."}\n`,
-            style: { fg: STYLE_SECTION_HEADER, italic: true },
-            properties: { type: "empty" },
-        });
-        return entries;
-    }
+const FILES_TREE_KEY = "files-tree";
+const FILES_FILTER_KEY = "files-filter";
 
-    // Per-file comment counts drive the `*N` badge.
+interface FilesTree {
+    nodes: TreeNode[];
+    keys: string[];
+    /** Node key → file key, for the file rows only. */
+    fileByNodeKey: Record<string, string>;
+    /** Index in `nodes` of each file row, so the selection can be
+     *  restored from `state.filesCurrentKey` on every rebuild. */
+    indexByFileKey: Record<string, number>;
+    /** Every category / directory key, the initial expanded set. */
+    groupKeys: string[];
+}
+
+/** Build the sidebar's node list: one row per category, per directory,
+ *  and per file, depth-first. The tree draws its own disclosure glyphs
+ *  and indents by depth, so the rows carry text only. */
+function buildFilesTree(): FilesTree {
+    const out: FilesTree = {
+        nodes: [], keys: [], fileByNodeKey: {}, indexByFileKey: {}, groupKeys: [],
+    };
     const commentCounts: Record<string, number> = {};
     for (const c of state.comments) commentCounts[c.file] = (commentCounts[c.file] || 0) + 1;
 
-    // Render straight from the shared grouping so the list and arrow-key
-    // navigation (visibleFiles) traverse the same order.
     const groups = fileGroups();
     const catCounts: Record<string, number> = {};
     for (const g of groups) catCounts[g.category] = (catCounts[g.category] || 0) + g.files.length;
 
-    let row1 = 1; // header occupied row 1
-    let shownAny = false;
     let lastCategory: string | undefined;
     for (const group of groups) {
-        shownAny = true;
         if (group.category !== lastCategory) {
             lastCategory = group.category;
             let label: string = group.category;
@@ -1845,82 +1788,97 @@ function buildFilesPanelEntries(): TextPropertyEntry[] {
             else if (group.category === 'unstaged') label = editor.t("section.unstaged") || "Changes";
             else if (group.category === 'untracked') label = editor.t("section.untracked") || "Untracked";
             const display = state.mode === 'range' ? label : label.toUpperCase();
-            row1++;
-            entries.push({
-                text: `${elideRight(` ${display} (${catCounts[group.category]})`, W)}\n`,
-                style: { fg: STYLE_SECTION_HEADER, bold: true },
-                properties: { type: "files-section" },
-            });
+            const key = `cat:${group.category}`;
+            out.groupKeys.push(key);
+            out.keys.push(key);
+            out.nodes.push(treeNode(
+                { text: `${display} (${catCounts[group.category]})`, style: { fg: STYLE_SECTION_HEADER, bold: true } },
+                { depth: 0, hasChildren: true },
+            ));
         }
 
-        const dirFiles = group.files;
-        const collapsed = state.collapsedDirs.has(group.dirKey);
         let added = 0, removed = 0;
-        for (const f of dirFiles) {
+        for (const f of group.files) {
             const c = fileChangeCounts(f);
             added += c.added; removed += c.removed;
         }
-        const tri = collapsed ? '▸' : '▾';
-        const countNote = collapsed
-            ? `  ${dirFiles.length} file${dirFiles.length === 1 ? '' : 's'}` : '';
-        row1++;
-        state.filesPanelDirByRow[row1] = group.dirKey;
-        // The counts are the part worth keeping when a path is too long,
-        // so the path is what gets elided (from the left — the leaf
-        // directory says more than the repo root).
-        const dirStats = `${countNote}  +${added} -${removed}`;
-        entries.push({
-            text: ` ${tri} ${elideLeft(group.dir, Math.max(4, W - 3 - dirStats.length))}${dirStats}\n`,
-            style: { fg: STYLE_SECTION_HEADER },
-            properties: { type: "files-dir", dirKey: group.dirKey },
-        });
-        if (collapsed) continue;
+        const dirKey = `dir:${group.dirKey}`;
+        out.groupKeys.push(dirKey);
+        out.keys.push(dirKey);
+        out.nodes.push(treeNode(
+            { text: `${group.dir}  +${added} -${removed}`, style: { fg: STYLE_SECTION_HEADER } },
+            { depth: 1, hasChildren: true },
+        ));
 
-        for (const file of dirFiles) {
+        for (const file of group.files) {
             const counts = fileChangeCounts(file);
             const key = fileKey(file);
-            const glyph = file.status || ' ';
             const badge = commentCounts[file.path] ? ` *${commentCounts[file.path]}` : '';
-            const stats = `  +${counts.added} -${counts.removed}${badge}`;
-            row1++;
-            const selected = key === state.filesCurrentKey;
-            const style: Partial<OverlayOptions> = selected
-                ? { bg: STYLE_SELECTED_BG, bold: true, extendToLineEnd: true }
-                : {};
-            state.filesPanelByRow[row1] = key;
-            // Basename only — the directory header carries the path.
-            entries.push({
-                text: `   ${glyph} ${elideRight(fileBaseOf(file.path), Math.max(4, W - 5 - stats.length))}${stats}\n`,
-                style,
-                properties: { type: "file", fileKey: key, filePath: file.path },
-            });
+            const nodeKey = `file:${key}`;
+            out.fileByNodeKey[nodeKey] = key;
+            out.indexByFileKey[key] = out.nodes.length;
+            out.keys.push(nodeKey);
+            out.nodes.push(treeNode(
+                {
+                    text: `${file.status || ' '} ${fileBaseOf(file.path)}  +${counts.added} -${counts.removed}${badge}`,
+                    properties: { type: "file", fileKey: key, filePath: file.path },
+                },
+                { depth: 2 },
+            ));
         }
     }
-    if (!shownAny && state.fileFilter) {
-        entries.push({
-            text: ` ${editor.t("status.filter_no_match") || "No files match"}\n`,
-            style: { fg: STYLE_SECTION_HEADER, italic: true },
-            properties: { type: "empty" },
-        });
-    }
-    return entries;
+    return out;
 }
 
-/** Scroll the FILES panel so the currently-selected file row stays visible.
- *  The panel's selection is plugin state, not a buffer cursor, so the host
- *  needs telling which row to keep in view — `scrollBufferToLine` is the
- *  buffer-group panel's version of "ensure this row is visible", and it
- *  leaves the viewport alone when the row already is. */
-function scrollFilesToSelected(): void {
-    if (state.groupId === null || !state.filesCurrentKey) return;
-    const filesId = state.panelBuffers["files"];
-    if (filesId === undefined) return;
-    for (const rowStr of Object.keys(state.filesPanelByRow)) {
-        if (state.filesPanelByRow[Number(rowStr)] === state.filesCurrentKey) {
-            editor.scrollBufferToLine(filesId, Number(rowStr) - 1);
-            return;
-        }
+/** The sidebar tree as last built — the map from a `select` event's node
+ *  key back to a file. */
+let filesTree: FilesTree = {
+    nodes: [], keys: [], fileByNodeKey: {}, indexByFileKey: {}, groupKeys: [],
+};
+
+/** Rows a side panel's list/tree can use: its height minus the header
+ *  (and the filter field when it is showing). */
+function panelListRows(panel: 'files' | 'comments'): number {
+    const height = state.panelHeights[panel] ?? Math.max(8, state.viewportHeight - 6);
+    const chrome = 1 + (panel === 'files' && filterEditing ? 1 : 0);
+    return Math.max(1, height - chrome);
+}
+
+/** The FILES panel spec: header, the filter field while `/` is open, and
+ *  the file tree. */
+function buildFilesPanelSpec(): WidgetSpec {
+    filesTree = buildFilesTree();
+    const selected = state.filesCurrentKey !== null
+        ? (filesTree.indexByFileKey[state.filesCurrentKey] ?? -1)
+        : -1;
+    const parts: WidgetSpec[] = [panelHeaderSpec('files', filesHeaderLabel())];
+    if (filterEditing) {
+        parts.push(text({
+            value: state.fileFilter,
+            cursorByte: filterCursor,
+            placeholder: editor.t("prompt.filter_files") || "Filter files",
+            fullWidth: true,
+            key: FILES_FILTER_KEY,
+        }));
     }
+    if (filesTree.nodes.length === 0) {
+        parts.push(raw([{
+            text: ` ${(state.fileFilter
+                ? editor.t("status.filter_no_match") || "No files match"
+                : editor.t("panel.no_changes") || "No changes.")}\n`,
+            style: { fg: STYLE_SECTION_HEADER, italic: true },
+        }]));
+    } else {
+        parts.push(tree({
+            nodes: filesTree.nodes,
+            itemKeys: filesTree.keys,
+            selectedIndex: selected,
+            visibleRows: panelListRows('files'),
+            expandedKeys: filesTree.groupKeys,
+            key: FILES_TREE_KEY,
+        }));
+    }
+    return col(...parts);
 }
 
 /** The COMMENTS panel's header label. */
@@ -1928,86 +1886,100 @@ function commentsHeaderLabel(): string {
     return (editor.t("panel.comments") || "Comments").toUpperCase();
 }
 
-/** The COMMENTS panel body, one entry per row below the header row. */
-function buildCommentsPanelEntries(): TextPropertyEntry[] {
-    const entries: TextPropertyEntry[] = [];
-    state.commentsByRow = {};
+// --- COMMENTS rail: a host-owned List ------------------------------------
+//
+// One list item per rendered row — a comment's location row plus the rows
+// its note wraps onto — all keyed back to the same comment. The host owns
+// selection, scrolling and click routing; the plugin maps the selected
+// item back to a comment and snaps the selection to that comment's
+// location row, so stepping with ↑↓ moves comment by comment while the
+// note still renders in full.
 
-    if (state.comments.length === 0) {
-        entries.push({
-            text: ` ${editor.t("panel.no_comments") || "No comments yet."}\n`,
-            style: { fg: STYLE_SECTION_HEADER, italic: true },
-            properties: { type: "empty" },
-        });
-        return entries;
-    }
+const COMMENTS_LIST_KEY = "comments-list";
 
-    // Order comments by their position in the unified stream. We approximate
-    // by sorting by (file index, line number, removed/added preference).
-    const fileIndex = (file: string, category: string | undefined): number => {
+interface CommentsList {
+    items: TextPropertyEntry[];
+    keys: string[];
+    /** Item index of each comment's location row. */
+    indexById: Record<string, number>;
+}
+
+/** Comments in stream order: by file, then by line. */
+function commentsInStreamOrder(): ReviewComment[] {
+    const fileIndex = (file: string): number => {
         for (let i = 0; i < state.files.length; i++) {
-            const f = state.files[i];
-            if (f.path === file) return i;
+            if (state.files[i].path === file) return i;
         }
         return Number.MAX_SAFE_INTEGER;
     };
-
-    const sortedComments = [...state.comments].sort((a, b) => {
-        // Look up via hunk's file
-        const hunkA = state.hunks.find(h => h.id === a.hunk_id);
-        const hunkB = state.hunks.find(h => h.id === b.hunk_id);
-        const fa = fileIndex(a.file, hunkA?.gitStatus);
-        const fb = fileIndex(b.file, hunkB?.gitStatus);
+    return [...state.comments].sort((a, b) => {
+        const fa = fileIndex(a.file);
+        const fb = fileIndex(b.file);
         if (fa !== fb) return fa - fb;
-        const la = a.new_line ?? a.old_line ?? 0;
-        const lb = b.new_line ?? b.old_line ?? 0;
-        return la - lb;
+        return (a.new_line ?? a.old_line ?? 0) - (b.new_line ?? b.old_line ?? 0);
     });
+}
 
-    // Each comment renders as a block: a "path:line" location row followed
-    // by the note text wrapped over as many rows as needed (no truncation).
-    // Every row maps back to the comment id, so clicking or selecting any
-    // row of the block jumps to that comment.
-    const panelWidth = Math.max(20, Math.floor(state.viewportWidth * 0.25) - 2);
-    let rowIdx = 1; // header is row 0 (0-indexed); comments start at row 1
-    for (const c of sortedComments) {
+function buildCommentsList(): CommentsList {
+    const out: CommentsList = { items: [], keys: [], indexById: {} };
+    const width = Math.max(12, panelWidthOf('comments') - 1);
+    for (const c of commentsInStreamOrder()) {
         const lineRef = c.new_line ?? c.old_line ?? 0;
         const path = c.file.split('/').pop() || c.file;
         const isCurrent = c.id === state.commentsHighlightId;
         const marker = isCurrent ? '>' : ' ';
-
-        // Location row.
-        rowIdx++;
         const locText = `${marker} ${path}:${lineRef}`;
-        const locSelected = rowIdx === state.commentsSelectedRow && state.focusPanel === 'comments';
-        const locDisplay = locText.length > panelWidth ? locText.slice(0, panelWidth - 1) + '…' : locText;
-        state.commentsByRow[rowIdx] = c.id;
-        entries.push({
-            text: locDisplay + "\n",
-            style: locSelected
-                ? { bg: STYLE_SELECTED_BG, bold: true, extendToLineEnd: true }
-                : { bold: true },
-            inlineOverlays: [{ start: 2, end: getByteLength(locText), style: { fg: STYLE_KEY_FG } }],
+        out.indexById[c.id] = out.items.length;
+        out.keys.push(`c:${c.id}#loc`);
+        out.items.push({
+            text: elideRight(locText, width),
+            style: { bold: true },
+            inlineOverlays: [{ start: 2, end: getByteLength(elideRight(locText, width)), style: { fg: STYLE_KEY_FG } }],
             properties: { type: "comment-nav", commentId: c.id, file: c.file, line: lineRef },
         });
-
-        // Body rows: the full note text, wrapped and indented.
         const body = c.text.replace(/\s+/g, ' ').trim();
-        for (const wl of wrapText(body, panelWidth - 3)) {
-            rowIdx++;
-            const bodySelected = rowIdx === state.commentsSelectedRow && state.focusPanel === 'comments';
-            state.commentsByRow[rowIdx] = c.id;
-            entries.push({
-                text: `   ${wl}\n`,
-                style: bodySelected
-                    ? { bg: STYLE_SELECTED_BG, extendToLineEnd: true }
-                    : (isCurrent ? undefined : { fg: STYLE_COMMENT }),
+        const lines = wrapText(body, Math.max(4, width - 3));
+        for (let i = 0; i < lines.length; i++) {
+            out.keys.push(`c:${c.id}#${i}`);
+            out.items.push({
+                text: `   ${lines[i]}`,
+                style: isCurrent ? undefined : { fg: STYLE_COMMENT },
                 properties: { type: "comment-nav", commentId: c.id, file: c.file, line: lineRef },
             });
         }
     }
+    return out;
+}
 
-    return entries;
+/** The rail as last built, for mapping a selection back to a comment. */
+let commentsList: CommentsList = { items: [], keys: [], indexById: {} };
+
+/** The COMMENTS panel spec: header plus the comment list. */
+function buildCommentsPanelSpec(): WidgetSpec {
+    commentsList = buildCommentsList();
+    if (commentsList.items.length === 0) {
+        return col(
+            panelHeaderSpec('comments', commentsHeaderLabel()),
+            raw([{
+                text: ` ${editor.t("panel.no_comments") || "No comments yet."}\n`,
+                style: { fg: STYLE_SECTION_HEADER, italic: true },
+            }]),
+        );
+    }
+    const selected = state.commentsSelectedId !== null
+        ? (commentsList.indexById[state.commentsSelectedId] ?? -1)
+        : -1;
+    return col(
+        panelHeaderSpec('comments', commentsHeaderLabel()),
+        list({
+            items: commentsList.items,
+            itemKeys: commentsList.keys,
+            selectedIndex: selected,
+            visibleRows: panelListRows('comments'),
+            focusable: true,
+            key: COMMENTS_LIST_KEY,
+        }),
+    );
 }
 
 /** Total number of raw diff lines across every hunk that passes the
@@ -2061,19 +2033,15 @@ function panelVisible(panel: 'files' | 'diff' | 'comments'): boolean {
  *  `setReviewPanelVisible` repaints on the way back in. */
 function renderFilesPanel(): void {
     if (filesPanel === null || !panelVisible('files')) return;
-    filesPanel.set(col(
-        panelHeaderSpec('files', filesHeaderLabel()),
-        raw(buildFilesPanelEntries()),
-    ));
+    filesPanel.set(buildFilesPanelSpec());
+    filesPanel.setFocusKey(filterEditing ? FILES_FILTER_KEY : FILES_TREE_KEY);
 }
 
 /** Repaint the COMMENTS rail, if it is on screen. */
 function renderCommentsPanel(): void {
     if (commentsPanel === null || !panelVisible('comments')) return;
-    commentsPanel.set(col(
-        panelHeaderSpec('comments', commentsHeaderLabel()),
-        raw(buildCommentsPanelEntries()),
-    ));
+    commentsPanel.set(buildCommentsPanelSpec());
+    if (state.focusPanel === 'comments') commentsPanel.setFocusKey(COMMENTS_LIST_KEY);
 }
 
 /** Push the plugin's visibility state into the host's group layout. */
@@ -2098,7 +2066,6 @@ function setReviewPanelVisible(panel: 'files' | 'comments', visible: boolean): v
     if (visible) {
         if (panel === 'files') {
             renderFilesPanel();
-            scrollFilesToSelected();
         } else {
             renderCommentsPanel();
         }
@@ -2126,6 +2093,55 @@ registerHandler("review_toggle_comments_panel", review_toggle_comments_panel);
  *  hit-testing and hands us the widget key. */
 editor.on("widget_event", (data) => {
     if (state.groupId === null) return;
+
+    // --- FILES tree: selection, activation, and the filter field --------
+    if (data.widget_key === FILES_TREE_KEY) {
+        const nodeKey = String((data.payload as Record<string, unknown>)?.["key"] ?? "");
+        if (data.event_type === "select") {
+            onFilesTreeSelect(nodeKey);
+            return;
+        }
+        if (data.event_type === "activate") {
+            // Enter on a file opens it the way Enter in the diff does;
+            // on a folder the host has already toggled the fold.
+            if (nodeKey.startsWith("file:")) void review_drill_down();
+            return;
+        }
+        return; // `expand` is host-owned; nothing to mirror.
+    }
+    if (data.widget_key === FILES_FILTER_KEY) {
+        if (data.event_type === "change") {
+            const payload = (data.payload ?? {}) as Record<string, unknown>;
+            if (typeof payload["value"] === "string") state.fileFilter = payload["value"];
+            if (typeof payload["cursorByte"] === "number") filterCursor = payload["cursorByte"];
+            applyFileFilter();
+            return;
+        }
+        if (data.event_type === "activate" || data.event_type === "cancel") {
+            closeFileFilter(data.event_type === "cancel");
+            return;
+        }
+        return;
+    }
+    // --- COMMENTS list --------------------------------------------------
+    if (data.widget_key === COMMENTS_LIST_KEY) {
+        const itemKey = String((data.payload as Record<string, unknown>)?.["key"] ?? "");
+        const commentId = itemKey.startsWith("c:") ? itemKey.slice(2).split("#")[0] : "";
+        if (!commentId) return;
+        if (data.event_type === "select") {
+            state.commentsSelectedId = commentId;
+            renderCommentsPanel();
+            return;
+        }
+        if (data.event_type === "activate") {
+            state.commentsSelectedId = commentId;
+            jumpToComment(commentId);
+            renderCommentsPanel();
+            return;
+        }
+        return;
+    }
+
     if (data.event_type !== "activate") return;
     switch (data.widget_key) {
         case PANEL_BUTTON_KEYS.files:
@@ -2142,6 +2158,25 @@ editor.on("widget_event", (data) => {
             return;
     }
 });
+
+/** A row of the FILES tree became the selection — by arrow key or click.
+ *  Selecting a file moves the review to it; selecting a category or
+ *  directory row is just navigation. */
+function onFilesTreeSelect(nodeKey: string): void {
+    const key = filesTree.fileByNodeKey[nodeKey];
+    if (key === undefined || key === state.filesCurrentKey) return;
+    state.filesCurrentKey = key;
+    if (state.focusOnly) {
+        // One file at a time (side-by-side, or an oversized changeset):
+        // the centre has to be rebuilt around the new file.
+        refreshFocusedFile();
+        return;
+    }
+    // The expanded stream already holds every file — just go there. No
+    // rebuild, so walking the sidebar with ↑↓ stays instant on a big diff.
+    const headerRow = state.fileHeaderRows[key];
+    if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+}
 
 /**
  * Full refresh — rebuild all three panels. Called on data changes
@@ -2432,54 +2467,16 @@ function on_review_mouse_click(data: {
         return;
     }
 
-    // Click in the file sidebar: jump to that file and hand focus to the
-    // diff so the user can immediately keep navigating.
-    if (data.buffer_id === state.panelBuffers["files"]) {
-        // Row 0 is the widget header (label + `✕`); its button reports
-        // through `widget_event`, and the rest of the row is inert.
-        if (data.buffer_row === 0) return;
-        // Directory header click: toggle that group's collapse.
-        const dirKey = state.filesPanelDirByRow[data.buffer_row + 1];
-        if (dirKey) {
-            if (state.collapsedDirs.has(dirKey)) state.collapsedDirs.delete(dirKey);
-            else state.collapsedDirs.add(dirKey);
-            renderFilesPanel();
-            return;
-        }
-        const key = state.filesPanelByRow[data.buffer_row + 1];
-        if (key) {
-            const file = state.files.find(f => fileKey(f) === key);
-            if (file) {
-                if (state.focusOnly) {
-                    // Focus mode: switch the center to the clicked file
-                    // (light refresh — center + sidebar + sticky only).
-                    state.filesCurrentKey = key;
-                    refreshFocusedFile();
-                } else {
-                    jumpToFile(file);
-                }
-            }
-        }
-        return;
-    }
+    // The FILES sidebar is a Tree widget: its rows, disclosure glyphs and
+    // header button all report through `widget_event`, so a raw click in
+    // that buffer has nothing left to do here.
+    if (data.buffer_id === state.panelBuffers["files"]) return;
 
     // Click in the comments panel: jump to the comment's location and
     // hand focus to the diff so the user can immediately keep navigating.
-    if (data.buffer_id === commentsId) {
-        // Row 0 is the widget header — see the FILES panel above.
-        if (data.buffer_row === 0) return;
-        const targetRow1 = data.buffer_row + 1;
-        const commentId = state.commentsByRow[targetRow1];
-        if (commentId) {
-            // Clicking a comment moves the diff to it but leaves focus in
-            // the rail — you clicked the rail, so the next arrow key
-            // should step to the next comment, not scroll the diff.
-            state.commentsSelectedRow = targetRow1;
-            jumpToComment(commentId);
-            renderCommentsPanel();
-        }
-        return;
-    }
+    // The COMMENTS rail is a List widget: its rows report through
+    // `widget_event`, so a raw click there has nothing left to do here.
+    if (data.buffer_id === commentsId) return;
 }
 registerHandler("on_review_mouse_click", on_review_mouse_click);
 
@@ -2508,7 +2505,6 @@ function jumpToComment(commentId: string): void {
             await buildCenterComposite(idx);
             if (state.groupId !== null && state.panelBuffers["files"] !== undefined) {
                 renderFilesPanel();
-                scrollFilesToSelected();
             }
             if (state.groupId !== null) {
                 renderCommentsPanel();
@@ -2569,8 +2565,10 @@ function on_review_viewport_changed(data: { split_id: number; buffer_id: number;
     // right edge instead of a guessed column.
     for (const panel of ['files', 'comments'] as const) {
         if (data.buffer_id !== state.panelBuffers[panel]) continue;
-        if (state.panelWidths[panel] === data.width) return;
+        if (state.panelWidths[panel] === data.width
+            && state.panelHeights[panel] === data.height) return;
         state.panelWidths[panel] = data.width;
+        state.panelHeights[panel] = data.height;
         if (panel === 'files') renderFilesPanel();
         else renderCommentsPanel();
         return;
@@ -2785,13 +2783,14 @@ function commentsInPanelOrder(): ReviewComment[] {
 function selectAndJumpToComment(c: ReviewComment) {
     if (state.groupId === null) return;
     jumpToComment(c.id);
-    // Find the comment's row in the panel (header is row 1, comments start at 2).
-    const sorted = commentsInPanelOrder();
-    const idx = sorted.findIndex(x => x.id === c.id);
-    if (idx >= 0) {
-        state.commentsSelectedRow = idx + 2;
-        renderCommentsPanel();
-    }
+    state.commentsSelectedId = c.id;
+    renderCommentsPanel();
+}
+
+/** Index of the selected comment among the comments, or -1. */
+function selectedCommentIndex(): number {
+    if (state.commentsSelectedId === null) return -1;
+    return commentsInPanelOrder().findIndex(c => c.id === state.commentsSelectedId);
 }
 
 function review_next_comment() {
@@ -2800,9 +2799,7 @@ function review_next_comment() {
         return;
     }
     const sorted = commentsInPanelOrder();
-    // Determine the comment-id currently under the diff cursor (if any).
-    const currentRow = state.commentsSelectedRow;
-    const currentIdx = currentRow >= 2 ? currentRow - 2 : -1;
+    const currentIdx = selectedCommentIndex();
     const nextIdx = Math.min(sorted.length - 1, currentIdx + 1);
     if (nextIdx === currentIdx && currentIdx >= 0) return;
     selectAndJumpToComment(sorted[nextIdx >= 0 ? nextIdx : 0]);
@@ -2815,9 +2812,8 @@ function review_prev_comment() {
         return;
     }
     const sorted = commentsInPanelOrder();
-    const currentRow = state.commentsSelectedRow;
-    const currentIdx = currentRow >= 2 ? currentRow - 2 : sorted.length;
-    const prevIdx = Math.max(0, currentIdx - 1);
+    const cur = selectedCommentIndex();
+    const prevIdx = Math.max(0, (cur < 0 ? sorted.length : cur) - 1);
     selectAndJumpToComment(sorted[prevIdx]);
 }
 registerHandler("review_prev_comment", review_prev_comment);
@@ -2833,8 +2829,8 @@ function review_focus_comments() {
     setReviewPanelVisible('comments', true);
     reviewSetFocus('comments');
     // Ensure the selection highlight shows immediately.
-    if (state.commentsSelectedRow < 2 && state.comments.length > 0) {
-        state.commentsSelectedRow = 2;
+    if (state.commentsSelectedId === null && state.comments.length > 0) {
+        state.commentsSelectedId = commentsInPanelOrder()[0].id;
     }
     renderCommentsPanel();
 }
@@ -2866,7 +2862,6 @@ function reviewSetFocus(panel: 'files' | 'diff' | 'comments'): void {
     if (panel === 'files') {
         selectedSidebarFile();
         renderFilesPanel();
-        scrollFilesToSelected();
     }
     refreshFocusIndicators();
 }
@@ -2923,20 +2918,16 @@ registerHandler("review_focus_prev", review_focus_prev);
  * jump the diff cursor to it (auto-expanding the file if collapsed).
  */
 function review_open_selected_comment() {
-    if (state.commentsSelectedRow < 2) return;
-    const commentId = state.commentsByRow[state.commentsSelectedRow];
-    if (!commentId) return;
-    jumpToComment(commentId);
+    if (state.commentsSelectedId === null) return;
+    jumpToComment(state.commentsSelectedId);
 }
 registerHandler("review_open_selected_comment", review_open_selected_comment);
 
 function review_comments_select_next() {
-    if (state.groupId === null) return;
-    if (state.comments.length === 0) return;
-    const total = state.comments.length;
-    const currentIdx = Math.max(0, state.commentsSelectedRow - 2);
-    const nextIdx = Math.min(total - 1, currentIdx + 1);
-    state.commentsSelectedRow = nextIdx + 2;
+    if (state.groupId === null || state.comments.length === 0) return;
+    const sorted = commentsInPanelOrder();
+    const next = Math.min(sorted.length - 1, selectedCommentIndex() + 1);
+    state.commentsSelectedId = sorted[Math.max(0, next)].id;
     renderCommentsPanel();
 }
 registerHandler("review_comments_select_next", review_comments_select_next);
@@ -3021,11 +3012,10 @@ function review_open_working_file() {
 registerHandler("review_open_working_file", review_open_working_file);
 
 function review_comments_select_prev() {
-    if (state.groupId === null) return;
-    if (state.comments.length === 0) return;
-    const currentIdx = Math.max(0, state.commentsSelectedRow - 2);
-    const prevIdx = Math.max(0, currentIdx - 1);
-    state.commentsSelectedRow = prevIdx + 2;
+    if (state.groupId === null || state.comments.length === 0) return;
+    const sorted = commentsInPanelOrder();
+    const cur = selectedCommentIndex();
+    state.commentsSelectedId = sorted[Math.max(0, (cur < 0 ? sorted.length : cur) - 1)].id;
     renderCommentsPanel();
 }
 registerHandler("review_comments_select_prev", review_comments_select_prev);
@@ -3033,13 +3023,14 @@ registerHandler("review_comments_select_prev", review_comments_select_prev);
 /** Home / End in the COMMENTS rail: first / last comment. */
 function review_comments_select_first() {
     if (state.groupId === null || state.comments.length === 0) return;
-    state.commentsSelectedRow = 2;
+    state.commentsSelectedId = commentsInPanelOrder()[0].id;
     renderCommentsPanel();
 }
 
 function review_comments_select_last() {
     if (state.groupId === null || state.comments.length === 0) return;
-    state.commentsSelectedRow = state.comments.length + 1;
+    const sorted = commentsInPanelOrder();
+    state.commentsSelectedId = sorted[sorted.length - 1].id;
     renderCommentsPanel();
 }
 
@@ -3205,7 +3196,7 @@ registerHandler("review_expand_all", review_expand_all);
 
 function review_nav_up() {
     if (state.focusPanel === 'comments') { review_comments_select_prev(); return; }
-    if (state.focusPanel === 'files') { review_goto_file(-1); return; }
+    if (state.focusPanel === 'files') { filesKey("Up"); return; }
     editor.executeAction("move_up");
     if (state.lineSelection) {
         // executeAction has already moved the cursor; sync the selection.
@@ -3219,7 +3210,7 @@ registerHandler("review_nav_up", review_nav_up);
 
 function review_nav_down() {
     if (state.focusPanel === 'comments') { review_comments_select_next(); return; }
-    if (state.focusPanel === 'files') { review_goto_file(1); return; }
+    if (state.focusPanel === 'files') { filesKey("Down"); return; }
     editor.executeAction("move_down");
     if (state.lineSelection) {
         state.lineSelection.endRow = state.lineSelection.endRow + 1;
@@ -3229,22 +3220,31 @@ function review_nav_down() {
 registerHandler("review_nav_down", review_nav_down);
 
 /** Left / Right belong to whichever panel has focus. In the diff they pan
- *  the (unwrapped) stream horizontally; in the FILES sidebar they fold and
- *  unfold the selected file's directory group — a sidebar keystroke must
- *  never reach through and scroll the diff behind it. */
+ *  the (unwrapped) stream horizontally; in the FILES sidebar the host's
+ *  tree folds and unfolds with them — a sidebar keystroke must never
+ *  reach through and scroll the diff behind it. */
 function review_nav_left() {
-    if (state.focusPanel === 'files') { setSelectedDirCollapsed(true); return; }
+    if (state.focusPanel === 'files') { filesKey("Left"); return; }
     if (state.focusPanel === 'comments') return;
     editor.executeAction("move_left");
 }
 registerHandler("review_nav_left", review_nav_left);
 
 function review_nav_right() {
-    if (state.focusPanel === 'files') { setSelectedDirCollapsed(false); return; }
+    if (state.focusPanel === 'files') { filesKey("Right"); return; }
     if (state.focusPanel === 'comments') return;
     editor.executeAction("move_right");
 }
 registerHandler("review_nav_right", review_nav_right);
+
+/** Hand a keystroke to the FILES panel's focused widget. The host's
+ *  smart-key dispatch does the rest: Up/Down move the tree's selection,
+ *  Left/Right fold and unfold, PageUp/PageDown page it, Enter activates —
+ *  and it scrolls the selection into view itself. */
+function filesKey(name: string): void {
+    if (filesPanel === null) return;
+    filesPanel.command(key(name));
+}
 
 /** The file the sidebar points at, falling back to the first visible one.
  *  In the expanded stream the selection tracks the diff cursor, which sits
@@ -3259,29 +3259,17 @@ function selectedSidebarFile(): FileEntry | null {
     return vis[0];
 }
 
-/** Collapse or expand the directory group holding the selected file. */
-function setSelectedDirCollapsed(collapsed: boolean): void {
-    const file = selectedSidebarFile();
-    if (!file) return;
-    const dirKey = `${file.category} ${fileDirOf(file.path)}`;
-    const had = state.collapsedDirs.has(dirKey);
-    if (collapsed === had) return;
-    if (collapsed) state.collapsedDirs.add(dirKey);
-    else state.collapsedDirs.delete(dirKey);
-    renderFilesPanel();
-}
-
 /** Home / End in a side panel jump to its first / last row; in the diff
  *  they keep the editor's start-of-line / end-of-line meaning. */
 function review_nav_home() {
-    if (state.focusPanel === 'files') { review_goto_file(-state.files.length); return; }
+    if (state.focusPanel === 'files') { filesKey("Home"); return; }
     if (state.focusPanel === 'comments') { review_comments_select_first(); return; }
     editor.executeAction("move_line_start");
 }
 registerHandler("review_nav_home", review_nav_home);
 
 function review_nav_end() {
-    if (state.focusPanel === 'files') { review_goto_file(state.files.length); return; }
+    if (state.focusPanel === 'files') { filesKey("End"); return; }
     if (state.focusPanel === 'comments') { review_comments_select_last(); return; }
     editor.executeAction("move_line_end");
 }
@@ -3289,14 +3277,14 @@ registerHandler("review_nav_end", review_nav_end);
 
 function review_page_up() {
     if (state.focusPanel === 'comments') { review_comments_select_prev(); return; }
-    if (state.focusPanel === 'files') { review_goto_file(-1); return; }
+    if (state.focusPanel === 'files') { filesKey("PageUp"); return; }
     editor.executeAction("move_page_up");
 }
 registerHandler("review_page_up", review_page_up);
 
 function review_page_down() {
     if (state.focusPanel === 'comments') { review_comments_select_next(); return; }
-    if (state.focusPanel === 'files') { review_goto_file(1); return; }
+    if (state.focusPanel === 'files') { filesKey("PageDown"); return; }
     editor.executeAction("move_page_down");
 }
 registerHandler("review_page_down", review_page_down);
@@ -4355,8 +4343,12 @@ async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
     editor.setBufferGroupPanelBuffer(state.groupId, "diff", compositeBufId);
     // createCompositeBuffer registers the composite as the active buffer of
     // the host split; re-focus the group panel so the review group stays the
-    // active tab and the sidebar/comments/toolbar remain visible.
+    // active tab and the sidebar/comments/toolbar remain visible — then hand
+    // focus back to whichever panel the user was actually in.
     editor.focusBufferGroupPanel(state.groupId, "diff");
+    if (state.focusPanel !== 'diff' && panelVisible(state.focusPanel)) {
+        editor.focusBufferGroupPanel(state.groupId, state.focusPanel);
+    }
     if (prev) {
         try {
             editor.closeCompositeBuffer(prev.compositeBufId);
@@ -4387,7 +4379,13 @@ function renderCenter(): void {
     if (state.panelBuffers["diff"] !== undefined) {
         editor.setBufferGroupPanelBuffer(state.groupId, "diff", state.panelBuffers["diff"]);
         editor.setPanelContent(state.groupId, "diff", buildDiffPanelEntries());
-        editor.focusBufferGroupPanel(state.groupId, "diff");
+        // Only claim focus when the diff is where focus belongs. Rebuilding
+        // the centre happens for reasons that have nothing to do with focus
+        // — a filter keystroke in the sidebar, a comment added — and
+        // stealing it there sends the next keystroke to the wrong panel.
+        if (state.focusPanel === 'diff') {
+            editor.focusBufferGroupPanel(state.groupId, "diff");
+        }
         applyFolds();
         applyCursorLineOverlay('diff');
     }
@@ -4406,7 +4404,6 @@ function refreshFocusedFile(): void {
     renderCenter();
     if (state.panelBuffers["files"] !== undefined) {
         renderFilesPanel();
-        scrollFilesToSelected();
     }
     // Unified: scroll the newly-focused file into position and put the cursor
     // on it, so navigating files actually moves the view to that file's diff
@@ -4895,19 +4892,46 @@ function review_goto_prev_file() { review_goto_file(-1); }
 registerHandler("review_goto_next_file", review_goto_next_file);
 registerHandler("review_goto_prev_file", review_goto_prev_file);
 
-// --- File filter (hunk-style `/`) ---
+// --- File filter: a field in the FILES panel -----------------------------
+//
+// `/` opens the sidebar with a Text widget under its header and puts the
+// panel into `review-filter` mode, where every printable key is text
+// rather than a review command. The host owns the field — caret,
+// selection, editing — and reports each edit as a `change` event; the
+// plugin only re-filters the tree. ↑↓ still walk the tree while the field
+// holds focus (the host forwards them), so you can type and pick without
+// leaving the panel.
+
+/** True while the filter field is open. */
+let filterEditing = false;
+/** Caret byte offset inside the field, mirrored from the host. */
+let filterCursor = 0;
+/** The filter as it was when the field opened, so Esc can put it back. */
+let filterBeforeEdit = "";
+
+const REVIEW_FILTER_MODE = "review-filter";
+
 function review_filter_files() {
-    const label = editor.t("prompt.filter_files") || "Filter files: ";
-    editor.startPromptWithInitial(label, "review-filter", state.fileFilter);
+    if (state.groupId === null) return;
+    setReviewPanelVisible('files', true);
+    filterBeforeEdit = state.fileFilter;
+    filterCursor = getByteLength(state.fileFilter);
+    filterEditing = true;
+    const filesBuf = state.panelBuffers["files"];
+    // While the field is open the panel's single-key commands (`s`, `c`,
+    // `n`, …) must not fire — they are letters the user is typing.
+    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, REVIEW_FILTER_MODE);
+    reviewSetFocus('files');
+    renderFilesPanel();
 }
 registerHandler("review_filter_files", review_filter_files);
 
-editor.on("prompt_confirmed", (args) => {
-    if (args.prompt_type !== "review-filter") return true;
-    state.fileFilter = (args.input || "").trim();
+/** Re-filter after an edit: the tree, the centre (the stream renders only
+ *  matching files) and the status line. */
+function applyFileFilter(): void {
     ensureFocusFile();
-    updateMagitDisplay();
-    jumpDiffCursorToRow(1, { recenter: false });
+    renderFilesPanel();
+    renderCenter();
     const vis = visibleFiles().length;
     editor.setStatus(
         state.fileFilter
@@ -4915,8 +4939,65 @@ editor.on("prompt_confirmed", (args) => {
                 || `Filter "${state.fileFilter}" — ${vis} file(s)`)
             : (editor.t("status.filter_cleared") || "Filter cleared")
     );
-    return true;
-});
+}
+
+/** Close the field. `revert` puts the query back to what it was when the
+ *  field opened (Esc); otherwise the typed query stands (Enter). */
+function closeFileFilter(revert: boolean): void {
+    if (!filterEditing) return;
+    filterEditing = false;
+    if (revert && state.fileFilter !== filterBeforeEdit) {
+        state.fileFilter = filterBeforeEdit;
+        applyFileFilter();
+    }
+    const filesBuf = state.panelBuffers["files"];
+    if (filesBuf !== undefined) editor.setBufferMode(filesBuf, "review-mode");
+    renderFilesPanel();
+}
+
+function review_filter_accept() { closeFileFilter(false); }
+registerHandler("review_filter_accept", review_filter_accept);
+
+function review_filter_cancel() { closeFileFilter(true); }
+registerHandler("review_filter_cancel", review_filter_cancel);
+
+/** Printable keys while the field is open. The host applies them to the
+ *  focused Text widget and reports the new value back as a `change`. */
+function review_filter_text_input(args: { text: string }): void {
+    if (!filterEditing || filesPanel === null || !args?.text) return;
+    filesPanel.command(textInputChar(args.text));
+}
+// The host dispatches unbound printable keys in an `allowTextInput`
+// mode as the `mode_text_input` action; the `filterEditing` guard keeps
+// this a no-op everywhere else (other plugins register it too).
+registerHandler("mode_text_input", review_filter_text_input);
+
+/** Editing keys (Backspace, arrows, …) and the tree-walking keys, both
+ *  handed to the host's smart-key dispatch for the focused field. */
+function review_filter_key(name: string): void {
+    if (filesPanel === null) return;
+    filesPanel.command(name === "Backspace" || name === "Delete"
+        ? textInputKey(name)
+        : key(name));
+}
+registerHandler("review_filter_backspace", () => review_filter_key("Backspace"));
+registerHandler("review_filter_delete", () => review_filter_key("Delete"));
+registerHandler("review_filter_up", () => review_filter_key("Up"));
+registerHandler("review_filter_down", () => review_filter_key("Down"));
+registerHandler("review_filter_left", () => review_filter_key("Left"));
+registerHandler("review_filter_right", () => review_filter_key("Right"));
+
+editor.defineMode(REVIEW_FILTER_MODE, [
+    ["Esc", "review_filter_cancel"],
+    ["Enter", "review_filter_accept"],
+    ["Backspace", "review_filter_backspace"],
+    ["Delete", "review_filter_delete"],
+    ["Up", "review_filter_up"],
+    ["Down", "review_filter_down"],
+    ["Left", "review_filter_left"],
+    ["Right", "review_filter_right"],
+    ["Tab", "review_filter_accept"],
+], true, true, false);
 
 // --- Watch / auto-reload (hunk-style `--watch`, opt-in via `W`) ---
 // When enabled, saving any file in the editor re-runs the diff and rebuilds,
@@ -5360,7 +5441,6 @@ async function compositeHunkNav(dir: 1 | -1): Promise<void> {
     await buildCenterComposite(); // rebuilds the composite, resets compositeHunkIdx = 0
     if (state.groupId !== null && state.panelBuffers["files"] !== undefined) {
         renderFilesPanel();
-        scrollFilesToSelected();
     }
     refreshStickyHeader(0);
 }
@@ -5890,8 +5970,7 @@ function resetPerSessionState(): void {
     state.collapsedFiles = new Set();
     state.collapsedSections = new Set();
     state.collapsedHunks = new Set();
-    state.commentsByRow = {};
-    state.commentsSelectedRow = 0;
+    state.commentsSelectedId = null;
     state.focusPanel = 'diff';
     state.commentsHighlightId = null;
     state.stickyCurrentFile = null;
@@ -6321,10 +6400,6 @@ function on_review_buffer_activated(data: { buffer_id: number }): void {
     if (newPanel !== null && !panelVisible(newPanel)) return;
     if (newPanel === null || newPanel === state.focusPanel) return;
     state.focusPanel = newPanel;
-    // Pin the FILES cursor to the selected row's start on *any* focus path
-    // (mouse included), so the panel never lands horizontally scrolled to a
-    // long row's end.
-    if (newPanel === 'files') scrollFilesToSelected();
     refreshFocusIndicators();
 }
 registerHandler("on_review_buffer_activated", on_review_buffer_activated);

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1456,7 +1456,7 @@ function buildToolbar(W: number): TextPropertyEntry[] {
                { key: "c", label: "comment" }],
     ];
     const row2: HintItem[][] = [
-        [{ key: "1 2", label: "split/stack" }, { key: "↑↓", label: "move in panel" },
+        [{ key: "1 2", label: "unified/split" }, { key: "↑↓", label: "move in panel" },
          { key: "Enter", label: "jump" }, { key: "Alt+o", label: "open file" }],
         inRange
             ? [{ key: "/", label: "filter" }, { key: "?", label: "help" },
@@ -2071,8 +2071,10 @@ function setReviewPanelVisible(panel: 'files' | 'comments', visible: boolean): v
             renderCommentsPanel();
         }
     } else if (state.focusPanel === panel) {
+        // Focus cannot stay on a panel that is no longer drawn.
         reviewSetFocus('diff');
     }
+    if (!visible && state.focusPanel === panel) state.focusPanel = 'diff';
     // The panel appearing or vanishing is its own feedback — no status
     // message — but the toolbar button carries the open/closed marker.
     renderToolbar();
@@ -4116,6 +4118,25 @@ async function fetchFileVersions(file: FileEntry): Promise<{ oldContent: string;
     return { oldContent, newContent, absPath };
 }
 
+/** How many review comments are anchored in `file`. Shown in the
+ *  side-by-side pane labels: the composite renders two real file buffers
+ *  with nowhere to put an inline comment box, so the label says the
+ *  comments are there and the COMMENTS rail (opened by
+ *  `review_set_layout` on the way in) carries the text. */
+function commentCountForFile(file: FileEntry): number {
+    let n = 0;
+    for (const c of state.comments) if (c.file === file.path) n++;
+    return n;
+}
+
+/** `label` with a `· N comments` suffix when the file carries any, and a
+ *  pointer at the rail while the rail is closed. */
+function paneLabelWithComments(label: string, count: number): string {
+    if (count === 0) return label;
+    const where = panelVisible('comments') ? '' : ' — see COMMENTS (C)';
+    return `${label}  ·  ${count} comment${count === 1 ? '' : 's'}${where}`;
+}
+
 async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
     if (state.groupId === null) return;
     ensureFocusFile();
@@ -4166,7 +4187,12 @@ async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
         layout: layoutCfg as never,
         sources: [
             { bufferId: oldRes.bufferId, label: "OLD (HEAD)", editable: false, style: { gutterStyle: "diff-markers" } },
-            { bufferId: newRes.bufferId, label: "NEW (Working)", editable: false, style: { gutterStyle: "diff-markers" } },
+            {
+                bufferId: newRes.bufferId,
+                label: paneLabelWithComments("NEW (Working)", commentCountForFile(file)),
+                editable: false,
+                style: { gutterStyle: "diff-markers" },
+            },
         ],
         hunks: compositeHunks.length > 0 ? compositeHunks : null,
         initialFocusHunk: compositeHunks.length > 0
@@ -4473,6 +4499,14 @@ function review_set_layout(layout: 'unified' | 'side-by-side'): void {
         // Unified expands every file, side-by-side renders one — the
         // center rebuild below has to see the new mode.
         syncFocusMode();
+        // Side-by-side has nowhere to draw an inline comment box: the
+        // center is two real file buffers. The NEW pane's label says how
+        // many the file carries and the rail carries the text (Enter on a
+        // row jumps the composite to it), so open it on the way in rather
+        // than leaving the comments written but unreadable.
+        if (layout === 'side-by-side' && state.comments.length > 0) {
+            setReviewPanelVisible('comments', true);
+        }
         renderCenter();
         refreshStickyHeader(state.diffViewportTopRow);
     }
@@ -4519,7 +4553,7 @@ async function review_help() {
         "             , / .      prev / next file",
         "             ] / [      next / prev comment",
         "             z a / z r  fold all / unfold all (Enter folds one)",
-        " Layout      1 / 2 / 0  split (side-by-side) / stack (unified) / auto",
+        " Layout      1 / 2 / 0  stack (unified) / split (side-by-side) / auto",
         " Panels      F / C      show / hide the files sidebar / comments rail",
         "                        (both start hidden; ✕ in a header closes it)",
         " View        a          show / hide inline notes",
@@ -6036,6 +6070,10 @@ function on_review_buffer_activated(data: { buffer_id: number }): void {
     if (data.buffer_id === diffId || data.buffer_id === compositeId) newPanel = 'diff';
     else if (data.buffer_id === commentsId) newPanel = 'comments';
     else if (data.buffer_id === filesId) newPanel = 'files';
+    // A hidden panel's buffer can still be "activated" (repainting it
+    // touches the buffer). It is not on screen, so it must not take the
+    // arrow keys — that stranded `j` / `Down` on an invisible file list.
+    if (newPanel !== null && !panelVisible(newPanel)) return;
     if (newPanel === null || newPanel === state.focusPanel) return;
     state.focusPanel = newPanel;
     // Pin the FILES cursor to the selected row's start on *any* focus path
@@ -6917,14 +6955,21 @@ editor.defineMode("review-mode", [
     // to. Mode bindings replace globals, so we must bind these
     // explicitly even though the actions are built-in.
     ["Home", "move_line_start"], ["End", "move_line_end"],
+    // Left / Right pan the unified stream horizontally. Nothing wraps
+    // in the diff panel, so a long line runs past the right edge; the
+    // cursor walking off it is what scrolls the viewport across, the
+    // same way it does in a normal buffer (Shift+wheel pans too).
+    ["Left", "move_left"], ["Right", "move_right"],
     // Hunk navigation across the unified stream.
     ["n", "review_next_hunk"], ["p", "review_prev_hunk"],
     // File navigation (hunk-style): focus the prev / next file.
     [",", "review_goto_prev_file"], [".", "review_goto_next_file"],
-    // Layout toggle (hunk-style): 1 = split (side-by-side of the file
-    // under the cursor), 2 = stack (unified), 0 = auto by terminal width.
-    ["1", "review_layout_split"],
-    ["2", "review_layout_stack"],
+    // Layout toggle: 1 = stack (the unified stream), 2 = split
+    // (side-by-side of the file under the cursor — two columns, two
+    // sides), 0 = auto by terminal width.
+    // 1 = one column (the unified stream), 2 = two columns (side-by-side).
+    ["1", "review_layout_stack"],
+    ["2", "review_layout_split"],
     ["0", "review_layout_auto"],
     // Show / hide the two side panels (both start hidden, so the diff
     // gets the full width until you ask for them).

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -4319,6 +4319,26 @@ interface EditorAPI {
 	*/
 	closeBufferGroup(groupId: number): boolean;
 	/**
+	* Show or hide one panel of a buffer group, without tearing the
+	* group down.
+	* 
+	* The panel's buffer, its content and its scroll position all
+	* survive being hidden — only the group's split tree changes, so
+	* the remaining panels take over the freed space and a re-shown
+	* panel comes back where it was. Use it for optional sidebars a
+	* mode wants to toggle (a file list, a comments rail) instead of
+	* closing and recreating the group.
+	* 
+	* Hiding a panel that holds focus moves focus to a panel that is
+	* still rendered; focusing a hidden panel is a no-op. Returns
+	* `false` if the group or panel is unknown, or if the call would
+	* hide the group's last visible panel.
+	* 
+	* Queued, like every layout mutation: the returned bool only reports
+	* that the command was sent.
+	*/
+	setBufferGroupPanelVisible(groupId: number, panelName: string, visible: boolean): boolean;
+	/**
 	* Focus a specific panel within a buffer group
 	*/
 	focusBufferGroupPanel(groupId: number, panelName: string): boolean;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3561,6 +3561,22 @@ interface EditorAPI {
 	*/
 	flushLayout(): boolean;
 	/**
+	* Put a composite buffer's cursor on the row showing `line`
+	* (0-indexed) of pane `pane` — 0 is the left/OLD pane — and scroll
+	* it into view.
+	* 
+	* `initialFocusHunk` on `createCompositeBuffer` lands the view on a
+	* hunk; this lands it on a *line*, which is what a plugin holding a
+	* concrete file position wants (following a review comment, or
+	* keeping the reader's place when a diff view flips between its
+	* unified and side-by-side layouts). No-op if that pane has no such
+	* line.
+	* 
+	* Queued, like every layout mutation: the returned bool only reports
+	* that the command was sent.
+	*/
+	setCompositeCursorLine(bufferId: number, pane: number, line: number): boolean;
+	/**
 	* Navigate to the next hunk in a composite buffer
 	*/
 	compositeNextHunk(bufferId: number): boolean;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -4335,6 +4335,18 @@ interface EditorAPI {
 	*/
 	closeBufferGroup(groupId: number): boolean;
 	/**
+	* Switch a virtual buffer's mode — the keybinding set that applies
+	* while it is focused.
+	* 
+	* A panel that grows a text field (an in-panel filter) needs the
+	* single-key commands of its normal mode to stop firing while the
+	* user types; giving the panel a text-input mode for the duration
+	* does that without the plugin re-registering bindings. Modes are
+	* declared with `defineMode`; a mode name with no definition falls
+	* back to the global bindings.
+	*/
+	setBufferMode(bufferId: number, mode: string): boolean;
+	/**
 	* Show or hide one panel of a buffer group, without tearing the
 	* group down.
 	* 

--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -201,6 +201,18 @@ impl crate::app::window::Window {
         Some(events)
     }
 
+    /// Whether `split_id` currently soft-wraps. Falls back to the global
+    /// `editor.line_wrap` for a split with no view state yet, so a cursor
+    /// motion arriving before the first render behaves as configured.
+    fn split_line_wrap(&self, split_id: LeafId) -> bool {
+        self.buffers
+            .splits()
+            .map(|(_, vs)| vs)
+            .and_then(|vs| vs.get(&split_id))
+            .map(|vs| vs.viewport.line_wrap_enabled)
+            .unwrap_or_else(|| self.config().editor.line_wrap)
+    }
+
     /// Handle visual line movement actions using the cached layout
     /// Returns Some(events) if the action was handled, None if it should fall through
     fn handle_visual_line_movement(
@@ -238,16 +250,22 @@ impl crate::app::window::Window {
             // When line wrapping is off, Home/End should move to the physical line
             // start/end, not the visual (horizontally-scrolled) row boundary.
             // Fall through to the standard handler which uses line_iterator.
-            Action::MoveLineEnd if self.config().editor.line_wrap => {
+            //
+            // Ask the split the cursor is actually in, not the global config:
+            // a plugin panel can turn wrap off for itself (`setLineWrap`, and
+            // every buffer-group panel does), and reading the global default
+            // there sent Home walking a wrap boundary that the unwrapped view
+            // never draws — one press landed mid-line instead of at column 1.
+            Action::MoveLineEnd if self.split_line_wrap(split_id) => {
                 VisualAction::LineEnd { is_select: false }
             }
-            Action::SelectLineEnd if self.config().editor.line_wrap => {
+            Action::SelectLineEnd if self.split_line_wrap(split_id) => {
                 VisualAction::LineEnd { is_select: true }
             }
-            Action::MoveLineStart if self.config().editor.line_wrap => {
+            Action::MoveLineStart if self.split_line_wrap(split_id) => {
                 VisualAction::LineStart { is_select: false }
             }
-            Action::SelectLineStart if self.config().editor.line_wrap => {
+            Action::SelectLineStart if self.split_line_wrap(split_id) => {
                 VisualAction::LineStart { is_select: true }
             }
             _ => return None, // Not a visual line action

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -540,13 +540,18 @@ impl super::Editor {
             hidden.insert(panel_name.to_string());
         }
         let existing_leaves = group.panel_splits.clone();
+        let current_buffers = group.panel_buffers.clone();
 
         // Rebuild the tree first: if the request would empty the group,
         // nothing has been mutated yet and we can decline it outright.
         let mut panel_splits: HashMap<String, LeafId> = HashMap::new();
-        let Some(inner_tree) =
-            self.build_visible_split_tree(&layout, &hidden, &existing_leaves, &mut panel_splits)
-        else {
+        let Some(inner_tree) = self.build_visible_split_tree(
+            &layout,
+            &hidden,
+            &existing_leaves,
+            &current_buffers,
+            &mut panel_splits,
+        ) else {
             tracing::warn!(
                 "setBufferGroupPanelVisible: hiding '{}' would leave group {} empty",
                 panel_name,
@@ -654,6 +659,7 @@ impl super::Editor {
         node: &GroupLayoutNode,
         hidden: &std::collections::HashSet<String>,
         existing: &HashMap<String, LeafId>,
+        current_buffers: &HashMap<String, BufferId>,
         panel_splits: &mut HashMap<String, LeafId>,
     ) -> Option<crate::view::split::SplitNode> {
         use crate::view::split::SplitNode;
@@ -664,7 +670,13 @@ impl super::Editor {
                 if hidden.contains(id) {
                     return None;
                 }
-                let buffer_id = (*buffer_id)?;
+                // `layout` records the buffer each panel was *created*
+                // with. A panel that has since been retargeted
+                // (`setBufferGroupPanelBuffer` — the review diff swaps its
+                // center panel to a composite for the side-by-side view)
+                // must keep the buffer it holds now; rebuilding from the
+                // layout's id would silently revert it.
+                let buffer_id = current_buffers.get(id).copied().or(*buffer_id)?;
                 let leaf_id = existing.get(id).copied().unwrap_or_else(|| {
                     LeafId(
                         self.windows
@@ -683,10 +695,10 @@ impl super::Editor {
                 first,
                 second,
             } => {
-                let first_node =
-                    self.build_visible_split_tree(first, hidden, existing, panel_splits);
-                let second_node =
-                    self.build_visible_split_tree(second, hidden, existing, panel_splits);
+                let first_node = self
+                    .build_visible_split_tree(first, hidden, existing, current_buffers, panel_splits);
+                let second_node = self
+                    .build_visible_split_tree(second, hidden, existing, current_buffers, panel_splits);
                 match (first_node, second_node) {
                     (Some(f), Some(s)) => {
                         let split_id = self

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -121,6 +121,12 @@ impl super::Editor {
             if let Some(bs) = vs.keyed_states.get_mut(&buffer_id) {
                 bs.show_line_numbers = false;
                 bs.highlight_current_line = false;
+                // Panel content is composed by the plugin at a width it
+                // already knows (it truncates or pre-wraps its own rows), so
+                // soft-wrapping it again just re-flows lines the plugin laid
+                // out — a diff row spilling onto three screen rows, say. Panels
+                // never wrap; the horizontal scrollbar handles overflow.
+                bs.viewport.line_wrap_enabled = false;
             }
             self.windows
                 .get_mut(&self.active_window)
@@ -195,6 +201,7 @@ impl super::Editor {
             layout,
             panel_buffers: panel_buffers.clone(),
             panel_splits,
+            hidden_panels: std::collections::HashSet::new(),
             representative_split: Some(group_leaf_id),
         };
 
@@ -484,16 +491,248 @@ impl super::Editor {
         }
     }
 
+    /// Show or hide one panel of a buffer group.
+    ///
+    /// The group is not torn down: the panel's buffer, its content and its
+    /// scroll position all survive being hidden, because only the group's
+    /// inner split tree is rebuilt (from `group.layout`, which always
+    /// describes every panel) with the hidden leaves left out. A split whose
+    /// children are all hidden collapses to the visible side, so the
+    /// remaining panels take over the freed space at their original ratios.
+    ///
+    /// Returns `false` — leaving the group untouched — when the group or
+    /// panel is unknown, or when hiding this panel would leave the group
+    /// with nothing to render.
+    #[cfg(feature = "plugins")]
+    pub(super) fn set_buffer_group_panel_visible(
+        &mut self,
+        group_id: usize,
+        panel_name: &str,
+        visible: bool,
+    ) -> bool {
+        use crate::view::split::SplitNode;
+
+        let bg_id = BufferGroupId(group_id);
+        let Some(group) = self.active_window().buffer_groups.get(&bg_id) else {
+            tracing::warn!("setBufferGroupPanelVisible: group {} not found", group_id);
+            return false;
+        };
+        if !group.panel_buffers.contains_key(panel_name) {
+            tracing::warn!(
+                "setBufferGroupPanelVisible: panel '{}' missing in group {}",
+                panel_name,
+                group_id
+            );
+            return false;
+        }
+        let already_hidden = group.hidden_panels.contains(panel_name);
+        if already_hidden == !visible {
+            return true;
+        }
+        let Some(group_leaf_id) = group.representative_split else {
+            return false;
+        };
+        let layout = group.layout.clone();
+        let mut hidden = group.hidden_panels.clone();
+        if visible {
+            hidden.remove(panel_name);
+        } else {
+            hidden.insert(panel_name.to_string());
+        }
+        let existing_leaves = group.panel_splits.clone();
+
+        // Rebuild the tree first: if the request would empty the group,
+        // nothing has been mutated yet and we can decline it outright.
+        let mut panel_splits: HashMap<String, LeafId> = HashMap::new();
+        let Some(inner_tree) =
+            self.build_visible_split_tree(&layout, &hidden, &existing_leaves, &mut panel_splits)
+        else {
+            tracing::warn!(
+                "setBufferGroupPanelVisible: hiding '{}' would leave group {} empty",
+                panel_name,
+                group_id
+            );
+            return false;
+        };
+
+        // Every panel keeps its leaf id and view state, visible or not, so a
+        // panel that comes back finds its scroll position where it left it.
+        // `panel_splits` therefore stays the full map; only the tree shrinks.
+        let mut all_splits = existing_leaves.clone();
+        all_splits.extend(panel_splits.iter().map(|(k, v)| (k.clone(), *v)));
+        let visible_leaves: std::collections::HashSet<LeafId> =
+            panel_splits.values().copied().collect();
+
+        // Panels shown for the first time need the same view state that
+        // `create_buffer_group` gives every panel at create time.
+        let (tw, th) = (self.terminal_width, self.terminal_height);
+        for (name, leaf_id) in &panel_splits {
+            let has_state = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.splits())
+                .map(|(_, vs)| vs.contains_key(leaf_id))
+                .unwrap_or(false);
+            if has_state {
+                continue;
+            }
+            let Some(buffer_id) = self
+                .active_window()
+                .buffer_groups
+                .get(&bg_id)
+                .and_then(|g| g.panel_buffers.get(name).copied())
+            else {
+                continue;
+            };
+            let mut vs = SplitViewState::with_buffer(tw, th, buffer_id);
+            vs.suppress_chrome = true;
+            vs.hide_tilde = true;
+            if let Some(bs) = vs.keyed_states.get_mut(&buffer_id) {
+                bs.show_line_numbers = false;
+                bs.highlight_current_line = false;
+                bs.viewport.line_wrap_enabled = false;
+            }
+            self.windows
+                .get_mut(&self.active_window)
+                .and_then(|w| w.split_view_states_mut())
+                .expect("active window must have a populated split layout")
+                .insert(*leaf_id, vs);
+        }
+
+        // Swap the tree in, keeping the group's focus on a leaf that is
+        // still rendered.
+        let mut fallback_leaf = None;
+        if let Some(SplitNode::Grouped {
+            layout: node_layout,
+            active_inner_leaf,
+            ..
+        }) = self
+            .active_window_mut()
+            .grouped_subtrees
+            .get_mut(&group_leaf_id)
+        {
+            *node_layout = Box::new(inner_tree);
+            if !visible_leaves.contains(active_inner_leaf) {
+                if let Some(leaf) = node_layout.leaf_split_ids().first().copied() {
+                    *active_inner_leaf = leaf;
+                }
+            }
+            fallback_leaf = Some(*active_inner_leaf);
+        }
+
+        if let Some(group) = self.active_window_mut().buffer_groups.get_mut(&bg_id) {
+            group.hidden_panels = hidden;
+            group.panel_splits = all_splits;
+        }
+
+        for vs in self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_view_states_mut())
+            .expect("active window must have a populated split layout")
+            .values_mut()
+        {
+            vs.layout_dirty = true;
+            if let (Some(focused), Some(fallback)) = (vs.focused_group_leaf, fallback_leaf) {
+                if !visible_leaves.contains(&focused) && existing_leaves.values().any(|l| *l == focused)
+                {
+                    vs.focused_group_leaf = Some(fallback);
+                }
+            }
+        }
+        self.plugin_render_requested = true;
+        true
+    }
+
+    /// Build a group's inner split tree from its layout, skipping hidden
+    /// panels and reusing each visible panel's existing leaf id (so its view
+    /// state — and with it the scroll position — carries over). Returns
+    /// `None` when every leaf in the subtree is hidden.
+    #[cfg(feature = "plugins")]
+    fn build_visible_split_tree(
+        &mut self,
+        node: &GroupLayoutNode,
+        hidden: &std::collections::HashSet<String>,
+        existing: &HashMap<String, LeafId>,
+        panel_splits: &mut HashMap<String, LeafId>,
+    ) -> Option<crate::view::split::SplitNode> {
+        use crate::view::split::SplitNode;
+
+        match node {
+            GroupLayoutNode::Scrollable { id, buffer_id, .. }
+            | GroupLayoutNode::Fixed { id, buffer_id, .. } => {
+                if hidden.contains(id) {
+                    return None;
+                }
+                let buffer_id = (*buffer_id)?;
+                let leaf_id = existing.get(id).copied().unwrap_or_else(|| {
+                    LeafId(
+                        self.windows
+                            .get_mut(&self.active_window)
+                            .and_then(|w| w.split_manager_mut())
+                            .expect("active window must have a populated split layout")
+                            .allocate_split_id(),
+                    )
+                });
+                panel_splits.insert(id.clone(), leaf_id);
+                Some(SplitNode::leaf(buffer_id, leaf_id.0))
+            }
+            GroupLayoutNode::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
+                let first_node =
+                    self.build_visible_split_tree(first, hidden, existing, panel_splits);
+                let second_node =
+                    self.build_visible_split_tree(second, hidden, existing, panel_splits);
+                match (first_node, second_node) {
+                    (Some(f), Some(s)) => {
+                        let split_id = self
+                            .windows
+                            .get_mut(&self.active_window)
+                            .and_then(|w| w.split_manager_mut())
+                            .expect("active window must have a populated split layout")
+                            .allocate_split_id();
+                        let mut split = SplitNode::split(*direction, f, s, *ratio, split_id);
+                        let fixed_first_size = fixed_height_of(first);
+                        let fixed_second_size = fixed_height_of(second);
+                        if let SplitNode::Split {
+                            fixed_first,
+                            fixed_second,
+                            ..
+                        } = &mut split
+                        {
+                            *fixed_first = fixed_first_size;
+                            *fixed_second = fixed_second_size;
+                        }
+                        Some(split)
+                    }
+                    // One side hidden: the survivor takes the whole rect.
+                    (Some(only), None) | (None, Some(only)) => Some(only),
+                    (None, None) => None,
+                }
+            }
+        }
+    }
+
     /// Focus a specific panel in a buffer group.
     ///
     /// If the panel's inner leaf is not in the main split tree (side-map
     /// approach), this activates the group tab on whichever split hosts it
     /// and marks the panel's leaf as the focused inner leaf.
+    ///
+    /// Focusing a hidden panel is a no-op — there is no rect to put a cursor
+    /// in, and routing keys at an unrendered panel would strand input.
     #[cfg(feature = "plugins")]
     pub(super) fn focus_panel(&mut self, group_id: usize, panel_name: String) {
         let bg_id = BufferGroupId(group_id);
         let (group_leaf_id, inner_leaf) = match self.active_window_mut().buffer_groups.get(&bg_id) {
             Some(group) => {
+                if group.hidden_panels.contains(&panel_name) {
+                    return;
+                }
                 let Some(&inner) = group.panel_splits.get(&panel_name) else {
                     return;
                 };
@@ -702,9 +941,14 @@ impl super::Editor {
                 });
                 // Match the panel-buffer presentation set in
                 // `build_group_layout` (no line numbers, no current-
-                // line highlight inside grouped panels).
+                // line highlight, no soft wrap inside grouped panels).
+                // The wrap flag must be cleared *after*
+                // `apply_config_defaults`, which would otherwise stamp
+                // the global `editor.line_wrap` (on by default) onto a
+                // panel the plugin already laid out to the panel width.
                 buf_state.show_line_numbers = false;
                 buf_state.highlight_current_line = false;
+                buf_state.viewport.line_wrap_enabled = false;
             }
             // 2) Now flip the active pointer.
             vs.active_buffer = new_buffer_id;

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -526,7 +526,7 @@ impl super::Editor {
             return false;
         }
         let already_hidden = group.hidden_panels.contains(panel_name);
-        if already_hidden == !visible {
+        if already_hidden != visible {
             return true;
         }
         let Some(group_leaf_id) = group.representative_split else {
@@ -616,7 +616,7 @@ impl super::Editor {
             .grouped_subtrees
             .get_mut(&group_leaf_id)
         {
-            *node_layout = Box::new(inner_tree);
+            **node_layout = inner_tree;
             if !visible_leaves.contains(active_inner_leaf) {
                 if let Some(leaf) = node_layout.leaf_split_ids().first().copied() {
                     *active_inner_leaf = leaf;
@@ -639,7 +639,8 @@ impl super::Editor {
         {
             vs.layout_dirty = true;
             if let (Some(focused), Some(fallback)) = (vs.focused_group_leaf, fallback_leaf) {
-                if !visible_leaves.contains(&focused) && existing_leaves.values().any(|l| *l == focused)
+                if !visible_leaves.contains(&focused)
+                    && existing_leaves.values().any(|l| *l == focused)
                 {
                     vs.focused_group_leaf = Some(fallback);
                 }
@@ -695,10 +696,20 @@ impl super::Editor {
                 first,
                 second,
             } => {
-                let first_node = self
-                    .build_visible_split_tree(first, hidden, existing, current_buffers, panel_splits);
-                let second_node = self
-                    .build_visible_split_tree(second, hidden, existing, current_buffers, panel_splits);
+                let first_node = self.build_visible_split_tree(
+                    first,
+                    hidden,
+                    existing,
+                    current_buffers,
+                    panel_splits,
+                );
+                let second_node = self.build_visible_split_tree(
+                    second,
+                    hidden,
+                    existing,
+                    current_buffers,
+                    panel_splits,
+                );
                 match (first_node, second_node) {
                     (Some(f), Some(s)) => {
                         let split_id = self

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -374,6 +374,63 @@ impl crate::app::window::Window {
         }
     }
 
+    /// Put the composite's cursor on the aligned row that shows source
+    /// line `line` (0-indexed) of pane `pane`, scrolled a third of the way
+    /// down the viewport — the same framing `composite_next_hunk` uses.
+    ///
+    /// This is how a caller holding a concrete file line (a review comment,
+    /// or the line the unified stream was sitting on before the layout
+    /// flipped) lands the side-by-side view on that exact line, rather than
+    /// on the top of the enclosing hunk. Returns `true` if the line is
+    /// present in that pane.
+    pub fn composite_cursor_to_source_line(
+        &mut self,
+        split_id: LeafId,
+        buffer_id: BufferId,
+        pane: usize,
+        line: usize,
+    ) -> bool {
+        let viewport_height = self.get_composite_viewport_height(split_id);
+        let target_row = self
+            .composite_buffers
+            .get(&buffer_id)
+            .and_then(|composite| {
+                composite
+                    .alignment
+                    .rows
+                    .iter()
+                    .position(|row| row.get_pane_line(pane).is_some_and(|r| r.line == line))
+            });
+        let Some(target_row) = target_row else {
+            return false;
+        };
+        // The view state is normally created by the first render of the
+        // composite. A caller placing the cursor right after building one
+        // (a layout flip) gets here first, so create it rather than
+        // dropping the request — `flush_layout` only reaches composites in
+        // the main split tree, not those inside a buffer group.
+        let Some(pane_count) = self.composite_buffers.get_mut(&buffer_id).map(|c| {
+            // An explicit cursor placement supersedes the framing the
+            // composite was created with: `initial_focus_hunk` is applied
+            // by the *first render*, which happens after this call and
+            // would otherwise scroll straight back to the hunk.
+            c.initial_focus_hunk = None;
+            c.pane_count()
+        }) else {
+            return false;
+        };
+        let view_state = self
+            .composite_view_states
+            .entry((split_id, buffer_id))
+            .or_insert_with(|| {
+                crate::view::composite_view::CompositeViewState::new(buffer_id, pane_count)
+            });
+        view_state.cursor_row = target_row;
+        view_state.scroll_row = target_row.saturating_sub(viewport_height / 3);
+        self.sync_editor_cursor_from_composite(split_id, buffer_id);
+        true
+    }
+
     /// Scroll a composite-buffer view to absolute row `row`, clamped.
     pub fn composite_scroll_to(&mut self, split_id: LeafId, buffer_id: BufferId, row: usize) {
         if let (Some(composite), Some(view_state)) = (

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -434,19 +434,20 @@ impl Editor {
                 Some(Ok(()))
             }
             ModeKeyDisposition::TextInput(ch) => {
-                // A panel mounted on this buffer with a focused Text
-                // widget takes the character directly — the host owns the
-                // field, so the plugin gets the edit back as a `change`
-                // event and never has to re-implement typing. Only when
-                // there is no such field does this fall back to the
-                // `mode_text_input` plugin action, which is registered
-                // under one global name and so can only ever reach a
-                // single plugin.
-                if let Some(panel_id) = focused_widget_panel {
-                    self.handle_widget_text_char(&panel_id, &ch.to_string());
-                    return Some(Ok(()));
-                }
-                let action_name = format!("mode_text_input:{}", ch);
+                // Qualify the dispatch with the mode that claimed the key
+                // so it reaches the plugin that *defined* that mode.
+                // `mode_text_input` alone is one global name, so several
+                // text-input modes would otherwise fight over it and the
+                // last plugin to call `defineMode` would swallow everyone
+                // else's typing. Deliberately still an async plugin
+                // action: a mode's other bindings (Space, Backspace, …)
+                // edit the same field through the same queue, and taking
+                // a host-side shortcut here would let plain characters
+                // overtake them and scramble the typed text.
+                let action_name = match view.effective_mode.as_deref() {
+                    Some(mode) => format!("mode_text_input@{}:{}", mode, ch),
+                    None => format!("mode_text_input:{}", ch),
+                };
                 Some(self.handle_action(Action::PluginAction(action_name)))
             }
             ModeKeyDisposition::Forward(action) => Some(self.handle_action(action)),

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -434,6 +434,18 @@ impl Editor {
                 Some(Ok(()))
             }
             ModeKeyDisposition::TextInput(ch) => {
+                // A panel mounted on this buffer with a focused Text
+                // widget takes the character directly — the host owns the
+                // field, so the plugin gets the edit back as a `change`
+                // event and never has to re-implement typing. Only when
+                // there is no such field does this fall back to the
+                // `mode_text_input` plugin action, which is registered
+                // under one global name and so can only ever reach a
+                // single plugin.
+                if let Some(panel_id) = focused_widget_panel {
+                    self.handle_widget_text_char(&panel_id, &ch.to_string());
+                    return Some(Ok(()));
+                }
                 let action_name = format!("mode_text_input:{}", ch);
                 Some(self.handle_action(Action::PluginAction(action_name)))
             }

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1924,28 +1924,57 @@ impl Editor {
     }
 
     /// Handle SetLineWrap command
+    ///
+    /// With no `split_id`, the wrap flag lands on every split showing
+    /// `buffer_id` — including a buffer-group panel, whose leaf is not in
+    /// the main split tree and is never the "active split". Aiming at the
+    /// active split there set the flag on whatever pane happened to be
+    /// focused and left the panel alone, so a panel plugin asking for wrap
+    /// (git-log's commit-detail pane, where a lock-file diff is unreadable
+    /// unwrapped) silently got none. Falls back to the active split when
+    /// the buffer isn't on screen anywhere.
     pub(super) fn handle_set_line_wrap(
         &mut self,
-        _buffer_id: BufferId,
+        buffer_id: BufferId,
         split_id: Option<SplitId>,
         enabled: bool,
     ) {
-        let target_split = split_id.map(LeafId).unwrap_or(
-            self.windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
+        let targets: Vec<LeafId> = match split_id {
+            Some(id) => vec![LeafId(id)],
+            None => {
+                let showing: Vec<LeafId> = self
+                    .windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.buffers.splits())
+                    .map(|(_, vs)| vs)
+                    .expect("active window must have a populated split layout")
+                    .iter()
+                    .filter(|(_, vs)| vs.active_buffer == buffer_id)
+                    .map(|(leaf_id, _)| *leaf_id)
+                    .collect();
+                if showing.is_empty() {
+                    vec![self
+                        .windows
+                        .get(&self.active_window)
+                        .and_then(|w| w.buffers.splits())
+                        .map(|(mgr, _)| mgr)
+                        .expect("active window must have a populated split layout")
+                        .active_split()]
+                } else {
+                    showing
+                }
+            }
+        };
+        for target_split in targets {
+            if let Some(view_state) = self
+                .windows
+                .get_mut(&self.active_window)
+                .and_then(|w| w.split_view_states_mut())
                 .expect("active window must have a populated split layout")
-                .active_split(),
-        );
-        if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
-            .expect("active window must have a populated split layout")
-            .get_mut(&target_split)
-        {
-            view_state.viewport.line_wrap_enabled = enabled;
+                .get_mut(&target_split)
+            {
+                view_state.viewport.line_wrap_enabled = enabled;
+            }
         }
     }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1623,6 +1623,13 @@ impl Editor {
                     request_id,
                 });
             }
+            PluginCommand::SetCompositeCursorLine {
+                buffer_id,
+                pane,
+                line,
+            } => {
+                self.handle_set_composite_cursor_line(buffer_id, pane, line);
+            }
             PluginCommand::CompositeNextHunk { buffer_id } => {
                 self.handle_composite_next_hunk(buffer_id);
             }
@@ -2207,6 +2214,17 @@ impl Editor {
         let split_id = self.active_window().effective_active_pair().0;
         self.active_window_mut()
             .composite_next_hunk(split_id, buffer_id);
+    }
+
+    fn handle_set_composite_cursor_line(
+        &mut self,
+        buffer_id: fresh_core::BufferId,
+        pane: usize,
+        line: usize,
+    ) {
+        let split_id = self.active_window().effective_active_pair().0;
+        self.active_window_mut()
+            .composite_cursor_to_source_line(split_id, buffer_id, pane, line);
     }
 
     fn handle_composite_prev_hunk(&mut self, buffer_id: fresh_core::BufferId) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5123,6 +5123,7 @@ impl Editor {
         let panel_width = self.widget_panel_width(buffer_id);
         let out = self.render_panel_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
+        self.sync_widget_panel_scrollable(buffer_id, &out.scroll_regions);
         self.widget_registry.mount(
             panel_key.clone(),
             buffer_id,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1662,6 +1662,12 @@ impl Editor {
             } => {
                 self.focus_panel(group_id, panel_name);
             }
+            PluginCommand::SetBufferMode { buffer_id, mode } => {
+                let buffer_id = self.resolve_buffer_id(buffer_id);
+                if let Some(meta) = self.active_window_mut().buffer_metadata.get_mut(&buffer_id) {
+                    meta.set_virtual_mode(mode);
+                }
+            }
             PluginCommand::SetBufferGroupPanelVisible {
                 group_id,
                 panel_name,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5123,7 +5123,6 @@ impl Editor {
         let panel_width = self.widget_panel_width(buffer_id);
         let out = self.render_panel_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
-        self.sync_widget_panel_scrollable(buffer_id, &out.scroll_regions);
         self.widget_registry.mount(
             panel_key.clone(),
             buffer_id,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1655,6 +1655,13 @@ impl Editor {
             } => {
                 self.focus_panel(group_id, panel_name);
             }
+            PluginCommand::SetBufferGroupPanelVisible {
+                group_id,
+                panel_name,
+                visible,
+            } => {
+                self.set_buffer_group_panel_visible(group_id, &panel_name, visible);
+            }
 
             // ==================== File Operations ====================
             PluginCommand::SaveBufferToPath { buffer_id, path } => {

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -1711,6 +1711,29 @@ impl Editor {
                 }
                 PromptResult::Done
             }
+            QuickOpenResult::ShowBufferGroup(group_leaf) => {
+                let group_leaf =
+                    crate::model::event::LeafId(crate::model::event::SplitId(group_leaf));
+                // The group tab lives in exactly one split; find it so the
+                // activation targets the same split a click on the tab would.
+                let split_id = self
+                    .windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.buffers.splits())
+                    .map(|(_, vs)| vs)
+                    .and_then(|view_states| {
+                        view_states.iter().find_map(|(split_id, vs)| {
+                            vs.open_buffers
+                                .iter()
+                                .any(|t| *t == crate::view::split::TabTarget::Group(group_leaf))
+                                .then_some(*split_id)
+                        })
+                    });
+                if let Some(split_id) = split_id {
+                    self.activate_group_tab(split_id, group_leaf);
+                }
+                PromptResult::Done
+            }
             QuickOpenResult::GotoLine(target) => {
                 // Large file opened in byte-offset mode: there is no line
                 // index yet, so a `:N` target can't be resolved to a byte

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -165,6 +165,52 @@ impl Editor {
         self.update_quick_open_suggestions(prefix);
     }
 
+    /// Buffer-group tabs, as `#` switcher entries.
+    ///
+    /// A group's own buffers are `hidden_from_tabs` — the group is the tab,
+    /// not any one panel — so listing buffers alone leaves a group like the
+    /// review-diff panels unreachable from the switcher once focus moves to
+    /// another tab. Emitting the group itself is what closes that gap; the
+    /// entry carries the group's leaf id so selecting it activates the tab
+    /// rather than trying to make a hidden panel buffer active.
+    fn quick_open_group_tabs(&self) -> Vec<BufferInfo> {
+        use crate::view::split::{SplitNode, TabTarget};
+        let Some(window) = self.windows.get(&self.active_window) else {
+            return Vec::new();
+        };
+        let Some((_, view_states)) = window.buffers.splits() else {
+            return Vec::new();
+        };
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for vs in view_states.values() {
+            for target in &vs.open_buffers {
+                let TabTarget::Group(leaf) = target else {
+                    continue;
+                };
+                if !seen.insert(*leaf) {
+                    continue;
+                }
+                let Some(SplitNode::Grouped { name, .. }) = window.grouped_subtrees.get(leaf)
+                else {
+                    continue;
+                };
+                out.push(BufferInfo {
+                    // Groups have no buffer of their own; `id` only orders
+                    // ties in the switcher, and the leaf id is stable and
+                    // unique among groups.
+                    id: leaf.0 .0,
+                    path: String::new(),
+                    name: name.clone(),
+                    modified: false,
+                    is_virtual: true,
+                    group_leaf: Some(leaf.0 .0),
+                });
+            }
+        }
+        out
+    }
+
     /// Build a QuickOpenContext from current editor state
     pub(super) fn build_quick_open_context(&self) -> QuickOpenContext {
         let metadata = &self.active_window().buffer_metadata;
@@ -190,6 +236,7 @@ impl Editor {
                             name,
                             modified: state.buffer.is_modified(),
                             is_virtual: false,
+                            group_leaf: None,
                         })
                     }
                     // No file path: only virtual buffers (plugin panels like
@@ -204,10 +251,12 @@ impl Editor {
                             name: meta.display_name.clone(),
                             modified: state.buffer.is_modified(),
                             is_virtual: true,
+                            group_leaf: None,
                         })
                     }
                 }
             })
+            .chain(self.quick_open_group_tabs())
             .collect();
 
         let has_lsp_config = {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4518,23 +4518,30 @@ impl Editor {
                     // clamped inside the split.
                     //
                     // A list that starts at column 0 owns the panel's whole
-                    // width, so its bar belongs against the right edge. Its
+                    // width, so its bar belongs at the right-hand edge. Its
                     // laid-out `width_cols` is deliberately a couple of
                     // columns short (`widget_panel_width` reserves them for
                     // exactly this bar), and drawing at that inboard edge
                     // put the bar *inside* the rows — blanking a character
-                    // cell mid-text and leaving the reserved columns empty
-                    // beside the split's own scrollbar.
+                    // cell mid-text and leaving the reserved columns empty.
+                    //
+                    // Where "the edge" is depends on the split: with the
+                    // buffer scrollbar on, the split keeps a column of its
+                    // own just past the content rect, so paint into that one
+                    // and the two coincide. Two tracks side by side is what
+                    // the reserved columns looked like before.
                     let region_right = content_rect
                         .x
                         .saturating_add(gutter)
                         .saturating_add(region.col_in_row as u16)
                         .saturating_add(region.width_cols.saturating_sub(1) as u16);
                     let panel_right = content_rect.x + content_rect.width.saturating_sub(1);
-                    let sb_x = if region.col_in_row == 0 {
-                        panel_right
-                    } else {
+                    let sb_x = if region.col_in_row != 0 {
                         region_right.min(panel_right)
+                    } else if self.config.editor.show_vertical_scrollbar {
+                        content_rect.x + content_rect.width
+                    } else {
+                        panel_right
                     };
                     jobs.push((
                         ratatui::layout::Rect {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -4516,12 +4516,26 @@ impl Editor {
                     }
                     // Scrollbar column = right edge of the list's region,
                     // clamped inside the split.
-                    let sb_x = content_rect
+                    //
+                    // A list that starts at column 0 owns the panel's whole
+                    // width, so its bar belongs against the right edge. Its
+                    // laid-out `width_cols` is deliberately a couple of
+                    // columns short (`widget_panel_width` reserves them for
+                    // exactly this bar), and drawing at that inboard edge
+                    // put the bar *inside* the rows — blanking a character
+                    // cell mid-text and leaving the reserved columns empty
+                    // beside the split's own scrollbar.
+                    let region_right = content_rect
                         .x
                         .saturating_add(gutter)
                         .saturating_add(region.col_in_row as u16)
-                        .saturating_add(region.width_cols.saturating_sub(1) as u16)
-                        .min(content_rect.x + content_rect.width.saturating_sub(1));
+                        .saturating_add(region.width_cols.saturating_sub(1) as u16);
+                    let panel_right = content_rect.x + content_rect.width.saturating_sub(1);
+                    let sb_x = if region.col_in_row == 0 {
+                        panel_right
+                    } else {
+                        region_right.min(panel_right)
+                    };
                     jobs.push((
                         ratatui::layout::Rect {
                             x: sb_x,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -619,14 +619,37 @@ impl Editor {
                     changed
                 );
                 if changed {
-                    if let Some(buffer_id) = self
+                    // Buffer-group panels are leaves of a stashed `Grouped`
+                    // subtree, not of the main split tree, so `get_buffer_id`
+                    // comes back empty for them and the hook used to be
+                    // dropped — a panel plugin never heard that its panel had
+                    // scrolled or been resized. Fall back to the grouped
+                    // subtrees for those leaves.
+                    let buffer_id = self
                         .windows
                         .get(&self.active_window)
                         .and_then(|w| w.buffers.splits())
                         .map(|(mgr, _)| mgr)
                         .expect("active window must have a populated split layout")
                         .get_buffer_id((*split_id).into())
-                    {
+                        .or_else(|| {
+                            self.active_window()
+                                .grouped_subtrees
+                                .values()
+                                .find_map(|node| {
+                                    if let crate::view::split::SplitNode::Grouped {
+                                        layout, ..
+                                    } = node
+                                    {
+                                        layout
+                                            .find((*split_id).into())
+                                            .and_then(|leaf| leaf.buffer_id())
+                                    } else {
+                                        None
+                                    }
+                                })
+                        });
+                    if let Some(buffer_id) = buffer_id {
                         // Compute top_line if line info is available
                         let top_line = self
                             .windows

--- a/crates/fresh-editor/src/app/types/buffer_group.rs
+++ b/crates/fresh-editor/src/app/types/buffer_group.rs
@@ -57,6 +57,15 @@ pub struct BufferGroup {
     pub panel_buffers: HashMap<String, BufferId>,
     /// All split leaf IDs in this group
     pub panel_splits: HashMap<String, LeafId>,
+    /// Panels currently hidden by `setBufferGroupPanelVisible`.
+    ///
+    /// A hidden panel keeps its buffer and its `SplitViewState` (so its
+    /// content and scroll position survive), but is left out when the
+    /// group's split tree is rebuilt, so nothing is rendered for it and
+    /// no rect routes mouse clicks to it. `layout` always describes the
+    /// group as created — the full set of panels — and is the source
+    /// the tree is rebuilt from.
+    pub hidden_panels: std::collections::HashSet<String>,
     /// The "representative" split that owns the tab entry.
     /// This is typically the first scrollable panel.
     pub representative_split: Option<LeafId>,

--- a/crates/fresh-editor/src/app/types/buffer_meta.rs
+++ b/crates/fresh-editor/src/app/types/buffer_meta.rs
@@ -112,6 +112,14 @@ impl BufferMetadata {
             BufferKind::File { .. } => None,
         }
     }
+
+    /// Re-point a virtual buffer at a different mode. No-op on a
+    /// file-backed buffer, whose keybindings come from its language.
+    pub fn set_virtual_mode(&mut self, new_mode: impl Into<String>) {
+        if let BufferKind::Virtual { mode } = &mut self.kind {
+            *mode = new_mode.into();
+        }
+    }
 }
 
 impl Default for BufferMetadata {

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -3790,7 +3790,11 @@ impl Editor {
     /// editor was constructed single-line. `text` may be a single
     /// codepoint, a grapheme cluster, or a multi-codepoint IME
     /// commit; `insert_str` handles each identically.
-    fn handle_widget_text_char(&mut self, panel_key: &crate::widgets::PanelKey, text: &str) {
+    pub(super) fn handle_widget_text_char(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        text: &str,
+    ) {
         if text.is_empty() || self.focused_text_mode(panel_key).1 {
             return;
         }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -913,30 +913,6 @@ impl Editor {
         }
     }
 
-    /// Hand vertical scrolling to the widget panel when its spec owns it.
-    ///
-    /// A list that starts at column 0 spans the panel and windows itself to
-    /// `visibleRows`, drawing its own scrollbar from `total`/`visible`. The
-    /// split would otherwise stack a second bar in its reserved column
-    /// beside that one — two tracks for one list, and the split's thumb
-    /// describes the buffer (always exactly one screenful) rather than the
-    /// list. A panel with no such region — a `Raw` body longer than the
-    /// panel, say — keeps the buffer scrollbar it relies on.
-    pub(super) fn sync_widget_panel_scrollable(
-        &mut self,
-        buffer_id: BufferId,
-        scroll_regions: &[crate::widgets::ScrollRegion],
-    ) {
-        let widget_owns_scroll = scroll_regions.iter().any(|r| r.col_in_row == 0);
-        if let Some(state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.buffers.get_mut(&buffer_id))
-        {
-            state.scrollable = !widget_owns_scroll;
-        }
-    }
-
     /// Mark every view of `buffer_id` as non-horizontally-scrollable.
     ///
     /// Called on each widget-panel repaint rather than once at mount:
@@ -1096,7 +1072,6 @@ impl Editor {
             }
             return;
         }
-        self.sync_widget_panel_scrollable(buffer_id, &scroll_regions);
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
             tracing::error!("rerender_widget_panel({}) failed: {}", panel_key, e);
         }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -913,6 +913,30 @@ impl Editor {
         }
     }
 
+    /// Hand vertical scrolling to the widget panel when its spec owns it.
+    ///
+    /// A list that starts at column 0 spans the panel and windows itself to
+    /// `visibleRows`, drawing its own scrollbar from `total`/`visible`. The
+    /// split would otherwise stack a second bar in its reserved column
+    /// beside that one — two tracks for one list, and the split's thumb
+    /// describes the buffer (always exactly one screenful) rather than the
+    /// list. A panel with no such region — a `Raw` body longer than the
+    /// panel, say — keeps the buffer scrollbar it relies on.
+    pub(super) fn sync_widget_panel_scrollable(
+        &mut self,
+        buffer_id: BufferId,
+        scroll_regions: &[crate::widgets::ScrollRegion],
+    ) {
+        let widget_owns_scroll = scroll_regions.iter().any(|r| r.col_in_row == 0);
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.buffers.get_mut(&buffer_id))
+        {
+            state.scrollable = !widget_owns_scroll;
+        }
+    }
+
     /// Mark every view of `buffer_id` as non-horizontally-scrollable.
     ///
     /// Called on each widget-panel repaint rather than once at mount:
@@ -1072,6 +1096,7 @@ impl Editor {
             }
             return;
         }
+        self.sync_widget_panel_scrollable(buffer_id, &scroll_regions);
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
             tracing::error!("rerender_widget_panel({}) failed: {}", panel_key, e);
         }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -858,6 +858,14 @@ impl Editor {
         entries: &[fresh_core::text_property::TextPropertyEntry],
         focus_cursor: Option<crate::widgets::FocusCursor>,
     ) {
+        // A widget panel is laid out to the panel's exact width and clipped
+        // there, so its view has nothing to scroll sideways to. Pin it
+        // before anything else: the focus cursor below can sit at the end
+        // of a row that reaches the right edge, and cursor-following would
+        // otherwise drag the whole panel — header included — left by a
+        // column or two.
+        self.pin_widget_panel_horizontal_scroll(buffer_id);
+
         // If the plugin has taken explicit control of this buffer's cursor
         // (via `setBufferShowCursors`), the widget runtime must not touch
         // its visibility or position — the plugin owns it. This lets a
@@ -901,6 +909,33 @@ impl Editor {
                     let cursor = vs.cursors.primary_mut();
                     cursor.position = byte;
                 }
+            }
+        }
+    }
+
+    /// Mark every view of `buffer_id` as non-horizontally-scrollable.
+    ///
+    /// Called on each widget-panel repaint rather than once at mount:
+    /// a panel that is hidden and shown again gets a fresh
+    /// `SplitViewState`, and the flag has to land on that one too.
+    fn pin_widget_panel_horizontal_scroll(&mut self, buffer_id: BufferId) {
+        for vs in self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_view_states_mut())
+            .expect("active window must have a populated split layout")
+            .values_mut()
+        {
+            if vs.buffer_state(buffer_id).is_none() {
+                continue;
+            }
+            if vs.active_buffer == buffer_id {
+                vs.viewport.horizontal_scroll_enabled = false;
+                vs.viewport.left_column = 0;
+            }
+            if let Some(bs) = vs.keyed_states.get_mut(&buffer_id) {
+                bs.viewport.horizontal_scroll_enabled = false;
+                bs.viewport.left_column = 0;
             }
         }
     }

--- a/crates/fresh-editor/src/input/buffer_mode.rs
+++ b/crates/fresh-editor/src/input/buffer_mode.rs
@@ -15,9 +15,11 @@ pub struct BufferMode {
     pub read_only: bool,
 
     /// When true, unbound character keys in a read-only mode are dispatched as
-    /// `PluginAction("mode_text_input:<char>")` instead of being silently dropped.
-    /// This allows plugins to handle inline text editing (e.g. search fields)
-    /// without registering individual bindings for every character.
+    /// `PluginAction("mode_text_input@<mode>:<char>")` instead of being silently
+    /// dropped. This allows plugins to handle inline text editing (e.g. search
+    /// fields) without registering individual bindings for every character. The
+    /// mode qualifier routes the character to the plugin that defined *this*
+    /// mode, so several text-input modes can coexist.
     pub allow_text_input: bool,
 
     /// When true, keys not bound by this mode fall through to the Normal-context

--- a/crates/fresh-editor/src/input/quick_open/mod.rs
+++ b/crates/fresh-editor/src/input/quick_open/mod.rs
@@ -32,6 +32,11 @@ pub enum QuickOpenResult {
     },
     /// Show a buffer by ID
     ShowBuffer(usize),
+    /// Activate a buffer-group tab by its group leaf id. A group (the
+    /// review-diff panels, say) owns several buffers but shows as one tab,
+    /// and its member buffers are hidden from tabs — so it is reachable
+    /// only through the group, not through any one of its buffers.
+    ShowBufferGroup(usize),
     /// Go to a line in the current buffer
     GotoLine(GotoLineTarget),
     /// Do nothing (provider handled it internally)
@@ -126,6 +131,11 @@ pub struct BufferInfo {
     /// `*Git Log*`) with no backing file path. Virtual buffers are listed in
     /// the `#` switcher even though `path` is empty.
     pub is_virtual: bool,
+    /// Set when this entry stands for a buffer-group tab rather than a
+    /// buffer, carrying the group's leaf id. Selecting it activates the
+    /// group instead of setting an active buffer — a group's own buffers
+    /// are hidden from tabs, so the group is the only way back to it.
+    pub group_leaf: Option<usize>,
 }
 
 /// Parse a `path:line:col` string into its components.

--- a/crates/fresh-editor/src/input/quick_open/providers.rs
+++ b/crates/fresh-editor/src/input/quick_open/providers.rs
@@ -111,6 +111,10 @@ impl QuickOpenProvider for CommandProvider {
 // Buffer Provider (prefix: "#")
 // ============================================================================
 
+/// Marks a suggestion value as a buffer-group leaf id rather than a buffer
+/// id. The two are separate id spaces and would otherwise collide.
+const GROUP_VALUE_PREFIX: &str = "group:";
+
 /// Provider for switching between open buffers
 pub struct BufferProvider;
 
@@ -152,9 +156,15 @@ impl QuickOpenProvider for BufferProvider {
                     buf.name.clone()
                 };
 
+                // A group entry is selected by its leaf id, not a buffer
+                // id, so the two namespaces are kept apart in the value.
+                let value = match buf.group_leaf {
+                    Some(leaf) => format!("{GROUP_VALUE_PREFIX}{leaf}"),
+                    None => buf.id.to_string(),
+                };
                 let suggestion = Suggestion::new(display_name)
                     .with_description(buf.path.clone())
-                    .with_value(buf.id.to_string());
+                    .with_value(value);
                 Some((suggestion, m.score, buf.id))
             })
             .collect();
@@ -170,11 +180,19 @@ impl QuickOpenProvider for BufferProvider {
         _query: &str,
         _context: &QuickOpenContext,
     ) -> QuickOpenResult {
-        suggestion
-            .and_then(|s| s.value.as_deref())
-            .and_then(|v| v.parse::<usize>().ok())
-            .map(QuickOpenResult::ShowBuffer)
-            .unwrap_or(QuickOpenResult::None)
+        let Some(value) = suggestion.and_then(|s| s.value.as_deref()) else {
+            return QuickOpenResult::None;
+        };
+        match value.strip_prefix(GROUP_VALUE_PREFIX) {
+            Some(leaf) => leaf
+                .parse::<usize>()
+                .map(QuickOpenResult::ShowBufferGroup)
+                .unwrap_or(QuickOpenResult::None),
+            None => value
+                .parse::<usize>()
+                .map(QuickOpenResult::ShowBuffer)
+                .unwrap_or(QuickOpenResult::None),
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1022,6 +1040,7 @@ mod tests {
                     name: "main.rs".to_string(),
                     modified: false,
                     is_virtual: false,
+                    group_leaf: None,
                 },
                 BufferInfo {
                     id: 2,
@@ -1029,6 +1048,7 @@ mod tests {
                     name: "lib.rs".to_string(),
                     modified: true,
                     is_virtual: false,
+                    group_leaf: None,
                 },
             ],
             active_buffer_id: 1,
@@ -1088,6 +1108,7 @@ mod tests {
             name: "*blame:lib.rs*".to_string(),
             modified: false,
             is_virtual: true,
+            group_leaf: None,
         });
         // A pathless, non-virtual buffer (e.g. unnamed scratch) must NOT appear.
         context.open_buffers.push(BufferInfo {
@@ -1096,6 +1117,7 @@ mod tests {
             name: "scratch".to_string(),
             modified: false,
             is_virtual: false,
+            group_leaf: None,
         });
 
         // Empty query lists everything that is eligible.
@@ -1115,6 +1137,42 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert!(filtered[0].text.contains("*blame:lib.rs*"));
         assert_eq!(filtered[0].value.as_deref(), Some("3"));
+    }
+
+    /// A buffer-group tab (the review-diff panels, say) is listed by its
+    /// group name and selects to `ShowBufferGroup` — its member buffers are
+    /// hidden from tabs, so the group is the only route back to it. The two
+    /// id spaces must not be confused: a group leaf and a buffer can share a
+    /// numeric id and still resolve to different results.
+    #[test]
+    fn test_buffer_provider_lists_and_selects_group_tabs() {
+        let provider = BufferProvider::new();
+        let mut context = make_test_context("/tmp");
+        context.open_buffers.push(BufferInfo {
+            id: 1,
+            path: String::new(),
+            name: "*Review Diff*".to_string(),
+            modified: false,
+            is_virtual: true,
+            group_leaf: Some(1),
+        });
+
+        let filtered = provider.suggestions("Review", &context);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0].text.contains("*Review Diff*"));
+
+        match provider.on_select(Some(&filtered[0]), "Review", &context) {
+            QuickOpenResult::ShowBufferGroup(leaf) => assert_eq!(leaf, 1),
+            other => panic!("expected ShowBufferGroup, got {other:?}"),
+        }
+
+        // A plain buffer with the same numeric id still resolves to a buffer.
+        let main = provider.suggestions("main", &context);
+        assert_eq!(main.len(), 1);
+        match provider.on_select(Some(&main[0]), "main", &context) {
+            QuickOpenResult::ShowBuffer(id) => assert_eq!(id, 1),
+            other => panic!("expected ShowBuffer, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/src/input/router.rs
+++ b/crates/fresh-editor/src/input/router.rs
@@ -501,7 +501,7 @@ pub enum ModeKeyDisposition {
     /// The key extends a pending chord — push it and wait.
     ChordPending,
     /// A text-input mode captures this character
-    /// (`mode_text_input:<ch>` plugin action).
+    /// (`mode_text_input@<mode>:<ch>` plugin action).
     TextInput(char),
     /// Clipboard / select-all chord forwarded despite the text-input
     /// mode block — it belongs to the focused widget Text input.

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -58,6 +58,16 @@ pub struct Viewport {
     /// When true, horizontal scrolling is disabled
     pub line_wrap_enabled: bool,
 
+    /// Whether the view may scroll sideways to follow the cursor.
+    ///
+    /// False for a buffer rendered by a mounted widget panel: the widget
+    /// runtime already lays its rows out to the panel's exact width and
+    /// clips them, and the "cursor" there is a focus marker rather than a
+    /// text caret. Letting it drag the view sideways shifts the whole
+    /// panel — header included — by however far past the edge the focused
+    /// row happens to end.
+    pub horizontal_scroll_enabled: bool,
+
     /// Terminal-grid wrap mode (fresh#2649): with `line_wrap_enabled`,
     /// rows break at exact column boundaries every `wrap_column` columns
     /// (no word-boundary preference, no gutter, no hanging indent),
@@ -177,6 +187,7 @@ impl Viewport {
             row_pass_owns_placement: false,
             horizontal_scroll_offset: 5,
             line_wrap_enabled: false,
+            horizontal_scroll_enabled: true,
             grid_wrap: false,
             wrap_indent: true,
             wrap_column: None,
@@ -1523,7 +1534,8 @@ impl Viewport {
         gutter_width: usize,
     ) {
         // Skip if line wrapping is enabled (all columns visible via wrapping)
-        if self.line_wrap_enabled {
+        // or if this view never scrolls sideways (a widget panel).
+        if self.line_wrap_enabled || !self.horizontal_scroll_enabled {
             self.left_column = 0;
             return;
         }
@@ -2344,6 +2356,12 @@ impl Viewport {
         line_length: usize,
         buffer: &mut Buffer,
     ) {
+        // A view that never scrolls sideways (a widget panel) stays pinned
+        // at column 0 whatever the cursor does.
+        if !self.horizontal_scroll_enabled {
+            self.left_column = 0;
+            return;
+        }
         // `self.width` is the content width; split layout has already removed
         // any vertical scrollbar column.
         let gutter_width = self.gutter_width(buffer);

--- a/crates/fresh-editor/tests/e2e/blog_showcases.rs
+++ b/crates/fresh-editor/tests/e2e/blog_showcases.rs
@@ -4379,6 +4379,23 @@ fn blog_showcase_fresh_0_4_0_review_diff() {
     h.wait_until(|h| h.screen_to_string().contains("COMMENTS"))
         .unwrap();
     snap(&mut h, &mut s, Some("C"), 220);
+    // Each panel takes focus as it appears; Tab back to the diff so the
+    // walk below moves the diff cursor and not a panel's selection. The
+    // Tab order is FILES → diff → COMMENTS, so how many steps that takes
+    // depends on which panels are open.
+    let panel_focused = |h: &EditorTestHarness| {
+        let screen = h.screen_to_string();
+        screen.contains("▸FILES") || screen.contains("▸COMMENTS")
+    };
+    for _ in 0..3 {
+        if !panel_focused(&h) {
+            break;
+        }
+        let before = h.screen_to_string();
+        h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        h.wait_until(|h| h.screen_to_string() != before).unwrap();
+    }
+    assert!(!panel_focused(&h), "focus never came back to the diff");
     hold(&mut h, &mut s, 6, 140);
 
     // [2] switches the center panel to a side-by-side OLD/NEW view.

--- a/crates/fresh-editor/tests/e2e/blog_showcases.rs
+++ b/crates/fresh-editor/tests/e2e/blog_showcases.rs
@@ -4381,11 +4381,11 @@ fn blog_showcase_fresh_0_4_0_review_diff() {
     snap(&mut h, &mut s, Some("C"), 220);
     hold(&mut h, &mut s, 6, 140);
 
-    // [1] switches the center panel to a side-by-side OLD/NEW view.
-    h.send_key(KeyCode::Char('1'), KeyModifiers::NONE).unwrap();
+    // [2] switches the center panel to a side-by-side OLD/NEW view.
+    h.send_key(KeyCode::Char('2'), KeyModifiers::NONE).unwrap();
     h.wait_until(|h| h.screen_to_string().contains("OLD (HEAD)"))
         .unwrap();
-    snap(&mut h, &mut s, Some("1"), 240);
+    snap(&mut h, &mut s, Some("2"), 240);
     hold(&mut h, &mut s, 6, 150);
 
     // Move onto a changed line and leave a comment with [c].

--- a/crates/fresh-editor/tests/e2e/blog_showcases.rs
+++ b/crates/fresh-editor/tests/e2e/blog_showcases.rs
@@ -4354,7 +4354,8 @@ fn blog_showcase_fresh_0_4_0_review_diff() {
 
     hold(&mut h, &mut s, 4, 110);
 
-    // Open Review Diff — a three-column layout: FILES | diff | COMMENTS.
+    // Open Review Diff — the full-width unified stream, with the FILES and
+    // COMMENTS panels a keystroke away.
     h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
     h.wait_for_prompt().unwrap();
@@ -4363,13 +4364,22 @@ fn blog_showcase_fresh_0_4_0_review_diff() {
         .unwrap();
     snap(&mut h, &mut s, Some("Review Diff"), 150);
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| {
-        let scr = h.screen_to_string();
-        scr.contains("FILES") && scr.contains("auth.rs") && scr.contains("COMMENTS")
-    })
-    .unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("auth.rs"))
+        .unwrap();
     snap(&mut h, &mut s, Some("Enter"), 260);
-    hold(&mut h, &mut s, 7, 140);
+    hold(&mut h, &mut s, 5, 140);
+
+    // The diff opens full-width; [F] and [C] bring in the file sidebar and
+    // the comments rail for the three-column review layout.
+    h.send_key(KeyCode::Char('F'), KeyModifiers::SHIFT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("FILES"))
+        .unwrap();
+    snap(&mut h, &mut s, Some("F"), 220);
+    h.send_key(KeyCode::Char('C'), KeyModifiers::SHIFT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("COMMENTS"))
+        .unwrap();
+    snap(&mut h, &mut s, Some("C"), 220);
+    hold(&mut h, &mut s, 6, 140);
 
     // [1] switches the center panel to a side-by-side OLD/NEW view.
     h.send_key(KeyCode::Char('1'), KeyModifiers::NONE).unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2084,6 +2084,30 @@ fn open_review_diff(harness: &mut EditorTestHarness) -> String {
     harness.screen_to_string()
 }
 
+/// Reveal the FILES sidebar (`F`) and return the resulting screen. Both
+/// side panels start hidden so the diff owns the full width; tests that
+/// exercise the sidebar have to ask for it first.
+fn show_files_panel(harness: &mut EditorTestHarness) -> String {
+    harness
+        .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("FILES"))
+        .unwrap();
+    harness.screen_to_string()
+}
+
+/// Reveal the COMMENTS rail (`C`) and return the resulting screen.
+fn show_comments_panel(harness: &mut EditorTestHarness) -> String {
+    harness
+        .send_key(KeyCode::Char('C'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("COMMENTS"))
+        .unwrap();
+    harness.screen_to_string()
+}
+
 /// Test that j/k delegate to native cursor motion in the unified-stream
 /// diff buffer (no more files-pane plugin-managed selection). Verifies
 /// the cursor moves down/up by one row without errors.
@@ -2228,7 +2252,9 @@ fn test_review_diff_shows_comments_panel() {
         .wait_until(|h| h.screen_to_string().contains("changed"))
         .unwrap();
 
-    let screen = open_review_diff(&mut harness);
+    open_review_diff(&mut harness);
+    // The rail starts hidden; `C` reveals it.
+    let screen = show_comments_panel(&mut harness);
 
     // The comments panel header and empty state are visible.
     assert!(
@@ -2421,6 +2447,9 @@ fn test_review_diff_tab_cycles_focus() {
         .unwrap();
 
     open_review_diff(&mut harness);
+    // The sidebar starts hidden and a hidden panel is not in the focus
+    // ring, so reveal it before cycling focus.
+    show_files_panel(&mut harness);
 
     // The diff panel holds focus initially; Tab moves focus to the FILES
     // panel, which gains the ▸ focus marker on its header.
@@ -2563,6 +2592,8 @@ fn test_review_diff_focus_switch_preserves_scroll() {
     harness.render().unwrap();
 
     let _ = open_review_diff(&mut harness);
+    // The FILES panel has to be on screen to be a focus target.
+    show_files_panel(&mut harness);
 
     // Scroll the cursor far down the unified stream using native `j`
     // motion. `j` delegates to the editor's `move_down`, which moves the
@@ -3940,7 +3971,8 @@ fn test_review_diff_comment_nav_single_keys() {
         .wait_until(|h| h.screen_to_string().contains("edit"))
         .unwrap();
 
-    let screen = open_review_diff(&mut harness);
+    open_review_diff(&mut harness);
+    let screen = show_comments_panel(&mut harness);
     assert!(
         screen.contains("No comments yet"),
         "Empty comments panel should be visible. Screen:\n{}",

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2084,20 +2084,51 @@ fn open_review_diff(harness: &mut EditorTestHarness) -> String {
     harness.screen_to_string()
 }
 
-/// Reveal the FILES sidebar (`F`) and return the resulting screen. Both
+/// True while a side panel — not the diff — holds keyboard focus. Each
+/// panel header carries a `▸` when it owns the keys.
+fn review_panel_has_focus(screen: &str) -> bool {
+    screen.contains("▸FILES") || screen.contains("▸COMMENTS")
+}
+
+/// Tab until the diff holds the keys again. `F` / `C` focus the panel they
+/// reveal, and the Tab order is FILES → diff → COMMENTS, so the number of
+/// steps back to the diff depends on which panels are already open.
+fn focus_review_diff(harness: &mut EditorTestHarness) {
+    for _ in 0..3 {
+        if !review_panel_has_focus(&harness.screen_to_string()) {
+            return;
+        }
+        let before = harness.screen_to_string();
+        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string() != before)
+            .unwrap();
+    }
+    assert!(
+        !review_panel_has_focus(&harness.screen_to_string()),
+        "focus never came back to the diff:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Reveal the FILES sidebar (`F`) and hand focus back to the diff. Both
 /// side panels start hidden so the diff owns the full width; tests that
-/// exercise the sidebar have to ask for it first.
+/// exercise the sidebar have to ask for it first, and `F` focuses what it
+/// reveals — so this returns the caller to the state it would otherwise
+/// assume, with the panel visible and the diff holding the keys.
 fn show_files_panel(harness: &mut EditorTestHarness) -> String {
     harness
         .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
         .unwrap();
     harness
-        .wait_until(|h| h.screen_to_string().contains("FILES"))
+        .wait_until(|h| h.screen_to_string().contains("▸FILES"))
         .unwrap();
+    focus_review_diff(harness);
     harness.screen_to_string()
 }
 
-/// Reveal the COMMENTS rail (`C`) and return the resulting screen.
+/// Reveal the COMMENTS rail (`C`) and hand focus back to the diff, for the
+/// same reason as `show_files_panel`.
 fn show_comments_panel(harness: &mut EditorTestHarness) -> String {
     harness
         .send_key(KeyCode::Char('C'), KeyModifiers::SHIFT)
@@ -2105,6 +2136,7 @@ fn show_comments_panel(harness: &mut EditorTestHarness) -> String {
     harness
         .wait_until(|h| h.screen_to_string().contains("COMMENTS"))
         .unwrap();
+    focus_review_diff(harness);
     harness.screen_to_string()
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
@@ -92,6 +92,27 @@ fn open_review_diff(harness: &mut EditorTestHarness) -> String {
     harness.screen_to_string()
 }
 
+/// Reveal the FILES sidebar (`F`); it starts hidden so the diff owns the
+/// full width.
+fn show_files_panel(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("FILES"))
+        .unwrap();
+}
+
+/// Reveal the COMMENTS rail (`C`).
+fn show_comments_panel(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('C'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("COMMENTS"))
+        .unwrap();
+}
+
 /// §5.2 — the review sidebar lists the changed file under a section header
 /// and shows add/remove counts.
 #[test]
@@ -100,6 +121,7 @@ fn test_review_sidebar_lists_files() {
     let repo = repo_with_modification();
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
 
     // The sidebar is populated asynchronously after the toolbar (with its
     // "next hunk" hint) appears, while "Generating Review Diff Stream..." is
@@ -124,6 +146,7 @@ fn test_review_layout_toggle_split_and_back() {
     let repo = repo_with_modification();
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
 
     // `1` renders the focused file as an in-panel side-by-side (the sidebar
     // stays); the status line confirms the mode.
@@ -375,6 +398,7 @@ fn test_review_help_opens_and_q_closes() {
     let repo = repo_with_modification();
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
 
     harness
         .send_key(KeyCode::Char('?'), KeyModifiers::NONE)
@@ -403,6 +427,7 @@ fn test_review_comments_rail_is_narrow() {
     let repo = repo_with_modification();
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
+    show_comments_panel(&mut harness);
 
     // The comments rail is populated asynchronously after the hint bar
     // appears — wait for its header rather than reading the first frame.

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
@@ -138,8 +138,8 @@ fn test_review_sidebar_lists_files() {
         .unwrap();
 }
 
-/// §5.1 — `1` switches to the side-by-side split, `2` returns to the
-/// unified stack with the sidebar intact.
+/// §5.1 — `2` switches to the side-by-side split (two columns, two
+/// sides), `1` returns to the unified stack with the sidebar intact.
 #[test]
 fn test_review_layout_toggle_split_and_back() {
     init_tracing_from_env();
@@ -148,10 +148,10 @@ fn test_review_layout_toggle_split_and_back() {
     open_review_diff(&mut harness);
     show_files_panel(&mut harness);
 
-    // `1` renders the focused file as an in-panel side-by-side (the sidebar
+    // `2` renders the focused file as an in-panel side-by-side (the sidebar
     // stays); the status line confirms the mode.
     harness
-        .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
+        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
         .unwrap();
     harness
         .wait_until(|h| {
@@ -160,9 +160,9 @@ fn test_review_layout_toggle_split_and_back() {
         })
         .unwrap();
 
-    // `2` returns to the unified stack, sidebar intact.
+    // `1` returns to the unified stack, sidebar intact.
     harness
-        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
+        .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
         .unwrap();
     harness
         .wait_until(|h| {
@@ -473,7 +473,7 @@ fn test_review_side_by_side_shift_wheel_scrolls_horizontally() {
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
     harness
-        .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
+        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
         .unwrap();
     harness
         .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
@@ -92,18 +92,46 @@ fn open_review_diff(harness: &mut EditorTestHarness) -> String {
     harness.screen_to_string()
 }
 
+/// True while a side panel — not the diff — holds keyboard focus.
+fn review_panel_has_focus(screen: &str) -> bool {
+    screen.contains("▸FILES") || screen.contains("▸COMMENTS")
+}
+
+/// Tab until the diff holds the keys again. `F` / `C` focus the panel they
+/// reveal, and the Tab order is FILES → diff → COMMENTS, so the number of
+/// steps back to the diff depends on which panels are already open.
+fn focus_review_diff(harness: &mut EditorTestHarness) {
+    for _ in 0..3 {
+        if !review_panel_has_focus(&harness.screen_to_string()) {
+            return;
+        }
+        let before = harness.screen_to_string();
+        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string() != before)
+            .unwrap();
+    }
+    assert!(
+        !review_panel_has_focus(&harness.screen_to_string()),
+        "focus never came back to the diff:\n{}",
+        harness.screen_to_string()
+    );
+}
+
 /// Reveal the FILES sidebar (`F`); it starts hidden so the diff owns the
-/// full width.
+/// full width. `F` focuses what it reveals, so hand the keys back to the
+/// diff — callers here drive the diff, not the sidebar.
 fn show_files_panel(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
         .unwrap();
     harness
-        .wait_until(|h| h.screen_to_string().contains("FILES"))
+        .wait_until(|h| h.screen_to_string().contains("▸FILES"))
         .unwrap();
+    focus_review_diff(harness);
 }
 
-/// Reveal the COMMENTS rail (`C`).
+/// Reveal the COMMENTS rail (`C`), likewise leaving focus on the diff.
 fn show_comments_panel(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('C'), KeyModifiers::SHIFT)
@@ -111,6 +139,7 @@ fn show_comments_panel(harness: &mut EditorTestHarness) {
     harness
         .wait_until(|h| h.screen_to_string().contains("COMMENTS"))
         .unwrap();
+    focus_review_diff(harness);
 }
 
 /// §5.2 — the review sidebar lists the changed file under a section header

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
@@ -221,14 +221,16 @@ fn test_review_inline_comment_renders_as_box() {
     );
 }
 
-/// §5.11 — `/` filters the file list: typing a query narrows the sidebar to
-/// matching files and hides the rest.
+/// §5.11 — `/` filters the file list: it opens the sidebar with a filter
+/// field under the header, and typing narrows the tree (and the stream) to
+/// matching files as you type — no bottom prompt involved.
 #[test]
 fn test_review_filter_narrows_files() {
     init_tracing_from_env();
     let repo = repo_with_two_files();
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
     // The file sidebar populates asynchronously after the toolbar appears, so
     // wait for both files rather than snapshotting a single (possibly early)
     // frame.
@@ -242,18 +244,23 @@ fn test_review_filter_narrows_files() {
     harness
         .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
         .unwrap();
-    harness.wait_for_prompt().unwrap();
+    // The field lives in the panel, so no prompt opens; type straight into it.
     harness.type_text("widget").unwrap();
-    harness.render().unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.wait_for_prompt_closed().unwrap();
-
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("widget.rs") && !s.contains("main.rs") && s.contains("/widget")
+            s.contains("widget.rs") && !s.contains("main.rs")
+        })
+        .unwrap();
+
+    // Enter closes the field and keeps the query.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("widget.rs") && !s.contains("main.rs")
         })
         .unwrap();
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6325,6 +6325,39 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Show or hide one panel of a buffer group, without tearing the
+    /// group down.
+    ///
+    /// The panel's buffer, its content and its scroll position all
+    /// survive being hidden — only the group's split tree changes, so
+    /// the remaining panels take over the freed space and a re-shown
+    /// panel comes back where it was. Use it for optional sidebars a
+    /// mode wants to toggle (a file list, a comments rail) instead of
+    /// closing and recreating the group.
+    ///
+    /// Hiding a panel that holds focus moves focus to a panel that is
+    /// still rendered; focusing a hidden panel is a no-op. Returns
+    /// `false` if the group or panel is unknown, or if the call would
+    /// hide the group's last visible panel.
+    ///
+    /// Queued, like every layout mutation: the returned bool only reports
+    /// that the command was sent.
+    #[qjs(rename = "setBufferGroupPanelVisible")]
+    pub fn set_buffer_group_panel_visible(
+        &self,
+        group_id: u32,
+        panel_name: String,
+        visible: bool,
+    ) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetBufferGroupPanelVisible {
+                group_id: group_id as usize,
+                panel_name,
+                visible,
+            })
+            .is_ok()
+    }
+
     /// Focus a specific panel within a buffer group
     #[qjs(rename = "focusBufferGroupPanel")]
     pub fn focus_buffer_group_panel(&self, group_id: u32, panel_name: String) -> bool {

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4950,17 +4950,23 @@ impl JsEditorApi {
         }
 
         // If allow_text_input is set, register a wildcard handler for text input
-        // so the plugin can receive arbitrary character input
+        // so the plugin can receive arbitrary character input.
+        //
+        // Register it twice: once under the mode-qualified name, which is
+        // what the host dispatches, and once under the bare name as a
+        // fallback. The bare name is a single global slot — every
+        // text-input mode overwrites it — so without the qualified entry
+        // the plugin that happened to call `defineMode` last would receive
+        // the characters typed into *every* other plugin's text field.
         let allow_text = allow_text_input.0.unwrap_or(false);
         if allow_text {
+            let handler = PluginHandler {
+                plugin_name: self.plugin_name.clone(),
+                handler_name: "mode_text_input".to_string(),
+            };
             let mut registered = self.registered_actions.borrow_mut();
-            registered.insert(
-                "mode_text_input".to_string(),
-                PluginHandler {
-                    plugin_name: self.plugin_name.clone(),
-                    handler_name: "mode_text_input".to_string(),
-                },
-            );
+            registered.insert(format!("mode_text_input@{}", name), handler.clone());
+            registered.insert("mode_text_input".to_string(), handler);
         }
 
         self.command_sender
@@ -9077,18 +9083,43 @@ impl QuickJsBackend {
         args_json: Option<&str>,
         request_id: Option<u64>,
     ) -> Result<()> {
-        // Handle mode_text_input:<char> — route to the plugin that registered
-        // "mode_text_input" and pass the character as an argument.
-        let (lookup_name, text_input_char) =
-            if let Some(ch) = action_name.strip_prefix("mode_text_input:") {
-                ("mode_text_input", Some(ch.to_string()))
-            } else {
-                (action_name, None)
-            };
+        // Handle text input from a mode that was defined with
+        // `allowTextInput`. The host dispatches the mode-qualified form
+        // `mode_text_input@<mode>:<char>`; resolve it to the plugin that
+        // defined *that* mode, and fall back to the bare `mode_text_input`
+        // registration for the unqualified form (and for a mode defined
+        // before this qualification existed). The character is everything
+        // after the first `:`, so a typed `:` survives intact.
+        let qualified = action_name
+            .strip_prefix("mode_text_input@")
+            .and_then(|rest| rest.split_once(':'));
+        let (lookup_name, fallback_name, text_input_char) = match qualified {
+            Some((mode, ch)) => (
+                format!("mode_text_input@{}", mode),
+                Some("mode_text_input"),
+                Some(ch.to_string()),
+            ),
+            None => match action_name.strip_prefix("mode_text_input:") {
+                Some(ch) => ("mode_text_input".to_string(), None, Some(ch.to_string())),
+                None => (action_name.to_string(), None, None),
+            },
+        };
 
-        let pair = self.registered_actions.borrow().get(lookup_name).cloned();
+        let pair = {
+            let registered = self.registered_actions.borrow();
+            registered
+                .get(&lookup_name)
+                .or_else(|| fallback_name.and_then(|n| registered.get(n)))
+                .cloned()
+        };
         let (plugin_name, function_name) = match pair {
             Some(handler) => (handler.plugin_name, handler.handler_name),
+            // No registration: fall back to a global function of the same
+            // name in the main context. For text input that is the bare
+            // handler name — the qualified lookup key is not a function.
+            None if text_input_char.is_some() => {
+                ("main".to_string(), "mode_text_input".to_string())
+            }
             None => ("main".to_string(), lookup_name.to_string()),
         };
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3770,6 +3770,30 @@ impl JsEditorApi {
         self.command_sender.send(PluginCommand::FlushLayout).is_ok()
     }
 
+    /// Put a composite buffer's cursor on the row showing `line`
+    /// (0-indexed) of pane `pane` — 0 is the left/OLD pane — and scroll
+    /// it into view.
+    ///
+    /// `initialFocusHunk` on `createCompositeBuffer` lands the view on a
+    /// hunk; this lands it on a *line*, which is what a plugin holding a
+    /// concrete file position wants (following a review comment, or
+    /// keeping the reader's place when a diff view flips between its
+    /// unified and side-by-side layouts). No-op if that pane has no such
+    /// line.
+    ///
+    /// Queued, like every layout mutation: the returned bool only reports
+    /// that the command was sent.
+    #[qjs(rename = "setCompositeCursorLine")]
+    pub fn set_composite_cursor_line(&self, buffer_id: u32, pane: u32, line: u32) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetCompositeCursorLine {
+                buffer_id: BufferId(buffer_id as usize),
+                pane: pane as usize,
+                line: line as usize,
+            })
+            .is_ok()
+    }
+
     /// Navigate to the next hunk in a composite buffer
     pub fn composite_next_hunk(&self, buffer_id: u32) -> bool {
         self.command_sender

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6349,6 +6349,25 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Switch a virtual buffer's mode — the keybinding set that applies
+    /// while it is focused.
+    ///
+    /// A panel that grows a text field (an in-panel filter) needs the
+    /// single-key commands of its normal mode to stop firing while the
+    /// user types; giving the panel a text-input mode for the duration
+    /// does that without the plugin re-registering bindings. Modes are
+    /// declared with `defineMode`; a mode name with no definition falls
+    /// back to the global bindings.
+    #[qjs(rename = "setBufferMode")]
+    pub fn set_buffer_mode(&self, buffer_id: u32, mode: String) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetBufferMode {
+                buffer_id: BufferId(buffer_id as usize),
+                mode,
+            })
+            .is_ok()
+    }
+
     /// Show or hide one panel of a buffer group, without tearing the
     /// group down.
     ///


### PR DESCRIPTION
Review Diff opened as three columns with only the focused file's hunks in the middle one, and the host soft-wrapped that panel — so a long added line spilled over three rows, and the mouse wheel hit the bottom of one file's diff with nothing below it. Fixing that surfaced a deeper problem: the panels were plugin-drawn text with the plugin keeping its own focus, selection, folding, scrolling and click hit-testing, which is where most of the bugs lived. They now run on the widget runtime.

### The diff

**Panels no longer soft-wrap.** Panel content is composed by the plugin at a width it already knows, so wrapping it again only breaks the layout the plugin laid out. `set_buffer_group_panel_buffer` was stamping the global `editor.line_wrap` (on by default) onto every panel it retargeted — that path is what made the review diff wrap. Nothing is truncated: `←`/`→` and Shift+wheel pan the stream.

**The unified stream expands every file**, so the wheel walks the whole review. Side-by-side stays one file at a time (it builds a composite of one file's OLD/NEW buffers), as does a changeset over 20k diff lines.

**The FILES sidebar and COMMENTS rail start hidden** and toggle with `F` / `C`, from the toolbar buttons, or from the `✕` in each panel header. Revealing a panel focuses it; hidden panels leave the focus ring.

**`1` is unified and `2` is side-by-side** (two columns, two sides), and a flip keeps the reader's place — the file and line under the cursor are carried across in both directions, landing on the nearest change when the line is outside every hunk.

### The panels

**FILES is a `Tree`**, nested by directory the way the file explorer is, with the same path compression: a run of directories that only contain one another is one row (`crates/fresh-editor/src`), and a level earns its own row when it holds a file or branches. Each ancestor totals the changes beneath it. The host owns selection, expand/collapse, scrolling the selection into view, row clipping and click routing. `/` focuses a filter field that lives under the header and filters as you type; `↓` steps from it into the results; `Enter` on a file hands focus to the diff.

**COMMENTS is a `List`** — one item per rendered row, all keyed back to their comment, so a note still wraps in full while selection and scrolling belong to the host. In side-by-side (where there is nowhere to draw an inline box) the NEW pane's label reports the file's comment count.

**The toolbar** is two `hintBar`s plus the two panel buttons.

Gone with them: `filesPanelByRow`, `filesPanelDirByRow`, `collapsedDirs`, `commentsByRow`, the manual scroll-to-selection, the panels' click hit-testing, and the hand-built toolbar row with its byte offsets and manual truncation.

### Host changes

* `setBufferGroupPanelVisible(groupId, panelName, visible)` — rebuilds a group's inner split tree from the layout it was created with, skipping hidden leaves; a split whose children are all hidden collapses to its visible side. Panels keep their buffer, view state and scroll position while hidden.
* `setCompositeCursorLine(bufferId, pane, line)` — puts a composite's cursor on the row showing a given source line, the line-level counterpart to `initialFocusHunk`.
* `setBufferMode(bufferId, mode)` — re-points a virtual buffer at another mode, so a panel can enter text-entry while its filter field is open.
* **A printable key in a text-input mode is now dispatched mode-qualified**, as `mode_text_input@MODE:CHAR`, and the backend resolves it to the plugin that defined *that* mode (falling back to the bare `mode_text_input` name). It used to go to whoever registered the single global `mode_text_input`, which each `defineMode(allowTextInput)` overwrote — so only one plugin in the editor could own a text field, and which one depended on load order.
* **Wrap-aware Home/End asks the split, not the global config.** A panel can turn wrap off for itself, and every buffer-group panel does; reading `editor.line_wrap` there sent Home walking a wrap boundary the unwrapped view never draws, so one press landed mid-line instead of at column 1.
* A widget panel's view no longer scrolls horizontally. Its rows are laid out to the panel's width and clipped there, so it has nothing to scroll to — but the focus cursor can sit at the end of a row that reaches the right edge, and cursor-following was dragging the whole panel, header included, a column left.
* A full-width widget list draws its scrollbar at the panel's right-hand edge — in the split's own reserved scrollbar column when the buffer scrollbar is on, so the two coincide instead of standing side by side. It used to draw at the list's laid-out right edge, which `widget_panel_width` deliberately keeps a couple of columns short, putting the bar inside the rows and blanking a character cell mid-text.
* `viewport_changed` now fires for buffer-group panels. Their leaves live in a stashed subtree, so the hook's buffer lookup came back empty and panel plugins never heard that a panel had scrolled or been resized.
* `setLineWrap` with no split id now reaches every split showing the buffer, including a group panel — git-log's commit-detail pane had been asking for wrap and getting none.

### Testing

Driven manually in tmux against a scratch repo throughout, most recently a pass over every flow in one sitting: opening the review, panning a 363-column line to its end and back, wheeling the whole stream to the last file, toggling panels from keys / buttons / the header `✕`, clicking each panel to focus it, the Tab ring, tree selection and folding, the filter field (type, step into results, commit, cancel), adding comments and walking them with `]` / `[`, both layout flips round-tripping to the same line, the nearest-hunk fallback, `n` / `p`, `,` / `.`, `z a` / `z r`, `S` / `U`, `?` and `q`. That pass is what turned up the Home/End, filter-cancel, scrollbar and path-compression fixes above. e2e tests that assumed the old panels now reveal them first and drive the in-panel filter; the 0.4.0 review-diff showcase gained an `F` / `C` beat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKkE4wffJTS5Bey3TV2998