### PR TITLE
file explorer: let plugins narrow which entries are shown

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3743,6 +3743,34 @@ pub enum PluginCommand {
         namespace: String,
     },
 
+    /// Narrow the file explorer to a set of paths for a namespace.
+    ///
+    /// Where decorations change how a row is *drawn*, a filter decides
+    /// whether it is drawn at all — letting a plugin offer "only files in git
+    /// status" or "only files with diagnostics" while the explorer stays
+    /// ignorant of what the filter means. Ancestors of the given paths stay
+    /// visible so the matches are reachable, and a given directory brings its
+    /// contents with it.
+    ///
+    /// Namespaces union: a path claimed by any namespace is shown. While any
+    /// filter is active it outranks the explorer's own ignore rules, so a
+    /// matched path appears even when it is gitignored or hidden.
+    SetFileExplorerFilter {
+        /// Namespace for grouping (e.g., "git-status")
+        namespace: String,
+        /// Paths to show. Relative paths resolve against the workspace root;
+        /// paths outside it are dropped. An empty list contributes nothing
+        /// and leaves the explorer unfiltered.
+        paths: Vec<String>,
+    },
+
+    /// Clear the file explorer filter for a namespace. Once no namespace is
+    /// filtering, the explorer returns to its normal view.
+    ClearFileExplorerFilter {
+        /// Namespace to clear (e.g., "git-status")
+        namespace: String,
+    },
+
     /// Set file explorer slot overrides for a namespace.
     ///
     /// This is additive: any slot field omitted by the plugin falls back to

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3709,6 +3709,16 @@ interface EditorAPI {
 	*/
 	clearFileExplorerDecorations(namespace: string): boolean;
 	/**
+	* Narrow the file explorer to `paths` for a namespace, hiding everything
+	* else. Ancestors of the given paths stay visible so the matches remain
+	* reachable, and naming a directory brings its contents with it.
+	*/
+	setFileExplorerFilter(namespace: string, paths: string[]): boolean;
+	/**
+	* Clear the file explorer filter for a namespace.
+	*/
+	clearFileExplorerFilter(namespace: string): boolean;
+	/**
 	* Set file explorer slot overrides for a namespace
 	*/
 	setFileExplorerSlots(namespace: string, slots: Record<string, unknown>[]): boolean;

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -1705,6 +1705,9 @@ impl crate::app::window::Window {
         }
         view.set_compact_directories(defaults.compact_directories);
         self.file_explorer = Some(view);
+        // A fresh view starts unfiltered, so any plugin filter this window is
+        // holding has to be re-applied or it would vanish on reopen.
+        self.apply_file_explorer_filters();
         // The initial build is done; release the column reservation set in
         // `init_file_explorer`. Clear it *before* the expand-to-path sync below
         // so that sync can re-acquire it (it early-returns if it's still set).
@@ -1806,6 +1809,50 @@ impl crate::app::window::Window {
     pub fn handle_clear_file_explorer_decorations(&mut self, namespace: &str) {
         self.file_explorer_decorations.remove(namespace);
         self.rebuild_file_explorer_decoration_cache();
+    }
+
+    /// Narrow the explorer to `paths` on behalf of `namespace`, so a plugin
+    /// can offer a filtered view ("only files in git status", "only files
+    /// with diagnostics") without the explorer knowing what the filter means.
+    ///
+    /// Paths are normalized and confined to the workspace root on the same
+    /// terms as decorations: relative entries are joined to the root and
+    /// anything that escapes it is dropped rather than honoured.
+    pub fn handle_set_file_explorer_filter(&mut self, namespace: String, paths: Vec<PathBuf>) {
+        let root = self.root.clone();
+        let normalized: Vec<PathBuf> = paths
+            .into_iter()
+            .filter_map(|path| {
+                let path = if path.is_absolute() {
+                    path
+                } else {
+                    root.join(&path)
+                };
+                let path = crate::app::normalize_path(&path);
+                crate::app::explorer_path_under_root(&path, &root)
+                    .then(|| crate::app::normalize_explorer_plugin_path(&path, &root))
+            })
+            .collect();
+
+        self.file_explorer_filters.insert(namespace, normalized);
+        self.apply_file_explorer_filters();
+    }
+
+    /// Drop `namespace`'s filter. Once no namespace is filtering, the explorer
+    /// returns to its normal ignore-rule-driven view.
+    pub fn handle_clear_file_explorer_filter(&mut self, namespace: &str) {
+        self.file_explorer_filters.remove(namespace);
+        self.apply_file_explorer_filters();
+    }
+
+    /// Push the window's filters into the live view. Called after any filter
+    /// mutation and again whenever the view is rebuilt, since a fresh
+    /// `FileTreeView` starts unfiltered.
+    pub fn apply_file_explorer_filters(&mut self) {
+        let filters = self.file_explorer_filters.clone();
+        if let Some(explorer) = self.file_explorer.as_mut() {
+            explorer.set_plugin_filters(filters);
+        }
     }
 
     /// Install (or replace) a namespace of plugin-supplied file-explorer slot

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -856,6 +856,15 @@ impl Editor {
                 self.active_window_mut()
                     .handle_clear_file_explorer_decorations(&namespace);
             }
+            PluginCommand::SetFileExplorerFilter { namespace, paths } => {
+                let paths = paths.into_iter().map(std::path::PathBuf::from).collect();
+                self.active_window_mut()
+                    .handle_set_file_explorer_filter(namespace, paths);
+            }
+            PluginCommand::ClearFileExplorerFilter { namespace } => {
+                self.active_window_mut()
+                    .handle_clear_file_explorer_filter(&namespace);
+            }
             PluginCommand::SetFileExplorerSlots { namespace, slots } => {
                 self.active_window_mut()
                     .handle_set_file_explorer_slots(namespace, slots);

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -712,6 +712,13 @@ pub struct Window {
     /// `file_explorer_decorations` changes.
     pub file_explorer_decoration_cache: crate::view::file_tree::FileExplorerDecorationCache,
 
+    /// Visibility filters supplied by plugins, keyed by namespace, holding
+    /// normalized absolute paths. Lives on the window rather than on the
+    /// `FileTreeView` because the view is rebuilt whenever the explorer is
+    /// reopened or the root changes — like the decorations above, a filter
+    /// has to outlive that and be re-applied to the new view.
+    pub file_explorer_filters: HashMap<String, Vec<std::path::PathBuf>>,
+
     /// Slot overrides supplied by plugins for the file explorer keyed by
     /// namespace. These are additive overrides: unspecified fields continue to
     /// fall back to compatibility providers.
@@ -2292,6 +2299,7 @@ impl Window {
             file_explorer_decorations: HashMap::new(),
             file_explorer_decoration_cache:
                 crate::view::file_tree::FileExplorerDecorationCache::default(),
+            file_explorer_filters: HashMap::new(),
             file_explorer_slot_overrides: HashMap::new(),
             file_explorer_slot_override_cache:
                 crate::view::file_tree::FileExplorerSlotOverrideCache::default(),

--- a/crates/fresh-editor/src/view/file_tree/filter.rs
+++ b/crates/fresh-editor/src/view/file_tree/filter.rs
@@ -1,0 +1,142 @@
+//! Plugin-supplied visibility filters for the file explorer.
+//!
+//! Decorations ([`super::decorations`]) and slot overrides ([`super::slots`])
+//! already flow plugin → explorer, changing how a row is *drawn*. A filter is
+//! the same channel one step earlier: it decides whether the row is drawn at
+//! all. That keeps the explorer ignorant of whatever the plugin is filtering
+//! *on* — git status, diagnostics, the steps of a code tour — while still
+//! offering "show me only the interesting files".
+//!
+//! Entries are namespaced exactly like decorations, so two plugins can filter
+//! without clobbering each other. The namespaces **union**: a path claimed by
+//! any namespace is shown. Intersecting would usually collapse the tree to
+//! nothing the moment a second plugin joined, which is a baffling result for
+//! the user and an easy bug for the plugin author.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// The union of every namespace's paths, precomputed for lookups during
+/// rendering. Rebuilt whenever a namespace is set or cleared — the same
+/// discipline as [`super::decorations::FileExplorerDecorationCache`].
+#[derive(Debug, Default, Clone)]
+pub struct ExplorerFilter {
+    /// Paths some plugin explicitly asked to show.
+    matched: HashSet<PathBuf>,
+    /// Ancestor directories of every matched path. Kept visible so the
+    /// matched entries below them are actually reachable — a filtered file
+    /// three levels down is useless if its parents are hidden.
+    ancestors: HashSet<PathBuf>,
+}
+
+impl ExplorerFilter {
+    /// No namespace has contributed any path, so the explorer is unfiltered.
+    /// Distinct from "a filter that matches nothing": a namespace set to an
+    /// empty path list contributes nothing and leaves the tree unfiltered,
+    /// which is what a plugin with zero results should produce.
+    pub fn is_empty(&self) -> bool {
+        self.matched.is_empty()
+    }
+
+    /// Whether `path` survives the filter.
+    ///
+    /// Three ways to pass: the path was matched outright; it is an ancestor
+    /// of something matched; or it lives *under* a matched directory —
+    /// filtering to a directory shows what is in it.
+    pub fn allows(&self, path: &Path) -> bool {
+        if self.ancestors.contains(path) {
+            return true;
+        }
+        let mut current = Some(path);
+        while let Some(candidate) = current {
+            if self.matched.contains(candidate) {
+                return true;
+            }
+            current = candidate.parent();
+        }
+        false
+    }
+
+    /// Recompute the union from the per-namespace path lists.
+    pub fn rebuild(namespaces: &HashMap<String, Vec<PathBuf>>) -> Self {
+        let mut matched = HashSet::new();
+        let mut ancestors = HashSet::new();
+
+        for paths in namespaces.values() {
+            for path in paths {
+                let mut parent = path.parent();
+                while let Some(dir) = parent {
+                    // Stop climbing once this ancestor is already recorded:
+                    // everything above it was recorded on an earlier pass.
+                    if !ancestors.insert(dir.to_path_buf()) {
+                        break;
+                    }
+                    parent = dir.parent();
+                }
+                matched.insert(path.clone());
+            }
+        }
+
+        Self { matched, ancestors }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter_of(paths: &[&str]) -> ExplorerFilter {
+        let mut namespaces = HashMap::new();
+        namespaces.insert(
+            "test".to_string(),
+            paths.iter().map(PathBuf::from).collect::<Vec<_>>(),
+        );
+        ExplorerFilter::rebuild(&namespaces)
+    }
+
+    #[test]
+    fn empty_when_no_namespace_contributes_a_path() {
+        assert!(ExplorerFilter::default().is_empty());
+        assert!(filter_of(&[]).is_empty());
+    }
+
+    #[test]
+    fn allows_the_matched_path_and_every_ancestor() {
+        let filter = filter_of(&["/repo/src/deep/main.rs"]);
+
+        assert!(filter.allows(Path::new("/repo/src/deep/main.rs")));
+        assert!(filter.allows(Path::new("/repo/src/deep")));
+        assert!(filter.allows(Path::new("/repo/src")));
+        assert!(filter.allows(Path::new("/repo")));
+    }
+
+    #[test]
+    fn rejects_siblings_of_a_matched_path() {
+        let filter = filter_of(&["/repo/src/main.rs"]);
+
+        assert!(!filter.allows(Path::new("/repo/src/other.rs")));
+        assert!(!filter.allows(Path::new("/repo/docs")));
+    }
+
+    #[test]
+    fn a_matched_directory_carries_its_contents() {
+        let filter = filter_of(&["/repo/src"]);
+
+        assert!(filter.allows(Path::new("/repo/src")));
+        assert!(filter.allows(Path::new("/repo/src/main.rs")));
+        assert!(filter.allows(Path::new("/repo/src/nested/deep.rs")));
+        assert!(!filter.allows(Path::new("/repo/docs/readme.md")));
+    }
+
+    #[test]
+    fn namespaces_union_rather_than_intersect() {
+        let mut namespaces = HashMap::new();
+        namespaces.insert("git".to_string(), vec![PathBuf::from("/repo/a.rs")]);
+        namespaces.insert("lsp".to_string(), vec![PathBuf::from("/repo/b.rs")]);
+        let filter = ExplorerFilter::rebuild(&namespaces);
+
+        assert!(filter.allows(Path::new("/repo/a.rs")));
+        assert!(filter.allows(Path::new("/repo/b.rs")));
+        assert!(!filter.allows(Path::new("/repo/c.rs")));
+    }
+}

--- a/crates/fresh-editor/src/view/file_tree/mod.rs
+++ b/crates/fresh-editor/src/view/file_tree/mod.rs
@@ -6,6 +6,7 @@
 
 mod cache;
 pub mod decorations;
+pub mod filter;
 pub mod ignore;
 pub mod node;
 pub mod search;
@@ -17,6 +18,7 @@ pub use decorations::{
     decoration_symbol, resolve_explorer_status, ExplorerRowStatus, FileExplorerDecoration,
     FileExplorerDecorationCache, ResolvedExplorerStatus,
 };
+pub use filter::ExplorerFilter;
 pub use ignore::{IgnorePatterns, IgnoreStatus};
 pub use node::{NodeId, NodeState, TreeNode};
 pub use search::FileExplorerSearch;

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -1,3 +1,4 @@
+use super::filter::ExplorerFilter;
 use super::ignore::IgnorePatterns;
 use super::node::NodeId;
 use super::search::FileExplorerSearch;
@@ -35,6 +36,10 @@ pub struct FileTreeView {
     /// Render single-child directory chains as a single row
     /// (`foo/bar/baz`). Mirrors VSCode's `explorer.compactFolders`.
     compact_directories: bool,
+    /// Plugin-supplied visibility filters, keyed by namespace, and the
+    /// union of them precomputed for lookups. See [`super::filter`].
+    plugin_filters: HashMap<String, Vec<PathBuf>>,
+    plugin_filter: ExplorerFilter,
 }
 
 /// Sort mode for file tree entries
@@ -63,7 +68,47 @@ impl FileTreeView {
             viewport_height: 10, // Default, will be updated during rendering
             search: FileExplorerSearch::new(),
             compact_directories: true,
+            plugin_filters: HashMap::new(),
+            plugin_filter: ExplorerFilter::default(),
         }
+    }
+
+    /// Narrow the explorer to `paths` (plus the ancestors that make them
+    /// reachable) on behalf of `namespace`. Replaces whatever that namespace
+    /// asked for previously; other namespaces are untouched and union with
+    /// this one.
+    ///
+    /// This is how a plugin offers a filtered view — "only files in git
+    /// status", "only files with diagnostics" — without the explorer needing
+    /// to know what the filter means.
+    pub fn set_plugin_filter(&mut self, namespace: impl Into<String>, paths: Vec<PathBuf>) {
+        self.plugin_filters.insert(namespace.into(), paths);
+        self.rebuild_plugin_filter();
+    }
+
+    /// Replace every namespace at once. Used when the view is rebuilt and the
+    /// window re-applies the filters it has been holding — a fresh
+    /// [`FileTreeView`] starts unfiltered, so without this a plugin's filter
+    /// would silently vanish when the explorer is reopened.
+    pub fn set_plugin_filters(&mut self, filters: HashMap<String, Vec<PathBuf>>) {
+        self.plugin_filters = filters;
+        self.rebuild_plugin_filter();
+    }
+
+    /// Drop `namespace`'s filter. With no namespaces left the explorer
+    /// returns to its normal ignore-rule-driven view.
+    pub fn clear_plugin_filter(&mut self, namespace: &str) {
+        self.plugin_filters.remove(namespace);
+        self.rebuild_plugin_filter();
+    }
+
+    /// Whether any namespace is currently narrowing the explorer.
+    pub fn has_plugin_filter(&self) -> bool {
+        !self.plugin_filter.is_empty()
+    }
+
+    fn rebuild_plugin_filter(&mut self) {
+        self.plugin_filter = ExplorerFilter::rebuild(&self.plugin_filters);
     }
 
     /// Toggle/set the compact-directory rendering mode.
@@ -840,15 +885,25 @@ impl FileTreeView {
         self.ignore_patterns.toggle_show_gitignored();
     }
 
-    /// Check if a node should be visible (not filtered by ignore patterns)
+    /// Check if a node should be visible (not filtered by ignore patterns,
+    /// nor excluded by a plugin-supplied filter).
     pub fn is_node_visible(&self, node_id: NodeId) -> bool {
-        if let Some(node) = self.tree.get_node(node_id) {
-            !self
-                .ignore_patterns
-                .is_ignored(&node.entry.path, node.is_dir())
-        } else {
-            false
+        let Some(node) = self.tree.get_node(node_id) else {
+            return false;
+        };
+
+        // A plugin filter is authoritative while it is active: "show only
+        // these" means exactly these, so a matched path stays visible even
+        // where an ignore rule would hide it. A changed file inside a
+        // gitignored directory is still a changed file, and hiding it would
+        // make the filtered view quietly incomplete.
+        if !self.plugin_filter.is_empty() {
+            return self.plugin_filter.allows(&node.entry.path);
         }
+
+        !self
+            .ignore_patterns
+            .is_ignored(&node.entry.path, node.is_dir())
     }
 
     /// Install a gitignore for `dir_path` from already-read bytes. Caller
@@ -1119,6 +1174,187 @@ mod tests {
         assert!(view.get_selected().is_some());
         assert_eq!(view.get_scroll_offset(), 0);
         assert_eq!(view.get_sort_mode(), SortMode::Type);
+    }
+
+    /// Names of every row the explorer would draw, for filter assertions.
+    /// Compact-directory folding is turned off by the caller so each node
+    /// gets its own row and the set is exactly "what is visible".
+    fn visible_names(view: &FileTreeView) -> Vec<String> {
+        view.get_display_nodes()
+            .into_iter()
+            .filter_map(|(id, _)| view.tree.get_node(id))
+            .map(|node| node.entry.name.clone())
+            .collect()
+    }
+
+    /// A plugin-supplied filter narrows the explorer to the given paths plus
+    /// the ancestors needed to reach them — the "show only files in git
+    /// status" case, without the explorer knowing anything about git.
+    #[tokio::test]
+    async fn test_plugin_filter_shows_only_matching_paths_and_their_ancestors() {
+        let (temp_dir, mut view) = create_test_view().await;
+        view.set_compact_directories(false);
+        let root = temp_dir.path().to_path_buf();
+
+        let root_id = view.tree.root_id();
+        view.tree.expand_node(root_id).await.unwrap();
+        let dir1_id = view.tree.get_node_by_path(&root.join("dir1")).unwrap().id;
+        view.tree.expand_node(dir1_id).await.unwrap();
+
+        // Unfiltered: everything is on screen.
+        let before = visible_names(&view);
+        for expected in ["dir1", "dir2", "file1.txt", "file2.txt", "file3.txt"] {
+            assert!(
+                before.contains(&expected.to_string()),
+                "unfiltered explorer must show {expected}, got {before:?}"
+            );
+        }
+
+        view.set_plugin_filter("git-explorer", vec![root.join("dir1/file1.txt")]);
+
+        let after = visible_names(&view);
+        assert!(
+            after.contains(&"file1.txt".to_string()),
+            "the filtered path must be visible, got {after:?}"
+        );
+        assert!(
+            after.contains(&"dir1".to_string()),
+            "an ancestor of a filtered path must stay visible or the file is \
+             unreachable, got {after:?}"
+        );
+        for hidden in ["file2.txt", "file3.txt", "dir2"] {
+            assert!(
+                !after.contains(&hidden.to_string()),
+                "{hidden} does not match the filter and must be hidden, got {after:?}"
+            );
+        }
+    }
+
+    /// Clearing the namespace restores the unfiltered tree, so a plugin
+    /// toggling its filter off leaves no trace.
+    #[tokio::test]
+    async fn test_clearing_plugin_filter_restores_every_entry() {
+        let (temp_dir, mut view) = create_test_view().await;
+        view.set_compact_directories(false);
+        let root = temp_dir.path().to_path_buf();
+
+        let root_id = view.tree.root_id();
+        view.tree.expand_node(root_id).await.unwrap();
+        let before = visible_names(&view);
+
+        view.set_plugin_filter("git-explorer", vec![root.join("file3.txt")]);
+        assert!(
+            !visible_names(&view).contains(&"dir2".to_string()),
+            "filter must be in effect before clearing"
+        );
+
+        view.clear_plugin_filter("git-explorer");
+        assert_eq!(
+            visible_names(&view),
+            before,
+            "clearing the only filter namespace must restore the original tree"
+        );
+    }
+
+    /// Filters from different plugins union rather than intersect: two
+    /// namespaces each contributing paths must not cancel each other out.
+    #[tokio::test]
+    async fn test_plugin_filters_from_separate_namespaces_union() {
+        let (temp_dir, mut view) = create_test_view().await;
+        view.set_compact_directories(false);
+        let root = temp_dir.path().to_path_buf();
+
+        let root_id = view.tree.root_id();
+        view.tree.expand_node(root_id).await.unwrap();
+
+        view.set_plugin_filter("git-explorer", vec![root.join("file3.txt")]);
+        view.set_plugin_filter("diagnostics", vec![root.join("dir2")]);
+
+        let names = visible_names(&view);
+        assert!(
+            names.contains(&"file3.txt".to_string()) && names.contains(&"dir2".to_string()),
+            "both namespaces' paths must be visible, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"dir1".to_string()),
+            "a path claimed by neither namespace must stay hidden, got {names:?}"
+        );
+    }
+
+    /// The window holds the filters and re-applies them whenever the explorer
+    /// view is rebuilt (reopen, root change), because a fresh `FileTreeView`
+    /// starts unfiltered. This covers the contract that re-application relies
+    /// on: handing the stored map to a brand-new view reproduces the filtered
+    /// state, and does so as a replacement rather than a merge.
+    #[tokio::test]
+    async fn test_set_plugin_filters_restores_state_on_a_rebuilt_view() {
+        let (temp_dir, mut original) = create_test_view().await;
+        original.set_compact_directories(false);
+        let root = temp_dir.path().to_path_buf();
+
+        let root_id = original.tree.root_id();
+        original.tree.expand_node(root_id).await.unwrap();
+        original.set_plugin_filter("git-explorer", vec![root.join("file3.txt")]);
+        let filtered = visible_names(&original);
+        assert!(!filtered.contains(&"dir1".to_string()));
+
+        // Rebuild the view the way the app does when the explorer reopens.
+        let manager = Arc::new(FsManager::new(Arc::new(StdFileSystem)));
+        let mut tree = FileTree::new(root.clone(), manager).await.unwrap();
+        let rebuilt_root = tree.root_id();
+        tree.expand_node(rebuilt_root).await.unwrap();
+        let mut rebuilt = FileTreeView::new(tree);
+        rebuilt.set_compact_directories(false);
+
+        assert!(
+            visible_names(&rebuilt).contains(&"dir1".to_string()),
+            "a freshly built view starts unfiltered — this is what makes \
+             re-application necessary"
+        );
+
+        let mut stored = HashMap::new();
+        stored.insert("git-explorer".to_string(), vec![root.join("file3.txt")]);
+        rebuilt.set_plugin_filters(stored);
+
+        assert_eq!(
+            visible_names(&rebuilt),
+            filtered,
+            "re-applying the stored filters must reproduce the filtered view"
+        );
+
+        // Replacement, not merge: handing over an empty map clears everything.
+        rebuilt.set_plugin_filters(HashMap::new());
+        assert!(
+            !rebuilt.has_plugin_filter(),
+            "an empty map must leave the view unfiltered"
+        );
+    }
+
+    /// While a filter is active it is authoritative: a matched path is shown
+    /// even where a gitignore rule would hide it. A changed file inside a
+    /// gitignored directory is still a changed file, and silently dropping it
+    /// would make the filtered view incomplete in a way the user cannot see.
+    #[tokio::test]
+    async fn test_plugin_filter_overrides_gitignore_for_matched_paths() {
+        let (temp_dir, mut view) = create_test_view().await;
+        view.set_compact_directories(false);
+        let root = temp_dir.path().to_path_buf();
+
+        let root_id = view.tree.root_id();
+        view.tree.expand_node(root_id).await.unwrap();
+        view.load_gitignore_from_bytes(&root, b"file3.txt\n", None);
+
+        assert!(
+            !visible_names(&view).contains(&"file3.txt".to_string()),
+            "precondition: the gitignore rule must hide file3.txt when unfiltered"
+        );
+
+        view.set_plugin_filter("git-explorer", vec![root.join("file3.txt")]);
+
+        assert!(
+            visible_names(&view).contains(&"file3.txt".to_string()),
+            "an explicitly filtered path must survive a gitignore rule"
+        );
     }
 
     #[tokio::test]

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -668,6 +668,11 @@ pub struct PluginTrackedState {
     pub virtual_text_ids: Vec<(BufferId, String)>,
     /// File explorer decoration namespaces
     pub file_explorer_namespaces: Vec<String>,
+    /// File explorer *filter* namespaces. Tracked separately from the
+    /// decoration namespaces because a stranded filter is worse than a
+    /// stranded badge: it hides files, and an unloaded plugin leaves nobody
+    /// able to restore them.
+    pub file_explorer_filter_namespaces: Vec<String>,
     /// Context names set by the plugin
     pub contexts_set: Vec<String>,
     // --- Phase 3: Resource cleanup ---
@@ -4314,6 +4319,39 @@ impl JsEditorApi {
         let scoped_namespace = format!("{}::{}", self.plugin_name, namespace);
         self.command_sender
             .send(PluginCommand::ClearFileExplorerDecorations {
+                namespace: scoped_namespace,
+            })
+            .is_ok()
+    }
+
+    /// Narrow the file explorer to `paths` for a namespace, hiding everything
+    /// else. Ancestors of the given paths stay visible so the matches remain
+    /// reachable, and naming a directory brings its contents with it.
+    pub fn set_file_explorer_filter(&self, namespace: String, paths: Vec<String>) -> bool {
+        let scoped_namespace = format!("{}::{}", self.plugin_name, namespace);
+
+        // Tracked like the decoration namespaces so unloading a plugin cannot
+        // leave the explorer filtered with nothing left to un-filter it.
+        self.plugin_tracked_state
+            .borrow_mut()
+            .entry(self.plugin_name.clone())
+            .or_default()
+            .file_explorer_filter_namespaces
+            .push(scoped_namespace.clone());
+
+        self.command_sender
+            .send(PluginCommand::SetFileExplorerFilter {
+                namespace: scoped_namespace,
+                paths,
+            })
+            .is_ok()
+    }
+
+    /// Clear the file explorer filter for a namespace.
+    pub fn clear_file_explorer_filter(&self, namespace: String) -> bool {
+        let scoped_namespace = format!("{}::{}", self.plugin_name, namespace);
+        self.command_sender
+            .send(PluginCommand::ClearFileExplorerFilter {
                 namespace: scoped_namespace,
             })
             .is_ok()
@@ -8797,6 +8835,21 @@ impl QuickJsBackend {
                     let _ = self
                         .command_sender
                         .send(PluginCommand::ClearFileExplorerSlots {
+                            namespace: ns.clone(),
+                        });
+                }
+            }
+
+            // Clear file explorer filter namespaces. Unlike decorations, a
+            // leftover filter hides files, so an unloaded plugin must not be
+            // able to leave the explorer narrowed with no way back.
+            let mut seen_filter_ns: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for ns in &tracked.file_explorer_filter_namespaces {
+                if seen_filter_ns.insert(ns.clone()) {
+                    let _ = self
+                        .command_sender
+                        .send(PluginCommand::ClearFileExplorerFilter {
                             namespace: ns.clone(),
                         });
                 }

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1456,6 +1456,8 @@ mod tests {
             "setLayoutHints",
             "setFileExplorerDecorations",
             "clearFileExplorerDecorations",
+            "setFileExplorerFilter",
+            "clearFileExplorerFilter",
             "setFileExplorerSlots",
             "clearFileExplorerSlots",
             "addVirtualText",


### PR DESCRIPTION
Decorations and slot overrides already flow plugin -> explorer, changing how a row is drawn. Nothing lets a plugin decide whether a row is drawn at all, so "show me only the files in git status" - the view both JetBrains and VS Code offer - cannot be built today. The explorer's own filters are no help: hidden-file and gitignore matching are filename and pattern checks, while git status needs live repository state, which is why every git feature in fresh ships as a plugin shelling out to git.

Add SetFileExplorerFilter / ClearFileExplorerFilter as that same channel one step earlier. A plugin hands over a set of paths; the explorer shows those, the ancestors needed to reach them, and the contents of any directory named. Core stays ignorant of what the filter means, so the same mechanism serves diagnostics, a code tour's files, or anything else a plugin can enumerate.

Three judgement calls worth a look:

- Namespaces union rather than intersect. Intersecting would collapse the tree the moment a second plugin joined - baffling for the user and an easy bug for the plugin author.

- An active filter outranks the explorer's ignore rules, so a matched path appears even when it is gitignored or hidden. A changed file inside a gitignored directory is still a changed file; dropping it would make the filtered view quietly incomplete.

- Filters are cleared when a plugin unloads, tracked separately from the decoration namespaces. A stranded decoration is cosmetic; a stranded filter hides files and outlives the only thing that could clear it.

Filters live on the window rather than on FileTreeView because the view is rebuilt whenever the explorer reopens or the root changes, and a fresh view starts unfiltered - the same reason decorations live there.

No menu entry yet. A "show all files" escape hatch belongs in the Explorer menu next to the existing toggles, but it needs an i18n key in all 15 locales and an e2e test, and where it belongs is worth agreeing on first.