### PR TITLE
review-diff: stop making the reader wait a frame, or a second

### DIFF
--- a/crates/fresh-core/Cargo.toml
+++ b/crates/fresh-core/Cargo.toml
@@ -9,7 +9,12 @@ homepage.workspace = true
 description = "Core types and utilities for the Fresh editor"
 
 [dependencies]
-serde.workspace = true
+# `rc` teaches serde to (de)serialize `Arc<T>`. `EditorStateSnapshot` shares
+# each buffer's text properties as `Arc<[TextProperty]>` rather than copying
+# them per tick, and the snapshot derives Serialize/Deserialize — without
+# this feature the crate only builds when something else in the graph turns
+# `rc` on, which is why building `fresh-core` on its own broke.
+serde = { workspace = true, features = ["rc"] }
 serde_json.workspace = true
 schemars.workspace = true
 anyhow.workspace = true

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3041,6 +3041,20 @@ pub enum PluginCommand {
         handle: OverlayHandle,
     },
 
+    /// Declare a one-line overlay that follows the buffer's cursor, or
+    /// withdraw it with `None`.
+    ///
+    /// The host re-places it from the cursor as part of drawing the frame,
+    /// so it marks the row the caret is on in that same frame. A plugin
+    /// painting the bar itself from `cursor_moved` cannot manage that: the
+    /// hook fires after the move, so its `addOverlay` lands one frame late
+    /// and the bar trails the caret for as long as an arrow key repeats.
+    SetCursorLineOverlay {
+        buffer_id: BufferId,
+        /// Styling, exactly as `AddOverlay` takes it. `None` removes the bar.
+        options: Option<OverlayOptions>,
+    },
+
     /// Set status message
     SetStatus { message: String },
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2403,9 +2403,14 @@ function markStreamDirty(): void {
 
 /** What the content currently in the stream buffer was built from. The
  *  focused file is part of it because the composite's stand-in stream
- *  carries only that file's body (`fileBodyRendered`). */
+ *  carries only that file's body (`fileBodyRendered`), and the panel's
+ *  width because inline comment boxes are wrapped to it. */
 function streamSignature(): string {
-    return `${state.streamRevision}|${state.focusOnly ? state.filesCurrentKey : '*'}`;
+    return [
+        state.streamRevision,
+        state.focusOnly ? state.filesCurrentKey : '*',
+        diffPanelWidth(),
+    ].join('|');
 }
 
 /**
@@ -2815,18 +2820,25 @@ function jumpToComment(commentId: string): void {
  *  content catches up the moment the pointer settles. */
 const PANEL_RELAYOUT_DEBOUNCE_MS = 60;
 
-const panelRelayoutTimers: { files: number | null; comments: number | null } = {
+const panelRelayoutTimers: { files: number | null; comments: number | null; diff: number | null } = {
     files: null,
     comments: null,
+    diff: null,
+};
+
+const RELAYOUT_HANDLERS: Record<'files' | 'comments' | 'diff', string> = {
+    files: "review_relayout_files",
+    comments: "review_relayout_comments",
+    diff: "review_relayout_diff",
 };
 
 /** Repaint `panel` once its size stops changing. */
-function schedulePanelRelayout(panel: 'files' | 'comments'): void {
+function schedulePanelRelayout(panel: 'files' | 'comments' | 'diff'): void {
     const pending = panelRelayoutTimers[panel];
     if (pending !== null) editor.clearInterval(pending);
     panelRelayoutTimers[panel] = editor.setTimeout(
         PANEL_RELAYOUT_DEBOUNCE_MS,
-        panel === 'files' ? "review_relayout_files" : "review_relayout_comments",
+        RELAYOUT_HANDLERS[panel],
     );
 }
 
@@ -2843,6 +2855,18 @@ function review_relayout_comments(): void {
     renderCommentsPanel();
 }
 registerHandler("review_relayout_comments", review_relayout_comments);
+
+/** The stream's inline comment boxes are wrapped to the diff panel's
+ *  width, so a width the layout did not know about leaves them the wrong
+ *  shape. Re-render once the width settles — the signature check inside
+ *  `mountStreamContent` makes this a no-op when the width is what the
+ *  content was already built to. */
+function review_relayout_diff(): void {
+    panelRelayoutTimers.diff = null;
+    if (state.groupId === null || state.reviewLayout === 'side-by-side') return;
+    renderCenter();
+}
+registerHandler("review_relayout_diff", review_relayout_diff);
 
 function on_review_viewport_changed(data: { split_id: number; buffer_id: number; top_byte: number; top_line: number | null; width: number; height: number }): void {
     if (state.groupId === null) return;
@@ -2867,13 +2891,13 @@ function on_review_viewport_changed(data: { split_id: number; buffer_id: number;
     }
     if (data.buffer_id !== state.panelBuffers["diff"]) return;
     // Inline comment boxes are laid out to this width (see
-    // `diffPanelWidth`); the next center rebuild picks up a change — and
-    // marking the stream dirty is what makes sure there *is* one, since
-    // an otherwise-unchanged stream is now reused rather than re-emitted.
-    if (state.panelWidths["diff"] !== data.width) {
-        markStreamDirty();
-    }
+    // `diffPanelWidth`), so it is part of the stream's signature: record
+    // it synchronously, then re-render once the width settles. Dragging a
+    // divider walks through every intervening width and none of them is
+    // worth a layout of the whole stream.
+    const widthChanged = state.panelWidths["diff"] !== data.width;
     state.panelWidths["diff"] = data.width;
+    if (widthChanged) schedulePanelRelayout('diff');
     // Height too, so `refreshViewportDimensions` has an authoritative
     // size for the diff pane and never has to trust whichever split
     // happens to hold focus.

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -288,8 +288,38 @@ interface ReviewState {
     isUntracked: boolean;
     hunkLineMap: Array<{ oldStart: number; newStart: number }>;
   } | null;
+  // The composite for the file the reader left when they switched to the
+  // unified stream, kept alive instead of destroyed. Switching back is
+  // then a panel swap rather than two `git show` calls, two whole-file
+  // buffers over the IPC boundary and an alignment pass. `signature`
+  // records what it was built from (see `compositeSignature`), so a
+  // review that has changed underneath it rebuilds rather than showing
+  // the reader a stale file.
+  parkedComposite: {
+    fileKey: string;
+    compositeBufId: number;
+    oldBufId: number;
+    newBufId: number;
+    absPath: string;
+    isUntracked: boolean;
+    hunkLineMap: Array<{ oldStart: number; newStart: number }>;
+    signature: string;
+  } | null;
   // Monotonic token guarding async center rebuilds (file-nav spam / watch).
   centerBuildToken: number;
+  // Bumped whenever anything the unified stream is built from changes.
+  // The stream costs a second to lay out on a big review, and re-emitting
+  // an identical one is not free-but-invisible: the panel swaps to the
+  // stream buffer immediately and the content lands a beat later, so the
+  // reader watches the old scroll position sit there and then jump.
+  streamRevision: number;
+  // `streamSignature()` as of the content currently in the stream buffer,
+  // or null when nothing has been emitted into it yet.
+  streamMountedSignature: string | null;
+  // Bumped by `refreshMagitData` — i.e. when the underlying git data is
+  // re-read, which is the one thing a hunk-range signature cannot see
+  // (a file can change without moving any hunk boundary).
+  dataRevision: number;
 }
 
 const state: ReviewState = {
@@ -342,17 +372,29 @@ const state: ReviewState = {
   lineSelection: null,
   reviewLayout: 'unified',
   centerComposite: null,
+  parkedComposite: null,
   centerBuildToken: 0,
+  streamRevision: 0,
+  streamMountedSignature: null,
+  dataRevision: 0,
 };
 
 function fileKey(f: FileEntry): string { return `${f.path}\0${f.category}`; }
 function fileKeyOf(path: string, category: string): string { return `${path}\0${category}`; }
 
-// Theme colour for the synthetic "cursor line" highlight in the panel
-// buffers. Reintroduced after the per-line bg overlay was deleted from the
-// builders — `applyCursorLineOverlay` writes it on every cursor_moved event.
+// Theme colour for the "cursor line" bar in the panel buffers. The bar
+// itself is declared once (`setCursorLineOverlay`) and placed by the host
+// from the cursor of the frame being drawn; painting it here from
+// `cursor_moved` left it a row behind a held arrow key, because the hook
+// only fires after the frame that already moved the caret.
 const STYLE_SELECTED_BG: OverlayColorSpec = "editor.selection_bg";
-const CURSOR_LINE_NS = "review-cursor-line";
+
+/** Mode carried by the buffers the editor's own cursor moves in — the
+ *  unified stream and the side-by-side composite. Same keymap as
+ *  `review-mode`, except that cursor motion is bound straight to the
+ *  built-in actions instead of taking a round trip through this plugin
+ *  (see `DIFF_NATIVE_MOTION`). */
+const REVIEW_DIFF_MODE = "review-diff";
 
 // --- Refresh State ---
 
@@ -2349,12 +2391,30 @@ function onFilesTreeSelect(nodeKey: string): void {
     if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
 }
 
+/** Declare that the unified stream's content is out of date: the next
+ *  render of the stream has to lay it out again.
+ *
+ *  Every caller that changes what the stream says goes through
+ *  `updateMagitDisplay` or `applyFileFilter`, so those two mark it — a
+ *  layout flip, which changes only *which* view is mounted, does not. */
+function markStreamDirty(): void {
+    state.streamRevision++;
+}
+
+/** What the content currently in the stream buffer was built from. The
+ *  focused file is part of it because the composite's stand-in stream
+ *  carries only that file's body (`fileBodyRendered`). */
+function streamSignature(): string {
+    return `${state.streamRevision}|${state.focusOnly ? state.filesCurrentKey : '*'}`;
+}
+
 /**
  * Full refresh — rebuild all three panels. Called on data changes
  * (refreshMagitData, comment add/edit, note edit, resize). NOT called on
  * scroll: scrolling is handled natively by the editor in the panel buffers.
  */
 function updateMagitDisplay(): void {
+    markStreamDirty();
     refreshViewportDimensions();
     if (state.groupId === null) return;
     syncFocusMode();
@@ -2807,7 +2867,12 @@ function on_review_viewport_changed(data: { split_id: number; buffer_id: number;
     }
     if (data.buffer_id !== state.panelBuffers["diff"]) return;
     // Inline comment boxes are laid out to this width (see
-    // `diffPanelWidth`); the next center rebuild picks up a change.
+    // `diffPanelWidth`); the next center rebuild picks up a change — and
+    // marking the stream dirty is what makes sure there *is* one, since
+    // an otherwise-unchanged stream is now reused rather than re-emitted.
+    if (state.panelWidths["diff"] !== data.width) {
+        markStreamDirty();
+    }
     state.panelWidths["diff"] = data.width;
     // Height too, so `refreshViewportDimensions` has an authoritative
     // size for the diff pane and never has to trust whichever split
@@ -2840,24 +2905,23 @@ function rowFromByte(topByte: number): number {
 }
 
 /**
- * Repaint the synthetic "cursor line" highlight in the diff panel.
+ * Ask the host for the "cursor line" bar in the diff panel.
  *
- * The diff panel buffer is created with show_cursors=true so the editor
- * moves the cursor natively, but a single-line bg overlay on the cursor row
- * gives a much more visible "you are here" indicator than the bare caret —
- * which matches the magit-style aesthetic and is what the user expects.
+ * The panel buffer is created with show_cursors=true so the editor moves
+ * the cursor natively, but a single-line bg bar on the cursor row gives a
+ * much more visible "you are here" indicator than the bare caret — which
+ * matches the magit-style aesthetic and is what the user expects.
+ *
+ * Declared once, not repainted: the host re-derives the bar's row from the
+ * cursor of the frame it is drawing. Painting it here from `cursor_moved`
+ * instead left it one row behind for as long as an arrow key repeated —
+ * the hook only fires after the frame that already moved the caret, so
+ * every repaint answered the previous frame's cursor.
  */
-function applyCursorLineOverlay(panel: 'diff'): void {
-    const bufId = state.panelBuffers[panel];
+function declareCursorLineBar(): void {
+    const bufId = state.panelBuffers["diff"];
     if (bufId === undefined) return;
-    editor.clearNamespace(bufId, CURSOR_LINE_NS);
-    const offsets = state.diffLineByteOffsets;
-    if (offsets.length < 2) return;
-    const idx = Math.max(0, Math.min(state.diffCursorRow - 1, offsets.length - 2));
-    const start = offsets[idx];
-    const end = offsets[idx + 1];
-    if (end <= start) return;
-    editor.addOverlay(bufId, CURSOR_LINE_NS, start, end, {
+    editor.setCursorLineOverlay(bufId, {
         bg: STYLE_SELECTED_BG,
         extendToLineEnd: true,
     });
@@ -3314,7 +3378,6 @@ function review_visual_cancel() {
         const diffId = state.panelBuffers["diff"];
         if (diffId !== undefined) editor.clearNamespace(diffId, "review-line-selection");
     }
-    applyCursorLineOverlay('diff');
 }
 registerHandler("review_visual_cancel", review_visual_cancel);
 
@@ -3443,17 +3506,15 @@ function review_expand_all() {
 }
 registerHandler("review_expand_all", review_expand_all);
 
+// The diff panel's own mode binds ↑/↓ straight to the built-in motions
+// (see `DIFF_NATIVE_MOTION`), so these two run only for a keystroke that
+// arrived while a side panel held focus. The line-selection follow-up that
+// used to live here now hangs off `cursor_moved`, which sees every motion
+// including the native ones.
 function review_nav_up() {
     if (state.focusPanel === 'comments') { review_comments_select_prev(); return; }
     if (state.focusPanel === 'files') { filesKey("Up"); return; }
     editor.executeAction("move_up");
-    if (state.lineSelection) {
-        // executeAction has already moved the cursor; sync the selection.
-        // Ensure we don't extend out of the hunk.
-        const newRow = Math.max(1, state.lineSelection.endRow - 1);
-        state.lineSelection.endRow = newRow;
-        paintLineSelectionOverlay();
-    }
 }
 registerHandler("review_nav_up", review_nav_up);
 
@@ -3461,10 +3522,6 @@ function review_nav_down() {
     if (state.focusPanel === 'comments') { review_comments_select_next(); return; }
     if (state.focusPanel === 'files') { filesKey("Down"); return; }
     editor.executeAction("move_down");
-    if (state.lineSelection) {
-        state.lineSelection.endRow = state.lineSelection.endRow + 1;
-        paintLineSelectionOverlay();
-    }
 }
 registerHandler("review_nav_down", review_nav_down);
 
@@ -3927,6 +3984,11 @@ async function refreshMagitData() {
         state.hunks = await fetchDiffsForFiles(status.files);
     }
     state.diffCursorRow = 1;
+    // The hunks and files under every cached view have just been replaced.
+    // A hunk-range signature can miss a file whose content changed without
+    // moving a boundary, so re-reading the data is itself the invalidation.
+    state.dataRevision++;
+    discardParkedComposite();
     updateMagitDisplay();
     restoreCursorAfterRebuild();
     updateReviewStatus();
@@ -4427,16 +4489,18 @@ function contentToLines(content: string): string[] {
     return lines;
 }
 
-/** Build composite source-buffer entries from file content. The last line
- *  gets no trailing newline so the buffer's line count matches the number of
- *  real lines — otherwise a trailing '\n' adds a phantom empty line with no
+/** Build a composite source buffer's content from a file's text. Entries
+ *  are spans, not lines, so the whole file is one of them: the composite
+ *  reads its line numbers from the buffer itself (`getCompositeCursorInfo`)
+ *  and never from per-line properties, and shipping one span instead of
+ *  one per line is what a large file's side-by-side switch was paying for.
+ *
+ *  The trailing newline is dropped so the buffer's line count matches the
+ *  number of real lines — otherwise it adds a phantom empty line with no
  *  ViewLine, which logs "ViewLine missing" when scrolled to the bottom. */
 function contentToEntries(content: string): TextPropertyEntry[] {
-    const lines = contentToLines(content);
-    return lines.map((line, idx) => ({
-        text: idx < lines.length - 1 ? line + '\n' : line,
-        properties: { type: 'line', lineNum: idx + 1 },
-    }));
+    const text = contentToLines(content).join('\n');
+    return text.length > 0 ? [{ text }] : [];
 }
 
 function compositeHunksForFile(fileHunks: Hunk[]): TsCompositeHunk[] {
@@ -4458,37 +4522,85 @@ function compositeHunksForFile(fileHunks: Hunk[]): TsCompositeHunk[] {
 }
 
 function teardownCenterComposite(): void {
-    const cc = state.centerComposite;
+    closeComposite(state.centerComposite);
+    state.centerComposite = null;
+}
+
+/** Close a composite and the two file buffers behind it. */
+function closeComposite(cc: { compositeBufId: number; oldBufId: number; newBufId: number } | null): void {
     if (!cc) return;
     try {
         editor.closeCompositeBuffer(cc.compositeBufId);
         editor.closeBuffer(cc.oldBufId);
         editor.closeBuffer(cc.newBufId);
     } catch { /* already gone */ }
-    state.centerComposite = null;
 }
 
+/** What a composite for `file` was built from. Two `git show` calls, two
+ *  whole-file buffers and an alignment pass are worth skipping when none
+ *  of this has moved — and worth redoing the moment any of it has. */
+function compositeSignature(file: FileEntry): string {
+    const ranges = state.hunks
+        .filter(h => h.file === file.path && (h.gitStatus || 'unstaged') === file.category)
+        .map(h => `${h.oldRange.start}-${h.oldRange.end}:${h.range.start}-${h.range.end}`)
+        .join(',');
+    // The comment count is in the pane label, so it is part of what was built.
+    return `${state.dataRevision}|${fileKey(file)}|${commentCountForFile(file)}|${ranges}`;
+}
+
+/** Keep the current composite alive off-screen so a flip back to
+ *  side-by-side is a panel swap. Only one is parked: the reader has one
+ *  place they left. */
+function parkCenterComposite(): void {
+    const cc = state.centerComposite;
+    state.centerComposite = null;
+    if (!cc) return;
+    const file = state.files.find(f => fileKey(f) === cc.fileKey);
+    if (!file) {
+        closeComposite(cc);
+        return;
+    }
+    if (state.parkedComposite && state.parkedComposite.compositeBufId !== cc.compositeBufId) {
+        closeComposite(state.parkedComposite);
+    }
+    state.parkedComposite = { ...cc, signature: compositeSignature(file) };
+}
+
+/** Drop the parked composite (if any). Called when the review data is
+ *  replaced or the session ends — anything holding buffers open past the
+ *  thing they render is a leak. */
+function discardParkedComposite(): void {
+    closeComposite(state.parkedComposite);
+    state.parkedComposite = null;
+}
+
+/** Read both sides of `file`. The two reads are independent, so they run
+ *  together: fetching one version at a time made opening side-by-side
+ *  wait out two full `git show` round trips back to back, and that pair
+ *  is the largest single cost of the switch. */
 async function fetchFileVersions(file: FileEntry): Promise<{ oldContent: string; newContent: string; absPath: string }> {
     const root = state.repo ? state.repo.root : (editor.getCwd() || "");
     const absPath = root ? editor.pathJoin(root, file.path) : file.path;
     const cwd = root || editor.getCwd();
-    let oldContent = "";
-    let newContent = "";
+    const gitShow = async (rev: string): Promise<string> => {
+        const shown = await editor.spawnProcess("git", ["show", `${rev}:${file.path}`], cwd);
+        return shown.exit_code === 0 ? shown.stdout : "";
+    };
     if (state.mode === 'range' && state.range) {
-        const showOld = await editor.spawnProcess("git", ["show", `${state.range.from}:${file.path}`], cwd);
-        if (showOld.exit_code === 0) oldContent = showOld.stdout;
-        const showNew = await editor.spawnProcess("git", ["show", `${state.range.to}:${file.path}`], cwd);
-        if (showNew.exit_code === 0) newContent = showNew.stdout;
+        const [oldContent, newContent] = await Promise.all([
+            gitShow(state.range.from),
+            gitShow(state.range.to),
+        ]);
         return { oldContent, newContent, absPath };
     }
-    if (file.category !== 'untracked' && file.status !== 'A') {
-        const show = await editor.spawnProcess("git", ["show", `HEAD:${file.path}`], cwd);
-        if (show.exit_code === 0) oldContent = show.stdout;
-    }
-    if (file.status !== 'D') {
-        const read = await editor.readFile(editor.authorityPath(absPath));
-        if (read !== null) newContent = read;
-    }
+    // Only the `git show` is a round trip; reading the working file is a
+    // synchronous host call, so there is nothing to overlap it with.
+    const oldContent = file.category !== 'untracked' && file.status !== 'A'
+        ? await gitShow("HEAD")
+        : "";
+    const newContent = file.status !== 'D'
+        ? (editor.readFile(editor.authorityPath(absPath)) ?? "")
+        : "";
     return { oldContent, newContent, absPath };
 }
 
@@ -4520,12 +4632,36 @@ async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
     const file = key ? state.files.find(f => fileKey(f) === key) : undefined;
     if (!file) {
         teardownCenterComposite();
+        discardParkedComposite();
         if (state.panelBuffers["diff"] !== undefined) {
             editor.setBufferGroupPanelBuffer(state.groupId, "diff", state.panelBuffers["diff"]);
-            editor.setPanelContent(state.groupId, "diff", buildDiffPanelEntries());
+            mountStreamContent();
         }
         return;
     }
+
+    // The composite the reader left behind, still describing this file as
+    // it stands: mount it instead of rebuilding it. Rebuilding costs two
+    // `git show` calls, two whole files across the IPC boundary and an
+    // alignment pass — seconds on a large file, every single flip.
+    const parked = state.parkedComposite;
+    if (parked && parked.fileKey === key && parked.signature === compositeSignature(file)) {
+        state.parkedComposite = null;
+        teardownCenterComposite();
+        const { signature: _signature, ...composite } = parked;
+        state.centerComposite = composite;
+        state.compositePane = 0;
+        editor.setBufferGroupPanelBuffer(state.groupId, "diff", composite.compositeBufId);
+        editor.focusBufferGroupPanel(state.groupId, "diff");
+        if (state.focusPanel !== 'diff' && panelVisible(state.focusPanel)) {
+            editor.focusBufferGroupPanel(state.groupId, state.focusPanel);
+        }
+        editor.flushLayout();
+        return;
+    }
+    // Not reusable — and only one composite is ever parked, so whatever is
+    // sitting there is now dead weight.
+    discardParkedComposite();
 
     const { oldContent, newContent, absPath } = await fetchFileVersions(file);
     if (token !== state.centerBuildToken || state.groupId === null) return;
@@ -4557,7 +4693,7 @@ async function buildCenterComposite(focusHunkIdx: number = 0): Promise<void> {
 
     const compositeBufId = await editor.createCompositeBuffer({
         name: `*Review: ${file.path}*`,
-        mode: "review-mode",
+        mode: REVIEW_DIFF_MODE,
         layout: layoutCfg as never,
         sources: [
             { bufferId: oldRes.bufferId, label: "OLD (HEAD)", editable: false, style: { gutterStyle: "diff-markers" } },
@@ -4636,10 +4772,10 @@ function renderCenter(): void {
     // Bump the build token so any in-flight side-by-side build is superseded
     // and won't swap a composite back in after we switch to unified.
     state.centerBuildToken++;
-    teardownCenterComposite();
+    parkCenterComposite();
     if (state.panelBuffers["diff"] !== undefined) {
         editor.setBufferGroupPanelBuffer(state.groupId, "diff", state.panelBuffers["diff"]);
-        editor.setPanelContent(state.groupId, "diff", buildDiffPanelEntries());
+        mountStreamContent();
         // Only claim focus when the diff is where focus belongs. Rebuilding
         // the centre happens for reasons that have nothing to do with focus
         // — a filter keystroke in the sidebar, a comment added — and
@@ -4647,9 +4783,26 @@ function renderCenter(): void {
         if (state.focusPanel === 'diff') {
             editor.focusBufferGroupPanel(state.groupId, "diff");
         }
-        applyFolds();
-        applyCursorLineOverlay('diff');
     }
+}
+
+/** Put the unified stream's content into the diff panel buffer — unless
+ *  the content already there was built from the same state, in which case
+ *  the buffer is exactly what a rebuild would produce.
+ *
+ *  Laying out a large review takes a noticeable beat, and it lands as one
+ *  host command *after* the panel has already swapped to the stream. The
+ *  reader therefore sees the stream at its old scroll position, waits,
+ *  and then watches it jump — for a rebuild that changed nothing. Flipping
+ *  between the two layouts is exactly that case. */
+function mountStreamContent(): void {
+    if (state.groupId === null) return;
+    const signature = streamSignature();
+    if (state.streamMountedSignature === signature) return;
+    editor.setPanelContent(state.groupId, "diff", buildDiffPanelEntries());
+    state.streamMountedSignature = signature;
+    // Fresh content, so the host's folds went with the old rows.
+    applyFolds();
 }
 
 /** Light refresh after the focused file changes (nav / sidebar click):
@@ -5250,6 +5403,8 @@ function flushPendingFileFilter(): void {
 /** Re-filter after an edit: the tree, the centre (the stream renders only
  *  matching files) and the status line. */
 function applyFileFilter(): void {
+    // The stream renders only matching files, so the filter changes it.
+    markStreamDirty();
     ensureFocusFile();
     renderFilesPanel();
     renderCenter();
@@ -5419,7 +5574,6 @@ function jumpDiffCursorToRow(row: number, options?: { recenter?: boolean }): voi
         editor.scrollBufferToLine(diffId, idx);
     }
     state.diffCursorRow = row;
-    applyCursorLineOverlay('diff');
     // The scroll this jump triggers reports back through
     // `viewport_changed`, which is what re-derives the sticky header.
     refreshStickyHeader(state.diffViewportTopRow);
@@ -6370,9 +6524,17 @@ async function openReviewPanels(groupName: string): Promise<boolean> {
     state.groupId = groupResult.groupId;
     state.panelBuffers = groupResult.panels;
     state.reviewBufferId = groupResult.panels["diff"];
+    // A brand-new stream buffer holds nothing yet, whatever the last
+    // session left recorded.
+    state.streamMountedSignature = null;
 
     if (state.panelBuffers["diff"] !== undefined) {
         (editor as any).setBufferShowCursors(state.panelBuffers["diff"], true);
+        // The stream is where the editor's cursor lives, so it takes the
+        // motion-native copy of the keymap; the side panels keep
+        // `review-mode`, whose ↑/↓ drive their widgets instead.
+        editor.setBufferMode(state.panelBuffers["diff"], REVIEW_DIFF_MODE);
+        declareCursorLineBar();
     }
 
     // Mount the widget panels over the group's toolbar / sidebar / rail
@@ -6473,6 +6635,8 @@ registerHandler("start_review_diff", start_review_diff);
 
 function stop_review_diff() {
     teardownCenterComposite();
+    discardParkedComposite();
+    state.streamMountedSignature = null;
     // Unmount before the buffers go away, so the host drops the panels'
     // widget state instead of holding it against dead buffer ids.
     for (const panel of [toolbarPanel, filesPanel, commentsPanel]) panel?.unmount();
@@ -6827,7 +6991,14 @@ function on_review_cursor_moved(data: {
             reviewConfirmation = null;
         }
         state.diffCursorRow = data.line;
-        applyCursorLineOverlay('diff');
+        // A visual line selection follows the cursor wherever it goes.
+        // Extending it from the ↑/↓ handlers only covered the keys those
+        // handlers still see; the cursor's own move event covers every
+        // motion, native ones included.
+        if (state.lineSelection && state.lineSelection.endRow !== data.line) {
+            state.lineSelection.endRow = Math.max(1, data.line);
+            paintLineSelectionOverlay();
+        }
         // Use the cursor row as a sticky-header anchor too — viewport_changed
         // doesn't always fire reliably for plugin-managed virtual buffers
         // (top_line can be null). Tracking the cursor row gives a snappy
@@ -7615,7 +7786,7 @@ editor.on("buffer_closed", (data) => {
     }
 });
 
-editor.defineMode("review-mode", [
+const REVIEW_MODE_BINDINGS: string[][] = [
     // Native cursor motion in the unified diff stream.
     ["Up", "review_nav_up"], ["Down", "review_nav_down"],
     ["k", "review_nav_up"], ["j", "review_nav_down"],
@@ -7689,6 +7860,40 @@ editor.defineMode("review-mode", [
     // Close & export
     ["q", "close"],
     ["e", "review_export_session"],
-], true);
+];
+
+/** Motion handlers that exist only to forward to a built-in action once
+ *  the diff panel has focus. In the diff's own mode they *are* the
+ *  built-in action.
+ *
+ *  A plugin action is a round trip: the host hands the key to the plugin
+ *  thread, the handler asks for `move_down`, and only a later frame moves
+ *  the caret. That is a whole frame of lag on every repeat of a held
+ *  arrow key — for a keystroke whose entire job is to move the cursor one
+ *  row. Bound directly, the move lands in the frame the key arrived in.
+ *
+ *  The side panels keep the plugin handlers: there ↑/↓ drive a widget's
+ *  selection, which the editor's own cursor motion cannot do. */
+const DIFF_NATIVE_MOTION: Record<string, string> = {
+    review_nav_up: "move_up",
+    review_nav_down: "move_down",
+    review_page_up: "move_page_up",
+    review_page_down: "move_page_down",
+    review_nav_home: "move_line_start",
+    review_nav_end: "move_line_end",
+    review_nav_left: "move_left",
+    review_nav_right: "move_right",
+};
+
+editor.defineMode("review-mode", REVIEW_MODE_BINDINGS, true);
+/** The diff panel's copy of the map. Same keys, same commands — only the
+ *  motions differ (see `DIFF_NATIVE_MOTION`). The buffer carrying this
+ *  mode is the one the editor's cursor lives in: the unified stream, and
+ *  the side-by-side composite. */
+editor.defineMode(
+    REVIEW_DIFF_MODE,
+    REVIEW_MODE_BINDINGS.map(([key, action]) => [key, DIFF_NATIVE_MOTION[action] ?? action]),
+    true,
+);
 
 editor.debug("Review Diff plugin loaded with review comments support");

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2886,13 +2886,18 @@ registerHandler("review_relayout_comments", review_relayout_comments);
 
 /** The stream's inline comment boxes are wrapped to the diff panel's
  *  width, so a width the layout did not know about leaves them the wrong
- *  shape. Re-render once the width settles — the signature check inside
- *  `mountStreamContent` makes this a no-op when the width is what the
- *  content was already built to. */
+ *  shape. Re-emit the content once the width settles — and *only* the
+ *  content: this runs off a timer, at a moment nobody asked for, so it
+ *  must not swap which buffer the panel shows or move focus the way a
+ *  full `renderCenter` does. Firing that in the middle of a drill-down
+ *  would pull the reader out of the composite they just opened. The
+ *  signature check inside `mountStreamContent` makes it a no-op when the
+ *  width is what the content was already built to. */
 function review_relayout_diff(): void {
     panelRelayoutTimers.diff = null;
     if (state.groupId === null || state.reviewLayout === 'side-by-side') return;
-    renderCenter();
+    if (state.centerComposite !== null) return;
+    mountStreamContent();
 }
 registerHandler("review_relayout_diff", review_relayout_diff);
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -5091,27 +5091,62 @@ const AUTO_SPLIT_MIN_WIDTH = 140;
  *  other view opens on the same line rather than at the top of the file. */
 interface ReviewAnchor {
     fileKey: string;
-    lineType: 'add' | 'remove' | 'context';
+    /** Absent when the cursor was not on a diff line — a hunk header, a
+     *  file header, a comment box. Those rows are where `n` and `,`/`.`
+     *  leave you, so they are exactly where a layout switch is likely to
+     *  happen from. */
+    lineType?: 'add' | 'remove' | 'context';
     oldLine?: number;
     newLine?: number;
+    /** The hunk the row belongs to, when it belongs to one. Carries a
+     *  header row across the switch on its own: it is enough to open the
+     *  other layout on that hunk and to find the row again coming back. */
+    hunkId?: string;
 }
 
 /** The anchor for the current cursor position. Reads the composite's
  *  cursor in side-by-side and the unified stream's row properties
- *  otherwise. */
+ *  otherwise.
+ *
+ *  A row that is not a diff line still anchors: pressing `n` leaves the
+ *  cursor on a hunk header, and requiring a `+`/`-`/context line meant
+ *  flipping the layout from there threw the reader's place away and
+ *  reopened the file at the top. */
 async function currentReviewAnchor(): Promise<ReviewAnchor | null> {
     const info = state.centerComposite
         ? await getCompositeLineInfo()
         : getCurrentLineInfo();
-    if (!info || !info.lineType) return null;
-    const file = state.files.find(f => f.path === info.file);
+    if (info && info.lineType) {
+        const file = state.files.find(f => f.path === info.file);
+        if (file) {
+            return {
+                fileKey: fileKey(file),
+                lineType: info.lineType,
+                oldLine: info.oldLine,
+                newLine: info.newLine,
+                hunkId: info.hunkId,
+            };
+        }
+    }
+    // Not on a diff line. In the stream the row still says which hunk (or
+    // at least which file) it belongs to.
+    if (state.centerComposite) return null;
+    const props = propsAtCursorRow();
+    if (!props) return null;
+    const path = typeof props["file"] === 'string' ? props["file"] as string : null;
+    const file = path !== null
+        ? state.files.find(f => f.path === path)
+        : state.files.find(f => fileKey(f) === state.filesCurrentKey);
     if (!file) return null;
-    return {
-        fileKey: fileKey(file),
-        lineType: info.lineType,
-        oldLine: info.oldLine,
-        newLine: info.newLine,
-    };
+    const hunkId = typeof props["hunkId"] === 'string' ? props["hunkId"] as string : undefined;
+    return { fileKey: fileKey(file), hunkId };
+}
+
+/** The hunk an anchor names, if it names one. */
+function anchorHunk(anchor: ReviewAnchor): Hunk | undefined {
+    return anchor.hunkId !== undefined
+        ? state.hunks.find(h => h.id === anchor.hunkId)
+        : undefined;
 }
 
 /** Index, within its file's hunks, of the hunk holding the anchor's line —
@@ -5123,6 +5158,12 @@ function anchorHunkIndex(anchor: ReviewAnchor): number {
     const fileHunks = state.hunks.filter(
         h => h.file === file.path && (h.gitStatus || 'unstaged') === file.category
     );
+    // The hunk the anchor names outright wins: a header row has no line
+    // to place inside a range.
+    if (anchor.hunkId !== undefined) {
+        const named = fileHunks.findIndex(h => h.id === anchor.hunkId);
+        if (named >= 0) return named;
+    }
     const idx = fileHunks.findIndex(h =>
         (anchor.newLine !== undefined
             && anchor.newLine >= h.range.start && anchor.newLine <= h.range.end)
@@ -5139,10 +5180,33 @@ function restoreReviewAnchor(anchor: ReviewAnchor): void {
     if (state.reviewLayout === 'side-by-side') {
         const cc = state.centerComposite;
         if (!cc) return;
-        const pane = anchor.lineType === 'remove' ? 0 : 1;
-        const line = anchor.lineType === 'remove' ? anchor.oldLine : anchor.newLine;
+        const hunk = anchorHunk(anchor);
+        // A header row names a hunk but no line: open on where that hunk
+        // starts. Its NEW side exists for everything but a pure deletion.
+        const pane = anchor.lineType === 'remove'
+            || (anchor.lineType === undefined && hunk !== undefined && hunk.range.start === 0)
+            ? 0 : 1;
+        const line = anchor.lineType === 'remove'
+            ? anchor.oldLine
+            : anchor.lineType !== undefined
+                ? anchor.newLine
+                : (pane === 0 ? hunk?.oldRange.start : hunk?.range.start);
         if (line === undefined) return;
         editor.setCompositeCursorLine(cc.compositeBufId, pane, line - 1);
+        return;
+    }
+    if (anchor.lineType === undefined) {
+        // Came from a header row: its own row in the stream is the place
+        // to land, not some line inside the hunk.
+        const hunkRow = anchor.hunkId !== undefined
+            ? state.hunkRowByHunkId[anchor.hunkId]
+            : undefined;
+        if (hunkRow !== undefined) {
+            jumpDiffCursorToRow(hunkRow);
+            return;
+        }
+        const fileRow = state.fileHeaderRows[anchor.fileKey];
+        if (fileRow !== undefined) jumpDiffCursorToRow(fileRow);
         return;
     }
     for (const rowStr of Object.keys(state.entryPropsByRow)) {
@@ -5200,8 +5264,15 @@ function nearestHunkRowToAnchor(anchor: ReviewAnchor): number | undefined {
 
 async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<void> {
     if (state.reviewLayout !== layout) {
-        // Read where the reader is *before* the center is rebuilt.
-        const anchor = await currentReviewAnchor();
+        // Read where the reader is *before* the center is rebuilt. On the
+        // way back from a side-by-side the reader never moved in, the row
+        // they left the stream on is a better answer than anything the
+        // composite's cursor can say: the composite has no header rows, so
+        // a hunk header becomes "the hunk's first line" on the round trip.
+        const anchor = (layout === 'unified' && await composedCursorUnmoved())
+            ? layoutReturn!.anchor
+            : await currentReviewAnchor();
+        layoutReturn = null;
         state.reviewLayout = layout;
         // Unified expands every file, side-by-side renders one — the
         // center rebuild below has to see the new mode.
@@ -5217,6 +5288,16 @@ async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<vo
             renderCenter();
         }
         if (anchor) restoreReviewAnchor(anchor);
+        if (layout === 'side-by-side' && anchor) {
+            const placed = await editor.getCompositeCursorInfo();
+            if (placed) {
+                layoutReturn = {
+                    anchor,
+                    pane: placed.focusedPane,
+                    line: placed.lines[placed.focusedPane] ?? null,
+                };
+            }
+        }
         // The sticky names the current file in side-by-side and the
         // top-of-view file in unified — either way it has just changed.
         refreshStickyHeader(state.diffViewportTopRow);
@@ -5227,6 +5308,21 @@ async function review_set_layout(layout: 'unified' | 'side-by-side'): Promise<vo
             : (editor.t("status.unified_view") || "Unified view")
     );
 }
+/** Where the switch into side-by-side put the composite's cursor, and the
+ *  stream row it came from. Cleared as soon as it is used or superseded. */
+let layoutReturn: { anchor: ReviewAnchor; pane: number; line: number | null } | null = null;
+
+/** True when the composite's cursor is still exactly where switching into
+ *  side-by-side put it — i.e. the reader looked and came back without
+ *  moving, so the row they left is still the row they mean. */
+async function composedCursorUnmoved(): Promise<boolean> {
+    if (layoutReturn === null || state.centerComposite === null) return false;
+    const info = await editor.getCompositeCursorInfo();
+    if (!info) return false;
+    return info.focusedPane === layoutReturn.pane
+        && (info.lines[info.focusedPane] ?? null) === layoutReturn.line;
+}
+
 async function review_layout_split() { await review_set_layout('side-by-side'); }
 registerHandler("review_layout_split", review_layout_split);
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2229,6 +2229,33 @@ function panelVisible(panel: 'files' | 'diff' | 'comments'): boolean {
 function renderFilesPanel(): void {
     if (filesPanel === null || !panelVisible('files')) return;
     filesPanel.set(buildFilesPanelSpec());
+    pointSidebarAtCurrentFile();
+}
+
+/** Move the sidebar's selection onto the review's current file.
+ *
+ *  A tree's selected row is host state after its first render — the
+ *  `selectedIndex` in a rebuilt spec is a seed the host ignores — so
+ *  repainting the panel with a new current file left the highlight
+ *  wherever the sidebar's own navigation had last put it. Reading down
+ *  the stream then walked the cursor through file after file with the
+ *  sidebar still pointing at the one you started in. This is the
+ *  host-side setter, so the selection actually moves (and scrolls itself
+ *  into view).
+ *
+ *  A directory or section row the user selected stays put: those are the
+ *  sidebar's own navigation, and folding one is a gesture the diff cursor
+ *  has no opinion about. */
+function pointSidebarAtCurrentFile(): void {
+    if (filesPanel === null || !panelVisible('files')) return;
+    if (state.filesCurrentKey === null) return;
+    if (filesSelectedNodeKey.startsWith("dir:") || filesSelectedNodeKey.startsWith("cat:")) return;
+    const nodeKey = `file:${state.filesCurrentKey}`;
+    if (nodeKey === filesSelectedNodeKey) return;
+    const idx = filesTree.keys.indexOf(nodeKey);
+    if (idx < 0) return;
+    filesSelectedNodeKey = nodeKey;
+    filesPanel.setSelectedIndex(FILES_TREE_KEY, idx);
 }
 
 /** Repaint the COMMENTS rail, if it is on screen. */
@@ -2403,13 +2430,19 @@ function markStreamDirty(): void {
 
 /** What the content currently in the stream buffer was built from. The
  *  focused file is part of it because the composite's stand-in stream
- *  carries only that file's body (`fileBodyRendered`), and the panel's
- *  width because inline comment boxes are wrapped to it. */
+ *  carries only that file's body (`fileBodyRendered`).
+ *
+ *  The panel's width counts only while notes are on screen: comment boxes
+ *  are the one thing wrapped to it (`pushLineComments`), and the host
+ *  reports the panel's real width a moment after the stream is first laid
+ *  out — so treating every width as significant put a full relayout in
+ *  the reader's way seconds into a review that had no notes in it. */
 function streamSignature(): string {
+    const widthShapesTheStream = state.showComments && state.comments.length > 0;
     return [
         state.streamRevision,
         state.focusOnly ? state.filesCurrentKey : '*',
-        diffPanelWidth(),
+        widthShapesTheStream ? diffPanelWidth() : '*',
     ].join('|');
 }
 
@@ -2598,16 +2631,16 @@ function refreshStickyHeader(topVisibleRow: number): void {
     }
 }
 
+
+
 /**
  * Helper: jump the diff cursor to the file's first hunk (or its file
  * header if it has no hunks). Auto-expands the file if collapsed.
  */
 function jumpToFile(file: FileEntry): void {
     const key = fileKey(file);
-    if (state.collapsedFiles.has(key)) {
-        state.collapsedFiles.delete(key);
-        updateMagitDisplay();
-    }
+    // Collapse is a fold, so revealing the file is one too — no relayout.
+    if (state.collapsedFiles.delete(key)) applyFolds();
     // Prefer this file's first hunk row; fall back to the file header.
     // Read the row from the build's own map rather than counting hunks:
     // the count used to skip collapsed files, but collapse is a conceal
@@ -2767,12 +2800,12 @@ function jumpToComment(commentId: string): void {
         return;
     }
 
-    // Auto-expand whatever's between the cursor and this comment.
+    // Auto-expand whatever's between the cursor and this comment. Two
+    // different costs hide here: revealing a collapse is a fold change,
+    // while changing which file the centre carries is a real relayout.
+    let revealed = false;
     let needRebuild = false;
-    if (hunk.gitStatus && state.collapsedSections.has(hunk.gitStatus)) {
-        state.collapsedSections.delete(hunk.gitStatus);
-        needRebuild = true;
-    }
+    if (hunk.gitStatus) revealed = state.collapsedSections.delete(hunk.gitStatus) || revealed;
     const file = state.files.find(f => f.path === hunk.file && f.category === hunk.gitStatus);
     if (file) {
         const key = fileKey(file);
@@ -2783,16 +2816,11 @@ function jumpToComment(commentId: string): void {
             state.filesCurrentKey = key;
             needRebuild = true;
         }
-        if (state.collapsedFiles.has(key)) {
-            state.collapsedFiles.delete(key);
-            needRebuild = true;
-        }
+        revealed = state.collapsedFiles.delete(key) || revealed;
     }
-    if (state.collapsedHunks.has(hunk.id)) {
-        state.collapsedHunks.delete(hunk.id);
-        needRebuild = true;
-    }
+    revealed = state.collapsedHunks.delete(hunk.id) || revealed;
     if (needRebuild) updateMagitDisplay();
+    else if (revealed) applyFolds();
     // Pin this comment as the highlighted one BEFORE jumping. Any
     // subsequent cursor_moved event that re-derives the highlight
     // will recompute the same id; doing it eagerly avoids a flicker
@@ -5676,19 +5704,23 @@ function jumpToGlobalHunk(globalIdx: number) {
     const target = state.hunks[globalIdx];
     const targetFileKey = fileKeyOf(target.file, target.gitStatus || 'unstaged');
     // Always expand any collapse on the target's section / file / hunk so
-    // n/p never silently lands on an invisible row.
-    if (target.gitStatus) state.collapsedSections.delete(target.gitStatus);
-    state.collapsedFiles.delete(targetFileKey);
-    state.collapsedHunks.delete(target.id);
+    // n/p never silently lands on an invisible row. Collapsing is a host
+    // fold over rows the stream already carries (see `applyFolds`), so
+    // revealing them is a fold change — re-laying-out the stream for it
+    // put a second of work behind every `n` on a large review, most of
+    // them for a target that was not collapsed in the first place.
+    let revealed = false;
+    if (target.gitStatus) revealed = state.collapsedSections.delete(target.gitStatus) || revealed;
+    revealed = state.collapsedFiles.delete(targetFileKey) || revealed;
+    revealed = state.collapsedHunks.delete(target.id) || revealed;
     if (!fileBodyRendered(targetFileKey)) {
         // Side-by-side: the composite draws one file, so the target has to
         // become the current file before its hunk row exists. This is how
         // `n`/`p` cross file boundaries there.
         state.filesCurrentKey = targetFileKey;
         refreshFocusedFile();
-    } else {
-        // Already laid out: rebuild so the just-expanded rows render.
-        updateMagitDisplay();
+    } else if (revealed) {
+        applyFolds();
     }
     // Look up the target hunk's row directly — much simpler than counting.
     const row = state.hunkRowByHunkId[target.id];

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3619,6 +3619,26 @@ interface EditorAPI {
 	*/
 	addOverlay(bufferId: number, namespace: string, start: number, end: number, options: Record<string, unknown>): boolean;
 	/**
+	* Declare a one-line overlay that follows this buffer's cursor.
+	* 
+	* Takes the same options as `addOverlay` and paints the same way — the
+	* difference is who places it. The host re-derives the range from the
+	* cursor while drawing each frame, so the bar marks the row the caret
+	* is on in that very frame. Painting it by hand from `cursor_moved`
+	* cannot: the hook fires after the move that already drew, so the bar
+	* lands a frame late and visibly trails a held arrow key.
+	* 
+	* Pass `null` to withdraw it.
+	* 
+	* ```typescript
+	* editor.setCursorLineOverlay(bufferId, {
+	* bg: "editor.selection_bg",
+	* extendToLineEnd: true,
+	* });
+	* ```
+	*/
+	setCursorLineOverlay(bufferId: number, options: unknown): boolean;
+	/**
 	* Clear all overlays in a namespace
 	*/
 	clearNamespace(bufferId: number, namespace: string): boolean;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -447,13 +447,14 @@ pub struct PerfCounters {
     /// per-tick cost returning, which is what `plugin_snapshot_scaling`
     /// watches for.
     pub text_properties_copied: u64,
-    /// Whole-panel content replacements applied for a plugin
-    /// (`SetPanelContent`). Laying out a big panel — a review diff of a
-    /// hundred commits, say — costs about a second, and the panel it
-    /// lands in is already on screen, so a needless one is a visible
-    /// stale-then-jump rather than invisible waste. Counted so a test can
-    /// assert which gestures re-lay-out a panel and which reuse it.
-    pub panel_content_sets: u64,
+    /// Rows shipped into a plugin's panel by `SetPanelContent`. Laying
+    /// out a big panel — a review diff of a hundred commits, say — costs
+    /// about a second, and the panel it lands in is already on screen, so
+    /// a needless one is a visible stale-then-jump rather than invisible
+    /// waste. Counted in rows rather than calls because that is what
+    /// separates re-emitting a whole diff stream from repainting the
+    /// one-row sticky header above it.
+    pub panel_content_rows: u64,
 }
 
 /// The main editor struct - manages multiple buffers, clipboard, and rendering

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -447,6 +447,13 @@ pub struct PerfCounters {
     /// per-tick cost returning, which is what `plugin_snapshot_scaling`
     /// watches for.
     pub text_properties_copied: u64,
+    /// Whole-panel content replacements applied for a plugin
+    /// (`SetPanelContent`). Laying out a big panel — a review diff of a
+    /// hundred commits, say — costs about a second, and the panel it
+    /// lands in is already on screen, so a needless one is a visible
+    /// stale-then-jump rather than invisible waste. Counted so a test can
+    /// assert which gestures re-lay-out a panel and which reuse it.
+    pub panel_content_sets: u64,
 }
 
 /// The main editor struct - manages multiple buffers, clipboard, and rendering

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -150,6 +150,31 @@ impl Editor {
         }
     }
 
+    /// Handle SetCursorLineOverlay command
+    pub(super) fn handle_set_cursor_line_overlay(
+        &mut self,
+        buffer_id: BufferId,
+        options: Option<OverlayOptions>,
+    ) {
+        let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .expect("active window present")
+            .buffer_state_mut(buffer_id)
+        else {
+            tracing::warn!("SetCursorLineOverlay: buffer {:?} not found", buffer_id);
+            return;
+        };
+        state.cursor_line_overlay.set_spec(options);
+        // The bar itself is placed by the next frame's decoration pass —
+        // ask for that frame, since declaring one usually happens while
+        // nothing else is redrawing.
+        #[cfg(feature = "plugins")]
+        {
+            self.plugin_render_requested = true;
+        }
+    }
+
     /// Handle RemoveOverlay command
     pub(super) fn handle_remove_overlay(&mut self, buffer_id: BufferId, handle: OverlayHandle) {
         if let Some(state) = self

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1669,7 +1669,7 @@ impl Editor {
                 panel_name,
                 entries,
             } => {
-                self.perf_counters.panel_content_sets += 1;
+                self.perf_counters.panel_content_rows += entries.len() as u64;
                 self.set_panel_content(group_id, panel_name, entries);
             }
             PluginCommand::CloseBufferGroup { group_id } => {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -451,6 +451,9 @@ impl Editor {
             PluginCommand::RemoveOverlay { buffer_id, handle } => {
                 self.handle_remove_overlay(buffer_id, handle);
             }
+            PluginCommand::SetCursorLineOverlay { buffer_id, options } => {
+                self.handle_set_cursor_line_overlay(buffer_id, options);
+            }
             PluginCommand::ClearAllOverlays { buffer_id } => {
                 self.handle_clear_all_overlays(buffer_id);
             }
@@ -1666,6 +1669,7 @@ impl Editor {
                 panel_name,
                 entries,
             } => {
+                self.perf_counters.panel_content_sets += 1;
                 self.set_panel_content(group_id, panel_name, entries);
             }
             PluginCommand::CloseBufferGroup { group_id } => {

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -17,6 +17,7 @@ use crate::primitives::reference_highlighter::ReferenceHighlighter;
 use crate::primitives::text_property::TextPropertyManager;
 use crate::view::bracket_highlight_overlay::BracketHighlightOverlay;
 use crate::view::conceal::ConcealManager;
+use crate::view::cursor_line_overlay::CursorLineOverlay;
 use crate::view::folding::LspFoldRanges;
 use crate::view::margin::{MarginAnnotation, MarginContent, MarginManager, MarginPosition};
 use crate::view::overlay::{Overlay, OverlayFace, OverlayManager, UnderlineStyle};
@@ -367,6 +368,11 @@ pub struct EditorState {
     /// Bracket matching highlight overlay
     pub bracket_highlight_overlay: BracketHighlightOverlay,
 
+    /// Host-placed bar following this buffer's cursor. Off unless a plugin
+    /// declares one (`setCursorLineOverlay`); placed from the cursor at
+    /// paint time, so it can never lag the caret it marks.
+    pub cursor_line_overlay: CursorLineOverlay,
+
     /// Cached LSP semantic tokens (converted to buffer byte ranges)
     pub semantic_tokens: Option<SemanticTokenStore>,
 
@@ -503,6 +509,7 @@ impl EditorState {
             debug_highlight_mode: false,
             reference_highlight_overlay: ReferenceHighlightOverlay::new(),
             bracket_highlight_overlay: BracketHighlightOverlay::new(),
+            cursor_line_overlay: CursorLineOverlay::new(),
             semantic_tokens: None,
             folding_ranges: LspFoldRanges::new(),
             language: "text".to_string(),

--- a/crates/fresh-editor/src/view/cursor_line_overlay.rs
+++ b/crates/fresh-editor/src/view/cursor_line_overlay.rs
@@ -1,0 +1,211 @@
+//! A single-line overlay that follows a buffer's cursor.
+//!
+//! A plugin that wants a magit-style "you are here" bar used to paint it
+//! itself, from the `cursor_moved` hook: the host moved the cursor, fired
+//! the hook, and painted the frame; the plugin's `addOverlay` only landed
+//! on the *next* one. Holding an arrow key then showed the bar one row
+//! behind the caret for as long as the key repeated — the highlight can
+//! never catch up, because every frame it is answering the previous
+//! frame's cursor.
+//!
+//! Declaring the bar once and letting the host place it removes the round
+//! trip entirely: the range is derived from the cursor at paint time, in
+//! the same pass that draws the caret, so the two cannot disagree.
+//!
+//! The plugin still owns the *appearance* — it hands over the same
+//! `OverlayOptions` it would have passed to `addOverlay`, so the bar looks
+//! exactly as it did when the plugin painted it by hand.
+
+use crate::model::buffer::Buffer;
+use crate::model::marker::MarkerList;
+use crate::view::overlay::{Overlay, OverlayFace, OverlayManager, OverlayNamespace};
+use fresh_core::api::OverlayOptions;
+use std::ops::Range;
+
+/// Namespace owning the cursor-line overlay. Host-managed: a plugin never
+/// adds to or clears this namespace itself.
+pub fn cursor_line_namespace() -> OverlayNamespace {
+    OverlayNamespace::from_string("cursor-line".to_string())
+}
+
+/// Per-buffer state for the cursor-following line overlay.
+#[derive(Debug, Clone, Default)]
+pub struct CursorLineOverlay {
+    /// Appearance the owning plugin asked for. `None` disables the overlay.
+    spec: Option<OverlayOptions>,
+    /// Byte range currently painted, so an update that would repaint the
+    /// same row does nothing (the common case: any cursor move within a
+    /// line, and every frame that redraws without one).
+    painted: Option<Range<usize>>,
+    /// Set when the spec changed, so the next update repaints even onto
+    /// the row already painted — the colours under it may be different.
+    spec_dirty: bool,
+}
+
+impl CursorLineOverlay {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare (or, with `None`, withdraw) the bar. The next update paints
+    /// it; the paint itself is deferred so this stays cheap to call from a
+    /// command handler that has no buffer to work with yet.
+    pub fn set_spec(&mut self, spec: Option<OverlayOptions>) {
+        self.spec = spec;
+        self.spec_dirty = true;
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.spec.is_some()
+    }
+
+    /// Re-place the bar on the line holding `cursor_position`. Returns
+    /// whether anything changed.
+    pub fn update(
+        &mut self,
+        buffer: &Buffer,
+        overlays: &mut OverlayManager,
+        marker_list: &mut MarkerList,
+        cursor_position: usize,
+    ) -> bool {
+        let ns = cursor_line_namespace();
+        self.spec_dirty &= self.spec.is_some();
+        let Some(spec) = self.spec.clone() else {
+            if self.painted.take().is_some() {
+                overlays.clear_namespace(&ns, marker_list);
+                return true;
+            }
+            return false;
+        };
+
+        let Some(range) = cursor_line_range(buffer, cursor_position) else {
+            if self.painted.take().is_some() {
+                overlays.clear_namespace(&ns, marker_list);
+                return true;
+            }
+            return false;
+        };
+
+        if self.painted.as_ref() == Some(&range) && !self.spec_dirty {
+            return false;
+        }
+        self.spec_dirty = false;
+
+        overlays.clear_namespace(&ns, marker_list);
+        let face = OverlayFace::from_options(&spec);
+        let overlay = Overlay::with_namespace(marker_list, range.clone(), face, ns)
+            // Same priority `addOverlay` gives a plugin's own overlays, so
+            // stacking against the rest of the buffer's decoration is
+            // unchanged from when the plugin painted this itself.
+            .with_priority_value(10)
+            .with_extend_to_line_end(spec.extend_to_line_end);
+        overlays.add(overlay);
+        self.painted = Some(range);
+        true
+    }
+}
+
+/// Byte range of the line holding `position`, newline included so the bar
+/// reaches the row's end. `None` for an empty buffer, where there is no
+/// row to paint.
+fn cursor_line_range(buffer: &Buffer, position: usize) -> Option<Range<usize>> {
+    if buffer.is_empty() {
+        return None;
+    }
+    let position = position.min(buffer.len());
+    let line = buffer.get_line_number(position);
+    let start = buffer.line_start_offset(line)?;
+    let end = buffer
+        .line_start_offset(line + 1)
+        .unwrap_or_else(|| buffer.len());
+    if end <= start {
+        return None;
+    }
+    Some(start..end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fresh_core::api::OverlayColorSpec;
+
+    fn spec() -> OverlayOptions {
+        OverlayOptions {
+            bg: Some(OverlayColorSpec::Rgb(1, 2, 3)),
+            extend_to_line_end: true,
+            ..Default::default()
+        }
+    }
+
+    fn buffer() -> Buffer {
+        Buffer::from_str_test("alpha\nbeta\ngamma\n")
+    }
+
+    #[test]
+    fn paints_the_line_holding_the_cursor() {
+        let buf = buffer();
+        let mut overlays = OverlayManager::new();
+        let mut markers = MarkerList::new();
+        let mut cl = CursorLineOverlay::new();
+        cl.set_spec(Some(spec()));
+
+        assert!(cl.update(&buf, &mut overlays, &mut markers, 8));
+        assert_eq!(overlays.all().len(), 1, "one bar, on one line");
+        // "beta\n" is bytes 6..11.
+        assert_eq!(cl.painted, Some(6..11));
+    }
+
+    #[test]
+    fn moving_within_a_line_does_not_repaint() {
+        let buf = buffer();
+        let mut overlays = OverlayManager::new();
+        let mut markers = MarkerList::new();
+        let mut cl = CursorLineOverlay::new();
+        cl.set_spec(Some(spec()));
+
+        assert!(cl.update(&buf, &mut overlays, &mut markers, 6));
+        assert!(!cl.update(&buf, &mut overlays, &mut markers, 9));
+        assert_eq!(overlays.all().len(), 1);
+    }
+
+    #[test]
+    fn moving_to_another_line_moves_the_bar() {
+        let buf = buffer();
+        let mut overlays = OverlayManager::new();
+        let mut markers = MarkerList::new();
+        let mut cl = CursorLineOverlay::new();
+        cl.set_spec(Some(spec()));
+
+        cl.update(&buf, &mut overlays, &mut markers, 0);
+        assert_eq!(cl.painted, Some(0..6));
+        assert!(cl.update(&buf, &mut overlays, &mut markers, 12));
+        assert_eq!(cl.painted, Some(11..17));
+        assert_eq!(overlays.all().len(), 1, "the old bar is gone");
+    }
+
+    #[test]
+    fn withdrawing_the_spec_clears_the_bar() {
+        let buf = buffer();
+        let mut overlays = OverlayManager::new();
+        let mut markers = MarkerList::new();
+        let mut cl = CursorLineOverlay::new();
+        cl.set_spec(Some(spec()));
+        cl.update(&buf, &mut overlays, &mut markers, 0);
+
+        cl.set_spec(None);
+        assert!(cl.update(&buf, &mut overlays, &mut markers, 0));
+        assert_eq!(overlays.all().len(), 0);
+    }
+
+    #[test]
+    fn an_empty_buffer_has_no_line_to_paint() {
+        let buf = Buffer::from_str_test("");
+        let mut overlays = OverlayManager::new();
+        let mut markers = MarkerList::new();
+        let mut cl = CursorLineOverlay::new();
+        cl.set_spec(Some(spec()));
+
+        assert!(!cl.update(&buf, &mut overlays, &mut markers, 0));
+        assert_eq!(overlays.all().len(), 0);
+    }
+}

--- a/crates/fresh-editor/src/view/mod.rs
+++ b/crates/fresh-editor/src/view/mod.rs
@@ -64,6 +64,8 @@ pub mod bracket_highlight_overlay;
 #[cfg(feature = "runtime")]
 pub mod calibration_wizard;
 #[cfg(feature = "runtime")]
+pub mod cursor_line_overlay;
+#[cfg(feature = "runtime")]
 pub mod event_debug;
 #[cfg(feature = "runtime")]
 pub mod file_browser_input;

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -176,6 +176,18 @@ pub(crate) fn decoration_context(
         theme.semantic_highlight_bg,
     );
 
+    // Place the cursor-following bar (if a plugin declared one) from the
+    // cursor this frame is about to draw. Doing it here rather than from
+    // the `cursor_moved` hook is the whole point: a plugin painting it
+    // itself is always answering the *previous* frame's cursor, so the bar
+    // trails the caret by a row for as long as an arrow key repeats.
+    state.cursor_line_overlay.update(
+        &state.buffer,
+        &mut state.overlays,
+        &mut state.marker_list,
+        primary_cursor_position,
+    );
+
     // Brackets inside comments and strings are prose/data, not structural
     // punctuation, so they must be excluded from bracket matching and rainbow
     // colorization (issue #2405). The highlighter already classifies these

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -65,6 +65,7 @@ pub mod plugin_keybinding_execution;
 pub mod plugin_snapshot_scaling;
 pub mod plugin_text_property_freshness;
 pub mod plugins_dir_in_working_dir;
+pub mod review_diff_cursor_and_layout;
 pub mod review_diff_hunk_parity;
 pub mod review_diff_layout_bench;
 pub mod review_diff_line_staging;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
@@ -1,0 +1,317 @@
+//! Review Diff: what a keystroke costs, and what a layout flip redoes.
+//!
+//! Four complaints from reading a hundred-commit range by hand, all of
+//! them about the same thing — work happening on the wrong side of the
+//! frame that shows it:
+//!
+//!   1. flipping back to the unified stream showed the old scroll
+//!      position, then jumped, because the panel swapped to the stream
+//!      buffer at once and its (identical) content landed a beat later;
+//!   2. flipping to side-by-side and back rebuilt both views every time;
+//!   3. the cursor-line bar trailed a held arrow key by one row, because
+//!      the plugin repainted it from `cursor_moved` — always answering
+//!      the frame that had already drawn;
+//!   4. moving the cursor at all went out to the plugin thread and back
+//!      before anything moved.
+//!
+//! The first two are asserted on the panel-relayout counter (a rebuild is
+//! not visible on screen — its *absence* is the fix), the last two on
+//! rendered output after a single frame.
+
+use crate::common::git_test_helper::GitTestRepo;
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+fn setup_audit_mode_plugin(repo: &GitTestRepo) {
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin(&plugins_dir, "audit_mode");
+    copy_plugin_lib(&plugins_dir);
+}
+
+/// A repo whose single file has a long, unbroken run of changed lines, so
+/// the stream has plenty of rows to walk with the cursor and the
+/// side-by-side view has a whole file to render.
+fn repo_with_long_diff() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+    let before: String = (0..60)
+        .map(|i| format!("fn original_{i}() {{ let x = {i}; }}\n"))
+        .collect();
+    repo.create_file("src/main.rs", &before);
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+    let after: String = (0..60)
+        .map(|i| format!("fn changed_{i}() {{ let y = {i}; }}\n"))
+        .collect();
+    repo.create_file("src/main.rs", &after);
+    repo
+}
+
+fn harness_for(repo: &GitTestRepo) -> EditorTestHarness {
+    EditorTestHarness::with_config_and_working_dir(160, 44, Config::default(), repo.path.clone())
+        .unwrap()
+}
+
+fn open_review_diff(harness: &mut EditorTestHarness) {
+    harness.run_palette_command("Review Diff").unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            if s.contains("TypeError") || s.contains("Error:") {
+                panic!("Error loading review diff. Screen:\n{}", s);
+            }
+            s.contains("next hunk") && !s.contains("Generating Review")
+        })
+        .unwrap();
+    // The toolbar lands before the stream does; wait for real diff rows.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("changed_0"))
+        .unwrap();
+}
+
+/// Screen row carrying the cursor-line bar, found by its background.
+///
+/// The bar is declared with `extendToLineEnd`, but the diff's own row
+/// backgrounds (added / removed / hunk body) paint over most of it — the
+/// panel's first column is the one place it always shows through.
+fn cursor_bar_row(harness: &EditorTestHarness) -> Option<u16> {
+    let selection_bg = harness.editor().theme().selection_bg;
+    let height = harness.buffer().area.height;
+    (0..height).find(|&y| {
+        harness
+            .get_cell_style(0, y)
+            .is_some_and(|style| style.bg == Some(selection_bg))
+    })
+}
+
+/// The diff row the bar is sitting on, as text.
+fn cursor_bar_text(harness: &EditorTestHarness) -> String {
+    let row = cursor_bar_row(harness).unwrap_or_else(|| {
+        panic!(
+            "no cursor-line bar on screen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    harness
+        .screen_to_string()
+        .lines()
+        .nth(row as usize)
+        .unwrap_or_default()
+        .trim_end()
+        .to_string()
+}
+
+/// Press a key and draw exactly one frame — no draining of plugin work in
+/// between, which is what `send_key` does and what hides a round trip.
+fn key_then_one_frame(harness: &mut EditorTestHarness, code: KeyCode) {
+    harness
+        .editor_mut()
+        .handle_key(code, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// Issues 3 and 4: one keypress, one frame — the caret moves and the bar
+/// moves with it.
+///
+/// Both halves used to need a round trip to the plugin thread: the key was
+/// bound to a plugin handler that asked for `move_down`, and the bar was
+/// repainted from the `cursor_moved` hook that fired afterwards. Neither
+/// could land in the frame the key arrived in, so a held arrow key drew a
+/// bar one row behind a caret that was itself a frame behind the key.
+#[test]
+fn test_cursor_and_its_bar_move_in_the_frame_the_key_arrives_in() {
+    init_tracing_from_env();
+    let repo = repo_with_long_diff();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    // Land inside the hunk body, where every row is a diff line.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..3 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    let before = cursor_bar_text(&harness);
+    assert!(
+        !before.is_empty(),
+        "expected the bar to sit on a diff row, got an empty one:\n{}",
+        harness.screen_to_string()
+    );
+
+    key_then_one_frame(&mut harness, KeyCode::Down);
+    let after = cursor_bar_text(&harness);
+    assert_ne!(
+        before,
+        after,
+        "one Down, one frame: the bar should already be on the next row.\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // ...and it is the row *below*, not any row: the bar tracks the caret
+    // rather than lagging it.
+    let screen = harness.screen_to_string();
+    let rows: Vec<&str> = screen.lines().collect();
+    let bar = cursor_bar_row(&harness).expect("bar on screen") as usize;
+    assert_eq!(
+        rows[bar - 1].trim_end(),
+        before,
+        "the bar moved somewhere other than one row down.\nScreen:\n{}",
+        screen
+    );
+}
+
+/// Issue 4, side-by-side half: the composite takes the same native
+/// motions, so a keypress moves its cursor in the frame it arrives in.
+#[test]
+fn test_side_by_side_cursor_moves_in_the_frame_the_key_arrives_in() {
+    init_tracing_from_env();
+    let repo = repo_with_long_diff();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
+        .unwrap();
+
+    let before = harness.editor().active_cursors().primary().position;
+    key_then_one_frame(&mut harness, KeyCode::Down);
+    assert_ne!(
+        before,
+        harness.editor().active_cursors().primary().position,
+        "Down should move the composite's cursor within the same frame.\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Issues 1 and 2: flipping between the layouts re-uses both views instead
+/// of rebuilding them.
+///
+/// The stream costs about a second to lay out on a large review, and the
+/// panel swaps to it before that lands — so a needless rebuild is not
+/// invisible waste, it is the reader watching a stale scroll position and
+/// then a jump. Nothing about the review changes when the layout flips, so
+/// nothing has to be laid out again.
+#[test]
+fn test_layout_flips_do_not_relayout_the_stream() {
+    init_tracing_from_env();
+    let repo = repo_with_long_diff();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    let before = harness.editor().perf_counters().panel_content_sets;
+    for _ in 0..2 {
+        harness
+            .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
+            .unwrap();
+        harness
+            .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("Unified view"))
+            .unwrap();
+    }
+    let after = harness.editor().perf_counters().panel_content_sets;
+
+    // The sticky header is a panel too and it *does* change on a flip (it
+    // names the current file), so the budget is not zero — but the stream,
+    // the expensive one, must not be among them. Four flips would be four
+    // stream layouts before the fix.
+    assert!(
+        after - before <= 4,
+        "four layout flips re-laid-out panels {} times; the stream should \
+         have been reused",
+        after - before
+    );
+
+    // The stream is still the real thing afterwards, not a stale husk.
+    assert!(
+        harness.screen_to_string().contains("changed_"),
+        "the reused stream should still show the diff:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// The reuse is not blind: a change to what the stream says still lays it
+/// out again. Toggling inline notes (`a`) is a pure view change over the
+/// same git data, so it exercises the invalidation without touching the
+/// repo.
+#[test]
+fn test_a_content_change_still_relayouts_the_stream() {
+    init_tracing_from_env();
+    let repo = repo_with_long_diff();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    let before = harness.editor().perf_counters().panel_content_sets;
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string().to_lowercase();
+            s.contains("notes shown") || s.contains("notes hidden")
+        })
+        .unwrap();
+    assert!(
+        harness.editor().perf_counters().panel_content_sets > before,
+        "a view toggle changes what the stream says, so it has to be laid \
+         out again"
+    );
+}
+
+/// Issue 1, the visible half: the line the reader was on in side-by-side
+/// is the line the stream comes back to.
+#[test]
+fn test_flip_back_to_unified_lands_on_the_line_the_reader_left() {
+    init_tracing_from_env();
+    let repo = repo_with_long_diff();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
+        .unwrap();
+    // Walk well down the file, past what the stream had on screen.
+    for _ in 0..30 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Unified view"))
+        .unwrap();
+
+    // The composite's cursor was ~30 lines into the file; the stream
+    // should have followed it there rather than staying at the top.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("changed_2") || screen.contains("original_2"),
+        "the stream should come back around the line the reader left, not \
+         the top of the file:\n{}",
+        screen
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
@@ -70,24 +70,44 @@ fn open_review_diff(harness: &mut EditorTestHarness) {
         })
         .unwrap();
     // The toolbar lands before the stream does; wait for real diff rows.
+    // A rewritten file diffs as 60 removals and then 60 additions, so the
+    // rows on screen are the `original_` side.
     harness
-        .wait_until(|h| h.screen_to_string().contains("changed_0"))
+        .wait_until(|h| h.screen_to_string().contains("original_0()"))
         .unwrap();
 }
 
-/// Screen row carrying the cursor-line bar, found by its background.
-///
-/// The bar is declared with `extendToLineEnd`, but the diff's own row
-/// backgrounds (added / removed / hunk body) paint over most of it — the
-/// panel's first column is the one place it always shows through.
+/// Screen row carrying the cursor-line bar, found by its background: the
+/// bar washes its whole row in the selection colour, and no other row in
+/// the diff carries more than a cell or two of it.
 fn cursor_bar_row(harness: &EditorTestHarness) -> Option<u16> {
     let selection_bg = harness.editor().theme().selection_bg;
-    let height = harness.buffer().area.height;
-    (0..height).find(|&y| {
-        harness
-            .get_cell_style(0, y)
-            .is_some_and(|style| style.bg == Some(selection_bg))
-    })
+    let area = harness.buffer().area;
+    (0..area.height)
+        .map(|y| {
+            let washed = (0..area.width)
+                .filter(|&x| {
+                    harness
+                        .get_cell_style(x, y)
+                        .is_some_and(|style| style.bg == Some(selection_bg))
+                })
+                .count();
+            (y, washed)
+        })
+        .max_by_key(|&(_, washed)| washed)
+        .filter(|&(_, washed)| washed > 3)
+        .map(|(y, _)| y)
+}
+
+/// Every cell's background, so a test can tell "the frame changed" from
+/// "the text changed" — a cursor move repaints highlights without moving
+/// a single character.
+fn background_fingerprint(harness: &EditorTestHarness) -> Vec<Option<ratatui::style::Color>> {
+    let area = harness.buffer().area;
+    (0..area.height)
+        .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+        .map(|(x, y)| harness.get_cell_style(x, y).and_then(|style| style.bg))
+        .collect()
 }
 
 /// The diff row the bar is sitting on, as text.
@@ -105,6 +125,22 @@ fn cursor_bar_text(harness: &EditorTestHarness) -> String {
         .unwrap_or_default()
         .trim_end()
         .to_string()
+}
+
+/// `2` then `1`, waiting for each layout to be the one on screen.
+fn flip_to_split_and_back(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Unified view"))
+        .unwrap();
 }
 
 /// Press a key and draw exactly one frame — no draining of plugin work in
@@ -187,13 +223,13 @@ fn test_side_by_side_cursor_moves_in_the_frame_the_key_arrives_in() {
         .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
         .unwrap();
 
-    let before = harness.editor().active_cursors().primary().position;
+    let before = background_fingerprint(&harness);
     key_then_one_frame(&mut harness, KeyCode::Down);
     assert_ne!(
         before,
-        harness.editor().active_cursors().primary().position,
-        "Down should move the composite's cursor within the same frame.\n\
-         Screen:\n{}",
+        background_fingerprint(&harness),
+        "Down should move the composite's cursor — and its row highlight — \
+         within the frame the key arrived in.\nScreen:\n{}",
         harness.screen_to_string()
     );
 }
@@ -213,37 +249,32 @@ fn test_layout_flips_do_not_relayout_the_stream() {
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
 
-    let before = harness.editor().perf_counters().panel_content_sets;
-    for _ in 0..2 {
-        harness
-            .send_key(KeyCode::Char('2'), KeyModifiers::NONE)
-            .unwrap();
-        harness
-            .wait_until(|h| h.screen_to_string().contains("Side-by-side view"))
-            .unwrap();
-        harness
-            .send_key(KeyCode::Char('1'), KeyModifiers::NONE)
-            .unwrap();
-        harness
-            .wait_until(|h| h.screen_to_string().contains("Unified view"))
-            .unwrap();
-    }
-    let after = harness.editor().perf_counters().panel_content_sets;
+    // One warm-up pair first. The panel reports its real width to the
+    // plugin only after the stream has been laid out once, and the inline
+    // comment boxes are wrapped to that width — so the first flip legitimately
+    // carries one relayout the reader is owed. What must not repeat is the
+    // one after it.
+    flip_to_split_and_back(&mut harness);
+
+    let before = harness.editor().perf_counters().panel_content_rows;
+    flip_to_split_and_back(&mut harness);
+    flip_to_split_and_back(&mut harness);
+    let after = harness.editor().perf_counters().panel_content_rows;
 
     // The sticky header is a panel too and it *does* change on a flip (it
-    // names the current file), so the budget is not zero — but the stream,
-    // the expensive one, must not be among them. Four flips would be four
-    // stream layouts before the fix.
+    // names the current file), so the budget is not zero — but it is a row
+    // or two per flip against the stream's ~125, which is what a rebuild
+    // would put through here twice over.
     assert!(
-        after - before <= 4,
-        "four layout flips re-laid-out panels {} times; the stream should \
-         have been reused",
+        after - before < 60,
+        "two layout flips re-laid-out {} panel rows; the stream should have \
+         been reused",
         after - before
     );
 
     // The stream is still the real thing afterwards, not a stale husk.
     assert!(
-        harness.screen_to_string().contains("changed_"),
+        harness.screen_to_string().contains("original_"),
         "the reused stream should still show the diff:\n{}",
         harness.screen_to_string()
     );
@@ -260,7 +291,7 @@ fn test_a_content_change_still_relayouts_the_stream() {
     let mut harness = harness_for(&repo);
     open_review_diff(&mut harness);
 
-    let before = harness.editor().perf_counters().panel_content_sets;
+    let before = harness.editor().perf_counters().panel_content_rows;
     harness
         .send_key(KeyCode::Char('a'), KeyModifiers::NONE)
         .unwrap();
@@ -271,9 +302,9 @@ fn test_a_content_change_still_relayouts_the_stream() {
         })
         .unwrap();
     assert!(
-        harness.editor().perf_counters().panel_content_sets > before,
-        "a view toggle changes what the stream says, so it has to be laid \
-         out again"
+        harness.editor().perf_counters().panel_content_rows - before > 60,
+        "a view toggle changes what the stream says, so the whole stream \
+         has to be laid out again"
     );
 }
 
@@ -305,11 +336,12 @@ fn test_flip_back_to_unified_lands_on_the_line_the_reader_left() {
         .wait_until(|h| h.screen_to_string().contains("Unified view"))
         .unwrap();
 
-    // The composite's cursor was ~30 lines into the file; the stream
-    // should have followed it there rather than staying at the top.
+    // The composite's cursor was ~30 lines into the file, which is past
+    // the bottom of the stream's viewport: the stream should have followed
+    // it there, leaving the file's first row behind.
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains("changed_2") || screen.contains("original_2"),
+        !screen.contains("original_0()"),
         "the stream should come back around the line the reader left, not \
          the top of the file:\n{}",
         screen

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
@@ -509,3 +509,43 @@ fn test_files_sidebar_follows_the_diff_cursor() {
         harness.screen_to_string()
     );
 }
+
+/// Issue 7: a hunk header is a place too.
+///
+/// `n` leaves the cursor on the `@@` row, which is exactly where a reader
+/// flips the layout from — and the anchor that carries the reader's place
+/// across the flip only understood `+`/`-`/context rows. Anchored on
+/// nothing, the switch back reopened the file wherever the composite
+/// happened to be, throwing away the hunk the reader was standing on.
+#[test]
+fn test_layout_flip_from_a_hunk_header_comes_back_to_it() {
+    init_tracing_from_env();
+    let repo = repo_with_two_changed_files();
+    let mut harness = harness_for(&repo);
+    open_review_diff_for(&mut harness, "alpha_changed_0");
+
+    // Second hunk: far enough from the top that losing the anchor shows.
+    for _ in 0..2 {
+        harness
+            .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    let header = cursor_bar_text(&harness);
+    assert!(
+        header.contains("@@"),
+        "`n` should leave the cursor on a hunk header, got `{}`:\n{}",
+        header.trim(),
+        harness.screen_to_string()
+    );
+
+    flip_to_split_and_back(&mut harness);
+
+    assert_eq!(
+        cursor_bar_text(&harness),
+        header,
+        "the flip should come back to the hunk header the reader left.\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_cursor_and_layout.rs
@@ -17,6 +17,14 @@
 //! The first two are asserted on the panel-relayout counter (a rebuild is
 //! not visible on screen — its *absence* is the fix), the last two on
 //! rendered output after a single frame.
+//!
+//! Two more from the same session, same shape:
+//!
+//!   5. `n` / `p` re-laid-out the whole stream on every press, to reveal
+//!      rows that a fold was hiding — usually with no fold in the way at
+//!      all;
+//!   6. the FILES sidebar stayed on the file you started in while the
+//!      cursor read its way down through the others.
 
 use crate::common::git_test_helper::GitTestRepo;
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
@@ -30,6 +38,26 @@ fn setup_audit_mode_plugin(repo: &GitTestRepo) {
     fs::create_dir_all(&plugins_dir).expect("create plugins dir");
     copy_plugin(&plugins_dir, "audit_mode");
     copy_plugin_lib(&plugins_dir);
+}
+
+/// Two changed files, so the cursor can walk out of one and into the next.
+fn repo_with_two_changed_files() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("src/alpha.rs", "fn alpha_original() {}\n");
+    repo.create_file("src/beta.rs", "fn beta_original() {}\n");
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+    let alpha: String = (0..12)
+        .map(|i| format!("fn alpha_changed_{i}() {{ let a = {i}; }}\n"))
+        .collect();
+    let beta: String = (0..12)
+        .map(|i| format!("fn beta_changed_{i}() {{ let b = {i}; }}\n"))
+        .collect();
+    repo.create_file("src/alpha.rs", &alpha);
+    repo.create_file("src/beta.rs", &beta);
+    repo
 }
 
 /// A repo whose single file has a long, unbroken run of changed lines, so
@@ -58,6 +86,15 @@ fn harness_for(repo: &GitTestRepo) -> EditorTestHarness {
 }
 
 fn open_review_diff(harness: &mut EditorTestHarness) {
+    // A rewritten file diffs as every removal and then every addition, so
+    // the rows on screen are the `original_` side.
+    open_review_diff_for(harness, "original_0()");
+}
+
+/// Open the review and wait until `first_row` — a string from the first
+/// diff rows the stream puts on screen — is actually rendered. The toolbar
+/// lands well before the stream does.
+fn open_review_diff_for(harness: &mut EditorTestHarness, first_row: &str) {
     harness.run_palette_command("Review Diff").unwrap();
     harness.wait_for_prompt_closed().unwrap();
     harness
@@ -69,12 +106,55 @@ fn open_review_diff(harness: &mut EditorTestHarness) {
             s.contains("next hunk") && !s.contains("Generating Review")
         })
         .unwrap();
-    // The toolbar lands before the stream does; wait for real diff rows.
-    // A rewritten file diffs as 60 removals and then 60 additions, so the
-    // rows on screen are the `original_` side.
     harness
-        .wait_until(|h| h.screen_to_string().contains("original_0()"))
+        .wait_until(|h| h.screen_to_string().contains(first_row))
         .unwrap();
+}
+
+/// Reveal the FILES sidebar (`F`) and hand the keys back to the diff —
+/// `F` focuses what it reveals, and these tests drive the diff.
+fn show_files_panel(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("FILES"))
+        .unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("\u{25b8}FILES"))
+        .unwrap();
+}
+
+/// Text of the sidebar's selected row, read off the screen by the
+/// selection band a widget tree paints behind its selected node
+/// (`ui.popup_selection_bg` — not the editor's own selection colour).
+/// Restricted to the columns left of the panel divider, so nothing in the
+/// diff beside it can be mistaken for the sidebar's selection.
+fn selected_sidebar_row(harness: &EditorTestHarness) -> Option<String> {
+    let selection_bg = harness.editor().theme().popup_selection_bg;
+    let screen = harness.screen_to_string();
+    let divider = screen
+        .lines()
+        .filter_map(|line| line.find('\u{2502}'))
+        .min()? as u16;
+    let area = harness.buffer().area;
+    (0..area.height).find_map(|y| {
+        let washed = (0..divider)
+            .filter(|&x| {
+                harness
+                    .get_cell_style(x, y)
+                    .is_some_and(|style| style.bg == Some(selection_bg))
+            })
+            .count();
+        if washed < 3 {
+            return None;
+        }
+        screen
+            .lines()
+            .nth(y as usize)
+            .map(|line| line.chars().take(divider as usize).collect())
+    })
 }
 
 /// Screen row carrying the cursor-line bar, found by its background: the
@@ -345,5 +425,87 @@ fn test_flip_back_to_unified_lands_on_the_line_the_reader_left() {
         "the stream should come back around the line the reader left, not \
          the top of the file:\n{}",
         screen
+    );
+}
+
+/// Issue 5: `n` and `p` are navigation, not a reason to lay the review
+/// out again.
+///
+/// They expand whatever collapse hides the target so the jump never lands
+/// on an invisible row — but collapsing is a host fold over rows the
+/// stream already carries, so revealing them costs a fold change, not a
+/// relayout. Re-emitting the stream for it put a second of work behind
+/// every press on a large review, and did it even when nothing was
+/// collapsed in the first place.
+#[test]
+fn test_hunk_navigation_does_not_relayout_the_stream() {
+    init_tracing_from_env();
+    let repo = repo_with_two_changed_files();
+    let mut harness = harness_for(&repo);
+    open_review_diff_for(&mut harness, "alpha_changed_0");
+
+    let before = harness.editor().perf_counters().panel_content_rows;
+    for _ in 0..4 {
+        harness
+            .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::NONE)
+        .unwrap();
+    let after = harness.editor().perf_counters().panel_content_rows;
+
+    // The sticky header is a panel and it does change as `n` crosses into
+    // another file, so this is not zero — but it is a row per press
+    // against the stream's dozens.
+    assert!(
+        after - before < 20,
+        "five hunk jumps re-laid-out {} panel rows; navigation should only \
+         move the cursor",
+        after - before
+    );
+}
+
+/// Issue 6: the FILES sidebar points at the file the cursor is in.
+///
+/// A tree's selected row is host state after its first render, so the
+/// plugin repainting the panel with a new "current file" moved nothing.
+#[test]
+fn test_files_sidebar_follows_the_diff_cursor() {
+    init_tracing_from_env();
+    let repo = repo_with_two_changed_files();
+    let mut harness = harness_for(&repo);
+    open_review_diff_for(&mut harness, "alpha_changed_0");
+    show_files_panel(&mut harness);
+
+    // Walk down until the cursor bar itself is sitting on a beta.rs row —
+    // both files fit on one screen here, so what is *visible* says nothing
+    // about where the cursor is.
+    let mut landed = false;
+    for _ in 0..60 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        if cursor_bar_text(&harness).contains("beta_changed_") {
+            landed = true;
+            break;
+        }
+    }
+    assert!(
+        landed,
+        "the cursor never reached beta.rs:\n{}",
+        harness.screen_to_string()
+    );
+
+    let selected = selected_sidebar_row(&harness).unwrap_or_else(|| {
+        panic!(
+            "no row selected in the sidebar:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    assert!(
+        selected.contains("beta.rs"),
+        "the sidebar should have followed the cursor into beta.rs, but it \
+         is on `{}`:\n{}",
+        selected.trim(),
+        harness.screen_to_string()
     );
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3966,6 +3966,71 @@ impl JsEditorApi {
         Ok(true)
     }
 
+    /// Declare a one-line overlay that follows this buffer's cursor.
+    ///
+    /// Takes the same options as `addOverlay` and paints the same way — the
+    /// difference is who places it. The host re-derives the range from the
+    /// cursor while drawing each frame, so the bar marks the row the caret
+    /// is on in that very frame. Painting it by hand from `cursor_moved`
+    /// cannot: the hook fires after the move that already drew, so the bar
+    /// lands a frame late and visibly trails a held arrow key.
+    ///
+    /// Pass `null` to withdraw it.
+    ///
+    /// ```typescript
+    /// editor.setCursorLineOverlay(bufferId, {
+    ///   bg: "editor.selection_bg",
+    ///   extendToLineEnd: true,
+    /// });
+    /// ```
+    #[qjs(rename = "setCursorLineOverlay")]
+    pub fn set_cursor_line_overlay<'js>(
+        &self,
+        _ctx: rquickjs::Ctx<'js>,
+        buffer_id: u32,
+        options: rquickjs::Value<'js>,
+    ) -> rquickjs::Result<bool> {
+        use fresh_core::api::OverlayColorSpec;
+
+        // Same parser shape as addOverlay; accepts `[r, g, b]` arrays or
+        // theme-key strings.
+        fn parse_color_spec(key: &str, obj: &rquickjs::Object<'_>) -> Option<OverlayColorSpec> {
+            if let Ok(theme_key) = obj.get::<_, String>(key) {
+                if !theme_key.is_empty() {
+                    return Some(OverlayColorSpec::ThemeKey(theme_key));
+                }
+            }
+            if let Ok(arr) = obj.get::<_, Vec<u8>>(key) {
+                if arr.len() >= 3 {
+                    return Some(OverlayColorSpec::Rgb(arr[0], arr[1], arr[2]));
+                }
+            }
+            None
+        }
+
+        let parsed = options.as_object().map(|obj| OverlayOptions {
+            fg: parse_color_spec("fg", obj),
+            bg: parse_color_spec("bg", obj),
+            underline: obj.get("underline").unwrap_or(false),
+            bold: obj.get("bold").unwrap_or(false),
+            italic: obj.get("italic").unwrap_or(false),
+            strikethrough: obj.get("strikethrough").unwrap_or(false),
+            extend_to_line_end: obj.get("extendToLineEnd").unwrap_or(false),
+            reversed: obj.get("reversed").unwrap_or(false),
+            fg_on_collision_only: obj.get("fgOnCollisionOnly").unwrap_or(false),
+            url: obj.get("url").ok(),
+        });
+
+        let _ = self
+            .command_sender
+            .send(PluginCommand::SetCursorLineOverlay {
+                buffer_id: BufferId(buffer_id as usize),
+                options: parsed,
+            });
+
+        Ok(true)
+    }
+
     /// Clear all overlays in a namespace
     pub fn clear_namespace(&self, buffer_id: u32, namespace: String) -> bool {
         self.command_sender


### PR DESCRIPTION
Seven complaints from reading a large range (`HEAD~100..HEAD`) by hand. They turned out to be the same shape: work landing on the wrong side of the frame that shows it.

Reproduced interactively (tmux, debug build, `HEAD~45..HEAD` — 60 files, ~11k diff lines) before and after.

### 1 + 2 — flipping layouts showed a stale frame, and took seconds

Pressing `1` swapped the panel to the stream buffer immediately, then re-emitted the stream's content behind it (`SetPanelContent`, measured at 0.6–1.0s on the editor thread). The reader saw the old scroll position sit there and then jump. Nothing the stream is built from changes when the layout flips, so the content is now re-laid-out only when its signature changes — a flip reuses what is already in the buffer.

Pressing `2` destroyed the composite on the way out and rebuilt it from scratch on the way back: two `git show` calls, two whole files across the IPC boundary, an alignment pass. It is now parked instead of destroyed and re-mounted when it still describes the file as it stands (invalidated by a data refresh, a hunk-range change, or a comment on that file). The two version reads also run concurrently, and each pane ships as one span rather than one per line — the per-line properties were never read back.

| flip | before | after |
|------|--------|-------|
| unified → side-by-side (first, cold) | 2.8s | 2.5s |
| side-by-side → unified | 2.6s | 0.14s |
| every subsequent flip | 2.6–2.8s | 0.13s |

### 3 — the cursor-line bar trailed a held arrow key by one row

The plugin painted the bar from the `cursor_moved` hook, which fires *after* the frame that already moved the caret — so every repaint answered the previous frame's cursor, and the bar could never catch up.

New plugin API `setCursorLineOverlay(bufferId, options)`: the plugin declares the bar once, with the same `OverlayOptions` it used to pass to `addOverlay`, and the host places it from the cursor in the decoration pass, alongside the other cursor-driven overlays (reference highlight, bracket match). The bar cannot disagree with the caret because both come from the same read. Appearance is unchanged.

### 4 — moving the cursor took a round trip

`↑ ↓ PageUp PageDown Home End ← →` were bound to plugin handlers whose entire job was to ask for the matching built-in action, so a keystroke went out to the plugin thread and back before anything moved. The buffers the editor's own cursor lives in (the unified stream and the side-by-side composite) now carry `review-diff`, a copy of the keymap that binds those keys straight to the built-ins. The side panels keep `review-mode`, where `↑`/`↓` drive a widget's selection and the plugin has to be involved. A visual line selection now follows the cursor from `cursor_moved`, which sees every motion rather than only the ones those handlers still receive.

### 5 — `n` / `p` cost seconds per press

Both expand whatever collapse hides the hunk they are jumping to, so the cursor never lands on a row a fold is eliding — and to do that they re-laid-out the whole stream. But collapsing is a host fold over rows the stream already carries (`applyFolds`), so revealing them is a fold change, not a relayout; and the expansion was unconditional, so most presses paid a full layout to reveal nothing. **2.7s → 0.05s per press** on the range above. Jump-to-file and jump-to-comment carried the same unconditional rebuild and take the fold path too, with the comment jump keeping its relayout for the one case that needs it (the centre carrying a different file).

### 6 — the FILES sidebar stayed where you left it

A widget tree's selected row is host state after its first render — the `selectedIndex` in a rebuilt spec is a seed the host ignores — so the plugin repainting the panel with a new current file moved nothing, and reading down the stream walked the cursor through file after file with the sidebar still pointing at the first one. The selection now moves through the host-side setter, which also scrolls it into view. A directory or section row the user selected stays put: folding one is the sidebar's own gesture, and the diff cursor has no opinion about it.

### 7 — flipping from a hunk header lost the reader's place

The anchor that carries the reader's position across `1`/`2` only understood `+`/`-`/context rows. `n` leaves the cursor on the `@@` header and `,`/`.` leave it on a file header — the rows a reader is most likely to flip from — and from any of them the anchor came back null, so the switch had nothing to restore and the file reopened wherever the composite happened to sit. A row that is not a diff line now anchors on the hunk (or file) it belongs to.

Coming back is exact rather than approximate: the composite has no header rows, so a header anchor could only round-trip as "the hunk's first line", one row off. Switching in remembers where it put the composite's cursor, and if the reader looked and came straight back without moving it, the row they left the stream on is restored verbatim; move in the composite and the cursor's own position wins instead.

### Also here

`fresh-core` only compiled when something else in the dependency graph happened to enable serde's `rc` feature, which took out the documented way to regenerate `plugins/lib/fresh.d.ts`. Fixed in its own commit.

`PerfCounters` gains `panel_content_rows`, so a test can assert which gestures re-lay-out a panel and which reuse it — a rebuild is not visible on screen, its absence is the fix. Rows rather than calls, because a flip legitimately repaints the one-row sticky header and what matters is the stream's hundred-plus rows going through again behind it.

The width-settle repaint (added while fixing 1+2) originally ran the full `renderCenter`, which swaps which buffer the panel shows and claims focus — fine from a keystroke, wrong from a timer firing 60ms after a width change nobody typed, since it could pull a reader out of a drill-down mid-read. It re-emits content only.

### Tests

`review_diff_cursor_and_layout.rs` drives one key and draws exactly one frame — without the drain `send_key` does, which is what hid the round trip — and asserts the caret and its bar both moved, in the stream and in the composite. Layout flips and hunk navigation are asserted against the relayout counter, with a view toggle (`a`) proving the reuse is not blind; the sidebar's selection and the hunk-header round trip are read off the rendered screen. Unit tests cover the overlay's placement, its no-op path and its withdrawal.

Every test in that file was checked against the pre-fix plugin: the bar doesn't move, the composite cursor doesn't move, two flips re-lay-out 254 panel rows, five hunk jumps re-lay-out 105, no sidebar row is selected, and the flip from a hunk header comes back on a `-fn beta_original() {}` line instead of the header.

Existing suites run locally: `review_diff*` (66), `audit_mode` (42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118er1QA463rHTzZvWmWYUN