### PR TITLE
Frame fenced code blocks in compose mode

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3523,6 +3523,23 @@ pub enum PluginCommand {
         epoch: Option<u64>,
     },
 
+    /// Remove *inline* virtual texts whose string id starts with `id_prefix`
+    /// and whose anchor byte falls in `[start, end)`. The inline analogue of
+    /// `ClearVirtualLinesInRange`, for the same reason: a per-line decoration
+    /// pass has to clear exactly the line it is rebuilding, in the same batch
+    /// as the re-add. Matching is by id prefix because the inline add path
+    /// stores no namespace. Anchors resolve live from the marker list.
+    ClearVirtualTextsInRange {
+        buffer_id: BufferId,
+        id_prefix: String,
+        start: usize,
+        end: usize,
+        /// Buffer version `start`/`end` were computed against (from the
+        /// `lines_changed` epoch); see `ClearVirtualLinesInRange`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        epoch: Option<u64>,
+    },
+
     /// Add a conceal range that hides or replaces a byte range during rendering.
     /// Used for Typora-style seamless markdown: hiding syntax markers like `**`, `[](url)`, etc.
     AddConceal {

--- a/crates/fresh-core/src/hooks.rs
+++ b/crates/fresh-core/src/hooks.rs
@@ -551,6 +551,27 @@ pub enum HookArgs {
     },
 }
 
+/// A line's role in an embedded-language region — the classification the
+/// highlighting engine already makes per line while parsing (see
+/// `docs/internal/embedded-language-highlighting.md`). Markdown fenced code
+/// blocks and Vue `<script>`/`<style>` blocks are the current hosts.
+///
+/// This is the *only* answer to "am I inside a fence" that a plugin can trust:
+/// it is not derivable from a line's own text (a bare ``` is an opener or a
+/// closer depending on every fence above it), and a plugin cannot read the
+/// buffer above its batch synchronously.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RegionLine {
+    /// The region's opening delimiter (Markdown: ```` ```rust ````). Its
+    /// info string, if any, is in the line's own `content`.
+    Open,
+    /// A content line strictly inside the region.
+    Body,
+    /// The region's closing delimiter.
+    Close,
+}
+
 /// Information about a single line for the LinesChanged hook
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct LineInfo {
@@ -562,6 +583,14 @@ pub struct LineInfo {
     pub byte_end: usize,
     /// The content of the line
     pub content: String,
+    /// This line's role in an embedded-language region, when the buffer's
+    /// grammar hosts them and the engine could resolve the line's region
+    /// state. Absent both for ordinary lines and when the state is
+    /// *unknown* — see `TextMateEngine::region_lines_in` for when that
+    /// happens — so consumers must treat absence as "no framing decision",
+    /// never as "outside a region".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<RegionLine>,
 }
 
 /// Location information for LSP references

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3775,6 +3775,13 @@ interface EditorAPI {
 	*/
 	clearVirtualLinesInRange(bufferId: number, namespace: string, start: number, end: number): boolean;
 	/**
+	* Clear *inline* virtual texts whose id starts with `idPrefix` and whose
+	* anchor byte falls in `[start, end)`. The inline analogue of
+	* `clearVirtualLinesInRange`, so a per-line pass can rebuild one line's
+	* inline decorations without dropping the rest of the set.
+	*/
+	clearVirtualTextsInRange(bufferId: number, idPrefix: string, start: number, end: number): boolean;
+	/**
 	* Add a virtual line (full line above/below a position)
 	* 
 	* The `options` object accepts:

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -5109,6 +5109,17 @@ interface HookEventMap {
 			byte_start: number;
 			byte_end: number;
 			content: string;
+			/** This line's role in an embedded-language region — a Markdown fenced
+			* code block, a Vue `<script>`/`<style>` block — as the highlighting
+			* engine classifies it while parsing. `"open"` and `"close"` are the
+			* delimiter lines; `"body"` is content strictly inside.
+			*
+			* Absent for ordinary lines AND when the region state could not be
+			* resolved (a >1MiB buffer whose viewport has no parse checkpoint before
+			* it yet). Treat absence as *unknown*, never as "outside a region": the
+			* point of this field is that a bare ``` opens or closes depending on
+			* every fence above it, so there is nothing to fall back on. */
+			region?: "open" | "body" | "close";
 		}[];
 		/** Buffer version these byte ranges were captured at. Pass back to
 		* coordinate-mapping APIs to repair stale offsets from this batch. */

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -237,12 +237,28 @@ function fenceInfoString(content: string): string {
   return m ? m[1] : "";
 }
 
-/** A horizontal code-block frame line of the given corner style, filling the
- * page measure. Two columns short of the measure for the same reason the
- * thematic-break rule is (see `wrapBudget`): the renderer reserves an
- * end-of-line column, and a border that reached it would wrap. */
+/** Total rendered width of a code block's frame, borders and side rails alike.
+ *
+ * One function so the four edges cannot disagree — a rail computed against a
+ * different budget than the border it has to meet is off by exactly the
+ * difference, on every line of the block.
+ *
+ * Four columns short of the measure, where the thematic-break rule needs only
+ * two. The extra pair is for the rails specifically: a body row is assembled
+ * as `│ ` + code + padding + ` │`, and that padding is a run of *spaces* —
+ * break opportunities to the word-wrap machine, which sees inline virtual text
+ * (`splice_inline_virtual_text` runs before wrapping in `wrap_index`). At the
+ * measure the closing rail is the word that no longer fits, and it wraps onto
+ * a row of its own. */
+function codeFrameWidth(measure: number): number {
+  return Math.max(4, measure - 4);
+}
+
+/** A horizontal code-block frame line of the given corner style. */
 function buildCodeFrameLine(measure: number, label: string, left: string, right: string): string {
-  const inner = Math.max(1, measure - 2 - displayWidth(left) - displayWidth(right));
+  const inner = Math.max(
+    1, codeFrameWidth(measure) - displayWidth(left) - displayWidth(right),
+  );
   if (label) {
     const tag = `─ ${label} `;
     const tagW = displayWidth(tag);
@@ -253,6 +269,107 @@ function buildCodeFrameLine(measure: number, label: string, left: string, right:
 
 // fg matches the table frame's so the two kinds of block read as one system.
 const codeFrameStyle = { fg: "editor.fg" };
+
+// =============================================================================
+// Code block side rails
+// =============================================================================
+//
+// The block's left and right edges, closing the box the delimiters cap. They
+// have to be *inline virtual text* rather than conceals: a conceal replaces
+// source bytes, and a rail adds columns that no byte pays for — concealing a
+// real character to make room would cost that character its syntax colour, on
+// every line, and blank lines inside a block have no character to spend.
+//
+// Rails are the one part of the block that touches its body lines, so they are
+// deliberately the *only* thing that does: the code itself is still never read
+// as markdown, and the highlighting still comes through untouched.
+//
+// Clearing follows the same per-line discipline as the borders, via the
+// id-prefix + byte-range form (`clearVirtualTextsInRange`). A byte-exact
+// removal by id would not do: under the async `lines_changed` lag a rail
+// placed on the previous pass rides a few bytes ahead of the event's
+// `byteStart`, so its id — derived from where it *was* — is not the id derived
+// from where the event says the line is now, and the stale rail would survive
+// alongside the new one. The range clear resolves anchors live, so it catches
+// the rail wherever it drifted to.
+const CODE_RAIL_ID_PREFIX = "mdcr:";
+
+// The rail glyphs carry no padding of their own: the renderer adds exactly one
+// space between inline virtual text and the source text it anchors to — after a
+// `before` hint, in front of an `after` hint, and on both sides of a `before`
+// hint anchored on a newline (`splice_inline_virtual_text`). That is the inlay
+// hint convention and it is not optional, so the widths below count it rather
+// than trying to avoid it: a left rail costs 2 columns, a right rail its
+// padding plus 2.
+const RAIL_GLYPH = "│";
+const RAIL_RENDERED_COLUMNS = 2;
+
+/** Remove this line's rails, clearing its whole content range for the same
+ * reason `clearRowBorders` does. Called for *every* line in a batch, so a line
+ * that stops being code loses its rails. */
+function clearCodeRails(bufferId: number, byteStart: number, byteEnd: number): void {
+  editor.clearVirtualTextsInRange(
+    bufferId, CODE_RAIL_ID_PREFIX, byteStart, Math.max(byteEnd, byteStart + 1),
+  );
+}
+
+/** Draw the rails for one code-body line.
+ *
+ * A line long enough to reach the right rail's column gets no right rail: the
+ * padding would be negative, and forcing one would push the row past the wrap
+ * width and put the rail on a row of its own — worse than an open edge. Such a
+ * line is also force-wrapped by the renderer, and its continuation rows are not
+ * source lines, so they carry no rails either. The left rail is always drawn on
+ * the line's first row, so the block's left side stays unbroken down the code
+ * itself. */
+function emitCodeRails(
+  bufferId: number,
+  lineContent: string,
+  byteStart: number,
+  measure: number,
+): void {
+  const width = codeFrameWidth(measure);
+  const contentEnd = lineContentEndByte(lineContent, byteStart);
+  const text = lineContent.replace(/\r?\n$/, "");
+  const pad = width - 2 * RAIL_RENDERED_COLUMNS - displayWidth(text);
+
+  // An empty line has no character to hang two separate rails off, so both
+  // edges and the gap between them go in one piece at its line break.
+  //
+  // Its anchor is the newline cell, and that is the one case the renderer pads
+  // on *both* sides rather than one. The run is therefore the full frame width
+  // but its glyphs sit one column inside it — a blank row inside a block reads
+  // very slightly pinched. There is no way to reclaim that column from here:
+  // the leading space belongs to the renderer, and a plugin cannot emit
+  // negative padding. (Indented blank-looking lines are unaffected — their
+  // anchor is a Space cell, which takes the ordinary one-sided padding.)
+  if (contentEnd <= byteStart) {
+    const gap = Math.max(1, width - 2 - 2);
+    editor.addVirtualTextStyled(
+      bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:e`, byteStart,
+      RAIL_GLYPH + " ".repeat(gap) + RAIL_GLYPH, codeFrameStyle, true,
+    );
+    return;
+  }
+
+  editor.addVirtualTextStyled(
+    bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:l`, byteStart,
+    RAIL_GLYPH, codeFrameStyle, true,
+  );
+  if (pad >= 0) {
+    // Anchor the closing rail *after the last character*, found by code point
+    // rather than by `contentEnd - 1`: a byte before the end lands inside a
+    // multi-byte glyph, and the line's last character is exactly where a
+    // multi-byte glyph is most likely to be.
+    const chars = Array.from(text);
+    const lastChar = chars[chars.length - 1];
+    const lastCharStart = charToByte(lineContent, text.length - lastChar.length, byteStart);
+    editor.addVirtualTextStyled(
+      bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:r`, lastCharStart,
+      " ".repeat(pad) + RAIL_GLYPH, codeFrameStyle, false,
+    );
+  }
+}
 
 // Table borders are emitted PER LINE, exactly like conceals: for each table row
 // in a `lines_changed` batch we clear the virtual lines anchored at that row and
@@ -824,6 +941,9 @@ function disableMarkdownCompose(bufferId: number): void {
     // Same for the inter-list-item spacer rows, so they can't linger as
     // orphaned virtual lines after compose is toggled off.
     editor.clearVirtualTextNamespace(bufferId, LIST_SPACING_NS);
+    // And the code blocks' side rails, which are inline virtual text rather
+    // than virtual lines and so are not covered by the namespace clears.
+    editor.removeVirtualTextsByPrefix(bufferId, CODE_RAIL_ID_PREFIX);
     const memos = (editor.queryMarkers(bufferId, 0, 0x7fffffff) as Array<{ id: string }>) || [];
     for (const m of memos) {
       if (m.id.startsWith(TABLE_WIDTH_NS_PREFIX)) editor.deleteMarker(bufferId, m.id);
@@ -2142,6 +2262,13 @@ editor.on("lines_changed", (data) => {
     // table row, e.g. its pipes were deleted, and stale frames left a few bytes
     // off by the async lag).
     clearRowBorders(data.buffer_id, line.byte_start, line.byte_end);
+    // Same clear-then-rebuild for the code block's side rails, so a line that
+    // stops being code loses them. Re-added below only for `body` lines — the
+    // delimiter rows draw their own corners as part of the border conceal.
+    clearCodeRails(data.buffer_id, line.byte_start, line.byte_end);
+    if (line.region === "body") {
+      emitCodeRails(data.buffer_id, line.content, line.byte_start, measure);
+    }
     // Same range-scoped clear-then-rebuild as the borders, so a line that stops
     // being a list item loses its spacer.
     editor.clearVirtualLinesInRange(

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -308,9 +308,8 @@ function codeInnerWidth(measure: number): number {
   return Math.max(1, codeFrameWidth(measure) - 2 * RAIL_RENDERED_COLUMNS);
 }
 
-/** How one code line is split across framed rows: the char offsets of the
- * spaces that end each row, and the `[start, end)` char range of each row's
- * text.
+/** How one code line is split across framed rows: where each row breaks, and
+ * the `[start, end)` char range of each row's text.
  *
  * A code line too wide for the frame has to break *somewhere* — the buffer has
  * line wrap on, so the renderer will otherwise fold it to column zero, outside
@@ -318,11 +317,12 @@ function codeInnerWidth(measure: number): number {
  * every row is a row this pass knows the width of, so every row can be railed
  * and padded to the frame.
  *
- * Breaks must land on Space characters. Space tokens carry their own
- * `source_offset`; the characters inside a Text token all share the token's
- * start, so a break asked for mid-token silently does nothing (the same
- * constraint the table-row wrapping documents). A run with no space wide enough
- * to break at therefore stays one over-long row — see `emitCodeRails`.
+ * Breaks prefer the last space that leaves a non-empty row, and fall back to
+ * cutting mid-word at the frame's inner width when there is no such space — a
+ * bare URL is one token and one row of the frame is not wide enough for it.
+ * The two cases differ in whether the break character survives: a break *on* a
+ * space consumes it (the row ends there), while a mid-word break sits before a
+ * character that still has to be drawn.
  *
  * Shared by the rail pass and the soft-break pass so the two cannot disagree
  * about where the rows are, exactly as `widthsForRow` is shared for tables. */
@@ -337,11 +337,19 @@ function codeRowLayout(text: string, measure: number): { breaks: number[]; rows:
 
   for (let i = 0; i < text.length; i++) {
     const w = displayWidth(text[i]);
-    if (column + w > inner && lastSpace > rowStart) {
-      // Break at the last space that still leaves a non-empty row.
-      breaks.push(lastSpace);
-      rows.push({ start: rowStart, end: lastSpace });
-      rowStart = lastSpace + 1;
+    if (column + w > inner && i > rowStart) {
+      if (lastSpace > rowStart) {
+        // Word break: the space ends the row and is consumed by it.
+        breaks.push(lastSpace);
+        rows.push({ start: rowStart, end: lastSpace });
+        rowStart = lastSpace + 1;
+      } else {
+        // Nothing to break at — cut the word. The break sits *before* this
+        // character, which starts the next row rather than being consumed.
+        breaks.push(i);
+        rows.push({ start: rowStart, end: i });
+        rowStart = i;
+      }
       lastSpace = -1;
       column = 0;
       for (let j = rowStart; j <= i; j++) column += displayWidth(text[j]);

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -227,16 +227,6 @@ function touchesFenceChars(text: string): boolean {
   return /[`~]/.test(text);
 }
 
-/** The info string of an opening fence — its language — or "" when bare.
- *
- * CommonMark's first word of the info string; the engine resolves the same
- * token to a grammar (`resolve_embedded_syntax`), so the label names exactly
- * the language the body is being highlighted as. */
-function fenceInfoString(content: string): string {
-  const m = content.match(/^\s*(?:`{3,}|~{3,})\s*(\S+)/);
-  return m ? m[1] : "";
-}
-
 /** Total rendered width of a code block's frame, borders and side rails alike.
  *
  * One function so the four edges cannot disagree — a rail computed against a
@@ -254,16 +244,16 @@ function codeFrameWidth(measure: number): number {
   return Math.max(4, measure - 4);
 }
 
-/** A horizontal code-block frame line of the given corner style. */
-function buildCodeFrameLine(measure: number, label: string, left: string, right: string): string {
+/** A horizontal code-block frame line of the given corner style.
+ *
+ * Deliberately unlabelled. The fence's info string is not repeated in the
+ * border: the block's language is already legible from the code itself, which
+ * is highlighted with that language's grammar, so the tag was a caption on a
+ * picture that says the same thing. */
+function buildCodeFrameLine(measure: number, left: string, right: string): string {
   const inner = Math.max(
     1, codeFrameWidth(measure) - displayWidth(left) - displayWidth(right),
   );
-  if (label) {
-    const tag = `─ ${label} `;
-    const tagW = displayWidth(tag);
-    if (tagW < inner) return left + tag + "─".repeat(inner - tagW) + right;
-  }
   return left + "─".repeat(inner) + right;
 }
 
@@ -313,59 +303,109 @@ function clearCodeRails(bufferId: number, byteStart: number, byteEnd: number): v
   );
 }
 
-/** Draw the rails for one code-body line.
+/** Columns of code a framed row can hold: the frame less both rails. */
+function codeInnerWidth(measure: number): number {
+  return Math.max(1, codeFrameWidth(measure) - 2 * RAIL_RENDERED_COLUMNS);
+}
+
+/** How one code line is split across framed rows: the char offsets of the
+ * spaces that end each row, and the `[start, end)` char range of each row's
+ * text.
  *
- * A line long enough to reach the right rail's column gets no right rail: the
- * padding would be negative, and forcing one would push the row past the wrap
- * width and put the rail on a row of its own — worse than an open edge. Such a
- * line is also force-wrapped by the renderer, and its continuation rows are not
- * source lines, so they carry no rails either. The left rail is always drawn on
- * the line's first row, so the block's left side stays unbroken down the code
- * itself. */
+ * A code line too wide for the frame has to break *somewhere* — the buffer has
+ * line wrap on, so the renderer will otherwise fold it to column zero, outside
+ * the frame and with no rails. Choosing the break points here instead means
+ * every row is a row this pass knows the width of, so every row can be railed
+ * and padded to the frame.
+ *
+ * Breaks must land on Space characters. Space tokens carry their own
+ * `source_offset`; the characters inside a Text token all share the token's
+ * start, so a break asked for mid-token silently does nothing (the same
+ * constraint the table-row wrapping documents). A run with no space wide enough
+ * to break at therefore stays one over-long row — see `emitCodeRails`.
+ *
+ * Shared by the rail pass and the soft-break pass so the two cannot disagree
+ * about where the rows are, exactly as `widthsForRow` is shared for tables. */
+interface CodeRow { start: number; end: number }
+function codeRowLayout(text: string, measure: number): { breaks: number[]; rows: CodeRow[] } {
+  const inner = codeInnerWidth(measure);
+  const breaks: number[] = [];
+  const rows: CodeRow[] = [];
+  let rowStart = 0;
+  let lastSpace = -1;
+  let column = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const w = displayWidth(text[i]);
+    if (column + w > inner && lastSpace > rowStart) {
+      // Break at the last space that still leaves a non-empty row.
+      breaks.push(lastSpace);
+      rows.push({ start: rowStart, end: lastSpace });
+      rowStart = lastSpace + 1;
+      lastSpace = -1;
+      column = 0;
+      for (let j = rowStart; j <= i; j++) column += displayWidth(text[j]);
+      continue;
+    }
+    if (text[i] === " ") lastSpace = i;
+    column += w;
+  }
+  rows.push({ start: rowStart, end: text.length });
+  return { breaks, rows };
+}
+
+/** Draw the rails for one code-body line, one pair per framed row.
+ *
+ * Rows come from `codeRowLayout`, so a wrapped line is railed and padded on
+ * every row rather than only its first. A row still wider than the frame — a
+ * long unbroken token, which has no space to break at — gets its left rail and
+ * no right one: forcing a right rail there would push the row past the wrap
+ * width and put the rail on a line of its own, which is worse than an open
+ * edge. */
 function emitCodeRails(
   bufferId: number,
   lineContent: string,
   byteStart: number,
   measure: number,
 ): void {
-  const width = codeFrameWidth(measure);
   const contentEnd = lineContentEndByte(lineContent, byteStart);
   const text = lineContent.replace(/\r?\n$/, "");
-  const pad = width - 2 * RAIL_RENDERED_COLUMNS - displayWidth(text);
+  const inner = codeInnerWidth(measure);
 
   // An empty line has no character to hang two separate rails off, so both
-  // edges and the gap between them go in one piece at its line break.
-  //
-  // Its anchor is the newline cell, and that is the one case the renderer pads
-  // on *both* sides rather than one. The run is therefore the full frame width
-  // but its glyphs sit one column inside it — a blank row inside a block reads
-  // very slightly pinched. There is no way to reclaim that column from here:
-  // the leading space belongs to the renderer, and a plugin cannot emit
-  // negative padding. (Indented blank-looking lines are unaffected — their
-  // anchor is a Space cell, which takes the ordinary one-sided padding.)
+  // edges and the gap between them go in one piece at its line break. Anchored
+  // on the newline of a line with nothing else in it, which the renderer pads
+  // on neither side, so the glyphs land in the frame's own columns.
   if (contentEnd <= byteStart) {
-    const gap = Math.max(1, width - 2 - 2);
     editor.addVirtualTextStyled(
       bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:e`, byteStart,
-      RAIL_GLYPH + " ".repeat(gap) + RAIL_GLYPH, codeFrameStyle, true,
+      RAIL_GLYPH + " ".repeat(inner + 2) + RAIL_GLYPH, codeFrameStyle, true,
     );
     return;
   }
 
-  editor.addVirtualTextStyled(
-    bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:l`, byteStart,
-    RAIL_GLYPH, codeFrameStyle, true,
-  );
-  if (pad >= 0) {
-    // Anchor the closing rail *after the last character*, found by code point
-    // rather than by `contentEnd - 1`: a byte before the end lands inside a
-    // multi-byte glyph, and the line's last character is exactly where a
-    // multi-byte glyph is most likely to be.
-    const chars = Array.from(text);
-    const lastChar = chars[chars.length - 1];
-    const lastCharStart = charToByte(lineContent, text.length - lastChar.length, byteStart);
+  const { rows } = codeRowLayout(text, measure);
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    if (row.end <= row.start) continue;
+    const rowText = text.slice(row.start, row.end);
+
     editor.addVirtualTextStyled(
-      bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:r`, lastCharStart,
+      bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:${r}:l`,
+      charToByte(lineContent, row.start, byteStart),
+      RAIL_GLYPH, codeFrameStyle, true,
+    );
+
+    const pad = inner - displayWidth(rowText);
+    if (pad < 0) continue; // unbreakable over-long row: leave the edge open
+    // Anchor the closing rail *after the last character* of the row, found by
+    // code point rather than by `end - 1`: a byte before the end lands inside
+    // a multi-byte glyph, and the row's last character is exactly where a
+    // multi-byte glyph is most likely to be.
+    const lastChar = Array.from(rowText).pop() as string;
+    const lastCharStart = charToByte(lineContent, row.end - lastChar.length, byteStart);
+    editor.addVirtualTextStyled(
+      bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:${r}:r`, lastCharStart,
       " ".repeat(pad) + RAIL_GLYPH, codeFrameStyle, false,
     );
   }
@@ -1465,8 +1505,8 @@ function processLineConceals(
   if (region === "open" || region === "close") {
     const frameEnd = lineContentEndByte(lineContent, byteStart);
     const frame = region === "open"
-      ? buildCodeFrameLine(measure, fenceInfoString(lineContent), "┌", "┐")
-      : buildCodeFrameLine(measure, "", "└", "┘");
+      ? buildCodeFrameLine(measure, "┌", "┐")
+      : buildCodeFrameLine(measure, "└", "┘");
     editor.addConceal(
       bufferId, "md-syntax", byteStart, frameEnd, frame,
       "unless-cursor-in", byteStart, lineScopeInclEnd,
@@ -1932,11 +1972,32 @@ function processLineSoftBreaks(
   // Clear existing soft breaks for this line range
   editor.clearSoftBreaksInRange(bufferId, byteStart, byteEnd);
 
-  // Code is never re-wrapped: its line breaks are significant, and a body line
-  // is not a markdown block at all. `parseMarkdownBlocks` cannot tell — it sees
-  // one line with no fence context — so it would read an indented code line as
-  // a paragraph and wrap it at the measure.
-  if (isCodeRegion(region)) return;
+  // Code is never re-flowed as prose: its line breaks are significant, and a
+  // body line is not a markdown block at all. `parseMarkdownBlocks` cannot tell
+  // — it sees one line with no fence context — so it would read an indented
+  // code line as a paragraph and wrap it at the measure.
+  //
+  // A code line too wide for the frame does still have to break, because the
+  // buffer has line wrap on and the renderer will otherwise fold it to column
+  // zero, outside the frame and unrailed. Breaking it here instead puts the
+  // fold where `emitCodeRails` expects a row to end, at the frame's inner
+  // width, and hangs the continuation under the code rather than under the
+  // rail. Same positions from the same helper, so the two passes agree.
+  if (isCodeRegion(region)) {
+    if (region !== "body") return;
+    const text = lineContent.replace(/\r?\n$/, "");
+    const viewport = editor.getViewport();
+    const measure = effectiveComposeWidth(viewport ? viewport.width : 80);
+    for (const charPos of codeRowLayout(text, measure).breaks) {
+      // Indent 0, not the rail's width: the continuation row's own left rail
+      // is virtual text spliced in ahead of the wrap, so it already supplies
+      // those columns. Asking for them again would indent the row twice.
+      editor.addSoftBreak(
+        bufferId, "md-wrap", charToByte(lineContent, charPos, byteStart), 0,
+      );
+    }
+    return;
+  }
 
   const viewport = editor.getViewport();
   if (!viewport) return;

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -138,7 +138,121 @@ type LineInfoLike = {
   byte_start: number;
   byte_end: number;
   content: string;
+  region?: RegionLine;
 };
+
+// =============================================================================
+// Fenced code blocks: framed from the editor's own region classification
+// =============================================================================
+//
+// A code block gets the same treatment a table does — its delimiters concealed
+// into a box-drawing frame, its body left to the syntax highlighter (embedded
+// fence highlighting has worked since issue #2689, so the body already renders
+// in the fence's own language).
+//
+// The one thing that is NOT like a table: "is this line a table row" is decided
+// from that line alone, but "is this line inside a fence" is not. A bare ```
+// opens or closes depending on every fence above it, `lines_changed` batches
+// carry only the lines an edit or scroll touched, and the plugin cannot read
+// the buffer above its batch synchronously (`getBufferText` is a Promise, and
+// the decoration pass has to emit its clear+add in one command batch).
+//
+// Deriving it plugin-side is therefore not possible correctly: any batch-local
+// rule frames a block whose opening fence happens to be visible and gives up on
+// one that isn't, so the frame appears and disappears with scroll position.
+// Nor can it be memoised — the table width memo is safe *because* it carries
+// only numbers, where staleness costs a column width for one frame; a memo of
+// fence extents would carry structure, and staleness there means framing the
+// wrong lines.
+//
+// So the editor answers it. `line.region` on the `lines_changed` payload is the
+// classification the highlighting engine already makes per line while parsing
+// (`open` / `body` / `close`, absent outside a region) — the same source of
+// truth that colours the block's contents, so the frame can never disagree with
+// the highlighting. It arrives with the batch, alongside coordinates the plugin
+// already trusts, so there is nothing to store and nothing to go stale.
+//
+// `region` is absent both for ordinary lines and when the editor could not
+// resolve the state (a >1MiB buffer whose viewport has no parse checkpoint
+// before it yet). Absence therefore means *unknown*, and an unknown fence line
+// is left rendering literally — the same conservative choice the table frame
+// makes when a neighbouring row is off-screen.
+type RegionLine = "open" | "body" | "close";
+
+/** Whether a line is inside a fenced code block (delimiters included). */
+function isCodeRegion(region: RegionLine | undefined): boolean {
+  return region !== undefined;
+}
+
+/** Whether a line reads as a fence delimiter from its own text alone.
+ *
+ * Only ever used to decide whether an *edit* may have restructured the
+ * document (see `fenceEditArmed`) — never to decide how a line renders, which
+ * is what `region` is for. It has to be textual precisely because it must also
+ * fire for a line that has just STOPPED being a delimiter. */
+function looksLikeFence(content: string): boolean {
+  return /^\s*(?:`{3,}|~{3,})/.test(content);
+}
+
+// Region membership is the one per-line property an edit can change for lines
+// it does not touch: appending a word to a closing ``` (CommonMark forbids an
+// info string on a closer) turns every line below it into code. The editor
+// re-fires `lines_changed` only for the edited line when the edit doesn't
+// change the line count — a structural edit already forces a whole-viewport
+// refresh in `event_apply` — so those lines below would keep the frame they
+// were last rendered with, disagreeing with the highlighting, which does
+// re-converge.
+//
+// Two narrow triggers force the one extra whole-viewport pass that repairs it,
+// between them covering both directions:
+//
+//   * the edit put a fence character into, or took one out of, the buffer —
+//     the only way to create or destroy a delimiter outright
+//     (`touchesFenceChars`, checked on the edit itself because the *deleted*
+//     text is not visible in any later batch);
+//   * the edited line is still delimiter-shaped afterwards — the ``` that just
+//     stopped closing because a word was appended to it (`fenceEditArmed`,
+//     checked on the batch, since only there is the line's new text known).
+//
+// Deliberately NOT "the edited line is inside a block": that is true of every
+// keystroke while typing code, and would put a whole-viewport refresh behind
+// each one. Typing that restructures a block always types a backtick.
+//
+// The armed flag is disarmed by the batch that acts on it, so the refresh's own
+// whole-viewport batch cannot re-arm it.
+const fenceEditArmed = new Set<number>();
+
+/** Whether an edit's text could create or destroy a fence delimiter. */
+function touchesFenceChars(text: string): boolean {
+  return /[`~]/.test(text);
+}
+
+/** The info string of an opening fence — its language — or "" when bare.
+ *
+ * CommonMark's first word of the info string; the engine resolves the same
+ * token to a grammar (`resolve_embedded_syntax`), so the label names exactly
+ * the language the body is being highlighted as. */
+function fenceInfoString(content: string): string {
+  const m = content.match(/^\s*(?:`{3,}|~{3,})\s*(\S+)/);
+  return m ? m[1] : "";
+}
+
+/** A horizontal code-block frame line of the given corner style, filling the
+ * page measure. Two columns short of the measure for the same reason the
+ * thematic-break rule is (see `wrapBudget`): the renderer reserves an
+ * end-of-line column, and a border that reached it would wrap. */
+function buildCodeFrameLine(measure: number, label: string, left: string, right: string): string {
+  const inner = Math.max(1, measure - 2 - displayWidth(left) - displayWidth(right));
+  if (label) {
+    const tag = `─ ${label} `;
+    const tagW = displayWidth(tag);
+    if (tagW < inner) return left + tag + "─".repeat(inner - tagW) + right;
+  }
+  return left + "─".repeat(inner) + right;
+}
+
+// fg matches the table frame's so the two kinds of block read as one system.
+const codeFrameStyle = { fg: "editor.fg" };
 
 // Table borders are emitted PER LINE, exactly like conceals: for each table row
 // in a `lines_changed` batch we clear the virtual lines anchored at that row and
@@ -1197,6 +1311,7 @@ function processLineConceals(
   byteStart: number,
   byteEnd: number,
   measure: number,
+  region: RegionLine | undefined,
   lineNumber?: number,
 ): void {
   // Clear existing conceals and overlays for this line first.
@@ -1217,10 +1332,32 @@ function processLineConceals(
   const lineScopeInclEnd = byteEnd + 1;
   const lineScopeStrictEnd = byteEnd;
 
-  // Skip lines inside code fences (we'd need multi-line context for this;
-  // for now, detect fence lines and code content lines)
   const trimmed = lineContent.trim();
-  if (trimmed.startsWith('```')) return; // fence line itself
+
+  // --- Fenced code blocks ---
+  // The delimiters become the block's frame; the body is left entirely alone,
+  // so the embedded-language highlighting shows through untouched and none of
+  // the inline markdown rules below fire inside code (a `*` in a glob, a `-`
+  // starting a shell line, a `#` comment are not emphasis, a bullet, or a
+  // heading). See the RegionLine notes above for why this is the editor's
+  // answer and not a local guess.
+  if (region === "body") return;
+  if (region === "open" || region === "close") {
+    const frameEnd = lineContentEndByte(lineContent, byteStart);
+    const frame = region === "open"
+      ? buildCodeFrameLine(measure, fenceInfoString(lineContent), "┌", "┐")
+      : buildCodeFrameLine(measure, "", "└", "┘");
+    editor.addConceal(
+      bufferId, "md-syntax", byteStart, frameEnd, frame,
+      "unless-cursor-in", byteStart, lineScopeInclEnd,
+    );
+    editor.addOverlay(bufferId, "md-emphasis", byteStart, frameEnd, codeFrameStyle);
+    return;
+  }
+  // A fence-looking line the editor could not classify: leave it literal
+  // rather than guess a corner. Same conservative choice the table frame
+  // makes for a row whose neighbour is off-screen.
+  if (looksLikeFence(lineContent)) return;
 
   // --- Thematic breaks: `---` / `***` / `___` → one full-measure rule ---
   // Rendered as a single conceal replacement rather than per-character
@@ -1669,10 +1806,17 @@ function processLineSoftBreaks(
   lineContent: string,
   byteStart: number,
   byteEnd: number,
+  region: RegionLine | undefined,
   lineNumber?: number,
 ): void {
   // Clear existing soft breaks for this line range
   editor.clearSoftBreaksInRange(bufferId, byteStart, byteEnd);
+
+  // Code is never re-wrapped: its line breaks are significant, and a body line
+  // is not a markdown block at all. `parseMarkdownBlocks` cannot tell — it sees
+  // one line with no fence context — so it would read an indented code line as
+  // a paragraph and wrap it at the measure.
+  if (isCodeRegion(region)) return;
 
   const viewport = editor.getViewport();
   if (!viewport) return;
@@ -1830,15 +1974,18 @@ function processLineSoftBreaks(
 
 /** Group consecutive table rows in a `lines_changed` batch (adjacency by
  * line_number). Each group is one table's currently-visible run; column widths
- * are uniform within a group. */
+ * are uniform within a group. Lines inside a fenced code block are not table
+ * rows however many pipes they contain, so they both fail to join a group and
+ * break one — matching how a code block separates two tables in the source. */
 function groupTableRows(lines: LineInfoLike[]): LineInfoLike[][] {
   const groups: LineInfoLike[][] = [];
   let cur: LineInfoLike[] = [];
   let lastLn = -2;
   for (const line of lines) {
-    if (isTableRowContent(line.content) && line.line_number === lastLn + 1) {
+    const isRow = !isCodeRegion(line.region) && isTableRowContent(line.content);
+    if (isRow && line.line_number === lastLn + 1) {
       cur.push(line);
-    } else if (isTableRowContent(line.content)) {
+    } else if (isRow) {
       if (cur.length) groups.push(cur);
       cur = [line];
     } else {
@@ -2002,8 +2149,8 @@ editor.on("lines_changed", (data) => {
       line.byte_start, Math.max(line.byte_end, line.byte_start + 1),
     );
 
-    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, measure, line.line_number);
-    processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, line.line_number);
+    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, measure, line.region, line.line_number);
+    processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, line.region, line.line_number);
 
     // Blank row after each list item, so items read as discrete entries.
     //
@@ -2020,14 +2167,19 @@ editor.on("lines_changed", (data) => {
     // Anchoring below every item is line-local, so clear-and-rebuild is always
     // a complete decision. The cost is one blank row after a list's final item
     // as well as between items, which reads as ordinary block separation.
-    if (isListItemContent(line.content)) {
+    //
+    // Inside a fence none of this applies: `- foo` in a shell block is not a
+    // list item and `| a | b |` in a code sample is not a table row, so both
+    // the spacer and the frame are skipped (the clears above already ran, so a
+    // line that becomes code loses whichever it had).
+    if (!isCodeRegion(line.region) && isListItemContent(line.content)) {
       editor.addVirtualLine(
         data.buffer_id, line.byte_start, "",
         listSpacingOptions, false, LIST_SPACING_NS, 0,
       );
     }
 
-    if (isTableRowContent(line.content)) {
+    if (!isCodeRegion(line.region) && isTableRowContent(line.content)) {
       const widths = currentRowWidths.get(line.byte_start) ?? [];
       const prev = byLineNum.get(line.line_number - 1);
       const next = byLineNum.get(line.line_number + 1);
@@ -2076,7 +2228,14 @@ editor.on("lines_changed", (data) => {
     );
   }
 
-  if (tableWidthsGrew) {
+  // One whole-viewport re-fire when an edit left a delimiter-shaped line
+  // behind: every line below it may have crossed into or out of a block, and
+  // those lines are not in this batch (see `fenceEditArmed`). Disarmed first,
+  // so the refresh's own batch — which contains the same line — cannot re-arm.
+  const fenceEdit = fenceEditArmed.delete(data.buffer_id)
+    && data.lines.some((l) => looksLikeFence(l.content));
+
+  if (tableWidthsGrew || fenceEdit) {
     editor.refreshLines(data.buffer_id);
   }
 });
@@ -2097,10 +2256,18 @@ function resetEditedTableWidths(bufferId: number, affStart: number, affEnd: numb
 editor.on("after_insert", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
   resetEditedTableWidths(data.buffer_id, data.affected_start, data.affected_end);
+  // Typed backticks can open or close a block; anything else can only stop an
+  // already-delimiter-shaped line from being one, which the batch will see.
+  if (touchesFenceChars(data.text)) editor.refreshLines(data.buffer_id);
+  else fenceEditArmed.add(data.buffer_id);
 });
 editor.on("after_delete", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
   resetEditedTableWidths(data.buffer_id, data.affected_start, data.affected_start);
+  // Deleted backticks are checked here, not in the batch: the text that is gone
+  // appears in no later `lines_changed` payload.
+  if (touchesFenceChars(data.deleted_text)) editor.refreshLines(data.buffer_id);
+  else fenceEditArmed.add(data.buffer_id);
 });
 // cursor_moved: no handler. Cursor-dependent reveal/conceal and table-row
 // un/re-wrap are baked into the markers as activation scopes (emitted in the

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -583,6 +583,36 @@ impl Editor {
         }
     }
 
+    /// Handle ClearVirtualTextsInRange — per-line *inline* virtual-text clear.
+    pub(super) fn handle_clear_virtual_texts_in_range(
+        &mut self,
+        buffer_id: BufferId,
+        id_prefix: String,
+        start: usize,
+        end: usize,
+        epoch: Option<u64>,
+    ) {
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .expect("active window present")
+            .buffer_state_mut(buffer_id)
+        {
+            // Same stale-range repair as the virtual-line clear above: the
+            // plugin computed `[start, end)` against the `lines_changed` epoch.
+            let (start, end) = match state.map_plugin_range(start, end, epoch) {
+                Some(r) => r,
+                None => return,
+            };
+            state.virtual_texts.clear_inline_in_range(
+                &mut state.marker_list,
+                &id_prefix,
+                start,
+                end,
+            );
+        }
+    }
+
     // ==================== Conceal Commands ====================
 
     /// Handle AddConceal command - add a conceal range that hides or replaces bytes

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -573,6 +573,15 @@ impl Editor {
             } => {
                 self.handle_clear_virtual_lines_in_range(buffer_id, namespace, start, end, epoch);
             }
+            PluginCommand::ClearVirtualTextsInRange {
+                buffer_id,
+                id_prefix,
+                start,
+                end,
+                epoch,
+            } => {
+                self.handle_clear_virtual_texts_in_range(buffer_id, id_prefix, start, end, epoch);
+            }
 
             // ==================== Conceal Commands ====================
             PluginCommand::AddConceal {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -318,11 +318,15 @@ impl Editor {
                         let mut fresh_ranges: Vec<(usize, usize)> = Vec::new();
                         let mut line_number = state.buffer.get_line_number(top_byte);
                         let mut iter = state.buffer.line_iterator(top_byte, estimated_line_length);
+                        // End of the last line walked, so the embedded-region
+                        // probe below covers exactly the lines we iterated.
+                        let mut walked_end = top_byte;
 
                         for _ in 0..visible_count {
                             if let Some((line_start, line_content)) = iter.next_line() {
                                 let byte_end = line_start + line_content.len();
                                 let byte_range = (line_start, byte_end);
+                                walked_end = byte_end;
 
                                 if !seen_byte_ranges.contains(&byte_range) {
                                     new_lines.push(crate::services::plugins::hooks::LineInfo {
@@ -330,6 +334,7 @@ impl Editor {
                                         byte_start: line_start,
                                         byte_end,
                                         content: line_content,
+                                        region: None,
                                     });
                                     fresh_ranges.push(byte_range);
                                 }
@@ -341,6 +346,35 @@ impl Editor {
 
                         let count = new_lines.len();
                         if !new_lines.is_empty() {
+                            // Whether each reported line sits inside an
+                            // embedded-language region (a Markdown fence, a Vue
+                            // `<script>`) — the one property of such a line that
+                            // is not derivable from its own text, and that a
+                            // plugin cannot read out of the buffer above its
+                            // batch synchronously. Attached here, alongside the
+                            // live coordinates, so a consumer never has to store
+                            // region structure of its own.
+                            //
+                            // The probe costs nothing for syntaxes that host no
+                            // regions (the overwhelming majority), and is skipped
+                            // entirely when there is nothing to report.
+                            let regions = state
+                                .highlighter
+                                .region_lines_in(&state.buffer, top_byte..walked_end);
+                            if !regions.is_empty() {
+                                let mut next = 0usize;
+                                for line in new_lines.iter_mut() {
+                                    // Both sides ascend by line start, so one
+                                    // forward walk pairs them.
+                                    while next < regions.len() && regions[next].0 < line.byte_start
+                                    {
+                                        next += 1;
+                                    }
+                                    if regions.get(next).is_some_and(|r| r.0 == line.byte_start) {
+                                        line.region = Some(regions[next].1);
+                                    }
+                                }
+                            }
                             pm_guard.run_hook(
                                 "lines_changed",
                                 crate::services::plugins::hooks::HookArgs::LinesChanged {

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -43,6 +43,7 @@ use crate::primitives::highlighter::{
     highlight_bg, highlight_color, HighlightCategory, HighlightSpan, Highlighter, Language,
 };
 use crate::view::theme::Theme;
+use fresh_core::hooks::RegionLine;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::Path;
@@ -1711,6 +1712,141 @@ impl TextMateEngine {
         None
     }
 
+    /// Classify every line start in `range` by its role in an
+    /// embedded-language region — `(line_start_byte, RegionLine)` pairs, in
+    /// increasing order. Lines outside any region are omitted.
+    ///
+    /// This exposes, read-only, the classification `parse_snapshot_line`
+    /// already makes per line (the `region scope before → after` table in
+    /// `docs/internal/embedded-language-highlighting.md`). It exists because
+    /// region membership is the one thing about a Markdown fence that is *not*
+    /// derivable from a line's own text — a bare ``` opens or closes depending
+    /// on every fence above it — and the `lines_changed` consumers that need it
+    /// (compose-mode code-block framing) run on the plugin thread, where the
+    /// buffer above the batch is not synchronously readable.
+    ///
+    /// Deliberately a probe, not a cache: it resumes from the nearest
+    /// checkpoint and drops everything it computes. That keeps it out of the
+    /// three incremental cache paths (`full_parse` / `extend_cache_forward` /
+    /// `try_partial_update`) entirely, so it cannot perturb highlighting, and
+    /// it needs no invalidation of its own. It creates no checkpoints and does
+    /// not touch `stats` — those measure the highlight cache's work, and
+    /// folding a separate read-only probe into them would make the assertions
+    /// that reason about cache behaviour meaningless.
+    ///
+    /// Cost: zero for the overwhelming majority of buffers (`embedding` is
+    /// empty unless the syntax hosts regions — currently only Markdown and
+    /// Vue), otherwise one span-less parse from the resume anchor — normally
+    /// the checkpoint within `CHECKPOINT_INTERVAL` bytes before `range.start` —
+    /// through `range.end`, and never more than `MAX_PARSE_BYTES` of it.
+    ///
+    /// Returns **empty** — not "no regions" — whenever the state at
+    /// `range.start` cannot be resolved within that budget: no usable anchor,
+    /// or one too far back to walk from. That is the same cold-start trade-off
+    /// the engine already documents for styling inside a huge region, and it is
+    /// why callers must treat an absent answer as "unknown".
+    pub fn region_lines_in(
+        &mut self,
+        buffer: &Buffer,
+        range: Range<usize>,
+    ) -> Vec<(usize, RegionLine)> {
+        if self.embedding.is_empty() || range.start >= range.end {
+            return Vec::new();
+        }
+        let parse_end = range.end.min(buffer.len());
+        if range.start >= parse_end {
+            return Vec::new();
+        }
+
+        // Resume anchor. Two rules, both stricter than
+        // `find_parse_resume_point`'s, because a wrong anchor here does not
+        // merely mis-colour a line — it reports the wrong region membership,
+        // and the caller frames the wrong lines:
+        //
+        //  * never start from a fresh state *mid-file*. A fresh state reads as
+        //    "outside a region", which is a confident wrong answer; only a real
+        //    checkpoint, or byte 0, can seed the walk.
+        //  * never resume from a checkpoint at or after `dirty_from`.
+        //    `notify_insert`/`notify_delete` shift checkpoint *positions* but
+        //    leave their stored states untouched — the repair happens lazily in
+        //    `try_partial_update` — so a checkpoint past an unrepaired edit can
+        //    still hold the region state from before it.
+        let dirty_limit = self.dirty_from.unwrap_or(usize::MAX);
+        let anchor_limit = range.start.min(dirty_limit.saturating_sub(1));
+        let search_start = anchor_limit.saturating_sub(MAX_PARSE_BYTES);
+        let nearest = self
+            .checkpoint_markers
+            .query_range(search_start, anchor_limit + 1)
+            .into_iter()
+            .filter(|(_, start, _)| *start <= anchor_limit)
+            .max_by_key(|(_, start, _)| *start);
+        let (mut current_offset, mut snapshot) = match nearest {
+            Some((id, cp_pos, _)) => match self.checkpoint_states.get(&id) {
+                Some(snap) => (cp_pos, snap.clone()),
+                None => return Vec::new(), // orphaned checkpoint
+            },
+            None if parse_end <= MAX_PARSE_BYTES => (
+                0,
+                ParseSnapshot::new(&self.syntax_set.syntaxes()[self.syntax_index]),
+            ),
+            None => return Vec::new(), // large file, no anchor: unknown
+        };
+
+        // Bound the walk itself, not just the anchor search. An edit high in a
+        // large buffer pulls `dirty_limit` — and with it the only trustworthy
+        // anchor — far above the viewport; without this, one `lines_changed`
+        // batch could drag a megabyte parse into the draw path. Better to
+        // report "unknown" and render conservatively.
+        if parse_end.saturating_sub(current_offset) > MAX_PARSE_BYTES {
+            return Vec::new();
+        }
+
+        let content = buffer.slice_bytes(current_offset..parse_end);
+        let content_bytes = match std::str::from_utf8(&content) {
+            Ok(s) => s.as_bytes(),
+            Err(_) => return Vec::new(),
+        };
+
+        let mut out = Vec::new();
+        let mut pos = 0;
+        while pos < content_bytes.len() {
+            let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
+            let line_start = current_offset;
+            if let Some(prepared) = prepared {
+                let was_in = self.active_region_spec(&snapshot.scopes);
+                // Spans are discarded: only the scope-stack transition the
+                // parse leaves on `snapshot` matters here.
+                let parsed = self.parse_snapshot_line(
+                    &mut snapshot,
+                    &prepared,
+                    current_offset,
+                    |_, _, _| {},
+                );
+                if !parsed {
+                    // A host parse error leaves region membership untouched
+                    // (see `parse_snapshot_line`); classifying from it would
+                    // be a guess, so stop rather than emit one.
+                    break;
+                }
+                let now_in = self.active_region_spec(&snapshot.scopes);
+                let role = match (was_in, now_in) {
+                    (None, Some(_)) => Some(RegionLine::Open),
+                    (Some(_), Some(_)) => Some(RegionLine::Body),
+                    (Some(_), None) => Some(RegionLine::Close),
+                    (None, None) => None,
+                };
+                if let Some(role) = role {
+                    if line_start >= range.start {
+                        out.push((line_start, role));
+                    }
+                }
+            }
+            pos = line_end;
+            current_offset += line_byte_len;
+        }
+        out
+    }
+
     /// Merge adjacent spans with same category
     fn merge_adjacent_spans(spans: &mut Vec<CachedSpan>) {
         if spans.len() < 2 {
@@ -1847,6 +1983,21 @@ impl HighlightEngine {
                 h.highlight_viewport(buffer, viewport_start, viewport_end, theme, context_bytes)
             }
             Self::None => Vec::new(),
+        }
+    }
+
+    /// Embedded-language region roles for the line starts in `range`; see
+    /// `TextMateEngine::region_lines_in`. Empty for engines that have no
+    /// notion of embedded regions — the tree-sitter backend has injections
+    /// disabled, so it hosts none.
+    pub fn region_lines_in(
+        &mut self,
+        buffer: &Buffer,
+        range: Range<usize>,
+    ) -> Vec<(usize, RegionLine)> {
+        match self {
+            Self::TextMate(h) => h.region_lines_in(buffer, range),
+            Self::TreeSitter(_) | Self::None => Vec::new(),
         }
     }
 
@@ -2268,6 +2419,132 @@ mod tests {
             Some(HighlightCategory::Keyword),
             "category lookups must agree with the returned spans"
         );
+    }
+
+    /// `region_lines_in` classifies each fence line the way the parse does:
+    /// delimiters as open/close, content as body, everything else omitted —
+    /// including for a *bare* fence, whose role is not derivable from the
+    /// line's own text.
+    #[test]
+    fn test_region_lines_classify_markdown_fences() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let content = "# T\n\n```rust\nlet x = 1;\n```\n\nprose\n\n```\nbare\n```\n\nend\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let at = |needle: &str| content.find(needle).unwrap();
+
+        let roles = engine.region_lines_in(&buffer, 0..buffer.len());
+        assert_eq!(
+            roles,
+            vec![
+                (at("```rust"), RegionLine::Open),
+                (at("let x = 1;"), RegionLine::Body),
+                (at("```\n\nprose"), RegionLine::Close),
+                (at("```\nbare"), RegionLine::Open),
+                (at("bare"), RegionLine::Body),
+                (at("```\n\nend"), RegionLine::Close),
+            ],
+            "prose lines are omitted; both delimiters of the bare fence are \
+             classified from the parse, not from their own text"
+        );
+    }
+
+    /// The probe is what makes a *scrolled-into* fence resolvable: asked only
+    /// about lines deep inside a block, it still answers, because it resumes
+    /// from the parse state before them rather than from the range start.
+    /// A batch-local reading of those same lines has no way to know.
+    #[test]
+    fn test_region_lines_resolve_a_range_starting_inside_a_fence() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let mut content = String::from("intro\n\n```rust\n");
+        for i in 0..200 {
+            content.push_str(&format!("let v{i} = {i};\n"));
+        }
+        content.push_str("```\n\ntail\n");
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+
+        // A window well past the opening fence — the shape of a scroll batch.
+        let start = content.find("let v150").unwrap();
+        let end = content.find("tail").unwrap();
+        let roles = engine.region_lines_in(&buffer, start..end);
+
+        assert_eq!(roles.first().map(|r| r.1), Some(RegionLine::Body));
+        assert_eq!(
+            roles
+                .iter()
+                .find(|(_, role)| *role == RegionLine::Close)
+                .map(|(byte, _)| *byte),
+            Some(content.rfind("```").unwrap()),
+            "the closing delimiter must be reported as a close even though the \
+             range never saw the opening fence"
+        );
+        assert!(
+            roles.iter().all(|(byte, _)| *byte >= start),
+            "nothing before the requested range is reported"
+        );
+    }
+
+    /// An edit that has not yet been repaired by a highlight pass must not be
+    /// answered from a checkpoint captured before it. Checkpoint *states* are
+    /// left stale by `notify_insert` (only their positions shift), so a probe
+    /// that trusted one would keep reporting the pre-edit region structure —
+    /// and the caller would frame lines that are no longer code.
+    #[test]
+    fn test_region_lines_ignore_checkpoints_stale_from_an_unrepaired_edit() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        // Long enough that checkpoints (every CHECKPOINT_INTERVAL bytes) land
+        // between the fence and the lines below it.
+        let mut content = String::from("```js\n");
+        for i in 0..40 {
+            content.push_str(&format!("const v{i} = {i};\n"));
+        }
+        content.push_str("```\n");
+        for i in 0..40 {
+            content.push_str(&format!("prose line {i}\n"));
+        }
+        let mut buffer = Buffer::from_str(&content, 0, test_fs());
+        engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let close_at = content.find("```\nprose").unwrap();
+        let probe_from = content.find("prose line 20").unwrap();
+        assert!(
+            engine
+                .region_lines_in(&buffer, probe_from..buffer.len())
+                .is_empty(),
+            "prose after the closed fence is outside any region"
+        );
+
+        // Break the closing fence *in place* (no line-count change, so nothing
+        // forces a re-parse) — every line below is now fence body.
+        let insert_at = close_at + 3;
+        buffer.insert(insert_at, " x");
+        engine.notify_insert(insert_at, 2);
+
+        let roles = engine.region_lines_in(&buffer, probe_from + 2..buffer.len());
+        assert!(
+            !roles.is_empty() && roles.iter().all(|(_, r)| *r == RegionLine::Body),
+            "with the fence no longer closed, the lines below must read as \
+             region body, not as the pre-edit prose; got {roles:?}"
+        );
+    }
+
+    /// Buffers whose syntax hosts no embedded regions pay nothing.
+    #[test]
+    fn test_region_lines_empty_for_non_hosting_syntax() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("main.rs"), None, &registry);
+        let buffer = Buffer::from_str("fn main() {\n    let x = 1;\n}\n", 0, test_fs());
+        assert!(engine.region_lines_in(&buffer, 0..buffer.len()).is_empty());
     }
 
     /// Fences naming an unknown language keep the host's raw-code styling.

--- a/crates/fresh-editor/src/services/plugins/hooks.rs
+++ b/crates/fresh-editor/src/services/plugins/hooks.rs
@@ -3,5 +3,5 @@
 //! Re-exports hook system types from fresh-core for backward compatibility.
 
 pub use fresh_core::hooks::{
-    hook_args_to_json, HookArgs, HookCallback, HookRegistry, LineInfo, LspLocation,
+    hook_args_to_json, HookArgs, HookCallback, HookRegistry, LineInfo, LspLocation, RegionLine,
 };

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -549,8 +549,15 @@ pub fn splice_inline_virtual_text(
     };
 
     let mut out: Vec<ViewTokenWire> = Vec::with_capacity(tokens.len());
+    // Whether nothing of this line's own source has been emitted yet. Only
+    // used to recognise a newline that *is* the whole line — an empty line —
+    // whose hints have no neighbouring text to be separated from.
+    let mut at_line_start = true;
     for token in tokens {
         let src = token.source_offset;
+        let is_newline = matches!(token.kind, ViewTokenWireKind::Newline);
+        let line_start_cell = at_line_start;
+        at_line_start = is_newline;
         match (&token.kind, src) {
             (ViewTokenWireKind::Text(s), Some(token_start)) => {
                 // Split the (possibly coalesced) Text token at each hint
@@ -599,14 +606,22 @@ pub fn splice_inline_virtual_text(
             (kind, Some(anchor)) => {
                 // Atomic source cell (Newline / Space / BinaryByte): hints
                 // anchor around the whole cell. A `BeforeChar` hint on a
-                // newline is an end-of-line hint and gets a leading space.
+                // newline is an end-of-line hint and gets a leading space to
+                // hold it off the text it trails.
+                //
+                // Unless the newline *is* the line: on an empty line there is
+                // no text on either side, so the padding separates the hint
+                // from nothing and merely indents it. Decorations that draw a
+                // column — markdown compose's code-block side rails — then sit
+                // one column inside their own frame on exactly the blank rows.
                 let anchor_is_newline = matches!(kind, ViewTokenWireKind::Newline);
+                let empty_line = anchor_is_newline && line_start_cell;
                 if let Some(hints) = before.get(&anchor) {
                     for (text, style) in hints {
-                        let padded = if anchor_is_newline {
-                            format!(" {text} ")
-                        } else {
-                            format!("{text} ")
+                        let padded = match (anchor_is_newline, empty_line) {
+                            (_, true) => text.clone(),
+                            (true, false) => format!(" {text} "),
+                            (false, _) => format!("{text} "),
                         };
                         out.push(virt(padded, style.clone()));
                     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -81,10 +81,20 @@ pub(crate) fn apply_grid_wrapping_transform(
 
 /// Apply soft breaks to a token stream.
 ///
-/// Walks tokens with a sorted break list `[(position, indent)]`. When a
-/// token's `source_offset` matches a break position:
-/// - For Space tokens: replace with Newline + indent Spaces
-/// - For other tokens: insert Newline + indent Spaces before the token
+/// Walks tokens with a sorted break list `[(position, indent)]`. A break at a
+/// position:
+/// - on a Space token: replaces it with Newline + indent Spaces
+/// - anywhere else: inserts Newline + indent Spaces before that byte, splitting
+///   the Text token it lands inside if it is not already at a token boundary
+///
+/// That last case is what lets a caller break a run with no space in it — a
+/// bare URL, a long path — at a chosen column. The characters of a Text token
+/// all share the token's start `source_offset`, so a mid-token break used to
+/// match nothing and silently do nothing, leaving the run to the renderer's own
+/// wrap, which folds it to column zero with none of the caller's framing or
+/// indentation. Splitting mirrors what `apply_conceal_ranges` already does for
+/// ranges landing inside a token; each piece keeps the token's style, so
+/// highlighting survives the break.
 ///
 /// Tokens without source_offset (injected/virtual) pass through unchanged.
 pub(crate) fn apply_soft_breaks(
@@ -97,6 +107,22 @@ pub(crate) fn apply_soft_breaks(
 
     let mut output = Vec::with_capacity(tokens.len() + soft_breaks.len() * 2);
     let mut break_idx = 0;
+
+    // Newline + `indent` spaces, the row break itself.
+    fn push_break(output: &mut Vec<ViewTokenWire>, indent: u16) {
+        output.push(ViewTokenWire {
+            source_offset: None,
+            kind: ViewTokenWireKind::Newline,
+            style: None,
+        });
+        for _ in 0..indent {
+            output.push(ViewTokenWire {
+                source_offset: None,
+                kind: ViewTokenWireKind::Space,
+                style: None,
+            });
+        }
+    }
 
     for token in tokens {
         let offset = match token.source_offset {
@@ -111,38 +137,55 @@ pub(crate) fn apply_soft_breaks(
             break_idx += 1;
         }
 
+        // A Text token can span several break positions; walk its characters
+        // and cut at each. The common case (no break inside) falls through the
+        // loop and re-emits the token whole.
+        if let ViewTokenWireKind::Text(s) = &token.kind {
+            let token_end = offset + s.len();
+            if soft_breaks[break_idx..]
+                .first()
+                .is_some_and(|(pos, _)| *pos < token_end)
+            {
+                let mut seg = String::new();
+                let mut seg_start = offset;
+                let mut byte_idx = 0usize;
+                for ch in s.chars() {
+                    let pos = offset + byte_idx;
+                    if break_idx < soft_breaks.len() && soft_breaks[break_idx].0 == pos {
+                        if !seg.is_empty() {
+                            output.push(ViewTokenWire {
+                                source_offset: Some(seg_start),
+                                kind: ViewTokenWireKind::Text(std::mem::take(&mut seg)),
+                                style: token.style.clone(),
+                            });
+                        }
+                        push_break(&mut output, soft_breaks[break_idx].1);
+                        seg_start = pos;
+                        break_idx += 1;
+                    }
+                    seg.push(ch);
+                    byte_idx += ch.len_utf8();
+                }
+                if !seg.is_empty() {
+                    output.push(ViewTokenWire {
+                        source_offset: Some(seg_start),
+                        kind: ViewTokenWireKind::Text(seg),
+                        style: token.style.clone(),
+                    });
+                }
+                continue;
+            }
+        }
+
         if break_idx < soft_breaks.len() && soft_breaks[break_idx].0 == offset {
             let indent = soft_breaks[break_idx].1;
             break_idx += 1;
 
             match &token.kind {
-                ViewTokenWireKind::Space => {
-                    output.push(ViewTokenWire {
-                        source_offset: None,
-                        kind: ViewTokenWireKind::Newline,
-                        style: None,
-                    });
-                    for _ in 0..indent {
-                        output.push(ViewTokenWire {
-                            source_offset: None,
-                            kind: ViewTokenWireKind::Space,
-                            style: None,
-                        });
-                    }
-                }
+                // The space *is* the break: it is consumed by the row end.
+                ViewTokenWireKind::Space => push_break(&mut output, indent),
                 _ => {
-                    output.push(ViewTokenWire {
-                        source_offset: None,
-                        kind: ViewTokenWireKind::Newline,
-                        style: None,
-                    });
-                    for _ in 0..indent {
-                        output.push(ViewTokenWire {
-                            source_offset: None,
-                            kind: ViewTokenWireKind::Space,
-                            style: None,
-                        });
-                    }
+                    push_break(&mut output, indent);
                     output.push(token);
                 }
             }

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -740,6 +740,66 @@ impl VirtualTextManager {
         }
     }
 
+    /// Remove INLINE virtual texts (BeforeChar/AfterChar) whose string id
+    /// starts with `id_prefix` and whose anchor falls in `[start, end)`.
+    ///
+    /// The inline counterpart of [`clear_lines_in_range`], and it exists for
+    /// the same reason: a plugin rebuilding one line's decorations needs to
+    /// drop that line's — and only that line's — previous ones, in the same
+    /// command batch as the re-add, or the decoration strobes for a frame.
+    /// Neither of the existing inline removals can do that: `remove_by_id`
+    /// needs the exact id, which a plugin can only reconstruct from the
+    /// position the decoration was *last* placed at, and `remove_by_prefix`
+    /// takes the whole set, dropping the lines outside the current batch.
+    ///
+    /// Matching is by id prefix rather than namespace because the inline add
+    /// path stores no namespace (only virtual *lines* carry one); the string
+    /// id plugins already supply serves the same grouping purpose.
+    ///
+    /// Anchors are resolved live from the marker list, so a line that has
+    /// shifted since the decoration was placed is matched at its current
+    /// position — which is what makes the clear tolerant of the lag between a
+    /// `lines_changed` hook and the plugin's reply.
+    pub fn clear_inline_in_range(
+        &mut self,
+        marker_list: &mut MarkerList,
+        id_prefix: &str,
+        start: usize,
+        end: usize,
+    ) {
+        if start >= end {
+            return;
+        }
+        let to_remove: Vec<VirtualTextId> = self
+            .texts
+            .iter()
+            .filter_map(|(id, vtext)| {
+                if !vtext.position.is_inline() {
+                    return None;
+                }
+                if !vtext
+                    .string_id
+                    .as_ref()
+                    .is_some_and(|s| s.starts_with(id_prefix))
+                {
+                    return None;
+                }
+                let pos = marker_list.get_position(vtext.marker_id)?;
+                (pos >= start && pos < end).then_some(*id)
+            })
+            .collect();
+
+        let removed = !to_remove.is_empty();
+        for id in to_remove {
+            if let Some(vtext) = self.texts.remove(&id) {
+                marker_list.delete(vtext.marker_id);
+            }
+        }
+        if removed {
+            self.bump_version();
+        }
+    }
+
     /// Query only virtual LINES (LineAbove/LineBelow) in a byte range
     ///
     /// Used by the render pipeline to inject header/footer lines.

--- a/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
@@ -100,10 +100,12 @@ fn park_cursor_at_top(harness: &mut EditorTestHarness) {
     harness.wait_for_async_quiescence(4).unwrap();
 }
 
-/// The headline case: a fenced block renders as a box labelled with its
-/// language, and the ``` delimiters are gone.
+/// The headline case: a fenced block renders as a box, and the ``` delimiters
+/// are gone. The border carries no language tag — the code inside is already
+/// highlighted with that language's grammar, so the tag said nothing the block
+/// did not.
 #[test]
-fn fenced_block_renders_as_a_labelled_frame() {
+fn fenced_block_renders_as_a_frame() {
     let (mut harness, _tmp) =
         compose_harness("# Doc\n\nIntro.\n\n```rust\nfn answer() -> u32 { 42 }\n```\n\nTail.\n");
 
@@ -113,9 +115,14 @@ fn fenced_block_renders_as_a_labelled_frame() {
     park_cursor_at_top(&mut harness);
 
     let screen = harness.screen_to_string();
+    let top_row = screen
+        .lines()
+        .find(|l| l.contains('┌'))
+        .expect("top border on screen");
     assert!(
-        screen.contains("─ rust ─"),
-        "the frame should carry the fence's info string.\nScreen:\n{screen}"
+        !top_row.chars().any(char::is_alphanumeric),
+        "the border carries no text at all — the fence's info string is not \
+         repeated in it; top row was {top_row:?}"
     );
     assert_eq!(tops(&screen).len(), 1, "one top border.\nScreen:\n{screen}");
     assert_eq!(
@@ -190,6 +197,75 @@ fn body_rails_line_up_with_the_border_corners() {
         top, bottom,
         "top and bottom borders must span the same columns.\nScreen:\n{screen}"
     );
+}
+
+/// Columns of the first and last box-drawing glyph on the row containing
+/// `needle`, or on the row that *is* `needle` when it names a border.
+fn frame_edges(screen: &str, row: &str) -> Option<(usize, usize)> {
+    let line = screen.lines().find(|l| l.contains(row))?;
+    let cols: Vec<usize> = line
+        .chars()
+        .enumerate()
+        .filter(|(_, c)| "┌┐└┘│─".contains(*c))
+        .map(|(i, _)| i)
+        .collect();
+    Some((*cols.first()?, *cols.last()?))
+}
+
+/// Every row of a block sits in the same columns — including the two the frame
+/// cannot draw the ordinary way.
+///
+/// A *blank* line has no character to anchor a rail to, so its rails hang off
+/// the newline cell; that is the one cell the renderer used to pad on both
+/// sides, which left blank rows visibly pinched one column inside their own
+/// frame. A line too wide for the frame is broken here rather than left to the
+/// renderer, which would fold it to column zero — outside the frame, with no
+/// rails on the continuation.
+#[test]
+fn blank_and_wrapped_rows_keep_the_frame_columns() {
+    let long = "    let v = compute(alpha, beta, gamma, delta, epsilon, zeta, eta, theta, iota);";
+    let md = format!("# Doc\n\n```rust\nfn f() {{\n\n{long}\n}}\n```\n\nTail.\n");
+    let (mut harness, _tmp) = compose_harness(&md);
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('└'))
+        .expect("the block should frame");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    let top = frame_edges(&screen, "┌").expect("top border on screen");
+
+    // The wrapped line's tail lands on a row of its own; both of its rows, and
+    // the blank row, must match the border's columns.
+    assert!(
+        screen.contains("iota"),
+        "the whole long line should still be on screen.\nScreen:\n{screen}"
+    );
+    let rows: Vec<&str> = screen
+        .lines()
+        .skip_while(|l| !l.contains('┌'))
+        .take_while(|l| !l.contains('└'))
+        .filter(|l| l.contains('│'))
+        .collect();
+    assert!(
+        rows.len() >= 5,
+        "expected the brace, blank, both rows of the wrapped line and the \
+         closing brace; saw {rows:?}"
+    );
+    for row in &rows {
+        let cols: Vec<usize> = row
+            .chars()
+            .enumerate()
+            .filter(|(_, c)| *c == '│')
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            (cols.first().copied(), cols.last().copied()),
+            (Some(top.0), Some(top.1)),
+            "every body row must be railed in the border's own columns; \
+             row {row:?} was not.\nScreen:\n{screen}"
+        );
+    }
 }
 
 /// A fence with no info string is framed at both ends.
@@ -355,12 +431,12 @@ fn breaking_a_closing_fence_reframes_the_lines_below_it() {
 
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains("─ js ─"),
-        "the surviving frame is the js block's.\nScreen:\n{screen}"
+        screen.contains("```sh"),
+        "the sh fence is inside the js block now, so it renders literally as \
+         code rather than opening a frame of its own.\nScreen:\n{screen}"
     );
     assert!(
-        !screen.contains("─ sh ─"),
-        "the sh fence is inside the js block now, so it is not a frame.\n\
-         Screen:\n{screen}"
+        screen.contains("``` x"),
+        "and so does the delimiter that stopped closing.\nScreen:\n{screen}"
     );
 }

--- a/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
@@ -134,6 +134,64 @@ fn fenced_block_renders_as_a_labelled_frame() {
     );
 }
 
+/// The box is closed on all four sides: the body line carries a `│` rail at
+/// each edge, in the same columns as the corners of the borders above and
+/// below it. Getting the width right is the whole difficulty — a rail computed
+/// against a different budget than its border is off on every line of the
+/// block, and one computed against the full measure wraps onto its own row.
+#[test]
+fn body_rails_line_up_with_the_border_corners() {
+    let (mut harness, _tmp) =
+        compose_harness("# Doc\n\n```rust\nfn answer() -> u32 { 42 }\n```\n\nTail.\n");
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('└'))
+        .expect("compose mode should frame the fenced block");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    let edges = |needle: char| -> Option<(usize, usize)> {
+        let line = screen.lines().find(|l| l.contains(needle))?;
+        let cols: Vec<usize> = line
+            .chars()
+            .enumerate()
+            .filter(|(_, c)| "┌┐└┘│─".contains(*c))
+            .map(|(i, _)| i)
+            .collect();
+        Some((*cols.first()?, *cols.last()?))
+    };
+
+    let top = edges('┌').expect("top border on screen");
+    let bottom = edges('└').expect("bottom border on screen");
+    let body = screen
+        .lines()
+        .find(|l| l.contains("fn answer"))
+        .expect("body line on screen");
+    let rails: Vec<usize> = body
+        .chars()
+        .enumerate()
+        .filter(|(_, c)| *c == '│')
+        .map(|(i, _)| i)
+        .collect();
+
+    assert_eq!(
+        rails.len(),
+        2,
+        "the body line should carry exactly two rails, one per edge; body \
+         line was {body:?}"
+    );
+    assert_eq!(
+        (rails[0], rails[1]),
+        top,
+        "the rails must sit in the same columns as the top border's corners.\n\
+         Screen:\n{screen}"
+    );
+    assert_eq!(
+        top, bottom,
+        "top and bottom borders must span the same columns.\nScreen:\n{screen}"
+    );
+}
+
 /// A fence with no info string is framed at both ends.
 ///
 /// This is the case a plugin cannot decide for itself: a bare ``` is an opener

--- a/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
@@ -1,0 +1,308 @@
+//! End-to-end: compose mode frames fenced code blocks the way it frames
+//! tables — the ``` delimiters concealed into a `┌─ lang ─┐` / `└────┘` box,
+//! the body left to the embedded-language highlighter.
+//!
+//! The property worth testing is not that a frame appears. It is that the
+//! frame is decided from the *editor's* region classification rather than from
+//! the lines a `lines_changed` batch happens to contain, so:
+//!
+//!   * a closing fence scrolled into view pages below its opener still closes
+//!     the box (the batch-local failure — a frame that comes and goes with
+//!     scroll position);
+//!   * a fence with no info string is framed correctly at both ends, which no
+//!     rule reading a line's own text can do (a bare ``` opens or closes
+//!     depending on every fence above it);
+//!   * an edit that silently changes which lines are inside a block re-frames
+//!     the lines it did not touch.
+//!
+//! All assertions are on rendered output only.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Open a markdown document with the real `markdown_compose` plugin loaded and
+/// compose mode enabled through the command palette.
+///
+/// Unlike the other compose suites this one needs the **full grammar
+/// registry**: the frame is drawn from the region classification the Markdown
+/// grammar produces, so with the default empty registry there is no Markdown
+/// syntax, no embedded-region host, and — correctly — no framing at all.
+fn compose_harness(md: &str) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("code.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new()
+            .with_working_dir(project_root.clone())
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    (harness, temp_dir)
+}
+
+/// Rows carrying a code-frame top / bottom border. Table frames are excluded:
+/// their corner rows always carry a `┬`/`┴` column junction, a code frame never
+/// does.
+fn frame_rows(screen: &str, corner: char) -> Vec<usize> {
+    screen
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| l.contains(corner) && !l.contains('┬') && !l.contains('┴'))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn tops(screen: &str) -> Vec<usize> {
+    frame_rows(screen, '┌')
+}
+
+fn bottoms(screen: &str) -> Vec<usize> {
+    frame_rows(screen, '└')
+}
+
+/// Park the cursor somewhere with no markup, so nothing on screen is being
+/// revealed for editing. Compose deliberately reveals the markup on the
+/// cursor's own line (and the line above it when the cursor is at column 0),
+/// which would otherwise read as a missing frame.
+fn park_cursor_at_top(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+}
+
+/// The headline case: a fenced block renders as a box labelled with its
+/// language, and the ``` delimiters are gone.
+#[test]
+fn fenced_block_renders_as_a_labelled_frame() {
+    let (mut harness, _tmp) =
+        compose_harness("# Doc\n\nIntro.\n\n```rust\nfn answer() -> u32 { 42 }\n```\n\nTail.\n");
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('┌'))
+        .expect("compose mode should frame the fenced block");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("─ rust ─"),
+        "the frame should carry the fence's info string.\nScreen:\n{screen}"
+    );
+    assert_eq!(tops(&screen).len(), 1, "one top border.\nScreen:\n{screen}");
+    assert_eq!(
+        bottoms(&screen).len(),
+        1,
+        "one bottom border.\nScreen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("```"),
+        "the delimiters are concealed by the frame.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("fn answer() -> u32 { 42 }"),
+        "the body is left untouched so its highlighting shows through.\n\
+         Screen:\n{screen}"
+    );
+}
+
+/// A fence with no info string is framed at both ends.
+///
+/// This is the case a plugin cannot decide for itself: a bare ``` is an opener
+/// or a closer depending on every fence above it, and a `lines_changed` batch
+/// carries no such context. Guessing from the line's own text inverts the box
+/// on exactly this document.
+#[test]
+fn bare_fence_is_framed_at_both_ends() {
+    let (mut harness, _tmp) = compose_harness("# Doc\n\n```\nplain preformatted\n```\n\nTail.\n");
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('└'))
+        .expect("a bare fence should still close its frame");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    let (top, bottom) = (tops(&screen), bottoms(&screen));
+    assert_eq!(top.len(), 1, "one top border.\nScreen:\n{screen}");
+    assert_eq!(bottom.len(), 1, "one bottom border.\nScreen:\n{screen}");
+    assert!(
+        top[0] < bottom[0],
+        "the box must open above and close below its content, not the other \
+         way round — top at row {}, bottom at row {}.\nScreen:\n{screen}",
+        top[0],
+        bottom[0],
+    );
+}
+
+/// The case a batch-local implementation gets wrong, and the reason the
+/// classification comes from the editor: scrolled deep into a block taller than
+/// the viewport, the closing fence still closes the box even though its opening
+/// fence has been off screen — and out of every `lines_changed` batch — for
+/// pages.
+#[test]
+fn closing_fence_frames_after_scrolling_past_the_opener() {
+    let mut md = String::from("# Doc\n\nIntro.\n\n```rust\n");
+    for i in 0..120 {
+        md.push_str(&format!("    let v{i} = compute({i});\n"));
+    }
+    md.push_str("```\n\nTail paragraph.\n");
+
+    let (mut harness, _tmp) = compose_harness(&md);
+    harness
+        .wait_until(|h| h.screen_to_string().contains('┌'))
+        .expect("the opening fence should frame");
+
+    // Scroll until the tail paragraph — and therefore the closing fence just
+    // above it — is on screen.
+    for _ in 0..12 {
+        if harness.screen_to_string().contains("Tail paragraph.") {
+            break;
+        }
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+        harness.wait_for_async_quiescence(4).unwrap();
+    }
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Tail paragraph."))
+        .expect("should have scrolled to the end of the block");
+    harness.wait_for_async_quiescence(6).unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("```"),
+        "the closing delimiter must still be concealed into a border after \
+         scrolling past its opener — a batch-local rule leaves it literal \
+         here.\nScreen:\n{screen}"
+    );
+    assert_eq!(
+        bottoms(&screen).len(),
+        1,
+        "exactly one bottom border, below the block.\nScreen:\n{screen}"
+    );
+    assert!(
+        tops(&screen).is_empty(),
+        "the opening fence is off screen, so no top border is drawn.\n\
+         Screen:\n{screen}"
+    );
+}
+
+/// Markdown syntax inside a code block is code, not markdown. Before the region
+/// classification was available the per-line pass had no way to know, so a `#`
+/// comment became a heading, a `-` became a bullet, and a line of pipes was
+/// drawn as a table — inside a shell block.
+#[test]
+fn markdown_syntax_inside_a_block_is_left_alone() {
+    let (mut harness, _tmp) = compose_harness(
+        "# Doc\n\n```sh\n# not a heading\n- not a bullet\n| not | a table |\n\
+         *not emphasis*\n```\n\nTail.\n",
+    );
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('└'))
+        .expect("the shell block should frame");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    for literal in [
+        "# not a heading",
+        "- not a bullet",
+        "| not | a table |",
+        "*not emphasis*",
+    ] {
+        assert!(
+            screen.contains(literal),
+            "{literal:?} is code and must render verbatim.\nScreen:\n{screen}"
+        );
+    }
+    assert!(
+        !screen.contains('┼'),
+        "no table frame may be drawn from pipes inside a code block.\n\
+         Screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains('•'),
+        "no bullet glyph inside a code block.\nScreen:\n{screen}"
+    );
+}
+
+/// An intra-line edit to a fence delimiter changes which lines are inside the
+/// block *below* the edit — lines the edit never touched and which the editor
+/// therefore does not re-offer on their own. Appending text to a closing fence
+/// stops it closing (CommonMark forbids an info string on a closer), so
+/// everything after it becomes block body and must lose its framing.
+///
+/// Without the plugin's post-edit re-fire those lines keep the frame they were
+/// last rendered with, disagreeing with the highlighting, which does converge.
+#[test]
+fn breaking_a_closing_fence_reframes_the_lines_below_it() {
+    let (mut harness, _tmp) =
+        compose_harness("# Doc\n\n```js\nconst a = 1;\n```\n\n```sh\necho hi\n```\n\nTail.\n");
+
+    harness
+        .wait_until(|h| tops(&h.screen_to_string()).len() == 2)
+        .expect("both blocks should frame");
+
+    // Land on the closing fence of the first block (line index 4) and append a
+    // word, so it is no longer a valid closer. No line count change, so nothing
+    // forces a whole-viewport refresh on the editor's side.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.type_text(" x").unwrap();
+    park_cursor_at_top(&mut harness);
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            tops(&s).len() == 1 && bottoms(&s).len() == 1
+        })
+        .expect(
+            "with the first block never closed, the second block's delimiters \
+             are body lines: exactly one frame should remain, opened by the js \
+             fence and closed by the file's last fence",
+        );
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("─ js ─"),
+        "the surviving frame is the js block's.\nScreen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("─ sh ─"),
+        "the sh fence is inside the js block now, so it is not a frame.\n\
+         Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
@@ -349,6 +349,65 @@ fn closing_fence_frames_after_scrolling_past_the_opener() {
     );
 }
 
+/// A run with no space in it — a bare URL, the shape every install snippet
+/// has — is cut mid-word rather than left to overflow.
+///
+/// This is the case a break-only-at-spaces rule cannot serve: there is no
+/// space to break at, so the row ran past the frame, lost its right rail, and
+/// was folded by the renderer to column zero with no rails at all on the
+/// remainder.
+#[test]
+fn an_unbreakable_run_is_cut_to_fit_the_frame() {
+    let url = "https://example.com/an/extremely/long/unbreakable/path/with/no/spaces/at/all/that/cannot/be/wrapped/anywhere";
+    let md = format!("# Doc\n\n```text\n{url}\n```\n\nTail.\n");
+    let (mut harness, _tmp) = compose_harness(&md);
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains('└'))
+        .expect("the block should frame");
+    park_cursor_at_top(&mut harness);
+
+    let screen = harness.screen_to_string();
+    let top = frame_edges(&screen, "┌").expect("top border on screen");
+    let rows: Vec<&str> = screen
+        .lines()
+        .skip_while(|l| !l.contains('┌'))
+        .take_while(|l| !l.contains('└'))
+        .filter(|l| l.contains('│'))
+        .collect();
+
+    assert!(
+        rows.len() >= 2,
+        "the url is wider than the frame, so it must occupy several rows; \
+         saw {rows:?}"
+    );
+    for row in &rows {
+        let cols: Vec<usize> = row
+            .chars()
+            .enumerate()
+            .filter(|(_, c)| *c == '│')
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            (cols.first().copied(), cols.last().copied()),
+            (Some(top.0), Some(top.1)),
+            "every row of the cut url must be railed in the border's own \
+             columns; row {row:?} was not.\nScreen:\n{screen}"
+        );
+    }
+
+    // And no character of it was dropped in the cutting.
+    let joined: String = rows
+        .iter()
+        .flat_map(|r| r.chars().filter(|c| !c.is_whitespace() && *c != '│'))
+        .collect();
+    assert_eq!(
+        joined, url,
+        "the url must be split across rows without losing or duplicating \
+         anything.\nScreen:\n{screen}"
+    );
+}
+
 /// Markdown syntax inside a code block is code, not markdown. Before the region
 /// classification was available the per-line pass had no way to know, so a `#`
 /// comment became a heading, a `-` became a bullet, and a line of pipes was

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -173,6 +173,8 @@ pub mod mark_mode_actions;
 pub mod markdown_compose;
 #[cfg(feature = "plugins")]
 pub mod markdown_compose_blocks;
+#[cfg(feature = "plugins")]
+pub mod markdown_compose_code_frame;
 pub mod markdown_compose_diagnostics;
 #[cfg(feature = "plugins")]
 pub mod markdown_compose_first_scroll_relayout;

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4544,6 +4544,28 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Clear *inline* virtual texts whose id starts with `idPrefix` and whose
+    /// anchor byte falls in `[start, end)`. The inline analogue of
+    /// `clearVirtualLinesInRange`, so a per-line pass can rebuild one line's
+    /// inline decorations without dropping the rest of the set.
+    pub fn clear_virtual_texts_in_range(
+        &self,
+        buffer_id: u32,
+        id_prefix: String,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        self.command_sender
+            .send(PluginCommand::ClearVirtualTextsInRange {
+                buffer_id: BufferId(buffer_id as usize),
+                id_prefix,
+                start: start as usize,
+                end: end as usize,
+                epoch: self.hook_epoch_for(buffer_id),
+            })
+            .is_ok()
+    }
+
     /// Add a virtual line (full line above/below a position)
     ///
     /// The `options` object accepts:

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -661,7 +661,23 @@ interface HookEventMap {
   };
   lines_changed: {
     buffer_id: number;
-    lines: { line_number: number; byte_start: number; byte_end: number; content: string }[];
+    lines: {
+      line_number: number;
+      byte_start: number;
+      byte_end: number;
+      content: string;
+      /** This line's role in an embedded-language region — a Markdown fenced
+       * code block, a Vue `<script>`/`<style>` block — as the highlighting
+       * engine classifies it while parsing. `"open"` and `"close"` are the
+       * delimiter lines; `"body"` is content strictly inside.
+       *
+       * Absent for ordinary lines AND when the region state could not be
+       * resolved (a >1MiB buffer whose viewport has no parse checkpoint before
+       * it yet). Treat absence as *unknown*, never as "outside a region": the
+       * point of this field is that a bare ``` opens or closes depending on
+       * every fence above it, so there is nothing to fall back on. */
+      region?: "open" | "body" | "close";
+    }[];
     /** Buffer version these byte ranges were captured at. Pass back to
      * coordinate-mapping APIs to repair stale offsets from this batch. */
     epoch: number;

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -135,6 +135,54 @@ string color), so nothing regresses.
   same documented trade-off the engine already makes for all multi-line
   constructs (strings, block comments, HTML `<style>`).
 
+### Region membership as an exported fact
+
+The per-line classification in the table above is not only used to pick a
+parser — it is the editor's *only* authoritative answer to "is this line
+inside a fence", and `TextMateEngine::region_lines_in` exports it. The
+`lines_changed` plugin hook carries it per line as
+`region: "open" | "body" | "close"`, and compose mode's fenced-code framing
+is built on it.
+
+Why it has to come from here. Region membership is the one property of a
+Markdown line that cannot be derived from the line's own text: a bare
+` ``` ` opens or closes depending on every fence above it (only a fence
+*with* an info string is unambiguously an opener, per CommonMark). A
+decoration plugin sees one `lines_changed` batch — the lines an edit or a
+scroll touched — and cannot read the buffer above it synchronously, so any
+plugin-side rule frames a block whose opening fence happens to be visible
+and gives up on one that isn't: a frame that appears and disappears with
+scroll position. Nor can it be memoised plugin-side; a memo of fence
+extents carries *structure*, and stale structure means framing the wrong
+lines (contrast the compose table-width memo, which carries only numbers).
+
+Driving it off the same classification that picks the parser also means the
+frame can never disagree with the colouring inside it. A fence the grammar
+does not recognize as a region — a ` ```js ` abutting a table row with no
+blank line between, which the Markdown grammar does not open a region for —
+is left unhighlighted *and* unframed, rather than framing a block the
+highlighter does not believe in.
+
+`region_lines_in` is a probe, not a cache: it resumes from the nearest
+checkpoint and discards what it computes, so it stays out of the three
+incremental cache paths and cannot perturb highlighting. Two rules keep it
+from answering confidently-wrong, both stricter than the highlight paths'
+own resume logic, because a wrong region is a wrong *frame* rather than a
+wrong colour:
+
+- it never resumes from a fresh state mid-file (a fresh state reads as
+  "outside a region"), only from a real checkpoint or byte 0;
+- it never resumes from a checkpoint at or after `dirty_from`.
+  `notify_insert`/`notify_delete` shift checkpoint *positions* but leave
+  their stored states for `try_partial_update` to repair lazily, so a
+  checkpoint past an unrepaired edit can still hold pre-edit region state.
+
+When neither is available — a buffer past `MAX_PARSE_BYTES` whose viewport
+has no checkpoint before it yet — it reports nothing, and consumers must
+read that as *unknown*, not as "outside a region". That is the same
+cold-start trade-off this engine already makes for styling inside a huge
+region.
+
 ### Adding a new host
 
 Add one `EmbeddingSpecDef` entry per region kind (host syntax name, the


### PR DESCRIPTION
Follow-up to #2967. #2993 landed slices 1–5 and deliberately left code block framing out; this lands it. Rebased onto master now that #2993 is merged.

A fenced block renders as a box, with the ``` delimiters concealed into the frame and the body left to the embedded-language highlighter:

```
┌──────────────────────────────────────────────────┐
│ fn answer() -> u32 {                             │
│     let s = "hello";                             │
│     42                                           │
│ }                                                │
└──────────────────────────────────────────────────┘
```

## Why this needed an editor-side change

Tables work because "is this line a table row" is decided from that line alone. "Is this line inside a fence" is not: a bare ``` opens or closes depending on every fence above it (only a fence carrying an info string is unambiguously an opener, per CommonMark), a `lines_changed` batch carries only the lines an edit or scroll touched, and a plugin cannot read the buffer above its batch synchronously — `getBufferText` returns a Promise, while the decoration pass must emit its clear+add in one command batch.

So any batch-local rule frames a block whose opening fence happens to be visible and abandons one that isn't: a frame that appears and disappears with scroll position. Memoising it plugin-side is worse, not better — a memo of fence extents carries *structure*, and stale structure means framing the wrong lines, unlike the compose table-width memo, which is safe precisely because it carries only numbers.

The editor already knows the answer. The embedded-language-region mechanism from #2689 classifies every line as it parses — region scope absent/present before and after — to decide whether the fence's own grammar or the host's styles it. This exports that classification rather than recomputing it, so the frame is drawn from the same source of truth that colours the block and the two can never disagree.

## Commits

**`feat(highlight): tell plugins which lines are inside a fenced code block`**

`TextMateEngine::region_lines_in` resumes from the nearest checkpoint and reports `open`/`body`/`close` per line; `lines_changed` carries it as `region` on each line, alongside coordinates the plugin already trusts — nothing to store, nothing to go stale.

It is a probe, not a cache: it discards what it computes, staying out of the three incremental cache paths (`full_parse` / `extend_cache_forward` / `try_partial_update`) so it cannot perturb highlighting, and needing no invalidation of its own. Two rules keep it from answering confidently-wrong, both stricter than the highlight paths' own resume logic, because a wrong region is a wrong *frame* rather than a wrong colour:

- never resume from a fresh state mid-file — a fresh state reads as "outside a region";
- never resume from a checkpoint at or after `dirty_from`, whose stored state `notify_insert` leaves for `try_partial_update` to repair lazily.

When neither a checkpoint nor byte 0 is reachable within budget it reports nothing, and consumers read that as *unknown* — the same cold-start trade-off the engine already documents for styling inside a huge region. Costs nothing for syntaxes that host no regions, which is nearly all of them.

**`feat(compose): frame fenced code blocks, and stop rendering code as markdown`**

Delimiters become the frame; body lines are left completely alone. That second half is a real bug fix: the per-line pass had no way to know a line was code, so inside a shell block `#` became a heading, `-` became a bullet with a spacer row, `*glob*` was italicised, and a line of pipes was drawn as a full table frame.

The borders are conceals, not virtual lines — one source line renders as one border line, riding the existing per-line clear-and-rebuild discipline and torn down with the rest of `md-syntax` on toggle-off.

An intra-line edit to a delimiter changes which lines are inside the block *below* it, and the editor re-fires `lines_changed` only for the edited line unless the line count changed. Two narrow triggers force the single repairing pass, between them covering both directions: the edit put a fence character into or took one out of the buffer (checked on the edit, since deleted text appears in no later batch), or the edited line is still delimiter-shaped afterwards (checked on the batch, where its new text is known).

**`feat(compose): close the code block frame with side rails`**

Rails cannot be conceals: a conceal replaces source bytes, and a rail adds columns no byte pays for. They use inline virtual text, and needed an API that did not exist — virtual *lines* have had a range-scoped clear since the table frame was rebuilt around one, but inline virtual text had only "by exact id" and "the whole prefix", neither of which can express "this line's, wherever they have drifted to" under the async lag. `ClearVirtualTextsInRange` is the inline analogue.

All four edges share one width function, so they cannot disagree.

**`fix(compose): align blank rows, rail wrapped rows, drop the language tag`**

Three defects found rendering a real README.

*Blank rows sat one column inside their own frame.* A blank line's rails hang off the newline cell, and that was the one cell `splice_inline_virtual_text` padded on both sides. The leading space holds an end-of-line hint off the text it trails — but when the newline *is* the line there is no text on either side, so it separated the hint from nothing and merely indented it. A newline that begins its own line now takes no padding.

*Long lines fell out of the frame.* A code line wider than the frame was left to the renderer's wrap, which folds it to column zero — outside the box, unrailed, and unrelated to the code above. Break points are now chosen here, at the frame's inner width, so every row is one this pass knows the width of and can rail and pad. One helper is shared with the rail pass so the two cannot disagree about where rows are.

*The border carried the fence's info string.* The block's language is already legible from the code inside it, which is highlighted with that language's grammar, so the tag was a caption on a picture that says the same thing.

**`fix(compose,view): break an unbreakable run instead of letting it overflow`**

A line with no space in it — a bare URL, the shape every install snippet has — still overflowed, because the plugin could only ask for breaks at spaces. That constraint was in the renderer: `apply_soft_breaks` matched a break against a token's `source_offset`, and every character of a Text token shares the token's start, so a mid-token break matched nothing and silently did nothing. It now splits the token at the break, the way `apply_conceal_ranges` already splits one for a range landing inside it; each piece keeps the token's style, so highlighting survives the cut. The row layout then falls back to cutting at the frame's inner width when no space leaves a non-empty row.

## Known limits

- A fence the grammar does not open a region for — a ` ```js ` abutting a table row with no blank line — is left literal rather than framed. It is unhighlighted on master too, so the frame stays in step with the colouring.
- Cursor behaviour is per-line, as elsewhere in compose: the cursor on a delimiter reverts *that* line to literal ``` so it stays editable; the cursor on a body line reveals nothing, since body lines carry no markup decorations. The block does not reveal as a whole.

## Verification

- 8 new e2e tests in `markdown_compose_code_frame.rs`, covering the labelless frame, rails aligned to the border corners, blank and wrapped rows holding the frame columns, a bare fence framed at both ends, a closing fence still framing after scrolling past its opener, an unbreakable run cut without losing a character, markdown syntax inside a block left alone, and an edit to a delimiter reframing the lines below it.
- 4 new engine unit tests, including a range starting deep inside a fence and a regression test for the stale-checkpoint resume (verified failing without the guard).
- `cargo fmt --check`, `cargo check --all-targets` and `plugins/check-types.sh` clean on the rebased tree. Regenerated `plugins/lib/fresh.d.ts`; `scripts/gen_schema.sh` produced no diff.
- Driven by hand in tmux against a debug build, with frame columns measured rather than eyeballed: several languages, a bare fence, blank lines inside a block, wide/CJK glyphs, wrapped and unbreakable lines, a block taller than the viewport scrolled end to end, a block adjacent to a table, typing a new fence, breaking and repairing a closing fence both by appending non-backtick text and by deleting backticks, typing inside a block, compose toggle-off, and 60- and 160-column panes.

**Reviewer note.** The last two commits touch `apply_soft_breaks`, which is on the path for *all* line wrapping, not just code blocks. The markdown suite was green locally at the commit before them; the full suite run against the final tree is CI's — the wrapping-adjacent suites (`wrap_index`, table row wrapping, terminal grid wrap) are the ones worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nj1tCEPKeseboyBuKqqg6Z