### PR TITLE
test(scrollbar): count the marker work instead of timing it

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar_marker_scroll_perf.rs
@@ -37,16 +37,28 @@
 //! per-frame price grows the further down the document the reader gets, and
 //! the total is quadratic in document length.
 //!
-//! These tests are measurements, so they assert on *shape* (late frames versus
-//! early frames, first pass versus second pass) rather than on wall-clock
-//! numbers, which vary by machine and by build profile. For scale, a release
-//! build on the machine this was written on scrolled a 20 000-line document
-//! with 1 000 headings in ~100 ms of marker work spread over 500 frames — 23 µs
-//! on the first frames, 400 µs on the last. Small next to the rest of a compose
-//! frame today; the point is that it grows with the square of the document.
+//! # Why these count instead of timing
+//!
+//! These tests are measurements, but what they measure is *counted work*, not
+//! wall-clock: markers the publish sweeps, markers the projection re-walks,
+//! projections rebuilt. Both O(M) terms are visible as counts — the retain
+//! sweeps the namespace it starts from, and
+//! [`ScrollbarMarkerBuckets::stats`](crate::view::scrollbar_marker::ScrollbarMarkerBuckets::stats)
+//! reports every marker a rebuild walked — and a count is an exact function of
+//! the document and the scroll, so it says the same thing on any machine, in
+//! any build profile, and on a loaded runner. Timings do not: these assertions
+//! were written against `Instant::elapsed` first, and the headingless case
+//! failed under `cargo nextest` on nothing but scheduler noise (a first decile
+//! of 11 µs against a last decile of 96 µs, both far below the resolution at
+//! which a few microseconds of preemption mean anything).
+//!
+//! For scale, a release build on the machine this was written on scrolled a
+//! 20 000-line document with 1 000 headings in ~100 ms of marker work spread
+//! over 500 frames — 23 µs on the first frames, 400 µs on the last. Small next
+//! to the rest of a compose frame today; the point is that it grows with the
+//! square of the document.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 use super::scrollbar::project_scrollbar_markers;
 use crate::state::EditorState;
@@ -97,9 +109,28 @@ fn heading_marker(start: usize) -> ResolvedMarker {
     }
 }
 
+/// The markers one frame of the scroll had to touch.
+#[derive(Debug, Clone, Copy, Default)]
+struct FrameWork {
+    /// Size of the namespace the publish's retain swept — the O(M) half of
+    /// `set_markers_in_range`. Zero on a frame that publishes nothing.
+    swept: u64,
+    /// Markers the projection re-walked, straight from
+    /// [`ProjectionStats`](crate::view::scrollbar_marker::ProjectionStats).
+    /// Zero on a frame the cached column served.
+    walked: u64,
+    /// 1 when the frame missed the projection cache, 0 when it hit.
+    rebuilds: u64,
+}
+
+impl FrameWork {
+    fn markers(&self) -> u64 {
+        self.swept + self.walked
+    }
+}
+
 /// One frame of a first-time downward scroll: publish the batch's headings the
 /// way the plugin does, then project the track the way the renderer does.
-/// Returns `(publish, project)` timings.
 fn scroll_frame(
     state: &mut EditorState,
     line_starts: &[usize],
@@ -107,11 +138,11 @@ fn scroll_frame(
     frame: usize,
     basis: MarkerBasis,
     publish: bool,
-) -> (Duration, Duration) {
+) -> FrameWork {
     let first = frame * VIEWPORT_LINES;
     let last = (first + VIEWPORT_LINES - 1).min(line_starts.len() - 1);
 
-    let mut publish_time = Duration::ZERO;
+    let mut swept = 0;
     if publish {
         let start_byte = line_starts[first];
         let end_byte = line_starts
@@ -123,44 +154,67 @@ fn scroll_frame(
             .map(|l| heading_marker(line_starts[l]))
             .collect();
 
-        let t = Instant::now();
+        // The retain walks the namespace as it stands before the batch lands,
+        // so that count *is* what this publish costs.
+        swept = state.scrollbar_markers.len() as u64;
         state.scrollbar_markers.set_markers_in_range(
             NS,
             start_byte,
             end_byte.max(start_byte + 1),
             markers,
         );
-        publish_time = t.elapsed();
     }
 
-    let t = Instant::now();
+    let before = state.scrollbar_marker_buckets.stats();
     let _ = project_scrollbar_markers(state, basis, TRACK_HEIGHT);
-    (publish_time, t.elapsed())
+    let after = state.scrollbar_marker_buckets.stats();
+
+    FrameWork {
+        swept,
+        walked: after.markers_walked - before.markers_walked,
+        rebuilds: after.rebuilds - before.rebuilds,
+    }
 }
 
 struct ScrollProfile {
-    per_frame: Vec<Duration>,
-    publish_total: Duration,
-    project_total: Duration,
+    per_frame: Vec<FrameWork>,
 }
 
 impl ScrollProfile {
-    fn total(&self) -> Duration {
-        self.publish_total + self.project_total
+    fn frames(&self) -> u64 {
+        self.per_frame.len() as u64
     }
 
-    /// Mean frame cost over the first / last tenth of the scroll.
-    fn first_decile(&self) -> Duration {
+    /// Every marker the pass swept or walked, over all frames.
+    fn total(&self) -> u64 {
+        self.per_frame.iter().map(FrameWork::markers).sum()
+    }
+
+    fn rebuilds(&self) -> u64 {
+        self.per_frame.iter().map(|f| f.rebuilds).sum()
+    }
+
+    /// Mean markers per frame over the first / last tenth of the scroll.
+    fn first_decile(&self) -> u64 {
         mean(&self.per_frame[..self.per_frame.len() / 10])
     }
 
-    fn last_decile(&self) -> Duration {
+    fn last_decile(&self) -> u64 {
         mean(&self.per_frame[self.per_frame.len() - self.per_frame.len() / 10..])
+    }
+
+    /// The single most expensive frame of the pass.
+    fn worst_frame(&self) -> u64 {
+        self.per_frame
+            .iter()
+            .map(FrameWork::markers)
+            .max()
+            .unwrap_or(0)
     }
 }
 
-fn mean(d: &[Duration]) -> Duration {
-    d.iter().sum::<Duration>() / d.len().max(1) as u32
+fn mean(frames: &[FrameWork]) -> u64 {
+    frames.iter().map(FrameWork::markers).sum::<u64>() / frames.len().max(1) as u64
 }
 
 fn scroll_document(
@@ -175,14 +229,16 @@ fn scroll_document(
     let frames = line_starts.len() / VIEWPORT_LINES;
     let mut profile = ScrollProfile {
         per_frame: Vec::with_capacity(frames),
-        publish_total: Duration::ZERO,
-        project_total: Duration::ZERO,
     };
     for frame in 0..frames {
-        let (p, q) = scroll_frame(state, line_starts, heading_every, frame, basis, publish);
-        profile.publish_total += p;
-        profile.project_total += q;
-        profile.per_frame.push(p + q);
+        profile.per_frame.push(scroll_frame(
+            state,
+            line_starts,
+            heading_every,
+            frame,
+            basis,
+            publish,
+        ));
     }
     profile
 }
@@ -198,20 +254,26 @@ fn first_scroll_frame_cost_grows_with_accumulated_markers() {
     let first_pass = scroll_document(&mut state, &line_starts, heading_every, true);
 
     eprintln!(
-        "first scroll: total {:?} (publish {:?}, project {:?}), \
-         first-decile frame {:?}, last-decile frame {:?}",
+        "first scroll: {} markers touched over {} frames, {} rebuilds, \
+         first-decile frame {}, last-decile frame {}",
         first_pass.total(),
-        first_pass.publish_total,
-        first_pass.project_total,
+        first_pass.frames(),
+        first_pass.rebuilds(),
         first_pass.first_decile(),
         first_pass.last_decile(),
     );
 
+    assert_eq!(
+        first_pass.rebuilds(),
+        first_pass.frames(),
+        "publishing on every frame moves the marker version, so no frame of a \
+         first pass can hit the cached column"
+    );
     assert!(
         first_pass.last_decile() > first_pass.first_decile() * 4,
-        "late frames should cost far more than early ones if the per-frame \
-         work is proportional to markers accumulated so far; \
-         first decile {:?}, last decile {:?}",
+        "late frames should touch far more markers than early ones if the \
+         per-frame work is proportional to markers accumulated so far; \
+         first decile {}, last decile {}",
         first_pass.first_decile(),
         first_pass.last_decile(),
     );
@@ -229,16 +291,22 @@ fn second_scroll_is_free_because_nothing_republishes() {
     let second_pass = scroll_document(&mut state, &line_starts, heading_every, false);
 
     eprintln!(
-        "first scroll {:?}, second scroll {:?}",
+        "first scroll {} markers touched, second scroll {}",
         first_pass.total(),
         second_pass.total()
     );
 
-    assert!(
-        second_pass.total() * 10 < first_pass.total(),
-        "a re-scroll should be at least an order of magnitude cheaper; \
-         first {:?}, second {:?}",
-        first_pass.total(),
+    assert_eq!(
+        second_pass.rebuilds(),
+        0,
+        "a re-scroll changes nothing in the projection key, so every frame \
+         must come off the cache"
+    );
+    assert_eq!(
+        second_pass.total(),
+        0,
+        "a re-scroll neither publishes nor re-projects, so it touches no \
+         markers at all; touched {}",
         second_pass.total()
     );
 }
@@ -255,21 +323,24 @@ fn a_document_without_headings_scrolls_flat() {
     let (mut state, line_starts) = markdown_state(20_000, usize::MAX);
 
     let flat = scroll_document(&mut state, &line_starts, usize::MAX, true);
+    let headings = state.scrollbar_markers.len() as u64;
 
     eprintln!(
-        "headingless scroll: total {:?}, first-decile frame {:?}, \
-         last-decile frame {:?}",
+        "headingless scroll: {} markers touched over {} frames for {headings} \
+         heading(s), {} rebuilds, worst frame {}",
         flat.total(),
-        flat.first_decile(),
-        flat.last_decile(),
+        flat.frames(),
+        flat.rebuilds(),
+        flat.worst_frame(),
     );
 
+    assert_eq!(flat.rebuilds(), flat.frames(), "still a miss every frame");
     assert!(
-        flat.last_decile() < flat.first_decile() * 4,
-        "with no markers accumulating, late frames should cost about what \
-         early ones do; first decile {:?}, last decile {:?}",
-        flat.first_decile(),
-        flat.last_decile(),
+        flat.worst_frame() <= 2 * headings,
+        "with no markers accumulating, every frame sweeps and walks the same \
+         lone heading however far down the document it is; worst frame {} for \
+         {headings} heading(s)",
+        flat.worst_frame(),
     );
 
     let heading_every = 20;
@@ -277,8 +348,9 @@ fn a_document_without_headings_scrolls_flat() {
     let with_headings = scroll_document(&mut state, &line_starts, heading_every, true);
     assert!(
         with_headings.total() > flat.total() * 5,
-        "the same scroll over the same number of lines costs far more once \
-         headings accumulate marks; headingless {:?}, with headings {:?}",
+        "the same scroll over the same number of lines touches far more \
+         markers once headings accumulate marks; headingless {}, with \
+         headings {}",
         flat.total(),
         with_headings.total(),
     );
@@ -298,11 +370,11 @@ fn first_scroll_cost_is_superlinear_in_document_length() {
     let small = cost(10_000);
     let large = cost(20_000);
 
-    eprintln!("10k lines {small:?}, 20k lines {large:?}");
+    eprintln!("10k lines {small} markers touched, 20k lines {large}");
 
     assert!(
         large > small * 2,
-        "twice the document should cost more than twice as much; \
-         10k {small:?}, 20k {large:?}"
+        "twice the document should touch more than twice as many markers; \
+         10k {small}, 20k {large}"
     );
 }

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1189,38 +1189,41 @@ impl EditorTestHarness {
     ///      iteration — to catch the `WidgetCommand` that a
     ///      completed plugin action just pushed.
     ///
-    /// (1) used to share a ~200 ms cap with (2). That cap was a
-    /// *timeout inside a test* (CONTRIBUTING.md Testing §3) hidden
-    /// behind every `send_key`/`type_text`: on a loaded CI runner a
-    /// plugin action that needed longer than the budget left the
-    /// drain early and *silently* (a `tracing::warn!` that CI never
-    /// renders), so the caller's next assertion sampled a pre-action
-    /// frame. That is a flake with no diagnostic — the screen dump
-    /// shows a plausible-looking stale frame and nothing says why.
+    /// (1) is waited out indefinitely, per CONTRIBUTING.md Testing §3:
+    /// wait for the state change, and let `cargo nextest` bound the test
+    /// from outside. It carried a cap of its own twice — ~200 ms, then
+    /// 10 s — and both were a *timeout inside a test* hidden behind every
+    /// `send_key`/`type_text`. On a loaded CI runner an action that
+    /// needed longer than the cap left the drain early, so the caller's
+    /// next assertion sampled a pre-action frame: a key that "did
+    /// nothing", a click whose effect never applied, and then a
+    /// `wait_until` for a state that could no longer arrive — a 3-minute
+    /// kill whose screen dump shows a plausible-looking stale frame and
+    /// says nothing about why. Raising the cap only made that rarer,
+    /// which is worse: the same flake, harder to catch.
     ///
-    /// (1) is now waited out with a budget generous enough that no
-    /// real plugin action can miss it, and giving up is loud on
-    /// stderr (the one channel nextest surfaces for a killed or
-    /// failed test). It stays bounded rather than indefinite because
-    /// a plugin callback that never returns must not deadlock every
-    /// subsequent keypress in the suite; a genuinely stuck action now
-    /// reports itself instead of quietly corrupting one assertion.
+    /// A genuinely stuck plugin callback now hangs this test until
+    /// nextest kills it, and says so on stderr every
+    /// `STUCK_REPORT_INTERVAL` while it waits — the one channel that
+    /// survives into a killed test's output. That is a loud, correct
+    /// failure in place of a quiet, wrong assertion.
     ///
-    /// (2) keeps a short bound of its own: legitimately continuous
-    /// message sources — PTY output, timer-driven plugin polls — never
-    /// go quiet, and waiting for silence that will never come would
-    /// hang every terminal test.
+    /// (2) keeps a short bound of its own, and that one is not a
+    /// timeout: legitimately continuous message sources — PTY output,
+    /// timer-driven plugin polls — never go quiet, so it bounds a wait
+    /// for silence that may never come rather than one for a state
+    /// change that must.
     fn drain_async_work(&mut self) {
         const SLEEP_PER_ITER: std::time::Duration = std::time::Duration::from_millis(1);
-        /// Real-wall-clock budget for (1). ~50x the old cap: far beyond
-        /// any plugin action these tests perform, still bounded.
-        const ACTION_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+        /// How often an in-flight action reports itself while (1) waits.
+        const STUCK_REPORT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
         /// Iterations of (2) to tolerate before concluding the source is
         /// continuous rather than settling.
         const TAIL_ITERS: usize = 200;
         const QUIET_ITERS: usize = 2;
 
         let start = std::time::Instant::now();
+        let mut last_report = start;
         let mut quiet_iters = 0;
         let mut tail_iters = 0;
         loop {
@@ -1229,17 +1232,20 @@ impl EditorTestHarness {
             if !self.editor.pending_plugin_actions_is_empty() {
                 quiet_iters = 0;
                 tail_iters = 0;
-                if start.elapsed() >= ACTION_BUDGET {
+                if last_report.elapsed() >= STUCK_REPORT_INTERVAL {
+                    last_report = std::time::Instant::now();
                     // stderr, not just tracing: CI runs with tracing
                     // disabled, and this is the only channel that
                     // survives into a failed/killed test's output.
                     eprintln!(
                         "drain_async_work: plugin actions still in-flight after {:.1}s — \
-                         giving up. The next assertion may observe a pre-action frame.",
+                         still waiting.",
                         start.elapsed().as_secs_f64()
                     );
-                    tracing::warn!("drain_async_work exceeded action budget");
-                    return;
+                    tracing::warn!(
+                        elapsed_s = start.elapsed().as_secs_f64(),
+                        "drain_async_work still waiting on plugin actions"
+                    );
                 }
                 // Give the plugin thread time to actually run the
                 // queued action(s) before re-checking. This is
@@ -2716,8 +2722,15 @@ impl EditorTestHarness {
     /// the ~50ms real sleep per tick this is a window of genuine silence.
     pub fn wait_for_async_quiescence(&mut self, idle_ticks: usize) -> anyhow::Result<()> {
         const WAIT_SLEEP: std::time::Duration = std::time::Duration::from_millis(50);
-        // Bound the wait so a genuinely stuck pipeline fails loudly instead of
-        // hanging the suite. Matches the spirit of the other wait_* helpers.
+        // Unlike `drain_async_work`'s wait for a pending action — which is a
+        // state change that must arrive, and so waits indefinitely — silence
+        // is not guaranteed to come at all: a terminal's PTY output and
+        // timer-driven plugin polls keep the pipeline legitimately busy
+        // forever (see `terminal.rs`, which waits here). So this stays
+        // bounded, and gives up out loud: a caller that wanted quiescence
+        // and got the bound instead is about to assert against a frame the
+        // plugin has not caught up to, and must be able to see that in the
+        // output rather than infer it from a puzzling assertion.
         const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
 
         let start = std::time::Instant::now();
@@ -2733,6 +2746,20 @@ impl EditorTestHarness {
             std::thread::sleep(WAIT_SLEEP);
             self.advance_time(WAIT_SLEEP);
             if start.elapsed() > MAX_WAIT {
+                // stderr, not just tracing: CI runs with tracing disabled,
+                // and this is the only channel that survives into a
+                // failed/killed test's output.
+                eprintln!(
+                    "wait_for_async_quiescence: pipeline still busy after {:.1}s — \
+                     giving up short of {idle_ticks} idle ticks. The next assertion \
+                     may observe a frame the plugin has not caught up to.",
+                    start.elapsed().as_secs_f64()
+                );
+                tracing::warn!(
+                    idle_ticks,
+                    elapsed_s = start.elapsed().as_secs_f64(),
+                    "wait_for_async_quiescence gave up before the pipeline went quiet"
+                );
                 break;
             }
         }

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -425,12 +425,26 @@ fn test_quick_open_goto_line_live_preview_mouse_click_commits() {
 
     // The pre-preview snapshot (line 1) must NOT overwrite the click target
     // (line 78) — status bar must report line 78 after the prompt closes.
+    //
+    // Wait for the status bar to report *a* line, then assert which one,
+    // rather than waiting for line 78 itself. The click and the Esc are both
+    // fully dispatched by the time we get here, so the cursor's line is
+    // already decided: if the click did not land where this test intends —
+    // absorbed by the suggestion popup's outer rect, or a row off — the
+    // status bar will say so on its first frame and no later frame will
+    // change it. Waiting on "Ln 78," in that case is a wait for a state that
+    // can no longer arrive, i.e. a 180 s nextest timeout with no failed
+    // assertion to point at (CONTRIBUTING Code §16); this way the same
+    // failure names the line the cursor actually ended on.
     harness
-        .wait_until(|h| h.screen_to_string().contains("Ln 78,"))
-        .expect(
-            "Cursor should stay on the clicked line 78 — pre-preview snapshot must be \
-             dropped on editor click",
-        );
+        .wait_until(|h| h.screen_to_string().contains(", Col "))
+        .expect("Status bar should be visible once the prompt closes");
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 78,"),
+        "Cursor should stay on the clicked line 78 — pre-preview snapshot must be \
+         dropped on editor click; screen:\n{screen}"
+    );
 }
 
 /// A buffer edit that shifts the cursor via `adjust_for_edit` while the

--- a/crates/fresh-editor/tests/e2e/dock_switch_wipes_outgoing_window.rs
+++ b/crates/fresh-editor/tests/e2e/dock_switch_wipes_outgoing_window.rs
@@ -19,7 +19,6 @@
 //! is caught mid-transition or after it settles.
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
-use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 use std::fs;
 use std::path::PathBuf;
@@ -52,14 +51,14 @@ fn setup_projects() -> (tempfile::TempDir, PathBuf) {
 
 /// Toggle the dock open via the command palette and wait for it to render
 /// *and* take keyboard focus (the plugin sets focus asynchronously).
+///
+/// `run_palette_command` rather than type-then-Enter: the palette rebuilds
+/// its suggestion list only on input change, so a command the orchestrator
+/// plugin has not registered yet never appears and never will. Enter would
+/// then fire on some other row and the focus wait below would block for
+/// good — the helper retypes until the row is really listed.
 fn open_dock(h: &mut EditorTestHarness) {
-    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    h.wait_for_prompt().unwrap();
-    h.type_text("Orchestrator: Toggle Dock").unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
-        .unwrap();
-    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.run_palette_command("Orchestrator: Toggle Dock").unwrap();
     h.wait_until(|h| h.screen_to_string().contains("Orchestrator") && h.editor().is_dock_focused())
         .unwrap();
 }
@@ -84,15 +83,10 @@ fn col_of(screen: &str, needle: &str) -> Option<u16> {
 }
 
 /// Open the file explorer in the active window through the command
-/// palette, and wait for its tree to carry the marker directory.
+/// palette, and wait for its tree to carry the marker directory. Same
+/// reason as `open_dock` for going through `run_palette_command`.
 fn open_explorer(h: &mut EditorTestHarness) {
-    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
-        .unwrap();
-    h.wait_for_prompt().unwrap();
-    h.type_text("Toggle File Explorer").unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("Toggle File Explorer"))
-        .unwrap();
-    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.run_palette_command("Toggle File Explorer").unwrap();
     h.wait_until(|h| h.screen_to_string().contains("zzbetaonly"))
         .unwrap();
 }
@@ -176,7 +170,13 @@ fn dock_switch_never_paints_two_workspaces_into_one_frame() {
     // explorer. Only this workspace has a sidebar.
     let beta_row = row_of(&h, "betaws");
     h.mouse_click(3, beta_row).unwrap();
-    h.wait_until(|h| !h.screen_to_string().contains("AAAA"))
+    // A row click both switches window and hands keyboard focus back to
+    // the editor, and the plugin issues those as separate commands. The
+    // sentinel below has to be typed into betaws' buffer, so wait for the
+    // focus half too — typed into a still-focused dock it would land in
+    // the session filter, where it is on screen (as the filter's own
+    // echo) without ever reaching a buffer.
+    h.wait_until(|h| !h.screen_to_string().contains("AAAA") && !h.editor().is_dock_focused())
         .unwrap();
     h.type_text("BBBB").unwrap();
     h.wait_until(|h| h.screen_to_string().contains("BBBB"))

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -126,15 +126,7 @@ fn comments_in_fenced_code_blocks_are_not_headings() {
         .expect("the one real `# Install` heading should be marked");
     // Let any marks for the 40 `#` comment lines have their chance to appear
     // before asserting that they don't.
-    let mut settle = usize::MAX;
-    harness
-        .wait_until_stable(|h| {
-            let n = marker_rows(h).len();
-            let stable = n == settle;
-            settle = n;
-            stable
-        })
-        .unwrap();
+    harness.wait_for_async_quiescence(8).unwrap();
 
     let (first, _) = harness.content_area_rows();
     assert_eq!(
@@ -199,15 +191,7 @@ fn only_top_level_headings_are_marked_by_default() {
         .expect("the `#` heading should be marked");
     // Give any deeper-level marks the same chance to appear before asserting
     // that they don't.
-    let mut settle = usize::MAX;
-    harness
-        .wait_until_stable(|h| {
-            let n = marker_rows(h).len();
-            let stable = n == settle;
-            settle = n;
-            stable
-        })
-        .unwrap();
+    harness.wait_for_async_quiescence(8).unwrap();
 
     let (first, _) = harness.content_area_rows();
     assert_eq!(
@@ -231,7 +215,23 @@ fn heading_marks_survive_exploring_the_document() {
     harness
         .wait_until(|h| !marker_rows(h).is_empty())
         .expect("initial heading marks");
+    // The first mark is not the whole set: compose mode's pre-scan walks the
+    // document over the async plugin bridge (see
+    // `every_heading_is_marked_without_scrolling`), so the marks arrive over
+    // several ticks. Reading the set on the frame the first mark lands
+    // compares a partial set against the complete one later — a scroll that
+    // "added" marks is how this test failed on CI, with an `initial` of two
+    // rows against an `after` of eighteen. Wait for the plugin pipeline
+    // itself to go quiet; a screen-stability streak does not do, because a
+    // plugin thread that has fallen behind emits identical stale frames.
+    harness.wait_for_async_quiescence(8).unwrap();
     let initial = marker_rows(&harness);
+    assert!(
+        initial.len() >= 10,
+        "the pre-scan should have marked the whole document before scrolling \
+         starts, otherwise this test compares two partial sets and proves \
+         nothing; saw {initial:?}"
+    );
 
     // Page down through the document so later sections enter the viewport,
     // letting the plugin's marks settle after each page.
@@ -239,16 +239,9 @@ fn heading_marks_survive_exploring_the_document() {
         harness
             .send_key(KeyCode::PageDown, KeyModifiers::NONE)
             .unwrap();
-        let mut prev = usize::MAX;
-        harness
-            .wait_until_stable(|h| {
-                let n = marker_rows(h).len();
-                let stable = n == prev;
-                prev = n;
-                stable
-            })
-            .unwrap();
+        harness.wait_for_async_quiescence(4).unwrap();
     }
+    harness.wait_for_async_quiescence(8).unwrap();
 
     // Each batch republishes only its own byte span, so the marks for the
     // sections scrolled past are left alone. With a whole-namespace replace

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -1010,6 +1010,42 @@ fn trigger_git_log(harness: &mut EditorTestHarness) {
     harness.wait_for_screen_contains("switch pane").unwrap();
 }
 
+/// Just the log pane: everything left of the vertical split divider.
+///
+/// The detail pane on the right renders `git show` output, which repeats
+/// the commit's own subject line, so a whole-screen match for a commit
+/// subject finds it there as readily as in the list.
+fn log_pane_of(harness: &EditorTestHarness) -> String {
+    harness
+        .screen_to_string()
+        .lines()
+        .map(|l| l.split('│').next().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Wait until the log pane is *usable*: chrome up **and** commit rows
+/// rendered, `subject` being one the log is known to contain.
+///
+/// The toolbar and the commit list are two widget panels, mounted by two
+/// separate host calls with the plugin building the row entries in
+/// between, so a frame can be painted with the toolbar up and the list
+/// still empty — measurably so: on a 200-commit log the list lands two to
+/// three ticks after the toolbar, and the gap only shrinks (it does not
+/// close) as the log gets shorter. `trigger_git_log` waits for the toolbar
+/// ("Tab switch pane"), which therefore says nothing about the rows, and
+/// waiting for it a second time is satisfied the instant it is checked.
+/// Anything that reads a row — or sends a key meant to move among them —
+/// has to wait for a row.
+fn wait_for_git_log_rows(harness: &mut EditorTestHarness, subject: &str) {
+    let subject = subject.to_string();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string().contains("switch pane") && log_pane_of(h).contains(&subject)
+        })
+        .unwrap();
+}
+
 /// Test git log opens and shows commits
 #[test]
 fn test_git_log_shows_commits() {
@@ -1032,13 +1068,8 @@ fn test_git_log_shows_commits() {
     // Trigger git log
     trigger_git_log(&mut harness);
 
-    // Wait for git log to load (sticky toolbar + at least one commit subject)
-    harness
-        .wait_until(|h| {
-            let screen = h.screen_to_string();
-            screen.contains("switch pane") && screen.contains("Initial commit")
-        })
-        .unwrap();
+    // Wait for git log to load: sticky toolbar *and* the commit rows.
+    wait_for_git_log_rows(&mut harness, "Initial commit");
 
     let screen = harness.screen_to_string();
     println!("Git log screen:\n{screen}");
@@ -1134,10 +1165,10 @@ fn test_git_log_show_commit_detail() {
     // Trigger git log
     trigger_git_log(&mut harness);
 
-    // Wait for git log to load
-    harness
-        .wait_until(|h| h.screen_to_string().contains("switch pane"))
-        .unwrap();
+    // Wait for git log to load. The rows have to be up before the keys
+    // below: sent at an empty log buffer they move no cursor and open no
+    // commit, and the waits that follow would hang rather than fail.
+    wait_for_git_log_rows(&mut harness, "Initial commit");
 
     // Move cursor to a commit line (down from header)
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
@@ -1273,10 +1304,10 @@ fn test_git_log_diff_coloring() {
     // Trigger git log
     trigger_git_log(&mut harness);
 
-    // Wait for git log to load
-    harness
-        .wait_until(|h| h.screen_to_string().contains("switch pane"))
-        .unwrap();
+    // Wait for git log to load. The rows have to be up before the keys
+    // below: sent at an empty log buffer they move no cursor and open no
+    // commit, and the waits that follow would hang rather than fail.
+    wait_for_git_log_rows(&mut harness, "Initial commit");
 
     // Move to the commit and show detail
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
@@ -1498,16 +1529,12 @@ fn test_git_log_keyboard_scroll_follows_selection() {
     .unwrap();
 
     trigger_git_log(&mut harness);
-    harness
-        .wait_until(|h| h.screen_to_string().contains("switch pane"))
-        .unwrap();
 
-    // HEAD (scrollcommit-30) is selected and its row sits at the top of
-    // the pane — visible before any scrolling.
-    assert!(
-        harness.screen_to_string().contains("scrollcommit-30"),
-        "newest commit's row should be visible at the top on open"
-    );
+    // HEAD (scrollcommit-30) is selected on open and its row sits at the
+    // top of the pane, so waiting for that row *is* the precondition the
+    // walk below needs — and it is a precondition to wait for rather than
+    // to assert on: see `wait_for_git_log_rows`.
+    wait_for_git_log_rows(&mut harness, "scrollcommit-30");
 
     // Walk the selection all the way to the oldest commit.
     for _ in 0..(total - 1) {
@@ -1523,17 +1550,12 @@ fn test_git_log_keyboard_scroll_follows_selection() {
         })
         .unwrap();
 
-    // Inspect only the log pane — the column left of the vertical split
-    // divider. The detail pane on the right shows the *previously opened*
-    // commit's diff (its `git show` is async and lags the synchronous
-    // selection), so a whole-screen match would spuriously find the
-    // newest commit's subject there.
+    // Inspect only the log pane: the detail pane on the right shows the
+    // *previously opened* commit's diff (its `git show` is async and lags
+    // the synchronous selection), so a whole-screen match would spuriously
+    // find the newest commit's subject there.
     let screen = harness.screen_to_string();
-    let log_pane: String = screen
-        .lines()
-        .map(|l| l.split('│').next().unwrap_or(""))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let log_pane = log_pane_of(&harness);
 
     // The discriminating check: the newest commit's row must have
     // scrolled off the top. If the viewport never followed the selection
@@ -1651,9 +1673,8 @@ fn test_git_log_cursor_line_matches_selected_commit() {
     .unwrap();
 
     trigger_git_log(&mut harness);
-    harness
-        .wait_until(|h| h.screen_to_string().contains("switch pane"))
-        .unwrap();
+    // The rows have to be up before the cursor keys below.
+    wait_for_git_log_rows(&mut harness, "linecommit-08");
 
     // HEAD starts on row 1. Move the cursor down three rows.
     for _ in 0..3 {

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1794,15 +1794,40 @@ fn test_issue2036_refresh_shows_immediate_feedback() {
     // Press `r` once. The very next render must already carry the
     // refresh-in-flight marker — that is the user's only signal that the
     // keystroke landed before the async git calls complete.
+    //
+    // Straight through `Editor::handle_key`, not `send_key`: the harness's
+    // key path drains async work to a fixed point before it returns, and
+    // for this plugin that means the whole `git status` + `git diff` chain.
+    // The refresh would then be over — final status on the status bar,
+    // new lines in the diff — before the first frame this test can look
+    // at, and the wait below would sit forever on a message that had
+    // already been overwritten. That is how this test timed out on CI: the
+    // 10s screen dumps showed the refreshed diff and `Review Diff: 1
+    // hunks` while the wait was still looking for "refreshing".
     harness
-        .send_key(KeyCode::Char('r'), KeyModifiers::NONE)
+        .editor_mut()
+        .handle_key(KeyCode::Char('r'), KeyModifiers::NONE)
         .unwrap();
+
+    // Watch the frames from the keypress on, and stop as soon as either
+    // the feedback shows or the refreshed diff lands without it — never
+    // keep waiting for a state that can no longer arrive. "extra line
+    // three" is one of the lines appended above, so it is on screen only
+    // once the refresh has picked the file change up.
+    let mut saw_feedback = false;
     harness
         .wait_until(|h| {
             let s = h.screen_to_string().to_lowercase();
-            s.contains("refreshing")
+            saw_feedback |= s.contains("refreshing");
+            saw_feedback || s.contains("extra line three")
         })
         .unwrap();
+    assert!(
+        saw_feedback,
+        "`r` must acknowledge the keypress before the async refresh lands; \
+         the refreshed diff appeared with no refresh-in-flight status ever \
+         rendered"
+    );
 
     // The refresh should ultimately complete and the post-refresh status
     // summary (the existing "Review Diff: N hunks" message) should land.


### PR DESCRIPTION
## Why

`view::ui::split_rendering::scrollbar_marker_scroll_perf` was flaky:

```
headingless scroll: total 13.767818ms, first-decile frame 11.195µs, last-decile frame 96.275µs
panicked at scrollbar_marker_scroll_perf.rs:267:
with no markers accumulating, late frames should cost about what early ones do;
first decile 11.195µs, last decile 96.275µs
```

Every assertion in the file compared ratios of `Instant::elapsed()` durations, so it measured the machine and the test runner as much as the editor. At these magnitudes — means over 50 frames, each a few microseconds — a bit of preemption while the other ~8 800 tests run in parallel flips the ratio with nothing about the editor having changed. CONTRIBUTING's testing rule 3 asks for tests that aren't time-sensitive.

Both O(M) terms the file is about are countable, and the counters were already there — `ProjectionStats`, whose doc even says it is kept per-buckets "so concurrent tests (and split panes) observe only their own work".

## What changed

Same four tests, same claims, counted instead of timed:

- **publish** — `set_markers_in_range`'s retain sweeps the namespace it starts from, so `scrollbar_markers.len()` before the call *is* what that publish costs.
- **projection** — `scrollbar_marker_buckets.stats()` reports `markers_walked` and `rebuilds` per frame.

The claims came out sharper rather than weaker:

| test | was | now (exact, every run) |
|---|---|---|
| first pass grows with accumulated markers | last decile > 4× first | `rebuilds == frames` (500), decile ratio 1900/100 = **19×** |
| second pass is free | total × 10 < first total | rebuilds **0**, markers touched **0** |
| headingless scroll is flat *(the flaky one)* | last decile < 4× first | worst frame == 2 == best frame, for 1 heading |
| cost is superlinear in length | large > small × 2 | 500 000 vs 125 000 — exactly **4×** for 2× the document |

`std::time` is gone from the file. The absolute release-build timings it had recorded stay in the module docs, where they document scale without deciding whether the suite is green, next to a note on why the assertions count.

## Testing

- `cargo test -p fresh-editor --lib scrollbar_marker_scroll_perf` — 4 passed, run 5× with identical numbers each time, 1.06–1.10 s total.
- `cargo fmt --check` clean; `cargo clippy -p fresh-editor --all-targets` reports nothing for this file.

## Not in scope

`tests/e2e/markdown_compose_scroll_perf.rs::heading_marks_are_not_the_reason` still asserts on wall-clock (`control.render_total() * 2 > marked.render_total()`). Unlike the cases above, that claim — removing the marks doesn't materially change the cost of a first scroll — is inherently about time and has no counted equivalent; the counted half of that test is already asserted on the line above it. It is also one-sided, so it only fails if the marked run comes out 2× slower. Left alone, worth watching if it ever goes red.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZLRg1CXQuBzUSEEofma39)_