### PR TITLE
fix(git-log): stop the detail panel's diff colours drifting off their rows

### DIFF
--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -334,7 +334,10 @@ function cachePathForHash(hash: string): string {
   // plugin adds no colouring of its own. A plugin-side overlay pass
   // used to duplicate it and was the only thing that could put a
   // stripe on the wrong row; the host's pass is also viewport-local,
-  // where the plugin's had to walk the whole buffer.
+  // where the plugin's had to walk the whole buffer. The host leaves
+  // one gap the overlay used to cover — the section context after a
+  // hunk header's closing `@@` gets no wash (#3021) — which is a
+  // host-side issue for every `.diff` buffer, not one to re-patch here.
   return `${editor.getDataDir()}/git-show/${hash}.diff`;
 }
 

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -3,6 +3,7 @@
 import {
   type GitCommit,
   buildCommitLogEntries,
+  byteLength,
   fetchGitLog,
 } from "./lib/git_history.ts";
 import {
@@ -474,7 +475,10 @@ async function applyDiffHighlights(bufferId: number): Promise<void> {
 
   // Walk lines tracking byte offsets; coalesce consecutive same-kind
   // rows into single ranges so a 30-line added block costs one
-  // overlay, not 30.
+  // overlay, not 30. Overlay offsets are UTF-8 bytes, so every line
+  // advances by its *byte* length — `line.length` counts UTF-16 code
+  // units, which drags every overlay below a non-ASCII line a few
+  // bytes too early and paints the stripes onto their neighbours.
   let byte = 0;
   let runKind: "+" | "-" | "@" | null = null;
   let runStart = 0;
@@ -496,7 +500,7 @@ async function applyDiffHighlights(bufferId: number): Promise<void> {
   };
 
   for (const line of text.split("\n")) {
-    const lineLen = line.length;
+    const lineLen = byteLength(line);
     const ch = line.charAt(0);
     let kind: "+" | "-" | "@" | null = null;
     if (ch === "+" && !line.startsWith("+++")) kind = "+";
@@ -1074,11 +1078,14 @@ async function deriveFileAndLineFromDiffCursor(
 
   // Locate the cursor's line index by walking byte offsets. `lines[i]`
   // covers bytes [byte, byte+len]; the `\n` separator lives at
-  // byte+len, so the next line starts at byte+len+1.
+  // byte+len, so the next line starts at byte+len+1. `len` is the
+  // line's UTF-8 byte length — the cursor is a byte offset, so a
+  // UTF-16 `.length` would land on the wrong line in any diff
+  // containing non-ASCII text.
   let byte = 0;
   let cursorLineIdx = lines.length - 1;
   for (let i = 0; i < lines.length; i++) {
-    const lineLen = lines[i].length;
+    const lineLen = byteLength(lines[i]);
     if (cursor <= byte + lineLen) {
       cursorLineIdx = i;
       break;

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -328,7 +328,13 @@ function renderLog(): void {
  */
 function cachePathForHash(hash: string): string {
   // `<dataDir>/git-show/<sha>.diff` — the .diff extension lets the
-  // syntax-highlight grammar kick in for free.
+  // syntax-highlight grammar kick in for free. That covers the whole
+  // detail panel: the host paints `+` / `-` / `@@` rows from
+  // `editor.diff_add_bg` / `diff_remove_bg` / `diff_modify_bg`, so the
+  // plugin adds no colouring of its own. A plugin-side overlay pass
+  // used to duplicate it and was the only thing that could put a
+  // stripe on the wrong row; the host's pass is also viewport-local,
+  // where the plugin's had to walk the whole buffer.
   return `${editor.getDataDir()}/git-show/${hash}.diff`;
 }
 
@@ -435,93 +441,6 @@ async function pollUntilSpawnDone(
   // says "complete". Written after the bytes are on disk so a reader
   // that sees the marker also sees the full diff.
   editor.writeFile(editor.localPath(donePathForHash(hash)), "");
-  // Apply diff coloring once the buffer is complete. Doing this
-  // pre-completion would either churn (re-walk on every refresh) or
-  // double-overlay newly-extended lines; on completion we walk once.
-  await applyDiffHighlights(bufferId);
-}
-
-// =============================================================================
-// Diff syntax highlighting via per-line bg overlays
-//
-// Sublime-syntax's bundled `Diff` definition only scopes the `diff`
-// keyword, so themes only colour that. Plugins are responsible for the
-// rest — same approach `live_diff` uses for inline diff coloring in
-// regular buffers.
-//
-// One overlay per line of added/removed content is fine for the
-// "normal commit" workload but explodes on giant commits (the
-// rewrite-bun commit is 1M lines = 1M overlays = back to the old
-// 500k-overlay problem this rewire eliminated). Gate on buffer size;
-// gracefully degrade to no highlighting for outliers.
-// =============================================================================
-
-const HIGHLIGHT_BG_ADDED = "editor.diff_add_bg";
-const HIGHLIGHT_BG_REMOVED = "editor.diff_remove_bg";
-const HIGHLIGHT_BG_HUNK = "editor.diff_modify_bg";
-const HIGHLIGHT_NAMESPACE = "git-log-diff";
-/** Skip overlay highlighting above this size. ~256 KB covers
- *  basically every hand-written commit comfortably; very large
- *  generated-file diffs (lockfiles, minified code) just stay
- *  uncoloured — the cost would be a few thousand-to-a-million
- *  overlays for content the user mostly skims. */
-const HIGHLIGHT_MAX_BYTES = 256 * 1024;
-
-async function applyDiffHighlights(bufferId: number): Promise<void> {
-  const total = editor.getBufferLength(bufferId);
-  if (total === 0 || total > HIGHLIGHT_MAX_BYTES) return;
-  const text = await editor.getBufferText(bufferId, 0, total);
-  if (!text) return;
-
-  // Walk lines tracking byte offsets; coalesce consecutive same-kind
-  // rows into single ranges so a 30-line added block costs one
-  // overlay, not 30. Overlay offsets are UTF-8 bytes, so every line
-  // advances by its *byte* length — `line.length` counts UTF-16 code
-  // units, which drags every overlay below a non-ASCII line a few
-  // bytes too early and paints the stripes onto their neighbours.
-  let byte = 0;
-  let runKind: "+" | "-" | "@" | null = null;
-  let runStart = 0;
-  let runEnd = 0;
-
-  const flushRun = () => {
-    if (runKind === null) return;
-    const bg =
-      runKind === "+"
-        ? HIGHLIGHT_BG_ADDED
-        : runKind === "-"
-        ? HIGHLIGHT_BG_REMOVED
-        : HIGHLIGHT_BG_HUNK;
-    editor.addOverlay(bufferId, HIGHLIGHT_NAMESPACE, runStart, runEnd, {
-      bg,
-      extendToLineEnd: true,
-    });
-    runKind = null;
-  };
-
-  for (const line of text.split("\n")) {
-    const lineLen = byteLength(line);
-    const ch = line.charAt(0);
-    let kind: "+" | "-" | "@" | null = null;
-    if (ch === "+" && !line.startsWith("+++")) kind = "+";
-    else if (ch === "-" && !line.startsWith("---")) kind = "-";
-    else if (line.startsWith("@@")) kind = "@";
-
-    if (kind !== runKind) {
-      flushRun();
-      if (kind !== null) {
-        runStart = byte;
-        runKind = kind;
-      }
-    }
-    if (kind !== null) {
-      // Include the trailing newline in the range so the bg colour
-      // fills the row even on empty lines that wrap-extend.
-      runEnd = byte + lineLen + 1;
-    }
-    byte += lineLen + 1;
-  }
-  flushRun();
 }
 
 /**

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1821,10 +1821,13 @@ impl TextMateEngine {
     /// Map scope stack to highlight category, memoising per-scope lookups.
     /// `scope.build_string()` is the costly step; the cache hides it after
     /// each scope atom has been seen once.
+    /// Innermost scope wins, except that a diff wash anywhere in the stack
+    /// beats it — see the free [`scope_stack_to_category`] for why.
     fn scope_stack_to_category(
         &mut self,
         scopes: &syntect::parsing::ScopeStack,
     ) -> Option<HighlightCategory> {
+        let mut innermost = None;
         for scope in scopes.as_slice().iter().rev() {
             let cat = match self.scope_category_cache.get(scope) {
                 Some(c) => *c,
@@ -1835,10 +1838,15 @@ impl TextMateEngine {
                 }
             };
             if let Some(c) = cat {
-                return Some(c);
+                if is_diff_wash(c) {
+                    return Some(c);
+                }
+                if innermost.is_none() {
+                    innermost = Some(c);
+                }
             }
         }
-        None
+        innermost
     }
 
     /// Classify every line start in `range` by its role in an
@@ -2439,15 +2447,40 @@ pub fn highlight_string(
     spans
 }
 
+/// Does `category` wash a whole diff row with a background colour?
+///
+/// These are the only categories `highlight_bg` gives a background to, and
+/// their scopes (`markup.inserted`, `markup.deleted`, `meta.diff.range`, …)
+/// cover the entire row. An inner scope that only carries a foreground must
+/// therefore not displace them — see [`scope_stack_to_category`].
+fn is_diff_wash(category: HighlightCategory) -> bool {
+    matches!(
+        category,
+        HighlightCategory::Inserted | HighlightCategory::Deleted | HighlightCategory::Changed
+    )
+}
+
 /// Map scope stack to highlight category (for highlight_string)
+///
+/// Innermost scope wins, *except* that a diff wash anywhere in the stack
+/// beats it. syntect's `Diff` grammar scopes the trailing section context of
+/// a `@@ -1,3 +1,5 @@ fn main()` header as its own entity inside
+/// `meta.diff.range.unified`; letting that inner, background-less scope win
+/// punched a hole through the middle of the hunk header's bar.
 fn scope_stack_to_category(scopes: &syntect::parsing::ScopeStack) -> Option<HighlightCategory> {
+    let mut innermost = None;
     for scope in scopes.as_slice().iter().rev() {
         let scope_str = scope.build_string();
         if let Some(cat) = scope_to_category(&scope_str) {
-            return Some(cat);
+            if is_diff_wash(cat) {
+                return Some(cat);
+            }
+            if innermost.is_none() {
+                innermost = Some(cat);
+            }
         }
     }
-    None
+    innermost
 }
 
 /// Merge adjacent spans with same color
@@ -3577,6 +3610,52 @@ mod tests {
             }
         } else {
             panic!("Expected TextMate engine for .diff file");
+        }
+    }
+
+    /// A hunk header carries the enclosing section after the closing `@@`
+    /// (`git diff` puts the surrounding function there on nearly every real
+    /// hunk). syntect scopes that trailing text as its own entity inside
+    /// `meta.diff.range.unified`, and taking the innermost scope's category
+    /// dropped the row's `diff_modify_bg` across exactly those columns — a
+    /// black hole punched through the middle of the hunk header's bar.
+    #[test]
+    fn test_diff_hunk_header_with_section_context_is_fully_covered() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        let content = "diff --git a/file.rs b/file.rs\n\
+             index aaa..bbb 100644\n\
+             --- a/file.rs\n\
+             +++ b/file.rs\n\
+             @@ -2,6 +2,8 @@ fn main() {\n\
+             +    let x = 1;\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        let HighlightEngine::TextMate(ref mut tm) = engine else {
+            panic!("Expected TextMate engine for .diff file");
+        };
+        let spans = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+
+        let hunk_start = content.find("@@ -2,6").expect("hunk header in fixture");
+        let hunk_end = hunk_start
+            + content[hunk_start..]
+                .find('\n')
+                .expect("hunk header is newline-terminated");
+        for byte_pos in hunk_start..hunk_end {
+            let span = spans
+                .iter()
+                .find(|s| s.range.start <= byte_pos && s.range.end > byte_pos);
+            assert_eq!(
+                span.and_then(|s| s.bg),
+                Some(theme.diff_modify_bg),
+                "byte {} (`{}`) of the hunk header should carry diff_modify_bg; got span={:?}",
+                byte_pos,
+                content[byte_pos..byte_pos + 1].escape_debug(),
+                span,
+            );
         }
     }
 

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1821,13 +1821,10 @@ impl TextMateEngine {
     /// Map scope stack to highlight category, memoising per-scope lookups.
     /// `scope.build_string()` is the costly step; the cache hides it after
     /// each scope atom has been seen once.
-    /// Innermost scope wins, except that a diff wash anywhere in the stack
-    /// beats it — see the free [`scope_stack_to_category`] for why.
     fn scope_stack_to_category(
         &mut self,
         scopes: &syntect::parsing::ScopeStack,
     ) -> Option<HighlightCategory> {
-        let mut innermost = None;
         for scope in scopes.as_slice().iter().rev() {
             let cat = match self.scope_category_cache.get(scope) {
                 Some(c) => *c,
@@ -1838,15 +1835,10 @@ impl TextMateEngine {
                 }
             };
             if let Some(c) = cat {
-                if is_diff_wash(c) {
-                    return Some(c);
-                }
-                if innermost.is_none() {
-                    innermost = Some(c);
-                }
+                return Some(c);
             }
         }
-        innermost
+        None
     }
 
     /// Classify every line start in `range` by its role in an
@@ -2447,40 +2439,15 @@ pub fn highlight_string(
     spans
 }
 
-/// Does `category` wash a whole diff row with a background colour?
-///
-/// These are the only categories `highlight_bg` gives a background to, and
-/// their scopes (`markup.inserted`, `markup.deleted`, `meta.diff.range`, …)
-/// cover the entire row. An inner scope that only carries a foreground must
-/// therefore not displace them — see [`scope_stack_to_category`].
-fn is_diff_wash(category: HighlightCategory) -> bool {
-    matches!(
-        category,
-        HighlightCategory::Inserted | HighlightCategory::Deleted | HighlightCategory::Changed
-    )
-}
-
 /// Map scope stack to highlight category (for highlight_string)
-///
-/// Innermost scope wins, *except* that a diff wash anywhere in the stack
-/// beats it. syntect's `Diff` grammar scopes the trailing section context of
-/// a `@@ -1,3 +1,5 @@ fn main()` header as its own entity inside
-/// `meta.diff.range.unified`; letting that inner, background-less scope win
-/// punched a hole through the middle of the hunk header's bar.
 fn scope_stack_to_category(scopes: &syntect::parsing::ScopeStack) -> Option<HighlightCategory> {
-    let mut innermost = None;
     for scope in scopes.as_slice().iter().rev() {
         let scope_str = scope.build_string();
         if let Some(cat) = scope_to_category(&scope_str) {
-            if is_diff_wash(cat) {
-                return Some(cat);
-            }
-            if innermost.is_none() {
-                innermost = Some(cat);
-            }
+            return Some(cat);
         }
     }
-    innermost
+    None
 }
 
 /// Merge adjacent spans with same color
@@ -3610,52 +3577,6 @@ mod tests {
             }
         } else {
             panic!("Expected TextMate engine for .diff file");
-        }
-    }
-
-    /// A hunk header carries the enclosing section after the closing `@@`
-    /// (`git diff` puts the surrounding function there on nearly every real
-    /// hunk). syntect scopes that trailing text as its own entity inside
-    /// `meta.diff.range.unified`, and taking the innermost scope's category
-    /// dropped the row's `diff_modify_bg` across exactly those columns — a
-    /// black hole punched through the middle of the hunk header's bar.
-    #[test]
-    fn test_diff_hunk_header_with_section_context_is_fully_covered() {
-        let registry =
-            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
-        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
-        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
-
-        let content = "diff --git a/file.rs b/file.rs\n\
-             index aaa..bbb 100644\n\
-             --- a/file.rs\n\
-             +++ b/file.rs\n\
-             @@ -2,6 +2,8 @@ fn main() {\n\
-             +    let x = 1;\n";
-        let buffer = Buffer::from_str(content, 0, test_fs());
-
-        let HighlightEngine::TextMate(ref mut tm) = engine else {
-            panic!("Expected TextMate engine for .diff file");
-        };
-        let spans = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
-
-        let hunk_start = content.find("@@ -2,6").expect("hunk header in fixture");
-        let hunk_end = hunk_start
-            + content[hunk_start..]
-                .find('\n')
-                .expect("hunk header is newline-terminated");
-        for byte_pos in hunk_start..hunk_end {
-            let span = spans
-                .iter()
-                .find(|s| s.range.start <= byte_pos && s.range.end > byte_pos);
-            assert_eq!(
-                span.and_then(|s| s.bg),
-                Some(theme.diff_modify_bg),
-                "byte {} (`{}`) of the hunk header should carry diff_modify_bg; got span={:?}",
-                byte_pos,
-                content[byte_pos..byte_pos + 1].escape_debug(),
-                span,
-            );
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_diff_highlight_offset.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_diff_highlight_offset.rs
@@ -1,14 +1,18 @@
 //! Regression: the Git Log detail panel's diff colouring drifted away from the
 //! lines it belongs to as soon as the commit contained non-ASCII text.
 //!
-//! `git_log` paints the streaming `git show` output itself, walking the diff
-//! line by line and adding one background overlay per run of `+` / `-` / `@@`
-//! rows. Overlay positions are **UTF-8 byte offsets**, but the walk advanced by
-//! `line.length` — the number of UTF-16 code units. Every multi-byte character
-//! above a row therefore pulled that row's stripe a few bytes earlier, so the
-//! green and red blocks bled onto the neighbouring context lines: the symptom
-//! is a diff whose colours are offset by a few characters from the text they
-//! describe.
+//! `git_log` used to paint the streamed `git show` output itself, walking the
+//! diff line by line and adding one background overlay per run of `+` / `-` /
+//! `@@` rows. Overlay positions are **UTF-8 byte offsets**, but the walk
+//! advanced by `line.length` — the number of UTF-16 code units. Every
+//! multi-byte character above a row therefore pulled that row's stripe a few
+//! bytes earlier, so the green and red blocks bled onto the neighbouring
+//! context lines: the symptom is a diff whose colours are offset by a few
+//! characters from the text they describe.
+//!
+//! That pass is gone — the buffer is a `.diff` file the host highlights on its
+//! own — so these tests now guard the rendered result rather than any one
+//! layer producing it.
 //!
 //! The commit below puts an accented added line above a plain added line so a
 //! single frame shows both sides of the drift: the plain `+` row must be
@@ -19,10 +23,31 @@
 //! counted UTF-16 units the same way and so opened the file at the wrong line.
 
 use crate::common::git_test_helper::{DirGuard, GitTestRepo};
-use crate::common::harness::EditorTestHarness;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 use ratatui::style::Color;
+
+/// A harness whose grammar registry can actually highlight the `.diff` buffer
+/// the detail panel shows. Tests default to an empty registry for startup
+/// speed, which leaves the panel's diff uncoloured — and this file's whole
+/// subject is which cells that colouring lands on.
+fn harness_with_highlighting(
+    width: u16,
+    height: u16,
+    working_dir: std::path::PathBuf,
+) -> EditorTestHarness {
+    EditorTestHarness::create(
+        width,
+        height,
+        HarnessOptions::new()
+            .with_config(Config::default())
+            .with_working_dir(working_dir)
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
+    )
+    .unwrap()
+}
 
 /// The context line that sits between the accented addition and the plain one.
 const CTX_ROW: &str = "CTX KEEP LINE";
@@ -97,13 +122,7 @@ fn git_log_diff_colours_stay_on_their_lines_after_non_ascii() {
     let original_dir = repo.change_to_repo_dir();
     let _guard = DirGuard::new(original_dir);
 
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
-        120,
-        40,
-        Config::default(),
-        repo.path.clone(),
-    )
-    .unwrap();
+    let mut harness = harness_with_highlighting(120, 40, repo.path.clone());
 
     harness.open_file(&repo.path.join("notes.txt")).unwrap();
     harness.render().unwrap();
@@ -127,9 +146,9 @@ fn git_log_diff_colours_stay_on_their_lines_after_non_ascii() {
                 && s.contains(CLEAN_ROW)
         })
         .unwrap();
-    // The text arrives before the colours: `applyDiffHighlights` runs once the
-    // `git show` stream completes, so a frame can show the diff with no
-    // overlays at all. Let the plugin pipeline go quiet before reading cells.
+    // The text can land a frame before its colouring does: `git show` streams
+    // into the buffer and the highlighter runs over what has arrived. Let the
+    // pipeline go quiet before reading cells.
     harness.wait_for_async_quiescence(3).unwrap();
 
     let screen = harness.screen_to_string();
@@ -216,13 +235,7 @@ fn git_log_enter_opens_the_line_under_the_cursor_after_non_ascii() {
     // Wide enough that no diff row wraps in the 40%-width detail panel — the
     // cursor is walked down by display rows below, so a wrapped row would
     // desync the count from the buffer's lines.
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
-        160,
-        45,
-        Config::default(),
-        repo.path.clone(),
-    )
-    .unwrap();
+    let mut harness = harness_with_highlighting(160, 45, repo.path.clone());
 
     harness.open_file(&repo.path.join("notes.txt")).unwrap();
     harness.render().unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_diff_highlight_offset.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_diff_highlight_offset.rs
@@ -1,0 +1,285 @@
+//! Regression: the Git Log detail panel's diff colouring drifted away from the
+//! lines it belongs to as soon as the commit contained non-ASCII text.
+//!
+//! `git_log` paints the streaming `git show` output itself, walking the diff
+//! line by line and adding one background overlay per run of `+` / `-` / `@@`
+//! rows. Overlay positions are **UTF-8 byte offsets**, but the walk advanced by
+//! `line.length` — the number of UTF-16 code units. Every multi-byte character
+//! above a row therefore pulled that row's stripe a few bytes earlier, so the
+//! green and red blocks bled onto the neighbouring context lines: the symptom
+//! is a diff whose colours are offset by a few characters from the text they
+//! describe.
+//!
+//! The commit below puts an accented added line above a plain added line so a
+//! single frame shows both sides of the drift: the plain `+` row must be
+//! coloured, and the context row between them must carry none of that colour.
+//!
+//! The second test covers the other walk over the same diff text — the one
+//! `Enter` uses to turn the cursor's byte offset into a file and line — which
+//! counted UTF-16 units the same way and so opened the file at the wrong line.
+
+use crate::common::git_test_helper::{DirGuard, GitTestRepo};
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use ratatui::style::Color;
+
+/// The context line that sits between the accented addition and the plain one.
+const CTX_ROW: &str = "CTX KEEP LINE";
+/// The plain (all-ASCII) added line below it.
+const ADDED_ROW: &str = "PLAIN ADD ROW";
+/// A context line below the whole hunk, used as the "no diff colour here"
+/// reference — the drift only ever pulls stripes *up*, so this row stays clean
+/// with and without the fix.
+const CLEAN_ROW: &str = "gamma three";
+
+/// Text of screen row `y`.
+fn row_text(harness: &EditorTestHarness, y: u16) -> String {
+    let buf = harness.buffer();
+    let mut row = String::new();
+    for x in 0..buf.area.width {
+        row.push_str(buf[(x, y)].symbol());
+    }
+    row
+}
+
+/// Row index of the first screen row containing `needle`.
+fn row_containing(harness: &EditorTestHarness, needle: &str) -> Option<u16> {
+    let height = harness.buffer().area.height;
+    (0..height).find(|&y| row_text(harness, y).contains(needle))
+}
+
+/// The distinct background colours painted across the *detail panel* part of
+/// row `y` — everything right of the split's `│` divider, so the commit list on
+/// the left can't colour the sample.
+fn detail_backgrounds(harness: &EditorTestHarness, y: u16) -> Vec<Color> {
+    let divider = row_text(harness, y).chars().position(|c| c == '│');
+    let first_x = divider.map(|d| d as u16 + 1).unwrap_or(0);
+    let buf = harness.buffer();
+    let mut seen: Vec<Color> = Vec::new();
+    for x in first_x..buf.area.width {
+        let bg = buf[(x, y)].style().bg.unwrap_or(Color::Reset);
+        if !seen.contains(&bg) {
+            seen.push(bg);
+        }
+    }
+    seen
+}
+
+// TODO: git command output differs on Windows; the other git_log tests skip it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn git_log_diff_colours_stay_on_their_lines_after_non_ascii() {
+    let repo = GitTestRepo::new();
+
+    repo.create_file(
+        "notes.txt",
+        &format!("alpha one\nbeta two\n{CTX_ROW}\n{CLEAN_ROW}\ndelta four\n"),
+    );
+    repo.git_add(&["notes.txt"]);
+    repo.git_commit("Add notes");
+
+    // The added accented line carries six multi-byte characters, so every
+    // overlay below it used to land six bytes too early — far enough to spill
+    // onto the tail of `CTX KEEP LINE`, but not so far that the run starts
+    // above it (which would move the defect off that row entirely).
+    repo.create_file(
+        "notes.txt",
+        &format!(
+            "alpha one\nbeta two\nañadido ñ·ñ·ñ\n{CTX_ROW}\n{ADDED_ROW}\n{CLEAN_ROW}\ndelta four\n"
+        ),
+    );
+    repo.git_add(&["notes.txt"]);
+    repo.git_commit("Add accented and plain lines");
+
+    repo.setup_git_log_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&repo.path.join("notes.txt")).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Every diff row under test must be on screen before a cell is sampled.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane")
+                && s.contains(CTX_ROW)
+                && s.contains(ADDED_ROW)
+                && s.contains(CLEAN_ROW)
+        })
+        .unwrap();
+    // The text arrives before the colours: `applyDiffHighlights` runs once the
+    // `git show` stream completes, so a frame can show the diff with no
+    // overlays at all. Let the plugin pipeline go quiet before reading cells.
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    let screen = harness.screen_to_string();
+    let find = |needle: &str| {
+        row_containing(&harness, needle)
+            .unwrap_or_else(|| panic!("`{needle}` never rendered.\nScreen:\n{screen}"))
+    };
+    let added_y = find(ADDED_ROW);
+    let ctx_y = find(CTX_ROW);
+    let clean_y = find(CLEAN_ROW);
+
+    // Whatever the theme paints an addition with is "every background on the
+    // `+` row that a plain context row doesn't have" — no theme colour is
+    // hard-coded here.
+    let context_bgs = detail_backgrounds(&harness, clean_y);
+    let added_bgs = detail_backgrounds(&harness, added_y);
+    let addition_only: Vec<Color> = added_bgs
+        .iter()
+        .copied()
+        .filter(|bg| !context_bgs.contains(bg))
+        .collect();
+    assert!(
+        !addition_only.is_empty(),
+        "the `+{ADDED_ROW}` row ({added_y}) should be painted with a background \
+         the context row ({clean_y}) doesn't have; saw {added_bgs:?} vs \
+         {context_bgs:?}\nScreen:\n{screen}",
+    );
+
+    // The context line between the two additions must carry none of it.
+    let ctx_bgs = detail_backgrounds(&harness, ctx_y);
+    let leaked: Vec<Color> = ctx_bgs
+        .iter()
+        .copied()
+        .filter(|bg| addition_only.contains(bg))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "the context row `{CTX_ROW}` ({ctx_y}) must carry no addition \
+         background — the stripe below it drifted up onto it; leaked {leaked:?} \
+         out of {ctx_bgs:?}\nScreen:\n{screen}",
+    );
+}
+
+/// The line the cursor is parked on in the second test. It sits below four
+/// accented lines, so the byte/UTF-16 drift accumulated above it is what
+/// decides whether `Enter` opens the file at the right place.
+const ENTER_TARGET: &str = "TARGET LINE";
+
+/// Pressing `Enter` on a diff row opens that file at *that* row's line. The
+/// cursor's byte offset is mapped to a diff line by the same kind of walk the
+/// colouring used, so with UTF-16 lengths the mapping slid several lines down
+/// the file once the diff contained non-ASCII text.
+// TODO: git command output differs on Windows; the other git_log tests skip it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn git_log_enter_opens_the_line_under_the_cursor_after_non_ascii() {
+    let repo = GitTestRepo::new();
+
+    // One new-file commit: every source line shows up as a `+` row, so the
+    // diff row the cursor lands on maps 1:1 onto a line number. The four
+    // accented lines contribute 60 bytes the UTF-16 walk never saw, which is
+    // enough to slide the mapping ~6 rows past `TARGET LINE` (line 6).
+    let accented = "ñññññ üüüüü ·····";
+    let mut content = String::new();
+    for _ in 0..4 {
+        content.push_str(accented);
+        content.push('\n');
+    }
+    content.push_str("aa\n");
+    content.push_str(ENTER_TARGET);
+    content.push('\n');
+    for i in 1..=10 {
+        content.push_str(&format!("fill {i:02}\n"));
+    }
+    repo.create_file("notes.txt", &content);
+    repo.git_add(&["notes.txt"]);
+    repo.git_commit("Add notes");
+
+    repo.setup_git_log_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    // Wide enough that no diff row wraps in the 40%-width detail panel — the
+    // cursor is walked down by display rows below, so a wrapped row would
+    // desync the count from the buffer's lines.
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&repo.path.join("notes.txt")).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane") && s.contains("Author:") && s.contains(ENTER_TARGET)
+        })
+        .unwrap();
+
+    // The detail panel opens scrolled to the top with its cursor on the first
+    // line (`commit <sha>`, the row above `Author:`), so the number of `Down`
+    // presses that lands on the target row is the on-screen distance between
+    // them.
+    let screen = harness.screen_to_string();
+    let author_y = row_containing(&harness, "Author:")
+        .unwrap_or_else(|| panic!("no `Author:` line in the diff.\nScreen:\n{screen}"));
+    let target_y = row_containing(&harness, ENTER_TARGET)
+        .unwrap_or_else(|| panic!("`{ENTER_TARGET}` never rendered.\nScreen:\n{screen}"));
+    let first_y = author_y - 1;
+    assert!(
+        target_y > first_y,
+        "the diff should render `{ENTER_TARGET}` below its `commit` header; \
+         saw rows {target_y} and {first_y}\nScreen:\n{screen}",
+    );
+
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    for _ in 0..(target_y - first_y) {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // git_log titles the file-at-commit view `*<hash>:notes.txt*`, so
+    // `:notes.txt` is unique to it (the diff pane only ever shows `b/notes.txt`).
+    harness
+        .wait_until(|h| h.screen_to_string().contains(":notes.txt"))
+        .unwrap();
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    // `TARGET LINE` is line 6 of notes.txt; the status bar reports where the
+    // cursor actually landed.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 6, Col 1"),
+        "Enter on the `+{ENTER_TARGET}` row should open notes.txt at line 6 \
+         (`Ln 6, Col 1`), but the cursor landed elsewhere.\nScreen:\n{screen}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -39,6 +39,7 @@ pub mod file_explorer_slots;
 pub mod find_file;
 pub mod git;
 pub mod git_log_current_file;
+pub mod git_log_diff_highlight_offset;
 pub mod git_log_indent_guide;
 pub mod git_log_split_tab_focus;
 pub mod git_statusbar;


### PR DESCRIPTION
Fixes #3014. Three commits: fix the drift, delete the layer that caused it, then repair what CI caught.

## The bug

Moving through commits in the Git Log view sometimes showed a detail-panel diff whose red/green backgrounds were **offset by a few characters** — the stripe started partway into the *context* line above an added block instead of on the `+` rows it belongs to.

It isn't random: it happens on every commit whose diff contains non-ASCII text (accents, `·`, `—`, `«»`, `©`, emoji…), and the drift grows with the number of multi-byte characters above the affected row.

Reproduced manually (tmux, 150x45, default theme), per-cell backgrounds read back with `tmux capture-pane -e`:

```
row |text                                          | background runs (screen columns)
 26 |' │ line 07 plain ascii content here'          | 89-147: bg16   (clean context line)
 27 |' │ line 08 plain ascii content here'          | 89-97: bg16, 98-147: bg22 (GREEN — wrong)
 28 |' │+PLAIN ADDED LINE AAAAAAAAAAAAAAAAAAAAAAAA' | 90-147: bg22
```

The shift is exactly the number of extra UTF-8 bytes the accented lines above contributed (26 bytes there, which lands 9 columns into the previous line — where the green starts).

## Commit 1 — count bytes, not UTF-16 units

`applyDiffHighlights` in `plugins/git_log.ts` walked the streamed `git show` output and added one background overlay per run of `+` / `-` / `@@` rows. Overlay positions are UTF-8 **byte** offsets, but the walk advanced by `line.length`, i.e. UTF-16 code units, so every multi-byte character above a row pulled that row's overlay earlier. With `extendToLineEnd` the misplaced start paints the tail of the neighbouring context line.

`deriveFileAndLineFromDiffCursor` walks the same text the same way to map the cursor's byte offset onto a diff line, so `Enter` ("open this file at this line") suffered the same drift and opened the file several lines below the row under the cursor.

Both walks now advance by `byteLength()` — the UTF-8 helper `lib/git_history.ts` already exports for exactly this case, and which `git_log.ts` already imports from.

New `tests/e2e/plugins/git_log_diff_highlight_offset.rs` — two e2e tests that drive the palette/keyboard and assert only on rendered output. The addition colour is derived from the frame (a `+` row vs a plain context row), so no theme colour is hard-coded. Measured against the unfixed plugin:

| | without fix | with fix |
|---|---|---|
| colouring | addition stripe leaks onto the `CTX KEEP LINE` row | context row clean |
| `Enter` | opens `notes.txt` at `Ln 12, Col 1` | opens at `Ln 6, Col 1` |

## Commit 2 — delete the plugin's colouring pass

The panel's diff buffer is a real file with a `.diff` extension, so the editor's own highlighting already washes `+` / `-` / `@@` rows with the same three theme colours. The plugin was painting a second, identical layer on top; the comment justifying it (*"Sublime-syntax's bundled `Diff` definition only scopes the `diff` keyword"*) no longer holds — `highlight_engine` has explicit diff-row colouring with its own coverage test.

Being redundant made it purely a liability:

* its hand-rolled byte walk was the only thing that could put a stripe on the wrong row (commit 1);
* it walked the whole buffer, where the host's pass is viewport-local;
* it skipped diffs over 256 KB, so the largest commits already relied on the host's colouring;
* it never ran on a cache hit at all — `ensureCommitBuffer` returns early when the `.done` marker is present, and `git_log_cleanup` clears `commitBuffers`, so simply closing and reopening the view already rendered every previously visited commit through the host. Nobody noticed, because the two layers paint identically.

Verified by capturing the panel before and after on three commits covering blank added rows, tabs, `\ No newline at end of file` and empty context lines. Every cell's background is unchanged, with one exception:

```
@@ -2,6 +2,8 @@ keep one
before: 90-147 rgb(60,55,0)                                  (uniform bar)
after:  90-104 rgb(60,55,0)  105-113 rgb(0,0,0)  114-147 rgb(60,55,0)
                             ^^^^^^^ " keep one" — hole in the bar
```

`git diff` puts the enclosing section after the closing `@@`, and syntect scopes that trailing text separately, with no diff background of its own. This is pre-existing host behaviour — every other `.diff` buffer in the editor renders hunk headers that way — and the plugin's overlay had been hiding it inside the git-log panel only. Filed as #3021 with the measurement; a fix belongs at the line level in the highlighter, not in this plugin, so it is out of scope here.

## Commit 3 — what CI caught

Two things commit 2 got wrong, both now fixed:

* **The e2e colour test failed on its own premise.** e2e harnesses default to an *empty grammar registry* for startup speed. While the plugin painted its own overlays that didn't matter; with the colouring now coming from the host, the panel rendered uncoloured and the `+` row carried nothing a context row didn't. Both tests now opt into `with_full_grammar_registry()`, which is the layer they are actually about.
* **An attempted host-side fix for the hunk-header gap was reverted.** The theory was that an inner, foreground-only scope outranked the row's `meta.diff.range`, so preferring a diff wash anywhere in the scope stack would close it. Its own unit test disproved that: those bytes come back with **no** background at all, so the diff scope isn't in their stack and the fix has to be line-level. `highlight_engine.rs` is back to its state before this PR — nothing outside `git_log` is touched.

## Verification

* Both e2e tests fail on the unfixed plugin and pass with it, run locally.
* Full git-log e2e suite: 21 passed / 0 failed / 1 ignored.
* `cargo fmt --check` clean; `plugins/check-types.sh` reports nothing for `git_log.ts` / `lib/git_history.ts` (the files it does flag are pre-existing and untouched).
* Confirmed interactively in tmux with the reporter's steps, before and after, including navigating up and down between commits.
* CI green on `f826a8b`: all 10 checks pass, including `test` on ubuntu, macOS and Windows.

Note that commit 2 deletes the code commit 1 fixes, so the colour test no longer reproduces the original defect — it now guards the rendered result. The byte-offset fix is still load-bearing for `deriveFileAndLineFromDiffCursor`, which the second e2e test does fail without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JvPDko97Z3M3WMRAkGGu9