### PR TITLE
fix(mouse): let a drag past the top/bottom edge keep selecting and scrolling

### DIFF
--- a/crates/fresh-editor/src/app/chrome/splits.rs
+++ b/crates/fresh-editor/src/app/chrome/splits.rs
@@ -1334,16 +1334,37 @@ impl Editor {
                 let gutter_width = state.margins.left_total_width() as u16;
                 let target_position = match terminal_grid_target {
                     Some(pos) => pos,
-                    None => crate::app::click_geometry::screen_to_buffer_position(
-                        col,
-                        row,
-                        content_rect,
-                        gutter_width,
-                        &cached_mappings,
-                        fallback,
-                        true, // Allow gutter clicks for drag selection
-                        compose_width,
-                    )?,
+                    None => {
+                        let target =
+                            crate::app::click_geometry::screen_to_buffer_position_with_overshoot(
+                                col,
+                                row,
+                                content_rect,
+                                gutter_width,
+                                &cached_mappings,
+                                fallback,
+                                true, // Allow gutter clicks for drag selection
+                                compose_width,
+                            )?;
+                        // Pointer outside the text area: the row→line lookup
+                        // can only name lines that are on screen, so it clamps
+                        // to the first/last visible one and the selection head
+                        // stops dead at the viewport edge. Carry the rows past
+                        // the edge into lines past the edge, so the head keeps
+                        // moving and the viewport follows it (issue #3006).
+                        //
+                        // Without this the drag only ever scrolls as a side
+                        // effect of the scroll-off margin, so a configured
+                        // `scroll_offset = 0` means dragging past the edge
+                        // does nothing at all.
+                        let rows_past_edge =
+                            target.row_overshoot as isize - target.row_undershoot as isize;
+                        crate::app::click_geometry::position_offset_by_lines(
+                            &state.buffer,
+                            target.position,
+                            rows_past_edge,
+                        )
+                    }
                 };
                 let (new_position, anchor_pos) = if drag_by_words {
                     if target_position >= anchor_position {
@@ -1396,6 +1417,21 @@ impl Editor {
 
         if let Some(event_log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {
             event_log.append(event.clone());
+        }
+        // A drag is cursor motion, so it owns vertical placement from here on
+        // — exactly like a key press, which clears this same flag in
+        // `handle_key`. A wheel or scrollbar scroll sets `skip_ensure_visible`
+        // so the render pass won't yank the viewport back to the cursor, and
+        // nothing on the mouse path used to clear it again: after any scroll
+        // by wheel or scrollbar, a drag-select moved the selection head but
+        // the viewport stayed frozen, in *both* directions (issue #3006).
+        if let Some(view_state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_view_states_mut())
+            .and_then(|states| states.get_mut(&leaf_id))
+        {
+            view_state.viewport.clear_skip_ensure_visible();
         }
         self.active_window_mut()
             .apply_event_to_buffer(buffer_id, leaf_id, &event);

--- a/crates/fresh-editor/src/app/click_geometry.rs
+++ b/crates/fresh-editor/src/app/click_geometry.rs
@@ -86,6 +86,12 @@ pub(crate) struct ClickTarget {
     /// rendered row). Vertical virtual space uses this to place the cursor
     /// on lines below the end of the buffer.
     pub row_overshoot: usize,
+    /// Visual rows *above* the content area (0 when the click hit a
+    /// rendered row). The row→line lookup clamps to the topmost visible
+    /// line, so without this the caller cannot tell "pointer on the first
+    /// text row" from "pointer six rows up on the menu bar" — which is
+    /// exactly what a drag past the top edge needs to know (issue #3006).
+    pub row_undershoot: usize,
     /// The clicked column within the content area (viewport-relative,
     /// after the gutter).
     pub text_col: usize,
@@ -126,6 +132,10 @@ pub(crate) fn screen_to_buffer_position_with_overshoot(
     // Calculate relative position in content area
     let content_col = col.saturating_sub(content_rect.x);
     let content_row = row.saturating_sub(content_rect.y);
+    // How far the pointer is *above* the first text row. `content_row`
+    // saturates to 0 there, so this is the only record that the pointer
+    // was outside the content area at the top.
+    let row_undershoot = content_rect.y.saturating_sub(row) as usize;
 
     tracing::trace!(
         col,
@@ -221,8 +231,50 @@ pub(crate) fn screen_to_buffer_position_with_overshoot(
         position,
         col_overshoot,
         row_overshoot,
+        row_undershoot,
         text_col,
     })
+}
+
+/// The byte position `lines` buffer lines above (negative) or below
+/// (positive) `position`, keeping `position`'s visual column.
+///
+/// Used to resolve a drag whose pointer is outside the text area
+/// vertically: the row→line lookup can only name lines that are on
+/// screen, so the caller converts the rows past the edge into a line
+/// past the edge here (issue #3006). Returns `position` unchanged for
+/// `lines == 0`, and clamps at the buffer's first/last line.
+pub(crate) fn position_offset_by_lines(
+    buffer: &crate::model::buffer::Buffer,
+    position: usize,
+    lines: isize,
+) -> usize {
+    use crate::primitives::display_width::{grapheme_byte_at_visual_column, visual_column_of};
+
+    if lines == 0 {
+        return position;
+    }
+    let line = buffer.get_line_number(position);
+    let target_line = if lines < 0 {
+        line.saturating_sub(lines.unsigned_abs())
+    } else {
+        line.saturating_add(lines as usize)
+    };
+    if target_line == line {
+        return position;
+    }
+    // Off the end of the buffer: the selection head belongs at the very
+    // last byte, which is what a drag below the last line asks for.
+    let (Some(line_start), Some(content)) = (
+        buffer.line_start_offset(target_line),
+        buffer.get_line(target_line),
+    ) else {
+        return if lines < 0 { 0 } else { buffer.len() };
+    };
+    let column = visual_column_of(buffer, position).unwrap_or(0);
+    let text = String::from_utf8_lossy(&content);
+    let text = text.trim_end_matches(['\n', '\r']);
+    line_start + grapheme_byte_at_visual_column(text, column)
 }
 
 /// Check whether a gutter click at `target_position` should toggle a fold.

--- a/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
@@ -27,6 +27,14 @@
 //! test also drags to a row inside the text area and requires the viewport
 //! to stay put there, so a fix that simply scrolled on every drag event
 //! could not pass.
+//!
+//! What each drag past an edge has to move is therefore two rendered
+//! numbers: the top `LINE nnn` marker (the viewport) and the outermost
+//! `LINE nnn` still carrying selection background (the head). Neither is
+//! "the line drawn on the edge row itself" — after the scroll the
+//! scroll-off margin leaves the head `scroll_offset` lines inside the
+//! viewport, so with the default margin the edge row shows an unselected
+//! line while the selection is still growing every event.
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -80,8 +88,7 @@ fn top_line(harness: &EditorTestHarness) -> u32 {
 }
 
 /// How many cells of screen `row` are painted with the selection
-/// background. A fully selected `LINE nnn` contributes at least its eight
-/// characters.
+/// background.
 fn selected_cells_in_row(harness: &EditorTestHarness, row: u16) -> usize {
     let selection_bg = harness.editor().theme().selection_bg;
     let buffer = harness.buffer();
@@ -89,6 +96,39 @@ fn selected_cells_in_row(harness: &EditorTestHarness, row: u16) -> usize {
     (0..width)
         .filter(|col| buffer.content[buffer.index_of(*col, row)].bg == selection_bg)
         .count()
+}
+
+/// The `LINE nnn` marker rendered on screen `row`, or `None` for a row
+/// that carries no buffer line.
+fn line_number_at_row(harness: &EditorTestHarness, row: u16) -> Option<u32> {
+    let screen = harness.screen_to_string();
+    let rest = screen.lines().nth(row as usize)?.split("LINE ").nth(1)?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse::<u32>().ok()
+}
+
+/// The `LINE nnn` numbers of the topmost and bottom-most content rows that
+/// carry any selection background: the rendered extent of the selection.
+///
+/// This — not "is the row at the very edge of the screen selected" — is
+/// what a drag past an edge moves. The scroll-off margin keeps the head a
+/// few lines inside the viewport after the scroll, so with the default
+/// `scroll_offset` the edge row itself shows an *un*selected line while the
+/// selection is still growing; and the head's own line is only selected
+/// from (or up to) the pointer's column, so its cell count is a handful,
+/// not a whole `LINE nnn`.
+fn selected_line_extent(harness: &EditorTestHarness, first_row: u16, last_row: u16) -> (u32, u32) {
+    let selected: Vec<u32> = (first_row..=last_row)
+        .filter(|row| selected_cells_in_row(harness, *row) > 0)
+        .filter_map(|row| line_number_at_row(harness, row))
+        .collect();
+    match (selected.first(), selected.last()) {
+        (Some(first), Some(last)) => (*first, *last),
+        _ => panic!(
+            "no selected cell on any content row. Screen:\n{}",
+            harness.screen_to_string()
+        ),
+    }
 }
 
 /// Open a 200-line fixture in the harness's window and report its own temp
@@ -108,7 +148,8 @@ fn open_fixture(
 /// The issue's own repro: park the viewport in the middle of the file with
 /// the wheel, then press inside the text and drag up onto the menu bar and
 /// hold there. Every further motion event must keep pulling the viewport
-/// toward the buffer's start and keep the top visible line selected.
+/// toward the buffer's start and keep pushing the top of the selection up
+/// with it.
 ///
 /// Before the fix the wheel's `skip_ensure_visible` flag was still set, so
 /// the viewport was pinned and the selection froze — the issue's "six
@@ -116,7 +157,7 @@ fn open_fixture(
 #[test]
 fn drag_above_the_text_area_scrolls_up_after_a_wheel_scroll() {
     let mut harness = EditorTestHarness::new(100, 20).unwrap();
-    let (_fixture, first_row, _last_row) = open_fixture(&mut harness);
+    let (_fixture, first_row, last_row) = open_fixture(&mut harness);
 
     // Scroll with the wheel — the way a user gets to the middle of a file
     // with the mouse, and the input that leaves the viewport flagged.
@@ -144,24 +185,29 @@ fn drag_above_the_text_area_scrolls_up_after_a_wheel_scroll() {
     );
 
     // Now hold the pointer above the text area. Each motion event must move
-    // the viewport further toward the start of the buffer.
-    let mut previous = after_wheel;
+    // the viewport further toward the start of the buffer *and* carry the
+    // head of the selection with it.
+    let mut previous_top = after_wheel;
+    let (mut previous_head, _) = selected_line_extent(&harness, first_row, last_row);
     for step in 0..3 {
         drag_to(&mut harness, 10, 0);
         let now = top_line(&harness);
         assert!(
-            now < previous,
+            now < previous_top,
             "drag step {step} above the text area must scroll up \
-             (top line was {previous}, now {now}). Screen:\n{}",
+             (top line was {previous_top}, now {now}). Screen:\n{}",
             harness.screen_to_string()
         );
+        let (head, _) = selected_line_extent(&harness, first_row, last_row);
         assert!(
-            selected_cells_in_row(&harness, first_row) >= "LINE 001".len(),
-            "the top visible line must be selected after dragging above the \
-             text area. Screen:\n{}",
+            head < previous_head,
+            "drag step {step} above the text area must extend the selection \
+             upward (it reached LINE {previous_head}, now LINE {head}). \
+             Screen:\n{}",
             harness.screen_to_string()
         );
-        previous = now;
+        previous_top = now;
+        previous_head = head;
     }
 }
 
@@ -192,23 +238,27 @@ fn drag_below_the_text_area_scrolls_down_after_a_wheel_scroll() {
 
     // `last_row + 1` is the status bar: outside the text area, which is
     // where the pointer sits when a user drags past the bottom edge.
-    let mut previous = after_wheel;
+    let mut previous_top = after_wheel;
+    let (_, mut previous_tail) = selected_line_extent(&harness, first_row, last_row);
     for step in 0..3 {
         drag_to(&mut harness, 10, last_row + 1);
         let now = top_line(&harness);
         assert!(
-            now > previous,
+            now > previous_top,
             "drag step {step} below the text area must scroll down \
-             (top line was {previous}, now {now}). Screen:\n{}",
+             (top line was {previous_top}, now {now}). Screen:\n{}",
             harness.screen_to_string()
         );
+        let (_, tail) = selected_line_extent(&harness, first_row, last_row);
         assert!(
-            selected_cells_in_row(&harness, last_row) >= "LINE 001".len(),
-            "the bottom visible line must be selected after dragging below \
-             the text area. Screen:\n{}",
+            tail > previous_tail,
+            "drag step {step} below the text area must extend the selection \
+             downward (it reached LINE {previous_tail}, now LINE {tail}). \
+             Screen:\n{}",
             harness.screen_to_string()
         );
-        previous = now;
+        previous_top = now;
+        previous_tail = tail;
     }
 }
 
@@ -240,36 +290,70 @@ fn drag_past_the_edges_scrolls_with_scroll_off_disabled() {
 
     press(&mut harness, 10, first_row + 5);
 
-    let mut previous = start;
+    // Same guard as the other two: a drag that stays inside the text area
+    // must not scroll, margin or no margin.
+    drag_to(&mut harness, 10, first_row + 8);
+    assert_eq!(
+        top_line(&harness),
+        start,
+        "a drag inside the text area must not scroll the viewport. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    let mut previous_top = start;
+    let (mut previous_head, _) = selected_line_extent(&harness, first_row, last_row);
     for step in 0..3 {
         drag_to(&mut harness, 10, 0);
         let now = top_line(&harness);
         assert!(
-            now < previous,
+            now < previous_top,
             "with scroll_offset = 0, drag step {step} above the text area must \
-             still scroll up (top line was {previous}, now {now}). Screen:\n{}",
+             still scroll up (top line was {previous_top}, now {now}). Screen:\n{}",
             harness.screen_to_string()
         );
-        previous = now;
+        let (head, _) = selected_line_extent(&harness, first_row, last_row);
+        assert!(
+            head < previous_head,
+            "with scroll_offset = 0, drag step {step} above the text area must \
+             still extend the selection upward (it reached LINE {previous_head}, \
+             now LINE {head}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous_top = now;
+        previous_head = head;
     }
-    assert!(
-        selected_cells_in_row(&harness, first_row) >= "LINE 001".len(),
-        "the top visible line must be selected after dragging above the text \
-         area. Screen:\n{}",
+    // With no margin the head *is* the top visible line, so here — unlike
+    // the default-`scroll_offset` tests above — the very first row carries
+    // the selection.
+    assert_eq!(
+        selected_line_extent(&harness, first_row, last_row).0,
+        top_line(&harness),
+        "with scroll_offset = 0 the selection must reach the top visible \
+         line. Screen:\n{}",
         harness.screen_to_string()
     );
 
     // And back down past the bottom edge, from the same held button.
-    let mut previous = top_line(&harness);
+    let mut previous_top = top_line(&harness);
+    let (_, mut previous_tail) = selected_line_extent(&harness, first_row, last_row);
     for step in 0..3 {
         drag_to(&mut harness, 10, last_row + 1);
         let now = top_line(&harness);
         assert!(
-            now > previous,
+            now > previous_top,
             "with scroll_offset = 0, drag step {step} below the text area must \
-             still scroll down (top line was {previous}, now {now}). Screen:\n{}",
+             still scroll down (top line was {previous_top}, now {now}). Screen:\n{}",
             harness.screen_to_string()
         );
-        previous = now;
+        let (_, tail) = selected_line_extent(&harness, first_row, last_row);
+        assert!(
+            tail > previous_tail,
+            "with scroll_offset = 0, drag step {step} below the text area must \
+             still extend the selection downward (it reached LINE \
+             {previous_tail}, now LINE {tail}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous_top = now;
+        previous_tail = tail;
     }
 }

--- a/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
@@ -1,0 +1,275 @@
+//! Regression tests for issue #3006 ("Additional" section): dragging the
+//! mouse beyond the boundaries of the text area neither extends the
+//! selection nor scrolls the viewport.
+//!
+//! Two independent defects make a drag past the top or bottom edge stop
+//! dead, and each test below drives exactly one of them.
+//!
+//! 1. **A scroll by wheel or scrollbar freezes the drag.** Those set the
+//!    viewport's `skip_ensure_visible` flag so the next render doesn't yank
+//!    the viewport back to the cursor. Only a *key* press cleared it again,
+//!    so after any wheel scroll a drag-select moved the selection head while
+//!    the viewport stayed put — in both directions. This is what the issue
+//!    reports as "upward drag is dead": the head is already clamped to the
+//!    topmost visible line (see 2), and with the viewport frozen there is
+//!    nothing left to move at all.
+//!
+//! 2. **The drag never asks for a line outside the viewport.** The row→line
+//!    lookup can only name lines that are on screen, so it clamps to the
+//!    first/last visible one. Any scrolling was therefore a side effect of
+//!    the scroll-off margin pushing the cursor away from the edge — with a
+//!    configured `scroll_offset = 0` the margin is gone and dragging past
+//!    either edge does nothing whatsoever.
+//!
+//! Every assertion reads rendered output only (CONTRIBUTING.md Testing §2):
+//! the window of `LINE nnn` markers on screen *is* the scroll position, and
+//! the run of cells carrying `theme.selection_bg` *is* the selection. Each
+//! test also drags to a row inside the text area and requires the viewport
+//! to stay put there, so a fix that simply scrolled on every drag event
+//! could not pass.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+/// Lines in the fixture — enough that the viewport can travel in either
+/// direction without hitting an end.
+const LINES: usize = 200;
+
+/// A button-down at a screen cell, which arms a text-selection drag.
+fn press(harness: &mut EditorTestHarness, col: u16, row: u16) {
+    harness
+        .send_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: col,
+            row,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// One drag-motion event with the button held, exactly as a terminal
+/// reports it (SGR `\x1b[<32;C;R M`).
+fn drag_to(harness: &mut EditorTestHarness, col: u16, row: u16) {
+    harness
+        .send_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: col,
+            row,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// The number of the topmost `LINE nnn` marker on screen. That marker is
+/// the buffer's first visible line, so this *is* the rendered scroll
+/// position — it changes the instant the viewport moves by one line and is
+/// identical frame-to-frame while it stays put.
+fn top_line(harness: &EditorTestHarness) -> u32 {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .flat_map(|line| line.split("LINE ").skip(1))
+        .filter_map(|rest| {
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            digits.parse::<u32>().ok()
+        })
+        .next()
+        .unwrap_or_else(|| panic!("no LINE marker on screen:\n{screen}"))
+}
+
+/// How many cells of screen `row` are painted with the selection
+/// background. A fully selected `LINE nnn` contributes at least its eight
+/// characters.
+fn selected_cells_in_row(harness: &EditorTestHarness, row: u16) -> usize {
+    let selection_bg = harness.editor().theme().selection_bg;
+    let buffer = harness.buffer();
+    let width = buffer.area.width;
+    (0..width)
+        .filter(|col| buffer.content[buffer.index_of(*col, row)].bg == selection_bg)
+        .count()
+}
+
+/// Open a 200-line fixture in the harness's window and report its own temp
+/// fixture (kept alive by the caller) plus the first and last screen row
+/// that carry buffer text.
+fn open_fixture(
+    harness: &mut EditorTestHarness,
+) -> (crate::common::fixtures::TestFixture, u16, u16) {
+    let content: Vec<String> = (1..=LINES).map(|i| format!("LINE {i:03}")).collect();
+    // `TestFixture` writes into its own temp dir, so tests stay isolated.
+    let fixture = harness.load_buffer_from_text(&content.join("\n")).unwrap();
+    harness.render().unwrap();
+    let (first, last) = harness.content_area_rows();
+    (fixture, first as u16, last as u16)
+}
+
+/// The issue's own repro: park the viewport in the middle of the file with
+/// the wheel, then press inside the text and drag up onto the menu bar and
+/// hold there. Every further motion event must keep pulling the viewport
+/// toward the buffer's start and keep the top visible line selected.
+///
+/// Before the fix the wheel's `skip_ensure_visible` flag was still set, so
+/// the viewport was pinned and the selection froze — the issue's "six
+/// further motion events over the tab bar and menu bar change nothing".
+#[test]
+fn drag_above_the_text_area_scrolls_up_after_a_wheel_scroll() {
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    let (_fixture, first_row, _last_row) = open_fixture(&mut harness);
+
+    // Scroll with the wheel — the way a user gets to the middle of a file
+    // with the mouse, and the input that leaves the viewport flagged.
+    for _ in 0..10 {
+        harness.mouse_scroll_down(30, first_row + 2).unwrap();
+    }
+    harness.render().unwrap();
+    let after_wheel = top_line(&harness);
+    assert!(
+        after_wheel > 10,
+        "the wheel should have scrolled well into the file, top line is {after_wheel}. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    press(&mut harness, 10, first_row + 5);
+
+    // Guard against over-fixing: a drag that stays inside the text area
+    // must not scroll at all.
+    drag_to(&mut harness, 10, first_row + 8);
+    assert_eq!(
+        top_line(&harness),
+        after_wheel,
+        "a drag inside the text area must not scroll the viewport. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Now hold the pointer above the text area. Each motion event must move
+    // the viewport further toward the start of the buffer.
+    let mut previous = after_wheel;
+    for step in 0..3 {
+        drag_to(&mut harness, 10, 0);
+        let now = top_line(&harness);
+        assert!(
+            now < previous,
+            "drag step {step} above the text area must scroll up \
+             (top line was {previous}, now {now}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        assert!(
+            selected_cells_in_row(&harness, first_row) >= "LINE 001".len(),
+            "the top visible line must be selected after dragging above the \
+             text area. Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous = now;
+    }
+}
+
+/// The same gesture downward. The issue reports that the downward drag
+/// "does work", but that measurement started from an unscrolled viewport;
+/// once the wheel has been used the very same freeze applies, and the
+/// selection cannot be dragged past the bottom edge either.
+#[test]
+fn drag_below_the_text_area_scrolls_down_after_a_wheel_scroll() {
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    let (_fixture, first_row, last_row) = open_fixture(&mut harness);
+
+    for _ in 0..10 {
+        harness.mouse_scroll_down(30, first_row + 2).unwrap();
+    }
+    harness.render().unwrap();
+    let after_wheel = top_line(&harness);
+
+    press(&mut harness, 10, first_row + 2);
+
+    drag_to(&mut harness, 10, first_row + 6);
+    assert_eq!(
+        top_line(&harness),
+        after_wheel,
+        "a drag inside the text area must not scroll the viewport. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // `last_row + 1` is the status bar: outside the text area, which is
+    // where the pointer sits when a user drags past the bottom edge.
+    let mut previous = after_wheel;
+    for step in 0..3 {
+        drag_to(&mut harness, 10, last_row + 1);
+        let now = top_line(&harness);
+        assert!(
+            now > previous,
+            "drag step {step} below the text area must scroll down \
+             (top line was {previous}, now {now}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        assert!(
+            selected_cells_in_row(&harness, last_row) >= "LINE 001".len(),
+            "the bottom visible line must be selected after dragging below \
+             the text area. Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous = now;
+    }
+}
+
+/// With `scroll_offset = 0` the scroll-off margin that used to do the
+/// scrolling by accident is gone, so this isolates defect 2: the drag has
+/// to name a line outside the viewport by itself.
+///
+/// The viewport is parked with the keyboard here, not the wheel, so no
+/// `skip_ensure_visible` flag is involved and only the row→line clamp is
+/// under test.
+#[test]
+fn drag_past_the_edges_scrolls_with_scroll_off_disabled() {
+    let mut config = fresh::config::Config::default();
+    config.editor.scroll_offset = 0;
+    let mut harness = EditorTestHarness::with_config(100, 20, config).unwrap();
+    let (_fixture, first_row, last_row) = open_fixture(&mut harness);
+
+    // Walk the cursor down so the viewport has room in both directions.
+    for _ in 0..40 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+    let start = top_line(&harness);
+    assert!(
+        start > 10,
+        "the cursor walk should have scrolled into the file, top line is {start}. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    press(&mut harness, 10, first_row + 5);
+
+    let mut previous = start;
+    for step in 0..3 {
+        drag_to(&mut harness, 10, 0);
+        let now = top_line(&harness);
+        assert!(
+            now < previous,
+            "with scroll_offset = 0, drag step {step} above the text area must \
+             still scroll up (top line was {previous}, now {now}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous = now;
+    }
+    assert!(
+        selected_cells_in_row(&harness, first_row) >= "LINE 001".len(),
+        "the top visible line must be selected after dragging above the text \
+         area. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // And back down past the bottom edge, from the same held button.
+    let mut previous = top_line(&harness);
+    for step in 0..3 {
+        drag_to(&mut harness, 10, last_row + 1);
+        let now = top_line(&harness);
+        assert!(
+            now > previous,
+            "with scroll_offset = 0, drag step {step} below the text area must \
+             still scroll down (top line was {previous}, now {now}). Screen:\n{}",
+            harness.screen_to_string()
+        );
+        previous = now;
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -111,6 +111,7 @@ pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
 pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
+pub mod issue_3006_drag_beyond_text_area;
 pub mod issue_3006_shift_select_at_buffer_edges;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;


### PR DESCRIPTION
Addresses the "Additional" half of #3006 — dragging the mouse beyond the text area neither extends the selection nor scrolls. The keyboard half of that issue (Shift+Up/Down at the file edges) is a separate change.

## Two causes, not one

The issue comment traced this to the clamp in `click_geometry.rs`, where `content_row = row.saturating_sub(content_rect.y)` folds every row above the content area onto the topmost visible line, with no counterpart to the explicit "below last visible line" branch. That is real, but it is not what makes the drag freeze in practice. Measuring against the unfixed code turned up a second cause that dominates:

* Drag up after scrolling the viewport **with the keyboard** — already worked. Top line walked `14 → 13 → 10 → 7 → 4 → 1`, selection growing.
* Drag up after scrolling **with the wheel** — the reported symptom exactly. Top pinned at 7, cursor pinned at `Ln 7`, selection frozen at 40 cells across 6+ motion events.
* Drag **down** after scrolling with the wheel — frozen the same way. The original measurement in the issue started from an unscrolled viewport, which is why the downward direction looked healthy there.

The wheel and the scrollbar set `skip_ensure_visible`, and until now only a key press ever cleared it. So the drag moved the cursor and the viewport simply refused to follow, in both directions.

The clamp is a genuine second defect, and isolating it shows how much it was hidden: with `editor.scroll_offset = 0`, dragging past either edge moved the viewport **zero** lines across 8 motion events. Every bit of scrolling in the default config was a side effect of the scroll-off margin — which also explains the fixed 3-line steps regardless of how far past the edge the pointer sat.

## The change

* `ClickTarget` gains `row_undershoot` (rows *above* the content area), the counterpart to the existing `row_overshoot` that the `saturating_sub` used to swallow silently.
* New `position_offset_by_lines`, which walks `n` buffer lines from a position while preserving the pointer's visual column, via `visual_column_of` + a grapheme-cluster walk so multibyte lines stay on a char boundary. Clamps at buffer start/end.
* `handle_text_selection_drag` reads the overshoot/undershoot instead of the clamped position, so the selection head can leave the viewport in both directions, and clears `skip_ensure_visible` on the dragged split before applying the move — mirroring what `handle_key` already does.

Scrolling is now proportional to how far past the edge the pointer is, rather than a fixed scroll-off-sized step.

## Still missing: autoscroll while the pointer is held still

Not implemented here. With the button held and the pointer parked outside the text area, nothing moves until a new motion event arrives, and a stationary pointer emits none — so this needs a tick-driven step.

The groundwork exists: `editor_tick` already hosts deadline-driven checks, and the test harness can drive it deterministically through `tick_and_render()` plus `advance_time()` on the injected `TestTimeSource`, so it can be covered without a time-based test. The shape would be recording the last outside-the-rect pointer position on each drag motion, clearing it on mouse-up and on re-entry, and replaying `handle_text_selection_drag` from `editor_tick` once a rate interval has elapsed on the injected clock — folding the next deadline into `next_periodic_redraw_deadline()`. One trap: existing tick timers such as `check_mouse_hover_timer` use real `Instant::elapsed()` rather than the injected time source, so an autoscroll timer must use `time_source()` or it will not be testable.

## Tests

`crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs`, driving raw mouse `Down`/`Drag` events and asserting only on rendered output — topmost `LINE nnn` marker for scroll position, `theme.selection_bg` cells for the selection. Per-test temp fixture, no timeouts or sleeps.

* `drag_above_the_text_area_scrolls_up_after_a_wheel_scroll`
* `drag_below_the_text_area_scrolls_down_after_a_wheel_scroll`
* `drag_past_the_edges_scrolls_with_scroll_off_disabled` — isolates the clamp with `scroll_offset = 0` and a keyboard-parked viewport, so the skip flag is not involved

Each also drags to a row *inside* the text area and asserts the viewport does not move, so a fix that scrolled on every drag event could not pass.

## Verification status — please read

**The reproducer tests were compiled but never executed, in either direction.** No pass or fail is being claimed for them; CI is the first real check. This was a deliberate instruction to skip local e2e runs, not an oversight.

What *was* measured is the behaviour of the unfixed code described above, using throwaway print-only tests that are not part of this commit. The committed assertions were designed from those numbers but derived by reasoning over `Viewport::ensure_visible` / `check_nowrap_visibility`. If CI fails, the likely spots are the exact selection-cell threshold and the "drag inside the text area must not scroll" guard rows.

The neighbouring `e2e::mouse` / `e2e::selection` / `e2e::block_selection` suites were also not run, so any regression from the changed drag-below behaviour — the head now lands one line *below* the last visible line rather than on it — is unverified.

Ran and clean: `cargo fmt --all`, `cargo check --all-targets` (only two pre-existing warnings, present in the baseline), `cargo clippy --all-targets` (no new warnings in the touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN

---
_Generated by [Claude Code](https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN)_