### PR TITLE
Redraws cost the window, not the buffer — plus review-diff filter, resize and sidebar

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1826,6 +1826,10 @@ fn default_tree_visible_rows() -> u32 {
 /// node (the classic single-line tree). A larger value renders every
 /// node as a fixed-height card of that many rows (the node's primary
 /// `text` line plus its `extra_lines`, blank-padded to the height).
+fn default_tree_indent_cols() -> u32 {
+    2
+}
+
 fn default_tree_item_height() -> u32 {
     1
 }
@@ -2428,6 +2432,13 @@ pub enum WidgetSpec {
         /// selection stay node-based; rows per node just vary.
         #[serde(default)]
         card_borders: bool,
+        /// Columns of indent per depth level. `2` (the default) is the
+        /// classic tree step. A panel only a couple of dozen columns wide
+        /// that nests several levels deep can drop to `1` and spend those
+        /// columns on node text instead — each level is still marked by
+        /// the disclosure glyph (or the blank standing in for one).
+        #[serde(default = "default_tree_indent_cols")]
+        indent_cols: u32,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1639,7 +1639,7 @@ let commentsPanel: WidgetPanel | null = null;
 function panelWidthOf(panel: 'files' | 'comments'): number {
     const known = state.panelWidths[panel];
     if (known && known > 0) return known;
-    return Math.max(12, Math.floor(state.viewportWidth * (panel === 'files' ? 0.16 : 0.15)));
+    return Math.max(12, Math.floor(state.viewportWidth * (panel === 'files' ? FILES_PANEL_RATIO : 0.15)));
 }
 
 /** `text` clipped to `width` columns, dropping characters from the left
@@ -1761,6 +1761,28 @@ function filesHeaderLabel(): string {
 
 const FILES_TREE_KEY = "files-tree";
 const FILES_FILTER_KEY = "files-filter";
+
+/** Share of the review's width the FILES sidebar opens at.
+ *
+ *  Read by both `REVIEW_LAYOUT` (the host's initial split) and
+ *  `panelWidthOf` (the plugin's own laying-out before the first
+ *  `viewport_changed` arrives) — they describe the same panel, so they
+ *  have to agree or the first paint is laid out to a width the panel
+ *  does not have. Once the user drags the divider the host's reported
+ *  width wins and this is no longer consulted.
+ *
+ *  Paths are long and the tree nests, so the old 0.16 left filenames
+ *  elided to a few characters on a typical terminal. */
+const FILES_PANEL_RATIO = 0.22;
+
+/** Columns of indent per tree level in the FILES sidebar.
+ *
+ *  One, not the host's default of two: this tree nests a directory chain
+ *  several levels deep in a panel only a couple of dozen columns wide, so
+ *  every column spent on indent comes straight off the filenames. One
+ *  column still reads as a level because each row also carries a
+ *  disclosure glyph (or the two spaces standing in for one). */
+const FILES_TREE_INDENT = 1;
 
 interface FilesTree {
     nodes: TreeNode[];
@@ -1887,19 +1909,17 @@ function buildFilesTree(): FilesTree {
         const key = `dir:${category} ${node.path}`;
         out.groupKeys.push(key);
         out.keys.push(key);
-        const stats = `  +${node.added} -${node.removed}`;
-        // The host indents 2 columns per depth level and draws a
-        // disclosure glyph; a segment is short, so this only bites on a
-        // deeply nested path in a narrow panel.
-        const room = Math.max(4, W - depth * 2 - 2 - stats.length);
+        // The host indents `FILES_TREE_INDENT` columns per depth level and
+        // draws a disclosure glyph; a segment is short, so this only bites
+        // on a deeply nested path in a narrow panel.
+        const room = Math.max(4, W - depth * FILES_TREE_INDENT - 2);
         out.nodes.push(treeNode(
-            { text: `${elideRight(node.name, room)}${stats}`, style: { fg: STYLE_SECTION_HEADER } },
+            { text: elideRight(node.name, room), style: { fg: STYLE_SECTION_HEADER } },
             { depth, hasChildren: true },
         ));
     };
 
     const pushFile = (file: FileEntry, depth: number): void => {
-        const counts = fileChangeCounts(file);
         const key = fileKey(file);
         const badge = commentCounts[file.path] ? ` *${commentCounts[file.path]}` : '';
         const nodeKey = `file:${key}`;
@@ -1915,8 +1935,8 @@ function buildFilesTree(): FilesTree {
         // file explorer this sidebar mirrors right-aligns status for the
         // same reason.
         const status = file.status ? ` ${file.status}` : '';
-        const stats = `  +${counts.added} -${counts.removed}${badge}${status}`;
-        const room = Math.max(4, W - depth * 2 - 2 - stats.length);
+        const stats = `${badge}${status}`;
+        const room = Math.max(4, W - depth * FILES_TREE_INDENT - 2 - stats.length);
         out.nodes.push(treeNode(
             {
                 text: `${elideRight(fileBaseOf(file.path), room)}${stats}`,
@@ -2023,6 +2043,7 @@ function buildFilesPanelSpec(): WidgetSpec {
             selectedIndex: selected,
             visibleRows: panelListRows('files'),
             expandedKeys: filesTree.groupKeys,
+            indentCols: FILES_TREE_INDENT,
             key: FILES_TREE_KEY,
         }));
     }
@@ -2276,7 +2297,7 @@ editor.on("widget_event", (data) => {
             const payload = (data.payload ?? {}) as Record<string, unknown>;
             if (typeof payload["value"] === "string") state.fileFilter = payload["value"];
             if (typeof payload["cursorByte"] === "number") filterCursor = payload["cursorByte"];
-            applyFileFilter();
+            scheduleFileFilter();
             return;
         }
         if (data.event_type === "activate" || data.event_type === "cancel") {
@@ -2756,6 +2777,43 @@ function jumpToComment(commentId: string): void {
     if (hunkRow !== undefined) jumpDiffCursorToRow(hunkRow);
 }
 
+/** Milliseconds of quiet before a resized side panel is repainted.
+ *
+ *  A divider drag delivers a `viewport_changed` per column crossed. The
+ *  host has already re-laid the panes out by then — this only defers the
+ *  panel's *content* rebuild, so the drag itself stays smooth and the
+ *  content catches up the moment the pointer settles. */
+const PANEL_RELAYOUT_DEBOUNCE_MS = 60;
+
+const panelRelayoutTimers: { files: number | null; comments: number | null } = {
+    files: null,
+    comments: null,
+};
+
+/** Repaint `panel` once its size stops changing. */
+function schedulePanelRelayout(panel: 'files' | 'comments'): void {
+    const pending = panelRelayoutTimers[panel];
+    if (pending !== null) editor.clearInterval(pending);
+    panelRelayoutTimers[panel] = editor.setTimeout(
+        PANEL_RELAYOUT_DEBOUNCE_MS,
+        panel === 'files' ? "review_relayout_files" : "review_relayout_comments",
+    );
+}
+
+function review_relayout_files(): void {
+    panelRelayoutTimers.files = null;
+    if (state.groupId === null) return;
+    renderFilesPanel();
+}
+registerHandler("review_relayout_files", review_relayout_files);
+
+function review_relayout_comments(): void {
+    panelRelayoutTimers.comments = null;
+    if (state.groupId === null) return;
+    renderCommentsPanel();
+}
+registerHandler("review_relayout_comments", review_relayout_comments);
+
 function on_review_viewport_changed(data: { split_id: number; buffer_id: number; top_byte: number; top_line: number | null; width: number; height: number }): void {
     if (state.groupId === null) return;
     // Side panels: remember how wide the host actually made them, and
@@ -2767,8 +2825,14 @@ function on_review_viewport_changed(data: { split_id: number; buffer_id: number;
             && state.panelHeights[panel] === data.height) return;
         state.panelWidths[panel] = data.width;
         state.panelHeights[panel] = data.height;
-        if (panel === 'files') renderFilesPanel();
-        else renderCommentsPanel();
+        // Record the size synchronously — everything laid out against it
+        // (`panelWidthOf`, the header's `✕` column) must see the new width
+        // at once — but coalesce the repaint. Dragging the divider walks
+        // through every intervening width, and each one would otherwise
+        // rebuild the whole tree and ship it across the IPC boundary; the
+        // intermediate widths are never worth painting, only the one the
+        // user stops on.
+        schedulePanelRelayout(panel);
         return;
     }
     if (data.buffer_id !== state.panelBuffers["diff"]) return;
@@ -5169,6 +5233,50 @@ function review_filter_files() {
 }
 registerHandler("review_filter_files", review_filter_files);
 
+/** Milliseconds of quiet before a typed filter is actually applied.
+ *
+ *  Long enough that a burst of typing costs one rebuild instead of one
+ *  per character, short enough to feel immediate after the last key. */
+const FILTER_DEBOUNCE_MS = 90;
+
+let filterApplyTimer: number | null = null;
+
+/** Apply the current filter, coalescing bursts of typing into one pass.
+ *
+ *  `applyFileFilter` rebuilds the whole unified diff — the stream renders
+ *  only matching files, so the centre genuinely changes — and on a large
+ *  review that is far too much to do between keystrokes. The field itself
+ *  stays responsive regardless: the host owns its text and echoes each
+ *  character immediately, so debouncing only defers the tree and centre.
+ *
+ *  Every keystroke cancels the pending pass, so intermediate queries are
+ *  never rendered at all — the abandoned work is dropped rather than
+ *  raced. Only the final query is applied. */
+function scheduleFileFilter(): void {
+    if (filterApplyTimer !== null) editor.clearInterval(filterApplyTimer);
+    filterApplyTimer = editor.setTimeout(FILTER_DEBOUNCE_MS, "review_apply_file_filter");
+}
+
+/** Timer target for `scheduleFileFilter`. */
+function review_apply_file_filter(): void {
+    filterApplyTimer = null;
+    if (state.groupId === null) return;
+    applyFileFilter();
+}
+registerHandler("review_apply_file_filter", review_apply_file_filter);
+
+/** Run a debounced filter pass now, if one is pending.
+ *
+ *  Anything that depends on the filter having been applied — closing the
+ *  field, navigating off it — flushes first so it never observes a tree
+ *  built from a stale query. */
+function flushPendingFileFilter(): void {
+    if (filterApplyTimer === null) return;
+    editor.clearInterval(filterApplyTimer);
+    filterApplyTimer = null;
+    applyFileFilter();
+}
+
 /** Re-filter after an edit: the tree, the centre (the stream renders only
  *  matching files) and the status line. */
 function applyFileFilter(): void {
@@ -5189,6 +5297,13 @@ function applyFileFilter(): void {
 function closeFileFilter(revert: boolean): void {
     if (!filterEditing) return;
     if (revert && state.fileFilter !== filterBeforeEdit) {
+        // Drop any pass still owed to the abandoned query — it would rebuild
+        // to the query being reverted away from, and then land *after* this
+        // one.
+        if (filterApplyTimer !== null) {
+            editor.clearInterval(filterApplyTimer);
+            filterApplyTimer = null;
+        }
         state.fileFilter = filterBeforeEdit;
         filterCursor = filterBeforeEdit.length;
         applyFileFilter();
@@ -5198,6 +5313,10 @@ function closeFileFilter(revert: boolean): void {
         // abandoned text over a tree that already reverted.
         filesPanel?.setValue(FILES_FILTER_KEY, filterBeforeEdit, filterCursor);
     }
+    // Enter: the typed query stands, so anything still owed has to land
+    // before the field closes — otherwise the tree behind it is one
+    // keystroke stale until the timer happens to fire.
+    flushPendingFileFilter();
     leaveFilterMode();
     // Focus lands on the tree — you filtered to pick a file.
     if (filesPanel !== null) filesPanel.setFocusKey(FILES_TREE_KEY);
@@ -6248,7 +6367,7 @@ const REVIEW_LAYOUT = JSON.stringify({
     second: {
         type: "split",
         direction: "h",
-        ratio: 0.16,
+        ratio: FILES_PANEL_RATIO,
         first: { type: "scrollable", id: "files" },
         second: {
             type: "split",

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1831,6 +1831,14 @@ type WidgetSpec = {
 	* selection stay node-based; rows per node just vary.
 	*/
 	cardBorders: boolean;
+	/**
+	* Columns of indent per depth level. `2` (the default) is the
+	* classic tree step. A panel only a couple of dozen columns wide
+	* that nests several levels deep can drop to `1` and spend those
+	* columns on node text instead — each level is still marked by
+	* the disclosure glyph (or the blank standing in for one).
+	*/
+	indentCols: number;
 	key?: string | null;
 } | {
 	"kind": "text";

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -528,6 +528,11 @@ export function tree(options: {
    * headers) render as plain single rows instead of being blank-padded
    * to the card height. */
   cardBorders?: boolean;
+  /** Columns of indent per depth level. `2` (default) is the classic
+   * tree step. Narrow panels that nest several levels deep can drop to
+   * `1` to spend those columns on the node text instead; the disclosure
+   * glyph (or the blank standing in for one) still marks each level. */
+  indentCols?: number;
   key?: string;
 }): WidgetSpec {
   return {
@@ -540,6 +545,7 @@ export function tree(options: {
     checkable: options.checkable ?? false,
     itemHeight: options.itemHeight ?? 1,
     cardBorders: options.cardBorders ?? false,
+    indentCols: options.indentCols ?? 2,
     key: options.key,
   };
 }

--- a/crates/fresh-editor/src/model/marker.rs
+++ b/crates/fresh-editor/src/model/marker.rs
@@ -105,6 +105,25 @@ impl MarkerList {
         id
     }
 
+    /// Create a marker covering a whole range, rather than a point.
+    ///
+    /// The tree's `query` is an ordinary max-end interval-overlap query, so a
+    /// marker inserted with its real extent is returned for any range it
+    /// touches — including a query that falls strictly *inside* it. Point
+    /// markers cannot answer that: an interval whose endpoints both sit
+    /// outside the query is invisible to a query over its endpoints. Callers
+    /// that need "give me the things covering this window" (overlay
+    /// viewport lookup) index their extent with this and keep their own
+    /// endpoint markers for the authoritative positions.
+    ///
+    /// Right gravity, matching `create`.
+    pub fn create_span(&mut self, start: usize, end: usize) -> MarkerId {
+        let tree_id = self.tree.insert(start as u64, end.max(start) as u64);
+        let id = MarkerId(tree_id);
+        self._affinity_map.insert(id, false);
+        id
+    }
+
     /// Delete a marker
     pub fn delete(&mut self, id: MarkerId) {
         self.tree.delete(id.0);

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -150,6 +150,20 @@ pub struct Overlay {
     /// End marker, also right gravity: text typed at the end extends it.
     pub end_marker: MarkerId,
 
+    /// Spatial index only: one marker covering the overlay's whole extent,
+    /// so the marker tree's interval-overlap query can return this overlay
+    /// for a viewport it *spans* — the case two endpoint markers cannot
+    /// answer, because both sit outside such a window.
+    ///
+    /// Never read for positions; `start_marker`/`end_marker` stay
+    /// authoritative. It is created with right gravity while a fixed-end
+    /// overlay's real end has left gravity, so the span can sit a byte wide
+    /// of the true range at an edit boundary. That is deliberate and safe in
+    /// one direction only: the span is a superset, so it can over-offer a
+    /// candidate (harmless — `query_viewport` re-checks every candidate
+    /// against the real markers) but never hide one.
+    pub span_marker: MarkerId,
+
     /// Visual appearance of the overlay
     pub face: OverlayFace,
 
@@ -185,12 +199,14 @@ impl Overlay {
     pub fn new(marker_list: &mut MarkerList, range: Range<usize>, face: OverlayFace) -> Self {
         let start_marker = marker_list.create(range.start); // left affinity
         let end_marker = marker_list.create(range.end); // right affinity
+        let span_marker = marker_list.create_span(range.start, range.end);
 
         Self {
             handle: OverlayHandle::new(),
             namespace: None,
             start_marker,
             end_marker,
+            span_marker,
             face,
             priority: 0,
             message: None,
@@ -227,12 +243,14 @@ impl Overlay {
     ) -> Self {
         let start_marker = marker_list.create(range.start); // left affinity
         let end_marker = marker_list.create_left_gravity(range.end);
+        let span_marker = marker_list.create_span(range.start, range.end);
 
         Self {
             handle: OverlayHandle::new(),
             namespace: Some(namespace),
             start_marker,
             end_marker,
+            span_marker,
             face,
             priority: 0,
             message: None,
@@ -340,6 +358,7 @@ impl OverlayManager {
         for (i, o) in self.overlays.iter().enumerate().skip(pos) {
             self.marker_to_idx.insert(o.start_marker, i);
             self.marker_to_idx.insert(o.end_marker, i);
+            self.marker_to_idx.insert(o.span_marker, i);
         }
         handle
     }
@@ -366,13 +385,16 @@ impl OverlayManager {
             let overlay = self.overlays.remove(pos);
             self.marker_to_idx.remove(&overlay.start_marker);
             self.marker_to_idx.remove(&overlay.end_marker);
+            self.marker_to_idx.remove(&overlay.span_marker);
             // Vec::remove shifts every subsequent entry down by one — repair.
             for (i, o) in self.overlays.iter().enumerate().skip(pos) {
                 self.marker_to_idx.insert(o.start_marker, i);
                 self.marker_to_idx.insert(o.end_marker, i);
+                self.marker_to_idx.insert(o.span_marker, i);
             }
             marker_list.delete(overlay.start_marker);
             marker_list.delete(overlay.end_marker);
+            marker_list.delete(overlay.span_marker);
             true
         } else {
             false
@@ -401,23 +423,26 @@ impl OverlayManager {
         else {
             return;
         };
-        let mut removed: Vec<(MarkerId, MarkerId)> = Vec::new();
+        let mut removed: Vec<(MarkerId, MarkerId, MarkerId)> = Vec::new();
         self.overlays.retain(|o| {
             let hit = o.namespace.as_ref() == Some(namespace);
             if hit {
-                removed.push((o.start_marker, o.end_marker));
+                removed.push((o.start_marker, o.end_marker, o.span_marker));
             }
             !hit
         });
-        for (start_marker, end_marker) in removed {
+        for (start_marker, end_marker, span_marker) in removed {
             self.marker_to_idx.remove(&start_marker);
             self.marker_to_idx.remove(&end_marker);
+            self.marker_to_idx.remove(&span_marker);
             marker_list.delete(start_marker);
             marker_list.delete(end_marker);
+            marker_list.delete(span_marker);
         }
         for (i, o) in self.overlays.iter().enumerate().skip(first) {
             self.marker_to_idx.insert(o.start_marker, i);
             self.marker_to_idx.insert(o.end_marker, i);
+            self.marker_to_idx.insert(o.span_marker, i);
         }
     }
 
@@ -594,11 +619,14 @@ impl OverlayManager {
         let removed = self.overlays.swap_remove(idx);
         self.marker_to_idx.remove(&removed.start_marker);
         self.marker_to_idx.remove(&removed.end_marker);
+        self.marker_to_idx.remove(&removed.span_marker);
         marker_list.delete(removed.start_marker);
         marker_list.delete(removed.end_marker);
+        marker_list.delete(removed.span_marker);
         if let Some(moved) = self.overlays.get(idx) {
             self.marker_to_idx.insert(moved.start_marker, idx);
             self.marker_to_idx.insert(moved.end_marker, idx);
+            self.marker_to_idx.insert(moved.span_marker, idx);
         }
     }
 
@@ -609,6 +637,7 @@ impl OverlayManager {
         for (i, o) in self.overlays.iter().enumerate() {
             self.marker_to_idx.insert(o.start_marker, i);
             self.marker_to_idx.insert(o.end_marker, i);
+            self.marker_to_idx.insert(o.span_marker, i);
         }
     }
 
@@ -645,57 +674,49 @@ impl OverlayManager {
         end: usize,
         marker_list: &MarkerList,
     ) -> Vec<(&Overlay, Range<usize>)> {
-        use std::collections::HashMap;
+        // Ask the marker tree which overlays touch the window at all. Every
+        // overlay indexes its whole extent as one span marker, so this is an
+        // ordinary interval-overlap query and it answers for all three
+        // shapes: starting inside, ending inside, and spanning the window
+        // with both endpoints outside. That last one is why this cannot be
+        // driven from the endpoint markers alone, and why this used to walk
+        // every overlay in the buffer instead — on a large diff that was
+        // ~22 000 overlays scanned to find the ~270 on screen, once per
+        // frame, and it is what made arrow keys, filter typing and divider
+        // drags all queue behind the redraw.
+        let hits = marker_list.query_range(start, end);
 
-        // Query the marker interval tree once for all markers in viewport
-        // This is O(log N + k) where k = markers in viewport
-        let visible_markers = marker_list.query_range(start, end);
-
-        // Build a quick lookup map: marker_id -> position
-        let marker_positions: HashMap<_, _> = visible_markers
-            .into_iter()
-            .map(|(id, start, _end)| (id, start))
-            .collect();
-
-        // Find overlays whose resolved range overlaps the viewport. Markers
-        // may be inside it, partially outside (a multi-line overlay scrolled
-        // half out of view), or entirely outside on both sides (an overlay
-        // taller than the window). The marker query is an index that makes the
-        // common case cheap, not the visibility test.
-        self.overlays
+        // A candidate can arrive up to three times (start, end and span
+        // markers all land in the window for a short overlay), so fold to
+        // distinct overlay indices before resolving anything.
+        let mut candidates: Vec<usize> = hits
             .iter()
-            .filter_map(|overlay| {
-                let start_in_vp = marker_positions.get(&overlay.start_marker).copied();
-                let end_in_vp = marker_positions.get(&overlay.end_marker).copied();
+            .filter_map(|(id, _, _)| self.marker_to_idx.get(id).copied())
+            .collect();
+        candidates.sort_unstable();
+        candidates.dedup();
 
-                // Resolve both endpoints, whether or not their markers landed
-                // in the viewport query. Requiring at least one marker inside
-                // dropped an overlay that *spans* the viewport — start above
-                // the top, end below the bottom — even though it covers every
-                // visible line. That is the common shape for anything taller
-                // than the window: a code-tour step range, a long diagnostic,
-                // a large diff hunk. The overlap test below decides visibility.
-                let start_pos =
-                    start_in_vp.or_else(|| marker_list.get_position(overlay.start_marker))?;
-                let end_pos = end_in_vp.or_else(|| marker_list.get_position(overlay.end_marker))?;
-
+        // The span marker is only an index — deliberately a superset, so it
+        // can offer a candidate that does not really overlap. The real
+        // markers decide, exactly as before.
+        candidates
+            .into_iter()
+            .filter_map(|idx| {
+                let overlay = self.overlays.get(idx)?;
+                let start_pos = marker_list.get_position(overlay.start_marker)?;
+                let end_pos = marker_list.get_position(overlay.end_marker)?;
                 let range = start_pos..end_pos;
 
-                // Only include if actually overlaps viewport.
-                // For zero-width ranges (e.g. diagnostics at a single position),
-                // check that the point is within [start, end] (inclusive).
-                // For non-zero ranges, check standard overlap: start < end && end > start.
+                // Zero-width ranges (a diagnostic at a single position) are
+                // inclusive at both ends; everything else is a standard
+                // half-open overlap test.
                 let included = if range.start == range.end {
                     range.start >= start && range.start <= end
                 } else {
                     range.start < end && range.end > start
                 };
 
-                if included {
-                    Some((overlay, range))
-                } else {
-                    None
-                }
+                included.then_some((overlay, range))
             })
             .collect()
     }
@@ -730,10 +751,14 @@ impl OverlayManager {
     /// Panics on any divergence. Used by property tests.
     #[cfg(test)]
     fn check_invariants(&self) {
+        // Three markers per overlay: the two authoritative endpoints plus
+        // the span that indexes its extent for `query_viewport`. All three
+        // must map to the overlay's slot, or a viewport query resolves the
+        // wrong overlay — or silently drops one.
         assert_eq!(
             self.marker_to_idx.len(),
-            self.overlays.len() * 2,
-            "marker_to_idx size != 2 * overlays.len()"
+            self.overlays.len() * 3,
+            "marker_to_idx size != 3 * overlays.len()"
         );
         for (i, o) in self.overlays.iter().enumerate() {
             assert_eq!(
@@ -748,6 +773,13 @@ impl OverlayManager {
                 Some(i),
                 "end_marker {:?} of overlay {} mismapped",
                 o.end_marker,
+                i,
+            );
+            assert_eq!(
+                self.marker_to_idx.get(&o.span_marker).copied(),
+                Some(i),
+                "span_marker {:?} of overlay {} mismapped",
+                o.span_marker,
                 i,
             );
         }
@@ -956,15 +988,76 @@ mod tests {
                 "end marker index stale for overlay {i}"
             );
         }
-        // The index must not still reference the removed overlays.
+        // The index must not still reference the removed overlays — three
+        // markers each (start, end, span), for the 50 that survive.
         assert_eq!(
             mgr.marker_to_idx.len(),
-            100,
-            "index holds exactly two markers per surviving overlay"
+            150,
+            "index holds exactly three markers per surviving overlay"
         );
+        for (i, o) in mgr.overlays.iter().enumerate() {
+            assert_eq!(
+                mgr.marker_to_idx.get(&o.span_marker),
+                Some(&i),
+                "span marker index stale for overlay {i}"
+            );
+        }
         // Clearing an absent namespace is a no-op.
         mgr.clear_namespace(&scratch, &mut marker_list);
         assert_eq!(mgr.overlays.len(), 50);
+    }
+
+    /// `query_viewport` is driven by the marker tree, so it must return every
+    /// overlay touching the window regardless of how the window sits inside
+    /// it — and must not depend on how much else the buffer carries.
+    ///
+    /// The spanning shape is the one that forced the old full scan: both
+    /// endpoints lie outside the window, so no query over endpoint markers
+    /// can find it. The span marker is what makes it answerable.
+    #[test]
+    fn test_query_viewport_finds_every_overlap_shape() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(100_000);
+        let mut mgr = OverlayManager::new();
+        let face = || OverlayFace::Background { color: Color::Red };
+
+        let starts_inside = mgr.add(Overlay::new(&mut marker_list, 4_950..5_010, face()));
+        let ends_inside = mgr.add(Overlay::new(&mut marker_list, 4_990..5_050, face()));
+        let wholly_inside = mgr.add(Overlay::new(&mut marker_list, 5_001..5_002, face()));
+        let spans = mgr.add(Overlay::new(&mut marker_list, 1_000..9_000, face()));
+        let before = mgr.add(Overlay::new(&mut marker_list, 10..20, face()));
+        let after = mgr.add(Overlay::new(&mut marker_list, 90_000..90_010, face()));
+
+        // Bury them in unrelated overlays: the answer must not change.
+        for i in 0..5_000 {
+            let at = 20_000 + i * 10;
+            mgr.add(Overlay::new(&mut marker_list, at..at + 4, face()));
+        }
+
+        let found: Vec<_> = mgr
+            .query_viewport(5_000, 5_005, &marker_list)
+            .into_iter()
+            .map(|(o, _)| o.handle.clone())
+            .collect();
+
+        for (label, handle) in [
+            ("starts inside", &starts_inside),
+            ("ends inside", &ends_inside),
+            ("wholly inside", &wholly_inside),
+            ("spans the window", &spans),
+        ] {
+            assert!(
+                found.contains(handle),
+                "{label} overlay missing from viewport query"
+            );
+        }
+        for (label, handle) in [("before", &before), ("after", &after)] {
+            assert!(
+                !found.contains(handle),
+                "{label} overlay must not be returned"
+            );
+        }
+        assert_eq!(found.len(), 4, "no unrelated overlay should be returned");
     }
 
     /// An overlay taller than the viewport still renders.

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -379,24 +379,46 @@ impl OverlayManager {
         }
     }
 
-    /// Remove all overlays in a namespace
+    /// Remove all overlays in a namespace.
+    ///
+    /// Removal is stable, which is what keeps this cheap. `swap_remove`
+    /// scrambles the priority ordering, and restoring it meant sorting every
+    /// overlay in the buffer and rebuilding the whole marker index — work
+    /// proportional to overlays this namespace has nothing to do with. That
+    /// is paid on a hot path: a plugin that repaints a one-row highlight
+    /// (the review diff's cursor line) clears and re-adds its namespace on
+    /// every cursor move, so an unrelated 20 000-overlay diff made each
+    /// arrow key cost milliseconds and holding one down crawl.
+    ///
+    /// Retaining in place preserves priority order, so no sort is needed,
+    /// and only indices at or after the first removal shift — everything
+    /// before it keeps its slot and needs no re-indexing.
     pub fn clear_namespace(&mut self, namespace: &OverlayNamespace, marker_list: &mut MarkerList) {
-        let mut indices: Vec<usize> = self
+        let Some(first) = self
             .overlays
             .iter()
-            .enumerate()
-            .filter_map(|(i, o)| (o.namespace.as_ref() == Some(namespace)).then_some(i))
-            .collect();
-        if indices.is_empty() {
+            .position(|o| o.namespace.as_ref() == Some(namespace))
+        else {
             return;
+        };
+        let mut removed: Vec<(MarkerId, MarkerId)> = Vec::new();
+        self.overlays.retain(|o| {
+            let hit = o.namespace.as_ref() == Some(namespace);
+            if hit {
+                removed.push((o.start_marker, o.end_marker));
+            }
+            !hit
+        });
+        for (start_marker, end_marker) in removed {
+            self.marker_to_idx.remove(&start_marker);
+            self.marker_to_idx.remove(&end_marker);
+            marker_list.delete(start_marker);
+            marker_list.delete(end_marker);
         }
-        indices.sort_unstable_by(|a, b| b.cmp(a));
-        for idx in indices {
-            self.swap_remove_at(idx, marker_list);
+        for (i, o) in self.overlays.iter().enumerate().skip(first) {
+            self.marker_to_idx.insert(o.start_marker, i);
+            self.marker_to_idx.insert(o.end_marker, i);
         }
-        // Restore priority order after swap_removes.
-        self.overlays.sort_by_key(|o| o.priority);
-        self.rebuild_marker_index();
     }
 
     /// Replace overlays in a namespace that overlap a range with new overlays.
@@ -864,6 +886,86 @@ impl Overlay {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Clearing a namespace must not disturb overlays outside it, and must
+    /// leave the marker index consistent for the ones that remain.
+    ///
+    /// The previous implementation `swap_remove`d, which scrambled priority
+    /// order, then repaired it by sorting every overlay and rebuilding the
+    /// entire marker index. That made a one-overlay clear cost time
+    /// proportional to the whole buffer — 2.9ms per call at 20 000 overlays,
+    /// paid on every cursor move by any plugin that repaints a highlight.
+    /// Order and index integrity are what the sort/rebuild were there for,
+    /// so this pins them directly.
+    #[test]
+    fn test_clear_namespace_preserves_order_and_index() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(10_000);
+        let mut mgr = OverlayManager::new();
+        let bulk = OverlayNamespace("bulk".to_string());
+        let scratch = OverlayNamespace("scratch".to_string());
+
+        // Interleave two namespaces across a range of priorities so a
+        // scrambling removal would be visible in the survivors' order.
+        for i in 0..50usize {
+            mgr.add(
+                Overlay::with_namespace(
+                    &mut marker_list,
+                    (i * 10)..(i * 10 + 4),
+                    OverlayFace::Background { color: Color::Red },
+                    bulk.clone(),
+                )
+                .with_priority_value(i as Priority),
+            );
+            mgr.add(
+                Overlay::with_namespace(
+                    &mut marker_list,
+                    (i * 10 + 5)..(i * 10 + 8),
+                    OverlayFace::Background { color: Color::Blue },
+                    scratch.clone(),
+                )
+                .with_priority_value(i as Priority),
+            );
+        }
+
+        mgr.clear_namespace(&scratch, &mut marker_list);
+
+        assert_eq!(mgr.overlays.len(), 50, "only the bulk namespace survives");
+        assert!(
+            mgr.overlays
+                .iter()
+                .all(|o| o.namespace.as_ref() == Some(&bulk)),
+            "no scratch overlay may survive"
+        );
+        assert!(
+            mgr.overlays
+                .windows(2)
+                .all(|w| w[0].priority <= w[1].priority),
+            "survivors stay in priority order"
+        );
+        // Every surviving overlay must be findable at its recorded index.
+        for (i, o) in mgr.overlays.iter().enumerate() {
+            assert_eq!(
+                mgr.marker_to_idx.get(&o.start_marker),
+                Some(&i),
+                "start marker index stale for overlay {i}"
+            );
+            assert_eq!(
+                mgr.marker_to_idx.get(&o.end_marker),
+                Some(&i),
+                "end marker index stale for overlay {i}"
+            );
+        }
+        // The index must not still reference the removed overlays.
+        assert_eq!(
+            mgr.marker_to_idx.len(),
+            100,
+            "index holds exactly two markers per surviving overlay"
+        );
+        // Clearing an absent namespace is a no-op.
+        mgr.clear_namespace(&scratch, &mut marker_list);
+        assert_eq!(mgr.overlays.len(), 50);
+    }
 
     /// An overlay taller than the viewport still renders.
     ///

--- a/crates/fresh-editor/src/widgets/actions.rs
+++ b/crates/fresh-editor/src/widgets/actions.rs
@@ -429,6 +429,7 @@ mod tests {
             checkable: false,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: Some("t".into()),
         };
         let new_nodes = vec![node("new1", 0, false), node("new2", 0, false)];
@@ -467,6 +468,7 @@ mod tests {
             checkable: true,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: Some("t".into()),
         };
         let ok = set_tree_checked_keys_in_spec(
@@ -506,6 +508,7 @@ mod tests {
             checkable: true,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: Some("t".into()),
         };
         let _ok = set_tree_checked_keys_in_spec(
@@ -534,6 +537,7 @@ mod tests {
             checkable: false,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: Some("real".into()),
         };
         assert!(!set_tree_nodes_in_spec(&mut spec, "wrong", vec![], vec![]));

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -872,6 +872,7 @@ fn render_collected(
             checkable,
             item_height,
             card_borders,
+            indent_cols,
             key: tree_key,
         } => render_widget_tree(
             nodes,
@@ -882,6 +883,7 @@ fn render_collected(
             *checkable,
             *item_height,
             *card_borders,
+            *indent_cols,
             tree_key.as_deref(),
             prev,
             next_state,
@@ -3188,6 +3190,7 @@ fn render_widget_tree(
     checkable: bool,
     item_height: u32,
     card_borders: bool,
+    indent_cols: u32,
     tree_key: Option<&str>,
     prev: &HashMap<String, WidgetInstanceState>,
     next_state: &mut HashMap<String, WidgetInstanceState>,
@@ -3390,6 +3393,7 @@ fn render_widget_tree(
             item_height,
             card_borders,
             panel_width,
+            indent_cols,
         );
         let mut entry = rendered.entry;
         let is_selected = abs_idx as i32 == effective_sel_abs;
@@ -5499,6 +5503,7 @@ pub fn render_tree_row(
     item_height: u32,
     card_borders: bool,
     panel_width: u32,
+    indent_cols: u32,
 ) -> RenderedTreeRow {
     // Bordered-card trees: card nodes render inside a rounded box; the
     // other nodes (folder headers) collapse to a plain single row
@@ -5511,7 +5516,7 @@ pub fn render_tree_row(
     } else {
         item_height
     };
-    let indent_cols = (node.depth as usize) * 2;
+    let indent_cols = (node.depth as usize) * (indent_cols as usize);
     let disclosure_glyph: &str = if node.has_children {
         if expanded {
             "▼"
@@ -7472,6 +7477,7 @@ mod tests {
             checkable: false,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: Some("sessions".to_string()),
         };
         let out = render_spec_with_options(
@@ -8511,13 +8517,14 @@ mod tests {
             checkable: false,
             item_height: 1,
             card_borders: false,
+            indent_cols: 2,
             key: key.map(|s| s.to_string()),
         }
     }
 
     #[test]
     fn tree_row_renders_disclosure_glyph_for_internal_collapsed() {
-        let r = render_tree_row(&tnode("file.txt", 0, true), false, false, 1, false, 80);
+        let r = render_tree_row(&tnode("file.txt", 0, true), false, false, 1, false, 80, 2);
         assert!(r.entry.text.starts_with('\u{25B6}'), "starts with ▶");
         assert!(r.entry.text.contains("file.txt"));
         assert!(r.disclosure_range.is_some());
@@ -8525,13 +8532,13 @@ mod tests {
 
     #[test]
     fn tree_row_renders_disclosure_glyph_for_internal_expanded() {
-        let r = render_tree_row(&tnode("file.txt", 0, true), true, false, 1, false, 80);
+        let r = render_tree_row(&tnode("file.txt", 0, true), true, false, 1, false, 80, 2);
         assert!(r.entry.text.starts_with('\u{25BC}'), "starts with ▼");
     }
 
     #[test]
     fn tree_row_leaf_uses_two_spaces_no_disclosure_hit() {
-        let r = render_tree_row(&tnode("match", 0, false), false, false, 1, false, 80);
+        let r = render_tree_row(&tnode("match", 0, false), false, false, 1, false, 80, 2);
         // No glyph, just spaces for alignment.
         assert!(r.entry.text.starts_with("  "));
         assert!(r.entry.text.contains("match"));
@@ -8540,7 +8547,7 @@ mod tests {
 
     #[test]
     fn tree_row_indents_by_depth_times_two() {
-        let r = render_tree_row(&tnode("nested", 2, false), false, false, 1, false, 80);
+        let r = render_tree_row(&tnode("nested", 2, false), false, false, 1, false, 80, 2);
         // depth=2 → 4 leading spaces, then 2 alignment spaces, then "nested".
         assert!(r.entry.text.starts_with("      nested"));
     }
@@ -8558,7 +8565,7 @@ mod tests {
             properties: Default::default(),
             unit: OffsetUnit::Byte,
         });
-        let r = render_tree_row(&node, false, false, 1, false, 80);
+        let r = render_tree_row(&node, false, false, 1, false, 80, 2);
         // depth=1 → 2 indent + 2 alignment = 4 prefix bytes (ASCII).
         // The plugin's [0..5] becomes [4..9].
         let plugin_overlay = r
@@ -8576,7 +8583,7 @@ mod tests {
         // Even with `checked: Some(_)`, no glyph if `checkable: false`.
         let mut node = tnode("file.rs", 0, false);
         node.checked = Some(true);
-        let r = render_tree_row(&node, false, false, 1, false, 80);
+        let r = render_tree_row(&node, false, false, 1, false, 80, 2);
         assert!(r.checkbox_range.is_none());
         assert!(!r.entry.text.contains("[v]"));
         assert!(!r.entry.text.contains("[ ]"));
@@ -8588,7 +8595,7 @@ mod tests {
         // Lets a checkable tree mix non-checkbox-bearing nodes
         // (e.g. a separator or header) with checkbox rows.
         let node = tnode("section", 0, false);
-        let r = render_tree_row(&node, false, true, 1, false, 80);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
         assert!(r.checkbox_range.is_none());
         assert!(!r.entry.text.contains("[v]"));
         assert!(!r.entry.text.contains("[ ]"));
@@ -8598,7 +8605,7 @@ mod tests {
     fn tree_row_renders_checked_glyph_after_disclosure() {
         let mut node = tnode("file.rs", 0, true);
         node.checked = Some(true);
-        let r = render_tree_row(&node, true, true, 1, false, 80);
+        let r = render_tree_row(&node, true, true, 1, false, 80, 2);
         assert!(r.checkbox_range.is_some(), "checkbox range emitted");
         let (cb_start, cb_end) = r.checkbox_range.unwrap();
         // Layout: ▼(3 bytes UTF-8) + " " + [v] + " " + body
@@ -8610,7 +8617,7 @@ mod tests {
     fn tree_row_renders_unchecked_glyph_for_leaf() {
         let mut node = tnode("match-row", 1, false);
         node.checked = Some(false);
-        let r = render_tree_row(&node, false, true, 1, false, 80);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
         let (cb_start, cb_end) = r
             .checkbox_range
             .expect("checkbox range for leaf with checked: Some");
@@ -8625,7 +8632,7 @@ mod tests {
         // verbatim (no UTF-8 boundary issues from the disclosure).
         let mut node = tnode("path/with/é", 0, true);
         node.checked = Some(true);
-        let r = render_tree_row(&node, false, true, 1, false, 80);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
         let (cb_start, cb_end) = r.checkbox_range.unwrap();
         assert!(r.entry.text.is_char_boundary(cb_start));
         assert!(r.entry.text.is_char_boundary(cb_end));
@@ -8857,6 +8864,7 @@ mod tests {
             checkable: false,
             item_height: 2,
             card_borders: true,
+            indent_cols: 2,
             key: Some("T".to_string()),
         };
         let out = render_spec(&spec, &HashMap::new(), "", width);
@@ -9193,6 +9201,7 @@ mod tests {
             checkable: false,
             item_height: 3,
             card_borders: true,
+            indent_cols: 2,
             key: Some("T".into()),
         };
         // A finite panel width: bordered cards draw `─` runs across the


### PR DESCRIPTION
Follow-up to the merged review-diff work. Five reported issues, plus the overlay-lookup rework that profiling turned up underneath three of them.

The two overlay changes are editor-wide: any buffer carrying many decorations (a large diff, but equally a big file with syntax highlighting, diagnostics or search hits) was paying redraw cost proportional to everything in it rather than what was on screen.

| | |
|---|---|
| **Redraw cost** | scaled with total overlays in the buffer → now with the viewport |
| **Cursor-line repaint** | sorted + reindexed every overlay per cursor move → now touches only its own namespace |
| **Files filter** | rebuilt the whole unified diff per keystroke → debounced |
| **Divider drag** | rebuilt the whole tree per column crossed → coalesced to the settled width |
| **Sidebar rows** | `+x -y` counts removed |
| **Sidebar layout** | opens wider (0.16 → 0.22), nests tighter (indent 2 → 1) |

Everything was driven by hand in tmux against a generated 54-file review (+4320 −2160), with pane captures parsed cell-by-cell for colour so panel columns and scrollbar tracks could be checked exactly.

---

## Viewport overlay lookup no longer scales with the buffer

`query_viewport` built an O(log n + k) marker-tree query and then walked every overlay in the buffer anyway — ~21,900 scanned to find the ~270 on screen. Every redraw paid it, so arrow keys, filter typing and divider drags all queued behind the same cost.

It couldn't use the index it built because an overlay is anchored by two *point* markers: a query over the window answers "starts here" and "ends here", but not "covers all of it" — a spanning overlay has both endpoints outside it (the case `test_query_viewport_keeps_overlay_spanning_the_viewport` pins).

Nothing new was needed to answer that. `IntervalTree::query` is an ordinary max-end interval-overlap query, so it already returns intervals that *contain* the queried range — it was simply never told an overlay's extent, only degenerate `insert(pos, pos)` points, while `insert_line_anchor` already stores real spans. Each overlay now also registers its extent as one interval marker; the lookup asks the tree, folds hits to distinct overlay indices through the `marker_to_idx` map that already existed, and resolves only those. It's the shape `replace_range_in_namespace` already used: narrow with the tree, then verify against the real markers.

Measured in situ — same buffer, same result set:

| | before | after |
|---|---|---|
| `query_viewport` (21,898 overlays, 271 visible) | 13,781 µs | **~450 µs** |
| render frame | ~38 ms | ~31 ms |
| per keypress, holding Down | ~139 ms | ~98 ms |

The span is an index and nothing else — the endpoint markers stay authoritative for positions. It carries right gravity while a fixed-end overlay's true end has left gravity, so at an edit boundary it can sit a byte wide of the real range. That asymmetry is the safe one: a superset can offer a candidate that the unchanged exact test then rejects, but it can never hide one.

**Holding Down is faster but still not fast.** ~31 ms of frame remains, now dominated by something other than this lookup, which I haven't identified — the profiling pointed here, and the next cost needs its own measurement.

## `clear_namespace` no longer touches the rest of the buffer

It removed overlays with `swap_remove`, scrambling the priority order the list is kept in, then repaired it by sorting **every** overlay in the buffer and rebuilding the **entire** marker index. The review diff's cursor-line highlight clears and re-adds its namespace on every cursor move, so an unrelated 20,000-overlay buffer made each arrow key cost milliseconds.

Retaining in place preserves priority order (no sort), and only indices at or after the first removal shift (partial re-index).

| overlays in buffer | before | after |
|---|---|---|
| 1,000 | 94 µs | 15 µs |
| 5,000 | 561 µs | 49 µs |
| 20,000 | 2.9 ms | 389 µs |

## Sidebar filter no longer rebuilds the diff per keystroke

`applyFileFilter` rebuilds the whole unified stream — it renders only matching files, so the centre genuinely changes — which is far too much between keystrokes. Debounced at 90 ms: each keystroke cancels the pending pass, so intermediate queries are dropped rather than rendered. Enter flushes what's pending; Esc drops it so an abandoned query can't land after the revert.

**This does not fully fix the reported slowness, and I verified that rather than assuming it.** The filter field itself trails typing by seconds on a large diff — typing `module_0` at speed leaves it reading `mo`. That is *pre-existing*: rebuilding with the pre-change plugin and repeating the test gives the same behaviour (`mod`). Characters are delayed, not lost — field and tree converge correctly. Note also that Enter can only flush events already *received*; events still in flight land after the field closes, so the tree can briefly show the previous query before converging.

## Divider drag no longer repaints per column

Mouse moves are already coalesced at the input layer and the drag itself only updates a split ratio — the cost was that every intervening width arrived as its own `viewport_changed` and rebuilt the entire tree across the IPC boundary. The size is still recorded synchronously — `panelWidthOf` and the header's `✕` need it at once — but the content repaint coalesces (60 ms) to the width the pointer settles on. Verified dragging 44 → 69 columns: panel reflows, `✕` lands at the new edge, scrollbar follows.

## Sidebar rows and layout

`+x -y` counts removed; comment badge and status letter stay.

`REVIEW_LAYOUT` and `panelWidthOf` describe the same panel and each carried its own copy of the ratio — they now read one constant, raised 0.16 → 0.22, because long paths were eliding to a few characters. Indent drops 2 → 1 column per level as an `indentCols` field on the Tree spec defaulting to the previous `2`: `render_tree_row` serves every Tree widget in the editor, so only the review sidebar asks for 1. `fresh.d.ts` regenerated.

## Known defect, not introduced here

When the FILES panel is scrolled, its **top row carries a stray thumb-coloured scrollbar cell** disconnected from the real thumb (thumb rows 20–49, track 7–19, row 6 painted as thumb). Stable across settle times and reproduces at both the default and a dragged-wider panel, so not a repaint transient. It looks like the widget list's bar and the split's buffer bar painting the shared column with different geometry — the two were made to coincide rather than stand side by side in the previous PR, but they can still disagree once the buffer scrolls.

## Testing

138 overlay/marker unit tests pass, including the marker-index proptest, the existing spanning-overlay case, and a new test covering all four overlap shapes — starts inside, ends inside, wholly inside, spans — with the overlays buried among 5,000 unrelated ones so a passing result can't come from a scan. `check_invariants` and the clear-namespace test now account for three markers per overlay.

Hand-verified on the 54-file review: single scrollbar at the panel's last column with a proportional thumb that tracks position and never overwrites row text; no counts on rows; indent one column per level with names aligned to their sibling directories; sticky header intact after `r` with the sidebar open; fold triangles rotate and round-trip; divider drag reflows correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKkE4wffJTS5Bey3TV2998