### PR TITLE
Let Shift+Up/Down reach the buffer edges from the first/last line

### DIFF
--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -1808,7 +1808,8 @@ fn handle_insert_tab(
 ///
 /// When `extend_selection` is false (MoveUp): collapses any selection to the top edge first
 /// (VSCode/Sublime behavior, issue #1566), then respects Emacs mark mode via deselect_on_move.
-/// When `extend_selection` is true (SelectUp): keeps the existing anchor fixed and extends it.
+/// When `extend_selection` is true (SelectUp): keeps the existing anchor fixed and extends it,
+/// and on the first line extends the head to the buffer start instead of doing nothing.
 fn handle_vertical_up(
     state: &mut EditorState,
     cursors: &Cursors,
@@ -1874,13 +1875,30 @@ fn handle_vertical_up(
                 old_sticky_column: cursor.sticky_column,
                 new_sticky_column: Some(goal_visual_column),
             });
+        } else if extend_selection && cursor.position > 0 {
+            // No line above: the cursor sits on the first line. Shift+Up still
+            // extends the selection head to the very start of the buffer
+            // (VSCode/Sublime behaviour, issue #3006). The goal column is kept
+            // so a later Shift+Down returns to the original column.
+            events.push(Event::MoveCursor {
+                cursor_id,
+                old_position: cursor.position,
+                new_position: 0,
+                old_anchor: cursor.anchor,
+                new_anchor: Some(cursor.anchor.unwrap_or(cursor.position)),
+                old_sticky_column: cursor.sticky_column,
+                new_sticky_column: Some(goal_visual_column),
+            });
         }
+        // Extending with the head already at the buffer start emits nothing, so
+        // the sticky column and any existing anchor survive untouched.
     }
 }
 
 /// Move or extend selection down by one line, using visual columns for wide-character accuracy.
 ///
-/// See [`handle_vertical_up`] for the `extend_selection` contract.
+/// See [`handle_vertical_up`] for the `extend_selection` contract; on the last line an extending
+/// move takes the head to the buffer end.
 fn handle_vertical_down(
     state: &mut EditorState,
     cursors: &Cursors,
@@ -1928,6 +1946,21 @@ fn handle_vertical_down(
                 new_position: new_pos,
                 old_anchor: cursor.anchor,
                 new_anchor,
+                old_sticky_column: cursor.sticky_column,
+                new_sticky_column: Some(goal_visual_column),
+            });
+        } else if extend_selection && cursor.position < state.buffer.len() {
+            // No line below: the cursor sits on the last line. Shift+Down still
+            // extends the selection head to the end of the buffer
+            // (VSCode/Sublime behaviour, issue #3006). Once the head is already
+            // there nothing is emitted, so the sticky column and any existing
+            // anchor survive untouched.
+            events.push(Event::MoveCursor {
+                cursor_id,
+                old_position: cursor.position,
+                new_position: state.buffer.len(),
+                old_anchor: cursor.anchor,
+                new_anchor: Some(cursor.anchor.unwrap_or(cursor.position)),
                 old_sticky_column: cursor.sticky_column,
                 new_sticky_column: Some(goal_visual_column),
             });

--- a/crates/fresh-editor/tests/e2e/issue_3006_shift_select_at_buffer_edges.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3006_shift_select_at_buffer_edges.rs
@@ -1,0 +1,196 @@
+//! Issue #3006: Shift+Up on the first line and Shift+Down on the last line did
+//! nothing at all — no cursor movement and no selection — instead of extending
+//! the selection to the start/end of the buffer like VSCode and Sublime do.
+//!
+//! These tests drive real key events and assert only on what ends up on screen:
+//! the selection background of individual content cells and the `Ln n, Col m`
+//! readout in the status bar.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use tempfile::TempDir;
+
+const LINE1: &str = "first line of the file";
+const LINE4: &str = "last line of the file";
+
+/// The fixture deliberately has *no* trailing newline, so line 4 really is the
+/// last line of the buffer.
+fn open_fixture(harness: &mut EditorTestHarness, temp_dir: &TempDir) {
+    let file_path = temp_dir.path().join("sel.txt");
+    std::fs::write(
+        &file_path,
+        format!("{LINE1}\nsecond line here\nthird line here\n{LINE4}"),
+    )
+    .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+}
+
+/// Is the cell `offset` columns into the on-screen rendering of `line` painted
+/// with the theme's selection background?
+fn cell_is_selected(harness: &EditorTestHarness, line: &str, offset: u16) -> bool {
+    let selection_bg = harness.editor().theme().selection_bg;
+    let (col, row) = harness.find_text_on_screen(line).unwrap_or_else(|| {
+        panic!(
+            "line {line:?} not on screen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    harness
+        .get_cell_style(col + offset, row)
+        .map(|style| style.bg == Some(selection_bg))
+        .unwrap_or(false)
+}
+
+/// Column offsets of `line` that are rendered with the selection background.
+fn selected_offsets(harness: &EditorTestHarness, line: &str) -> Vec<u16> {
+    (0..line.chars().count() as u16)
+        .filter(|&offset| cell_is_selected(harness, line, offset))
+        .collect()
+}
+
+/// Shift+Up with the cursor on the very first line must extend the selection
+/// from the cursor back to the start of the buffer.
+#[test]
+fn shift_up_on_first_line_selects_to_buffer_start() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    open_fixture(&mut harness, &temp_dir);
+
+    // Put the cursor on line 1, column 11 (just after "first line").
+    for _ in 0..10 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    assert!(
+        harness.get_status_bar().contains("Ln 1, Col 11"),
+        "precondition: cursor on line 1 column 11, status bar says: {}",
+        harness.get_status_bar()
+    );
+    assert_eq!(
+        selected_offsets(&harness, LINE1),
+        Vec::<u16>::new(),
+        "precondition: nothing selected yet"
+    );
+
+    harness.send_key(KeyCode::Up, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        selected_offsets(&harness, LINE1),
+        (0..10).collect::<Vec<u16>>(),
+        "Shift+Up on the first line should highlight everything from the buffer \
+         start up to the cursor:\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        harness.get_status_bar().contains("Ln 1, Col 1"),
+        "Shift+Up on the first line should move the cursor to column 1, status bar says: {}",
+        harness.get_status_bar()
+    );
+}
+
+/// Shift+Down with the cursor on the very last line must extend the selection
+/// from the cursor to the end of the buffer.
+#[test]
+fn shift_down_on_last_line_selects_to_buffer_end() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    open_fixture(&mut harness, &temp_dir);
+
+    // Put the cursor on line 4 (the last line), column 11.
+    for _ in 0..3 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    for _ in 0..10 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    assert!(
+        harness.get_status_bar().contains("Ln 4, Col 11"),
+        "precondition: cursor on line 4 column 11, status bar says: {}",
+        harness.get_status_bar()
+    );
+    assert_eq!(
+        selected_offsets(&harness, LINE4),
+        Vec::<u16>::new(),
+        "precondition: nothing selected yet"
+    );
+
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        selected_offsets(&harness, LINE4),
+        (10..LINE4.len() as u16).collect::<Vec<u16>>(),
+        "Shift+Down on the last line should highlight everything from the cursor \
+         to the end of the buffer:\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        harness
+            .get_status_bar()
+            .contains(&format!("Ln 4, Col {}", LINE4.len() + 1)),
+        "Shift+Down on the last line should move the cursor past the last character, \
+         status bar says: {}",
+        harness.get_status_bar()
+    );
+}
+
+/// An already-active selection whose head has arrived on the first line must
+/// keep growing to the buffer start, and pressing Shift+Up once more when the
+/// head is already there must change nothing on screen.
+#[test]
+fn shift_up_extends_existing_selection_to_buffer_start_then_stops() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    open_fixture(&mut harness, &temp_dir);
+
+    // Cursor on line 2, column 11, then select up onto line 1.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    for _ in 0..10 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.send_key(KeyCode::Up, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        selected_offsets(&harness, LINE1),
+        (10..LINE1.len() as u16).collect::<Vec<u16>>(),
+        "precondition: selection reaches from line 1 column 11 down into line 2:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Second Shift+Up: the head is on line 1, so it must run to the buffer start.
+    harness.send_key(KeyCode::Up, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        selected_offsets(&harness, LINE1),
+        (0..LINE1.len() as u16).collect::<Vec<u16>>(),
+        "Shift+Up on the first line should extend the existing selection to the \
+         buffer start:\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        harness.get_status_bar().contains("Ln 1, Col 1"),
+        "status bar says: {}",
+        harness.get_status_bar()
+    );
+
+    // Third Shift+Up: the head is already at the buffer start, nothing may change.
+    let before = harness.screen_to_string();
+    harness.send_key(KeyCode::Up, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.screen_to_string(),
+        before,
+        "Shift+Up with the head already at the buffer start should be a no-op"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -109,6 +109,7 @@ pub mod issue_2876_prompt_input_hscroll;
 pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
 pub mod issue_2969_wheel_over_chrome;
+pub mod issue_3006_shift_select_at_buffer_edges;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
Addresses the keyboard half of #3006. The mouse-drag half of that issue is #3016.

## What was happening

Shift+Up with the cursor on the first line, and Shift+Down on the last line, did nothing at all — no cursor movement and no selection, where VSCode and Sublime extend the selection to the buffer start / end.

Reproduced on a 4-line file with no trailing newline: from `Ln 1, Col 11`, Shift+Up left the pane byte-identical with zero selection cells on screen; from `Ln 4, Col 11`, Shift+Down did the same. Shift+Up from line 2 selected normally, so the binding itself was never in doubt.

The cause is that both handlers exit early rather than clamping. In `handle_vertical_up`, the entire per-cursor body sits inside `if let Some((prev_line_start, …)) = iter.prev()`; on the first line that is `None`, so the loop pushes no `Event::MoveCursor` at all — position and anchor are both left untouched, which is why no selection appears rather than an empty one. `handle_vertical_down` mirrors it: it has an `else` branch, but it is gated on `!extend_selection && cursor.anchor.is_none() && vs_mode.cursor_beyond_eol()` — the virtual-space float below the buffer end — so with Shift held it is skipped.

## The change

`crates/fresh-editor/src/input/actions.rs` only. Each handler gains one arm for the no-adjacent-line case under `extend_selection`, moving the head to byte 0 (up) or `buffer.len()` (down) with the same anchor rule the normal path uses. In the down handler the new arm is inserted *before* the virtual-space fallback, which keeps its `!extend_selection` gate intact.

Decisions worth reviewing:

* **Already at the edge** — nothing is emitted, guarded by `position > 0` / `position < len`. A zero-length move would rewrite the sticky column and could plant an anchor where the user has no selection, so a repeated Shift+Up at the top is a true no-op.
* **Sticky column** — preserved as the same `goal_visual_column` the normal path computes, not reset to the edge column. Shift+Up from `Ln 1, Col 11` reaches the buffer start, and a following Shift+Down returns to `Ln 2, Col 11`, matching VSCode.
* **Anchor** — `Some(cursor.anchor.unwrap_or(cursor.position))`, identical to the normal path, so `deselect_on_move` / Emacs mark mode and multi-cursor are unaffected; the loop is per-cursor and unchanged.

Left out deliberately: the **unshifted** Up/Down case at the edges. VSCode moves the caret to buffer start/end there too and it arguably deserves the same treatment, but the unshifted Down path is owned by the virtual-space float-below-EOF branch and the interaction needs its own design. The issue asks only about Shift.

## Tests

`crates/fresh-editor/tests/e2e/issue_3006_shift_select_at_buffer_edges.rs`. Per-test `TempDir`, no timeouts or sleeps, no model/view accessors — assertions are on rendered cell backgrounds (`get_cell_style(...).bg == theme.selection_bg`, cells located via `find_text_on_screen`) and on the status-bar row.

* `shift_up_on_first_line_selects_to_buffer_start`
* `shift_down_on_last_line_selects_to_buffer_end`
* `shift_up_extends_existing_selection_to_buffer_start_then_stops` — also pins the no-op decision: a third Shift+Up must leave the screen byte-identical

## Verification status

The fail-without / pass-with check **was** run, before the instruction to leave e2e to CI arrived. With the fix, all three passed. With `input/actions.rs` reverted and the tests kept, all three failed:

```
panicked at issue_3006_shift_select_at_buffer_edges.rs:78:5:
assertion `left == right` failed: Shift+Up on the first line should highlight
everything from the buffer start up to the cursor
  left: []
 right: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```

and for the existing-selection case, `left: [10..21]` against `right: [0..21]`. Neighbouring suites (`e2e::selection`, `e2e::movement`, `e2e::virtual_space`, `e2e::block_selection`, `e2e::sticky_column_units`) were 92 passed / 0 failed / 2 ignored.

**One caveat on exactly what is committed:** after those runs, a behaviour-preserving cleanup was applied to avoid a `clippy::collapsible_if` — the down-branch inner `if` folded into the `else if` condition, with the virtual-space arm regaining its explicit `!extend_selection` gate — plus a comment reword and a `cargo fmt` reflow in the test file. The committed tree was **not** re-run against the tests, so CI is the first check of the exact contents of this PR.

Static checks on the committed tree: `cargo fmt --check` clean, `cargo check --all-targets` clean (only the two pre-existing warnings in `config_io.rs` and `orchestrator_plugin_api.rs`), `cargo clippy -p fresh-editor --lib` with no warnings in `input/actions.rs`. `cargo clippy --all-targets` and the full e2e suite were skipped deliberately. No GUI code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN

---
_Generated by [Claude Code](https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN)_