### PR TITLE
fix(highlight): give a parse checkpoint the state that belongs to its own position

### DIFF
--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1347,11 +1347,22 @@ impl TextMateEngine {
             current_offset += line_byte_len;
             bytes_since_checkpoint += line_byte_len;
 
-            // Check convergence at checkpoint markers
+            // Check convergence at checkpoint markers. `snapshot` is now the
+            // state *after* this line, which is the state *before* the next
+            // one — so it is the right state for a checkpoint at any position
+            // up to and including this line's end, and the wrong one for a
+            // checkpoint sitting on this line's start. That checkpoint was
+            // already settled by the previous line's pass with the state that
+            // belongs to it (see `full_parse` for the same rule); walk past it
+            // rather than comparing — or storing — a state one line late.
+            let line_start = current_offset - line_byte_len;
             while marker_idx < markers_ahead.len() && markers_ahead[marker_idx].1 <= current_offset
             {
-                let (marker_id, _) = markers_ahead[marker_idx];
+                let (marker_id, marker_pos) = markers_ahead[marker_idx];
                 marker_idx += 1;
+                if marker_pos <= line_start {
+                    continue;
+                }
                 if let Some(stored) = self.checkpoint_states.get(&marker_id) {
                     if *stored == snapshot {
                         self.stats.convergences += 1;
@@ -1695,13 +1706,32 @@ impl TextMateEngine {
                 safe_snapshot = snapshot.clone();
             }
 
-            // Update checkpoint states as we pass them. Done after the
-            // line is parsed (state now reflects end-of-line) so a
-            // checkpoint placed at the line's start position carries
-            // the state at that position, ready to feed the next line.
+            // Update checkpoint states as we pass them. A checkpoint at
+            // position `p` stores the state *before* `p` — that is the
+            // contract every resume path relies on
+            // (`find_parse_resume_point`, `try_partial_update`,
+            // `structure_lines_in` all parse the line at `p` starting from
+            // it), so the state to store is the one that reflects
+            // everything up to but not including `p`.
+            //
+            // The range is therefore half-open at the *low* end
+            // (`query_range` is inclusive both ways): a checkpoint sitting on
+            // this line's start must keep the state it was given at the end of
+            // the previous line, not the state that includes this line. Giving
+            // it the end-of-line state shifts it one line late, and resuming
+            // from it re-parses the line with the state that follows it — for
+            // Markdown that inverts fence parity at a delimiter line, so every
+            // prose line below a code block reads as fence body until the next
+            // delimiter (issue: prose framed as code after scrolling into a
+            // file mid-document).
             let markers_here: Vec<(MarkerId, usize)> = self
                 .checkpoint_markers
-                .query_range(current_offset.saturating_sub(line_byte_len), current_offset)
+                .query_range(
+                    current_offset
+                        .saturating_sub(line_byte_len)
+                        .saturating_add(1),
+                    current_offset,
+                )
                 .into_iter()
                 .map(|(id, start, _)| (id, start))
                 .collect();
@@ -2833,6 +2863,82 @@ mod tests {
             !roles.is_empty() && roles.iter().all(|(_, r)| *r == RegionLine::Body),
             "with the fence no longer closed, the lines below must read as \
              region body, not as the pre-edit prose; got {roles:?}"
+        );
+    }
+
+    /// A checkpoint stores the state *before* its position — every resume path
+    /// (`find_parse_resume_point`, `try_partial_update`, `structure_lines_in`)
+    /// parses the line at that position starting from it. `full_parse` used to
+    /// overwrite a checkpoint sitting on a line start with the state *after*
+    /// that line, so resuming from it re-parsed the line under the state that
+    /// follows it.
+    ///
+    /// On a Markdown fence delimiter that inverts parity: the closing ```
+    /// re-read from "outside" *opens* a region, and every prose line below the
+    /// code block reads as fence body. Compose mode then frames that prose as
+    /// code — visible when a file is opened mid-document, because the viewport
+    /// starts below the poisoned checkpoint and only recovers once it scrolls
+    /// above it.
+    #[test]
+    fn test_checkpoint_state_belongs_to_its_own_position() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("README.md"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        // Sized so the closing fence starts at exactly CHECKPOINT_INTERVAL:
+        // the opening line is 8 bytes and each code line 31, so eight of them
+        // put the walk at 256 and the checkpoint lands on the delimiter — the
+        // one line where a state one line late changes what the parse means.
+        let mut content = String::from("```bash\n");
+        for _ in 0..8 {
+            content.push_str(&format!("echo {}\n", "x".repeat(25)));
+        }
+        assert_eq!(content.len(), CHECKPOINT_INTERVAL);
+        let close_fence = content.len();
+        content.push_str("```\n\n");
+        let prose_start = content.len();
+        for i in 0..12 {
+            content.push_str(&format!("prose line {i} with a `code` span in it\n"));
+        }
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+
+        // The cold probe walks from byte 0, so it is the ground truth.
+        let cold = engine.region_lines_in(&buffer, 0..buffer.len());
+        assert_eq!(
+            cold.last().map(|(byte, role)| (*byte, *role)),
+            Some((close_fence, RegionLine::Close)),
+            "precondition: the fence closes and nothing below it is a region"
+        );
+
+        // The highlight pass that runs on the same frame lays down checkpoints
+        // — one of them on the closing delimiter, by the sizing above.
+        engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        // Every viewport the file can be opened at must read the document the
+        // same way, whichever checkpoint it resumes from.
+        for (line_start, _) in content.match_indices('\n').map(|(i, _)| (i + 1, ())) {
+            if line_start >= buffer.len() {
+                break;
+            }
+            let expected: Vec<_> = cold
+                .iter()
+                .filter(|(byte, _)| *byte >= line_start)
+                .copied()
+                .collect();
+            assert_eq!(
+                engine.region_lines_in(&buffer, line_start..buffer.len()),
+                expected,
+                "probe from byte {line_start} disagrees with the cold walk"
+            );
+        }
+
+        // The symptom itself: prose below the block is not code.
+        assert!(
+            engine
+                .region_lines_in(&buffer, prose_start..buffer.len())
+                .is_empty(),
+            "prose after the closed fence must not read as fence body"
         );
     }
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_code_frame.rs
@@ -499,3 +499,109 @@ fn breaking_a_closing_fence_reframes_the_lines_below_it() {
         "and so does the delimiter that stopped closing.\nScreen:\n{screen}"
     );
 }
+
+/// A prose line of exactly `bytes` bytes, newline included.
+///
+/// The exact sizing is the point: the highlighter drops a parse checkpoint
+/// every `CHECKPOINT_INTERVAL` (256) bytes, at the first line start past that
+/// many bytes, and the test below needs one to land on a fence delimiter.
+fn sized_line(prefix: &str, bytes: usize) -> String {
+    let mut line = prefix.to_string();
+    while line.len() < bytes - 1 {
+        line.push_str(" filler");
+    }
+    line.truncate(bytes - 1);
+    line.push('\n');
+    line
+}
+
+/// Opening a file part-way down and scrolling up must not frame prose as code.
+///
+/// A viewport that starts mid-document reads the region structure by resuming
+/// from the nearest parse checkpoint above it rather than from the top of the
+/// file. A checkpoint stores the state *before* its own position; one that
+/// landed on a fence delimiter used to store the state from *after* that line,
+/// so resuming there re-parsed a closing ``` as an opening one and every prose
+/// line below the block reported as fence body — framed, rails and all, with
+/// its inline markup left literal. It cleared only once the view scrolled above
+/// the poisoned checkpoint, which is exactly the "scroll up far enough and it
+/// fixes itself" shape of the report.
+#[test]
+fn prose_below_a_block_is_not_framed_when_the_view_starts_mid_document() {
+    // 256 bytes of prose, then a 256-byte block: the second checkpoint lands
+    // on the block's closing delimiter.
+    let mut md = String::new();
+    for i in 0..4 {
+        md.push_str(&sized_line(&format!("Intro line {i}"), 64));
+    }
+    assert_eq!(md.len(), 256, "preamble must fill exactly one interval");
+    md.push_str("```bash\n");
+    for _ in 0..8 {
+        md.push_str(&format!("echo {}\n", "x".repeat(25)));
+    }
+    assert_eq!(
+        md.len(),
+        512,
+        "closing fence must start on the next interval"
+    );
+    md.push_str("```\n\n");
+    for i in 0..40 {
+        md.push_str(&sized_line(&format!("Prose {i} with a `code` span"), 64));
+        md.push('\n');
+    }
+    // Markup-free last line, so parking the cursor at the end of the buffer
+    // never reveals the raw markup of a line the assertions read.
+    md.push_str("TAIL MARKER\n");
+
+    let (mut harness, _tmp) = compose_harness(&md);
+    harness
+        .wait_until(|h| h.screen_to_string().contains('┌'))
+        .expect("the block should frame");
+
+    // Jump to the end: the prose below the block is now first drawn — and so
+    // first classified — with the viewport well past that checkpoint, the way
+    // it is when a file is opened at a line in the middle.
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
+
+    // Walk back up a notch at a time, checking every intermediate view. The
+    // document's first line coming into view is the signal that the sweep has
+    // covered every position the viewport can start from.
+    let mut reached_top = false;
+    for _ in 0..120 {
+        let screen = harness.screen_to_string();
+        for row in screen.lines().filter(|l| l.contains("Prose ")) {
+            assert!(
+                !row.contains('│') && !row.contains('┌') && !row.contains('└'),
+                "prose below the code block must not be framed as code; row \
+                 was {row:?}.\nScreen:\n{screen}"
+            );
+            assert!(
+                !row.contains('`'),
+                "prose below the code block keeps its inline markup concealed \
+                 — literal backticks mean it was read as code; row was \
+                 {row:?}.\nScreen:\n{screen}"
+            );
+        }
+        reached_top = screen.contains("Intro line 0");
+        if reached_top {
+            break;
+        }
+        harness.mouse_scroll_up(10, 10).unwrap();
+        harness.wait_for_async_quiescence(4).unwrap();
+    }
+
+    assert!(
+        reached_top,
+        "the sweep must reach the top of the document, so the window where the \
+         stale checkpoint was the nearest anchor is covered"
+    );
+    let screen = harness.screen_to_string();
+    assert_eq!(
+        tops(&screen).len(),
+        1,
+        "back at the top, the one real block still frames.\nScreen:\n{screen}"
+    );
+}


### PR DESCRIPTION
Fixes #3001.

## The bug

The highlighter drops a parse checkpoint every `CHECKPOINT_INTERVAL` (256) bytes so a viewport that starts part-way down a file can resume from the nearest one instead of re-parsing from byte 0. A checkpoint at byte `p` is resumed from by parsing the line *at* `p`, so the state it stores must be the state **before** `p`.

Two paths stored the state from one line later:

* `full_parse` refreshed "checkpoints we just passed" with `query_range(line_start, line_end)` after parsing the line. `MarkerList::query_range` is inclusive at both ends, so a checkpoint sitting on the line's *start* — which is where `maybe_create_checkpoint` puts every checkpoint it creates — was overwritten with the end-of-line state.
* `try_partial_update` consumed its convergence markers with `pos <= current_offset` after the same advance, so a marker on the line start was compared against, and then stored with, that same one-line-late state.

For most grammars the two states differ harmlessly. On a Markdown fence delimiter it inverts parity: resuming at a closing ` ``` ` from the "outside a region" state re-reads it as an *opening* fence, so every line below the code block classifies as fence body until the next delimiter.

That classification is what compose mode frames blocks from (`structure_lines_in` → `line.region` → `markdown_compose`), so the prose under a code block renders as a framed, railed code block with its inline markup left literal. It only shows when the viewport starts below the poisoned checkpoint — opening a file at a line in the middle — and clears once the view scrolls above it, which is the "scroll up far enough and it fixes itself" shape of the report.

On `README.md`, probing the region structure with the viewport top on lines 109–113 reported lines 110–144 as fence body; from line 108 up it reported the truth.

## The fix

Both sites now leave a checkpoint on the current line's start alone. It was already given the right state by the previous line's pass (a line start is the previous line's end), so skipping it is enough — no extra bookkeeping, and the `line_end` case, which is the one this loop exists for, is unchanged.

## Tests

* `test_checkpoint_state_belongs_to_its_own_position` (unit) — a document sized so a checkpoint lands exactly on a fence's closing delimiter; every probe position must agree with the cold walk from byte 0. Without the fix it reports `(256, Open)` plus fence body for all the prose below, against an expected `(256, Close)`.
* `prose_below_a_block_is_not_framed_when_the_view_starts_mid_document` (e2e, rendered output only) — jumps to the end of such a document, then wheel-scrolls back to the top asserting no prose row ever carries a frame glyph or a literal backtick. Without the fix it fails on a row rendered as `│ Prose 3 with a `code` span filler … │`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cg7xud2hDYHyuRHGEQpDx

---
_Generated by [Claude Code](https://claude.ai/code/session_013cg7xud2hDYHyuRHGEQpDx)_