### PR TITLE
fix(compose): wrapped quote bars and no fold arrows in compose mode

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3360,6 +3360,18 @@ pub enum PluginCommand {
     /// Enable/disable line numbers for a buffer
     SetLineNumbers { buffer_id: BufferId, enabled: bool },
 
+    /// Set the plugin's fold-indicator default for a buffer's view state.
+    ///
+    /// `None` withdraws the plugin's opinion, restoring whatever the user's
+    /// own setting resolves to. Stored apart from the user's toggle and never
+    /// persisted, so a mode that hides the gutter arrows (markdown compose)
+    /// can neither overwrite a deliberate choice nor outlive itself in the
+    /// saved workspace.
+    SetFoldIndicators {
+        buffer_id: BufferId,
+        enabled: Option<bool>,
+    },
+
     /// Enable/disable indentation guides for a buffer, overriding the global
     /// `editor.indentation_guide` default. Used by tool views (e.g. the Git Log
     /// commit-detail diff) that show non-editable content where the guides are

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -924,6 +924,32 @@ pub enum OverlayColorSpec {
     ThemeKey(String),
 }
 
+/// A glyph run drawn at the head of a soft break's continuation row.
+///
+/// The break's `indent` stays the authoritative column count for the
+/// continuation: the prefix is drawn *inside* those columns and the
+/// remainder renders as spaces. That keeps every width consumer (scroll
+/// math, the wrap index, the row-count cache) reading a single number,
+/// while the renderer gets something to draw there — a `▌` continuing a
+/// wrapped block quote's bar, say, instead of a blank gap.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub struct SoftBreakPrefix {
+    /// Text to draw at the start of the continuation row.
+    pub text: String,
+    /// Foreground colour, theme key or RGB. `None` = the row's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fg: Option<OverlayColorSpec>,
+    /// Background colour, theme key or RGB. `None` = the row's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bg: Option<OverlayColorSpec>,
+    #[serde(default)]
+    pub bold: bool,
+    #[serde(default)]
+    pub italic: bool,
+}
+
 /// Modifier-only overlay applied to a byte range within a virtual line's
 /// text. Used by plugins (live-diff) to bold + underline removed words on
 /// a deletion virtual line without varying the line's overall fg/bg.
@@ -3639,7 +3665,8 @@ pub enum PluginCommand {
         namespace: OverlayNamespace,
         /// Byte offset where the break should be injected
         position: usize,
-        /// Number of hanging indent spaces after the break
+        /// Total width of the continuation row's indent, in columns. Also
+        /// bounds `prefix`, which is drawn inside it.
         indent: u16,
         /// Hook epoch `position` was computed against (auto-stamped); the editor
         /// remaps it forward before injecting the break, so a stale wrap point
@@ -3649,6 +3676,10 @@ pub enum PluginCommand {
         /// Optional cursor-dependent activation rule. `None` = always active.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         activation: Option<MarkerActivation>,
+        /// Optional glyph run drawn at the head of the continuation row,
+        /// inside `indent`. `None` = the indent renders blank.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prefix: Option<SoftBreakPrefix>,
     },
 
     /// Clear all soft breaks in a namespace

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -4188,6 +4188,18 @@ interface EditorAPI {
 	*/
 	setLineNumbers(bufferId: number, enabled: boolean): boolean;
 	/**
+	* Show or hide the gutter's fold indicators (`▾` / `▸`) for a buffer in
+	* the active split, the way `setLineNumbers` does for line numbers.
+	* 
+	* Pass `null` to withdraw the plugin's opinion and fall back to the
+	* user's own setting. The plugin's value is stored separately from that
+	* setting and is never persisted, so it can neither overwrite a
+	* deliberate choice — "Toggle Folding Indicators (Current Buffer)" still
+	* wins while this is set — nor leak into the saved session. A mode that
+	* hides them should still clear its value on the way out.
+	*/
+	setFoldIndicators(bufferId: number, enabled: boolean | null): boolean;
+	/**
 	* Enable or disable indentation guides for a buffer, overriding the global
 	* `editor.indentation_guide` setting. Tool views that render non-editable
 	* content (e.g. the Git Log commit-detail diff) disable them.

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3709,8 +3709,15 @@ interface EditorAPI {
 	* 
 	* `activation` optionally makes the break cursor-dependent — same
 	* semantics as `addConceal`'s activation parameters.
+	* 
+	* `prefix` optionally draws a glyph run at the head of the continuation
+	* row, shaped `{ text, fg?, bg?, bold?, italic? }` with the same colour
+	* spec `addOverlay` takes (a theme key string or an `[r, g, b]` array).
+	* It is drawn *inside* the `indent` columns rather than in addition to
+	* them, so a wrapped block quote can keep its `▌` down every row without
+	* shifting the text. `indent` grows to fit a prefix wider than it.
 	*/
-	addSoftBreak(bufferId: number, namespace: string, position: number, indent: number, activation?: string, scopeStart?: number, scopeEnd?: number): boolean;
+	addSoftBreak(bufferId: number, namespace: string, position: number, indent: number, activation?: string | null, scopeStart?: number | null, scopeEnd?: number | null, prefix?: Record<string, unknown> | null): boolean;
 	/**
 	* Clear all soft breaks in a namespace
 	*/

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -1426,6 +1426,36 @@ const QUOTE_BAR = "▌";
 const quoteBarStyle = { fg: "syntax.type" };
 const quoteTextStyle = { fg: "syntax.comment", italic: true };
 
+/** The leading `>` marker run of a block quote line, or null if there is none.
+ *
+ * `runStart`/`runEnd` are character offsets into `lineContent`; `rendered` is
+ * how the run's columns look once compose mode has concealed it — every `>`
+ * replaced by the bar glyph, every other character (the leading indent, the
+ * spaces between and after markers) left as a space. Width is preserved
+ * one-for-one, so the quoted text keeps its source column.
+ *
+ * Shared by the conceal pass, which draws the run in place on the source row,
+ * and the soft-break pass, which repeats it as the continuation rows' indent.
+ * Both must agree on where the run ends: that column is where the quoted text
+ * starts, and therefore where every wrapped row has to line up.
+ */
+function quoteMarkerRun(
+  lineContent: string,
+): { runStart: number; runEnd: number; rendered: string } | null {
+  // Spaces and tabs only, never `\s`: `lineContent` can carry its trailing
+  // newline, and `[>\s]*` would swallow it into the run — putting a phantom
+  // column into `rendered` and pushing `runEnd` past the end of the row.
+  const match = lineContent.match(/^([ \t]*)(>[> \t]*)/);
+  if (!match) return null;
+  const runStart = match[1].length;
+  const runEnd = runStart + match[2].length;
+  let rendered = "";
+  for (let i = 0; i < runEnd; i++) {
+    rendered += lineContent[i] === '>' ? QUOTE_BAR : " ";
+  }
+  return { runStart, runEnd, rendered };
+}
+
 function headingTextStyle(level: number): Record<string, unknown> {
   const idx = Math.min(Math.max(level, 1), HEADING_TEXT_STYLES.length) - 1;
   return HEADING_TEXT_STYLES[idx];
@@ -1824,10 +1854,9 @@ function processLineConceals(
   //
   // Falls through to inline-span processing, so emphasis and links inside a
   // quote still render.
-  const quoteRun = lineContent.match(/^(\s*)(>[>\s]*)/);
+  const quoteRun = quoteMarkerRun(lineContent);
   if (quoteRun) {
-    const runStart = quoteRun[1].length;
-    const runEnd = runStart + quoteRun[2].length;
+    const { runStart, runEnd } = quoteRun;
     for (let i = runStart; i < runEnd; i++) {
       if (lineContent[i] !== '>') continue;
       const markerByte = charToByte(lineContent, i, byteStart);
@@ -2088,8 +2117,28 @@ function processLineSoftBreaks(
   // width, not the source's. Otherwise a wrapped nested item's continuation
   // rows sit left of its text and its last row can overrun the measure.
   const listInfo = listItemInfo(lineContent, width);
+
+  // A block quote's bar is drawn by concealing its `>` markers, which only
+  // exist on the source row — so a quote long enough to wrap used to lose the
+  // bar on every continuation row and the block's left edge broke apart.
+  // Repeat the concealed marker run as the continuation rows' indent instead:
+  // the run's own columns, `>` rendered as the bar and everything else blank.
+  // It replaces the indent rather than adding to it (the editor charges the
+  // prefix against `indent`), so the quoted text stays in its source column.
+  //
+  // Deliberately not cursor-gated, unlike the conceals: the head of a
+  // continuation row is entirely virtual — there is no source markup there to
+  // reveal for editing — so hiding the bar while the cursor sits on the quote
+  // would only break the block's edge exactly when the user is working in it.
+  const quoteRun = block.type === 'blockquote' ? quoteMarkerRun(lineContent) : null;
+  const quotePrefix = quoteRun
+    ? { text: quoteRun.rendered, ...quoteBarStyle }
+    : null;
+
   const hangingIndent = listInfo
     ? listInfo.renderedIndent + listInfo.markerLen
+    : quoteRun
+    ? editor.stringWidth(quoteRun.rendered)
     : block.hangingIndent;
 
   // Compute per-character visual width so concealed markup (emphasis
@@ -2149,7 +2198,14 @@ function processLineSoftBreaks(
       if (column + 1 + nextWordLen > wrapBudget && nextWordLen > 0) {
         // Add a soft break at this space's buffer position
         const breakBytePos = byteStart + editor.utf8ByteLength(lineContent.slice(0, i));
-        editor.addSoftBreak(bufferId, "md-wrap", breakBytePos, hangingIndent);
+        if (quotePrefix) {
+          editor.addSoftBreak(
+            bufferId, "md-wrap", breakBytePos, hangingIndent,
+            undefined, undefined, undefined, quotePrefix,
+          );
+        } else {
+          editor.addSoftBreak(bufferId, "md-wrap", breakBytePos, hangingIndent);
+        }
         column = hangingIndent;
         i++;
         continue;

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -964,6 +964,13 @@ function enableMarkdownCompose(bufferId: number): void {
   // Hide line numbers in compose mode
   editor.setLineNumbers(bufferId, false);
 
+  // Same for the gutter's fold arrows: they are a code-editor affordance, and
+  // a document preview with no line numbers has no use for them — they only
+  // break up the clean left edge. Compose passes an opinion, not a setting:
+  // the editor keeps it apart from the user's own "Toggle Folding Indicators"
+  // choice, which still wins here and is what comes back on the way out.
+  editor.setFoldIndicators(bufferId, false);
+
   // Enable native line wrapping so that long lines without whitespace
   // (which the plugin can't soft-break) are force-wrapped by the Rust
   // wrapping transform at the content width.
@@ -1002,6 +1009,11 @@ function disableMarkdownCompose(bufferId: number): void {
 
     // Re-enable line numbers
     editor.setLineNumbers(bufferId, true);
+
+    // Withdraw the fold-indicator opinion rather than forcing them back on:
+    // `null` restores whatever the user's own setting resolves to, which for
+    // someone who had deliberately turned the arrows off is still off.
+    editor.setFoldIndicators(bufferId, null);
 
     // Clear layout hints, emphasis overlays, conceals, and soft breaks
     editor.setLayoutHints(bufferId, null, {});

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1971,6 +1971,43 @@ impl Editor {
         }
     }
 
+    /// Handle SetFoldIndicators command
+    ///
+    /// Per-(split, buffer) like `SetLineNumbers`, and for the same reason:
+    /// compose mode is itself per-split, so a source-mode split showing the
+    /// same buffer must keep its own gutter.
+    ///
+    /// Writes `fold_indicators_plugin_override`, never the user's
+    /// `fold_indicators_override` — see `BufferViewState` for why those are
+    /// two fields. `None` withdraws the plugin's opinion.
+    pub(super) fn handle_set_fold_indicators(
+        &mut self,
+        buffer_id: BufferId,
+        enabled: Option<bool>,
+    ) {
+        let active_split = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(mgr, _)| mgr)
+            .expect("active window must have a populated split layout")
+            .active_split();
+        if let Some(view_state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_view_states_mut())
+            .expect("active window must have a populated split layout")
+            .get_mut(&active_split)
+        {
+            if let Some(buf_state) = view_state.buffer_state_mut(buffer_id) {
+                buf_state.fold_indicators_plugin_override = enabled;
+            } else {
+                // Buffer not yet in this split — fall back to setting on active
+                view_state.fold_indicators_plugin_override = enabled;
+            }
+        }
+    }
+
     /// Handle SetIndentationGuide command
     ///
     /// Records a per-buffer override for indentation-guide visibility. Unlike

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -799,7 +799,11 @@ impl Editor {
         indent: u16,
         epoch: Option<u64>,
         activation: Option<fresh_core::api::MarkerActivation>,
+        prefix: Option<fresh_core::api::SoftBreakPrefix>,
     ) {
+        use fresh_core::api::OverlayColorSpec;
+        use ratatui::style::{Color, Modifier, Style};
+
         if let Some(state) = self
             .windows
             .get_mut(&self.active_window)
@@ -822,12 +826,44 @@ impl Editor {
                     scope_end,
                 })
             });
-            state.soft_breaks.add_with_activation(
+            // Concrete colours become the fallback style; theme keys are kept
+            // separate so they re-resolve every frame and follow live theme
+            // changes — same split as plugin virtual text (see
+            // `handle_add_virtual_text` above).
+            let prefix = prefix.map(|p| {
+                let mut style = Style::default();
+                let mut fg_theme_key = None;
+                let mut bg_theme_key = None;
+                match p.fg {
+                    Some(OverlayColorSpec::Rgb(r, g, b)) => style = style.fg(Color::Rgb(r, g, b)),
+                    Some(OverlayColorSpec::ThemeKey(k)) => fg_theme_key = Some(k),
+                    None => {}
+                }
+                match p.bg {
+                    Some(OverlayColorSpec::Rgb(r, g, b)) => style = style.bg(Color::Rgb(r, g, b)),
+                    Some(OverlayColorSpec::ThemeKey(k)) => bg_theme_key = Some(k),
+                    None => {}
+                }
+                if p.bold {
+                    style = style.add_modifier(Modifier::BOLD);
+                }
+                if p.italic {
+                    style = style.add_modifier(Modifier::ITALIC);
+                }
+                crate::view::soft_break::SoftBreakPrefix {
+                    text: p.text,
+                    style,
+                    fg_theme_key,
+                    bg_theme_key,
+                }
+            });
+            state.soft_breaks.add_full(
                 &mut state.marker_list,
                 namespace,
                 position,
                 indent,
                 activation,
+                prefix,
             );
             #[cfg(feature = "plugins")]
             {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -760,6 +760,9 @@ impl Editor {
             PluginCommand::SetLineNumbers { buffer_id, enabled } => {
                 self.handle_set_line_numbers(buffer_id, enabled);
             }
+            PluginCommand::SetFoldIndicators { buffer_id, enabled } => {
+                self.handle_set_fold_indicators(buffer_id, enabled);
+            }
             PluginCommand::SetIndentationGuide { buffer_id, enabled } => {
                 self.handle_set_indentation_guide(buffer_id, enabled);
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -652,9 +652,10 @@ impl Editor {
                 indent,
                 epoch,
                 activation,
+                prefix,
             } => {
                 self.handle_add_soft_break(
-                    buffer_id, namespace, position, indent, epoch, activation,
+                    buffer_id, namespace, position, indent, epoch, activation, prefix,
                 );
             }
             PluginCommand::ClearSoftBreakNamespace {

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -706,8 +706,10 @@ impl EditorState {
         let soft_breaks = if self.soft_breaks.is_empty() {
             Vec::new()
         } else {
+            // `theme: None` — the index measures and never draws, so a
+            // continuation prefix contributes its width here but no colour.
             self.soft_breaks
-                .query_viewport(0, end, &self.marker_list, &no_cursors)
+                .query_viewport_rendered(0, end, &self.marker_list, &no_cursors, None)
         };
 
         let conceals = if self.conceals.is_empty() {

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -539,10 +539,17 @@ pub fn compute_line_layout(
 
     // Step 2: soft breaks (Compose mode only; same gating as the renderer).
     if is_compose && !state.soft_breaks.is_empty() {
-        let sb =
-            state
-                .soft_breaks
-                .query_viewport(line_start, line_end, &state.marker_list, cursors);
+        // `theme: None` — this output feeds scroll math and coordinate
+        // queries, never the screen, so a continuation prefix's colour is
+        // irrelevant here. Its *width* is not, and that comes through
+        // regardless (same split as `resolve_inline_hints` below).
+        let sb = state.soft_breaks.query_viewport_rendered(
+            line_start,
+            line_end,
+            &state.marker_list,
+            cursors,
+            None,
+        );
         if !sb.is_empty() {
             tokens = apply_soft_breaks(tokens, &sb);
         }

--- a/crates/fresh-editor/src/view/soft_break.rs
+++ b/crates/fresh-editor/src/view/soft_break.rs
@@ -20,9 +20,47 @@
 
 use crate::model::marker::{MarkerId, MarkerList};
 use crate::view::activation::ScopedActivation;
+use crate::view::theme::Theme;
 use fresh_core::api::MarkerActivation;
 use fresh_core::overlay::OverlayNamespace;
+use ratatui::style::Style;
 use std::collections::HashMap;
+
+/// A glyph run drawn at the head of a continuation row, stored the way
+/// `VirtualText` stores its styling: concrete colours in `style` as the
+/// fallback, theme keys kept separate so they re-resolve on every frame
+/// and follow live theme changes.
+///
+/// Its display width never exceeds the break's `indent` — the manager
+/// widens `indent` to fit at insert time (see [`SoftBreakManager::add_full`]),
+/// which is what lets every width consumer keep reading `indent` alone.
+#[derive(Debug, Clone)]
+pub struct SoftBreakPrefix {
+    pub text: String,
+    pub style: Style,
+    pub fg_theme_key: Option<String>,
+    pub bg_theme_key: Option<String>,
+}
+
+impl SoftBreakPrefix {
+    /// Resolve the on-screen `Style` against a live theme. Theme keys win
+    /// over the fallback's colours; modifiers from the fallback survive.
+    /// Same contract as [`crate::view::virtual_text::VirtualText::resolved_style`].
+    pub fn resolved_style(&self, theme: &Theme) -> Style {
+        let mut style = self.style;
+        if let Some(key) = &self.fg_theme_key {
+            if let Some(color) = theme.resolve_theme_key(key) {
+                style = style.fg(color);
+            }
+        }
+        if let Some(key) = &self.bg_theme_key {
+            if let Some(color) = theme.resolve_theme_key(key) {
+                style = style.bg(color);
+            }
+        }
+        style
+    }
+}
 
 /// A soft break point that injects a line break during rendering
 #[derive(Debug, Clone)]
@@ -33,13 +71,46 @@ pub struct SoftBreakPoint {
     /// Marker at the break position (right affinity — shifts with inserted text)
     pub marker_id: MarkerId,
 
-    /// Number of hanging indent spaces to insert after the break
+    /// Total width of the continuation row's indent, in columns. The single
+    /// number every width consumer reads; `prefix` is drawn inside it.
     pub indent: u16,
 
     /// Optional cursor-dependent activation rule, scope stored relative to
     /// the break marker. `None` = always active. Filtered at query time so
     /// cursor movement never mutates the marker set (see view/activation.rs).
     pub activation: Option<ScopedActivation>,
+
+    /// Optional glyph run drawn at the head of the continuation row.
+    /// `None` = the whole indent renders blank.
+    pub prefix: Option<SoftBreakPrefix>,
+}
+
+/// One soft break resolved for a render pass: where to break, how wide the
+/// continuation indent is, and what (if anything) to draw in it.
+///
+/// The token-producing transform takes these rather than raw
+/// `SoftBreakPoint`s so measurement-only callers — the wrap index, the row
+/// count cache — can build the same stream from plain `(position, indent)`
+/// pairs via [`SoftBreakRender::plain`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct SoftBreakRender {
+    pub position: usize,
+    pub indent: u16,
+    /// Continuation-row glyphs and their theme-resolved style. The style is
+    /// `None` when the caller has no theme (measurement paths), which
+    /// changes colour only — never width.
+    pub prefix: Option<(String, Option<Style>)>,
+}
+
+impl SoftBreakRender {
+    /// A break with a blank continuation indent.
+    pub fn plain(position: usize, indent: u16) -> Self {
+        Self {
+            position,
+            indent,
+            prefix: None,
+        }
+    }
 }
 
 impl SoftBreakPoint {
@@ -106,7 +177,34 @@ impl SoftBreakManager {
         indent: u16,
         activation: Option<MarkerActivation>,
     ) {
+        self.add_full(marker_list, namespace, position, indent, activation, None);
+    }
+
+    /// As [`add_with_activation`](Self::add_with_activation), plus a glyph
+    /// run for the continuation row.
+    ///
+    /// `indent` is widened to the prefix's display width when the caller
+    /// asks for a prefix wider than the indent it declared. `indent` is the
+    /// only width the scroll math and the wrap index ever see, so letting a
+    /// prefix overflow it would put the renderer and those consumers on
+    /// different column counts for the same row.
+    pub fn add_full(
+        &mut self,
+        marker_list: &mut MarkerList,
+        namespace: OverlayNamespace,
+        position: usize,
+        indent: u16,
+        activation: Option<MarkerActivation>,
+        prefix: Option<SoftBreakPrefix>,
+    ) {
         let marker_id = marker_list.create(position);
+
+        let indent = match &prefix {
+            Some(p) => indent.max(
+                u16::try_from(fresh_core::display_width::str_width(&p.text)).unwrap_or(u16::MAX),
+            ),
+            None => indent,
+        };
 
         let idx = self.breaks.len();
         self.marker_to_idx.insert(marker_id, idx);
@@ -115,6 +213,7 @@ impl SoftBreakManager {
             marker_id,
             indent,
             activation: activation.map(|rule| ScopedActivation::from_absolute(&rule, position)),
+            prefix,
         });
         self.version = self.version.wrapping_add(1);
     }
@@ -234,6 +333,52 @@ impl SoftBreakManager {
         results
     }
 
+    /// As [`query_viewport`](Self::query_viewport), but carrying each break's
+    /// continuation prefix — what the token transform needs to actually draw
+    /// the row.
+    ///
+    /// `theme` is `Some` on the drawing path and `None` on measurement paths
+    /// (the per-line layout the scroll math reads). The prefix text is
+    /// emitted either way; only its colour depends on the theme, so both
+    /// paths lay out identical columns. Same split as
+    /// [`crate::view::ui::split_rendering::transforms::resolve_inline_hints`].
+    pub fn query_viewport_rendered(
+        &self,
+        start: usize,
+        end: usize,
+        marker_list: &MarkerList,
+        cursors: &[usize],
+        theme: Option<&Theme>,
+    ) -> Vec<SoftBreakRender> {
+        let mut results: Vec<SoftBreakRender> = self
+            .breaks
+            .iter()
+            .filter_map(|b| {
+                let pos = b.position(marker_list);
+                if let Some(a) = &b.activation {
+                    if !a.is_active(pos, cursors) {
+                        return None;
+                    }
+                }
+                if pos < start || pos >= end {
+                    return None;
+                }
+                Some(SoftBreakRender {
+                    position: pos,
+                    indent: b.indent,
+                    prefix: b
+                        .prefix
+                        .as_ref()
+                        .map(|p| (p.text.clone(), theme.map(|t| p.resolved_style(t)))),
+                })
+            })
+            .collect();
+
+        results.sort_by_key(|b| b.position);
+
+        results
+    }
+
     /// Earliest soft break in `start..end` whose cursor-dependent activation
     /// currently differs from the canonical evaluation. See
     /// `ConcealManager::earliest_cursor_divergence` — same contract.
@@ -326,6 +471,70 @@ mod tests {
             .map(|(p, _)| p)
             .collect();
         assert_eq!(kept, vec![5, 65]);
+    }
+
+    fn prefix(text: &str) -> SoftBreakPrefix {
+        SoftBreakPrefix {
+            text: text.to_string(),
+            style: Style::default(),
+            fg_theme_key: None,
+            bg_theme_key: None,
+        }
+    }
+
+    /// `indent` is the only width the scroll math and the wrap index ever
+    /// read, so a prefix wider than the indent the plugin declared has to
+    /// grow it — otherwise the renderer would draw a row wider than every
+    /// other consumer believes it to be.
+    #[test]
+    fn test_soft_break_prefix_widens_a_too_narrow_indent() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(100);
+        let mut manager = SoftBreakManager::new();
+
+        manager.add_full(&mut marker_list, ns(), 10, 1, None, Some(prefix("▌ ")));
+
+        let breaks = manager.query_viewport(0, 100, &marker_list, &[]);
+        assert_eq!(breaks, vec![(10, 2)]);
+    }
+
+    /// An indent wider than the prefix is left alone — the prefix is drawn
+    /// inside it and the rest pads out.
+    #[test]
+    fn test_soft_break_prefix_narrower_than_indent_keeps_the_indent() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(100);
+        let mut manager = SoftBreakManager::new();
+
+        manager.add_full(&mut marker_list, ns(), 10, 6, None, Some(prefix("▌ ")));
+
+        let breaks = manager.query_viewport(0, 100, &marker_list, &[]);
+        assert_eq!(breaks, vec![(10, 6)]);
+    }
+
+    /// The width-only and render queries must report the same columns for
+    /// the same break: they feed the scroll math and the renderer, and a
+    /// disagreement between those two is what puts the cursor on the wrong
+    /// row.
+    #[test]
+    fn test_soft_break_queries_agree_on_indent() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(100);
+        let mut manager = SoftBreakManager::new();
+
+        manager.add_full(&mut marker_list, ns(), 10, 1, None, Some(prefix("▌ ")));
+        manager.add(&mut marker_list, ns(), 40, 3);
+
+        let widths = manager.query_viewport(0, 100, &marker_list, &[]);
+        let rendered = manager.query_viewport_rendered(0, 100, &marker_list, &[], None);
+
+        let pairs: Vec<(usize, u16)> = rendered.iter().map(|b| (b.position, b.indent)).collect();
+        assert_eq!(widths, pairs);
+        assert_eq!(
+            rendered[0].prefix.as_ref().map(|(t, _)| t.as_str()),
+            Some("▌ ")
+        );
+        assert_eq!(rendered[1].prefix, None);
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -197,6 +197,19 @@ pub struct BufferViewState {
     /// arrows in this split without touching existing folds. Persisted in the
     /// per-file workspace state.
     pub fold_indicators_override: Option<bool>,
+    /// Plugin-supplied fold-indicator default for this (split, buffer), set
+    /// via `setFoldIndicators`. `None` = no plugin opinion. Markdown compose
+    /// uses it to drop the gutter arrows from a document preview.
+    ///
+    /// Deliberately separate from `fold_indicators_override` and deliberately
+    /// **not** persisted: it is a mode's transient opinion, not a preference.
+    /// Keeping the two apart means compose can never overwrite a choice the
+    /// user made, can never leak a forced value into the saved workspace, and
+    /// needs no save/restore dance to put things back when it exits — the
+    /// user's setting is still sitting there untouched. It loses to that
+    /// setting in `fold_indicators_visible`, so the toggle action keeps
+    /// working while composing.
+    pub fold_indicators_plugin_override: Option<bool>,
 
     /// Plugin-managed state (arbitrary key-value pairs).
     /// Plugins can store per-buffer-per-split state here via the `setViewState`/`getViewState` API.
@@ -254,6 +267,7 @@ impl BufferViewState {
             highlight_current_line_override: None,
             indentation_guide_user_override: None,
             fold_indicators_override: None,
+            fold_indicators_plugin_override: None,
             plugin_state: std::collections::HashMap::new(),
             folds: FoldManager::new(),
         }
@@ -272,10 +286,16 @@ impl BufferViewState {
     /// global value there would silently undo "Toggle X (Current Buffer)" the
     /// next time that buffer was activated. Fields with no override
     /// (`None`, the case for every freshly created view state) are unaffected.
-    /// Whether the gutter should draw fold arrows in this split. Defaults to
-    /// on; only the per-buffer toggle turns them off.
+    /// Whether the gutter should draw fold arrows in this split.
+    ///
+    /// The user's own toggle wins outright; a plugin (markdown compose)
+    /// supplies the default when they have not expressed one; failing both,
+    /// they show. That ordering is what lets "Toggle Folding Indicators"
+    /// still do something while a mode is hiding them.
     pub fn fold_indicators_visible(&self) -> bool {
-        self.fold_indicators_override.unwrap_or(true)
+        self.fold_indicators_override
+            .or(self.fold_indicators_plugin_override)
+            .unwrap_or(true)
     }
 
     pub fn apply_config_defaults(&mut self, defaults: ViewConfigDefaults) {
@@ -330,6 +350,9 @@ impl Clone for BufferViewState {
             highlight_current_line_override: self.highlight_current_line_override,
             indentation_guide_user_override: self.indentation_guide_user_override,
             fold_indicators_override: self.fold_indicators_override,
+            // Carried like `view_mode`: a split cloned from a composing one
+            // is composing too, and should hide its arrows for the same reason.
+            fold_indicators_plugin_override: self.fold_indicators_plugin_override,
             plugin_state: self.plugin_state.clone(),
             // Fold markers are per-view; clones start with no folded ranges.
             folds: FoldManager::new(),
@@ -1953,6 +1976,42 @@ impl SplitManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two fold-indicator overrides are a precedence, not a single flag:
+    /// a plugin supplies the default, the user's own toggle overrules it, and
+    /// with neither set the arrows show. Getting this backwards would either
+    /// let compose mode silently discard a deliberate setting, or leave
+    /// "Toggle Folding Indicators" doing nothing while composing.
+    #[test]
+    fn test_fold_indicator_precedence() {
+        let mut vs = BufferViewState::new(80, 24);
+        assert!(vs.fold_indicators_visible(), "default is on");
+
+        vs.fold_indicators_plugin_override = Some(false);
+        assert!(
+            !vs.fold_indicators_visible(),
+            "a plugin can hide them when the user has no opinion",
+        );
+
+        vs.fold_indicators_override = Some(true);
+        assert!(
+            vs.fold_indicators_visible(),
+            "the user's own choice overrules the plugin's",
+        );
+
+        vs.fold_indicators_plugin_override = None;
+        assert!(
+            vs.fold_indicators_visible(),
+            "withdrawing the plugin's opinion leaves the user's choice standing",
+        );
+
+        vs.fold_indicators_override = Some(false);
+        vs.fold_indicators_plugin_override = Some(true);
+        assert!(
+            !vs.fold_indicators_visible(),
+            "a user who hid them keeps them hidden whatever the plugin says",
+        );
+    }
 
     #[test]
     fn test_create_split_manager() {

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -9,7 +9,9 @@
 //! None of these depend on any shared render-time "mega struct".
 
 use super::style::{create_wrapped_virtual_lines, token_style_from_ratatui};
+use crate::primitives::display_width::str_width;
 use crate::state::EditorState;
+use crate::view::soft_break::SoftBreakRender;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::ViewLine;
 use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
@@ -81,11 +83,11 @@ pub(crate) fn apply_grid_wrapping_transform(
 
 /// Apply soft breaks to a token stream.
 ///
-/// Walks tokens with a sorted break list `[(position, indent)]`. A break at a
-/// position:
-/// - on a Space token: replaces it with Newline + indent Spaces
-/// - anywhere else: inserts Newline + indent Spaces before that byte, splitting
-///   the Text token it lands inside if it is not already at a token boundary
+/// Walks tokens with a sorted break list. A break at a position:
+/// - on a Space token: replaces it with Newline + the continuation indent
+/// - anywhere else: inserts Newline + the continuation indent before that byte,
+///   splitting the Text token it lands inside if it is not already at a token
+///   boundary
 ///
 /// That last case is what lets a caller break a run with no space in it — a
 /// bare URL, a long path — at a chosen column. The characters of a Text token
@@ -96,10 +98,17 @@ pub(crate) fn apply_grid_wrapping_transform(
 /// ranges landing inside a token; each piece keeps the token's style, so
 /// highlighting survives the break.
 ///
+/// The continuation indent is `indent` columns wide. A break carrying a
+/// [`SoftBreakRender::prefix`] draws that glyph run at the head of those
+/// columns and pads the rest with Spaces; without one the whole indent is
+/// Spaces, as it always was. The prefix never widens the row — the manager
+/// grew `indent` to fit it at insert time — so the columns a measurement-only
+/// caller computes from `indent` alone still match what gets drawn.
+///
 /// Tokens without source_offset (injected/virtual) pass through unchanged.
 pub(crate) fn apply_soft_breaks(
     tokens: Vec<ViewTokenWire>,
-    soft_breaks: &[(usize, u16)],
+    soft_breaks: &[SoftBreakRender],
 ) -> Vec<ViewTokenWire> {
     if soft_breaks.is_empty() {
         return tokens;
@@ -108,14 +117,24 @@ pub(crate) fn apply_soft_breaks(
     let mut output = Vec::with_capacity(tokens.len() + soft_breaks.len() * 2);
     let mut break_idx = 0;
 
-    // Newline + `indent` spaces, the row break itself.
-    fn push_break(output: &mut Vec<ViewTokenWire>, indent: u16) {
+    // Newline + the break's continuation indent: a prefix at its head when the
+    // break carries one, spaces for the rest of the columns.
+    fn push_break(output: &mut Vec<ViewTokenWire>, brk: &SoftBreakRender) {
         output.push(ViewTokenWire {
             source_offset: None,
             kind: ViewTokenWireKind::Newline,
             style: None,
         });
-        for _ in 0..indent {
+        let mut spaces = brk.indent as usize;
+        if let Some((text, style)) = &brk.prefix {
+            spaces = spaces.saturating_sub(str_width(text));
+            output.push(ViewTokenWire {
+                source_offset: None,
+                kind: ViewTokenWireKind::Text(text.clone()),
+                style: style.map(token_style_from_ratatui),
+            });
+        }
+        for _ in 0..spaces {
             output.push(ViewTokenWire {
                 source_offset: None,
                 kind: ViewTokenWireKind::Space,
@@ -133,25 +152,25 @@ pub(crate) fn apply_soft_breaks(
             }
         };
 
-        while break_idx < soft_breaks.len() && soft_breaks[break_idx].0 < offset {
+        while break_idx < soft_breaks.len() && soft_breaks[break_idx].position < offset {
             break_idx += 1;
         }
 
         // A Text token can span several break positions; walk its characters
         // and cut at each. The common case (no break inside) falls through the
         // loop and re-emits the token whole.
-        if let ViewTokenWireKind::Text(s) = &token.kind {
-            let token_end = offset + s.len();
+        if let ViewTokenWireKind::Text(str_tok) = &token.kind {
+            let token_end = offset + str_tok.len();
             if soft_breaks[break_idx..]
                 .first()
-                .is_some_and(|(pos, _)| *pos < token_end)
+                .is_some_and(|b| b.position < token_end)
             {
                 let mut seg = String::new();
                 let mut seg_start = offset;
                 let mut byte_idx = 0usize;
-                for ch in s.chars() {
+                for ch in str_tok.chars() {
                     let pos = offset + byte_idx;
-                    if break_idx < soft_breaks.len() && soft_breaks[break_idx].0 == pos {
+                    if break_idx < soft_breaks.len() && soft_breaks[break_idx].position == pos {
                         if !seg.is_empty() {
                             output.push(ViewTokenWire {
                                 source_offset: Some(seg_start),
@@ -159,7 +178,7 @@ pub(crate) fn apply_soft_breaks(
                                 style: token.style.clone(),
                             });
                         }
-                        push_break(&mut output, soft_breaks[break_idx].1);
+                        push_break(&mut output, &soft_breaks[break_idx]);
                         seg_start = pos;
                         break_idx += 1;
                     }
@@ -177,15 +196,15 @@ pub(crate) fn apply_soft_breaks(
             }
         }
 
-        if break_idx < soft_breaks.len() && soft_breaks[break_idx].0 == offset {
-            let indent = soft_breaks[break_idx].1;
+        if break_idx < soft_breaks.len() && soft_breaks[break_idx].position == offset {
+            let brk = &soft_breaks[break_idx];
             break_idx += 1;
 
             match &token.kind {
                 // The space *is* the break: it is consumed by the row end.
-                ViewTokenWireKind::Space => push_break(&mut output, indent),
+                ViewTokenWireKind::Space => push_break(&mut output, brk),
                 _ => {
-                    push_break(&mut output, indent);
+                    push_break(&mut output, brk);
                     output.push(token);
                 }
             }
@@ -684,4 +703,96 @@ pub fn splice_inline_virtual_text(
     }
 
     out
+}
+
+#[cfg(test)]
+mod soft_break_tests {
+    use super::*;
+
+    /// One `Text` token per source byte, the shape `build_base_tokens`
+    /// produces for a plain ASCII line.
+    fn chars(text: &str) -> Vec<ViewTokenWire> {
+        text.char_indices()
+            .map(|(i, c)| ViewTokenWire {
+                source_offset: Some(i),
+                kind: if c == ' ' {
+                    ViewTokenWireKind::Space
+                } else {
+                    ViewTokenWireKind::Text(c.to_string())
+                },
+                style: None,
+            })
+            .collect()
+    }
+
+    /// The columns emitted between the injected Newline and the next source
+    /// token — the continuation row's indent, as text.
+    fn continuation_indent(tokens: &[ViewTokenWire]) -> String {
+        let newline = tokens
+            .iter()
+            .position(|t| matches!(t.kind, ViewTokenWireKind::Newline))
+            .expect("no soft break was injected");
+        tokens[newline + 1..]
+            .iter()
+            .take_while(|t| t.source_offset.is_none())
+            .map(|t| match &t.kind {
+                ViewTokenWireKind::Text(s) => s.clone(),
+                ViewTokenWireKind::Space => " ".to_string(),
+                _ => String::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_plain_break_indents_with_spaces() {
+        let out = apply_soft_breaks(chars("one two"), &[SoftBreakRender::plain(3, 4)]);
+        assert_eq!(continuation_indent(&out), "    ");
+    }
+
+    /// The prefix is drawn *inside* the indent, not in addition to it: the
+    /// continuation row is still `indent` columns wide, which is what keeps
+    /// the quoted text in the column the first row put it in.
+    #[test]
+    fn a_prefix_is_drawn_inside_the_indent() {
+        let brk = SoftBreakRender {
+            position: 3,
+            indent: 4,
+            prefix: Some(("▌".to_string(), None)),
+        };
+        let out = apply_soft_breaks(chars("one two"), &[brk]);
+        assert_eq!(continuation_indent(&out), "▌   ");
+    }
+
+    /// A prefix exactly filling the indent leaves no padding behind it.
+    #[test]
+    fn a_prefix_filling_the_indent_emits_no_padding() {
+        let brk = SoftBreakRender {
+            position: 3,
+            indent: 2,
+            prefix: Some(("▌ ".to_string(), None)),
+        };
+        let out = apply_soft_breaks(chars("one two"), &[brk]);
+        assert_eq!(continuation_indent(&out), "▌ ");
+    }
+
+    /// A break landing on a non-Space token keeps that token, unlike the
+    /// Space case where the break consumes it.
+    #[test]
+    fn a_break_on_a_non_space_token_keeps_the_token() {
+        let brk = SoftBreakRender {
+            position: 4,
+            indent: 2,
+            prefix: Some(("▌ ".to_string(), None)),
+        };
+        let out = apply_soft_breaks(chars("one two"), &[brk]);
+        assert_eq!(continuation_indent(&out), "▌ ");
+        let tail: String = out
+            .iter()
+            .filter_map(|t| match (&t.kind, t.source_offset) {
+                (ViewTokenWireKind::Text(s), Some(_)) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tail, "onetwo", "no source character may be dropped");
+    }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -252,11 +252,12 @@ pub(super) fn build_view_data(
             .next_back()
             .unwrap_or(viewport.top_byte())
             + 1;
-        let soft_breaks = state.soft_breaks.query_viewport(
+        let soft_breaks = state.soft_breaks.query_viewport_rendered(
             viewport.top_byte(),
             viewport_end,
             &state.marker_list,
             cursor_positions,
+            Some(theme),
         );
         if !soft_breaks.is_empty() {
             tokens = apply_soft_breaks(tokens, &soft_breaks);

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -24,6 +24,7 @@
 
 use crate::model::buffer::{Buffer, LineEnding};
 use crate::view::line_wrap_cache::CacheViewMode;
+use crate::view::soft_break::SoftBreakRender;
 use crate::view::ui::split_rendering::base_tokens::build_line_tokens_from;
 use crate::view::wrap_machine::{RowCarry, RowInfo, WrapMachine, WrapOutput, WrapRule};
 use fresh_core::api::{ViewTokenWire, ViewTokenWireKind};
@@ -76,8 +77,11 @@ pub fn fold_signature(folds: &[std::ops::Range<usize>]) -> u64 {
 /// activation belongs to the renderer's window, where it is cheap and local.
 #[derive(Debug, Clone, Default)]
 pub struct IndexDecorations {
-    /// Sorted `(byte, indent)`.
-    pub soft_breaks: Vec<(usize, u16)>,
+    /// Sorted by position. Carries each break's continuation prefix as well
+    /// as its indent so the index builds the *same* token stream the
+    /// renderer does; the prefix's style is unresolved here (the index
+    /// measures and never draws).
+    pub soft_breaks: Vec<SoftBreakRender>,
     /// Sorted by start; `None` replacement means "hide", `Some` means "replace".
     pub conceals: Vec<(std::ops::Range<usize>, Option<String>)>,
     /// Inline hints, styleless — the index measures and never draws.
@@ -160,8 +164,8 @@ impl IndexDecorations {
                 p
             }
         };
-        for (p, _) in &mut self.soft_breaks {
-            *p = shift(*p);
+        for b in &mut self.soft_breaks {
+            b.position = shift(b.position);
         }
         for p in &mut self.virtual_lines {
             *p = shift(*p);
@@ -191,9 +195,9 @@ impl IndexDecorations {
         diff_sorted(
             &self.soft_breaks,
             &new.soft_breaks,
-            |a| a.0,
+            |a| a.position,
             |a, b| a == b,
-            &mut |e: &(usize, u16)| ranges.push(e.0..e.0 + 1),
+            &mut |e: &SoftBreakRender| ranges.push(e.position..e.position + 1),
         );
         diff_sorted(
             &self.conceals,
@@ -273,15 +277,15 @@ impl IndexDecorations {
         line_start: usize,
         line_end: usize,
     ) -> (
-        Vec<(usize, u16)>,
+        Vec<SoftBreakRender>,
         Vec<(std::ops::Range<usize>, Option<&str>)>,
         Vec<crate::view::ui::split_rendering::transforms::InlineHint>,
     ) {
         let breaks = self
             .soft_breaks
             .iter()
-            .filter(|(p, _)| *p >= line_start && *p < line_end)
-            .copied()
+            .filter(|b| b.position >= line_start && b.position < line_end)
+            .cloned()
             .collect();
         let conceals = self
             .conceals
@@ -1649,7 +1653,7 @@ mod tests {
         let l31 = buffer.line_start_offset(31).unwrap();
         let l32 = buffer.line_start_offset(32).unwrap();
         let decorations = IndexDecorations {
-            soft_breaks: vec![(l30 + 10, 2)],
+            soft_breaks: vec![SoftBreakRender::plain(l30 + 10, 2)],
             conceals: vec![(l31 + 2..l31 + 8, Some("*".to_string()))],
             virtual_lines: vec![l32],
             ..Default::default()
@@ -1695,7 +1699,7 @@ mod tests {
         let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
         let l20 = buffer.line_start_offset(20).unwrap();
         let decorated = IndexDecorations {
-            soft_breaks: vec![(l20 + 8, 0)],
+            soft_breaks: vec![SoftBreakRender::plain(l20 + 8, 0)],
             ..Default::default()
         };
         let mut index = built_with(&mut buffer, 20, &decorated);
@@ -1911,8 +1915,8 @@ mod tests {
         let line_count = buffer.line_count().unwrap() as u64;
         let before = index.stats();
 
-        let breaks: Vec<(usize, u16)> = (0..40)
-            .map(|l| (buffer.line_start_offset(l).unwrap() + 3, 0))
+        let breaks: Vec<SoftBreakRender> = (0..40)
+            .map(|l| SoftBreakRender::plain(buffer.line_start_offset(l).unwrap() + 3, 0))
             .collect();
         let decorations = IndexDecorations {
             soft_breaks: breaks,

--- a/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
@@ -327,6 +327,54 @@ fn test_nested_quote_renders_two_bars() {
 }
 
 // ---------------------------------------------------------------------------
+// Fold indicators
+// ---------------------------------------------------------------------------
+
+/// Compose mode drops the gutter's fold arrows, and gets them back on exit.
+///
+/// They are a code-editor affordance: compose already hides line numbers, and
+/// a document preview has no use for a fold control — they only broke up the
+/// clean left edge. Nested list items give the indent-based fold detector
+/// something to mark, which is what makes the second half of this test a real
+/// check rather than an assertion about an empty gutter.
+#[test]
+fn test_fold_indicators_are_hidden_while_composing() {
+    let (mut harness, _tmp) = composed(LIST_MD, 100, 30);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains('▾') && !screen.contains('▸'),
+        "compose mode should draw no fold indicators.\nScreen:\n{screen}",
+    );
+
+    // Toggle compose back off.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Source markers coming back is the "compose is off" signal.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("**"))
+        .unwrap();
+    harness.wait_for_async_quiescence(8).unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains('▾'),
+        "the fold indicator should come back when compose is turned off — \
+         compose withdraws its opinion rather than owning the setting.\n\
+         Screen:\n{screen}",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Wrapped block quotes
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
@@ -327,6 +327,134 @@ fn test_nested_quote_renders_two_bars() {
 }
 
 // ---------------------------------------------------------------------------
+// Wrapped block quotes
+// ---------------------------------------------------------------------------
+
+/// One quote line, no newlines in it, long enough that compose mode has to
+/// soft-wrap it several times. `ALPHAWORD` / `OMEGAWORD` bracket the text so
+/// the first and last visual rows can be found without matching each other.
+const WRAPPED_QUOTE_MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+> ALPHAWORD begins a single quoted line with no newlines in it that is deliberately long \
+enough that compose mode has to soft-wrap it across several visual rows, which is exactly \
+where the bar used to stop being drawn, and it runs on for a good while yet so the wrap \
+happens at any measure before it finally reaches OMEGAWORD.
+
+Trailing paragraph.
+";
+
+/// Rows of the wrapped quote, top to bottom: from the one holding `ALPHAWORD`
+/// through the one holding `OMEGAWORD`. Panics unless the quote actually
+/// wrapped — a fixture that fits on one row would make these tests pass
+/// vacuously.
+fn wrapped_quote_rows(harness: &EditorTestHarness) -> Vec<String> {
+    let screen = harness.screen_to_string();
+    let rows: Vec<&str> = screen.lines().collect();
+    let find = |needle: &str| {
+        rows.iter()
+            .position(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("'{needle}' not on screen.\nScreen:\n{screen}"))
+    };
+    let first = find("ALPHAWORD");
+    let last = find("OMEGAWORD");
+    assert!(
+        last > first,
+        "the quote must soft-wrap for this test to mean anything, but ALPHAWORD and \
+         OMEGAWORD landed on the same row.\nScreen:\n{screen}",
+    );
+    rows[first..=last].iter().map(|l| l.to_string()).collect()
+}
+
+/// Every visual row of a soft-wrapped quote carries the bar, so the block
+/// reads as one bordered aside. Only the first row used to have one: the bar
+/// comes from concealing the `>` marker, which exists on the source row alone,
+/// and the continuation rows were indented but bare.
+#[test]
+fn test_wrapped_quote_keeps_its_bar_on_every_row() {
+    let (harness, _tmp) = composed(WRAPPED_QUOTE_MD, 100, 30);
+    let rows = wrapped_quote_rows(&harness);
+
+    let bar_column = glyph_column(&rows[0], '▌');
+    for row in &rows {
+        assert_eq!(
+            glyph_column(row, '▌'),
+            bar_column,
+            "every row of a wrapped quote should carry the bar in the same column, \
+             but {row:?} does not match the first row's column {bar_column}.\n\
+             Rows:\n{rows:#?}",
+        );
+    }
+}
+
+/// The bar sits in the continuation indent rather than in front of it, so the
+/// quoted text keeps one column on every row. A prefix added *on top of* the
+/// indent would push the continuation rows one cell right of the first.
+#[test]
+fn test_wrapped_quote_text_stays_in_one_column() {
+    let (harness, _tmp) = composed(WRAPPED_QUOTE_MD, 100, 30);
+    let rows = wrapped_quote_rows(&harness);
+
+    let text_column = |row: &str| {
+        let bar = glyph_column(row, '▌');
+        row.chars()
+            .enumerate()
+            .skip(bar + 1)
+            .find(|(_, c)| !c.is_whitespace())
+            .map(|(i, _)| i)
+            .unwrap_or_else(|| panic!("no text after the bar on {row:?}"))
+    };
+
+    let first = text_column(&rows[0]);
+    for row in &rows {
+        assert_eq!(
+            text_column(row),
+            first,
+            "quoted text should start in the same column on every wrapped row, \
+             but {row:?} starts at {} not {first}.\nRows:\n{rows:#?}",
+            text_column(row),
+        );
+    }
+}
+
+/// Putting the cursor on the quote reveals the `>` on its source row, as it
+/// does for all markup — but the continuation rows keep their bar. Their
+/// leading columns are entirely virtual: there is no source markup there to
+/// reveal, and dropping the bar would break the block's edge exactly when the
+/// user is working inside it.
+#[test]
+fn test_wrapped_quote_keeps_its_bar_while_the_cursor_is_on_it() {
+    let (mut harness, _tmp) = composed(WRAPPED_QUOTE_MD, 100, 30);
+
+    // Line 3 of the fixture is the quote.
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("3").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("> ALPHAWORD"))
+        .unwrap();
+    harness.wait_for_async_quiescence(8).unwrap();
+
+    let rows = wrapped_quote_rows(&harness);
+    assert!(
+        rows[0].contains("> ALPHAWORD"),
+        "the cursor's own row should reveal its `>` for editing, got {:?}",
+        rows[0],
+    );
+    for row in &rows[1..] {
+        assert!(
+            row.contains('▌'),
+            "a continuation row should keep its bar while the cursor is on the \
+             quote, got {row:?}.\nRows:\n{rows:#?}",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Lists (issue item "lists")
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1087,6 +1087,42 @@ impl JsEditorApi {
             scope_end: end as usize,
         })
     }
+
+    /// Build `addSoftBreak`'s optional continuation-row prefix from its JS
+    /// object. A missing or empty `text` yields `None` — an empty prefix is
+    /// indistinguishable from no prefix, and storing one would make the
+    /// renderer emit a zero-width token per wrapped row for nothing.
+    fn parse_soft_break_prefix(
+        obj: rquickjs::Object<'_>,
+    ) -> Option<fresh_core::api::SoftBreakPrefix> {
+        use fresh_core::api::OverlayColorSpec;
+
+        fn parse_color_spec(key: &str, obj: &rquickjs::Object<'_>) -> Option<OverlayColorSpec> {
+            if let Ok(theme_key) = obj.get::<_, String>(key) {
+                if !theme_key.is_empty() {
+                    return Some(OverlayColorSpec::ThemeKey(theme_key));
+                }
+            }
+            if let Ok(arr) = obj.get::<_, Vec<u8>>(key) {
+                if arr.len() >= 3 {
+                    return Some(OverlayColorSpec::Rgb(arr[0], arr[1], arr[2]));
+                }
+            }
+            None
+        }
+
+        let text: String = obj.get("text").ok()?;
+        if text.is_empty() {
+            return None;
+        }
+        Some(fresh_core::api::SoftBreakPrefix {
+            text,
+            fg: parse_color_spec("fg", &obj),
+            bg: parse_color_spec("bg", &obj),
+            bold: obj.get("bold").unwrap_or(false),
+            italic: obj.get("italic").unwrap_or(false),
+        })
+    }
 }
 
 #[plugin_api_impl]
@@ -4182,15 +4218,23 @@ impl JsEditorApi {
     ///
     /// `activation` optionally makes the break cursor-dependent — same
     /// semantics as `addConceal`'s activation parameters.
-    pub fn add_soft_break(
+    ///
+    /// `prefix` optionally draws a glyph run at the head of the continuation
+    /// row, shaped `{ text, fg?, bg?, bold?, italic? }` with the same colour
+    /// spec `addOverlay` takes (a theme key string or an `[r, g, b]` array).
+    /// It is drawn *inside* the `indent` columns rather than in addition to
+    /// them, so a wrapped block quote can keep its `▌` down every row without
+    /// shifting the text. `indent` grows to fit a prefix wider than it.
+    pub fn add_soft_break<'js>(
         &self,
         buffer_id: u32,
         namespace: String,
         position: u32,
         indent: u32,
-        activation: rquickjs::function::Opt<String>,
-        scope_start: rquickjs::function::Opt<u32>,
-        scope_end: rquickjs::function::Opt<u32>,
+        activation: rquickjs::function::Opt<Option<String>>,
+        scope_start: rquickjs::function::Opt<Option<u32>>,
+        scope_end: rquickjs::function::Opt<Option<u32>>,
+        prefix: rquickjs::function::Opt<Option<rquickjs::Object<'js>>>,
     ) -> bool {
         // Track namespace for cleanup on unload
         self.plugin_tracked_state
@@ -4207,7 +4251,16 @@ impl JsEditorApi {
                 position: position as usize,
                 indent: indent as u16,
                 epoch: self.hook_epoch_for(buffer_id),
-                activation: Self::parse_activation(activation.0, scope_start.0, scope_end.0),
+                // `Opt<Option<T>>` rather than `Opt<T>`: `Opt` alone only
+                // covers a *missing* argument, so a caller that wants a later
+                // parameter (a `prefix` with no activation, say) and passes
+                // `undefined` for these would hit a conversion error.
+                activation: Self::parse_activation(
+                    activation.0.flatten(),
+                    scope_start.0.flatten(),
+                    scope_end.0.flatten(),
+                ),
+                prefix: prefix.0.flatten().and_then(Self::parse_soft_break_prefix),
             })
             .is_ok()
     }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5622,6 +5622,24 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Show or hide the gutter's fold indicators (`▾` / `▸`) for a buffer in
+    /// the active split, the way `setLineNumbers` does for line numbers.
+    ///
+    /// Pass `null` to withdraw the plugin's opinion and fall back to the
+    /// user's own setting. The plugin's value is stored separately from that
+    /// setting and is never persisted, so it can neither overwrite a
+    /// deliberate choice — "Toggle Folding Indicators (Current Buffer)" still
+    /// wins while this is set — nor leak into the saved session. A mode that
+    /// hides them should still clear its value on the way out.
+    pub fn set_fold_indicators(&self, buffer_id: u32, enabled: Option<bool>) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetFoldIndicators {
+                buffer_id: BufferId(buffer_id as usize),
+                enabled,
+            })
+            .is_ok()
+    }
+
     /// Enable or disable indentation guides for a buffer, overriding the global
     /// `editor.indentation_guide` setting. Tool views that render non-editable
     /// content (e.g. the Git Log commit-detail diff) disable them.

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1503,6 +1503,7 @@ mod tests {
             "setLineIndicator",
             "clearLineIndicators",
             "setLineNumbers",
+            "setFoldIndicators",
             "setIndentationGuide",
             "setViewMode",
             "setViewState",


### PR DESCRIPTION
Two leftover rendering bugs in markdown compose/preview mode, follow-ups to #2967. One commit each; they are independent.

## Bug 1 — a wrapped quote loses its bar on continuation rows (`222649a`)

A block quote's bar comes from concealing its `>` marker, which exists on the source row only. A quote long enough to soft-wrap drew the bar once and left every continuation row indented but bare, breaking apart the left edge of a block that should read as one aside.

**Why this needed an editor-side change.** `addSoftBreak`'s `indent` is a column count, so it can open a blank continuation but cannot put a glyph there. Nor could the existing machinery: `wrap_indent` is a boolean over the *renderer's own* wrapping, not a per-break value, and inline virtual text anchors to a source byte, which a continuation row's head is not. Pairing a separate virtual text with each break would also mean two marker sets that have to stay in lockstep through every edit — when they drift you get a bar with no break, or a break with no bar. There is no pre-existing wrap-prefix concept.

So soft breaks get a continuation prefix of their own: optional text plus a colour spec, resolved against the live theme each frame the way plugin virtual text already is.

The prefix is drawn **inside** the break's `indent` rather than in addition to it, and `indent` grows to fit a prefix wider than it. That keeps `indent` the single column count every width consumer reads, so the scroll math, the row-count cache and the wrap index all keep agreeing with the renderer about where a row ends. `IndexDecorations.soft_breaks` moves from `(usize, u16)` to `SoftBreakRender` for the same reason — the index now builds the same token stream the renderer does, not a prefix-less lookalike.

`markdown_compose` repeats the quote's concealed marker run as that prefix, so nested (`> >`) and indented quotes continue at their own depth. It is deliberately *not* cursor-gated, unlike the conceals it mirrors: the head of a continuation row is entirely virtual, so there is no source markup there to reveal for editing, and hiding the bar would break the block's edge exactly when you are working inside it.

One API fix fell out. `addSoftBreak`'s trailing optionals were `Opt<T>`, which only tolerates a *missing* argument — passing `undefined` to reach a later parameter threw `Error converting from js 'undefined' into type 'string'`. They are now `Opt<Option<T>>`.

## Bug 2 — fold markers should not show in compose mode (`d14328c`)

The `▾`/`▸` gutter indicators stayed visible in compose, where they are noise: compose already hides line numbers, and a document preview has no use for a code-editor fold control. They appeared against list items and fence bodies and broke up the clean left edge.

The mechanism existed (`BufferViewState::fold_indicators_override`, read by `fold_indicators_visible()`) but had no plugin-facing setter, so this adds `setFoldIndicators(bufferId, enabled)` mirroring `setLineNumbers` — per (split, buffer), because compose is itself per-split and a source-mode split on the same buffer must keep its gutter.

The plugin does not write the user's override, though. That field is a deliberate choice ("Toggle Folding Indicators (Current Buffer)") and it is persisted to the workspace, so a compose-forced value there would both discard the setting and outlive the mode in the saved session — and restoring a hardcoded `true` on exit would discard it just as surely. Compose's value lands in a second, unpersisted field, and `fold_indicators_visible()` resolves user override → plugin → on. That ordering keeps the toggle action working while composing, and means turning compose off only has to withdraw the opinion (`null`) for the user's choice to stand again — no save-and-restore, nothing to get wrong.

## Verification

Rendering changes, so both were checked interactively in tmux against a debug build as well as under test.

Wrapped quote, 160 cols:

```
before:  ▾▌ A single quoted line ... compose mode
            has to soft-wrap it across several visual rows...

after:    ▌ A single quoted line ... compose mode
          ▌ has to soft-wrap it across several visual rows...
```

Fold indicators, 160 cols (nested list + fence fixture):

```
before:   ▾• Outer list item        after:   • Outer list item
          ▾fn main() {                       fn main() {
```

Also checked by hand: 60-col pane (four wrapped rows, all barred); nested `> >` renders `▌ ▌` on every row; an indented `  >` keeps its offset; typing inside a wrapped quote re-wraps with the bars intact; the cursor on the quote line reveals `>` on the source row while continuation rows keep their bar; compose toggled off leaves nothing behind and brings the fold arrows back.

The `▾` disappearing from the quote line in the first capture is not a regression. Indent-based fold detection runs on *rendered* rows, so the old blank wrap indent was fabricating a fold — confirmed by reverting only the plugin against the same Rust build.

## Tests

- 3 e2e for the wrapped bar (same column on every row, text column unchanged, bar survives the cursor being on the quote), each verified to fail without the plugin change
- 1 e2e for fold indicators hidden while composing and restored on exit
- 4 unit tests on the token transform (prefix drawn inside the indent, no padding when it fills, no source character dropped)
- 3 unit tests on `SoftBreakManager` (indent widening, and the width-only and render queries agreeing)
- 1 unit test on the fold-indicator precedence, which is not observable on screen in every direction

The `markdown_compose` suite was green at 100 passed / 9 ignored (97 baseline + 3) before the last two tests were added; CI covers the rest. `cargo clippy --all-targets` goes 285 → 286 warnings, 0 errors — the addition is `too_many_arguments` on `add_soft_break` (9/7), matching the identical pre-existing warning on `add_conceal`. `cargo check --all-targets --features gui` is clean. `fresh.d.ts` and `./scripts/gen_schema.sh` regenerated per CONTRIBUTING rule 6.

## Noted, not addressed

Toggling compose off with `page_view: true` in config leaves the inter-list-item spacer rows on screen. Neither commit touches virtual text, and `test_list_spacers_are_removed_when_compose_is_disabled` passes on this branch — that test toggles compose *on* from source mode, whereas this path has Rust auto-enabling compose at open. Likely a pre-existing gap in the auto-enable path, but I did not build master to confirm, so treat it as unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8mtJNsh1wHi2JkVKgg1go

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8mtJNsh1wHi2JkVKgg1go)_