### PR TITLE
fix(wrap-index): stop re-laying-out the whole document on every wheel notch in markdown compose mode

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -4271,12 +4271,12 @@ mod tests {
         use crate::model::marker::MarkerList;
 
         let mut markers = MarkerList::new();
-        let m0 = markers.create(200, false);
-        let m1 = markers.create(401, false);
-        let m2 = markers.create(602, false);
-        let m3 = markers.create(803, false);
-        let m5 = markers.create(1205, false);
-        let m6 = markers.create(1406, false);
+        let m0 = markers.create(200);
+        let m1 = markers.create(401);
+        let m2 = markers.create(602);
+        let m3 = markers.create(803);
+        let m5 = markers.create(1205);
+        let m6 = markers.create(1406);
 
         // Simulate remove_in_range removing marker m5 inside [1005, 1206).
         markers.delete(m5);

--- a/crates/fresh-editor/src/app/recovery_actions.rs
+++ b/crates/fresh-editor/src/app/recovery_actions.rs
@@ -154,6 +154,9 @@ impl Editor {
                                     state.buffer.insert(0, &text);
                                     // Mark as modified since it differs from disk
                                     state.buffer.set_modified(true);
+                                    // Wholesale replacement, never described as
+                                    // edit damage. See `WrapIndex::damage_all`.
+                                    state.wrap_indices.damage_all();
                                 }
                                 // Invalidate the event log's saved position so undo
                                 // can't incorrectly clear the modified flag
@@ -311,6 +314,9 @@ impl Editor {
                                     state.buffer.insert(0, &text);
                                     state.buffer.set_modified(true);
                                     state.buffer.set_recovery_pending(false);
+                                    // Wholesale replacement, never described as
+                                    // edit damage. See `WrapIndex::damage_all`.
+                                    state.wrap_indices.damage_all();
                                 }
                                 self.active_event_log_mut().clear_saved_position();
                                 self.sync_lsp_after_recovery_replay(buffer_id);

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -357,12 +357,7 @@ impl crate::app::window::Window {
             if buffer_len <= large_file_threshold {
                 // When line wrapping is enabled, use visual row calculations
                 if line_wrap_enabled {
-                    let pipeline_inputs_ver = crate::view::line_wrap_cache::pipeline_inputs_version(
-                        state.buffer.version(),
-                        state.soft_breaks.version(),
-                        state.conceals.version(),
-                        state.virtual_texts.version(),
-                    );
+                    let pipeline_inputs_ver = state.pipeline_inputs();
                     super::scrollbar_math::scrollbar_drag_relative_visual(
                         state,
                         row,
@@ -576,12 +571,7 @@ impl crate::app::window::Window {
                 if line_wrap_enabled {
                     // calculate_scrollbar_jump_visual already handles max scroll limiting
                     // and returns both byte position and view line offset
-                    let pipeline_inputs_ver = crate::view::line_wrap_cache::pipeline_inputs_version(
-                        state.buffer.version(),
-                        state.soft_breaks.version(),
-                        state.conceals.version(),
-                        state.virtual_texts.version(),
-                    );
+                    let pipeline_inputs_ver = state.pipeline_inputs();
                     super::scrollbar_math::scrollbar_jump_visual(
                         state,
                         ratio,

--- a/crates/fresh-editor/src/app/scrollbar_math.rs
+++ b/crates/fresh-editor/src/app/scrollbar_math.rs
@@ -83,39 +83,18 @@ fn scroll_geometry(
 fn total_rows(
     state: &mut EditorState,
     geometry: WrapIndexGeometry,
-    pipeline_inputs_ver: u64,
+    inputs: crate::view::line_wrap_cache::PipelineInputs,
     fold_ranges: Vec<std::ops::Range<usize>>,
 ) -> usize {
     let line_ending = state.buffer.line_ending();
-    // Snapshot virtual-line anchors so the per-line lookup borrows this list
-    // rather than `state`, whose buffer the build holds mutably.
-    let virtual_positions: Vec<usize> = if state.virtual_texts.is_empty() {
-        Vec::new()
-    } else {
-        let end = state.buffer.len() + 1;
-        let mut v: Vec<usize> = state
-            .virtual_texts
-            .query_lines_in_range(&state.marker_list, 0, end)
-            .into_iter()
-            .map(|(pos, _)| pos)
-            .collect();
-        v.sort_unstable();
-        v
-    };
-    let virtual_rows = |start: usize, end: usize| -> u32 {
-        let lo = virtual_positions.partition_point(|p| *p < start);
-        let hi = virtual_positions.partition_point(|p| *p < end);
-        (hi - lo) as u32
-    };
     // Resolved before `entry` takes `&mut state`.
     let decorations = state.index_decorations(geometry.view_mode, fold_ranges, &[]);
     let index = state.wrap_indices.entry(geometry);
     index.ensure_built(
         &mut state.buffer,
         geometry,
-        pipeline_inputs_ver,
+        inputs,
         line_ending,
-        &virtual_rows,
         &decorations,
     );
     index.total_rows() as usize
@@ -133,7 +112,7 @@ pub(crate) fn scrollbar_jump_visual(
     wrap_width: usize,
     show_line_numbers: bool,
     grid_cols: Option<usize>,
-    pipeline_inputs_ver: u64,
+    pipeline_inputs_ver: crate::view::line_wrap_cache::PipelineInputs,
     fold_ranges: Vec<std::ops::Range<usize>>,
 ) -> (usize, usize) {
     if state.buffer.is_empty() || viewport_height == 0 {
@@ -182,7 +161,7 @@ pub(crate) fn scrollbar_drag_relative_visual(
     wrap_width: usize,
     show_line_numbers: bool,
     grid_cols: Option<usize>,
-    pipeline_inputs_ver: u64,
+    pipeline_inputs_ver: crate::view::line_wrap_cache::PipelineInputs,
     fold_ranges: Vec<std::ops::Range<usize>>,
 ) -> (usize, usize) {
     if state.buffer.is_empty() || viewport_height == 0 || scrollbar_height <= 1 {

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -4413,12 +4413,7 @@ fn wrap_scroll_geometry(
     if !view_state.viewport.line_wrap_enabled || state.wrap_indices.is_empty() {
         return None;
     }
-    let inputs_version = crate::view::line_wrap_cache::pipeline_inputs_version(
-        state.buffer.version(),
-        state.soft_breaks.version(),
-        state.conceals.version(),
-        state.virtual_texts.version(),
-    );
+    let inputs = state.pipeline_inputs();
     let geometry = crate::view::ui::split_rendering::wrap_index_geometry_for(
         &view_state.viewport,
         &state.buffer,
@@ -4429,6 +4424,6 @@ fn wrap_scroll_geometry(
     state
         .wrap_indices
         .get(&geometry)
-        .is_some_and(|index| index.is_built_for(&geometry, inputs_version))
+        .is_some_and(|index| index.is_built_for(&geometry, inputs))
         .then_some(geometry)
 }

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -302,6 +302,10 @@ impl Editor {
                                 state.buffer.insert(0, &text);
                                 state.buffer.set_modified(true);
                                 state.buffer.set_recovery_pending(false);
+                                // The document is a different document now, and
+                                // this path never described the change as edit
+                                // damage. See `WrapIndex::damage_all`.
+                                state.wrap_indices.damage_all();
                                 // Invalidate saved position so undo can't
                                 // incorrectly clear the modified flag
                                 if let Some(log) =
@@ -2371,6 +2375,9 @@ impl crate::app::window::Window {
                             state.buffer.insert(0, &text);
                             state.buffer.set_modified(true);
                             state.buffer.set_recovery_pending(false);
+                            // Wholesale replacement, never described as edit
+                            // damage. See `WrapIndex::damage_all`.
+                            state.wrap_indices.damage_all();
                             mutated = true;
                             tracing::info!(
                                 "Restored unsaved changes for {:?} from hot exit recovery",

--- a/crates/fresh-editor/src/model/marker.rs
+++ b/crates/fresh-editor/src/model/marker.rs
@@ -63,36 +63,30 @@ impl MarkerList {
         }
     }
 
-    /// Create a new marker at the given position
+    /// Create a new **right-gravity** point marker at the given position:
+    /// text inserted exactly at `position` pushes the marker forward.
     ///
-    /// # Arguments
-    /// * `position` - Byte offset in the buffer
-    /// * `left_affinity` - If true, marker stays before text inserted at this position
+    /// This used to take a `left_affinity: bool` that was stored in a side map
+    /// and never reached the tree — every marker was right-gravity regardless,
+    /// while call sites (and their comments) claimed otherwise. Code that
+    /// mirrors marker movement has to model gravity exactly, and a parameter
+    /// that silently does nothing is how it gets modelled wrong: see
+    /// `IndexDecorations::shift_for_edit`, which was written to match the
+    /// argument rather than the behaviour. Callers that genuinely need the
+    /// other gravity use [`create_left_gravity`](Self::create_left_gravity),
+    /// which does reach the tree.
     ///
-    /// # Returns
-    /// The ID of the newly created marker
-    ///
-    /// Note: Point markers are represented as zero-length intervals in the tree.
-    /// The IntervalTree handles position adjustments using interval semantics, which
-    /// differs slightly from explicit affinity for zero-length markers at exact edit
-    /// positions. In practice, this doesn't affect the LSP diagnostics use case.
-    pub fn create(&mut self, position: usize, left_affinity: bool) -> MarkerId {
+    /// Point markers are zero-length intervals; the tree resolves adjustment
+    /// with interval semantics.
+    pub fn create(&mut self, position: usize) -> MarkerId {
         let pos = position as u64;
 
         // Create a zero-length interval for point markers
-        // The IntervalTree handles affinity through its interval spanning logic
         let tree_id = self.tree.insert(pos, pos);
         let id = MarkerId(tree_id);
+        self._affinity_map.insert(id, false);
 
-        // Store affinity for compatibility (though not strictly needed by tree)
-        self._affinity_map.insert(id, left_affinity);
-
-        tracing::trace!(
-            "Created marker {:?} at position {} with {} affinity",
-            id,
-            position,
-            if left_affinity { "left" } else { "right" }
-        );
+        tracing::trace!("Created marker {:?} at position {}", id, position);
 
         id
     }
@@ -403,7 +397,7 @@ mod tests {
         let mut per_edit = MarkerList::new();
         let ids: Vec<_> = positions
             .iter()
-            .map(|&pos| (batched.create(pos, false), per_edit.create(pos, false)))
+            .map(|&pos| (batched.create(pos), per_edit.create(pos)))
             .collect();
 
         batched.adjust_for_bulk_edits(&edits);
@@ -435,7 +429,7 @@ mod tests {
     fn test_create_marker_at_start() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(0, true);
+        let m1 = list.create(0);
         assert_eq!(list.marker_count(), 1);
         assert_eq!(list.get_position(m1), Some(0));
         list.check_invariants().unwrap();
@@ -445,8 +439,8 @@ mod tests {
     fn test_create_multiple_markers() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(5, true);
-        let m2 = list.create(15, false);
+        let m1 = list.create(5);
+        let m2 = list.create(15);
 
         assert_eq!(list.get_position(m1), Some(5));
         assert_eq!(list.get_position(m2), Some(15));
@@ -457,7 +451,7 @@ mod tests {
     fn test_insert_before_marker() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
+        let m1 = list.create(10);
         assert_eq!(list.get_position(m1), Some(10));
 
         // Insert 5 bytes before marker
@@ -472,7 +466,7 @@ mod tests {
     fn test_insert_after_marker() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
+        let m1 = list.create(10);
         assert_eq!(list.get_position(m1), Some(10));
 
         // Insert 5 bytes after marker
@@ -488,7 +482,7 @@ mod tests {
         let mut list = MarkerList::new();
 
         // Left affinity: marker stays before inserted text
-        let m1 = list.create(10, true);
+        let m1 = list.create(10);
 
         // Insert at marker position
         list.adjust_for_insert(10, 5);
@@ -507,7 +501,7 @@ mod tests {
         let mut list = MarkerList::new();
 
         // Right affinity: marker moves after inserted text
-        let m1 = list.create(10, false);
+        let m1 = list.create(10);
 
         // Insert at marker position
         list.adjust_for_insert(10, 5);
@@ -521,7 +515,7 @@ mod tests {
     fn test_delete_before_marker() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(15, true);
+        let m1 = list.create(15);
         assert_eq!(list.get_position(m1), Some(15));
 
         // Delete 5 bytes before marker (at position 5)
@@ -536,7 +530,7 @@ mod tests {
     fn test_delete_after_marker() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
+        let m1 = list.create(10);
         assert_eq!(list.get_position(m1), Some(10));
 
         // Delete 5 bytes after marker (at position 15)
@@ -551,7 +545,7 @@ mod tests {
     fn test_delete_marker() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
+        let m1 = list.create(10);
 
         // Delete at the marker position
         list.adjust_for_delete(10, 5);
@@ -567,9 +561,9 @@ mod tests {
     fn test_delete_multiple_markers() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
-        let m2 = list.create(15, true);
-        let m3 = list.create(20, true);
+        let m1 = list.create(10);
+        let m2 = list.create(15);
+        let m3 = list.create(20);
 
         // Delete range [8, 18) covering m1 and m2
         list.adjust_for_delete(8, 10);
@@ -588,9 +582,9 @@ mod tests {
         let mut list = MarkerList::new();
 
         // Create markers at 10, 20, 30
-        let m1 = list.create(10, true);
-        let m2 = list.create(20, true);
-        let m3 = list.create(30, true);
+        let m1 = list.create(10);
+        let m2 = list.create(20);
+        let m3 = list.create(30);
 
         // Insert at 15
         list.adjust_for_insert(15, 5);
@@ -612,8 +606,8 @@ mod tests {
     fn test_marker_deletion_with_delete_method() {
         let mut list = MarkerList::new();
 
-        let m1 = list.create(10, true);
-        let m2 = list.create(15, false);
+        let m1 = list.create(10);
+        let m2 = list.create(15);
 
         // Delete m1
         list.delete(m1);
@@ -669,7 +663,7 @@ mod tests {
                 let markers: Vec<_> = unique_positions
                     .iter()
                     .enumerate()
-                    .map(|(i, &pos)| list.create(pos, i % 2 == 0))
+                    .map(|(_i, &pos)| list.create(pos))
                     .collect();
 
                 // Apply random operations
@@ -706,7 +700,7 @@ mod tests {
 
                 // Create markers in order with given spacing
                 let markers: Vec<_> = (0..5)
-                    .map(|i| list.create(i * initial_spacing, true))
+                    .map(|i| list.create(i * initial_spacing))
                     .collect();
 
                 // Apply operations
@@ -780,7 +774,7 @@ mod tests {
                 for (i, &p) in unique_positions.iter().enumerate() {
                     let right_gravity = i % 2 == 0;
                     let id = if right_gravity {
-                        list.create(p, i % 2 == 0)
+                        list.create(p)
                     } else {
                         list.create_left_gravity(p)
                     };

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -718,7 +718,7 @@ impl TextMateEngine {
             current_offset + CHECKPOINT_INTERVAL / 2,
         );
         if nearby.is_empty() {
-            let marker_id = self.checkpoint_markers.create(current_offset, true);
+            let marker_id = self.checkpoint_markers.create(current_offset);
             self.checkpoint_states.insert(marker_id, snapshot.clone());
         }
     }

--- a/crates/fresh-editor/src/primitives/textmate_engine.rs
+++ b/crates/fresh-editor/src/primitives/textmate_engine.rs
@@ -161,7 +161,7 @@ impl TextMateEngine {
                     current_offset + CHECKPOINT_INTERVAL / 2,
                 );
                 if nearby.is_empty() {
-                    let marker_id = self.checkpoint_markers.create(current_offset, true);
+                    let marker_id = self.checkpoint_markers.create(current_offset);
                     self.checkpoint_states
                         .insert(marker_id, (state.clone(), current_scopes.clone()));
                 }

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -1343,6 +1343,14 @@ impl EditorState {
         // consolidate_after_save() can replace buffers between snapshot and restore.
         if let Some(snapshot) = new_snapshot {
             self.buffer.restore_buffer_state(snapshot);
+            // Swapping the piece tree replaces the document without ever
+            // describing the change as edit damage, so any built row index
+            // now describes a document that no longer exists. The version
+            // bump would route the next `ensure_built` to a rebuild anyway,
+            // but `damage_bytes` checks only whether a build exists — an edit
+            // arriving before the next render would repair the stale one and
+            // then mark it current. See `WrapIndex::damage_all`.
+            self.wrap_indices.damage_all();
 
             // A snapshot restore with no per-edit triples (hot-exit recovery,
             // logs loaded from disk) changes content opaquely: the ring can't

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -1468,6 +1468,18 @@ impl EditorState {
     }
 
     /// Restore displaced markers to their exact original positions.
+    ///
+    /// This teleports marker positions rather than shifting them, so it is the
+    /// one mutation that moves a decoration without any manager's version
+    /// moving with it. `WrapIndex` mirrors those positions and repairs itself
+    /// by diffing snapshots *keyed on those versions*, so it cannot notice
+    /// this on its own: undoing a deletion that displaced a conceal's markers
+    /// would otherwise leave the index laid out against positions the
+    /// renderer no longer uses, and nothing would ever correct it.
+    ///
+    /// Dropping the builds is the honest response — a teleport has no local
+    /// damage to describe — and it is rare enough (only undo, and only for
+    /// deletions that displaced markers) to be worth a rebuild.
     pub fn restore_displaced_markers(&mut self, displaced: &[(u64, usize)]) {
         for &(tagged_id, original_pos) in displaced {
             let dm = DisplacedMarker::decode(tagged_id, original_pos);
@@ -1479,6 +1491,9 @@ impl EditorState {
                     self.margins.set_indicator_position(MarkerId(id), position);
                 }
             }
+        }
+        if !displaced.is_empty() {
+            self.wrap_indices.damage_all();
         }
     }
 

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -728,11 +728,36 @@ impl EditorState {
             crate::view::ui::split_rendering::transforms::resolve_inline_hints(self, None, 0, end)
         };
 
+        let virtual_lines = if self.virtual_texts.is_empty() {
+            Vec::new()
+        } else {
+            let mut v: Vec<usize> = self
+                .virtual_texts
+                .query_lines_in_range(&self.marker_list, 0, end)
+                .into_iter()
+                .map(|(pos, _)| pos)
+                .collect();
+            v.sort_unstable();
+            v
+        };
+
         crate::view::wrap_index::IndexDecorations {
             soft_breaks,
             conceals,
             inline_hints,
             folds,
+            virtual_lines,
+        }
+    }
+
+    /// The versions of everything that feeds line layout, as one value — the
+    /// currency `WrapIndex` and its callers trade in.
+    pub fn pipeline_inputs(&self) -> crate::view::line_wrap_cache::PipelineInputs {
+        crate::view::line_wrap_cache::PipelineInputs {
+            buffer: self.buffer.version(),
+            soft_breaks: self.soft_breaks.version(),
+            conceals: self.conceals.version(),
+            virtual_text: self.virtual_texts.version(),
         }
     }
 
@@ -759,40 +784,14 @@ impl EditorState {
             return;
         }
         let line_ending = self.buffer.line_ending();
-        // Snapshot the virtual-line anchors so the lookup borrows this list
-        // rather than `self`, whose buffer the repair holds mutably.
-        let virtual_positions: Vec<usize> = if self.virtual_texts.is_empty() {
-            Vec::new()
-        } else {
-            let mut v: Vec<usize> = self
-                .virtual_texts
-                .query_lines_in_range(&self.marker_list, 0, self.buffer.len() + 1)
-                .into_iter()
-                .map(|(pos, _)| pos)
-                .collect();
-            v.sort_unstable();
-            v
-        };
-        let virtual_rows = |start: usize, end: usize| -> u32 {
-            let lo = virtual_positions.partition_point(|p| *p < start);
-            let hi = virtual_positions.partition_point(|p| *p < end);
-            (hi - lo) as u32
-        };
         // Computed after the edit, so the repaired index is marked current and
-        // the next render reuses it instead of rebuilding.
-        let new_version = crate::view::line_wrap_cache::pipeline_inputs_version(
-            self.buffer.version(),
-            self.soft_breaks.version(),
-            self.conceals.version(),
-            self.virtual_texts.version(),
-        );
-        self.wrap_indices.damage_bytes(
-            &mut self.buffer,
-            damage,
-            line_ending,
-            &virtual_rows,
-            new_version,
-        );
+        // the next render reuses it instead of rebuilding. Virtual-line
+        // positions are no longer snapshotted here — each index carries them
+        // in its decoration snapshot, which the repair shifts along with the
+        // edit.
+        let new_inputs = self.pipeline_inputs();
+        self.wrap_indices
+            .damage_bytes(&mut self.buffer, damage, line_ending, new_inputs);
     }
 
     fn apply_insert(

--- a/crates/fresh-editor/src/view/conceal.rs
+++ b/crates/fresh-editor/src/view/conceal.rs
@@ -32,10 +32,13 @@ pub struct ConcealRange {
     /// Namespace for bulk operations (shared with overlay namespace system)
     pub namespace: OverlayNamespace,
 
-    /// Start marker (left affinity - stays before inserted text)
+    /// Start marker. Right gravity, like every marker `MarkerList::create`
+    /// makes: text inserted exactly at the conceal's start is swallowed by
+    /// the conceal rather than appearing before it.
     pub start_marker: MarkerId,
 
-    /// End marker (right affinity - moves after inserted text)
+    /// End marker, also right gravity: text typed at the conceal's end
+    /// extends it.
     pub end_marker: MarkerId,
 
     /// Optional replacement text to show instead of the concealed content.
@@ -114,8 +117,8 @@ impl ConcealManager {
         replacement: Option<String>,
         activation: Option<MarkerActivation>,
     ) {
-        let start_marker = marker_list.create(range.start, true); // left affinity
-        let end_marker = marker_list.create(range.end, false); // right affinity
+        let start_marker = marker_list.create(range.start);
+        let end_marker = marker_list.create(range.end);
 
         let idx = self.ranges.len();
         self.marker_to_idx.insert(start_marker, idx);

--- a/crates/fresh-editor/src/view/conceal.rs
+++ b/crates/fresh-editor/src/view/conceal.rs
@@ -383,6 +383,13 @@ impl ConcealManager {
         None
     }
 
+    /// Number of stored conceal ranges. Every viewport query walks all of
+    /// them (see [`query_viewport_excluding`](Self::query_viewport_excluding)),
+    /// so this is the size of a per-frame scan.
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
     /// Returns true if there are no conceal ranges
     pub fn is_empty(&self) -> bool {
         self.ranges.is_empty()

--- a/crates/fresh-editor/src/view/folding.rs
+++ b/crates/fresh-editor/src/view/folding.rs
@@ -79,8 +79,9 @@ impl FoldManager {
             return;
         }
 
-        let start_marker = marker_list.create(start, true); // left affinity
-        let end_marker = marker_list.create(end, false); // right affinity
+        // Both right gravity, like every `MarkerList::create` marker.
+        let start_marker = marker_list.create(start);
+        let end_marker = marker_list.create(end);
 
         self.ranges.push(FoldRange {
             start_marker,
@@ -339,8 +340,8 @@ impl LspFoldRanges {
             // Right affinity: text inserted at the line start pushes the marker
             // down with the content (so it keeps pointing at the same *code*,
             // not the same *byte offset*).
-            let start_marker = marker_list.create(start_byte, false);
-            let end_marker = marker_list.create(end_byte, false);
+            let start_marker = marker_list.create(start_byte);
+            let end_marker = marker_list.create(end_byte);
             self.ranges.push(LspFoldEntry {
                 start_marker,
                 end_marker,

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -119,33 +119,39 @@ pub fn cursor_sig_for_line(cursors: &[usize], line_start: usize, line_end: usize
     sig
 }
 
-/// Derive the combined pipeline-inputs version from the three source
-/// versions.  Any change to any of them flips the combined value.  This
-/// is not a hash — it's a packed integer with enough bit-budget to make
-/// accidental collisions astronomically unlikely in a single session.
+/// The versions of everything that feeds line layout, kept apart.
 ///
-/// * `buffer_version` gets the low 32 bits (wrapped to u32).  Buffer
-///   edits are the most frequent source of change.
-/// * `soft_breaks_version` is shifted up 32 bits.
-/// * `conceal_version` is shifted up 48 bits.
-/// * `virtual_text_version` is shifted up 16 bits.  Folded so that
-///   adding / removing plugin virtual lines (e.g.
-///   markdown_compose's table borders, git blame headers)
-///   invalidates the same caches the other three sources do —
-///   `WrapIndex` adds virtual line counts to its prefix sums and
-///   would otherwise serve a stale total when the plugin re-tiles a
-///   table.
-#[inline]
-pub fn pipeline_inputs_version(
-    buffer_version: u64,
-    soft_breaks_version: u32,
-    conceal_version: u32,
-    virtual_text_version: u32,
-) -> u64 {
-    (buffer_version & 0xFFFF_FFFF)
-        ^ ((soft_breaks_version as u64) << 32)
-        ^ ((conceal_version as u64) << 48)
-        ^ ((virtual_text_version as u64) << 16)
+/// This replaces a packed-XOR `u64`: equality still answers "is anything
+/// stale", but the components stay visible, and *which* one moved is the
+/// load-bearing distinction — a buffer edit is repaired locally by
+/// [`WrapIndex::damage_bytes`](crate::view::wrap_index::WrapIndex::damage_bytes),
+/// while a decoration change is repaired by diffing the old decoration
+/// snapshot against the new one. A packed integer could express neither
+/// without unpacking tricks, and its collision story ("astronomically
+/// unlikely") is replaced by plain field equality.
+///
+/// `virtual_text` is folded in so that adding / removing plugin virtual
+/// lines (e.g. markdown_compose's table borders, git blame headers)
+/// invalidates the same consumers the other sources do — `WrapIndex` adds
+/// virtual line counts to its prefix sums and would otherwise serve a
+/// stale total when the plugin re-tiles a table.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct PipelineInputs {
+    pub buffer: u64,
+    pub soft_breaks: u32,
+    pub conceals: u32,
+    pub virtual_text: u32,
+}
+
+impl PipelineInputs {
+    /// Do the decoration components (everything except the buffer text)
+    /// match? The buffer half has its own repair channel, so this is the
+    /// question `ensure_built` asks to pick diff-repair over rebuild.
+    pub fn decorations_match(&self, other: &PipelineInputs) -> bool {
+        self.soft_breaks == other.soft_breaks
+            && self.conceals == other.conceals
+            && self.virtual_text == other.virtual_text
+    }
 }
 
 /// Estimate the in-memory size of a `Vec<ViewLine>` for byte-budget
@@ -621,18 +627,6 @@ pub fn compute_line_layout(
     result
 }
 
-/// Combined version of all pipeline inputs on the given state.  Fold into
-/// a `LineWrapKey` to make stale entries unreachable on any mutation.
-#[inline]
-pub fn state_pipeline_inputs_version(state: &EditorState) -> u64 {
-    pipeline_inputs_version(
-        state.buffer.version(),
-        state.soft_breaks.version(),
-        state.conceals.version(),
-        state.virtual_texts.version(),
-    )
-}
-
 /// Row counts keyed the same way [`LineWrapCache`] keys layouts, for the
 /// consumers that only ever ask "how many rows?" — the viewport's scroll
 /// hot paths.
@@ -1093,28 +1087,32 @@ mod tests {
     }
 
     #[test]
-    fn pipeline_inputs_version_changes_when_any_source_changes() {
-        let a = pipeline_inputs_version(100, 5, 3, 7);
-        assert_ne!(
-            a,
-            pipeline_inputs_version(101, 5, 3, 7),
-            "buffer bump changes version"
+    fn pipeline_inputs_distinguishes_the_buffer_from_the_decorations() {
+        let a = PipelineInputs {
+            buffer: 100,
+            soft_breaks: 5,
+            conceals: 3,
+            virtual_text: 7,
+        };
+        assert_ne!(a, PipelineInputs { buffer: 101, ..a });
+        assert!(
+            a.decorations_match(&PipelineInputs { buffer: 101, ..a }),
+            "a buffer edit alone leaves the decoration half current"
         );
-        assert_ne!(
-            a,
-            pipeline_inputs_version(100, 6, 3, 7),
-            "soft-break bump changes version"
-        );
-        assert_ne!(
-            a,
-            pipeline_inputs_version(100, 5, 4, 7),
-            "conceal bump changes version"
-        );
-        assert_ne!(
-            a,
-            pipeline_inputs_version(100, 5, 3, 8),
-            "virtual-text bump changes version"
-        );
+        for changed in [
+            PipelineInputs {
+                soft_breaks: 6,
+                ..a
+            },
+            PipelineInputs { conceals: 4, ..a },
+            PipelineInputs {
+                virtual_text: 8,
+                ..a
+            },
+        ] {
+            assert_ne!(a, changed);
+            assert!(!a.decorations_match(&changed));
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -67,10 +67,15 @@ pub enum CacheViewMode {
 /// layout.  Every mutable input must be represented here — if the
 /// caller forgets one, stale entries can be returned.
 ///
-/// The `pipeline_inputs_version` folds in the buffer version plus the
-/// soft-break and conceal managers' versions (see
-/// [`pipeline_inputs_version`]).  The remaining fields are geometry /
-/// viewport config.
+/// `pipeline_inputs_version` is the buffer version, and that is
+/// sufficient: the only live consumer is [`RowCountCache`], whose value
+/// is a pure function of the line's raw text and the geometry fields
+/// below.  Decorations never enter it — `Viewport`'s row counting adds
+/// virtual rows *outside* the cache and returns before consulting it at
+/// all when soft breaks apply — so a decoration version could not stale
+/// an entry.  Layout that does model decorations goes through
+/// [`WrapIndex`](crate::view::wrap_index::WrapIndex), which keys on the
+/// full [`PipelineInputs`] instead.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct LineWrapKey {
     pub pipeline_inputs_version: u64,

--- a/crates/fresh-editor/src/view/margin.rs
+++ b/crates/fresh-editor/src/view/margin.rs
@@ -372,7 +372,7 @@ impl MarginManager {
         mut indicator: LineIndicator,
     ) -> MarkerId {
         // Create a marker at this byte position (left affinity - stays before inserted text)
-        let marker_id = self.indicator_markers.create(byte_offset, true);
+        let marker_id = self.indicator_markers.create(byte_offset);
         indicator.marker_id = marker_id;
 
         self.line_indicators

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -144,10 +144,10 @@ pub struct Overlay {
     /// Namespace this overlay belongs to (for bulk removal)
     pub namespace: Option<OverlayNamespace>,
 
-    /// Start marker (left affinity - stays before inserted text)
+    /// Start marker. Right gravity, like every `MarkerList::create` marker.
     pub start_marker: MarkerId,
 
-    /// End marker (right affinity - moves after inserted text)
+    /// End marker, also right gravity: text typed at the end extends it.
     pub end_marker: MarkerId,
 
     /// Visual appearance of the overlay
@@ -183,8 +183,8 @@ impl Overlay {
     ///
     /// Returns the overlay (which contains its handle for later removal)
     pub fn new(marker_list: &mut MarkerList, range: Range<usize>, face: OverlayFace) -> Self {
-        let start_marker = marker_list.create(range.start, true); // left affinity
-        let end_marker = marker_list.create(range.end, false); // right affinity
+        let start_marker = marker_list.create(range.start); // left affinity
+        let end_marker = marker_list.create(range.end); // right affinity
 
         Self {
             handle: OverlayHandle::new(),
@@ -225,7 +225,7 @@ impl Overlay {
         face: OverlayFace,
         namespace: OverlayNamespace,
     ) -> Self {
-        let start_marker = marker_list.create(range.start, true); // left affinity
+        let start_marker = marker_list.create(range.start); // left affinity
         let end_marker = marker_list.create_left_gravity(range.end);
 
         Self {

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -213,13 +213,13 @@ impl ScrollbarMarkerManager {
         let take = resolved.len().min(room);
 
         for m in resolved.into_iter().take(take) {
-            // Start anchors with left affinity so text typed at the marked
-            // position pushes the marker along with its content.
-            let start = self.markers.create(m.start, true);
+            // Right gravity, so text typed at the marked position pushes the
+            // marker along with its content.
+            let start = self.markers.create(m.start);
             let end = m
                 .end
                 .filter(|e| *e > m.start)
-                .map(|e| self.markers.create(e, false));
+                .map(|e| self.markers.create(e));
             entries.push(MarkerEntry {
                 start,
                 end,

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -387,6 +387,20 @@ pub struct MarkerCell {
 #[derive(Debug, Default)]
 pub struct ScrollbarMarkerBuckets {
     entries: Vec<(ProjectionKey, Vec<Option<MarkerCell>>)>,
+    stats: ProjectionStats,
+}
+
+/// How much projecting has actually cost this buffer.
+///
+/// A rebuild walks every stored marker, so `markers_walked / marker count` is
+/// how many times the whole set has been re-projected — the number that
+/// separates "projected once, then cached" from "re-projected on every frame
+/// of a scroll". Kept per-buckets rather than in a process-wide counter so
+/// concurrent tests (and split panes) observe only their own work.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectionStats {
+    pub rebuilds: u64,
+    pub markers_walked: u64,
 }
 
 /// How many distinct scrollbar geometries to keep projected at once.
@@ -399,6 +413,11 @@ impl ScrollbarMarkerBuckets {
 
     pub fn clear(&mut self) {
         self.entries.clear();
+    }
+
+    /// Projection work done for this buffer so far. See [`ProjectionStats`].
+    pub fn stats(&self) -> ProjectionStats {
+        self.stats
     }
 
     fn lookup(&self, key: &ProjectionKey) -> Option<usize> {
@@ -467,6 +486,8 @@ pub fn project<'a>(
     }
 
     let cells = build_cells(manager, core, basis, track_height, row_of_byte);
+    buckets.stats.rebuilds += 1;
+    buckets.stats.markers_walked += manager.len() as u64;
 
     if buckets.entries.len() >= MAX_CACHED_PROJECTIONS {
         buckets.entries.remove(0);

--- a/crates/fresh-editor/src/view/soft_break.rs
+++ b/crates/fresh-editor/src/view/soft_break.rs
@@ -106,7 +106,7 @@ impl SoftBreakManager {
         indent: u16,
         activation: Option<MarkerActivation>,
     ) {
-        let marker_id = marker_list.create(position, false); // right affinity
+        let marker_id = marker_list.create(position);
 
         let idx = self.breaks.len();
         self.marker_to_idx.insert(marker_id, idx);

--- a/crates/fresh-editor/src/view/soft_break.rs
+++ b/crates/fresh-editor/src/view/soft_break.rs
@@ -257,6 +257,13 @@ impl SoftBreakManager {
             .min()
     }
 
+    /// Number of stored soft breaks. Every viewport query walks all of them
+    /// (see [`query_viewport`](Self::query_viewport)), so this is the size of
+    /// a per-frame scan.
+    pub fn len(&self) -> usize {
+        self.breaks.len()
+    }
+
     /// Returns true if there are no soft breaks
     pub fn is_empty(&self) -> bool {
         self.breaks.is_empty()

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -23,6 +23,8 @@ mod orchestration;
 pub(crate) use orchestration::render_buffer::wrap_index_geometry_for;
 mod post_pass;
 pub(crate) mod scrollbar;
+#[cfg(test)]
+mod scrollbar_marker_scroll_perf;
 mod spans;
 mod style;
 pub(crate) mod transforms;

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -2041,9 +2041,8 @@ mod tests {
         index.ensure_built(
             &mut state.buffer,
             geometry,
-            0,
+            Default::default(),
             crate::model::buffer::LineEnding::LF,
-            &|_, _| 0,
             &Default::default(),
         );
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -215,12 +215,7 @@ pub(crate) fn compute_buffer_layout(
             &view_mode,
             crate::view::wrap_index::fold_signature(&fold_ranges),
         );
-        let inputs_version = crate::view::line_wrap_cache::pipeline_inputs_version(
-            state.buffer.version(),
-            state.soft_breaks.version(),
-            state.conceals.version(),
-            state.virtual_texts.version(),
-        );
+        let inputs = state.pipeline_inputs();
         let cursor_byte = cursors.primary().position;
         let buffer_len = state.buffer.len();
         // Large-file mode has no line data at all — the gutter is byte-based
@@ -237,35 +232,15 @@ pub(crate) fn compute_buffer_layout(
             });
         if within_bounds || (indexable && state.wrap_indices.get(&geometry).is_some()) {
             let line_ending = state.buffer.line_ending();
-            // Snapshot virtual-line anchors so the per-line lookup borrows
-            // this list rather than `state`, whose buffer the build holds
-            // mutably (same shape as scrollbar_math::total_rows).
-            let virtual_positions: Vec<usize> = if state.virtual_texts.is_empty() {
-                Vec::new()
-            } else {
-                let end = state.buffer.len() + 1;
-                let mut v: Vec<usize> = state
-                    .virtual_texts
-                    .query_lines_in_range(&state.marker_list, 0, end)
-                    .into_iter()
-                    .map(|(pos, _)| pos)
-                    .collect();
-                v.sort_unstable();
-                v
-            };
-            let virtual_rows = |start: usize, end: usize| -> u32 {
-                let lo = virtual_positions.partition_point(|p| *p < start);
-                let hi = virtual_positions.partition_point(|p| *p < end);
-                (hi - lo) as u32
-            };
+            // Decorations — virtual-line anchors included — are resolved into
+            // one owned snapshot before `entry` takes `&mut state`.
             let decorations = state.index_decorations(geometry.view_mode, fold_ranges.clone(), &[]);
             let index = state.wrap_indices.entry(geometry);
             index.ensure_built(
                 &mut state.buffer,
                 geometry,
-                inputs_version,
+                inputs,
                 line_ending,
-                &virtual_rows,
                 &decorations,
             );
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -290,7 +290,7 @@ pub(super) fn scrollbar_visual_row_counts(
     fold_ranges: Vec<std::ops::Range<usize>>,
 ) -> (usize, usize) {
     use crate::primitives::line_wrapping::WrapConfig;
-    use crate::view::line_wrap_cache::{pipeline_inputs_version, CacheViewMode};
+    use crate::view::line_wrap_cache::CacheViewMode;
     use crate::view::ui::split_rendering::MAX_SAFE_LINE_WIDTH;
     use crate::view::wrap_index::WrapIndexGeometry;
     use crate::view::wrap_machine::WrapRule;
@@ -317,12 +317,7 @@ pub(super) fn scrollbar_visual_row_counts(
             .max(2);
         (effective_width, gutter_width, wrap_config.hanging_indent)
     };
-    let pipeline_inputs_ver = pipeline_inputs_version(
-        state.buffer.version(),
-        state.soft_breaks.version(),
-        state.conceals.version(),
-        state.virtual_texts.version(),
-    );
+    let inputs = state.pipeline_inputs();
 
     // The wrap index answers both numbers directly: `total_rows` is O(1) off the
     // Fenwick tree and `row_of_byte` is a binary search. The path this replaced
@@ -350,36 +345,16 @@ pub(super) fn scrollbar_visual_row_counts(
         fold_signature: crate::view::wrap_index::fold_signature(&fold_ranges),
     };
 
-    // Snapshot virtual-line anchors so the per-line lookup borrows this list
-    // rather than `state`, whose buffer the build holds mutably.
-    let virtual_positions: Vec<usize> = if state.virtual_texts.is_empty() {
-        Vec::new()
-    } else {
-        let mut v: Vec<usize> = state
-            .virtual_texts
-            .query_lines_in_range(&state.marker_list, 0, buffer_len + 1)
-            .into_iter()
-            .map(|(pos, _)| pos)
-            .collect();
-        v.sort_unstable();
-        v
-    };
-    let virtual_rows = |start: usize, end: usize| -> u32 {
-        let lo = virtual_positions.partition_point(|p| *p < start);
-        let hi = virtual_positions.partition_point(|p| *p < end);
-        (hi - lo) as u32
-    };
-
     let line_ending = state.buffer.line_ending();
-    // Resolved before `entry` takes `&mut state`.
+    // Decorations — virtual-line anchors included — resolved into one owned
+    // snapshot before `entry` takes `&mut state`.
     let decorations = state.index_decorations(geometry.view_mode, fold_ranges, &[]);
     let index = state.wrap_indices.entry(geometry);
     index.ensure_built(
         &mut state.buffer,
         geometry,
-        pipeline_inputs_ver,
+        inputs,
         line_ending,
-        &virtual_rows,
         &decorations,
     );
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
@@ -3,10 +3,11 @@
 //!
 //! This isolates a real inefficiency — the marks are re-projected on every
 //! frame of a first scroll, so the cost is quadratic in document length — and
-//! measures it. It is *not* the explanation for a first scroll feeling slow:
-//! the end-to-end attribution in `e2e::markdown_compose_scroll_perf` shows the
-//! per-line decoration rebuild dominating by orders of magnitude. Keep this as
-//! the bound on what the marks can cost as documents (and heading counts) grow.
+//! measures it. It was *not* the explanation for a first scroll feeling slow:
+//! that was the wrap index rebuilding the whole document per frame, since
+//! fixed by diff repair (see `e2e::markdown_compose_first_scroll_relayout`).
+//! Keep this as the bound on what the marks can cost as documents (and
+//! heading counts) grow.
 //!
 //! # What the production path does
 //!

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
@@ -1,0 +1,307 @@
+//! How much the scrollbar's heading marks cost on a first scroll through a
+//! large markdown buffer.
+//!
+//! This isolates a real inefficiency — the marks are re-projected on every
+//! frame of a first scroll, so the cost is quadratic in document length — and
+//! measures it. It is *not* the explanation for a first scroll feeling slow:
+//! the end-to-end attribution in `e2e::markdown_compose_scroll_perf` shows the
+//! per-line decoration rebuild dominating by orders of magnitude. Keep this as
+//! the bound on what the marks can cost as documents (and heading counts) grow.
+//!
+//! # What the production path does
+//!
+//! `markdown_compose` marks every heading on the scrollbar track. It learns
+//! about lines through `lines_changed`, which only ever carries lines the
+//! editor has not offered before (`Window::seen_byte_ranges`, see
+//! `app::render`), so on a *first* downward scroll every frame delivers a
+//! fresh batch and the plugin answers with `setScrollbarMarkersInRange` for
+//! that batch's byte span — see `HEADING_MARKER_NS` in
+//! `plugins/markdown_compose.ts`. Scrolling back over the same lines delivers
+//! nothing, the plugin publishes nothing, and the projection stays cached.
+//! That asymmetry is exactly the "slow the first time" shape of the report.
+//!
+//! The two costs the loop pays per frame are:
+//!
+//! * [`ScrollbarMarkerManager::set_markers_in_range`] — an O(M) retain over
+//!   the namespace, where M is every heading found *so far*.
+//! * [`project_scrollbar_markers`] — publication bumps the marker version, so
+//!   the [`ProjectionKey`](crate::view::scrollbar_marker::ProjectionKey)
+//!   changes on every frame of the scroll and the cached column is always a
+//!   miss. The rebuild resolves all M anchors and, on the logical-line basis a
+//!   markdown file of this size uses, does an O(log n) `get_line_number`
+//!   descent per anchor.
+//!
+//! Both terms are proportional to markers accumulated so far, and the scroll
+//! runs one per frame, so the first pass costs O(frames × headings) — the
+//! per-frame price grows the further down the document the reader gets, and
+//! the total is quadratic in document length.
+//!
+//! These tests are measurements, so they assert on *shape* (late frames versus
+//! early frames, first pass versus second pass) rather than on wall-clock
+//! numbers, which vary by machine and by build profile. For scale, a release
+//! build on the machine this was written on scrolled a 20 000-line document
+//! with 1 000 headings in ~100 ms of marker work spread over 500 frames — 23 µs
+//! on the first frames, 400 µs on the last. Small next to the rest of a compose
+//! frame today; the point is that it grows with the square of the document.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use super::scrollbar::project_scrollbar_markers;
+use crate::state::EditorState;
+use crate::view::scrollbar_marker::{MarkerBasis, ResolvedMarker};
+
+const NS: &str = "md-headings";
+/// Rows of terminal the reader scrolls by, and the marker track's height.
+const VIEWPORT_LINES: usize = 40;
+const TRACK_HEIGHT: usize = 38;
+
+/// A markdown-shaped buffer: `lines` lines with an ATX heading every
+/// `heading_every` lines. Returns the state and the byte offset of every line
+/// start, which stands in for what `lines_changed` hands the plugin.
+fn markdown_state(lines: usize, heading_every: usize) -> (EditorState, Vec<usize>) {
+    let fs: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(crate::model::filesystem::StdFileSystem);
+    let mut state = EditorState::new(
+        80,
+        VIEWPORT_LINES as u16,
+        crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+        fs,
+    );
+
+    let mut text = String::new();
+    let mut line_starts = Vec::with_capacity(lines);
+    for i in 0..lines {
+        line_starts.push(text.len());
+        if i % heading_every == 0 {
+            text.push_str(&format!("## Section {i}\n"));
+        } else {
+            text.push_str("body text for this section, long enough to look like prose\n");
+        }
+    }
+    state.buffer.insert(0, &text);
+    // A file just opened from disk: no unsaved diff, so the editor's own marks
+    // stay off the track and the measurement is purely the plugin's.
+    state.buffer.mark_saved_snapshot();
+
+    (state, line_starts)
+}
+
+fn heading_marker(start: usize) -> ResolvedMarker {
+    ResolvedMarker {
+        start,
+        end: None,
+        color: fresh_core::api::OverlayColorSpec::Rgb(200, 120, 0),
+        priority: 9,
+    }
+}
+
+/// One frame of a first-time downward scroll: publish the batch's headings the
+/// way the plugin does, then project the track the way the renderer does.
+/// Returns `(publish, project)` timings.
+fn scroll_frame(
+    state: &mut EditorState,
+    line_starts: &[usize],
+    heading_every: usize,
+    frame: usize,
+    basis: MarkerBasis,
+    publish: bool,
+) -> (Duration, Duration) {
+    let first = frame * VIEWPORT_LINES;
+    let last = (first + VIEWPORT_LINES - 1).min(line_starts.len() - 1);
+
+    let mut publish_time = Duration::ZERO;
+    if publish {
+        let start_byte = line_starts[first];
+        let end_byte = line_starts
+            .get(last + 1)
+            .copied()
+            .unwrap_or_else(|| state.buffer.len());
+        let markers: Vec<ResolvedMarker> = (first..=last)
+            .filter(|l| l % heading_every == 0)
+            .map(|l| heading_marker(line_starts[l]))
+            .collect();
+
+        let t = Instant::now();
+        state.scrollbar_markers.set_markers_in_range(
+            NS,
+            start_byte,
+            end_byte.max(start_byte + 1),
+            markers,
+        );
+        publish_time = t.elapsed();
+    }
+
+    let t = Instant::now();
+    let _ = project_scrollbar_markers(state, basis, TRACK_HEIGHT);
+    (publish_time, t.elapsed())
+}
+
+struct ScrollProfile {
+    per_frame: Vec<Duration>,
+    publish_total: Duration,
+    project_total: Duration,
+}
+
+impl ScrollProfile {
+    fn total(&self) -> Duration {
+        self.publish_total + self.project_total
+    }
+
+    /// Mean frame cost over the first / last tenth of the scroll.
+    fn first_decile(&self) -> Duration {
+        mean(&self.per_frame[..self.per_frame.len() / 10])
+    }
+
+    fn last_decile(&self) -> Duration {
+        mean(&self.per_frame[self.per_frame.len() - self.per_frame.len() / 10..])
+    }
+}
+
+fn mean(d: &[Duration]) -> Duration {
+    d.iter().sum::<Duration>() / d.len().max(1) as u32
+}
+
+fn scroll_document(
+    state: &mut EditorState,
+    line_starts: &[usize],
+    heading_every: usize,
+    publish: bool,
+) -> ScrollProfile {
+    let basis = MarkerBasis::LogicalLines {
+        total: line_starts.len() as u64,
+    };
+    let frames = line_starts.len() / VIEWPORT_LINES;
+    let mut profile = ScrollProfile {
+        per_frame: Vec::with_capacity(frames),
+        publish_total: Duration::ZERO,
+        project_total: Duration::ZERO,
+    };
+    for frame in 0..frames {
+        let (p, q) = scroll_frame(state, line_starts, heading_every, frame, basis, publish);
+        profile.publish_total += p;
+        profile.project_total += q;
+        profile.per_frame.push(p + q);
+    }
+    profile
+}
+
+/// The report, reproduced: on a first pass through the document each frame
+/// costs more than the last, because both the publish and the projection are
+/// O(headings seen so far) and run once per frame.
+#[test]
+fn first_scroll_frame_cost_grows_with_accumulated_markers() {
+    let heading_every = 20;
+    let (mut state, line_starts) = markdown_state(20_000, heading_every);
+
+    let first_pass = scroll_document(&mut state, &line_starts, heading_every, true);
+
+    eprintln!(
+        "first scroll: total {:?} (publish {:?}, project {:?}), \
+         first-decile frame {:?}, last-decile frame {:?}",
+        first_pass.total(),
+        first_pass.publish_total,
+        first_pass.project_total,
+        first_pass.first_decile(),
+        first_pass.last_decile(),
+    );
+
+    assert!(
+        first_pass.last_decile() > first_pass.first_decile() * 4,
+        "late frames should cost far more than early ones if the per-frame \
+         work is proportional to markers accumulated so far; \
+         first decile {:?}, last decile {:?}",
+        first_pass.first_decile(),
+        first_pass.last_decile(),
+    );
+}
+
+/// The other half of the report: the *second* pass is nearly free. Nothing
+/// republishes (the editor never re-offers a line it has already offered), so
+/// the marker version stands still and every projection is a cache hit.
+#[test]
+fn second_scroll_is_free_because_nothing_republishes() {
+    let heading_every = 20;
+    let (mut state, line_starts) = markdown_state(20_000, heading_every);
+
+    let first_pass = scroll_document(&mut state, &line_starts, heading_every, true);
+    let second_pass = scroll_document(&mut state, &line_starts, heading_every, false);
+
+    eprintln!(
+        "first scroll {:?}, second scroll {:?}",
+        first_pass.total(),
+        second_pass.total()
+    );
+
+    assert!(
+        second_pass.total() * 10 < first_pass.total(),
+        "a re-scroll should be at least an order of magnitude cheaper; \
+         first {:?}, second {:?}",
+        first_pass.total(),
+        second_pass.total()
+    );
+}
+
+/// The driver is the *accumulated marker count*, not the publish call itself.
+/// A document of the same length with no headings at all publishes an empty
+/// batch on every frame — the plugin emits marks for every batch, so the
+/// version still moves and the projection is still a miss every frame — and
+/// the scroll stays flat and cheap.
+#[test]
+fn a_document_without_headings_scrolls_flat() {
+    // `heading_every > lines` produces a document with a single heading on
+    // line 0 and nothing else, so the marker set never grows.
+    let (mut state, line_starts) = markdown_state(20_000, usize::MAX);
+
+    let flat = scroll_document(&mut state, &line_starts, usize::MAX, true);
+
+    eprintln!(
+        "headingless scroll: total {:?}, first-decile frame {:?}, \
+         last-decile frame {:?}",
+        flat.total(),
+        flat.first_decile(),
+        flat.last_decile(),
+    );
+
+    assert!(
+        flat.last_decile() < flat.first_decile() * 4,
+        "with no markers accumulating, late frames should cost about what \
+         early ones do; first decile {:?}, last decile {:?}",
+        flat.first_decile(),
+        flat.last_decile(),
+    );
+
+    let heading_every = 20;
+    let (mut state, line_starts) = markdown_state(20_000, heading_every);
+    let with_headings = scroll_document(&mut state, &line_starts, heading_every, true);
+    assert!(
+        with_headings.total() > flat.total() * 5,
+        "the same scroll over the same number of lines costs far more once \
+         headings accumulate marks; headingless {:?}, with headings {:?}",
+        flat.total(),
+        with_headings.total(),
+    );
+}
+
+/// Doubling the document length more than doubles the first-scroll cost: the
+/// frame count and the marker count both scale with it, and they multiply.
+#[test]
+fn first_scroll_cost_is_superlinear_in_document_length() {
+    let heading_every = 20;
+
+    let cost = |lines: usize| {
+        let (mut state, line_starts) = markdown_state(lines, heading_every);
+        scroll_document(&mut state, &line_starts, heading_every, true).total()
+    };
+
+    let small = cost(10_000);
+    let large = cost(20_000);
+
+    eprintln!("10k lines {small:?}, 20k lines {large:?}");
+
+    assert!(
+        large > small * 2,
+        "twice the document should cost more than twice as much; \
+         10k {small:?}, 20k {large:?}"
+    );
+}

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -214,7 +214,7 @@ impl VirtualTextManager {
     ) -> VirtualTextId {
         // Create marker at position
         // Use right affinity (false) so the marker stays with the following character
-        let marker_id = marker_list.create(position, false);
+        let marker_id = marker_list.create(position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;
@@ -265,7 +265,7 @@ impl VirtualTextManager {
             "add_with_theme_keys requires BeforeChar or AfterChar"
         );
 
-        let marker_id = marker_list.create(position, false);
+        let marker_id = marker_list.create(position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;
@@ -306,7 +306,7 @@ impl VirtualTextManager {
         priority: i32,
         string_id: String,
     ) -> VirtualTextId {
-        let marker_id = marker_list.create(position, false);
+        let marker_id = marker_list.create(position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;
@@ -353,7 +353,7 @@ impl VirtualTextManager {
             "add_with_id_and_theme_keys requires BeforeChar or AfterChar"
         );
 
-        let marker_id = marker_list.create(position, false);
+        let marker_id = marker_list.create(position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;
@@ -446,7 +446,7 @@ impl VirtualTextManager {
             "add_line requires LineAbove or LineBelow"
         );
 
-        let marker_id = marker_list.create(position, false);
+        let marker_id = marker_list.create(position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -85,6 +85,12 @@ pub struct IndexDecorations {
     /// Collapsed byte ranges, sorted by start. Per split, unlike the rest —
     /// see [`WrapIndexGeometry::fold_signature`], which keys the index on them.
     pub folds: Vec<std::ops::Range<usize>>,
+    /// Sorted anchor bytes of plugin virtual *lines* (whole extra rows, e.g.
+    /// markdown_compose's table borders). Part of the snapshot so the index
+    /// derives per-line virtual row counts itself — callers used to pass a
+    /// closure over a side list, which left the snapshot incomplete and the
+    /// virtual half undiffable.
+    pub virtual_lines: Vec<usize>,
 }
 
 impl IndexDecorations {
@@ -93,6 +99,126 @@ impl IndexDecorations {
             && self.conceals.is_empty()
             && self.inline_hints.is_empty()
             && self.folds.is_empty()
+            && self.virtual_lines.is_empty()
+    }
+
+    /// Virtual lines anchored in `start..end`.
+    pub fn virtual_rows_in(&self, start: usize, end: usize) -> u32 {
+        let lo = self.virtual_lines.partition_point(|p| *p < start);
+        let hi = self.virtual_lines.partition_point(|p| *p < end);
+        (hi - lo) as u32
+    }
+
+    /// Move every stored position the way the buffer's markers moved for this
+    /// edit, so the snapshot stays in current buffer coordinates.
+    ///
+    /// Positions inside the removed span clamp to its start; positions after
+    /// it shift by the edit's delta; a position exactly at an insertion point
+    /// stays put (left gravity). The live markers resolve gravity per marker,
+    /// so an entry *at* the edit boundary can land one byte off — but such an
+    /// entry is on the edited line, whose decorations the plugin re-emits (the
+    /// edit re-fires `lines_changed` for it), and the re-emit shows up as a
+    /// snapshot diff that repairs the line exactly. Every entry *away* from
+    /// the boundary shifts identically to its marker, no gravity involved.
+    ///
+    /// The map is monotone, so all five lists stay sorted.
+    pub fn shift_for_edit(&mut self, start: usize, removed: usize, inserted: usize) {
+        if removed == 0 && inserted == 0 {
+            return;
+        }
+        let end_old = start + removed;
+        let delta = inserted as i64 - removed as i64;
+        let shift = |p: usize| -> usize {
+            if p <= start {
+                p
+            } else if p < end_old {
+                start
+            } else {
+                (p as i64 + delta).max(0) as usize
+            }
+        };
+        for (p, _) in &mut self.soft_breaks {
+            *p = shift(*p);
+        }
+        for p in &mut self.virtual_lines {
+            *p = shift(*p);
+        }
+        for h in &mut self.inline_hints {
+            h.anchor = shift(h.anchor);
+        }
+        for (r, _) in &mut self.conceals {
+            let s = shift(r.start);
+            *r = s..shift(r.end).max(s);
+        }
+        for r in &mut self.folds {
+            let s = shift(r.start);
+            *r = s..shift(r.end).max(s);
+        }
+    }
+
+    /// Byte ranges where `self` and `new` disagree, coalesced and sorted — the
+    /// exact damage a decoration change did, computed with no help from the
+    /// managers. Every entry present in one snapshot but not the other (moved
+    /// entries count as removed + added) contributes its range; a line whose
+    /// decorations appear in neither diff side wraps identically under both
+    /// snapshots, which is what makes repairing only these ranges sound.
+    fn changed_ranges(&self, new: &IndexDecorations) -> Vec<std::ops::Range<usize>> {
+        let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
+
+        diff_sorted(
+            &self.soft_breaks,
+            &new.soft_breaks,
+            |a| a.0,
+            |a, b| a == b,
+            &mut |e: &(usize, u16)| ranges.push(e.0..e.0 + 1),
+        );
+        diff_sorted(
+            &self.conceals,
+            &new.conceals,
+            |a| a.0.start,
+            |a, b| a == b,
+            &mut |e: &(std::ops::Range<usize>, Option<String>)| {
+                ranges.push(e.0.start..e.0.end.max(e.0.start + 1))
+            },
+        );
+        // Layout-relevant hint equality: anchor, text, and placement decide
+        // where rows break; style is draw-only (and `None` on index paths).
+        diff_sorted(
+            &self.inline_hints,
+            &new.inline_hints,
+            |h| h.anchor,
+            |a, b| a.anchor == b.anchor && a.text == b.text && a.position == b.position,
+            &mut |h: &crate::view::ui::split_rendering::transforms::InlineHint| {
+                ranges.push(h.anchor..h.anchor + 1)
+            },
+        );
+        diff_sorted(
+            &self.virtual_lines,
+            &new.virtual_lines,
+            |p| *p,
+            |a, b| a == b,
+            &mut |p: &usize| ranges.push(*p..*p + 1),
+        );
+        // Folds are part of the geometry key, so two snapshots under one
+        // geometry should agree — diffed anyway so correctness never rests on
+        // `fold_signature` being collision-free.
+        diff_sorted(
+            &self.folds,
+            &new.folds,
+            |r| r.start,
+            |a, b| a == b,
+            &mut |r: &std::ops::Range<usize>| ranges.push(r.start..r.end.max(r.start + 1)),
+        );
+
+        ranges.sort_by_key(|r| r.start);
+        let mut merged: Vec<std::ops::Range<usize>> = Vec::with_capacity(ranges.len());
+        for r in ranges {
+            match merged.last_mut() {
+                Some(last) if r.start <= last.end => last.end = last.end.max(r.end),
+                _ => merged.push(r),
+            }
+        }
+        merged
     }
 
     /// Is every byte of `line_start..line_end` inside a collapsed range?
@@ -143,6 +269,50 @@ impl IndexDecorations {
             .cloned()
             .collect();
         (breaks, conceals, hints)
+    }
+}
+
+/// Two-pointer symmetric difference over position-sorted slices.
+///
+/// Items whose sort keys differ belong to one side only; items at the same
+/// key are compared with `eq` (equal → common, skipped; different → both are
+/// damage). Ties on the key are resolved conservatively — a run of same-key
+/// entries that differs in any way reports the whole run — which only ever
+/// *over*-reports damage, never under.
+fn diff_sorted<T>(
+    old: &[T],
+    new: &[T],
+    key: impl Fn(&T) -> usize,
+    eq: impl Fn(&T, &T) -> bool,
+    damaged: &mut impl FnMut(&T),
+) {
+    let (mut i, mut j) = (0, 0);
+    while i < old.len() && j < new.len() {
+        let (a, b) = (&old[i], &new[j]);
+        match key(a).cmp(&key(b)) {
+            std::cmp::Ordering::Less => {
+                damaged(a);
+                i += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                damaged(b);
+                j += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                if !eq(a, b) {
+                    damaged(a);
+                    damaged(b);
+                }
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    for a in &old[i..] {
+        damaged(a);
+    }
+    for b in &new[j..] {
+        damaged(b);
     }
 }
 
@@ -288,68 +458,113 @@ pub struct WrapIndex {
     lines: Vec<LineWrap>,
     rows: Fenwick,
     built: bool,
-    /// Version of the plugin inputs the current build reflects. A change means
-    /// the effective text differs without the buffer changing, which local
-    /// repair cannot express — see [`WrapIndex::damage_all`].
-    pipeline_inputs_version: u64,
-    /// The decorations this build was made with, kept so repair rebuilds a line
-    /// the same way the full build did. Safe to hold across edits: any change to
-    /// the decorations themselves bumps `pipeline_inputs_version`, which forces a
-    /// rebuild rather than a repair, so a repair only ever sees a pure-text edit
-    /// against the snapshot it was built with.
+    /// Versions of the pipeline inputs the current build reflects, kept
+    /// per-component so staleness has a *shape*: a buffer mismatch is repaired
+    /// by [`WrapIndex::damage_bytes`], a decoration mismatch by diffing the
+    /// stored snapshot against the fresh one (see [`WrapIndex::ensure_built`]).
+    inputs: crate::view::line_wrap_cache::PipelineInputs,
+    /// The decorations this build reflects, in **current buffer coordinates**:
+    /// repairs rebuild lines against it, and `damage_bytes` shifts its
+    /// positions the way the live markers shifted, so it never goes stale
+    /// across text edits. Content changes arrive by diff — `ensure_built`
+    /// compares it against the freshly resolved snapshot and repairs exactly
+    /// the lines where they disagree.
     decorations: IndexDecorations,
     stats: WrapIndexStats,
 }
 
-/// How much full rebuilding this index has done.
+/// How much building this index has done, and through which channel.
 ///
-/// `ensure_built` is O(buffer) — it lays out every logical line — so
-/// `lines_built` divided by the buffer's line count is how many times the whole
-/// document has been re-laid-out. One is the design; one *per frame* is what a
-/// stream of `pipeline_inputs_version` bumps produces, and is the difference
-/// between a scroll that costs the viewport and a scroll that costs the file.
+/// A full rebuild is O(buffer) — it lays out every logical line — so
+/// `lines_built` divided by the buffer's line count is how many times the
+/// whole document has been re-laid-out; one is the design. Decoration changes
+/// land in `decoration_repairs` / `lines_repaired` instead, and during a
+/// scroll through a plugin-decorated file the repaired count tracks the lines
+/// the plugin touched — the difference between a scroll that costs the
+/// viewport and one that costs the file.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct WrapIndexStats {
     pub rebuilds: u64,
     pub lines_built: u64,
+    pub decoration_repairs: u64,
+    pub lines_repaired: u64,
+}
+
+impl WrapIndexStats {
+    fn merge(self, other: WrapIndexStats) -> WrapIndexStats {
+        WrapIndexStats {
+            rebuilds: self.rebuilds + other.rebuilds,
+            lines_built: self.lines_built + other.lines_built,
+            decoration_repairs: self.decoration_repairs + other.decoration_repairs,
+            lines_repaired: self.lines_repaired + other.lines_repaired,
+        }
+    }
 }
 
 impl WrapIndex {
-    pub fn is_built_for(&self, geometry: &WrapIndexGeometry, pipeline_inputs_version: u64) -> bool {
-        self.built
-            && self.geometry.as_ref() == Some(geometry)
-            && self.pipeline_inputs_version == pipeline_inputs_version
+    pub fn is_built_for(
+        &self,
+        geometry: &WrapIndexGeometry,
+        inputs: crate::view::line_wrap_cache::PipelineInputs,
+    ) -> bool {
+        self.built && self.geometry.as_ref() == Some(geometry) && self.inputs == inputs
     }
 
     pub fn lines(&self) -> &[LineWrap] {
         &self.lines
     }
 
-    /// Full-rebuild work this index has done. See [`WrapIndexStats`].
+    /// Build work this index has done. See [`WrapIndexStats`].
     pub fn stats(&self) -> WrapIndexStats {
         self.stats
     }
 
-    /// Build for `geometry`, unless already current.
+    /// Make the index current for `geometry`, choosing the cheapest sufficient
+    /// path:
     ///
-    /// The build is the one O(buffer) operation in the design; everything after
-    /// it is repair. Callers gate it the way `scrollbar_line_counts` does.
+    /// * everything matches — free;
+    /// * only the decoration versions moved — diff the stored snapshot against
+    ///   `decorations` and rebuild exactly the disagreeing lines. This is what
+    ///   keeps a first scroll through a plugin-decorated file O(viewport) per
+    ///   frame: each `lines_changed` batch damages only the lines it decorated,
+    ///   while the rebuild-per-frame it replaced cost O(buffer) per frame;
+    /// * the buffer version or geometry moved — full rebuild, the one
+    ///   O(buffer) operation in the design. (Buffer edits normally arrive via
+    ///   [`WrapIndex::damage_bytes`] and never reach this case; hitting it
+    ///   means the index was cold or the buffer was replaced wholesale.)
     pub fn ensure_built(
         &mut self,
         buffer: &mut Buffer,
         geometry: WrapIndexGeometry,
-        pipeline_inputs_version: u64,
+        inputs: crate::view::line_wrap_cache::PipelineInputs,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
         decorations: &IndexDecorations,
     ) {
-        if self.is_built_for(&geometry, pipeline_inputs_version) {
+        if self.is_built_for(&geometry, inputs) {
             return;
         }
+        if self.built
+            && self.geometry.as_ref() == Some(&geometry)
+            && self.inputs.buffer == inputs.buffer
+            && self.repair_decorations(buffer, inputs, line_ending, decorations)
+        {
+            return;
+        }
+        self.rebuild_full(buffer, geometry, inputs, line_ending, decorations);
+    }
+
+    fn rebuild_full(
+        &mut self,
+        buffer: &mut Buffer,
+        geometry: WrapIndexGeometry,
+        inputs: crate::view::line_wrap_cache::PipelineInputs,
+        line_ending: LineEnding,
+        decorations: &IndexDecorations,
+    ) {
         let line_count = buffer.line_count().unwrap_or(1).max(1);
         let mut lines = Vec::with_capacity(line_count);
         for line in 0..line_count {
-            let vrows = line_virtual_rows(buffer, line, virtual_rows);
+            let vrows = line_virtual_rows(buffer, line, decorations);
             lines.push(build_line(
                 buffer,
                 line,
@@ -365,9 +580,68 @@ impl WrapIndex {
         self.rows.rebuild(&counts);
         self.lines = lines;
         self.geometry = Some(geometry);
-        self.pipeline_inputs_version = pipeline_inputs_version;
+        self.inputs = inputs;
         self.decorations = decorations.clone();
         self.built = true;
+    }
+
+    /// Adopt a decoration change by rebuilding only the lines where the stored
+    /// snapshot and `decorations` disagree. Returns `false` when a rebuild is
+    /// the better tool — the damage covers most of the buffer, or the line
+    /// count disagrees (a text edit that bypassed `damage_bytes`).
+    ///
+    /// Sound because both snapshots are in current buffer coordinates
+    /// (`damage_bytes` keeps the stored one shifted), so a line outside every
+    /// diff range sees byte-identical decorations under either snapshot and
+    /// its layout cannot differ. Decorations never change the *logical* line
+    /// structure — that is buffer text — so lines are rebuilt in place and no
+    /// splice is needed.
+    fn repair_decorations(
+        &mut self,
+        buffer: &mut Buffer,
+        inputs: crate::view::line_wrap_cache::PipelineInputs,
+        line_ending: LineEnding,
+        decorations: &IndexDecorations,
+    ) -> bool {
+        let line_count = buffer.line_count().unwrap_or(1).max(1);
+        if line_count != self.lines.len() {
+            return false;
+        }
+        let last_line = line_count - 1;
+        // Merge the byte ranges into line spans before deciding anything:
+        // ranges are many and small (one per changed decoration), lines are
+        // what repair pays for.
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+        for range in self.decorations.changed_ranges(decorations) {
+            let first = buffer.get_line_number(range.start.min(buffer.len()));
+            let last = buffer
+                .get_line_number(range.end.min(buffer.len()))
+                .min(last_line);
+            match spans.last_mut() {
+                Some((_, prev_last)) if first <= *prev_last + 1 => {
+                    *prev_last = (*prev_last).max(last)
+                }
+                _ => spans.push((first, last)),
+            }
+        }
+        let damaged: usize = spans.iter().map(|(f, l)| l - f + 1).sum();
+        if damaged > line_count / 2 {
+            return false;
+        }
+
+        // The new snapshot must be in place before any line is rebuilt —
+        // `rebuild_one` reads `self.decorations`.
+        self.decorations = decorations.clone();
+        let geometry = self.geometry.expect("repair_decorations requires a build");
+        for (first, last) in spans {
+            for line in first..=last {
+                self.rebuild_one(buffer, line, geometry.rule, line_ending);
+            }
+        }
+        self.inputs = inputs;
+        self.stats.decoration_repairs += 1;
+        self.stats.lines_repaired += damaged as u64;
+        true
     }
 
     // -- queries -------------------------------------------------------------
@@ -477,13 +751,12 @@ impl WrapIndex {
 
     // -- damage contract -----------------------------------------------------
 
-    /// A plugin input changed; rebuild lazily on the next query.
+    /// Throw the build away; the next query rebuilds from scratch.
     ///
-    /// Soft breaks, conceals, and inline virtual text change the effective text
-    /// being wrapped without the buffer changing, and their managers report only
-    /// a version — not a damaged byte range — so there is nothing local to
-    /// repair. Narrowing this to ranged damage is a later refinement; the
-    /// contract's shape does not change.
+    /// The big hammer, for changes with no expressible locality (buffer
+    /// replaced wholesale). Decoration changes no longer come through here —
+    /// `ensure_built` repairs them by diffing the stored snapshot against the
+    /// fresh one.
     pub fn damage_all(&mut self) {
         self.built = false;
     }
@@ -500,8 +773,7 @@ impl WrapIndex {
         buffer: &mut Buffer,
         edit: EditDamage,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
-        new_pipeline_inputs_version: u64,
+        new_inputs: crate::view::line_wrap_cache::PipelineInputs,
     ) {
         if !self.built {
             return;
@@ -509,18 +781,27 @@ impl WrapIndex {
         let Some(geometry) = self.geometry else {
             return;
         };
-        // Adopt the post-edit version, or the repair is wasted: the version
-        // folds in `buffer.version()`, so every edit changes it, and the next
-        // `ensure_built` would find the index stale and rebuild the whole buffer
-        // from scratch — after this method had just done the incremental work.
-        // Measured at ~26% of a keystroke on a single-line file: the repair
-        // (10.5%) and then the full rebuild (15.6%) that discarded it.
+        // The snapshot mirrors the marker-backed decorations, which the edit
+        // just shifted — shift the mirror the same way *before* any line is
+        // rebuilt against it. (Repairs used to read the unshifted snapshot and
+        // relied on the next decoration bump's full rebuild to heal the drift;
+        // with decoration bumps now repaired by diffing against this snapshot,
+        // it has to be kept honest instead.)
+        self.decorations
+            .shift_for_edit(edit.start, edit.removed, edit.inserted);
+        // Adopt the post-edit *buffer* version, or the repair is wasted: every
+        // edit changes it, and the next `ensure_built` would find the index
+        // stale and rebuild the whole buffer from scratch — after this method
+        // had just done the incremental work. Measured at ~26% of a keystroke
+        // on a single-line file: the repair (10.5%) and then the full rebuild
+        // (15.6%) that discarded it.
         //
-        // Sound because a repair only ever describes a *text* edit. The
-        // decoration managers' versions are the other half of this value and
-        // they cannot move in the same call — a decoration change comes through
-        // `damage_all`, which invalidates instead.
-        self.pipeline_inputs_version = new_pipeline_inputs_version;
+        // Only the buffer component: this call describes a text edit, and the
+        // decoration components answer a different question. If a decoration
+        // batch landed since the last frame, its versions must still read as
+        // stale afterwards so `ensure_built` diffs and repairs it — adopting
+        // them here would swallow that change until the plugin's next bump.
+        self.inputs.buffer = new_inputs.buffer;
         let new_last = buffer.get_line_number(edit.start + edit.inserted);
         let spans_lines = edit.line_end_before != edit.line_before || new_last != edit.line_before;
         let line_count = buffer.line_count().unwrap_or(1).max(1);
@@ -536,12 +817,11 @@ impl WrapIndex {
                 edit.line_end_before,
                 new_last,
                 line_ending,
-                virtual_rows,
             );
             return;
         }
 
-        self.repair_line(buffer, geometry.rule, edit, line_ending, virtual_rows);
+        self.repair_line(buffer, geometry.rule, edit, line_ending);
     }
 
     /// Rebuild old lines `[first, old_last]` as new lines `[first, new_last]`.
@@ -549,7 +829,6 @@ impl WrapIndex {
     /// Lines before `first` are untouched. Lines after keep their `LineWrap`
     /// unchanged — `row_starts` are line-relative, so a line that merely shifted
     /// in the buffer needs no work at all.
-    #[allow(clippy::too_many_arguments)]
     fn repair_span(
         &mut self,
         buffer: &mut Buffer,
@@ -558,12 +837,11 @@ impl WrapIndex {
         old_last: usize,
         new_last: usize,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
     ) {
         let first = first.min(self.lines.len());
         let mut rebuilt = Vec::new();
         for line in first..=new_last {
-            let vrows = line_virtual_rows(buffer, line, virtual_rows);
+            let vrows = line_virtual_rows(buffer, line, &self.decorations);
             rebuilt.push(build_line(
                 buffer,
                 line,
@@ -591,7 +869,6 @@ impl WrapIndex {
         rule: WrapRule,
         edit: EditDamage,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
     ) {
         let line = edit.line_before;
         if line >= self.lines.len() {
@@ -616,11 +893,11 @@ impl WrapIndex {
             resume_idx -= 1;
         }
         if !self.lines[line].resumable[resume_idx] {
-            self.rebuild_one(buffer, line, rule, line_ending, virtual_rows);
+            self.rebuild_one(buffer, line, rule, line_ending);
             return;
         }
 
-        let vrows = line_virtual_rows(buffer, line, virtual_rows);
+        let vrows = line_virtual_rows(buffer, line, &self.decorations);
         let line_start = buffer.line_start_offset(line).unwrap_or(0);
         let resume_rel = self.lines[line].row_starts[resume_idx];
         let resume_carry = self.lines[line].carries[resume_idx];
@@ -641,7 +918,7 @@ impl WrapIndex {
         // longer address anything while the line still has content.
         let tail = tokens_from(&stream, resume_byte);
         if !resume_is_safe(&stream, resume_byte) || (tail.is_empty() && !stream.is_empty()) {
-            self.rebuild_one(buffer, line, rule, line_ending, virtual_rows);
+            self.rebuild_one(buffer, line, rule, line_ending);
             return;
         }
 
@@ -745,10 +1022,9 @@ impl WrapIndex {
         line: usize,
         rule: WrapRule,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
     ) {
         let old_total = self.lines[line].total_rows();
-        let vrows = line_virtual_rows(buffer, line, virtual_rows);
+        let vrows = line_virtual_rows(buffer, line, &self.decorations);
         self.lines[line] = build_line(buffer, line, rule, line_ending, vrows, &self.decorations);
         let new_total = self.lines[line].total_rows();
         self.rows.set(line, old_total, new_total);
@@ -779,18 +1055,17 @@ impl EditDamage {
     }
 }
 
-/// Virtual rows anchored in `line`, resolved through the caller's span lookup.
-fn line_virtual_rows(
-    buffer: &mut Buffer,
-    line: usize,
-    virtual_rows: &dyn Fn(usize, usize) -> u32,
-) -> u32 {
+/// Virtual rows anchored in `line`, resolved from the decoration snapshot.
+fn line_virtual_rows(buffer: &mut Buffer, line: usize, decorations: &IndexDecorations) -> u32 {
+    if decorations.virtual_lines.is_empty() {
+        return 0;
+    }
     let start = buffer.line_start_offset(line).unwrap_or(0);
     let end = buffer
         .line_start_offset(line + 1)
         .unwrap_or_else(|| buffer.len())
         .min(buffer.len());
-    virtual_rows(start, end)
+    decorations.virtual_rows_in(start, end)
 }
 
 /// Canonical token stream for one logical line: the renderer's decoration chain.
@@ -1112,8 +1387,11 @@ mod tests {
         }
     }
 
-    fn no_virtual(_line_start: usize, _line_end: usize) -> u32 {
-        0
+    fn inputs(buffer_version: u64) -> crate::view::line_wrap_cache::PipelineInputs {
+        crate::view::line_wrap_cache::PipelineInputs {
+            buffer: buffer_version,
+            ..Default::default()
+        }
     }
 
     fn built(buffer: &mut Buffer, width: usize) -> WrapIndex {
@@ -1121,9 +1399,8 @@ mod tests {
         index.ensure_built(
             buffer,
             geometry(width),
-            0,
+            inputs(0),
             LineEnding::LF,
-            &no_virtual,
             &IndexDecorations::default(),
         );
         index
@@ -1163,8 +1440,7 @@ mod tests {
                 line_end_before,
             },
             LineEnding::LF,
-            &no_virtual,
-            0,
+            inputs(0),
         );
     }
 
@@ -1190,8 +1466,7 @@ mod tests {
         let line_before = buffer.get_line_number(start);
         let line_start_before = buffer.line_start_offset(line_before).unwrap_or(0);
         buffer.insert(start, "x");
-        let after =
-            crate::view::line_wrap_cache::pipeline_inputs_version(buffer.version(), 0, 0, 0);
+        let after = inputs(buffer.version());
         assert!(
             !index.is_built_for(&geom, after),
             "precondition: the edit must have staled the version"
@@ -1208,7 +1483,6 @@ mod tests {
                 line_end_before: line_before,
             },
             LineEnding::LF,
-            &no_virtual,
             after,
         );
 
@@ -1217,6 +1491,240 @@ mod tests {
             "the repair left the index stale, so the next render rebuilds and \
              the repair was wasted"
         );
+    }
+
+    /// A build with `decorations` from scratch, for comparing repairs against.
+    fn built_with(buffer: &mut Buffer, width: usize, decorations: &IndexDecorations) -> WrapIndex {
+        let mut index = WrapIndex::default();
+        index.ensure_built(
+            buffer,
+            geometry(width),
+            inputs(0),
+            LineEnding::LF,
+            decorations,
+        );
+        index
+    }
+
+    /// Prose that wraps at the test width, so decorations move real row
+    /// boundaries.
+    fn paragraphs(lines: usize) -> String {
+        (0..lines)
+            .map(|i| long_line(12 + (i % 5)))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The core of the diff-repair contract: a decoration change re-lays-out
+    /// only the lines it touched, and the result is indistinguishable from a
+    /// from-scratch build with the new snapshot. This is what turned a first
+    /// scroll through a plugin-decorated file from O(frames x buffer) into
+    /// O(frames x batch).
+    #[test]
+    fn decoration_change_repairs_only_touched_lines_and_equals_rebuild() {
+        let text = paragraphs(60);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let mut index = built(&mut buffer, 20);
+        assert_eq!(index.stats().rebuilds, 1);
+
+        // A plugin batch decorates a handful of lines mid-document: a soft
+        // break, a conceal, and a virtual line, all in lines 30..33.
+        let l30 = buffer.line_start_offset(30).unwrap();
+        let l31 = buffer.line_start_offset(31).unwrap();
+        let l32 = buffer.line_start_offset(32).unwrap();
+        let decorations = IndexDecorations {
+            soft_breaks: vec![(l30 + 10, 2)],
+            conceals: vec![(l31 + 2..l31 + 8, Some("*".to_string()))],
+            virtual_lines: vec![l32],
+            ..Default::default()
+        };
+        let bumped = crate::view::line_wrap_cache::PipelineInputs {
+            conceals: 1,
+            soft_breaks: 1,
+            virtual_text: 1,
+            ..inputs(0)
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry(20),
+            bumped,
+            LineEnding::LF,
+            &decorations,
+        );
+
+        let stats = index.stats();
+        assert_eq!(stats.rebuilds, 1, "the change must not trigger a rebuild");
+        assert_eq!(stats.decoration_repairs, 1);
+        assert!(
+            stats.lines_repaired <= 6,
+            "three decorated lines should repair a handful of lines, not {}",
+            stats.lines_repaired
+        );
+        assert!(
+            index.is_built_for(&geometry(20), bumped),
+            "the repair must leave the index current"
+        );
+
+        let fresh = built_with(&mut buffer, 20, &decorations);
+        assert_eq!(structure(&index), structure(&fresh));
+        assert_eq!(index.total_rows(), fresh.total_rows());
+    }
+
+    /// Removing decorations is damage too: the diff sees entries present only
+    /// in the *old* snapshot and repairs their lines back to plain layout.
+    #[test]
+    fn decoration_removal_repairs_back_to_plain_layout() {
+        let text = paragraphs(40);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let l20 = buffer.line_start_offset(20).unwrap();
+        let decorated = IndexDecorations {
+            soft_breaks: vec![(l20 + 8, 0)],
+            ..Default::default()
+        };
+        let mut index = built_with(&mut buffer, 20, &decorated);
+        let plain_rows = built(&mut buffer, 20).total_rows();
+        assert_ne!(index.total_rows(), plain_rows, "the soft break added a row");
+
+        let bumped = crate::view::line_wrap_cache::PipelineInputs {
+            soft_breaks: 1,
+            ..inputs(0)
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry(20),
+            bumped,
+            LineEnding::LF,
+            &IndexDecorations::default(),
+        );
+        assert_eq!(index.stats().rebuilds, 1);
+        assert_eq!(index.stats().decoration_repairs, 1);
+        assert_eq!(index.total_rows(), plain_rows);
+    }
+
+    /// A version bump with no actual decoration change — plugins republish
+    /// identical state all the time — adopts the new version for free instead
+    /// of rebuilding anything.
+    #[test]
+    fn no_op_decoration_bump_repairs_zero_lines() {
+        let text = paragraphs(30);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let mut index = built(&mut buffer, 20);
+
+        let bumped = crate::view::line_wrap_cache::PipelineInputs {
+            conceals: 7,
+            ..inputs(0)
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry(20),
+            bumped,
+            LineEnding::LF,
+            &IndexDecorations::default(),
+        );
+        let stats = index.stats();
+        assert_eq!(
+            (stats.rebuilds, stats.lines_repaired),
+            (1, 0),
+            "identical snapshots must cost nothing"
+        );
+        assert!(index.is_built_for(&geometry(20), bumped));
+    }
+
+    /// The snapshot shifts with text edits, so a decoration diff computed
+    /// *after* an edit compares like coordinates with like: an edit above the
+    /// decorated region followed by an unrelated decoration change must not
+    /// see the shifted entries as damage and re-lay-out their lines.
+    #[test]
+    fn snapshot_shifts_with_edits_so_later_diffs_stay_local() {
+        let text = paragraphs(50);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let l30 = buffer.line_start_offset(30).unwrap();
+        let l40 = buffer.line_start_offset(40).unwrap();
+        let mut decorations = IndexDecorations {
+            soft_breaks: vec![(l30 + 5, 0)],
+            conceals: vec![(l30 + 12..l30 + 15, None)],
+            ..Default::default()
+        };
+        let mut index = built_with(&mut buffer, 20, &decorations);
+
+        // Text edit on line 0, far above the decorations.
+        let ins = "prefix ";
+        buffer.insert(0, ins);
+        let after_edit = inputs(buffer.version());
+        index.damage_bytes(
+            &mut buffer,
+            EditDamage {
+                start: 0,
+                removed: 0,
+                inserted: ins.len(),
+                line_before: 0,
+                line_start_before: 0,
+                line_end_before: 0,
+            },
+            LineEnding::LF,
+            after_edit,
+        );
+
+        // The plugin now decorates line 40; the line-30 entries have shifted
+        // in the live managers, and the caller's fresh snapshot reflects that.
+        decorations.shift_for_edit(0, 0, ins.len());
+        decorations.soft_breaks.push((l40 + ins.len() + 4, 0));
+        let bumped = crate::view::line_wrap_cache::PipelineInputs {
+            soft_breaks: 1,
+            ..after_edit
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry(20),
+            bumped,
+            LineEnding::LF,
+            &decorations,
+        );
+
+        let stats = index.stats();
+        assert_eq!(stats.rebuilds, 1, "no full rebuild anywhere in this dance");
+        assert!(
+            stats.lines_repaired <= 2,
+            "only the newly decorated line should repair; repaired {}",
+            stats.lines_repaired
+        );
+        let fresh = built_with(&mut buffer, 20, &decorations);
+        assert_eq!(structure(&index), structure(&fresh));
+    }
+
+    /// Damage spanning most of the document falls back to one full rebuild —
+    /// cheaper than line-at-a-time repair and the honest description of what
+    /// happened.
+    #[test]
+    fn mass_decoration_change_falls_back_to_rebuild() {
+        let text = paragraphs(40);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let mut index = built(&mut buffer, 20);
+
+        let breaks: Vec<(usize, u16)> = (0..40)
+            .map(|l| (buffer.line_start_offset(l).unwrap() + 3, 0))
+            .collect();
+        let decorations = IndexDecorations {
+            soft_breaks: breaks,
+            ..Default::default()
+        };
+        let bumped = crate::view::line_wrap_cache::PipelineInputs {
+            soft_breaks: 1,
+            ..inputs(0)
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry(20),
+            bumped,
+            LineEnding::LF,
+            &decorations,
+        );
+
+        let stats = index.stats();
+        assert_eq!(stats.rebuilds, 2, "every line damaged -> rebuild, once");
+        assert_eq!(stats.decoration_repairs, 0);
+        let fresh = built_with(&mut buffer, 20, &decorations);
+        assert_eq!(structure(&index), structure(&fresh));
     }
 
     /// The merge gate for incremental repair: a repaired index is
@@ -1379,9 +1887,8 @@ mod tests {
             set.entry(geometry(width)).ensure_built(
                 &mut buffer,
                 geometry(width),
-                0,
+                inputs(0),
                 LineEnding::LF,
-                &no_virtual,
                 &IndexDecorations::default(),
             );
         }
@@ -1393,6 +1900,7 @@ mod tests {
         let line_before = buffer.get_line_number(start);
         let line_start_before = buffer.line_start_offset(line_before).unwrap_or(0);
         buffer.insert(start, "X");
+        let after_edit = inputs(buffer.version());
         set.damage_bytes(
             &mut buffer,
             EditDamage {
@@ -1404,8 +1912,7 @@ mod tests {
                 line_end_before: line_before,
             },
             LineEnding::LF,
-            &no_virtual,
-            0,
+            after_edit,
         );
 
         for width in [16usize, 40] {
@@ -1571,11 +2078,7 @@ impl WrapIndexSet {
         self.entries
             .iter()
             .fold(WrapIndexStats::default(), |acc, (_, i)| {
-                let s = i.stats();
-                WrapIndexStats {
-                    rebuilds: acc.rebuilds + s.rebuilds,
-                    lines_built: acc.lines_built + s.lines_built,
-                }
+                acc.merge(i.stats())
             })
     }
 
@@ -1626,21 +2129,14 @@ impl WrapIndexSet {
         buffer: &mut Buffer,
         edit: EditDamage,
         line_ending: LineEnding,
-        virtual_rows: &dyn Fn(usize, usize) -> u32,
-        new_pipeline_inputs_version: u64,
+        new_inputs: crate::view::line_wrap_cache::PipelineInputs,
     ) {
         for (_, index) in &mut self.entries {
-            index.damage_bytes(
-                buffer,
-                edit,
-                line_ending,
-                virtual_rows,
-                new_pipeline_inputs_version,
-            );
+            index.damage_bytes(buffer, edit, line_ending, new_inputs);
         }
     }
 
-    /// A plugin input changed; every geometry rebuilds lazily.
+    /// Every geometry rebuilds lazily. See [`WrapIndex::damage_all`].
     pub fn damage_all(&mut self) {
         for (_, index) in &mut self.entries {
             index.damage_all();

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -121,10 +121,12 @@ impl IndexDecorations {
     ///   inside it clamps to `start`, one after it moves back by `removed`.
     /// * **Insertion** is *right gravity*: a position sitting exactly at the
     ///   insertion point is pushed forward. Every decoration anchor in the
-    ///   editor is right-gravity, because `MarkerList::create` stores its
-    ///   `left_affinity` argument in a map nothing reads and always calls
-    ///   `tree.insert`, which is right-gravity. (`conceal.rs` even labels its
-    ///   start marker "left affinity"; the tree does not honour it.)
+    ///   editor is right-gravity, because that is all `MarkerList::create`
+    ///   makes. (It used to take a `left_affinity` flag that never reached
+    ///   the tree, and call sites labelled their markers by that flag rather
+    ///   than by what the tree did — which is how this was written backwards
+    ///   in the first place. The flag is gone; `create_left_gravity` is the
+    ///   real thing.)
     ///
     /// Getting the insertion rule backwards is not a boundary nicety: typing
     /// one character immediately before a conceal left the snapshot's copy of

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -112,29 +112,50 @@ impl IndexDecorations {
     /// Move every stored position the way the buffer's markers moved for this
     /// edit, so the snapshot stays in current buffer coordinates.
     ///
-    /// Positions inside the removed span clamp to its start; positions after
-    /// it shift by the edit's delta; a position exactly at an insertion point
-    /// stays put (left gravity). The live markers resolve gravity per marker,
-    /// so an entry *at* the edit boundary can land one byte off — but such an
-    /// entry is on the edited line, whose decorations the plugin re-emits (the
-    /// edit re-fires `lines_changed` for it), and the re-emit shows up as a
-    /// snapshot diff that repairs the line exactly. Every entry *away* from
-    /// the boundary shifts identically to its marker, no gravity involved.
+    /// This mirrors `MarkerList`, and has to agree with it exactly: the repair
+    /// paths lay lines out against this snapshot, and a position that drifts
+    /// from its marker makes the index describe a line the renderer never
+    /// draws. Two rules, matching `IntervalTree::adjust_recursive`:
     ///
-    /// The map is monotone, so all five lists stay sorted.
+    /// * **Deletion** collapses the removed span onto its start — a position
+    ///   inside it clamps to `start`, one after it moves back by `removed`.
+    /// * **Insertion** is *right gravity*: a position sitting exactly at the
+    ///   insertion point is pushed forward. Every decoration anchor in the
+    ///   editor is right-gravity, because `MarkerList::create` stores its
+    ///   `left_affinity` argument in a map nothing reads and always calls
+    ///   `tree.insert`, which is right-gravity. (`conceal.rs` even labels its
+    ///   start marker "left affinity"; the tree does not honour it.)
+    ///
+    /// Getting the insertion rule backwards is not a boundary nicety: typing
+    /// one character immediately before a conceal left the snapshot's copy of
+    /// it a full insertion-length behind the live one, so the index believed
+    /// the line had fewer visible columns than the renderer drew. Nothing
+    /// detected it either, because an insertion bumps no decoration version,
+    /// so `ensure_built` short-circuits and never reaches the diff. Sources
+    /// that re-publish per edit (markdown_compose) healed a frame later;
+    /// sources that do not (LSP inlay hints) stayed wrong indefinitely.
+    ///
+    /// The composed map is monotone, so all five lists stay sorted.
     pub fn shift_for_edit(&mut self, start: usize, removed: usize, inserted: usize) {
         if removed == 0 && inserted == 0 {
             return;
         }
         let end_old = start + removed;
-        let delta = inserted as i64 - removed as i64;
         let shift = |p: usize| -> usize {
-            if p <= start {
+            // Production applies the halves as separate marker adjustments
+            // (`apply_delete`, then `apply_insert`); a replace is their
+            // composition, so compose them here in the same order.
+            let p = if p <= start {
                 p
             } else if p < end_old {
                 start
             } else {
-                (p as i64 + delta).max(0) as usize
+                p - removed
+            };
+            if p >= start {
+                p + inserted
+            } else {
+                p
             }
         };
         for (p, _) in &mut self.soft_breaks {
@@ -200,8 +221,12 @@ impl IndexDecorations {
             &mut |p: &usize| ranges.push(*p..*p + 1),
         );
         // Folds are part of the geometry key, so two snapshots under one
-        // geometry should agree — diffed anyway so correctness never rests on
-        // `fold_signature` being collision-free.
+        // geometry normally agree and this arm finds nothing. It is not a
+        // backstop against a `fold_signature` collision — folds are not in
+        // `PipelineInputs`, so a fold-only change with a colliding signature
+        // never reaches the diff at all. It earns its place for the case where
+        // some other manager's version moves in the same frame as a fold
+        // change, where it keeps the two snapshots from disagreeing silently.
         diff_sorted(
             &self.folds,
             &new.folds,
@@ -410,7 +435,13 @@ impl Fenwick {
     }
 
     /// Replace entry `i`'s value.
+    ///
+    /// `i` is always a line the caller has already indexed in `lines`, and the
+    /// tree is rebuilt from `lines` whenever that vector's length changes, so
+    /// an out-of-range index means the two have drifted apart — which would
+    /// otherwise show up only as quietly wrong row totals, forever.
     pub fn set(&mut self, i: usize, old: u32, new: u32) {
+        debug_assert!(i < self.n, "Fenwick index {i} out of range for {}", self.n);
         if old != new && i < self.n {
             self.add(i, new as i64 - old as i64);
         }
@@ -477,11 +508,16 @@ pub struct WrapIndex {
 ///
 /// A full rebuild is O(buffer) — it lays out every logical line — so
 /// `lines_built` divided by the buffer's line count is how many times the
-/// whole document has been re-laid-out; one is the design. Decoration changes
-/// land in `decoration_repairs` / `lines_repaired` instead, and during a
-/// scroll through a plugin-decorated file the repaired count tracks the lines
-/// the plugin touched — the difference between a scroll that costs the
-/// viewport and one that costs the file.
+/// whole document has been re-laid-out; one is the design. Everything
+/// incremental lands in `lines_repaired`, counted at the point a line is
+/// actually re-laid-out, so it covers *both* repair channels: decoration
+/// diffs and text edits. Counting only the decoration side would leave a
+/// regression that made every keystroke repair a wide span invisible to the
+/// tests that use these numbers as their cost oracle.
+///
+/// `decoration_repairs` counts diffs that found real work; a version bump
+/// whose snapshot turned out identical is free and is not counted, so the
+/// number means "batches that changed something", not "batches seen".
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct WrapIndexStats {
     pub rebuilds: u64,
@@ -613,7 +649,13 @@ impl WrapIndex {
         // what repair pays for.
         let mut spans: Vec<(usize, usize)> = Vec::new();
         for range in self.decorations.changed_ranges(decorations) {
-            let first = buffer.get_line_number(range.start.min(buffer.len()));
+            // Both ends clamp to a real line: `get_line_number` falls back to
+            // byte arithmetic when the buffer carries no line metadata, and an
+            // unclamped `first` there could exceed `last` and underflow the
+            // width below.
+            let first = buffer
+                .get_line_number(range.start.min(buffer.len()))
+                .min(last_line);
             let last = buffer
                 .get_line_number(range.end.min(buffer.len()))
                 .min(last_line);
@@ -628,6 +670,14 @@ impl WrapIndex {
         if damaged > line_count / 2 {
             return false;
         }
+        if spans.is_empty() {
+            // The versions moved but the decorations did not — plugins
+            // republish identical state constantly. Adopting the versions is
+            // the whole job; an empty diff means the snapshots are equal, so
+            // there is nothing to copy and no layout work to report.
+            self.inputs = inputs;
+            return true;
+        }
 
         // The new snapshot must be in place before any line is rebuilt —
         // `rebuild_one` reads `self.decorations`.
@@ -635,12 +685,13 @@ impl WrapIndex {
         let geometry = self.geometry.expect("repair_decorations requires a build");
         for (first, last) in spans {
             for line in first..=last {
+                // Each `rebuild_one` reports its own line, so `lines_repaired`
+                // needs no separate accounting here.
                 self.rebuild_one(buffer, line, geometry.rule, line_ending);
             }
         }
         self.inputs = inputs;
         self.stats.decoration_repairs += 1;
-        self.stats.lines_repaired += damaged as u64;
         true
     }
 
@@ -757,6 +808,16 @@ impl WrapIndex {
     /// replaced wholesale). Decoration changes no longer come through here —
     /// `ensure_built` repairs them by diffing the stored snapshot against the
     /// fresh one.
+    ///
+    /// Nothing calls this today. The paths that replace a buffer's contents
+    /// outright — file reload, auto-revert, `apply_bulk_edit`'s snapshot
+    /// restore — leave the index alone and rely on `buffer.version()` moving,
+    /// which routes `ensure_built` to a full rebuild. That works, but it is an
+    /// implicit dependency rather than a stated one: `damage_bytes` checks
+    /// only `self.built`, so an edit arriving between such a replacement and
+    /// the next render would repair lines that describe the *old* document and
+    /// then mark the index current. A render always intervenes in practice.
+    /// Calling this from those paths is the explicit fix.
     pub fn damage_all(&mut self) {
         self.built = false;
     }
@@ -839,6 +900,7 @@ impl WrapIndex {
         line_ending: LineEnding,
     ) {
         let first = first.min(self.lines.len());
+        self.stats.lines_repaired += (new_last + 1).saturating_sub(first) as u64;
         let mut rebuilt = Vec::new();
         for line in first..=new_last {
             let vrows = line_virtual_rows(buffer, line, &self.decorations);
@@ -1007,13 +1069,26 @@ impl WrapIndex {
             resumable = vec![true];
         }
 
+        // Every field `build_line` sets has to be refreshed here too, or a
+        // repaired line and a rebuilt one describe the same text differently.
+        // `hidden` is the easy one to forget: it gates `total_rows()` to zero,
+        // so a stale one hides or reveals a line's whole row budget.
+        let line_start = buffer.line_start_offset(line).unwrap_or(0);
+        let line_end = buffer
+            .line_start_offset(line + 1)
+            .unwrap_or_else(|| buffer.len())
+            .min(buffer.len());
+        let hidden = self.decorations.line_is_hidden(line_start, line_end);
+
         let lw = &mut self.lines[line];
         lw.row_starts = starts;
         lw.carries = carries;
         lw.resumable = resumable;
         lw.virtual_rows = vrows;
+        lw.hidden = hidden;
         let new_total = lw.total_rows();
         self.rows.set(line, old_total, new_total);
+        self.stats.lines_repaired += 1;
     }
 
     fn rebuild_one(
@@ -1028,6 +1103,7 @@ impl WrapIndex {
         self.lines[line] = build_line(buffer, line, rule, line_ending, vrows, &self.decorations);
         let new_total = self.lines[line].total_rows();
         self.rows.set(line, old_total, new_total);
+        self.stats.lines_repaired += 1;
     }
 }
 
@@ -1369,6 +1445,7 @@ fn absorb_finished(
 mod tests {
     use super::*;
     use crate::model::filesystem::StdFileSystem;
+    use crate::state::EditorState;
     use std::sync::Arc;
 
     fn test_fs() -> Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> {
@@ -1446,11 +1523,11 @@ mod tests {
 
     /// A repair must leave the index *usable*, not merely correct.
     ///
-    /// `pipeline_inputs_version` folds in `buffer.version()`, so every edit
-    /// changes it. For one release `damage_bytes` updated the rows and left the
-    /// version stale, so the next `ensure_built` found the index out of date and
-    /// rebuilt the whole buffer — the repair ran and was thrown away, ~26% of a
-    /// keystroke doing the same work twice.
+    /// The inputs include `buffer.version()`, so every edit changes them. For
+    /// one release `damage_bytes` updated the rows and left the version stale,
+    /// so the next `ensure_built` found the index out of date and rebuilt the
+    /// whole buffer — the repair ran and was thrown away, ~26% of a keystroke
+    /// doing the same work twice.
     ///
     /// Nothing caught it: `repair_equals_rebuild` compares a repaired index
     /// against a rebuilt one, which is exactly what kept happening. Equality was
@@ -1493,6 +1570,40 @@ mod tests {
         );
     }
 
+    /// Build (or refresh) the index the renderer would use for `geometry` —
+    /// the same call sequence as `render_buffer`, so tests exercise the
+    /// production path rather than a shortcut.
+    fn build_index(state: &mut EditorState, geometry: WrapIndexGeometry) {
+        let decorations = state.index_decorations(geometry.view_mode, Vec::new(), &[]);
+        let inputs = state.pipeline_inputs();
+        let line_ending = state.buffer.line_ending();
+        let index = state.wrap_indices.entry(geometry);
+        index.ensure_built(
+            &mut state.buffer,
+            geometry,
+            inputs,
+            line_ending,
+            &decorations,
+        );
+    }
+
+    /// An index built from scratch against the state's *live* decorations —
+    /// the oracle for what a maintained index must agree with.
+    fn fresh_index(state: &mut EditorState, geometry: WrapIndexGeometry) -> WrapIndex {
+        let decorations = state.index_decorations(geometry.view_mode, Vec::new(), &[]);
+        let inputs = state.pipeline_inputs();
+        let line_ending = state.buffer.line_ending();
+        let mut index = WrapIndex::default();
+        index.ensure_built(
+            &mut state.buffer,
+            geometry,
+            inputs,
+            line_ending,
+            &decorations,
+        );
+        index
+    }
+
     /// A build with `decorations` from scratch, for comparing repairs against.
     fn built_with(buffer: &mut Buffer, width: usize, decorations: &IndexDecorations) -> WrapIndex {
         let mut index = WrapIndex::default();
@@ -1515,17 +1626,16 @@ mod tests {
             .join("\n")
     }
 
-    /// The core of the diff-repair contract: a decoration change re-lays-out
-    /// only the lines it touched, and the result is indistinguishable from a
-    /// from-scratch build with the new snapshot. This is what turned a first
-    /// scroll through a plugin-decorated file from O(frames x buffer) into
-    /// O(frames x batch).
+    /// The cost contract: a decoration change costs the lines it touched, and
+    /// the answer is still what a from-scratch build would say. This is what
+    /// turned a first scroll through a plugin-decorated file from
+    /// O(frames x buffer) into O(frames x batch).
     #[test]
-    fn decoration_change_repairs_only_touched_lines_and_equals_rebuild() {
+    fn a_decoration_change_costs_the_lines_it_touched() {
         let text = paragraphs(60);
         let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
         let mut index = built(&mut buffer, 20);
-        assert_eq!(index.stats().rebuilds, 1);
+        let before = index.stats();
 
         // A plugin batch decorates a handful of lines mid-document: a soft
         // break, a conceal, and a virtual line, all in lines 30..33.
@@ -1552,17 +1662,18 @@ mod tests {
             &decorations,
         );
 
-        let stats = index.stats();
-        assert_eq!(stats.rebuilds, 1, "the change must not trigger a rebuild");
-        assert_eq!(stats.decoration_repairs, 1);
+        let after = index.stats();
+        let laid_out = (after.lines_built - before.lines_built)
+            + (after.lines_repaired - before.lines_repaired);
         assert!(
-            stats.lines_repaired <= 6,
-            "three decorated lines should repair a handful of lines, not {}",
-            stats.lines_repaired
+            laid_out <= 6,
+            "decorating three lines should lay out a handful of lines, not \
+             {laid_out} (the document is {} lines)",
+            index.lines().len(),
         );
         assert!(
             index.is_built_for(&geometry(20), bumped),
-            "the repair must leave the index current"
+            "the index must be current afterwards, or the next frame pays again"
         );
 
         let fresh = built_with(&mut buffer, 20, &decorations);
@@ -1582,8 +1693,12 @@ mod tests {
             ..Default::default()
         };
         let mut index = built_with(&mut buffer, 20, &decorated);
-        let plain_rows = built(&mut buffer, 20).total_rows();
-        assert_ne!(index.total_rows(), plain_rows, "the soft break added a row");
+        let plain = built(&mut buffer, 20);
+        assert_ne!(
+            index.total_rows(),
+            plain.total_rows(),
+            "the soft break added a row"
+        );
 
         let bumped = crate::view::line_wrap_cache::PipelineInputs {
             soft_breaks: 1,
@@ -1596,9 +1711,8 @@ mod tests {
             LineEnding::LF,
             &IndexDecorations::default(),
         );
-        assert_eq!(index.stats().rebuilds, 1);
-        assert_eq!(index.stats().decoration_repairs, 1);
-        assert_eq!(index.total_rows(), plain_rows);
+        assert_eq!(index.total_rows(), plain.total_rows());
+        assert_eq!(structure(&index), structure(&plain));
     }
 
     /// A version bump with no actual decoration change — plugins republish
@@ -1609,6 +1723,7 @@ mod tests {
         let text = paragraphs(30);
         let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
         let mut index = built(&mut buffer, 20);
+        let before = index.stats();
 
         let bumped = crate::view::line_wrap_cache::PipelineInputs {
             conceals: 7,
@@ -1621,85 +1736,174 @@ mod tests {
             LineEnding::LF,
             &IndexDecorations::default(),
         );
-        let stats = index.stats();
-        assert_eq!(
-            (stats.rebuilds, stats.lines_repaired),
-            (1, 0),
-            "identical snapshots must cost nothing"
+        let after = index.stats();
+        let laid_out = (after.lines_built - before.lines_built)
+            + (after.lines_repaired - before.lines_repaired);
+        assert_eq!(laid_out, 0, "identical snapshots must cost no layout work");
+        assert!(
+            index.is_built_for(&geometry(20), bumped),
+            "and the bump must still be adopted, or every later frame re-diffs"
         );
-        assert!(index.is_built_for(&geometry(20), bumped));
     }
 
-    /// The snapshot shifts with text edits, so a decoration diff computed
-    /// *after* an edit compares like coordinates with like: an edit above the
-    /// decorated region followed by an unrelated decoration change must not
-    /// see the shifted entries as damage and re-lay-out their lines.
+    /// **The spec, in one sentence: an index that has been maintained across
+    /// edits must answer exactly as an index built from scratch right now.**
+    ///
+    /// Snapshots, diffs, shifting, repair channels — all of that is mechanism,
+    /// and this test knows none of it. It drives a real [`EditorState`]: real
+    /// decoration managers, real marker tree, the real edit path, and the same
+    /// build call the renderer makes. After each edit it asks the maintained
+    /// index and a fresh one the same questions, and they must agree.
+    ///
+    /// Edits are placed where maintenance is hardest — exactly on a
+    /// decoration's start and end, inside it, and straddling it. Testing the
+    /// maintenance machinery against a hand-computed expectation is what let
+    /// the original bug through: the expectation was derived the same wrong
+    /// way as the code, so both agreed on the wrong answer. A fresh build
+    /// cannot be wrong in the same direction, because it does no maintenance
+    /// at all.
     #[test]
-    fn snapshot_shifts_with_edits_so_later_diffs_stay_local() {
-        let text = paragraphs(50);
-        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
-        let l30 = buffer.line_start_offset(30).unwrap();
-        let l40 = buffer.line_start_offset(40).unwrap();
-        let mut decorations = IndexDecorations {
-            soft_breaks: vec![(l30 + 5, 0)],
-            conceals: vec![(l30 + 12..l30 + 15, None)],
-            ..Default::default()
-        };
-        let mut index = built_with(&mut buffer, 20, &decorations);
+    fn a_maintained_index_answers_like_a_fresh_build() {
+        use crate::model::cursor::Cursors;
+        use crate::model::event::Event;
+        use fresh_core::overlay::OverlayNamespace;
 
-        // Text edit on line 0, far above the decorations.
-        let ins = "prefix ";
-        buffer.insert(0, ins);
-        let after_edit = inputs(buffer.version());
-        index.damage_bytes(
-            &mut buffer,
-            EditDamage {
-                start: 0,
-                removed: 0,
-                inserted: ins.len(),
-                line_before: 0,
-                line_start_before: 0,
-                line_end_before: 0,
-            },
-            LineEnding::LF,
-            after_edit,
-        );
+        /// Narrow enough that hiding or revealing a run of text moves a row
+        /// boundary — otherwise every layout compares equal and the test
+        /// proves nothing.
+        const WIDTH: usize = 20;
+        const LINE: usize = 60;
 
-        // The plugin now decorates line 40; the line-30 entries have shifted
-        // in the live managers, and the caller's fresh snapshot reflects that.
-        decorations.shift_for_edit(0, 0, ins.len());
-        decorations.soft_breaks.push((l40 + ins.len() + 4, 0));
-        let bumped = crate::view::line_wrap_cache::PipelineInputs {
-            soft_breaks: 1,
-            ..after_edit
-        };
-        index.ensure_built(
-            &mut buffer,
-            geometry(20),
-            bumped,
-            LineEnding::LF,
-            &decorations,
-        );
+        #[derive(Debug, Clone, Copy)]
+        enum Edit {
+            Insert(usize, usize),
+            Delete(usize, usize),
+        }
 
-        let stats = index.stats();
-        assert_eq!(stats.rebuilds, 1, "no full rebuild anywhere in this dance");
-        assert!(
-            stats.lines_repaired <= 2,
-            "only the newly decorated line should repair; repaired {}",
-            stats.lines_repaired
+        // Three long lines; a conceal hiding a run of line 1, a soft break in
+        // line 2. Byte layout is fixed so the edit positions below can be
+        // written relative to the decorations.
+        let text = format!(
+            "{}\n{}\n{}\n",
+            "a".repeat(LINE),
+            "b".repeat(LINE),
+            "c".repeat(LINE)
         );
-        let fresh = built_with(&mut buffer, 20, &decorations);
-        assert_eq!(structure(&index), structure(&fresh));
+        let line1 = LINE + 1;
+        let line2 = 2 * (LINE + 1);
+        let conceal = line1 + 10..line1 + 30;
+        let soft_break = line2 + 30;
+
+        let cases = [
+            // The case that mattered: typing where a decoration is anchored.
+            ("insert at conceal start", Edit::Insert(conceal.start, 40)),
+            ("insert at conceal end", Edit::Insert(conceal.end, 40)),
+            ("insert at soft break", Edit::Insert(soft_break, 40)),
+            ("insert inside conceal", Edit::Insert(conceal.start + 5, 40)),
+            ("insert before conceal", Edit::Insert(line1, 40)),
+            (
+                "insert one byte at conceal start",
+                Edit::Insert(conceal.start, 1),
+            ),
+            ("delete up to conceal start", Edit::Delete(line1, 10)),
+            ("delete from conceal start", Edit::Delete(conceal.start, 10)),
+            (
+                "delete straddling conceal end",
+                Edit::Delete(conceal.end - 5, 10),
+            ),
+            ("delete across a line break", Edit::Delete(LINE - 3, 8)),
+        ];
+
+        for (label, edit) in cases {
+            let mut state = EditorState::new(
+                80,
+                24,
+                crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+                test_fs(),
+            );
+            let mut cursors = Cursors::new();
+            let cursor_id = cursors.primary_id();
+            state.apply(
+                &mut cursors,
+                &Event::Insert {
+                    position: 0,
+                    text: text.clone(),
+                    cursor_id,
+                },
+            );
+
+            // Decorate through the real managers, so the real markers carry
+            // these positions through the edit.
+            let ns = OverlayNamespace::from_string("test".to_string());
+            state
+                .conceals
+                .add(&mut state.marker_list, ns.clone(), conceal.clone(), None);
+            state
+                .soft_breaks
+                .add(&mut state.marker_list, ns, soft_break, 0);
+
+            let geom = geometry(WIDTH);
+            build_index(&mut state, geom);
+
+            match edit {
+                Edit::Insert(position, len) => state.apply(
+                    &mut cursors,
+                    &Event::Insert {
+                        position,
+                        text: "x".repeat(len),
+                        cursor_id,
+                    },
+                ),
+                Edit::Delete(start, len) => {
+                    let whole = state.buffer.to_string().expect("buffer is utf-8");
+                    let deleted_text = whole[start..start + len].to_string();
+                    state.apply(
+                        &mut cursors,
+                        &Event::Delete {
+                            range: start..start + len,
+                            deleted_text,
+                            cursor_id,
+                        },
+                    )
+                }
+            }
+
+            // A render follows every edit, so run the same build call it makes
+            // before reading anything back.
+            build_index(&mut state, geom);
+            let maintained = state
+                .wrap_indices
+                .get(&geom)
+                .map(|i| (structure(i), i.total_rows()))
+                .expect("index present");
+
+            let fresh = fresh_index(&mut state, geom);
+            assert_eq!(
+                maintained.0,
+                structure(&fresh),
+                "{label}: maintained index disagrees with a fresh build"
+            );
+            assert_eq!(
+                maintained.1,
+                fresh.total_rows(),
+                "{label}: maintained total rows disagree with a fresh build"
+            );
+        }
     }
 
     /// Damage spanning most of the document falls back to one full rebuild —
-    /// cheaper than line-at-a-time repair and the honest description of what
-    /// happened.
+    /// Decorating every line at once stays correct and stays bounded.
+    ///
+    /// Which strategy the index picks to get there is its own business — the
+    /// promise is that the answer is right and the work is proportional to the
+    /// damage, not quadratic in it.
     #[test]
-    fn mass_decoration_change_falls_back_to_rebuild() {
+    fn a_decoration_change_touching_every_line_stays_bounded() {
         let text = paragraphs(40);
         let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
         let mut index = built(&mut buffer, 20);
+        let line_count = buffer.line_count().unwrap() as u64;
+        let before = index.stats();
 
         let breaks: Vec<(usize, u16)> = (0..40)
             .map(|l| (buffer.line_start_offset(l).unwrap() + 3, 0))
@@ -1720,11 +1924,18 @@ mod tests {
             &decorations,
         );
 
-        let stats = index.stats();
-        assert_eq!(stats.rebuilds, 2, "every line damaged -> rebuild, once");
-        assert_eq!(stats.decoration_repairs, 0);
+        let after = index.stats();
+        let laid_out = (after.lines_built - before.lines_built)
+            + (after.lines_repaired - before.lines_repaired);
+        assert!(
+            laid_out <= line_count,
+            "damaging every line should cost about one pass over the document, \
+             not more: {laid_out} lines laid out for {line_count} lines"
+        );
+
         let fresh = built_with(&mut buffer, 20, &decorations);
         assert_eq!(structure(&index), structure(&fresh));
+        assert_eq!(index.total_rows(), fresh.total_rows());
     }
 
     /// The merge gate for incremental repair: a repaired index is

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -809,15 +809,19 @@ impl WrapIndex {
     /// `ensure_built` repairs them by diffing the stored snapshot against the
     /// fresh one.
     ///
-    /// Nothing calls this today. The paths that replace a buffer's contents
-    /// outright — file reload, auto-revert, `apply_bulk_edit`'s snapshot
-    /// restore — leave the index alone and rely on `buffer.version()` moving,
-    /// which routes `ensure_built` to a full rebuild. That works, but it is an
-    /// implicit dependency rather than a stated one: `damage_bytes` checks
-    /// only `self.built`, so an edit arriving between such a replacement and
-    /// the next render would repair lines that describe the *old* document and
+    /// Its one caller is `EditorState::restore_displaced_markers`, which
+    /// teleports marker positions on undo without any decoration version
+    /// moving — the only change the version-keyed diff cannot see.
+    ///
+    /// The paths that replace a buffer's contents outright — file reload,
+    /// auto-revert, `apply_bulk_edit`'s snapshot restore — still do not call
+    /// it, relying instead on `buffer.version()` moving to route
+    /// `ensure_built` to a full rebuild. That works, but it is an implicit
+    /// dependency rather than a stated one: `damage_bytes` checks only
+    /// `self.built`, so an edit arriving between such a replacement and the
+    /// next render would repair lines that describe the *old* document and
     /// then mark the index current. A render always intervenes in practice.
-    /// Calling this from those paths is the explicit fix.
+    /// Calling this from those paths too is the explicit fix.
     pub fn damage_all(&mut self) {
         self.built = false;
     }

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -298,6 +298,20 @@ pub struct WrapIndex {
     /// rebuild rather than a repair, so a repair only ever sees a pure-text edit
     /// against the snapshot it was built with.
     decorations: IndexDecorations,
+    stats: WrapIndexStats,
+}
+
+/// How much full rebuilding this index has done.
+///
+/// `ensure_built` is O(buffer) — it lays out every logical line — so
+/// `lines_built` divided by the buffer's line count is how many times the whole
+/// document has been re-laid-out. One is the design; one *per frame* is what a
+/// stream of `pipeline_inputs_version` bumps produces, and is the difference
+/// between a scroll that costs the viewport and a scroll that costs the file.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WrapIndexStats {
+    pub rebuilds: u64,
+    pub lines_built: u64,
 }
 
 impl WrapIndex {
@@ -309,6 +323,11 @@ impl WrapIndex {
 
     pub fn lines(&self) -> &[LineWrap] {
         &self.lines
+    }
+
+    /// Full-rebuild work this index has done. See [`WrapIndexStats`].
+    pub fn stats(&self) -> WrapIndexStats {
+        self.stats
     }
 
     /// Build for `geometry`, unless already current.
@@ -340,6 +359,8 @@ impl WrapIndex {
                 decorations,
             ));
         }
+        self.stats.rebuilds += 1;
+        self.stats.lines_built += line_count as u64;
         let counts: Vec<u32> = lines.iter().map(|l| l.total_rows()).collect();
         self.rows.rebuild(&counts);
         self.lines = lines;
@@ -1544,6 +1565,20 @@ pub struct WrapIndexSet {
 const MAX_GEOMETRIES: usize = 4;
 
 impl WrapIndexSet {
+    /// Full-rebuild work summed over every geometry of this buffer. Evicted
+    /// geometries take their counts with them, so this is a floor, not a total.
+    pub fn stats(&self) -> WrapIndexStats {
+        self.entries
+            .iter()
+            .fold(WrapIndexStats::default(), |acc, (_, i)| {
+                let s = i.stats();
+                WrapIndexStats {
+                    rebuilds: acc.rebuilds + s.rebuilds,
+                    lines_built: acc.lines_built + s.lines_built,
+                }
+            })
+    }
+
     /// The index for `geometry`, creating it if this geometry is new.
     ///
     /// The returned index may need building; the caller decides whether to pay

--- a/crates/fresh-editor/tests/e2e/markdown_compose_first_scroll_relayout.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_first_scroll_relayout.rs
@@ -1,0 +1,234 @@
+//! Why the *first* mouse-wheel scroll down a markdown file in compose mode is
+//! extremely slow, and every pass after it is fast.
+//!
+//! # The loop
+//!
+//! 1. `lines_changed` only carries lines the editor has never offered the
+//!    plugin (`Window::seen_byte_ranges`), so a first downward scroll produces
+//!    a fresh batch on every frame — and a second pass over the same lines
+//!    produces none.
+//! 2. For each batch `markdown_compose` adds conceals and soft breaks, which
+//!    bump `ConcealManager::version` / `SoftBreakManager::version`.
+//! 3. Those versions are folded into
+//!    [`pipeline_inputs_version`](fresh::view::line_wrap_cache::pipeline_inputs_version),
+//!    which is the cache key of [`WrapIndex`](fresh::view::wrap_index::WrapIndex).
+//! 4. A key change means `WrapIndex::ensure_built` cannot repair, so it lays
+//!    out **every logical line in the document** again — the one O(buffer)
+//!    operation in the design — on that frame.
+//!
+//! So a first scroll re-lays-out the whole file once per frame. Wheel
+//! scrolling is the worst case because each notch is its own frame with its
+//! own batch: cost is O(notches × document), not O(notches × viewport).
+//!
+//! # Measured against the real binary
+//!
+//! Driving `fresh` in tmux with SGR wheel events, 60 notches, measuring the
+//! process's own CPU (first pass / second pass over the same lines):
+//!
+//! | document | first | second |
+//! |---|---|---|
+//! | 2 003 lines | 0.92 s | 0.12 s |
+//! | 3 511 lines | 1.50 s | 0.11 s |
+//! | 4 915 lines | 1.95 s | 0.14 s |
+//! | 5 201 lines | 0.18 s | 0.12 s |
+//! | 4 915 lines, compose **off** | 0.10 s | 0.11 s |
+//!
+//! First-pass cost is linear in document length and vanishes just past 5 000
+//! lines — `MAX_WRAP_SCROLLBAR_LINES`, above which the index is not built at
+//! all and the effect disappears along with it. So the pathology is bounded to
+//! documents under that ceiling; a genuinely huge file is accidentally spared.
+//!
+//! These tests assert on `WrapIndexStats` — counted layout work, not
+//! wall-clock — so they mean the same thing on any machine.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::view::wrap_index::WrapIndexStats;
+
+/// Lines per document. Comfortably under `MAX_WRAP_SCROLLBAR_LINES` (5 000),
+/// which is where the index stops being built and the effect stops existing.
+const DOC_LINES: usize = 2_400;
+/// Wheel notches per pass, sent one frame at a time the way a wheel arrives.
+const NOTCHES: usize = 60;
+
+/// Prose with the inline markup compose mode decorates — emphasis becomes
+/// conceals, and the length makes it wrap, which produces soft breaks. Both
+/// are what bump the version that invalidates the layout index.
+fn document(lines: usize) -> String {
+    let mut md = String::from("# Document\n\n");
+    let mut n = 2;
+    let mut section = 0;
+    while n < lines {
+        md.push_str(&format!("## Section {section}\n\n"));
+        n += 2;
+        for p in 0..6 {
+            md.push_str(&format!(
+                "Paragraph {p} of section {section}, with **bold** and *italic* \
+                 and `code` spans, written long enough that compose mode has to \
+                 reflow it across several rows of the terminal.\n\n"
+            ));
+            n += 2;
+        }
+        section += 1;
+    }
+    md
+}
+
+fn compose_harness(md: &str) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("doc.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        100,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    (harness, temp_dir)
+}
+
+fn wrap_stats(harness: &EditorTestHarness) -> WrapIndexStats {
+    harness.editor().active_state().wrap_indices.stats()
+}
+
+fn delta(before: WrapIndexStats, after: WrapIndexStats) -> WrapIndexStats {
+    WrapIndexStats {
+        rebuilds: after.rebuilds - before.rebuilds,
+        lines_built: after.lines_built - before.lines_built,
+    }
+}
+
+/// Scroll down `notches` wheel clicks, settling the plugin's decorations
+/// between them the way a real wheel leaves time between frames.
+fn wheel_down(harness: &mut EditorTestHarness, notches: usize) -> WrapIndexStats {
+    let before = wrap_stats(harness);
+    for _ in 0..notches {
+        harness.mouse_scroll_down(10, 10).unwrap();
+        for _ in 0..3 {
+            harness.tick_and_render().unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(8));
+            harness.advance_time(std::time::Duration::from_millis(8));
+        }
+    }
+    delta(before, wrap_stats(harness))
+}
+
+fn wheel_up(harness: &mut EditorTestHarness, notches: usize) {
+    for _ in 0..notches {
+        harness.mouse_scroll_up(10, 10).unwrap();
+    }
+    harness.wait_until_stable(|_| true).unwrap();
+}
+
+/// The reproduction: a first wheel-scroll re-lays-out the whole document over
+/// and over, a second scroll over the same lines lays out nothing.
+#[test]
+fn first_wheel_scroll_relayouts_the_whole_document_repeatedly() {
+    let (mut harness, _tmp) = compose_harness(&document(DOC_LINES));
+    let doc_lines = harness
+        .editor()
+        .active_state()
+        .buffer
+        .line_count()
+        .unwrap_or(DOC_LINES) as u64;
+
+    let first = wheel_down(&mut harness, NOTCHES);
+
+    wheel_up(&mut harness, NOTCHES + 20);
+    let second = wheel_down(&mut harness, NOTCHES);
+
+    eprintln!(
+        "document {doc_lines} lines; first pass: {} rebuilds, {} lines laid out \
+         ({:.1}x the document); second pass: {} rebuilds, {} lines laid out",
+        first.rebuilds,
+        first.lines_built,
+        first.lines_built as f64 / doc_lines as f64,
+        second.rebuilds,
+        second.lines_built,
+    );
+
+    assert!(
+        first.lines_built > doc_lines * 5,
+        "a first wheel-scroll should be re-laying out the whole document many \
+         times over: {} lines laid out for a {doc_lines}-line document",
+        first.lines_built,
+    );
+    assert!(
+        second.lines_built * 4 < first.lines_built,
+        "the second pass over the same lines should lay out far less; \
+         first {} lines, second {}",
+        first.lines_built,
+        second.lines_built,
+    );
+}
+
+/// The control that names the trigger: the same document, the same scroll,
+/// with compose mode off. No plugin decorations arrive, so
+/// `pipeline_inputs_version` never moves, the index is built once, and the
+/// first pass costs the same as the second.
+#[test]
+fn without_compose_mode_the_index_is_built_once() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let md_path = temp_dir.path().join("doc.md");
+    std::fs::write(&md_path, document(DOC_LINES)).unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        100,
+        40,
+        Default::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    let doc_lines = harness
+        .editor()
+        .active_state()
+        .buffer
+        .line_count()
+        .unwrap_or(DOC_LINES) as u64;
+
+    let first = wheel_down(&mut harness, NOTCHES);
+
+    eprintln!(
+        "no compose: {} rebuilds, {} lines laid out for a {doc_lines}-line document",
+        first.rebuilds, first.lines_built,
+    );
+
+    assert!(
+        first.lines_built < doc_lines * 3,
+        "with no decorations arriving, a scroll should not keep re-laying out \
+         the document: {} lines laid out for {doc_lines} lines",
+        first.lines_built,
+    );
+}

--- a/crates/fresh-editor/tests/e2e/markdown_compose_first_scroll_relayout.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_first_scroll_relayout.rs
@@ -1,7 +1,8 @@
-//! Why the *first* mouse-wheel scroll down a markdown file in compose mode is
-//! extremely slow, and every pass after it is fast.
+//! Regression tests for the bug where the *first* mouse-wheel scroll down a
+//! markdown file in compose mode was extremely slow while every pass after it
+//! was fast.
 //!
-//! # The loop
+//! # The loop that caused it
 //!
 //! 1. `lines_changed` only carries lines the editor has never offered the
 //!    plugin (`Window::seen_byte_ranges`), so a first downward scroll produces
@@ -9,34 +10,25 @@
 //!    produces none.
 //! 2. For each batch `markdown_compose` adds conceals and soft breaks, which
 //!    bump `ConcealManager::version` / `SoftBreakManager::version`.
-//! 3. Those versions are folded into
-//!    [`pipeline_inputs_version`](fresh::view::line_wrap_cache::pipeline_inputs_version),
-//!    which is the cache key of [`WrapIndex`](fresh::view::wrap_index::WrapIndex).
-//! 4. A key change means `WrapIndex::ensure_built` cannot repair, so it lays
-//!    out **every logical line in the document** again — the one O(buffer)
-//!    operation in the design — on that frame.
+//! 3. Those versions are part of
+//!    [`PipelineInputs`](fresh::view::line_wrap_cache::PipelineInputs), the
+//!    cache key of [`WrapIndex`](fresh::view::wrap_index::WrapIndex).
+//! 4. The key was a packed integer, so `ensure_built` could only compare it
+//!    for equality — any decoration change forced a re-layout of **every
+//!    logical line in the document**, once per frame. Cost was O(notches ×
+//!    document); measured against the release binary in tmux, a 60-notch
+//!    first pass on a 4 915-line file cost 1.95 s of CPU against 0.14 s for
+//!    the second pass, growing linearly with document length up to
+//!    `MAX_WRAP_SCROLLBAR_LINES` (5 000), past which the index is not built.
 //!
-//! So a first scroll re-lays-out the whole file once per frame. Wheel
-//! scrolling is the worst case because each notch is its own frame with its
-//! own batch: cost is O(notches × document), not O(notches × viewport).
+//! # The fix these tests lock in
 //!
-//! # Measured against the real binary
-//!
-//! Driving `fresh` in tmux with SGR wheel events, 60 notches, measuring the
-//! process's own CPU (first pass / second pass over the same lines):
-//!
-//! | document | first | second |
-//! |---|---|---|
-//! | 2 003 lines | 0.92 s | 0.12 s |
-//! | 3 511 lines | 1.50 s | 0.11 s |
-//! | 4 915 lines | 1.95 s | 0.14 s |
-//! | 5 201 lines | 0.18 s | 0.12 s |
-//! | 4 915 lines, compose **off** | 0.10 s | 0.11 s |
-//!
-//! First-pass cost is linear in document length and vanishes just past 5 000
-//! lines — `MAX_WRAP_SCROLLBAR_LINES`, above which the index is not built at
-//! all and the effect disappears along with it. So the pathology is bounded to
-//! documents under that ceiling; a genuinely huge file is accidentally spared.
+//! `WrapIndex` now keeps its decoration snapshot in current buffer
+//! coordinates and, when only the decoration versions moved, diffs the stored
+//! snapshot against the fresh one and re-lays-out exactly the disagreeing
+//! lines (`WrapIndex::repair_decorations`). A first scroll therefore costs
+//! O(notches × batch) — the lines the plugin actually decorated — and the
+//! whole-document rebuild happens once, when the index is first built.
 //!
 //! These tests assert on `WrapIndexStats` — counted layout work, not
 //! wall-clock — so they mean the same thing on any machine.
@@ -122,6 +114,8 @@ fn delta(before: WrapIndexStats, after: WrapIndexStats) -> WrapIndexStats {
     WrapIndexStats {
         rebuilds: after.rebuilds - before.rebuilds,
         lines_built: after.lines_built - before.lines_built,
+        decoration_repairs: after.decoration_repairs - before.decoration_repairs,
+        lines_repaired: after.lines_repaired - before.lines_repaired,
     }
 }
 
@@ -147,10 +141,17 @@ fn wheel_up(harness: &mut EditorTestHarness, notches: usize) {
     harness.wait_until_stable(|_| true).unwrap();
 }
 
-/// The reproduction: a first wheel-scroll re-lays-out the whole document over
-/// and over, a second scroll over the same lines lays out nothing.
+/// The regression this file exists for: a first wheel-scroll must cost the
+/// lines the plugin decorated, not the document times the frame count.
+///
+/// Layout work is bounded by a small multiple of the document: the initial
+/// index build(s) are O(document) each and legitimate, and the diff repairs
+/// touch each newly decorated line a bounded number of times. Before the fix
+/// this scroll laid out ~82x the document (197 702 lines for a 2 411-line
+/// file); the bound here is an order of magnitude under that while leaving
+/// room for an extra build on a geometry change.
 #[test]
-fn first_wheel_scroll_relayouts_the_whole_document_repeatedly() {
+fn first_wheel_scroll_costs_the_batches_not_the_document() {
     let (mut harness, _tmp) = compose_harness(&document(DOC_LINES));
     let doc_lines = harness
         .editor()
@@ -165,34 +166,46 @@ fn first_wheel_scroll_relayouts_the_whole_document_repeatedly() {
     let second = wheel_down(&mut harness, NOTCHES);
 
     eprintln!(
-        "document {doc_lines} lines; first pass: {} rebuilds, {} lines laid out \
-         ({:.1}x the document); second pass: {} rebuilds, {} lines laid out",
+        "document {doc_lines} lines; first pass: {} rebuilds / {} lines built, \
+         {} repairs / {} lines repaired; second pass: {} rebuilds / {} lines \
+         built, {} repairs / {} lines repaired",
         first.rebuilds,
         first.lines_built,
-        first.lines_built as f64 / doc_lines as f64,
+        first.decoration_repairs,
+        first.lines_repaired,
         second.rebuilds,
         second.lines_built,
+        second.decoration_repairs,
+        second.lines_repaired,
     );
 
     assert!(
-        first.lines_built > doc_lines * 5,
-        "a first wheel-scroll should be re-laying out the whole document many \
-         times over: {} lines laid out for a {doc_lines}-line document",
+        first.lines_built <= doc_lines * 4,
+        "a first wheel-scroll must not re-lay-out the document per frame: \
+         {} lines built for a {doc_lines}-line document",
         first.lines_built,
     );
     assert!(
-        second.lines_built * 4 < first.lines_built,
-        "the second pass over the same lines should lay out far less; \
-         first {} lines, second {}",
-        first.lines_built,
-        second.lines_built,
+        first.decoration_repairs > 0,
+        "the plugin's batches should be arriving as diff repairs"
+    );
+    assert!(
+        first.lines_repaired <= doc_lines * 4,
+        "diff repairs should touch each decorated line a bounded number of \
+         times: {} lines repaired for a {doc_lines}-line document",
+        first.lines_repaired,
+    );
+    assert_eq!(
+        second.lines_built, 0,
+        "a second pass over the same lines produces no batches and must \
+         build nothing"
     );
 }
 
 /// The control that names the trigger: the same document, the same scroll,
-/// with compose mode off. No plugin decorations arrive, so
-/// `pipeline_inputs_version` never moves, the index is built once, and the
-/// first pass costs the same as the second.
+/// with compose mode off. No plugin decorations arrive, so the pipeline
+/// inputs never move, the index is built once, and the first pass costs the
+/// same as the second.
 #[test]
 fn without_compose_mode_the_index_is_built_once() {
     init_tracing_from_env();

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
@@ -1,35 +1,29 @@
-//! Reproduction and attribution for "scrolling down a large markdown buffer is
-//! very slow the first time" — driven through the real `markdown_compose`
-//! plugin, on a document with the inline markup compose mode actually
-//! decorates.
+//! Attribution tests for "scrolling down a large markdown buffer is very slow
+//! the first time" — driven through the real `markdown_compose` plugin, on a
+//! document with the inline markup compose mode actually decorates.
 //!
-//! # The symptom is real
+//! The asymmetry the report described comes from `Window::seen_byte_ranges`:
+//! `lines_changed` only ever carries lines the editor has never offered the
+//! plugin before, so a first pass runs the whole per-line decoration pipeline
+//! — emphasis overlays, conceals, soft breaks, heading marks — and a second
+//! pass over the same lines runs none of it. The dominant cost — the wrap
+//! index rebuilding the whole document once per frame — is fixed (diff
+//! repair; see `markdown_compose_first_scroll_relayout`, which locks it), so
+//! the first pass now pays only the one-time decoration work itself.
 //!
-//! A first downward pass costs several times what a second pass over the same
-//! lines costs (`first_scroll_costs_far_more_than_the_second`). The asymmetry
-//! comes from `Window::seen_byte_ranges`: `lines_changed` only ever carries
-//! lines the editor has never offered the plugin before, so the first pass
-//! runs the whole per-line decoration pipeline — emphasis overlays, conceals,
-//! soft breaks, heading marks — and the second pass runs none of it.
+//! What this file pins down is the scrollbar half of the story:
 //!
-//! # It is not the scrollbar's heading marks
-//!
-//! The report suspected the heading marks on the scrollbar track, and there is
-//! a genuine inefficiency there: the plugin republishes for every batch, which
-//! moves the marker version, which misses `ProjectionKey` and re-walks every
-//! heading found so far — once per frame of the scroll, i.e. O(frames ×
-//! headings). `first_scroll_reprojects_every_heading_on_every_frame` measures
-//! that, and `view::ui::split_rendering::scrollbar_marker_scroll_perf` measures
-//! its growth in isolation.
-//!
-//! But it is nowhere near big enough to be the reported slowness.
-//! `heading_marks_are_not_the_reason` runs the same scroll over the same
-//! document with the headings removed: the marker work drops by more than an
-//! order of magnitude and the first pass costs the same. What the first pass
-//! is actually paying for is the per-line decoration rebuild, whose dominant
-//! term is `OverlayManager` — see `view::overlay::tests::perf_full_buffer_rebuild_pass`
-//! and its conceal/soft-break siblings, which walk every stored entry per
-//! line.
+//! * The heading marks were the report's suspect, and there is a genuine
+//!   inefficiency there — the plugin republishes for every batch, which moves
+//!   the marker version, misses `ProjectionKey`, and re-walks every heading
+//!   found so far, once per frame: O(frames × headings).
+//!   `first_scroll_reprojects_every_heading_on_every_frame` measures it, and
+//!   `view::ui::split_rendering::scrollbar_marker_scroll_perf` measures its
+//!   growth in isolation.
+//! * But it was never big enough to be the reported slowness:
+//!   `heading_marks_are_not_the_reason` runs the same scroll with the
+//!   headings removed — the marker work drops by an order of magnitude and
+//!   the pass costs about the same.
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crate::common::tracing::init_tracing_from_env;
@@ -193,10 +187,14 @@ fn scroll_down(harness: &mut EditorTestHarness, pages: usize) -> ScrollCost {
     }
 }
 
-/// The reported symptom: the first pass down a markdown document in compose
-/// mode costs several times what the identical second pass costs.
+/// The first/second-pass asymmetry, post-fix: the first pass still does the
+/// one-time decoration work, but the second pass is a pure replay — nothing
+/// republishes, so the marker projection is a cache hit on every frame. (The
+/// wall-clock ratio between the passes is reported for eyeballs but not
+/// asserted; the counted bound on first-pass layout work lives in
+/// `markdown_compose_first_scroll_relayout`.)
 #[test]
-fn first_scroll_costs_far_more_than_the_second() {
+fn second_scroll_is_a_pure_replay() {
     let (mut harness, _tmp) = compose_harness(&document_with_headings(120, 8));
 
     let first = scroll_down(&mut harness, PAGES);
@@ -221,13 +219,6 @@ fn first_scroll_costs_far_more_than_the_second() {
         decoration_census(&harness),
     );
 
-    assert!(
-        first.render_total() > second.render_total() * 3 / 2,
-        "the first pass should cost distinctly more than the second; \
-         first {:?}, second {:?}",
-        first.render_total(),
-        second.render_total(),
-    );
     assert_eq!(
         second.stats.markers_walked, 0,
         "nothing republishes on a second pass, so the projection is cached"

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
@@ -1,0 +1,307 @@
+//! Reproduction and attribution for "scrolling down a large markdown buffer is
+//! very slow the first time" — driven through the real `markdown_compose`
+//! plugin, on a document with the inline markup compose mode actually
+//! decorates.
+//!
+//! # The symptom is real
+//!
+//! A first downward pass costs several times what a second pass over the same
+//! lines costs (`first_scroll_costs_far_more_than_the_second`). The asymmetry
+//! comes from `Window::seen_byte_ranges`: `lines_changed` only ever carries
+//! lines the editor has never offered the plugin before, so the first pass
+//! runs the whole per-line decoration pipeline — emphasis overlays, conceals,
+//! soft breaks, heading marks — and the second pass runs none of it.
+//!
+//! # It is not the scrollbar's heading marks
+//!
+//! The report suspected the heading marks on the scrollbar track, and there is
+//! a genuine inefficiency there: the plugin republishes for every batch, which
+//! moves the marker version, which misses `ProjectionKey` and re-walks every
+//! heading found so far — once per frame of the scroll, i.e. O(frames ×
+//! headings). `first_scroll_reprojects_every_heading_on_every_frame` measures
+//! that, and `view::ui::split_rendering::scrollbar_marker_scroll_perf` measures
+//! its growth in isolation.
+//!
+//! But it is nowhere near big enough to be the reported slowness.
+//! `heading_marks_are_not_the_reason` runs the same scroll over the same
+//! document with the headings removed: the marker work drops by more than an
+//! order of magnitude and the first pass costs the same. What the first pass
+//! is actually paying for is the per-line decoration rebuild, whose dominant
+//! term is `OverlayManager` — see `view::overlay::tests::perf_full_buffer_rebuild_pass`
+//! and its conceal/soft-break siblings, which walk every stored entry per
+//! line.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::view::scrollbar_marker::ProjectionStats;
+use std::time::Duration;
+
+/// A body paragraph with the inline markup compose mode actually decorates —
+/// emphasis, which becomes overlays and conceals — and long enough to wrap,
+/// which produces soft breaks. Without these a synthetic document is
+/// decoration-free and measures nothing but the bare renderer.
+fn body_line(section: usize, line: usize) -> String {
+    format!(
+        "Body line {line} of section {section}, with **bold** and *italic* and \
+         `code` spans, written long enough that compose mode has to reflow it \
+         across several rows of the terminal.\n"
+    )
+}
+
+/// Sections of body text under an ATX heading, the shape of a long document
+/// with real structure (a changelog, a spec, a book chapter).
+fn document_with_headings(sections: usize, filler_lines: usize) -> String {
+    let mut md = String::new();
+    for s in 0..sections {
+        md.push_str(&format!("## Section {s}\n\n"));
+        for l in 0..filler_lines {
+            md.push_str(&body_line(s, l));
+        }
+        md.push('\n');
+    }
+    md
+}
+
+/// The same document with no headings at all: same length, same inline markup,
+/// same conceal and soft-break load — nothing to mark on the scrollbar.
+fn document_without_headings(lines: usize) -> String {
+    let mut md = String::from("# Title\n\n");
+    for l in 0..lines {
+        md.push_str(&body_line(0, l));
+    }
+    md
+}
+
+fn compose_harness(md: &str) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("long.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        80,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    (harness, temp_dir)
+}
+
+fn stats(harness: &EditorTestHarness) -> ProjectionStats {
+    harness
+        .editor()
+        .active_state()
+        .scrollbar_marker_buckets
+        .stats()
+}
+
+fn marker_count(harness: &EditorTestHarness) -> usize {
+    harness.editor().active_state().scrollbar_markers.len()
+}
+
+/// Everything the compose plugin has accumulated for this buffer. All of these
+/// grow as the document is explored, and the per-line clear+re-add pass walks
+/// each store in full for every line it touches.
+fn decoration_census(harness: &EditorTestHarness) -> String {
+    let state = harness.editor().active_state();
+    format!(
+        "{} overlays, {} conceals, {} soft breaks, {} virtual texts, \
+         {} scrollbar markers",
+        state.overlays.all().len(),
+        state.conceals.len(),
+        state.soft_breaks.len(),
+        state.virtual_texts.len(),
+        state.scrollbar_markers.len(),
+    )
+}
+
+/// What one downward pass cost.
+struct ScrollCost {
+    stats: ProjectionStats,
+    /// Time inside `tick_and_render` only — the settle sleeps that let the
+    /// plugin thread catch up are deliberately excluded, so this is the work
+    /// the editor itself does, comparable between passes.
+    per_page: Vec<Duration>,
+}
+
+impl ScrollCost {
+    fn render_total(&self) -> Duration {
+        self.per_page.iter().sum()
+    }
+}
+
+/// Ticks spent settling each page, and the real time allowed between them for
+/// the plugin thread to answer the `lines_changed` batch.
+const SETTLE_TICKS: usize = 8;
+const SETTLE_SLEEP: Duration = Duration::from_millis(10);
+const PAGES: usize = 40;
+
+/// Page down `pages` times, letting the plugin's decorations settle after each.
+fn scroll_down(harness: &mut EditorTestHarness, pages: usize) -> ScrollCost {
+    let before = stats(harness);
+    let mut per_page = Vec::with_capacity(pages);
+
+    for _ in 0..pages {
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+        let mut page = Duration::ZERO;
+        for _ in 0..SETTLE_TICKS {
+            let t = std::time::Instant::now();
+            harness.tick_and_render().unwrap();
+            page += t.elapsed();
+            // Untimed: the plugin answers hooks on its own thread, and this
+            // measures the editor's frame, not the plugin's latency.
+            std::thread::sleep(SETTLE_SLEEP);
+            harness.advance_time(SETTLE_SLEEP);
+        }
+        per_page.push(page);
+    }
+
+    let after = stats(harness);
+    ScrollCost {
+        stats: ProjectionStats {
+            rebuilds: after.rebuilds - before.rebuilds,
+            markers_walked: after.markers_walked - before.markers_walked,
+        },
+        per_page,
+    }
+}
+
+/// The reported symptom: the first pass down a markdown document in compose
+/// mode costs several times what the identical second pass costs.
+#[test]
+fn first_scroll_costs_far_more_than_the_second() {
+    let (mut harness, _tmp) = compose_harness(&document_with_headings(120, 8));
+
+    let first = scroll_down(&mut harness, PAGES);
+
+    // Back to the top. Ctrl+Home scrolls over lines the editor has already
+    // offered the plugin, so no `lines_changed` batch is produced and none of
+    // the per-line decoration work runs again.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_until_stable(|_| true).unwrap();
+
+    let second = scroll_down(&mut harness, PAGES);
+
+    eprintln!(
+        "first scroll: render {:?}, {} markers walked; \
+         second scroll: render {:?}, {} markers walked; accumulated {}",
+        first.render_total(),
+        first.stats.markers_walked,
+        second.render_total(),
+        second.stats.markers_walked,
+        decoration_census(&harness),
+    );
+
+    assert!(
+        first.render_total() > second.render_total() * 3 / 2,
+        "the first pass should cost distinctly more than the second; \
+         first {:?}, second {:?}",
+        first.render_total(),
+        second.render_total(),
+    );
+    assert_eq!(
+        second.stats.markers_walked, 0,
+        "nothing republishes on a second pass, so the projection is cached"
+    );
+}
+
+/// ...but the heading marks are not why. The same scroll over a document with
+/// no headings does a fraction of the marker work and costs the same.
+#[test]
+fn heading_marks_are_not_the_reason() {
+    let (mut with_headings, _a) = compose_harness(&document_with_headings(120, 8));
+    let marked = scroll_down(&mut with_headings, PAGES);
+    let marked_census = decoration_census(&with_headings);
+
+    let (mut without_headings, _b) = compose_harness(&document_without_headings(120 * 10));
+    let control = scroll_down(&mut without_headings, PAGES);
+
+    eprintln!(
+        "with headings:    render {:?}, {} markers walked, accumulated {marked_census}",
+        marked.render_total(),
+        marked.stats.markers_walked,
+    );
+    eprintln!(
+        "without headings: render {:?}, {} markers walked, accumulated {}",
+        control.render_total(),
+        control.stats.markers_walked,
+        decoration_census(&without_headings),
+    );
+
+    // The counted work is unambiguous where wall-clock is noisy: the control
+    // accumulates no marks, so its rebuilds walk almost nothing.
+    assert!(
+        control.stats.markers_walked * 10 < marked.stats.markers_walked,
+        "the control should do almost no marker work; control {} vs {}",
+        control.stats.markers_walked,
+        marked.stats.markers_walked,
+    );
+
+    // And removing every mark does not make the first scroll cheaper — so the
+    // marks are not what the first scroll is spending its time on.
+    assert!(
+        control.render_total() * 2 > marked.render_total(),
+        "removing the heading marks should not materially change the cost of \
+         a first scroll; with headings {:?}, without {:?}",
+        marked.render_total(),
+        control.render_total(),
+    );
+}
+
+/// The inefficiency the report pointed at is real, even though it is not the
+/// cause here: during a first scroll the whole heading set is re-projected
+/// once per frame, so the work is O(frames × headings) rather than O(headings).
+/// Its absolute size is measured in
+/// `view::ui::split_rendering::scrollbar_marker_scroll_perf`.
+#[test]
+fn first_scroll_reprojects_every_heading_on_every_frame() {
+    let (mut harness, _tmp) = compose_harness(&document_with_headings(120, 8));
+
+    let first = scroll_down(&mut harness, PAGES);
+    let headings = marker_count(&harness);
+
+    eprintln!(
+        "first scroll: {} rebuilds, {} markers walked for {headings} headings",
+        first.stats.rebuilds, first.stats.markers_walked,
+    );
+
+    assert!(
+        headings > 10,
+        "the scroll should have discovered a good number of headings, saw {headings}"
+    );
+    assert!(
+        first.stats.markers_walked > (headings * 5) as u64,
+        "the marker set should have been re-walked several times over during \
+         one downward scroll — {} markers walked for {headings} headings",
+        first.stats.markers_walked
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -171,6 +171,8 @@ pub mod macros;
 pub mod mark_mode_actions;
 pub mod markdown_compose;
 pub mod markdown_compose_diagnostics;
+#[cfg(feature = "plugins")]
+pub mod markdown_compose_scroll_perf;
 pub mod markdown_compose_scroll_reach;
 #[cfg(feature = "plugins")]
 pub mod markdown_compose_scrollbar_markers;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -172,6 +172,8 @@ pub mod mark_mode_actions;
 pub mod markdown_compose;
 pub mod markdown_compose_diagnostics;
 #[cfg(feature = "plugins")]
+pub mod markdown_compose_first_scroll_relayout;
+#[cfg(feature = "plugins")]
 pub mod markdown_compose_scroll_perf;
 pub mod markdown_compose_scroll_reach;
 #[cfg(feature = "plugins")]


### PR DESCRIPTION
## Problem

Wheel-scrolling down a large markdown file in compose mode was extremely slow on the first pass, then fast when re-scrolling the same region.

The loop: `lines_changed` only carries lines the editor has never offered the plugin, so a first scroll produces a decoration batch per wheel notch; each batch adds conceals/soft breaks, bumping their manager versions; those versions were XOR-packed into `WrapIndex`'s cache key, and on any key change `ensure_built` could only respond with its O(buffer) full build. Cost was **O(notches × document)** — one full re-layout of the file per wheel notch.

Measured by driving the release binary in tmux with SGR wheel events (60 notches, process CPU, first pass / second pass):

| document | first | second |
|---|---|---|
| 2,003 lines | 0.92 s | 0.12 s |
| 3,511 lines | 1.50 s | 0.11 s |
| 4,915 lines | 1.95 s | 0.14 s |
| 5,201 lines | 0.18 s | 0.12 s |
| 4,915 lines, compose off | 0.10 s | 0.11 s |

First-pass cost grows linearly with document length and falls off a cliff past `MAX_WRAP_SCROLLBAR_LINES` (5,000), where the index stops being built — so the bug hit *medium* files hardest and accidentally spared huge ones. In-editor counters confirmed the mechanism: 60 notches over a 2,411-line document did **82 full rebuilds, 197,702 lines laid out (82× the document)**.

## Fix

Make decoration staleness *repairable* instead of fatal:

- **`PipelineInputs` struct replaces the packed-XOR u64.** Equality still answers "is anything stale", but which component moved is now visible: a buffer mismatch takes the existing `damage_bytes` repair channel, a decoration mismatch takes a new one. The XOR packing and its collision caveat are deleted.
- **Snapshot-diff repair.** On a decoration-only mismatch, `ensure_built` diffs the stored decoration snapshot against the freshly resolved one (two-pointer walk over the sorted vecs), coalesces disagreements into line spans, and rebuilds exactly those lines in place. Full rebuild remains the fallback when damage covers most of the buffer or the line count disagrees. A version bump with an identical snapshot — plugins republish constantly — costs one diff walk and repairs nothing.
- **The snapshot stays in current buffer coordinates.** `damage_bytes` now shifts the stored positions the way the live markers shifted. This also fixes a latent bug: text-edit repairs used to rebuild lines against the *unshifted* snapshot and relied on the next decoration bump's full rebuild to heal the drift.
- **`damage_bytes` adopts only the buffer component** of the new inputs. The old whole-key adoption could silently swallow a decoration change landing in the same frame as an edit.
- **Virtual-line anchors move into `IndexDecorations`**, replacing the virtual-positions-plus-closure dance duplicated at four call sites.

A first scroll now costs O(notches × batch) — the lines the plugin actually decorated — and the O(buffer) build happens once.

## Tests

- New `wrap_index` unit tests: diff-repaired index is indistinguishable from a from-scratch build; decoration removal repairs back to plain layout; no-op version bumps repair zero lines; the snapshot shifts with edits so later diffs stay local; mass decoration changes fall back to one rebuild.
- `e2e::markdown_compose_first_scroll_relayout` flips from documenting the bug to locking the fix, asserting on counted layout work (`WrapIndexStats`), not wall-clock: a first wheel-scroll must build at most a small multiple of the document and arrive as diff repairs; a second pass must build nothing.
- `e2e::markdown_compose_scroll_perf` keeps the attribution tests for the scrollbar heading-mark inefficiency (real but minor, measured separately in `scrollbar_marker_scroll_perf`) and drops the assertion that the first-pass slowness exists.

First two commits are the investigation that isolated the cause (reproduction harness + counters); the third is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qij582dee5V9fKPamJzrqH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qij582dee5V9fKPamJzrqH)_