### PR TITLE
Draw compose-mode table frame edges from the editor, not from the batch

### DIFF
--- a/crates/fresh-core/src/hooks.rs
+++ b/crates/fresh-core/src/hooks.rs
@@ -572,6 +572,48 @@ pub enum RegionLine {
     Close,
 }
 
+/// A line's role in a table the buffer's grammar recognizes.
+///
+/// Companion to [`RegionLine`], and the same idea one step generalized:
+/// a per-line structural classification the highlighting engine already
+/// makes while parsing, exported so a decoration plugin needs no block
+/// model of its own. `open`/`body`/`close` is the wrong vocabulary for a
+/// table — a table has a header row, a delimiter row and data rows, and
+/// its *last* line is not a delimiter of any kind — so this is a
+/// separate type rather than a reuse of that one.
+///
+/// Unlike region membership, "is this a table row" *is* derivable from a
+/// line's own text, which is why absence here is recoverable: a consumer
+/// may fall back to its own text rule (see `markdown_compose`). What is
+/// not derivable line-locally is everything else in this struct — where
+/// the table starts and ends — because that needs the neighbouring lines,
+/// and a `lines_changed` batch holds only the lines a scroll or an edit
+/// touched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TableRole {
+    /// The column-name row, above the delimiter row.
+    Header,
+    /// The `|---|---|` row separating the header from the body.
+    Delimiter,
+    /// A data row.
+    Row,
+}
+
+/// Where a line sits in its table. See [`TableRole`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct TableLine {
+    pub role: TableRole,
+    /// The first data row — the one directly below the delimiter row.
+    /// Only ever true for [`TableRole::Row`].
+    pub first_row: bool,
+    /// The table's final line. Reported only when the engine could see
+    /// the line *after* the table; when it could not, this stays false,
+    /// which is the conservative answer (no closing edge drawn) rather
+    /// than a confidently wrong one.
+    pub last: bool,
+}
+
 /// Information about a single line for the LinesChanged hook
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct LineInfo {
@@ -591,6 +633,12 @@ pub struct LineInfo {
     /// never as "outside a region".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<RegionLine>,
+    /// This line's place in a table, when the buffer's grammar scopes
+    /// tables and the engine could resolve the line's table state.
+    /// Absent for ordinary lines and when the state is *unknown* — see
+    /// `TextMateEngine::structure_lines_in`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<TableLine>,
 }
 
 /// Location information for LSP references

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -5127,6 +5127,26 @@ interface HookEventMap {
 			* point of this field is that a bare ``` opens or closes depending on
 			* every fence above it, so there is nothing to fall back on. */
 			region?: "open" | "body" | "close";
+			/** Where this line sits in a table the buffer's grammar recognizes.
+			* `role` is the line's kind (`"header"` is the column-name row,
+			* `"delimiter"` the `|---|---|` row, `"row"` a data row); `first_row`
+			* marks the data row directly below the delimiter; `last` marks the
+			* table's final line.
+			*
+			* Companion to `region`, and recoverable where that is not: "is this a
+			* table row" *is* derivable from a line's own text, so a consumer may
+			* fall back to its own rule when this is absent. What it cannot derive
+			* is where the table starts and ends — that needs the neighbouring
+			* lines, and an edit-sized batch does not contain them.
+			*
+			* `last` is false rather than unknown when the engine could not see the
+			* line below the table, so a consumer drawing a closing edge from it
+			* draws none instead of one in the wrong place. */
+			table?: {
+				role: "header" | "delimiter" | "row";
+				first_row: boolean;
+				last: boolean;
+			};
 		}[];
 		/** Buffer version these byte ranges were captured at. Pass back to
 		* coordinate-mapping APIs to repair stale offsets from this batch. */

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -139,7 +139,36 @@ type LineInfoLike = {
   byte_end: number;
   content: string;
   region?: RegionLine;
+  table?: TableLine;
 };
+
+// Where a line sits in a table, as the highlighting engine classifies it from
+// the Markdown grammar's own `meta.table` scope while parsing.
+//
+// This is the same trick `region` is (see below), one step generalized, and it
+// exists for the half of the table frame that has always been guesswork.
+// "Is this line a table row" is decided from the line alone — that part was
+// never the problem. What is NOT line-local is which *edge* of the frame a row
+// carries: the `┌─┬─┐` goes above the header and the `└─┴─┘` below the last
+// row, and both of those are facts about the line's *neighbours*. A
+// `lines_changed` batch holds only the lines a scroll or an edit touched, so
+// when the neighbour was off-screen the plugin had to guess, and guessed
+// conservatively: a table scrolled past its top drew a `├─┼─┤` where its `┌─┬─┐`
+// belonged, and kept it even after scrolling back, because by then the line
+// above was no longer in a batch either.
+//
+// The engine has the answer for free — it already tracks where the table's
+// scope opens and closes while parsing — so it now says so per line, alongside
+// coordinates the plugin already trusts. Nothing is stored, so nothing goes
+// stale.
+//
+// Unlike `region`, absence here is *recoverable*: the batch-local rules below
+// still work, just conservatively. So absence falls back to them rather than
+// dropping the frame — which matters, because the grammar scopes fewer things
+// as tables than this plugin renders as tables (a table inside a blockquote,
+// for one), and a buffer too large to resolve would otherwise lose every frame.
+type TableRole = "header" | "delimiter" | "row";
+type TableLine = { role: TableRole; first_row: boolean; last: boolean };
 
 // =============================================================================
 // Fenced code blocks: framed from the editor's own region classification
@@ -2377,23 +2406,40 @@ editor.on("lines_changed", (data) => {
 
     if (!isCodeRegion(line.region) && isTableRowContent(line.content)) {
       const widths = currentRowWidths.get(line.byte_start) ?? [];
-      const prev = byLineNum.get(line.line_number - 1);
-      const next = byLineNum.get(line.line_number + 1);
-      // First/last is local. A row is first if it's the buffer's line 0 or its
-      // previous line is present in this batch and is NOT a table row; last if
-      // its next line is present and not a table row. When a neighbour is
-      // off-screen (absent from the batch) we conservatively treat the row as
-      // mid-table, so a tall table scrolled past its top/bottom never draws a
-      // spurious frame edge — it redraws when that neighbour re-enters a batch.
-      const isFirst = line.line_number === 0 || (prev !== undefined && !isTableRowContent(prev.content));
-      // Last if the next line is present and not a table row, OR this row is the
-      // final line of the buffer (no next line exists at all — distinct from a
-      // next line merely off-screen, which we treat as mid-table).
-      const isLast =
-        (next !== undefined && !isTableRowContent(next.content)) ||
-        (next === undefined && line.byte_end >= bufEnd);
-      const isSep = isSepRowContent(line.content);
-      const prevIsSep = prev !== undefined && isSepRowContent(prev.content);
+      let isFirst: boolean, isSep: boolean, prevIsSep: boolean, isLast: boolean;
+      if (line.table) {
+        // The engine placed this row in its table (see `TableLine`). Every
+        // edge is then a property of the line itself, so the frame is the same
+        // whether the batch is a whole viewport or the one line an edit
+        // touched — which is the entire point.
+        isFirst = line.table.role === "header";
+        isSep = line.table.role === "delimiter";
+        // The delimiter row already renders as `├─┼─┤` from its own pipes, so
+        // the first data row must not draw a second one above itself.
+        prevIsSep = line.table.first_row;
+        isLast = line.table.last;
+      } else {
+        // No answer from the engine — the grammar doesn't scope this as a
+        // table (it is inside a blockquote, say, or interrupts a paragraph),
+        // or the buffer is too large to resolve the state. Fall back to the
+        // batch-local rules: a row is first if it's the buffer's line 0 or its
+        // previous line is present in this batch and is NOT a table row; last
+        // if its next line is present and not a table row. When a neighbour is
+        // off-screen we conservatively treat the row as mid-table, so a tall
+        // table scrolled past its top/bottom never draws a spurious frame edge
+        // — it redraws when that neighbour re-enters a batch.
+        const prev = byLineNum.get(line.line_number - 1);
+        const next = byLineNum.get(line.line_number + 1);
+        isFirst = line.line_number === 0 || (prev !== undefined && !isTableRowContent(prev.content));
+        // Last if the next line is present and not a table row, OR this row is
+        // the final line of the buffer (no next line exists at all — distinct
+        // from a next line merely off-screen, which we treat as mid-table).
+        isLast =
+          (next !== undefined && !isTableRowContent(next.content)) ||
+          (next === undefined && line.byte_end >= bufEnd);
+        isSep = isSepRowContent(line.content);
+        prevIsSep = prev !== undefined && isSepRowContent(prev.content);
+      }
       emitRowBorders(data.buffer_id, line.byte_start, widths, isFirst, isSep, prevIsSep, isLast);
     }
   }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -335,6 +335,7 @@ impl Editor {
                                         byte_end,
                                         content: line_content,
                                         region: None,
+                                        table: None,
                                     });
                                     fresh_ranges.push(byte_range);
                                 }
@@ -346,32 +347,59 @@ impl Editor {
 
                         let count = new_lines.len();
                         if !new_lines.is_empty() {
-                            // Whether each reported line sits inside an
-                            // embedded-language region (a Markdown fence, a Vue
-                            // `<script>`) — the one property of such a line that
-                            // is not derivable from its own text, and that a
-                            // plugin cannot read out of the buffer above its
-                            // batch synchronously. Attached here, alongside the
-                            // live coordinates, so a consumer never has to store
-                            // region structure of its own.
+                            // What the grammar says about each reported line's
+                            // place in the document's structure: whether it sits
+                            // inside an embedded-language region (a Markdown
+                            // fence, a Vue `<script>`), and where it sits in a
+                            // table. These are the properties a decoration
+                            // plugin cannot work out for itself — region
+                            // membership is not derivable from a line's own text
+                            // at all, and a table's first/last row needs the
+                            // neighbouring lines, which an edit-sized batch does
+                            // not contain. Attached here, alongside the live
+                            // coordinates, so a consumer never has to store
+                            // structure of its own.
                             //
-                            // The probe costs nothing for syntaxes that host no
-                            // regions (the overwhelming majority), and is skipped
-                            // entirely when there is nothing to report.
-                            let regions = state
+                            // One probe answers both. It costs nothing for
+                            // syntaxes with neither (the overwhelming majority),
+                            // and each list is skipped when it has nothing to
+                            // report.
+                            let structure = state
                                 .highlighter
-                                .region_lines_in(&state.buffer, top_byte..walked_end);
-                            if !regions.is_empty() {
+                                .structure_lines_in(&state.buffer, top_byte..walked_end);
+                            if !structure.regions.is_empty() {
                                 let mut next = 0usize;
                                 for line in new_lines.iter_mut() {
                                     // Both sides ascend by line start, so one
                                     // forward walk pairs them.
-                                    while next < regions.len() && regions[next].0 < line.byte_start
+                                    while next < structure.regions.len()
+                                        && structure.regions[next].0 < line.byte_start
                                     {
                                         next += 1;
                                     }
-                                    if regions.get(next).is_some_and(|r| r.0 == line.byte_start) {
-                                        line.region = Some(regions[next].1);
+                                    if structure
+                                        .regions
+                                        .get(next)
+                                        .is_some_and(|r| r.0 == line.byte_start)
+                                    {
+                                        line.region = Some(structure.regions[next].1);
+                                    }
+                                }
+                            }
+                            if !structure.tables.is_empty() {
+                                let mut next = 0usize;
+                                for line in new_lines.iter_mut() {
+                                    while next < structure.tables.len()
+                                        && structure.tables[next].0 < line.byte_start
+                                    {
+                                        next += 1;
+                                    }
+                                    if structure
+                                        .tables
+                                        .get(next)
+                                        .is_some_and(|t| t.0 == line.byte_start)
+                                    {
+                                        line.table = Some(structure.tables[next].1);
                                     }
                                 }
                             }

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -43,7 +43,7 @@ use crate::primitives::highlighter::{
     highlight_bg, highlight_color, HighlightCategory, HighlightSpan, Highlighter, Language,
 };
 use crate::view::theme::Theme;
-use fresh_core::hooks::RegionLine;
+use fresh_core::hooks::{RegionLine, TableLine, TableRole};
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::Path;
@@ -276,6 +276,9 @@ pub struct TextMateEngine {
     // Region kinds this syntax hosts (see `EMBEDDING_SPECS`); empty for
     // the vast majority of syntaxes.
     embedding: Vec<EmbeddingSpec>,
+    // Body scope of this syntax's tables (see `TABLE_SPECS`); `None` for
+    // every syntax that doesn't scope them.
+    table_body_scope: Option<syntect::parsing::Scope>,
     // Fence-language-token → syntax index memo (None = unrecognized).
     embedded_syntax_memo: HashMap<String, Option<usize>>,
     // Reusable per-line span buffers for embedding hosts, so region
@@ -367,6 +370,97 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
 /// Cap on watched language scopes per host; far above any real spec
 /// table (Vue, the largest host, has one distinct language scope).
 const MAX_WATCH_SCOPES: usize = 8;
+
+/// Declares how a host syntax scopes a *table*: a block whose rows the
+/// grammar recognizes, but which embeds no second language.
+///
+/// Deliberately **not** an `EMBEDDING_SPECS` entry. That table means
+/// something specific — a region whose language the document names, which
+/// the engine runs a child parser over — and a table is neither. What the
+/// two share is the *pattern*: a per-line structural classification the
+/// host grammar already makes while parsing, exported so a decoration
+/// plugin needs no block model of its own.
+///
+/// Only `body_scope` is read from the scope *stack*. The header and
+/// delimiter rows are identified positionally from that stack's
+/// transitions (see `structure_lines_in`), which is why they need no
+/// scope of their own here: a grammar that closes over the body is enough
+/// to place every edge of the frame.
+struct TableSpecDef {
+    host_syntax: &'static str,
+    /// Scope (prefix) the host grammar keeps on the stack from the end of
+    /// the delimiter row through the table's last row.
+    body_scope: &'static str,
+}
+
+/// One entry per host syntax that scopes tables. Markdown is the only
+/// one today; the bundled grammar pushes `meta.table.markdown` on the
+/// delimiter row and pops it after the table's last row.
+const TABLE_SPECS: &[TableSpecDef] = &[TableSpecDef {
+    host_syntax: "Markdown",
+    body_scope: "meta.table",
+}];
+
+/// How far past the requested range `structure_lines_in` may walk to see
+/// the line that closes a table. One line is enough; this is the byte
+/// budget for finding it, generous enough for any realistic line and
+/// small enough that it never turns a viewport probe into a scan.
+const TABLE_LOOKAHEAD_BYTES: usize = 8192;
+
+/// What the host grammar says about each line in a range: its role in an
+/// embedded-language region, and its place in a table. Both lists are
+/// keyed by line start byte, ascending. See
+/// [`TextMateEngine::structure_lines_in`].
+#[derive(Debug, Default, Clone)]
+pub struct StructureLines {
+    pub regions: Vec<(usize, RegionLine)>,
+    pub tables: Vec<(usize, TableLine)>,
+}
+
+impl StructureLines {
+    /// Record a table line, dropping it if it falls outside the caller's
+    /// range — the walk deliberately covers more lines than the caller
+    /// asked about (a checkpoint below `range.start`, one line of
+    /// lookahead past `range.end`), and those extra lines exist only to
+    /// classify the ones inside it.
+    fn push_table(
+        &mut self,
+        line_start: usize,
+        role: TableRole,
+        first_row: bool,
+        range: &Range<usize>,
+    ) {
+        if line_start >= range.start && line_start < range.end {
+            self.tables.push((
+                line_start,
+                TableLine {
+                    role,
+                    first_row,
+                    last: false,
+                },
+            ));
+        }
+    }
+
+    /// Mark the table line starting at `line_start` — the one the walk just
+    /// found the end of the table below — as its table's last.
+    ///
+    /// Keyed by position rather than "whatever was recorded last", because
+    /// the two part company exactly when it matters: a range that stops
+    /// mid-table drops the rows after it, so the last *recorded* line can be
+    /// several rows above the one the table actually ends on. Marking that
+    /// one would close the frame in the middle of the table. When the real
+    /// last row was dropped, this is a no-op — correct, since the caller is
+    /// not rendering it.
+    fn mark_table_line_last(&mut self, line_start: Option<usize>) {
+        let Some(line_start) = line_start else { return };
+        if let Some((start, line)) = self.tables.last_mut() {
+            if *start == line_start {
+                line.last = true;
+            }
+        }
+    }
+}
 
 /// `EmbeddingSpecDef` with its scope selectors interned as syntect `Scope`
 /// atoms for cheap prefix matching in the per-line parse loop.
@@ -614,8 +708,12 @@ impl TextMateEngine {
         syntax_index: usize,
         ts_language: Option<Language>,
     ) -> Self {
-        let embedding =
-            EmbeddingSpec::compile_for_syntax(&syntax_set.syntaxes()[syntax_index].name);
+        let syntax_name = syntax_set.syntaxes()[syntax_index].name.clone();
+        let embedding = EmbeddingSpec::compile_for_syntax(&syntax_name);
+        let table_body_scope = TABLE_SPECS
+            .iter()
+            .find(|d| d.host_syntax == syntax_name)
+            .and_then(|d| syntect::parsing::Scope::new(d.body_scope).ok());
         Self {
             syntax_set,
             syntax_index,
@@ -627,6 +725,7 @@ impl TextMateEngine {
             ts_language,
             stats: HighlightStats::default(),
             embedding,
+            table_body_scope,
             embedded_syntax_memo: HashMap::new(),
             host_span_scratch: Vec::new(),
             child_span_scratch: Vec::new(),
@@ -1716,14 +1815,34 @@ impl TextMateEngine {
     /// embedded-language region — `(line_start_byte, RegionLine)` pairs, in
     /// increasing order. Lines outside any region are omitted.
     ///
-    /// This exposes, read-only, the classification `parse_snapshot_line`
-    /// already makes per line (the `region scope before → after` table in
-    /// `docs/internal/embedded-language-highlighting.md`). It exists because
-    /// region membership is the one thing about a Markdown fence that is *not*
-    /// derivable from a line's own text — a bare ``` opens or closes depending
-    /// on every fence above it — and the `lines_changed` consumers that need it
-    /// (compose-mode code-block framing) run on the plugin thread, where the
-    /// buffer above the batch is not synchronously readable.
+    /// Thin projection of [`Self::structure_lines_in`]; see that method for
+    /// the mechanism, cost and the meaning of an empty answer.
+    pub fn region_lines_in(
+        &mut self,
+        buffer: &Buffer,
+        range: Range<usize>,
+    ) -> Vec<(usize, RegionLine)> {
+        self.structure_lines_in(buffer, range).regions
+    }
+
+    /// Classify every line start in `range` by its role in the structures
+    /// the host grammar recognizes: embedded-language regions
+    /// (`markup.raw.code-fence`, Vue `<script>`) and tables. Both lists are
+    /// in increasing order of line start; lines with no role are omitted.
+    ///
+    /// This exposes, read-only, classifications the parse already makes per
+    /// line — for regions the `region scope before → after` table in
+    /// `docs/internal/embedded-language-highlighting.md`, for tables the same
+    /// before/after test against the table body scope. It exists because
+    /// those are the properties of a Markdown line that a decoration plugin
+    /// cannot work out for itself: region membership is not derivable from a
+    /// line's own text at all (a bare ``` opens or closes depending on every
+    /// fence above it), and while "is this a table row" *is* line-local,
+    /// "is this the table's first/last row" is not — the plugin thread sees
+    /// one `lines_changed` batch and cannot read the buffer around it
+    /// synchronously.
+    ///
+    /// One walk answers both, so a Markdown viewport is not parsed twice.
     ///
     /// Deliberately a probe, not a cache: it resumes from the nearest
     /// checkpoint and drops everything it computes. That keeps it out of the
@@ -1734,28 +1853,35 @@ impl TextMateEngine {
     /// folding a separate read-only probe into them would make the assertions
     /// that reason about cache behaviour meaningless.
     ///
-    /// Cost: zero for the overwhelming majority of buffers (`embedding` is
-    /// empty unless the syntax hosts regions — currently only Markdown and
-    /// Vue), otherwise one span-less parse from the resume anchor — normally
-    /// the checkpoint within `CHECKPOINT_INTERVAL` bytes before `range.start` —
-    /// through `range.end`, and never more than `MAX_PARSE_BYTES` of it.
+    /// Cost: zero for the overwhelming majority of buffers (neither
+    /// `embedding` nor `table_body_scope` is set unless the syntax hosts
+    /// these — currently only Markdown and Vue), otherwise one span-less
+    /// parse from the resume anchor — normally the checkpoint within
+    /// `CHECKPOINT_INTERVAL` bytes before `range.start` — through `range.end`
+    /// plus at most one line, and never more than `MAX_PARSE_BYTES` of it.
     ///
-    /// Returns **empty** — not "no regions" — whenever the state at
+    /// Returns **empty** — not "no structures" — whenever the state at
     /// `range.start` cannot be resolved within that budget: no usable anchor,
     /// or one too far back to walk from. That is the same cold-start trade-off
     /// the engine already documents for styling inside a huge region, and it is
     /// why callers must treat an absent answer as "unknown".
-    pub fn region_lines_in(
-        &mut self,
-        buffer: &Buffer,
-        range: Range<usize>,
-    ) -> Vec<(usize, RegionLine)> {
-        if self.embedding.is_empty() || range.start >= range.end {
-            return Vec::new();
+    pub fn structure_lines_in(&mut self, buffer: &Buffer, range: Range<usize>) -> StructureLines {
+        let table_scope = self.table_body_scope;
+        if (self.embedding.is_empty() && table_scope.is_none()) || range.start >= range.end {
+            return StructureLines::default();
         }
-        let parse_end = range.end.min(buffer.len());
+        // One line past `range.end`, so the table's last row inside the range
+        // can be recognized as last: that is the one fact about a table line
+        // which needs the line *after* it. Bounded, and only the tail of the
+        // walk — everything below still only emits for lines inside `range`.
+        let lookahead = if table_scope.is_some() {
+            TABLE_LOOKAHEAD_BYTES
+        } else {
+            0
+        };
+        let parse_end = range.end.saturating_add(lookahead).min(buffer.len());
         if range.start >= parse_end {
-            return Vec::new();
+            return StructureLines::default();
         }
 
         // Resume anchor. Two rules, both stricter than
@@ -1783,13 +1909,13 @@ impl TextMateEngine {
         let (mut current_offset, mut snapshot) = match nearest {
             Some((id, cp_pos, _)) => match self.checkpoint_states.get(&id) {
                 Some(snap) => (cp_pos, snap.clone()),
-                None => return Vec::new(), // orphaned checkpoint
+                None => return StructureLines::default(), // orphaned checkpoint
             },
             None if parse_end <= MAX_PARSE_BYTES => (
                 0,
                 ParseSnapshot::new(&self.syntax_set.syntaxes()[self.syntax_index]),
             ),
-            None => return Vec::new(), // large file, no anchor: unknown
+            None => return StructureLines::default(), // large file, no anchor: unknown
         };
 
         // Bound the walk itself, not just the anchor search. An edit high in a
@@ -1798,22 +1924,38 @@ impl TextMateEngine {
         // batch could drag a megabyte parse into the draw path. Better to
         // report "unknown" and render conservatively.
         if parse_end.saturating_sub(current_offset) > MAX_PARSE_BYTES {
-            return Vec::new();
+            return StructureLines::default();
         }
 
         let content = buffer.slice_bytes(current_offset..parse_end);
         let content_bytes = match std::str::from_utf8(&content) {
             Ok(s) => s.as_bytes(),
-            Err(_) => return Vec::new(),
+            Err(_) => return StructureLines::default(),
         };
 
-        let mut out = Vec::new();
+        let mut out = StructureLines::default();
+        // The table walk is one line behind the region walk: the *header* row
+        // is the line before the delimiter row, and the *last* row is the line
+        // before the table's body scope drops. Neither is knowable when that
+        // line is parsed, so both are settled retroactively — the header by
+        // holding on to the previous line's start, the last row by patching the
+        // entry already pushed. This is why the walk runs one line past
+        // `range.end`: without that line the final row inside the range could
+        // never be told apart from a row with more table below it.
+        let mut prev_line_start: Option<usize> = None;
+        // Start of the most recent line the walk saw *inside* a table, whether
+        // or not it fell in the caller's range. `mark_table_line_last` matches
+        // on it, so a table continuing past `range.end` never closes early.
+        let mut last_table_line_start: Option<usize> = None;
+        let mut prev_in_table = false;
+        let mut after_delimiter = false;
         let mut pos = 0;
         while pos < content_bytes.len() {
             let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
             let line_start = current_offset;
             if let Some(prepared) = prepared {
                 let was_in = self.active_region_spec(&snapshot.scopes);
+                let was_table = table_scope.is_some_and(|s| scopes_contain(&snapshot.scopes, s));
                 // Spans are discarded: only the scope-stack transition the
                 // parse leaves on `snapshot` matters here.
                 let parsed = self.parse_snapshot_line(
@@ -1836,13 +1978,55 @@ impl TextMateEngine {
                     (None, None) => None,
                 };
                 if let Some(role) = role {
-                    if line_start >= range.start {
-                        out.push((line_start, role));
+                    if line_start >= range.start && line_start < range.end {
+                        out.regions.push((line_start, role));
                     }
                 }
+
+                if let Some(scope) = table_scope {
+                    let now_table = scopes_contain(&snapshot.scopes, scope);
+                    match (was_table, now_table) {
+                        // The body scope opens on the delimiter row, so the
+                        // line above it is the header — emitted now, and still
+                        // in ascending order because it precedes this one.
+                        (false, true) => {
+                            if let Some(header_start) = prev_line_start {
+                                out.push_table(header_start, TableRole::Header, false, &range);
+                            }
+                            out.push_table(line_start, TableRole::Delimiter, false, &range);
+                            last_table_line_start = Some(line_start);
+                            after_delimiter = true;
+                        }
+                        (true, true) => {
+                            out.push_table(line_start, TableRole::Row, after_delimiter, &range);
+                            last_table_line_start = Some(line_start);
+                            after_delimiter = false;
+                        }
+                        // The table ended above this line, so the previous one
+                        // was its last. Only trust this when the line that
+                        // closed it is whole: a truncated tail could be a table
+                        // row that merely looks like the end.
+                        (true, false) => {
+                            if prepared.ends_with_newline || line_end == content_bytes.len() {
+                                out.mark_table_line_last(last_table_line_start);
+                            }
+                            after_delimiter = false;
+                        }
+                        (false, false) => after_delimiter = false,
+                    }
+                    prev_in_table = now_table;
+                }
             }
+            prev_line_start = Some(line_start);
             pos = line_end;
             current_offset += line_byte_len;
+        }
+        // A table that runs to the end of the buffer has no line below it to
+        // close it, and the walk above therefore never sees the transition. The
+        // buffer's own end is that closing edge — but only when the walk really
+        // reached it, not when it stopped at the lookahead bound.
+        if prev_in_table && current_offset >= buffer.len() {
+            out.mark_table_line_last(last_table_line_start);
         }
         out
     }
@@ -1998,6 +2182,16 @@ impl HighlightEngine {
         match self {
             Self::TextMate(h) => h.region_lines_in(buffer, range),
             Self::TreeSitter(_) | Self::None => Vec::new(),
+        }
+    }
+
+    /// Region *and* table roles for the line starts in `range`, from one
+    /// walk; see `TextMateEngine::structure_lines_in`. Empty for engines
+    /// with no notion of either.
+    pub fn structure_lines_in(&mut self, buffer: &Buffer, range: Range<usize>) -> StructureLines {
+        match self {
+            Self::TextMate(h) => h.structure_lines_in(buffer, range),
+            Self::TreeSitter(_) | Self::None => StructureLines::default(),
         }
     }
 
@@ -2448,6 +2642,111 @@ mod tests {
             ],
             "prose lines are omitted; both delimiters of the bare fence are \
              classified from the parse, not from their own text"
+        );
+    }
+
+    /// Table classification, from the same walk and the same grammar scopes.
+    ///
+    /// The header row is the interesting one: the body scope opens on the
+    /// *delimiter* row, so the header is identified as the line above it —
+    /// which is exactly the fact a consumer holding one `lines_changed` batch
+    /// cannot get for itself when that batch starts at the header.
+    #[test]
+    fn test_structure_lines_classify_markdown_tables() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let content = "intro\n\n| K | V |\n|---|---|\n| a | b |\n| c | d |\n\nafter\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let at = |needle: &str| content.find(needle).unwrap();
+        let line = |role, first_row, last| TableLine {
+            role,
+            first_row,
+            last,
+        };
+
+        let tables = engine.structure_lines_in(&buffer, 0..buffer.len()).tables;
+        assert_eq!(
+            tables,
+            vec![
+                (at("| K | V |"), line(TableRole::Header, false, false)),
+                (at("|---|---|"), line(TableRole::Delimiter, false, false)),
+                (at("| a | b |"), line(TableRole::Row, true, false)),
+                (at("| c | d |"), line(TableRole::Row, false, true)),
+            ],
+            "prose is omitted; the header is the line above the delimiter, and \
+             the last row is the one above the line that closes the table"
+        );
+    }
+
+    /// A table running to the end of the buffer has no line below it, so the
+    /// transition that closes one never fires. The buffer's end is that edge.
+    #[test]
+    fn test_structure_lines_close_a_table_at_end_of_buffer() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let content = "intro\n\n| K | V |\n|---|---|\n| a | b |\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        let tables = engine.structure_lines_in(&buffer, 0..buffer.len()).tables;
+        assert_eq!(
+            tables.last().map(|(_, t)| (t.role, t.last)),
+            Some((TableRole::Row, true)),
+            "the final row of a table at end-of-buffer is its last"
+        );
+    }
+
+    /// Asked about a range that stops mid-table, the probe must not call the
+    /// range's final row the table's last: there is more table below it, and a
+    /// consumer would close the frame in the middle. It sees this only because
+    /// it walks one line past the range it was asked about.
+    #[test]
+    fn test_structure_lines_do_not_close_a_table_at_the_range_edge() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let content = "| K | V |\n|---|---|\n| a | b |\n| c | d |\n| e | f |\n\nafter\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let cut = content.find("| e | f |").unwrap();
+
+        let tables = engine.structure_lines_in(&buffer, 0..cut).tables;
+        assert_eq!(
+            tables.last().map(|(p, t)| (*p, t.last)),
+            Some((content.find("| c | d |").unwrap(), false)),
+            "the last row *inside the range* is not the table's last row"
+        );
+        assert!(
+            tables.iter().all(|(p, _)| *p < cut),
+            "the lookahead line is classified but never reported"
+        );
+    }
+
+    /// Region and table classification come from one walk, and neither
+    /// disturbs the other: a fence and a table in the same document are each
+    /// reported on their own lines only.
+    #[test]
+    fn test_structure_lines_report_regions_and_tables_together() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+
+        let content = "| K |\n|---|\n| a |\n\n```rust\nlet x = 1;\n```\n\nend\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        let structure = engine.structure_lines_in(&buffer, 0..buffer.len());
+        assert_eq!(structure.tables.len(), 3, "header, delimiter, one row");
+        assert_eq!(structure.regions.len(), 3, "open, body, close");
+        let table_starts: Vec<usize> = structure.tables.iter().map(|(p, _)| *p).collect();
+        assert!(
+            structure
+                .regions
+                .iter()
+                .all(|(p, _)| !table_starts.contains(p)),
+            "no line is reported as both"
         );
     }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -11,7 +11,7 @@
 use super::style::{create_wrapped_virtual_lines, token_style_from_ratatui};
 use crate::state::EditorState;
 use crate::view::theme::Theme;
-use crate::view::ui::view_pipeline::ViewLine;
+use crate::view::ui::view_pipeline::{LineStart, ViewLine};
 use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
 use crate::view::wrap_machine::{WrapMachine, WrapRule};
 use fresh_core::api::{ViewTokenStyle, ViewTokenWire, ViewTokenWireKind};
@@ -372,6 +372,40 @@ pub(crate) fn apply_conceal_ranges(
     output
 }
 
+/// Whether this visual row continues the source line above it rather than
+/// starting one of its own.
+///
+/// Two different things cut a source line into rows, and neither ends it: the
+/// wrap machine's `Break`, and a plugin *soft break* — which reaches the token
+/// stream as an injected `Newline` (`source_offset: None`, see
+/// `apply_soft_breaks`) and is how compose mode folds a table cell or a framed
+/// code line. Only a newline that came from a source byte ends the line.
+///
+/// Injected newlines from virtual *lines* are not a case here: those are added
+/// by `inject_virtual_lines` itself, downstream of the rows it reads.
+fn continues_previous_line(line: &ViewLine) -> bool {
+    matches!(
+        line.line_start,
+        LineStart::AfterBreak | LineStart::AfterInjectedNewline
+    )
+}
+
+/// End byte of the logical source line whose first visual row is `idx` —
+/// the end of its last continuation row, so a `LineAbove` anchored anywhere
+/// in a wrapped line still resolves against the whole line.
+fn logical_end(source_lines: &[ViewLine], idx: usize) -> Option<usize> {
+    let mut end = None;
+    for (offset, line) in source_lines[idx..].iter().enumerate() {
+        if offset > 0 && !continues_previous_line(line) {
+            break;
+        }
+        if let Some(b) = line.char_source_bytes.iter().rev().find_map(|m| *m) {
+            end = Some(b + 1);
+        }
+    }
+    end
+}
+
 /// Inject `LineAbove` / `LineBelow` virtual lines into the view line stream.
 ///
 /// `wrap_width` is the viewport's effective content width when soft-wrap is
@@ -422,59 +456,93 @@ pub(super) fn inject_virtual_lines(
 
     let mut result = Vec::with_capacity(source_lines.len() + virtual_lines.len());
 
-    for source_line in source_lines {
-        let line_start_byte = source_line.char_source_bytes.iter().find_map(|m| *m);
+    // `source_lines` are *visual* rows: a wrapped source line arrives as a
+    // first row plus one `AfterBreak` continuation per fold. A virtual line
+    // belongs above or below the whole source line, not above or below the
+    // fold its anchor byte happens to land in — so both passes run against
+    // the logical line's byte range, and emit at its first / last visual row.
+    //
+    // Placing a `LineBelow` at the anchor's own row is what put compose
+    // mode's `└─┴─┘` table border directly under the *first* visual row of a
+    // wrapped final row, leaving the rest of that row's text below a frame
+    // that had already closed.
+    let logical_start_of: Vec<Option<usize>> = {
+        let mut starts = Vec::with_capacity(source_lines.len());
+        let mut current: Option<usize> = None;
+        for line in &source_lines {
+            let row_start = line.char_source_bytes.iter().find_map(|m| *m);
+            if !continues_previous_line(line) {
+                current = row_start;
+            }
+            // A continuation row inherits its line's start; a first row that
+            // maps to no source byte (a virtual line already in the stream)
+            // contributes none.
+            starts.push(current.or(row_start));
+        }
+        starts
+    };
+
+    for (idx, source_line) in source_lines.iter().enumerate() {
+        let logical_start = logical_start_of[idx];
         let line_end_byte = source_line
             .char_source_bytes
             .iter()
             .rev()
             .find_map(|m| *m)
             .map(|b| b + 1);
+        let is_first_row = !continues_previous_line(source_line);
+        let is_last_row = source_lines
+            .get(idx + 1)
+            .is_none_or(|next| !continues_previous_line(next));
 
-        if let (Some(start), Some(end)) = (line_start_byte, line_end_byte) {
-            for (anchor_pos, vtext) in &virtual_lines {
-                if *anchor_pos >= start
-                    && *anchor_pos < end
-                    && vtext.position == VirtualTextPosition::LineAbove
-                {
-                    let glyph = vtext.gutter_glyph.as_ref().map(|g| {
-                        (
-                            g.clone(),
-                            vtext.gutter_color.unwrap_or(theme.line_number_fg),
-                        )
-                    });
-                    result.extend(create_wrapped_virtual_lines(
-                        &vtext.text,
-                        vtext.resolved_style(theme),
-                        wrap_width,
-                        glyph,
-                        &vtext.text_overlays,
-                    ));
+        if is_first_row {
+            if let (Some(start), Some(end)) = (logical_start, logical_end(&source_lines, idx)) {
+                for (anchor_pos, vtext) in &virtual_lines {
+                    if *anchor_pos >= start
+                        && *anchor_pos < end
+                        && vtext.position == VirtualTextPosition::LineAbove
+                    {
+                        let glyph = vtext.gutter_glyph.as_ref().map(|g| {
+                            (
+                                g.clone(),
+                                vtext.gutter_color.unwrap_or(theme.line_number_fg),
+                            )
+                        });
+                        result.extend(create_wrapped_virtual_lines(
+                            &vtext.text,
+                            vtext.resolved_style(theme),
+                            wrap_width,
+                            glyph,
+                            &vtext.text_overlays,
+                        ));
+                    }
                 }
             }
         }
 
         result.push(source_line.clone());
 
-        if let (Some(start), Some(end)) = (line_start_byte, line_end_byte) {
-            for (anchor_pos, vtext) in &virtual_lines {
-                if *anchor_pos >= start
-                    && *anchor_pos < end
-                    && vtext.position == VirtualTextPosition::LineBelow
-                {
-                    let glyph = vtext.gutter_glyph.as_ref().map(|g| {
-                        (
-                            g.clone(),
-                            vtext.gutter_color.unwrap_or(theme.line_number_fg),
-                        )
-                    });
-                    result.extend(create_wrapped_virtual_lines(
-                        &vtext.text,
-                        vtext.resolved_style(theme),
-                        wrap_width,
-                        glyph,
-                        &vtext.text_overlays,
-                    ));
+        if is_last_row {
+            if let (Some(start), Some(end)) = (logical_start, line_end_byte) {
+                for (anchor_pos, vtext) in &virtual_lines {
+                    if *anchor_pos >= start
+                        && *anchor_pos < end
+                        && vtext.position == VirtualTextPosition::LineBelow
+                    {
+                        let glyph = vtext.gutter_glyph.as_ref().map(|g| {
+                            (
+                                g.clone(),
+                                vtext.gutter_color.unwrap_or(theme.line_number_fg),
+                            )
+                        });
+                        result.extend(create_wrapped_virtual_lines(
+                            &vtext.text,
+                            vtext.resolved_style(theme),
+                            wrap_width,
+                            glyph,
+                            &vtext.text_overlays,
+                        ));
+                    }
                 }
             }
         }

--- a/crates/fresh-editor/tests/e2e/markdown_compose_table_border.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_table_border.rs
@@ -666,11 +666,14 @@ fn structure_changing_edit_clears_seen_byte_ranges() {
 ///
 /// A well-formed frame ends with the bottom border: no table content line may
 /// appear after it.
+///
+/// Fixed in `inject_virtual_lines`: a `LineBelow` virtual line now follows the
+/// last visual row of the source line it is anchored in, rather than the row
+/// its anchor byte happens to land in. A plugin soft break — how compose mode
+/// folds a wide cell — reaches the view as an *injected* newline, so the rows
+/// it produces are continuations of one source line, not lines of their own.
 #[cfg(feature = "plugins")]
 #[test]
-#[ignore = "reproduces an unfixed bug: the bottom border renders after the \
-            first visual row of a wrapped last row, so the continuation spills \
-            below the closed frame. Run with --ignored."]
 fn test_table_bottom_border_below_wrapped_last_row() {
     use crate::common::harness::{copy_plugin, copy_plugin_lib};
     use crossterm::event::{KeyCode, KeyModifiers};

--- a/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
@@ -1,0 +1,184 @@
+//! End-to-end: compose mode draws a table's frame edges from the *editor's*
+//! table classification rather than from the lines a `lines_changed` batch
+//! happens to contain.
+//!
+//! "Is this line a table row" was never the hard part — that is decided from
+//! the line's own text. Which *edge* of the frame a row carries is: the
+//! `┌─┬─┐` belongs above the header and the `└─┴─┘` below the last row, and
+//! both are facts about the row's neighbours. A batch holds only the lines a
+//! scroll or an edit touched, so whenever the neighbour was absent the plugin
+//! had to guess — and the guess showed, as a table whose top edge turned into
+//! an inter-row separator and stayed that way.
+//!
+//! These suites need the **full grammar registry**: the classification comes
+//! from the Markdown grammar's own `meta.table` scope, so with the default
+//! empty registry there is no Markdown syntax and no classification at all
+//! (and a `wait_until` on it would hang rather than fail).
+//!
+//! All assertions are on rendered output only.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Open a markdown document with the real `markdown_compose` plugin loaded and
+/// compose mode enabled through the command palette.
+#[cfg(feature = "plugins")]
+fn compose_harness(md: &str, width: u16, height: u16) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("table.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        width,
+        height,
+        HarnessOptions::new()
+            .with_working_dir(project_root.clone())
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    (harness, temp_dir)
+}
+
+/// The screen row index of the line holding `needle`.
+#[cfg(feature = "plugins")]
+fn row_of(screen: &str, needle: &str) -> usize {
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("{needle:?} not on screen.\nScreen:\n{screen}"))
+}
+
+/// Paging away from a table and back must not cost it its top edge.
+///
+/// This is the reported "scrolling glitches the table" bug. `lines_changed` is
+/// edge-triggered on byte ranges the editor has not reported before, so the
+/// batch that brings a table's header back into view can begin *at* that
+/// header — the blank line above it, the plugin's only evidence that this row
+/// starts the table, having never left the screen and so never re-fired. The
+/// batch-local rule then read the row as mid-table and replaced its `┌─┬─┐`
+/// with an inter-row `├─┼─┤`, and it stayed that way: nothing re-fires that
+/// line again until it is edited or scrolled away and back once more.
+///
+/// With the classification on the payload the row says "header" for itself, so
+/// the batch's contents stop mattering.
+#[cfg(feature = "plugins")]
+#[test]
+fn table_top_border_survives_paging_away_and_back() {
+    let mut md = String::from("# Doc\n\nintro paragraph\n\n| Key | Value |\n|-----|-------|\n");
+    for i in 0..40 {
+        md.push_str(&format!("| k{i:02} | v{i:02} |\n"));
+    }
+    md.push_str("\nafter\n");
+
+    let (mut harness, _tmp) = compose_harness(&md, 100, 30);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains('┌'))
+        .unwrap();
+
+    // Sanity: the frame opens with a top border before any scrolling.
+    let before = harness.screen_to_string();
+    let header_row = row_of(&before, "Key");
+    assert!(
+        before.lines().nth(header_row - 1).unwrap().contains('┌'),
+        "expected a top border above the header before scrolling.\nScreen:\n{before}"
+    );
+
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+    }
+
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::PageUp, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+    }
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("Key"))
+        .unwrap();
+
+    let after = harness.screen_to_string();
+    let header_row = row_of(&after, "Key");
+    let above = after.lines().nth(header_row - 1).unwrap();
+    assert!(
+        above.contains('┌') && !above.contains('├'),
+        "paging away from the table and back replaced its top border with an \
+         inter-row separator: the row above the header is {above:?}.\nScreen:\n{after}"
+    );
+}
+
+/// The same property at the other edge: editing the last row must not cost the
+/// table its bottom border, which needs the (absent) line *below* it.
+#[cfg(feature = "plugins")]
+#[test]
+fn table_bottom_border_survives_an_edit_in_its_last_row() {
+    let md = "\
+intro paragraph
+
+| Key | Value |
+|-----|-------|
+| a | b |
+| c | d |
+
+after
+";
+    let (mut harness, _tmp) = compose_harness(md, 100, 30);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains('└'))
+        .unwrap();
+
+    // Line 5 (0-based) is the last data row; column 3 is just after its `c`.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..5 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.type_text("z").unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("cz"))
+        .unwrap();
+
+    let after = harness.screen_to_string();
+    let last_row = row_of(&after, "cz");
+    let below = after.lines().nth(last_row + 1).unwrap();
+    assert!(
+        below.contains('└'),
+        "editing inside the last row left the table unclosed: the row below it \
+         is {below:?}.\nScreen:\n{after}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -186,6 +186,7 @@ pub mod markdown_compose_scroll_reach;
 #[cfg(feature = "plugins")]
 pub mod markdown_compose_scrollbar_markers;
 pub mod markdown_compose_table_border;
+pub mod markdown_compose_table_structure;
 pub mod markdown_fenced_code_highlighting;
 pub mod memory_scroll_leak;
 pub mod menu_bar;

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -677,6 +677,26 @@ interface HookEventMap {
        * point of this field is that a bare ``` opens or closes depending on
        * every fence above it, so there is nothing to fall back on. */
       region?: "open" | "body" | "close";
+      /** Where this line sits in a table the buffer's grammar recognizes.
+       * `role` is the line's kind (`"header"` is the column-name row,
+       * `"delimiter"` the `|---|---|` row, `"row"` a data row); `first_row`
+       * marks the data row directly below the delimiter; `last` marks the
+       * table's final line.
+       *
+       * Companion to `region`, and recoverable where that is not: "is this a
+       * table row" *is* derivable from a line's own text, so a consumer may
+       * fall back to its own rule when this is absent. What it cannot derive
+       * is where the table starts and ends — that needs the neighbouring
+       * lines, and an edit-sized batch does not contain them.
+       *
+       * `last` is false rather than unknown when the engine could not see the
+       * line below the table, so a consumer drawing a closing edge from it
+       * draws none instead of one in the wrong place. */
+      table?: {
+        role: "header" | "delimiter" | "row";
+        first_row: boolean;
+        last: boolean;
+      };
     }[];
     /** Buffer version these byte ranges were captured at. Pass back to
      * coordinate-mapping APIs to repair stale offsets from this batch. */

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -139,7 +139,9 @@ string color), so nothing regresses.
 
 The per-line classification in the table above is not only used to pick a
 parser — it is the editor's *only* authoritative answer to "is this line
-inside a fence", and `TextMateEngine::region_lines_in` exports it. The
+inside a fence", and `TextMateEngine::region_lines_in` exports it (a thin
+projection of `structure_lines_in`, which also classifies tables — see
+"Generalizing the pattern" below). The
 `lines_changed` plugin hook carries it per line as
 `region: "open" | "body" | "close"`, and compose mode's fenced-code framing
 is built on it.
@@ -162,6 +164,60 @@ does not recognize as a region — a ` ```js ` abutting a table row with no
 blank line between, which the Markdown grammar does not open a region for —
 is left unhighlighted *and* unframed, rather than framing a block the
 highlighter does not believe in.
+
+### Generalizing the pattern: tables
+
+Tables are the first case that borrowed the *pattern* without belonging to
+the mechanism. A Markdown table embeds no second language, so it has no
+`EMBEDDING_SPECS` entry and `region_lines_in` correctly reports nothing for
+its lines. What transfers is the shape of the answer: a per-line structural
+classification the host grammar already makes while parsing, delivered on
+the `lines_changed` payload, so the consumer stores no block model.
+
+`structure_lines_in` is the single walk that produces both. Tables get
+their own tiny spec table (`TABLE_SPECS`: host syntax → table *body*
+scope, `meta.table` for Markdown) and their own vocabulary, because
+`open`/`body`/`close` does not describe a table:
+
+| line | `meta.table` before → after | reported as |
+|---|---|---|
+| header row | absent → absent | `header` (the line *above* a delimiter) |
+| delimiter row | absent → present | `delimiter` |
+| data row | present → present | `row` (`first_row` on the one below the delimiter) |
+| line below the table | present → absent | nothing; the line above it is marked `last` |
+
+Two things fall out of that table and are worth stating plainly:
+
+- **The header is not covered by the body scope.** The grammar opens
+  `meta.table` on the *delimiter* row, so a pure before/after test cannot
+  see the header at all. It is identified positionally, as the line above
+  the delimiter — which also means a walk that resumes from a checkpoint
+  *inside* a table never claims to know where that table began. That is
+  the honest answer, and it costs nothing: a header above the resume
+  anchor is off-screen anyway.
+- **`last` needs the line below.** It is the one fact here that a forward
+  walk cannot settle in place, so the walk runs one line past the range it
+  was asked about (`TABLE_LOOKAHEAD_BYTES`). Where it cannot — the range
+  ends at the lookahead bound, or the walk stopped early — `last` stays
+  false, which draws no closing edge rather than one in the wrong place.
+
+The consequence for consumers is different from regions, and the
+difference is the point. Region membership has no fallback: absence must
+be read as *unknown*, because a bare ` ``` ` tells you nothing on its own.
+"Is this line a table row" **is** line-local, so a consumer may fall back
+to its own text rule — and compose mode does, deliberately. The grammar
+scopes fewer things as tables than the plugin renders as tables (a table
+inside a blockquote is not scoped; a table interrupting a paragraph is
+correctly not scoped, since GFM tables cannot interrupt one), and a buffer
+too large to resolve would otherwise lose every frame it has today. So the
+editor's answer is authoritative *when present*, and the batch-local rules
+stay as the degradation path.
+
+What this does **not** fix is column widths. Knowing a table's extent is
+not the same as being able to read its off-screen rows, which a plugin
+still cannot do synchronously, so compose mode's grow-only width memo
+stays. That memo is safe for the reason it always was: it carries only
+numbers, where staleness costs a column width for one frame.
 
 `region_lines_in` is a probe, not a cache: it resumes from the nearest
 checkpoint and discards what it computes, so it stays out of the three


### PR DESCRIPTION
Follow-up to #2995. Applies the pattern that landed there for fenced code blocks — editor-side per-line structural classification, delivered on the `lines_changed` payload — to tables, and fixes the two rendering bugs that pattern exposes.

## What was actually wrong

Reproduced by hand in tmux against a debug build, frame columns measured programmatically rather than eyeballed:

**1. A table's top border degrades into an inter-row separator, and stays there.** Page down through a document and back up, and the `┌─┬─┐` above a table's header has become `├─┼─┤` — permanently, even with the table back at the top of the screen and the blank line above it visible. Nothing re-fires that line again until it is edited or scrolled away once more.

```
 before (correct)                          after paging down and back
 ┌────────┬───────...───┐                  ├────────┼───────...───┤
 │ Key    │ Value       │                  │ Key    │ Value       │
 ├────────┼───────...───┤                  ├────────┼───────...───┤
```

**2. A wrapped last row spills below its own closed frame.** The `└─┴─┘` lands after the *first* visual row of a row that wrapped:

```
 │ Productivity    │ command palette, menu bar, keyboard macros, git log, and   │
 └─────────────────┴───────────────────────────────────────────────────────────┘
 │                 │ more                                                       │   ← outside the frame
```

**3. The grow-only width memo makes layout depend on scroll history.** A 300-row table opens with its columns 6 and 7 wide; scroll past a row that is wider and back, and the same rows now render 6 and 67 wide. Not fixed here — see below.

**4. A ragged table's frame does not close.** Rows with fewer cells than the widest get no right edge, because cell separators are conceals of source pipes and a row has only as many pipes as it has. Not fixed here.

## The design question: does the grammar scope tables?

Yes — verified against the bundled syntect Markdown grammar rather than assumed. It pushes `meta.table.header` on the header row, `meta.table.header-separator` on the delimiter row, and keeps `meta.table` on the stack from the delimiter through the table's last row.

But the vocabulary does not transfer. `open`/`body`/`close` does not describe a thing with a header row and a delimiter row, and a naive reuse of `region_lines_in`'s before/after test would classify a table wrong in two places: the body scope opens on the *delimiter*, so the header is `absent → absent` and invisible, while the line *after* the table is `present → absent` and would be claimed as part of it.

So tables get their own small spec table (`TABLE_SPECS`: host syntax → table body scope) and their own vocabulary — `header` / `delimiter` / `row`, plus `first_row` and `last`. Deliberately **not** an `EMBEDDING_SPECS` entry: that table means "a region whose language the document names", and a table embeds no language. What generalizes is the pattern, not the spec.

Two facts need more than one line, and both are handled honestly:

- the **header** is identified as the line *above* the delimiter, so a walk resuming from a checkpoint inside a table reports no header rather than guessing one;
- **`last`** needs the line *below* the table, so the walk runs one bounded line (`TABLE_LOOKAHEAD_BYTES`) past the range it was asked about. Where it cannot see that line, `last` stays false — no closing edge rather than one in the wrong place. A unit test covers a range that stops mid-table, and caught a real bug in the first version of the retroactive marking.

Both classifications now come from **one** walk (`structure_lines_in`), so a Markdown viewport is not parsed twice; `region_lines_in` is a projection of it.

### What this does *not* fix, and why

**Column widths.** Knowing a table's extent is not the same as being able to read its off-screen rows, and `getBufferText` is still a Promise. The grow-only width memo stays, and glitch 3 above is unchanged. The memo remains safe for the reason it always was — it carries only numbers, where staleness costs a column width for one frame.

**Ragged tables.** Cell separators are conceals of source pipes; making short rows pad out to the column count means decoupling column layout from pipe positions, which is the inline-virtual-text rails treatment code blocks got. That is a real option now that `apply_soft_breaks` handles mid-token breaks, but it is a rewrite of the conceal pass rather than an extension of it, and it is not in this PR.

**Absence falls back rather than failing closed** — the one deliberate difference from `region`. Region membership has no fallback: a bare ` ``` ` tells you nothing on its own. "Is this line a table row" *is* line-local, and the grammar scopes fewer things as tables than compose mode renders as tables (a table inside a blockquote is not scoped; a table interrupting a paragraph is correctly not scoped, since GFM tables cannot interrupt one). A buffer too large to resolve would otherwise lose every frame it has today. So the editor's answer is authoritative when present, and the batch-local rules stay as the degradation path — strictly additive, no case renders worse than before.

## Commits

**`feat(highlight): tell plugins where a line sits in a markdown table`** — `structure_lines_in`, `TableRole`/`TableLine` on the `lines_changed` payload, regenerated `fresh.d.ts`, and the design doc's new "Generalizing the pattern: tables" section.

**`fix(view): put a virtual line below the whole source line, not its first fold`** — `inject_virtual_lines` walks *visual* rows and placed a `LineBelow` after whichever row the anchor byte landed in. Both passes now resolve against the logical line's byte range. The continuation test had to cover two different cuts, and only one was already spelled `AfterBreak`: a plugin **soft break** — how compose mode folds a wide cell or a framed code line — reaches the token stream as an injected `Newline`, not a wrap `Break`.

**`fix(compose): draw table frame edges from the editor's classification`** — the plugin reads `line.table` when present, keeping the batch-local rules as fallback.

## Verification

- `cargo test --test e2e_tests markdown_compose`: **108 passed, 0 failed** (was 105 + 2 ignored), including the 8 in `markdown_compose_code_frame.rs`.
- **Un-ignores `test_table_bottom_border_below_wrapped_last_row`**, committed as a repro of an unfixed bug. Verified it still fails without the renderer change (`table content spilled below the bottom border at row 13`) and passes with it.
- 4 new engine unit tests for `structure_lines_in`: header/delimiter/row classification, close at end-of-buffer, no early close at a range edge, and regions + tables from one walk without either claiming the other's lines.
- Wrapping-adjacent suites, since both changed files sit on the wrap path: `wrap` e2e **98 passed**, `view::` unit **1003 passed**.
- `cargo fmt --all`, `plugins/check-types.sh markdown_compose.ts` clean. `scripts/gen_schema.sh` not needed — no config or schema types touched.
- Driven by hand in tmux at 60 and 160 columns against a fixture covering a table wider than the measure, one very wide cell, a widest row below the fold, a wrapped last row, a table adjacent to a code block, CJK/emoji cells, a ragged table, and a table interrupting a paragraph. Frame columns extracted per row and compared rather than eyeballed. Compose toggle-off verified to tear every decoration down.

### Honest gaps

- **The two new e2e tests in `markdown_compose_table_structure.rs` are characterization coverage, not repros.** They assert real screen invariants but pass with the change stubbed out: the harness's `lines_changed` batches include the neighbouring lines, and an in-table edit forces a whole-viewport refresh through the width memo, so the batch-local failure does not arise there. The failure is real — captured twice in tmux — and is covered where it *is* deterministic, in the engine unit tests. Flagging rather than dressing it up.
- **`test_wide_table_not_corrupted_by_rapid_delete_above` still fails under `--ignored`**, unchanged by this PR. The failing frame shows a partially-applied conceal (`│ Category | Features |`), which is the flakiness its own doc comment describes, not misplaced coordinates. It stays ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaLYvoQL1wNRh8fHjB8Bu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaLYvoQL1wNRh8fHjB8Bu2)_