### PR TITLE
fix(markdown): mark every heading on the scrollbar, not just the visited ones

### DIFF
--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -477,6 +477,104 @@ function headingLevel(content: string): number {
   return m ? m[1].length : 0;
 }
 
+// Deepest heading level that earns a mark. The track oversamples hard — one
+// cell covers many lines in any real document — so marking every level packs
+// several headings into one cell and the shallowest of them is all that
+// survives. Marking only `#` by default keeps a cell's meaning stable.
+// `plugins.markdown_compose.settings.headingMarkerMaxLevel` overrides it; 0
+// turns the marks off.
+const DEFAULT_HEADING_MARKER_MAX_LEVEL = 1;
+
+function headingMarkerMaxLevel(): number {
+  const cfg = (editor.getPluginConfig() ?? {}) as { headingMarkerMaxLevel?: number };
+  const v = cfg.headingMarkerMaxLevel;
+  if (typeof v !== "number" || !isFinite(v)) return DEFAULT_HEADING_MARKER_MAX_LEVEL;
+  return Math.max(0, Math.min(6, Math.floor(v)));
+}
+
+/** Marks for the headings in `text`, whose first byte is at `baseByte`. */
+function headingMarkersIn(text: string, baseByte: number, maxLevel: number): ScrollbarMarker[] {
+  const markers: ScrollbarMarker[] = [];
+  let offset = baseByte;
+  for (const line of text.split("\n")) {
+    const level = headingLevel(line);
+    if (level > 0 && level <= maxLevel) {
+      markers.push({
+        position: offset,
+        color: headingMarkerColor(level),
+        priority: 10 - level,
+      });
+    }
+    offset += utf8Length(line) + 1; // +1 for the "\n" split consumed
+  }
+  return markers;
+}
+
+/** UTF-8 byte length; marker positions are byte offsets, JS indices are not. */
+function utf8Length(str: string): number {
+  let n = 0;
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code <= 0x7f) n += 1;
+    else if (code <= 0x7ff) n += 2;
+    else if (code >= 0xd800 && code <= 0xdfff) { n += 4; i++; }
+    else n += 3;
+  }
+  return n;
+}
+
+// Byte cap for the one-shot scan, from the editor's own large-file setting.
+function prescanByteLimit(): number {
+  const cfg = editor.getConfig() as { editor?: { large_file_threshold_bytes?: number } } | null;
+  const v = cfg?.editor?.large_file_threshold_bytes;
+  return typeof v === "number" && v > 0 ? v : 1048576;
+}
+
+/**
+ * Mark every heading in the document, once, when compose mode turns on.
+ *
+ * Without this the track only ever shows the parts of the file that have been
+ * scrolled through, because `lines_changed` reports the viewport. Worse than
+ * the missing marks: a track cell covers many lines, so which heading wins a
+ * shared cell depended on how far the reader had scrolled, and cells changed
+ * colour under them. A complete set makes the winner a property of the
+ * document.
+ *
+ * The whole-namespace `setScrollbarMarkers` is correct here even though the
+ * per-batch pass uses the range-scoped form: this runs first and publishes
+ * everything, and each later batch replaces only its own byte span.
+ *
+ * Over-limit files keep the old lazy behaviour rather than losing marks. The
+ * size probe is the read itself — asking for `limit + 1` bytes costs a bounded
+ * copy and tells us whether the buffer exceeds the limit, so no separate
+ * length API is needed.
+ */
+async function prescanHeadingMarkers(bufferId: number): Promise<void> {
+  const maxLevel = headingMarkerMaxLevel();
+  if (maxLevel === 0) return;
+
+  const limit = prescanByteLimit();
+  let text: string;
+  try {
+    text = await editor.getBufferText(bufferId, 0, limit + 1);
+  } catch (e) {
+    editor.debug(`Heading pre-scan skipped for buffer ${bufferId}: ${e}`);
+    return;
+  }
+  if (utf8Length(text) > limit) {
+    editor.debug(`Heading pre-scan skipped for buffer ${bufferId}: over ${limit} bytes`);
+    return;
+  }
+  // The await gave the user time to toggle compose off (or close the buffer);
+  // publishing now would strand marks the disable path has already cleared.
+  if (!isComposingInAnySplit(bufferId)) return;
+
+  editor.setScrollbarMarkers(
+    bufferId, HEADING_MARKER_NS,
+    headingMarkersIn(text, 0, maxLevel),
+  );
+}
+
 // Per-render column widths, keyed by a row's byte_start. Rebuilt at the top of
 // every `lines_changed` pass (computeRowWidths) and read synchronously in the
 // same pass by the conceal and border code.
@@ -976,6 +1074,12 @@ function enableMarkdownCompose(bufferId: number): void {
 
   // Trigger a refresh so lines_changed hooks fire for visible content
   editor.refreshLines(bufferId);
+
+  // Mark every heading in the document, not just the ones scrolled past.
+  // Fire-and-forget: the per-batch pass below keeps the marks current either
+  // way, so a failed or skipped scan degrades to the old lazy behaviour.
+  void prescanHeadingMarkers(bufferId);
+
   editor.debug(`Markdown compose enabled for buffer ${bufferId}`);
 }
 
@@ -2399,16 +2503,18 @@ editor.on("lines_changed", (data) => {
   }
 
   // Publish this batch's heading marks. Range-scoped to the batch's byte span
-  // so headings outside it — already-visited parts of the document — keep
-  // their marks; see HEADING_MARKER_NS. Emitted even when the batch has no
-  // headings, so a line that stops being one loses its mark.
-  if (data.lines.length > 0) {
+  // so headings outside it — the rest of the document, marked by the pre-scan
+  // at compose time — keep their marks; see HEADING_MARKER_NS. Emitted even
+  // when the batch has no headings, so a line that stops being one loses its
+  // mark.
+  const maxLevel = headingMarkerMaxLevel();
+  if (data.lines.length > 0 && maxLevel > 0) {
     const batchStart = data.lines[0].byte_start;
     const batchEnd = data.lines[data.lines.length - 1].byte_end;
-    const headingMarkers = [];
+    const headingMarkers: ScrollbarMarker[] = [];
     for (const line of data.lines) {
       const level = headingLevel(line.content);
-      if (level === 0) continue;
+      if (level === 0 || level > maxLevel) continue;
       headingMarkers.push({
         // Byte offsets, not line numbers: they are exact regardless of file
         // size, and the editor anchors them so later edits shift the marks.

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -492,21 +492,46 @@ function headingMarkerMaxLevel(): number {
   return Math.max(0, Math.min(6, Math.floor(v)));
 }
 
-/** Marks for the headings in `text`, whose first byte is at `baseByte`. */
-function headingMarkersIn(text: string, baseByte: number, maxLevel: number): ScrollbarMarker[] {
+/**
+ * The headings in `text`, skipping fenced code blocks.
+ *
+ * A `#` at the start of a line inside a fence is a comment in whatever
+ * language the block is written in — `# Binary package (recommended)` in a
+ * bash block is the common case — not a heading. This scan tracks fences
+ * itself because it works from raw text, where the editor's `region`
+ * classification (which the per-line pass uses for exactly this question)
+ * isn't available. Both answer the same question from the same rule; only
+ * the input differs.
+ */
+function scanHeadings(text: string, maxLevel: number): ScrollbarMarker[] {
   const markers: ScrollbarMarker[] = [];
-  let offset = baseByte;
+  let offset = 0;
+  let fenceStart = -1;
+  let fenceChar = "";
+
   for (const line of text.split("\n")) {
-    const level = headingLevel(line);
-    if (level > 0 && level <= maxLevel) {
-      markers.push({
-        position: offset,
-        color: headingMarkerColor(level),
-        priority: 10 - level,
-      });
+    const lineBytes = utf8Length(line);
+    const fence = line.trim().match(/^(`{3,}|~{3,})/);
+    if (fence) {
+      if (fenceStart < 0) {
+        fenceStart = offset;
+        fenceChar = fence[1][0];
+      } else if (fence[1][0] === fenceChar) {
+        fenceStart = -1;
+      }
+    } else if (fenceStart < 0) {
+      const level = headingLevel(line);
+      if (level > 0 && level <= maxLevel) {
+        markers.push({
+          position: offset,
+          color: headingMarkerColor(level),
+          priority: 10 - level,
+        });
+      }
     }
-    offset += utf8Length(line) + 1; // +1 for the "\n" split consumed
+    offset += lineBytes + 1; // +1 for the "\n" the split consumed
   }
+
   return markers;
 }
 
@@ -571,8 +596,32 @@ async function prescanHeadingMarkers(bufferId: number): Promise<void> {
 
   editor.setScrollbarMarkers(
     bufferId, HEADING_MARKER_NS,
-    headingMarkersIn(text, 0, maxLevel),
+    scanHeadings(text, maxLevel),
   );
+}
+
+// How long to wait after the last keystroke before rescanning. The scan is a
+// bounded read plus a linear walk, but it is whole-document work and there is
+// no reason to do it per keystroke.
+const HEADING_RESCAN_DEBOUNCE_MS = 300;
+const headingRescanTokens = new Map<number, number>();
+
+/**
+ * Rescan after an edit, once the typing stops.
+ *
+ * Marker anchors shift with edits on their own, so the marks stay glued to
+ * their headings without this. What an edit can change and anchors cannot
+ * express is *structure*: a line that stopped being a heading, one that
+ * became one, or — the reason this exists — a newly opened or closed code
+ * fence, which changes whether the `#` lines inside it are headings at all.
+ */
+async function scheduleHeadingRescan(bufferId: number): Promise<void> {
+  const token = (headingRescanTokens.get(bufferId) ?? 0) + 1;
+  headingRescanTokens.set(bufferId, token);
+  await editor.delay(HEADING_RESCAN_DEBOUNCE_MS);
+  if (headingRescanTokens.get(bufferId) !== token) return; // superseded
+  if (!isComposingInAnySplit(bufferId)) return;
+  await prescanHeadingMarkers(bufferId);
 }
 
 // Per-render column widths, keyed by a row's byte_start. Rebuilt at the top of
@@ -1113,6 +1162,9 @@ function disableMarkdownCompose(bufferId: number): void {
     editor.clearConcealNamespace(bufferId, "md-syntax");
     editor.clearSoftBreakNamespace(bufferId, "md-wrap");
     editor.clearScrollbarMarkers(bufferId, HEADING_MARKER_NS);
+    // Make any rescan still inside its debounce window a no-op, rather than
+    // a republish landing after the clear.
+    headingRescanTokens.delete(bufferId);
 
     editor.refreshLines(bufferId);
     editor.debug(`Markdown compose disabled for buffer ${bufferId}`);
@@ -2515,6 +2567,12 @@ editor.on("lines_changed", (data) => {
     for (const line of data.lines) {
       const level = headingLevel(line.content);
       if (level === 0 || level > maxLevel) continue;
+      // `# ...` inside a fenced block is a comment in the block's language,
+      // not a heading. The batch cannot decide that from its own lines, so it
+      // takes the editor's classification — the same source the frame uses,
+      // and current by construction, where a plugin-side memo of fence
+      // extents would be stale for exactly the edit that moved a fence.
+      if (isCodeRegion(line.region)) continue;
       headingMarkers.push({
         // Byte offsets, not line numbers: they are exact regardless of file
         // size, and the editor anchors them so later edits shift the marks.
@@ -2562,6 +2620,7 @@ editor.on("after_insert", (data) => {
   // already-delimiter-shaped line from being one, which the batch will see.
   if (touchesFenceChars(data.text)) editor.refreshLines(data.buffer_id);
   else fenceEditArmed.add(data.buffer_id);
+  void scheduleHeadingRescan(data.buffer_id);
 });
 editor.on("after_delete", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
@@ -2570,6 +2629,7 @@ editor.on("after_delete", (data) => {
   // appears in no later `lines_changed` payload.
   if (touchesFenceChars(data.deleted_text)) editor.refreshLines(data.buffer_id);
   else fenceEditArmed.add(data.buffer_id);
+  void scheduleHeadingRescan(data.buffer_id);
 });
 // cursor_moved: no handler. Cursor-dependent reveal/conceal and table-row
 // un/re-wrap are baked into the markers as activation scopes (emitted in the
@@ -2578,7 +2638,9 @@ editor.on("after_delete", (data) => {
 // re-fires lines_changed, never bumps the conceal/soft-break versions, and
 // never invalidates the line-wrap cache or visual-row index.
 editor.on("buffer_closed", (data) => {
-  // View state is cleaned up automatically when the buffer is removed from keyed_states
+  // View state is cleaned up automatically when the buffer is removed from
+  // keyed_states; the plugin's own per-buffer scan state is not.
+  headingRescanTokens.delete(data.buffer_id);
 });
 editor.on("viewport_changed", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -479,18 +479,8 @@ function headingLevel(content: string): number {
 
 // Deepest heading level that earns a mark. The track oversamples hard — one
 // cell covers many lines in any real document — so marking every level packs
-// several headings into one cell and the shallowest of them is all that
-// survives. Marking only `#` by default keeps a cell's meaning stable.
-// `plugins.markdown_compose.settings.headingMarkerMaxLevel` overrides it; 0
-// turns the marks off.
-const DEFAULT_HEADING_MARKER_MAX_LEVEL = 1;
-
-function headingMarkerMaxLevel(): number {
-  const cfg = (editor.getPluginConfig() ?? {}) as { headingMarkerMaxLevel?: number };
-  const v = cfg.headingMarkerMaxLevel;
-  if (typeof v !== "number" || !isFinite(v)) return DEFAULT_HEADING_MARKER_MAX_LEVEL;
-  return Math.max(0, Math.min(6, Math.floor(v)));
-}
+// several headings into one cell where only the shallowest survives anyway.
+const HEADING_MARKER_MAX_LEVEL = 1;
 
 /**
  * The headings in `text`, skipping fenced code blocks.
@@ -503,25 +493,27 @@ function headingMarkerMaxLevel(): number {
  * isn't available. Both answer the same question from the same rule; only
  * the input differs.
  */
-function scanHeadings(text: string, maxLevel: number): ScrollbarMarker[] {
+function scanHeadings(text: string): ScrollbarMarker[] {
   const markers: ScrollbarMarker[] = [];
   let offset = 0;
-  let fenceStart = -1;
+  let inFence = false;
   let fenceChar = "";
 
   for (const line of text.split("\n")) {
     const lineBytes = utf8Length(line);
-    const fence = line.trim().match(/^(`{3,}|~{3,})/);
-    if (fence) {
-      if (fenceStart < 0) {
-        fenceStart = offset;
-        fenceChar = fence[1][0];
-      } else if (fence[1][0] === fenceChar) {
-        fenceStart = -1;
+    if (looksLikeFence(line)) {
+      // A closer has to match its opener's character, so a ``` inside a ~~~
+      // block is content, not a delimiter.
+      const char = line.trimStart()[0];
+      if (!inFence) {
+        inFence = true;
+        fenceChar = char;
+      } else if (char === fenceChar) {
+        inFence = false;
       }
-    } else if (fenceStart < 0) {
+    } else if (!inFence) {
       const level = headingLevel(line);
-      if (level > 0 && level <= maxLevel) {
+      if (level > 0 && level <= HEADING_MARKER_MAX_LEVEL) {
         markers.push({
           position: offset,
           color: headingMarkerColor(level),
@@ -575,9 +567,6 @@ function prescanByteLimit(): number {
  * length API is needed.
  */
 async function prescanHeadingMarkers(bufferId: number): Promise<void> {
-  const maxLevel = headingMarkerMaxLevel();
-  if (maxLevel === 0) return;
-
   const limit = prescanByteLimit();
   let text: string;
   try {
@@ -594,34 +583,7 @@ async function prescanHeadingMarkers(bufferId: number): Promise<void> {
   // publishing now would strand marks the disable path has already cleared.
   if (!isComposingInAnySplit(bufferId)) return;
 
-  editor.setScrollbarMarkers(
-    bufferId, HEADING_MARKER_NS,
-    scanHeadings(text, maxLevel),
-  );
-}
-
-// How long to wait after the last keystroke before rescanning. The scan is a
-// bounded read plus a linear walk, but it is whole-document work and there is
-// no reason to do it per keystroke.
-const HEADING_RESCAN_DEBOUNCE_MS = 300;
-const headingRescanTokens = new Map<number, number>();
-
-/**
- * Rescan after an edit, once the typing stops.
- *
- * Marker anchors shift with edits on their own, so the marks stay glued to
- * their headings without this. What an edit can change and anchors cannot
- * express is *structure*: a line that stopped being a heading, one that
- * became one, or — the reason this exists — a newly opened or closed code
- * fence, which changes whether the `#` lines inside it are headings at all.
- */
-async function scheduleHeadingRescan(bufferId: number): Promise<void> {
-  const token = (headingRescanTokens.get(bufferId) ?? 0) + 1;
-  headingRescanTokens.set(bufferId, token);
-  await editor.delay(HEADING_RESCAN_DEBOUNCE_MS);
-  if (headingRescanTokens.get(bufferId) !== token) return; // superseded
-  if (!isComposingInAnySplit(bufferId)) return;
-  await prescanHeadingMarkers(bufferId);
+  editor.setScrollbarMarkers(bufferId, HEADING_MARKER_NS, scanHeadings(text));
 }
 
 // Per-render column widths, keyed by a row's byte_start. Rebuilt at the top of
@@ -1162,9 +1124,6 @@ function disableMarkdownCompose(bufferId: number): void {
     editor.clearConcealNamespace(bufferId, "md-syntax");
     editor.clearSoftBreakNamespace(bufferId, "md-wrap");
     editor.clearScrollbarMarkers(bufferId, HEADING_MARKER_NS);
-    // Make any rescan still inside its debounce window a no-op, rather than
-    // a republish landing after the clear.
-    headingRescanTokens.delete(bufferId);
 
     editor.refreshLines(bufferId);
     editor.debug(`Markdown compose disabled for buffer ${bufferId}`);
@@ -2559,14 +2518,13 @@ editor.on("lines_changed", (data) => {
   // at compose time — keep their marks; see HEADING_MARKER_NS. Emitted even
   // when the batch has no headings, so a line that stops being one loses its
   // mark.
-  const maxLevel = headingMarkerMaxLevel();
-  if (data.lines.length > 0 && maxLevel > 0) {
+  if (data.lines.length > 0) {
     const batchStart = data.lines[0].byte_start;
     const batchEnd = data.lines[data.lines.length - 1].byte_end;
     const headingMarkers: ScrollbarMarker[] = [];
     for (const line of data.lines) {
       const level = headingLevel(line.content);
-      if (level === 0 || level > maxLevel) continue;
+      if (level === 0 || level > HEADING_MARKER_MAX_LEVEL) continue;
       // `# ...` inside a fenced block is a comment in the block's language,
       // not a heading. The batch cannot decide that from its own lines, so it
       // takes the editor's classification — the same source the frame uses,
@@ -2618,18 +2576,22 @@ editor.on("after_insert", (data) => {
   resetEditedTableWidths(data.buffer_id, data.affected_start, data.affected_end);
   // Typed backticks can open or close a block; anything else can only stop an
   // already-delimiter-shaped line from being one, which the batch will see.
-  if (touchesFenceChars(data.text)) editor.refreshLines(data.buffer_id);
-  else fenceEditArmed.add(data.buffer_id);
-  void scheduleHeadingRescan(data.buffer_id);
+  if (touchesFenceChars(data.text)) {
+    editor.refreshLines(data.buffer_id);
+    // A fence flip changes whether the `#` lines under it are headings, for
+    // the whole document — including the parts this batch cannot see.
+    void prescanHeadingMarkers(data.buffer_id);
+  } else fenceEditArmed.add(data.buffer_id);
 });
 editor.on("after_delete", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;
   resetEditedTableWidths(data.buffer_id, data.affected_start, data.affected_start);
   // Deleted backticks are checked here, not in the batch: the text that is gone
   // appears in no later `lines_changed` payload.
-  if (touchesFenceChars(data.deleted_text)) editor.refreshLines(data.buffer_id);
-  else fenceEditArmed.add(data.buffer_id);
-  void scheduleHeadingRescan(data.buffer_id);
+  if (touchesFenceChars(data.deleted_text)) {
+    editor.refreshLines(data.buffer_id);
+    void prescanHeadingMarkers(data.buffer_id);
+  } else fenceEditArmed.add(data.buffer_id);
 });
 // cursor_moved: no handler. Cursor-dependent reveal/conceal and table-row
 // un/re-wrap are baked into the markers as activation scopes (emitted in the
@@ -2638,9 +2600,7 @@ editor.on("after_delete", (data) => {
 // re-fires lines_changed, never bumps the conceal/soft-break versions, and
 // never invalidates the line-wrap cache or visual-row index.
 editor.on("buffer_closed", (data) => {
-  // View state is cleaned up automatically when the buffer is removed from
-  // keyed_states; the plugin's own per-buffer scan state is not.
-  headingRescanTokens.delete(data.buffer_id);
+  // View state is cleaned up automatically when the buffer is removed from keyed_states
 });
 editor.on("viewport_changed", (data) => {
   if (!isComposingInAnySplit(data.buffer_id)) return;

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -543,47 +543,41 @@ fn build_cells(
     // `resolved()` returns owned colours while `core` lends them, so the two
     // sources are walked as one sequence of (start, end, colour, priority,
     // source) with the colour cloned once, at the cell it wins.
-    let mut paint = |start: usize,
-                     end: Option<usize>,
-                     color: &OverlayColorSpec,
-                     priority: i32,
-                     source: u8| {
-        let start_row = (row_of_byte(start).min(total.saturating_sub(1)) * h / total) as usize;
-        let end_row = match end {
-            Some(e) if e > start => {
-                (row_of_byte(e).min(total.saturating_sub(1)) * h / total) as usize
-            }
-            _ => start_row,
-        };
-
-        // `max(start_row)` is a guard, not arithmetic: a `row_of_byte` that
-        // answered non-monotonically (a missing entry in a pre-resolved map,
-        // say) would otherwise index a backwards range and panic — in the
-        // render path, where a wrong mark is survivable and a crash is not.
-        let last = end_row.max(start_row).min(track_height - 1);
-        let candidate = CellRank {
-            priority,
-            source,
-            start,
-        };
-        let span = start_row.min(last)..=last;
-        for (cell, held) in cells[span.clone()]
-            .iter_mut()
-            .zip(best[span].iter_mut())
-        {
-            let better = match held {
-                Some(existing) => candidate.beats(existing),
-                None => true,
+    let mut paint =
+        |start: usize, end: Option<usize>, color: &OverlayColorSpec, priority: i32, source: u8| {
+            let start_row = (row_of_byte(start).min(total.saturating_sub(1)) * h / total) as usize;
+            let end_row = match end {
+                Some(e) if e > start => {
+                    (row_of_byte(e).min(total.saturating_sub(1)) * h / total) as usize
+                }
+                _ => start_row,
             };
-            if better {
-                *cell = Some(MarkerCell {
-                    color: color.clone(),
-                    priority,
-                });
-                *held = Some(candidate);
+
+            // `max(start_row)` is a guard, not arithmetic: a `row_of_byte` that
+            // answered non-monotonically (a missing entry in a pre-resolved map,
+            // say) would otherwise index a backwards range and panic — in the
+            // render path, where a wrong mark is survivable and a crash is not.
+            let last = end_row.max(start_row).min(track_height - 1);
+            let candidate = CellRank {
+                priority,
+                source,
+                start,
+            };
+            let span = start_row.min(last)..=last;
+            for (cell, held) in cells[span.clone()].iter_mut().zip(best[span].iter_mut()) {
+                let better = match held {
+                    Some(existing) => candidate.beats(existing),
+                    None => true,
+                };
+                if better {
+                    *cell = Some(MarkerCell {
+                        color: color.clone(),
+                        priority,
+                    });
+                    *held = Some(candidate);
+                }
             }
-        }
-    };
+        };
 
     for (start, end, color, priority, source) in core_marks {
         paint(start, end, color, priority, source);

--- a/crates/fresh-editor/src/view/scrollbar_marker.rs
+++ b/crates/fresh-editor/src/view/scrollbar_marker.rs
@@ -511,26 +511,43 @@ fn build_cells(
     let total = basis.total().max(1);
     let h = track_height as u64;
 
-    // Core marks are laid down first, so a plugin marker of *equal* priority
-    // painted after them wins the cell — the same order of precedence the
-    // gutter applies between the blue unsaved bar and a plugin indicator.
+    // A plugin marker of *equal* priority beats a core mark — the same order
+    // of precedence the gutter applies between the blue unsaved bar and a
+    // plugin indicator. That is `SOURCE_PLUGIN > SOURCE_CORE` in the ranking
+    // key below, not an artifact of paint order, so the two sources can be
+    // walked in either order.
     // Core ranges project through `endpoints()` — the same pairs any caller
     // that pre-resolves coordinates seeded its map from. (Plugin markers keep
     // their documented exclusive-`end` projection: their ends are
     // line-relative, where the difference is sub-cell.)
     let core_marks = core.into_iter().flat_map(|c| {
         c.endpoints()
-            .map(move |(s, e)| (s, Some(e), &c.color, c.priority))
+            .map(move |(s, e)| (s, Some(e), &c.color, c.priority, SOURCE_CORE))
     });
     let plugin_marks = manager
         .resolved()
         .into_iter()
-        .map(|m| (m.start, m.end, m.color, m.priority));
+        .map(|m| (m.start, m.end, m.color, m.priority, SOURCE_PLUGIN));
+
+    // Which marker owns a contended cell is decided by a total order over the
+    // markers themselves — priority, then source, then position — never by the
+    // order they happen to be painted in. Paint order is not a stable
+    // property: `resolved()` walks namespaces in `BTreeMap` order and each
+    // namespace's markers in *insertion* order, and for a namespace fed
+    // viewport-by-viewport (markdown headings) insertion order is the user's
+    // scroll history. Ranking on paint order therefore made a cell's colour
+    // change as the reader scrolled, with nothing about the document having
+    // changed.
+    let mut best: Vec<Option<CellRank>> = vec![None; track_height];
 
     // `resolved()` returns owned colours while `core` lends them, so the two
-    // sources are walked as one sequence of (start, end, colour, priority)
-    // with the colour cloned once, at the cell it wins.
-    let mut paint = |start: usize, end: Option<usize>, color: &OverlayColorSpec, priority: i32| {
+    // sources are walked as one sequence of (start, end, colour, priority,
+    // source) with the colour cloned once, at the cell it wins.
+    let mut paint = |start: usize,
+                     end: Option<usize>,
+                     color: &OverlayColorSpec,
+                     priority: i32,
+                     source: u8| {
         let start_row = (row_of_byte(start).min(total.saturating_sub(1)) * h / total) as usize;
         let end_row = match end {
             Some(e) if e > start => {
@@ -544,9 +561,18 @@ fn build_cells(
         // say) would otherwise index a backwards range and panic — in the
         // render path, where a wrong mark is survivable and a crash is not.
         let last = end_row.max(start_row).min(track_height - 1);
-        for cell in cells[start_row.min(last)..=last].iter_mut() {
-            let better = match cell {
-                Some(existing) => priority >= existing.priority,
+        let candidate = CellRank {
+            priority,
+            source,
+            start,
+        };
+        let span = start_row.min(last)..=last;
+        for (cell, held) in cells[span.clone()]
+            .iter_mut()
+            .zip(best[span].iter_mut())
+        {
+            let better = match held {
+                Some(existing) => candidate.beats(existing),
                 None => true,
             };
             if better {
@@ -554,18 +580,47 @@ fn build_cells(
                     color: color.clone(),
                     priority,
                 });
+                *held = Some(candidate);
             }
         }
     };
 
-    for (start, end, color, priority) in core_marks {
-        paint(start, end, color, priority);
+    for (start, end, color, priority, source) in core_marks {
+        paint(start, end, color, priority, source);
     }
-    for (start, end, color, priority) in plugin_marks {
-        paint(start, end, &color, priority);
+    for (start, end, color, priority, source) in plugin_marks {
+        paint(start, end, &color, priority, source);
     }
 
     cells
+}
+
+/// Core marks rank below plugin marks at equal priority.
+const SOURCE_CORE: u8 = 0;
+const SOURCE_PLUGIN: u8 = 1;
+
+/// The ranking key that decides a contended cell, highest wins.
+///
+/// Every field is a property of the marker, so the winner is the same however
+/// the marker set was assembled — and, for a set that grows as the user
+/// explores the document, a cell keeps the colour it had once a
+/// higher-ranking marker for it exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CellRank {
+    priority: i32,
+    source: u8,
+    /// Earlier position wins an otherwise exact tie, so two markers of the
+    /// same priority and source resolve by document order rather than by
+    /// whichever was published last.
+    start: usize,
+}
+
+impl CellRank {
+    fn beats(&self, other: &CellRank) -> bool {
+        (self.priority, self.source) > (other.priority, other.source)
+            || ((self.priority, self.source) == (other.priority, other.source)
+                && self.start < other.start)
+    }
 }
 
 #[cfg(test)]
@@ -817,6 +872,59 @@ mod tests {
         mgr.set_markers("b", vec![point(505, 1, blue())]);
         let cells = project_bytes(&mgr, 1000, 10);
         assert_eq!(cells[5].as_ref().unwrap().color, red());
+    }
+
+    /// A contended cell must not depend on the order its markers were
+    /// published in. Markers for a namespace that publishes viewport by
+    /// viewport (markdown headings) arrive in the reader's scroll order, so
+    /// ranking on paint order made the cell change colour under them.
+    #[test]
+    fn shared_cell_ignores_publication_order() {
+        // Same two markers, same cell, opposite publication order.
+        let deep_first = {
+            let mut mgr = ScrollbarMarkerManager::new();
+            mgr.set_markers_in_range("md", 500, 510, vec![point(505, 1, blue())]);
+            mgr.set_markers_in_range("md", 495, 500, vec![point(497, 5, red())]);
+            project_bytes(&mgr, 1000, 10)
+        };
+        let shallow_first = {
+            let mut mgr = ScrollbarMarkerManager::new();
+            mgr.set_markers_in_range("md", 495, 500, vec![point(497, 5, red())]);
+            mgr.set_markers_in_range("md", 500, 510, vec![point(505, 1, blue())]);
+            project_bytes(&mgr, 1000, 10)
+        };
+
+        assert_eq!(
+            deep_first[4].as_ref().unwrap().color,
+            red(),
+            "the higher-priority marker owns the cell however it was published"
+        );
+        assert_eq!(
+            deep_first[4].as_ref().map(|c| &c.color),
+            shallow_first[4].as_ref().map(|c| &c.color),
+            "publication order must not change the winner"
+        );
+    }
+
+    /// With priority and source equal there is still a stable answer: the
+    /// marker earlier in the document.
+    #[test]
+    fn exact_tie_resolves_by_document_order() {
+        let earlier_last = {
+            let mut mgr = ScrollbarMarkerManager::new();
+            mgr.set_markers_in_range("md", 505, 510, vec![point(505, 3, blue())]);
+            mgr.set_markers_in_range("md", 500, 505, vec![point(501, 3, red())]);
+            project_bytes(&mgr, 1000, 10)
+        };
+        let earlier_first = {
+            let mut mgr = ScrollbarMarkerManager::new();
+            mgr.set_markers_in_range("md", 500, 505, vec![point(501, 3, red())]);
+            mgr.set_markers_in_range("md", 505, 510, vec![point(505, 3, blue())]);
+            project_bytes(&mgr, 1000, 10)
+        };
+
+        assert_eq!(earlier_last[5].as_ref().unwrap().color, red());
+        assert_eq!(earlier_first[5].as_ref().unwrap().color, red());
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scroll_perf.rs
@@ -48,7 +48,9 @@ fn body_line(section: usize, line: usize) -> String {
 fn document_with_headings(sections: usize, filler_lines: usize) -> String {
     let mut md = String::new();
     for s in 0..sections {
-        md.push_str(&format!("## Section {s}\n\n"));
+        // Level 1: only top-level headings are marked on the scrollbar by
+        // default, and these tests are about the cost of the marks.
+        md.push_str(&format!("# Section {s}\n\n"));
         for l in 0..filler_lines {
             md.push_str(&body_line(s, l));
         }

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -94,21 +94,93 @@ fn markdown_compose_marks_headings_on_the_scrollbar() {
     );
 }
 
-/// Marks accumulate as the document is explored: scrolling to parts of the
-/// file the plugin had not yet seen adds their headings without dropping the
-/// marks for sections already visited.
+/// The track describes the whole document from the moment compose mode is on
+/// — the headline fix for issue #2990.
+///
+/// Marks used to be published viewport by viewport out of `lines_changed`, so
+/// the track only showed the parts already scrolled through. A structure map
+/// that needs the reader to explore the document before it describes it is not
+/// a structure map.
+#[test]
+fn every_heading_is_marked_without_scrolling() {
+    // 30 sections of 20 lines: the opening viewport holds barely one of them.
+    let (mut harness, _tmp) = compose_harness(&document_with_headings(30, 20));
+
+    // The pre-scan reads the buffer over the async plugin bridge, so the full
+    // set lands a few ticks after the toggle returns.
+    harness
+        .wait_until(|h| marker_rows(h).len() >= 10)
+        .expect("compose mode should mark headings across the whole document");
+
+    let rows = marker_rows(&harness);
+    let (first, last) = harness.content_area_rows();
+    let (first, last) = (first as u16, last as u16);
+    let track = (last - first + 1) as f32;
+
+    // Coverage reaches content that has never been on screen: the last
+    // section's heading is at the end of the file, so its mark belongs near
+    // the bottom of the track.
+    let deepest = (*rows.last().unwrap() - first) as f32 / track;
+    assert!(
+        deepest > 0.8,
+        "deepest mark should sit near the end of the track, was at \
+         {deepest:.2} of it; rows {rows:?}"
+    );
+}
+
+/// Only top-level headings are marked by default: a track cell covers many
+/// lines, so marking every level packs several headings into one cell where
+/// only the shallowest survives anyway.
+#[test]
+fn only_top_level_headings_are_marked_by_default() {
+    let mut md = String::from("# The one top level heading\n\n");
+    for s in 0..30 {
+        md.push_str(&format!("## Sub {s}\n\n### Deeper {s}\n\n"));
+        for l in 0..20 {
+            md.push_str(&format!("Body line {l} of section {s}.\n"));
+        }
+    }
+
+    let (mut harness, _tmp) = compose_harness(&md);
+
+    harness
+        .wait_until(|h| !marker_rows(h).is_empty())
+        .expect("the `#` heading should be marked");
+    // Give any deeper-level marks the same chance to appear before asserting
+    // that they don't.
+    let mut settle = usize::MAX;
+    harness
+        .wait_until_stable(|h| {
+            let n = marker_rows(h).len();
+            let stable = n == settle;
+            settle = n;
+            stable
+        })
+        .unwrap();
+
+    let (first, _) = harness.content_area_rows();
+    assert_eq!(
+        marker_rows(&harness),
+        vec![first as u16],
+        "only the single `#` heading should be marked, at the top of the track"
+    );
+}
+
+/// Exploring the document does not disturb the marks: scrolling neither drops
+/// the headings outside the viewport nor adds to a set that is already
+/// complete.
 ///
 /// This is the property that `setScrollbarMarkersInRange` exists for — a
 /// whole-namespace replace on every `lines_changed` batch would leave only the
 /// headings near the viewport marked.
 #[test]
-fn heading_marks_accumulate_as_the_document_is_explored() {
+fn heading_marks_survive_exploring_the_document() {
     let (mut harness, _tmp) = compose_harness(&document_with_headings(20, 14));
 
     harness
         .wait_until(|h| !marker_rows(h).is_empty())
         .expect("initial heading marks");
-    let initial = marker_rows(&harness).len();
+    let initial = marker_rows(&harness);
 
     // Page down through the document so later sections enter the viewport,
     // letting the plugin's marks settle after each page.
@@ -127,16 +199,13 @@ fn heading_marks_accumulate_as_the_document_is_explored() {
             .unwrap();
     }
 
-    // The plugin republishes only the region it just saw, so headings from
-    // sections already scrolled past keep their marks and the total grows.
-    // With a whole-namespace replace this count stays flat — only the
-    // headings near the viewport would survive each batch.
+    // Each batch republishes only its own byte span, so the marks for the
+    // sections scrolled past are left alone. With a whole-namespace replace
+    // per batch, only the headings near the viewport would survive.
     let after = marker_rows(&harness);
-    assert!(
-        after.len() > initial,
-        "marks should accumulate while scrolling: started with {initial}, \
-         ended with {} ({after:?})",
-        after.len()
+    assert_eq!(
+        after, initial,
+        "the marked rows should be identical before and after scrolling"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -94,6 +94,57 @@ fn markdown_compose_marks_headings_on_the_scrollbar() {
     );
 }
 
+/// A `#` at the start of a line inside a fenced code block is a comment in the
+/// block's language, not a heading, and must not be marked.
+///
+/// Shell blocks make this constant: `# Binary package (recommended)` above an
+/// install command is ordinary prose in a bash fence, and every such line used
+/// to put a mark on the track.
+#[test]
+fn comments_in_fenced_code_blocks_are_not_headings() {
+    let mut md = String::from("# Install\n\n");
+    md.push_str("**Using an AUR helper (such as `yay` or `paru`):**\n\n");
+    for s in 0..20 {
+        md.push_str("```bash\n");
+        md.push_str(&format!(
+            "# Binary package (recommended, faster install) {s}\n"
+        ));
+        md.push_str("yay -S fresh-editor-bin\n\n");
+        md.push_str("# Or build from source\n");
+        md.push_str("yay -S fresh-editor\n");
+        md.push_str("```\n\n");
+        for l in 0..15 {
+            md.push_str(&format!("Prose line {l} of section {s}.\n"));
+        }
+        md.push('\n');
+    }
+
+    let (mut harness, _tmp) = compose_harness(&md);
+
+    harness
+        .wait_until(|h| !marker_rows(h).is_empty())
+        .expect("the one real `# Install` heading should be marked");
+    // Let any marks for the 40 `#` comment lines have their chance to appear
+    // before asserting that they don't.
+    let mut settle = usize::MAX;
+    harness
+        .wait_until_stable(|h| {
+            let n = marker_rows(h).len();
+            let stable = n == settle;
+            settle = n;
+            stable
+        })
+        .unwrap();
+
+    let (first, _) = harness.content_area_rows();
+    assert_eq!(
+        marker_rows(&harness),
+        vec![first as u16],
+        "only the `# Install` heading is a heading; the 40 shell comments \
+         inside the bash fences are not"
+    );
+}
+
 /// The track describes the whole document from the moment compose mode is on
 /// — the headline fix for issue #2990.
 ///


### PR DESCRIPTION
Fixes #2990.

Rebased onto master after the embedded-language work landed, which changed how the second half of this is implemented — see "Fence handling" below.

## The problem

The heading marks on the scrollbar track are meant to be a map of the document's structure, but they were published viewport by viewport out of `lines_changed`, so the track only described the parts already scrolled through — 5 marked cells on open for a 49-heading document, 47 only after paging through the whole thing.

The lazy set had a second, worse consequence. A track cell covers many lines, so headings contend for cells, and `build_cells` resolved that contention by paint order (`priority >= existing.priority` — last painted wins). Paint order is `resolved()`: namespaces in `BTreeMap` order, then each namespace's markers in *insertion* order, which for headings is the reader's scroll history. So which heading owned a cell — and therefore the cell's colour — changed as the reader scrolled, with nothing about the document having changed.

Measured with a `###` at line 130 and a `#` at line 230 projecting to the same cell: magenta while only the `###` had been visited, cyan once the `#` was, and it stayed cyan.

Separately, a `#` at the start of a line inside a fenced code block — `# Binary package (recommended, faster install)` in a bash block — matched the ATX heading rule and got a mark. The pre-scan made that louder, since it finds every such line in the file rather than only the ones scrolled past.

## The changes

**Pre-scan the document when compose mode turns on** and publish the whole heading set at once with `setScrollbarMarkers`; the per-batch range-scoped publishes continue to keep it current. The size probe is the read itself — asking for `large_file_threshold_bytes + 1` bytes costs a bounded copy and answers whether the buffer is over the limit, so no new length API was needed. Over-limit files keep the old lazy behaviour rather than losing their marks. Positions are byte offsets, so the scan measures UTF-8 lengths rather than JS string indices.

**Rank contended cells by a property of the markers** — priority, then source, then document position — instead of by paint order. Plugin marks still outrank core marks at equal priority; that was previously implicit in painting core first and is now explicit in the ranking key.

**Mark only top-level `#` headings.** Marking every level packs several headings into one cell where only the shallowest survives anyway.

**Fence handling** splits between the two paths, because they have different inputs. The per-line pass takes `line.region` — the highlighting engine's own classification, added in 5a8daf4 — which is current by construction; a plugin-side memo of fence extents would be stale for exactly the edit that moved a fence. The whole-document scan tracks fences itself, since it reads raw text where `region` isn't available, but shares the `looksLikeFence` predicate. A fence flip changes whether the `#` lines under it are headings for the whole document, including parts no batch can see, so the scan re-runs off the existing `touchesFenceChars` edit signal.

## Tests

`heading_marks_accumulate_as_the_document_is_explored` asserted that the mark count *grows* while scrolling — it encoded the reported bug as a property. It is now `heading_marks_survive_exploring_the_document`, asserting the marked rows are identical before and after scrolling, which is the invariant `setScrollbarMarkersInRange` actually protects.

The `markdown_compose_scroll_perf` fixture built its document from `## Section` headings and so measured zero marks once top-level-only became the default; it now uses `#`.

New coverage:

- `every_heading_is_marked_without_scrolling` — a 30-section document is marked to the bottom of the track with no scrolling.
- `comments_in_fenced_code_blocks_are_not_headings` — a document with one real heading and 40 `#` comments across 20 bash fences gets exactly one mark.
- `only_top_level_headings_are_marked_by_default` — one `#` and 60 deeper headings, one mark.
- `exact_tie_resolves_by_document_order` — verified to fail against emulated last-wins ranking.
- `shared_cell_ignores_publication_order` — guards the ranking invariant (it passes pre-fix, since differing priorities were already order-independent; the tie test is the discriminating one).

26/26 `view::scrollbar_marker` unit tests and 108 passed / 0 failed across the `markdown_compose` e2e suite.

## Manual verification

Driven interactively in tmux against a debug build, truecolor session, reading the marker column out of `capture-pane -e`:

| check | before | after |
| --- | --- | --- |
| 49-heading document at open, no scrolling | 5 marks clustered at the top | 12 marks (one per `#` section) spread evenly across rows 0-43 |
| deeper levels | `##`/`###`/`####` all marked, `###`+`####` sharing a colour | only `#` marked |
| contended cell, `###` visited but not `#` | magenta (`syntax.type`) | cyan (`syntax.keyword`) |
| same cell after visiting both, thumb moved away | cyan — the colour changed under the reader | cyan — unchanged throughout |
| document with 2 headings and 5 `#` comments in bash/sh/python fences | 7 marks | 2 marks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vXDj18xPijbWctZaUptn6