### PR TITLE
fix(language): highlight .h headers as the language detection actually chose

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -1622,6 +1622,7 @@ impl Editor {
                     first_line.as_deref(),
                     &self.grammar_registry,
                     &self.config.languages,
+                    state.buffer.filesystem().as_ref(),
                 );
 
                 if detected.highlighter.has_highlighting() || !state.highlighter.has_highlighting()

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -362,6 +362,7 @@ impl Editor {
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),
+                buffer.filesystem().as_ref(),
             );
 
         let mut state = EditorState::from_buffer_with_language(buffer, detected);
@@ -552,6 +553,7 @@ impl Editor {
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),
+                buffer.filesystem().as_ref(),
             );
 
         let mut state = EditorState::from_buffer_with_language(buffer, detected);
@@ -784,6 +786,9 @@ impl Editor {
         // Detect language from the container path (the basename's
         // extension is what matters; the directory tree is
         // container-side and won't match host-relative globs anyway).
+        // For the same reason the buffer's host filesystem can't see that
+        // tree, so the `.h` C++ probe finds nothing here and a container
+        // header stays C — the pre-existing behaviour for this path.
         let first_line = buffer.first_line_lossy();
         let detected =
             crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
@@ -792,6 +797,7 @@ impl Editor {
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),
+                buffer.filesystem().as_ref(),
             );
         let mut state = EditorState::from_buffer_with_language(buffer, detected);
         state.editing_disabled = true;
@@ -1172,6 +1178,7 @@ impl crate::app::window::Window {
                     &self.resources.grammar_registry,
                     &self.resources.config.languages,
                     self.resources.config.default_language.as_deref(),
+                    buffer.filesystem().as_ref(),
                 );
             EditorState::from_buffer_with_language(buffer, detected)
         } else {

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -113,6 +113,7 @@ impl Editor {
                             first_line.as_deref(),
                             &self.grammar_registry,
                             &self.config.languages,
+                            state.buffer.filesystem().as_ref(),
                         );
                     state.apply_language(detected);
                     state.apply_buffer_config(&self.config);

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -1334,6 +1334,7 @@ impl Editor {
                             first_line.as_deref(),
                             &self.grammar_registry,
                             &self.config.languages,
+                            state.buffer.filesystem().as_ref(),
                         );
                     state.apply_language(detected);
                     state.apply_buffer_config(&self.config);

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -799,6 +799,7 @@ impl Editor {
                                 first_line.as_deref(),
                                 &self.grammar_registry,
                                 &self.config.languages,
+                                state.buffer.filesystem().as_ref(),
                             );
                         new_language = detected.name.clone();
                         state.apply_language(detected);

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -3471,6 +3471,7 @@ impl Window {
                 &self.resources.grammar_registry,
                 &self.config().languages,
                 self.config().default_language.as_deref(),
+                buffer.filesystem().as_ref(),
             );
         let state = crate::state::EditorState::from_buffer_with_language(buffer, detected);
 

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1846,6 +1846,7 @@ impl crate::app::window::Window {
                 &self.resources.grammar_registry,
                 &self.resources.config.languages,
                 self.resources.config.default_language.as_deref(),
+                buffer.filesystem().as_ref(),
             );
         let mut state = EditorState::from_buffer_with_language(buffer, detected);
         state

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -9472,13 +9472,14 @@ mod tests {
     /// commas) but no default language claimed it.
     #[test]
     fn test_default_languages_map_jsonc_filenames() {
+        use crate::model::filesystem::StdFileSystem;
         use crate::services::lsp::manager::detect_language;
         use std::path::Path;
 
         let languages = Config::default_languages();
         for filename in ["bun.lock", "tsconfig.json", "devcontainer.json"] {
             assert_eq!(
-                detect_language(Path::new(filename), &languages),
+                detect_language(Path::new(filename), &languages, &StdFileSystem),
                 Some("jsonc".to_string()),
                 "expected `{filename}` to be detected as jsonc"
             );

--- a/crates/fresh-editor/src/primitives/detected_language.rs
+++ b/crates/fresh-editor/src/primitives/detected_language.rs
@@ -59,13 +59,22 @@ impl DetectedLanguage {
     /// via the `FileSystem` trait — supplies it so the registry never does
     /// its own I/O. Pass `None` when there is no content to inspect (e.g.,
     /// virtual buffers, unsaved files).
+    ///
+    /// `fs` is the filesystem that owns `path`, normally
+    /// `buffer.filesystem()`. Detection is *not* purely a function of the
+    /// path: `detect_language` probes the surrounding tree to decide whether
+    /// a `.h` is a C or a C++ header (#3009). Passing the process-local
+    /// filesystem for a file that lives on an SSH host makes that probe
+    /// answer about the wrong machine, so the filesystem is threaded in
+    /// rather than assumed.
     pub fn from_path(
         path: &Path,
         first_line: Option<&str>,
         registry: &GrammarRegistry,
         languages: &HashMap<String, LanguageConfig>,
+        fs: &dyn crate::model::filesystem::FileSystem,
     ) -> Self {
-        Self::from_path_with_fallback(path, first_line, registry, languages, None)
+        Self::from_path_with_fallback(path, first_line, registry, languages, None, fs)
     }
 
     /// Like `from_path`, but also accepts an optional default language name
@@ -77,13 +86,14 @@ impl DetectedLanguage {
         registry: &GrammarRegistry,
         languages: &HashMap<String, LanguageConfig>,
         default_language: Option<&str>,
+        fs: &dyn crate::model::filesystem::FileSystem,
     ) -> Self {
         // Resolve the config/LSP language id *independently* of the grammar
         // catalog. A file matching a `[languages.foo]` rule must end up with
         // `name = "foo"` so comment prefix / tab config / LSP routing all
         // work — even when the grammar registry is empty (common in tests)
         // or has no matching entry.
-        let config_lang_id = crate::services::lsp::manager::detect_language(path, languages);
+        let config_lang_id = crate::services::lsp::manager::detect_language(path, languages, fs);
         let align = |d: Self| -> Self {
             Self::align_with_config_id(d, &config_lang_id, registry, languages)
         };
@@ -240,6 +250,13 @@ pub fn resolve_language_id(
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::model::filesystem::{
+        DirEntry, EntryType, FileMetadata, FilePermissions, FileReader, FileSearchCursor,
+        FileSearchOptions, FileSystem, FileWriter, NoopFileSystem, SearchMatch, StdFileSystem,
+    };
+    use std::io;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// The default `[languages]` table — `c` owns `h`, `cpp` does not.
     fn default_languages() -> HashMap<String, LanguageConfig> {
@@ -250,6 +267,204 @@ mod tests {
         let mut registry = GrammarRegistry::default();
         registry.apply_language_config(languages);
         registry
+    }
+
+    /// A `FileSystem` whose entire contents live in this struct and exist
+    /// nowhere on the process's disk.
+    ///
+    /// This is the point of the type: the `.h` → C++ probe used to call
+    /// `std::fs` directly, so on an SSH session it answered about the local
+    /// machine instead of the host owning the file and the promotion became
+    /// a silent no-op. A test that writes real files into a tempdir cannot
+    /// catch that — `std::fs` and the injected filesystem agree there. These
+    /// paths are unopenable by `std::fs`, so any answer other than "wrong"
+    /// proves detection went through the trait.
+    ///
+    /// `ops` counts the calls the probe actually makes, which is how the
+    /// remote I/O budget is asserted: each of these is one blocking agent
+    /// round trip when the filesystem is a real `RemoteFileSystem`.
+    struct FakeTree {
+        /// Directory path → names of the entries it contains.
+        dirs: HashMap<PathBuf, Vec<String>>,
+        /// File path → contents.
+        files: HashMap<PathBuf, Vec<u8>>,
+        /// `Some(..)` makes this look like an SSH filesystem to
+        /// `ProbeBudget`, exactly as `RemoteFileSystem` does.
+        connection: Option<String>,
+        ops: AtomicUsize,
+    }
+
+    impl FakeTree {
+        fn new() -> Self {
+            Self {
+                dirs: HashMap::new(),
+                files: HashMap::new(),
+                connection: None,
+                ops: AtomicUsize::new(0),
+            }
+        }
+
+        /// Mark this filesystem as remote, so the probe budgets it like an
+        /// SSH host (see `ProbeBudget` in `services/lsp/manager.rs`).
+        fn remote(mut self) -> Self {
+            self.connection = Some("user@fake-host".to_string());
+            self
+        }
+
+        /// Add a file, registering it under its parent directory too.
+        fn file(mut self, path: &str, contents: &str) -> Self {
+            let path = PathBuf::from(path);
+            if let (Some(parent), Some(name)) = (
+                path.parent().map(Path::to_path_buf),
+                path.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string),
+            ) {
+                self.dirs.entry(parent).or_default().push(name);
+            }
+            self.files.insert(path, contents.as_bytes().to_vec());
+            self
+        }
+
+        fn ops(&self) -> usize {
+            self.ops.load(Ordering::SeqCst)
+        }
+
+        fn count_op(&self) {
+            self.ops.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn missing<T>() -> io::Result<T> {
+            Err(io::Error::new(io::ErrorKind::NotFound, "not in fake tree"))
+        }
+    }
+
+    impl FileSystem for FakeTree {
+        fn read_dir(&self, path: &Path) -> io::Result<Vec<DirEntry>> {
+            self.count_op();
+            let Some(names) = self.dirs.get(path) else {
+                return Self::missing();
+            };
+            Ok(names
+                .iter()
+                .map(|name| DirEntry::new(path.join(name), name.clone(), EntryType::File))
+                .collect())
+        }
+
+        fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+            self.count_op();
+            match self.files.get(path) {
+                Some(bytes) => Ok(FileMetadata::new(bytes.len() as u64)),
+                None => Self::missing(),
+            }
+        }
+
+        fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+            self.count_op();
+            let Some(bytes) = self.files.get(path) else {
+                return Self::missing();
+            };
+            let start = offset as usize;
+            let end = start.saturating_add(len);
+            if end > bytes.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "read past end of fake file",
+                ));
+            }
+            Ok(bytes[start..end].to_vec())
+        }
+
+        fn remote_connection_info(&self) -> Option<&str> {
+            self.connection.as_deref()
+        }
+
+        // ---- boilerplate: everything the probe must never touch ----
+        fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+            NoopFileSystem.read_file(path)
+        }
+        fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+            NoopFileSystem.write_file(path, data)
+        }
+        fn create_file(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+            NoopFileSystem.create_file(path)
+        }
+        fn open_file(&self, path: &Path) -> io::Result<Box<dyn FileReader>> {
+            NoopFileSystem.open_file(path)
+        }
+        fn open_file_for_write(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+            NoopFileSystem.open_file_for_write(path)
+        }
+        fn open_file_for_append(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+            NoopFileSystem.open_file_for_append(path)
+        }
+        fn set_file_length(&self, path: &Path, len: u64) -> io::Result<()> {
+            NoopFileSystem.set_file_length(path, len)
+        }
+        fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+            NoopFileSystem.rename(from, to)
+        }
+        fn copy(&self, from: &Path, to: &Path) -> io::Result<u64> {
+            NoopFileSystem.copy(from, to)
+        }
+        fn remove_file(&self, path: &Path) -> io::Result<()> {
+            NoopFileSystem.remove_file(path)
+        }
+        fn remove_dir(&self, path: &Path) -> io::Result<()> {
+            NoopFileSystem.remove_dir(path)
+        }
+        fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+            NoopFileSystem.symlink_metadata(path)
+        }
+        fn is_dir(&self, path: &Path) -> io::Result<bool> {
+            NoopFileSystem.is_dir(path)
+        }
+        fn is_file(&self, path: &Path) -> io::Result<bool> {
+            NoopFileSystem.is_file(path)
+        }
+        fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()> {
+            NoopFileSystem.set_permissions(path, permissions)
+        }
+        fn create_dir(&self, path: &Path) -> io::Result<()> {
+            NoopFileSystem.create_dir(path)
+        }
+        fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+            NoopFileSystem.create_dir_all(path)
+        }
+        fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+            NoopFileSystem.canonicalize(path)
+        }
+        fn current_uid(&self) -> u32 {
+            0
+        }
+        fn search_file(
+            &self,
+            path: &Path,
+            pattern: &str,
+            opts: &FileSearchOptions,
+            cursor: &mut FileSearchCursor,
+        ) -> io::Result<Vec<SearchMatch>> {
+            NoopFileSystem.search_file(path, pattern, opts, cursor)
+        }
+        fn sudo_write(
+            &self,
+            path: &Path,
+            data: &[u8],
+            mode: u32,
+            uid: u32,
+            gid: u32,
+        ) -> io::Result<()> {
+            NoopFileSystem.sudo_write(path, data, mode, uid, gid)
+        }
+        fn walk_files(
+            &self,
+            root: &Path,
+            skip_dirs: &[&str],
+            cancel: &std::sync::atomic::AtomicBool,
+            on_file: &mut dyn FnMut(&Path, &str) -> bool,
+        ) -> io::Result<()> {
+            NoopFileSystem.walk_files(root, skip_dirs, cancel, on_file)
+        }
     }
 
     /// #3009: a `.h` header sitting next to C++ sources must highlight with
@@ -265,7 +480,8 @@ mod tests {
 
         let languages = default_languages();
         let registry = registry_with(&languages);
-        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+        let detected =
+            DetectedLanguage::from_path(&header, None, &registry, &languages, &StdFileSystem);
 
         assert_eq!(detected.name, "cpp");
         assert_eq!(detected.display_name, "C++");
@@ -283,7 +499,8 @@ mod tests {
 
         let languages = default_languages();
         let registry = registry_with(&languages);
-        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+        let detected =
+            DetectedLanguage::from_path(&header, None, &registry, &languages, &StdFileSystem);
 
         assert_eq!(detected.name, "c");
         assert_eq!(detected.display_name, "C");
@@ -307,7 +524,8 @@ mod tests {
             .extensions
             .push("h".to_string());
         let registry = registry_with(&languages);
-        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+        let detected =
+            DetectedLanguage::from_path(&header, None, &registry, &languages, &StdFileSystem);
 
         assert_eq!(detected.name, "cpp");
         assert_eq!(detected.ts_language, Some(Language::Cpp));
@@ -325,7 +543,8 @@ mod tests {
         let mut languages = default_languages();
         languages.remove("cpp");
         let registry = registry_with(&languages);
-        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+        let detected =
+            DetectedLanguage::from_path(&header, None, &registry, &languages, &StdFileSystem);
 
         assert_eq!(detected.name, "c");
         assert_eq!(detected.ts_language, Some(Language::C));
@@ -343,7 +562,13 @@ mod tests {
         languages.insert("mylang".to_string(), alias);
         let registry = registry_with(&languages);
 
-        let detected = DetectedLanguage::from_path(Path::new("a.ml2"), None, &registry, &languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("a.ml2"),
+            None,
+            &registry,
+            &languages,
+            &StdFileSystem,
+        );
         assert_eq!(detected.name, "mylang");
         assert_eq!(detected.ts_language, Some(Language::Rust));
     }
@@ -362,8 +587,176 @@ mod tests {
         // `.rs` to Rust, and the unknown grammar name must leave it alone.
         let registry = GrammarRegistry::default();
 
-        let detected = DetectedLanguage::from_path(Path::new("a.rs"), None, &registry, &languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("a.rs"),
+            None,
+            &registry,
+            &languages,
+            &StdFileSystem,
+        );
         assert_eq!(detected.name, "weird");
         assert_eq!(detected.ts_language, Some(Language::Rust));
+    }
+
+    /// The remote fix, stated positively: the C++ sibling exists only in the
+    /// injected filesystem, at a path `std::fs` cannot open. Before the
+    /// filesystem was threaded through, the probe called `std::fs::read_dir`
+    /// on `/remote-project/src`, got `NotFound`, and left the header as C —
+    /// which is exactly what an SSH user saw for every header in a remote
+    /// C++ tree.
+    #[test]
+    fn test_h_header_promotion_reads_injected_filesystem_not_local_disk() {
+        let fs = FakeTree::new()
+            .remote()
+            .file("/remote-project/src/widget.h", "")
+            .file("/remote-project/src/widget.cpp", "");
+        assert!(
+            !Path::new("/remote-project/src/widget.cpp").exists(),
+            "the fixture must not exist on the real disk, or it proves nothing"
+        );
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("/remote-project/src/widget.h"),
+            None,
+            &registry,
+            &languages,
+            &fs,
+        );
+
+        assert_eq!(detected.name, "cpp");
+        assert_eq!(detected.display_name, "C++");
+        assert_eq!(detected.ts_language, Some(Language::Cpp));
+    }
+
+    /// The same fix stated negatively, and the sharper half: the process's
+    /// own disk *does* hold a C++ sibling next to the header path, while the
+    /// injected filesystem holds only C. A probe that still reached for
+    /// `std::fs` would promote to C++ here; the correct answer is C, because
+    /// the injected filesystem is the one that owns the file.
+    #[test]
+    fn test_h_header_promotion_ignores_local_disk_when_injected_fs_says_c() {
+        let tmp = tempfile::tempdir().unwrap();
+        let header = tmp.path().join("widget.h");
+        std::fs::write(&header, "").unwrap();
+        std::fs::write(tmp.path().join("widget.cpp"), "").unwrap();
+
+        // The fake reports the same directory containing only C sources.
+        let dir = tmp.path().to_string_lossy().to_string();
+        let fs = FakeTree::new()
+            .remote()
+            .file(&format!("{dir}/widget.h"), "")
+            .file(&format!("{dir}/widget.c"), "");
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages, &fs);
+
+        assert_eq!(
+            detected.name, "c",
+            "promotion must follow the injected filesystem, not the local disk"
+        );
+        assert_eq!(detected.ts_language, Some(Language::C));
+    }
+
+    /// A remote filesystem's sync methods are blocking agent round trips on
+    /// the single-threaded editor loop, so the probe spends exactly one on
+    /// the file-open path: the sibling listing. The ten-deep
+    /// `compile_commands.json` ancestor walk is not affordable there and is
+    /// budgeted away — a remote header under `include/` stays C rather than
+    /// costing up to a dozen serialized round trips before the file can be
+    /// shown.
+    #[test]
+    fn test_remote_probe_spends_one_op_and_skips_ancestor_walk() {
+        let fs = FakeTree::new()
+            .remote()
+            .file("/proj/include/widget.h", "")
+            .file(
+                "/proj/compile_commands.json",
+                r#"[{"command":"clang++ -std=c++17 -c widget.cpp"}]"#,
+            );
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("/proj/include/widget.h"),
+            None,
+            &registry,
+            &languages,
+            &fs,
+        );
+
+        assert_eq!(detected.name, "c", "remote budget skips the ancestor walk");
+        assert_eq!(
+            fs.ops(),
+            1,
+            "exactly one filesystem op (the sibling listing) may reach a remote host"
+        );
+    }
+
+    /// The mirror of the budget test: the identical tree on a *local*
+    /// filesystem still walks ancestors and finds the C++ marker, so
+    /// budgeting the remote path costs local users nothing.
+    #[test]
+    fn test_local_probe_still_walks_ancestors_for_compile_commands() {
+        let fs = FakeTree::new().file("/proj/include/widget.h", "").file(
+            "/proj/compile_commands.json",
+            r#"[{"command":"clang++ -std=c++17 -c widget.cpp"}]"#,
+        );
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("/proj/include/widget.h"),
+            None,
+            &registry,
+            &languages,
+            &fs,
+        );
+
+        assert_eq!(detected.name, "cpp");
+        assert_eq!(detected.ts_language, Some(Language::Cpp));
+    }
+
+    /// `FileSystem::read_range` is `read_exact`-shaped: asking for more bytes
+    /// than the file holds fails outright. The marker read therefore clamps
+    /// to the file's real size, and a small `compile_commands.json` — the
+    /// normal case — must still be read rather than erroring into "not C++".
+    #[test]
+    fn test_small_compile_commands_is_read_despite_the_one_mib_cap() {
+        let fs = FakeTree::new().file("/proj/include/widget.h", "").file(
+            "/proj/compile_commands.json",
+            r#"[{"command":"g++ -c a.cpp"}]"#,
+        );
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(
+            Path::new("/proj/include/widget.h"),
+            None,
+            &registry,
+            &languages,
+            &fs,
+        );
+
+        assert_eq!(detected.name, "cpp");
+    }
+
+    /// Detection must not probe the filesystem at all for the overwhelming
+    /// majority of files — only a `.h` resolving to `c` in a config that
+    /// knows `cpp` can trigger it. Guards the ordering in `detect_language`
+    /// that keeps file open off the I/O path for everything else.
+    #[test]
+    fn test_non_header_paths_touch_no_filesystem() {
+        let fs = FakeTree::new().remote();
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+
+        for name in ["/proj/main.rs", "/proj/main.c", "/proj/widget.hpp"] {
+            let _ = DetectedLanguage::from_path(Path::new(name), None, &registry, &languages, &fs);
+        }
+
+        assert_eq!(fs.ops(), 0, "no filesystem access for non-`.h` paths");
     }
 }

--- a/crates/fresh-editor/src/primitives/detected_language.rs
+++ b/crates/fresh-editor/src/primitives/detected_language.rs
@@ -84,15 +84,12 @@ impl DetectedLanguage {
         // work — even when the grammar registry is empty (common in tests)
         // or has no matching entry.
         let config_lang_id = crate::services::lsp::manager::detect_language(path, languages);
-        let override_name = |mut d: Self| -> Self {
-            if let Some(id) = config_lang_id.clone() {
-                d.name = id;
-            }
-            d
+        let align = |d: Self| -> Self {
+            Self::align_with_config_id(d, &config_lang_id, registry, languages)
         };
 
         if let Some(entry) = registry.find_by_path(path, first_line) {
-            return override_name(Self::from_entry(entry, registry));
+            return align(Self::from_entry(entry, registry));
         }
 
         // No grammar match — try the user-configured default language for
@@ -105,11 +102,68 @@ impl DetectedLanguage {
                 .filter(|g| !g.is_empty())
                 .unwrap_or(lang_key);
             if let Some(entry) = registry.find_by_name(grammar) {
-                return override_name(Self::from_entry(entry, registry));
+                return align(Self::from_entry(entry, registry));
             }
         }
 
-        override_name(Self::plain_text())
+        align(Self::plain_text())
+    }
+
+    /// Make the highlighter, tree-sitter grammar and display name agree with
+    /// the language id detection resolved.
+    ///
+    /// Detection has two halves that historically answered independently:
+    /// `detect_language` resolves the config/LSP id from `[languages.*]`
+    /// (including content-independent promotions such as `.h` → `cpp` inside
+    /// a C++ tree, #3009), while `GrammarRegistry::find_by_path` resolves the
+    /// grammar from the extension table. When they disagree the buffer ends
+    /// up with a C++ language id and a C grammar: the status bar says `C`,
+    /// keywords like `namespace` / `template` render unhighlighted, and `::`
+    /// doesn't scope.
+    ///
+    /// Rather than patching each caller, this is the single fork where the two
+    /// halves are reconciled: the config id wins, and the grammar is
+    /// re-resolved through that id's `[languages.<id>].grammar`. If the id has
+    /// no grammar the registry knows about, the path-resolved grammar is kept
+    /// — an unknown config key must never downgrade working highlighting.
+    ///
+    /// Cost is one hash lookup; no filesystem access and no buffer scan are
+    /// added on top of what `detect_language` already does.
+    fn align_with_config_id(
+        mut detected: Self,
+        config_lang_id: &Option<String>,
+        registry: &GrammarRegistry,
+        languages: &HashMap<String, LanguageConfig>,
+    ) -> Self {
+        let Some(id) = config_lang_id.as_deref() else {
+            return detected;
+        };
+
+        // The grammar the config id asks for. An empty `grammar` field means
+        // "same name as the key" — matching `apply_language_config`.
+        let grammar_name = languages
+            .get(id)
+            .map(|lc| lc.grammar.as_str())
+            .filter(|g| !g.is_empty())
+            .unwrap_or(id);
+
+        if let Some(entry) = registry
+            .find_by_name(grammar_name)
+            .or_else(|| registry.find_by_name(id))
+        {
+            // `find_by_name` resolves aliases, so an entry with the same
+            // `language_id` *is* the grammar we already have — the common
+            // case (`[languages.rust] grammar = "Rust"` on a `.rs` file), and
+            // nothing but the name needs stamping.
+            if entry.language_id != detected.name {
+                let mut aligned = Self::from_entry(entry, registry);
+                aligned.name = id.to_string();
+                return aligned;
+            }
+        }
+
+        detected.name = id.to_string();
+        detected
     }
 
     /// Set language by syntax name (user selected from the language palette).
@@ -180,4 +234,136 @@ pub fn resolve_language_id(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    /// The default `[languages]` table — `c` owns `h`, `cpp` does not.
+    fn default_languages() -> HashMap<String, LanguageConfig> {
+        Config::default().languages
+    }
+
+    fn registry_with(languages: &HashMap<String, LanguageConfig>) -> GrammarRegistry {
+        let mut registry = GrammarRegistry::default();
+        registry.apply_language_config(languages);
+        registry
+    }
+
+    /// #3009: a `.h` header sitting next to C++ sources must highlight with
+    /// the C++ grammar, not just route to clangd in C++ mode. Before the
+    /// alignment step the id said `cpp` while the grammar and the status-bar
+    /// label said `C`.
+    #[test]
+    fn test_h_header_beside_cpp_sibling_detects_cpp_grammar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let header = tmp.path().join("widget.h");
+        std::fs::write(&header, "namespace ui { class Widget {}; }\n").unwrap();
+        std::fs::write(tmp.path().join("widget.cpp"), "").unwrap();
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+
+        assert_eq!(detected.name, "cpp");
+        assert_eq!(detected.display_name, "C++");
+        assert_eq!(detected.ts_language, Some(Language::Cpp));
+    }
+
+    /// The mirror case: the same bytes in a plain C project stay C, so the
+    /// promotion can't turn every header into C++.
+    #[test]
+    fn test_h_header_in_pure_c_project_stays_c_grammar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let header = tmp.path().join("widget.h");
+        std::fs::write(&header, "namespace ui { class Widget {}; }\n").unwrap();
+        std::fs::write(tmp.path().join("widget.c"), "").unwrap();
+
+        let languages = default_languages();
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+
+        assert_eq!(detected.name, "c");
+        assert_eq!(detected.display_name, "C");
+        assert_eq!(detected.ts_language, Some(Language::C));
+    }
+
+    /// The pre-existing user workaround — moving `h` into
+    /// `languages.cpp.extensions` — must still force C++ unconditionally,
+    /// with no C++ sibling anywhere in the tree.
+    #[test]
+    fn test_user_config_can_force_h_to_cpp_without_siblings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let header = tmp.path().join("lonely.h");
+        std::fs::write(&header, "").unwrap();
+
+        let mut languages = default_languages();
+        languages.get_mut("c").unwrap().extensions = vec!["c".to_string()];
+        languages
+            .get_mut("cpp")
+            .unwrap()
+            .extensions
+            .push("h".to_string());
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+
+        assert_eq!(detected.name, "cpp");
+        assert_eq!(detected.ts_language, Some(Language::Cpp));
+    }
+
+    /// And the other direction: a user with no `cpp` language configured
+    /// keeps the C grammar even in a tree full of C++ sources.
+    #[test]
+    fn test_user_config_without_cpp_language_keeps_h_as_c() {
+        let tmp = tempfile::tempdir().unwrap();
+        let header = tmp.path().join("widget.h");
+        std::fs::write(&header, "").unwrap();
+        std::fs::write(tmp.path().join("widget.cpp"), "").unwrap();
+
+        let mut languages = default_languages();
+        languages.remove("cpp");
+        let registry = registry_with(&languages);
+        let detected = DetectedLanguage::from_path(&header, None, &registry, &languages);
+
+        assert_eq!(detected.name, "c");
+        assert_eq!(detected.ts_language, Some(Language::C));
+    }
+
+    /// Aliasing a built-in grammar under a custom config key must keep that
+    /// grammar — the alignment step resolves `[languages.mylang].grammar` and
+    /// lands on the very entry the path lookup already produced.
+    #[test]
+    fn test_config_alias_keeps_aliased_grammar() {
+        let mut languages = default_languages();
+        let mut alias = languages.get("rust").cloned().unwrap();
+        alias.extensions = vec!["ml2".to_string()];
+        alias.grammar = "Rust".to_string();
+        languages.insert("mylang".to_string(), alias);
+        let registry = registry_with(&languages);
+
+        let detected = DetectedLanguage::from_path(Path::new("a.ml2"), None, &registry, &languages);
+        assert_eq!(detected.name, "mylang");
+        assert_eq!(detected.ts_language, Some(Language::Rust));
+    }
+
+    /// A config key whose grammar the registry knows nothing about must not
+    /// downgrade the highlighting the path lookup already resolved.
+    #[test]
+    fn test_unknown_config_grammar_keeps_path_resolved_highlighter() {
+        let mut languages = default_languages();
+        let mut odd = languages.get("rust").cloned().unwrap();
+        odd.extensions = vec!["rs".to_string()];
+        odd.grammar = "no-such-grammar".to_string();
+        languages.remove("rust");
+        languages.insert("weird".to_string(), odd);
+        // Deliberately *not* applying the config: the registry still resolves
+        // `.rs` to Rust, and the unknown grammar name must leave it alone.
+        let registry = GrammarRegistry::default();
+
+        let detected = DetectedLanguage::from_path(Path::new("a.rs"), None, &registry, &languages);
+        assert_eq!(detected.name, "weird");
+        assert_eq!(detected.ts_language, Some(Language::Rust));
+    }
 }

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -1941,9 +1941,18 @@ impl Drop for LspManager {
 /// config **key** (`[languages.mylang]` → `"mylang"`) rather than the
 /// catalog entry's `language_id`, which is needed for LSP routing when a
 /// user aliases an existing grammar.
+///
+/// `fs` is the filesystem that actually owns `path` — the buffer's own
+/// filesystem, not the process's. Only the `.h` → `cpp` promotion below
+/// touches it; every other rule is pure path/config matching. It is a
+/// required argument rather than an `Option` precisely because the bug it
+/// fixes was a probe that quietly answered "no" against the wrong
+/// filesystem: on a remote session there is no correct behaviour for a
+/// caller that cannot say which host the file lives on.
 pub fn detect_language(
     path: &std::path::Path,
     languages: &std::collections::HashMap<String, crate::config::LanguageConfig>,
+    fs: &dyn crate::model::filesystem::FileSystem,
 ) -> Option<String> {
     let detected = detect_language_by_config(path, languages);
 
@@ -1952,10 +1961,15 @@ pub fn detect_language(
     // If the detected language is `c`, the file is `.h`, and the surrounding
     // tree smells like C++ (sibling C++ sources or an ancestor
     // `compile_commands.json`), promote to `cpp` so the LSP binding is right.
+    //
+    // The cheap path/config predicates are deliberately ordered before
+    // `header_in_cpp_tree`, so the only I/O in this function is skipped
+    // entirely for every file that is not a `.h` resolving to `c` in a
+    // config that knows `cpp`.
     if detected.as_deref() == Some("c")
         && path.extension().and_then(|e| e.to_str()) == Some("h")
         && languages.contains_key("cpp")
-        && header_in_cpp_tree(path)
+        && header_in_cpp_tree(path, fs)
     {
         return Some("cpp".to_string());
     }
@@ -2021,31 +2035,41 @@ fn detect_language_by_config(
 ///     extension (`c++`, `.cpp`, `.cc`, `.cxx`, `.C` ). This still covers
 ///     the fmt / Chromium / LLVM / Qt-style layouts where the header
 ///     lives deep under `include/` while sources sit in `src/` at the
-///     project root.
+///     project root. This second signal is budgeted away on a remote
+///     filesystem, where each level would be a blocking round trip —
+///     see [`ProbeBudget`].
 ///
-/// Bounded by depth (10), by a single shallow `read_dir` at the start,
-/// and by a capped 1 MiB read of `compile_commands.json`, so the cost is
-/// a handful of `stat`s plus at most one bounded read on file open.
+/// All access goes through `fs` — the filesystem that owns the header —
+/// so the probe answers about the host the file actually lives on. Reading
+/// the process-local disk here made the promotion a silent no-op on every
+/// SSH session: a `.h` in a remote C++ tree found no siblings, fell back to
+/// `c`, and highlighted as C.
+///
 /// Silent on any I/O error — if we can't see the filesystem we fall back
 /// to the default config answer (C), which is the pre-fix behavior.
 ///
-/// NOTE(remote-fs): Uses `std::fs` directly, matching the pre-existing
-/// `detect_workspace_root` in this module. On SSH sessions the probe
-/// sees the local filesystem, so the promotion silently becomes a no-op
-/// (returns `false`, falls back to `c`). Fixing this requires threading
-/// `&dyn FileSystem` through `detect_language` and
-/// `DetectedLanguage::from_path` — a cross-cutting refactor that should
-/// be done alongside the same fix for `detect_workspace_root`.
-fn header_in_cpp_tree(path: &std::path::Path) -> bool {
+/// NOTE(remote-fs): `detect_workspace_root` in this module still uses
+/// `std::fs` via `Path::exists` and has the same remote blind spot (an
+/// SSH workspace root resolves to the file's own directory instead of the
+/// project root). It is *not* fixed here: its three call sites sit inside
+/// LSP server spawn/initialize, `LspManager` holds no filesystem, and
+/// `resolve_root_uri` deliberately walks *host* paths before applying
+/// `path_translation` for devcontainers — so "which filesystem" is a real
+/// design question there, not a mechanical substitution.
+fn header_in_cpp_tree(
+    path: &std::path::Path,
+    fs: &dyn crate::model::filesystem::FileSystem,
+) -> bool {
     let Some(start_dir) = path.parent() else {
         return false;
     };
+    let budget = ProbeBudget::for_filesystem(fs);
 
-    // 1. Sibling scan in the header's own directory.
-    if let Ok(entries) = std::fs::read_dir(start_dir) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            let Some(ext) = p.extension().and_then(|e| e.to_str()) else {
+    // 1. Sibling scan in the header's own directory: one shallow,
+    //    non-recursive listing, and the decisive signal.
+    if let Ok(entries) = fs.read_dir(start_dir) {
+        for entry in &entries {
+            let Some(ext) = entry.path.extension().and_then(|e| e.to_str()) else {
                 continue;
             };
             if matches!(
@@ -2057,44 +2081,113 @@ fn header_in_cpp_tree(path: &std::path::Path) -> bool {
         }
     }
 
-    // 2. Walk ancestors for compile_commands.json, and only promote if
+    // 2. Walk up looking for compile_commands.json, and only promote if
     //    the file actually carries a C++ marker — CMake emits it for
-    //    pure-C builds too.
+    //    pure-C builds too. `budget.compile_commands_dirs` is 0 on a
+    //    remote filesystem, which skips this loop entirely without ever
+    //    issuing a request (see `ProbeBudget`).
     let mut current = Some(start_dir);
-    let mut depth = 0u32;
+    let mut visited = 0u32;
     while let Some(dir) = current {
-        let cc = dir.join("compile_commands.json");
-        if cc.is_file() && compile_commands_has_cpp_marker(&cc) {
-            return true;
-        }
-        if depth >= 10 {
+        if visited >= budget.compile_commands_dirs {
             break;
         }
-        depth += 1;
+        if compile_commands_has_cpp_marker(&dir.join("compile_commands.json"), fs) {
+            return true;
+        }
+        visited += 1;
         current = dir.parent();
     }
 
     false
 }
 
-/// Returns true when `compile_commands.json` contains a C++ marker —
-/// either the literal substring `c++` (covers `-std=c++17`, `clang++`,
-/// `g++`, the `c++` compiler name) or a C++ source extension in a
-/// context where it cannot be confused with an adjacent header path
-/// (`.cpp`, `.cc`, `.cxx`). Reads at most 1 MiB so multi-megabyte
-/// compile DBs from large monorepos don't block file open; a valid CMake
-/// entry fits comfortably in that window.
-fn compile_commands_has_cpp_marker(path: &std::path::Path) -> bool {
-    use std::io::Read;
+/// How much filesystem I/O the `.h` tree probe may spend, decided by the
+/// filesystem that owns the file rather than by a flag a caller could get
+/// wrong.
+///
+/// This exists because the two backends have costs that differ by four
+/// orders of magnitude for the *same* trait call. `StdFileSystem`'s
+/// `read_dir` / `metadata` are microsecond syscalls. `RemoteFileSystem`
+/// implements the whole sync `FileSystem` surface with
+/// `AgentChannel::request_blocking` — one blocking SSH round trip each,
+/// on the editor thread. Language detection runs on the file-open path, so
+/// the unbudgeted probe (one `ls` plus up to eleven `stat`s plus a read)
+/// would be up to thirteen serialized round trips before a remote `.h`
+/// could be displayed, and the editor loop is single-threaded: a stalled
+/// link would freeze the UI for the request timeout on each one. (The same
+/// hazard is called out in `services/remote/filesystem.rs`, where the
+/// `$HOME`/temp-dir lookups are cached specifically to keep blocking
+/// requests off the editor thread.)
+///
+/// So the remote budget buys only the decisive signal — the single sibling
+/// listing, which is one round trip and covers the ordinary
+/// `widget.h`/`widget.cpp` layout that motivated #3009 — and declines the
+/// ancestor walk. A remote header under an `include/` tree with sources
+/// elsewhere therefore still reads as C: strictly better than today's
+/// unconditional no-op, and it does not trade a highlighting nicety for a
+/// frozen editor. Carrying the depth as data (rather than an
+/// `if is_remote` inside the loop) keeps "walk ten ancestors over SSH"
+/// unrepresentable instead of merely unreached.
+#[derive(Clone, Copy)]
+struct ProbeBudget {
+    /// How many directories the `compile_commands.json` walk may visit,
+    /// counting from the header's own directory upward. `0` disables the
+    /// walk outright, so no request is issued at all.
+    compile_commands_dirs: u32,
+}
+
+impl ProbeBudget {
+    /// Directories visited on a local filesystem: the header's own plus
+    /// ten ancestors — deep enough for the fmt / Chromium / LLVM / Qt
+    /// layouts where the header sits several levels under `include/`.
+    const LOCAL_COMPILE_COMMANDS_DIRS: u32 = 11;
+
+    fn for_filesystem(fs: &dyn crate::model::filesystem::FileSystem) -> Self {
+        // `remote_connection_info` is the trait's own locality signal:
+        // `Some("user@host")` exactly for filesystems whose sync methods
+        // are blocking round trips.
+        let compile_commands_dirs = if fs.remote_connection_info().is_some() {
+            0
+        } else {
+            Self::LOCAL_COMPILE_COMMANDS_DIRS
+        };
+        Self {
+            compile_commands_dirs,
+        }
+    }
+}
+
+/// Returns true when `compile_commands.json` exists at `path` and contains
+/// a C++ marker — either the literal substring `c++` (covers `-std=c++17`,
+/// `clang++`, `g++`, the `c++` compiler name) or a C++ source extension in
+/// a context where it cannot be confused with an adjacent header path
+/// (`.cpp`, `.cc`, `.cxx`).
+///
+/// Existence and size come from a single `metadata_if_exists`, which is one
+/// filesystem op (one round trip on a remote host) and subsumes the former
+/// separate `is_file` check. The read is then clamped to
+/// `min(size, 1 MiB)`: the cap keeps multi-megabyte compile DBs from large
+/// monorepos off the file-open path, and clamping to the real size is
+/// required because `FileSystem::read_range` is `read_exact`-shaped and
+/// fails outright on a short file. A directory or unreadable path simply
+/// fails the read and answers `false`.
+fn compile_commands_has_cpp_marker(
+    path: &std::path::Path,
+    fs: &dyn crate::model::filesystem::FileSystem,
+) -> bool {
     const MAX_READ: u64 = 1_048_576;
 
-    let Ok(file) = std::fs::File::open(path) else {
+    let Some(meta) = fs.metadata_if_exists(path) else {
         return false;
     };
-    let mut buf = Vec::with_capacity(64 * 1024);
-    if file.take(MAX_READ).read_to_end(&mut buf).is_err() {
+    let len = meta.size.min(MAX_READ) as usize;
+    if len == 0 {
         return false;
     }
+    let Ok(buf) = fs.read_range(path, 0, len) else {
+        return false;
+    };
     let Ok(text) = std::str::from_utf8(&buf) else {
         return false;
     };
@@ -2113,6 +2206,7 @@ fn compile_commands_has_cpp_marker(path: &std::path::Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::filesystem::StdFileSystem;
     use std::path::Path;
 
     #[test]
@@ -2397,33 +2491,48 @@ mod tests {
 
         // Test configured languages
         assert_eq!(
-            detect_language(Path::new("main.rs"), &languages),
+            detect_language(Path::new("main.rs"), &languages, &StdFileSystem),
             Some("rust".to_string())
         );
         assert_eq!(
-            detect_language(Path::new("index.js"), &languages),
+            detect_language(Path::new("index.js"), &languages, &StdFileSystem),
             Some("javascript".to_string())
         );
         assert_eq!(
-            detect_language(Path::new("App.jsx"), &languages),
+            detect_language(Path::new("App.jsx"), &languages, &StdFileSystem),
             Some("javascript".to_string())
         );
         assert_eq!(
-            detect_language(Path::new("Program.cs"), &languages),
+            detect_language(Path::new("Program.cs"), &languages, &StdFileSystem),
             Some("csharp".to_string())
         );
 
         // Test unconfigured extensions return None
-        assert_eq!(detect_language(Path::new("main.py"), &languages), None);
-        assert_eq!(detect_language(Path::new("file.xyz"), &languages), None);
-        assert_eq!(detect_language(Path::new("file"), &languages), None);
+        assert_eq!(
+            detect_language(Path::new("main.py"), &languages, &StdFileSystem),
+            None
+        );
+        assert_eq!(
+            detect_language(Path::new("file.xyz"), &languages, &StdFileSystem),
+            None
+        );
+        assert_eq!(
+            detect_language(Path::new("file"), &languages, &StdFileSystem),
+            None
+        );
     }
 
     #[test]
     fn test_detect_language_no_extension() {
         let languages = test_languages();
-        assert_eq!(detect_language(Path::new("README"), &languages), None);
-        assert_eq!(detect_language(Path::new("Makefile"), &languages), None);
+        assert_eq!(
+            detect_language(Path::new("README"), &languages, &StdFileSystem),
+            None
+        );
+        assert_eq!(
+            detect_language(Path::new("Makefile"), &languages, &StdFileSystem),
+            None
+        );
     }
 
     #[test]
@@ -2458,19 +2567,22 @@ mod tests {
 
         // Path glob: /etc/**/rc.* should match
         assert_eq!(
-            detect_language(Path::new("/etc/rc.conf"), &languages),
+            detect_language(Path::new("/etc/rc.conf"), &languages, &StdFileSystem),
             Some("shell".to_string())
         );
         assert_eq!(
-            detect_language(Path::new("/etc/init/rc.local"), &languages),
+            detect_language(Path::new("/etc/init/rc.local"), &languages, &StdFileSystem),
             Some("shell".to_string())
         );
         // Path glob should NOT match different root
-        assert_eq!(detect_language(Path::new("/var/rc.conf"), &languages), None);
+        assert_eq!(
+            detect_language(Path::new("/var/rc.conf"), &languages, &StdFileSystem),
+            None
+        );
 
         // Filename glob: *rc should still work
         assert_eq!(
-            detect_language(Path::new("lfrc"), &languages),
+            detect_language(Path::new("lfrc"), &languages, &StdFileSystem),
             Some("shell".to_string())
         );
     }
@@ -2604,7 +2716,7 @@ mod tests {
         // default-config answer (`c`) survives.
         let languages = c_cpp_languages();
         assert_eq!(
-            detect_language(Path::new("foo.h"), &languages),
+            detect_language(Path::new("foo.h"), &languages, &StdFileSystem),
             Some("c".to_string())
         );
     }
@@ -2621,7 +2733,7 @@ mod tests {
 
         let languages = c_cpp_languages();
         assert_eq!(
-            detect_language(&header, &languages),
+            detect_language(&header, &languages, &StdFileSystem),
             Some("cpp".to_string())
         );
     }
@@ -2638,7 +2750,7 @@ mod tests {
 
         let languages = c_cpp_languages();
         assert_eq!(
-            detect_language(&header, &languages),
+            detect_language(&header, &languages, &StdFileSystem),
             Some("cpp".to_string())
         );
     }
@@ -2661,7 +2773,7 @@ mod tests {
 
         let languages = c_cpp_languages();
         assert_eq!(
-            detect_language(&header, &languages),
+            detect_language(&header, &languages, &StdFileSystem),
             Some("cpp".to_string())
         );
     }
@@ -2683,7 +2795,10 @@ mod tests {
         std::fs::write(&header, "").unwrap();
 
         let languages = c_cpp_languages();
-        assert_eq!(detect_language(&header, &languages), Some("c".to_string()));
+        assert_eq!(
+            detect_language(&header, &languages, &StdFileSystem),
+            Some("c".to_string())
+        );
     }
 
     #[test]
@@ -2697,7 +2812,10 @@ mod tests {
         std::fs::write(project.join("lib.c"), "").unwrap();
 
         let languages = c_cpp_languages();
-        assert_eq!(detect_language(&header, &languages), Some("c".to_string()));
+        assert_eq!(
+            detect_language(&header, &languages, &StdFileSystem),
+            Some("c".to_string())
+        );
     }
 
     #[test]
@@ -2712,7 +2830,10 @@ mod tests {
         std::fs::write(&header, "").unwrap();
 
         let languages = c_cpp_languages();
-        assert_eq!(detect_language(&header, &languages), Some("c".to_string()));
+        assert_eq!(
+            detect_language(&header, &languages, &StdFileSystem),
+            Some("c".to_string())
+        );
     }
 
     #[test]
@@ -2735,7 +2856,7 @@ mod tests {
 
         let languages = c_cpp_languages();
         assert_eq!(
-            detect_language(&header, &languages),
+            detect_language(&header, &languages, &StdFileSystem),
             Some("cpp".to_string())
         );
     }
@@ -2751,7 +2872,10 @@ mod tests {
         std::fs::write(project.join("main.cpp"), "").unwrap();
 
         let languages = c_cpp_languages();
-        assert_eq!(detect_language(&source, &languages), Some("c".to_string()));
+        assert_eq!(
+            detect_language(&source, &languages, &StdFileSystem),
+            Some("c".to_string())
+        );
     }
 
     #[test]
@@ -2767,7 +2891,10 @@ mod tests {
 
         let mut languages = c_cpp_languages();
         languages.remove("cpp");
-        assert_eq!(detect_language(&header, &languages), Some("c".to_string()));
+        assert_eq!(
+            detect_language(&header, &languages, &StdFileSystem),
+            Some("c".to_string())
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -596,8 +596,13 @@ impl EditorState {
     ) -> anyhow::Result<Self> {
         let buffer = Buffer::load_from_file(path, large_file_threshold, fs)?;
         let first_line = buffer.first_line_lossy();
-        let detected =
-            DetectedLanguage::from_path(path, first_line.as_deref(), registry, languages);
+        let detected = DetectedLanguage::from_path(
+            path,
+            first_line.as_deref(),
+            registry,
+            languages,
+            buffer.filesystem().as_ref(),
+        );
         let mut state = Self::new_from_buffer(buffer);
         state.apply_language(detected);
         Ok(state)
@@ -621,8 +626,13 @@ impl EditorState {
     ) -> anyhow::Result<Self> {
         let buffer = Buffer::load_from_file_force_text(path, large_file_threshold, fs)?;
         let first_line = buffer.first_line_lossy();
-        let detected =
-            DetectedLanguage::from_path(path, first_line.as_deref(), registry, languages);
+        let detected = DetectedLanguage::from_path(
+            path,
+            first_line.as_deref(),
+            registry,
+            languages,
+            buffer.filesystem().as_ref(),
+        );
         let mut state = Self::new_from_buffer(buffer);
         state.apply_language(detected);
         Ok(state)

--- a/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
@@ -122,8 +122,51 @@ fn test_h_header_in_pure_c_project_stays_c() {
     );
 }
 
+/// The directory name the fake host serves its C++ tree from. Only the
+/// leaf name is a literal — the root it hangs off is discovered at runtime
+/// (see [`fake_remote_root`]).
+const REMOTE_PROJECT_DIR: &str = "remote-cpp-project";
+
+/// An absolute path that exists on no machine: the filesystem root the test
+/// process is already running on, plus a directory name nobody creates.
+///
+/// The root component is *discovered* rather than written down, because an
+/// absolute path is not a portable literal. `"/remote-cpp-project"` is
+/// absolute on Unix, but on Windows `Path::is_absolute` requires a prefix
+/// (a drive letter or UNC share) in addition to the root, so the same
+/// literal is a *relative* path there. `Window::open_file_no_focus_inner`
+/// re-anchors relative paths to the session's base directory, so on Windows
+/// the header opened as `C:\…\remote-cpp-project\widget.h`, `RemoteTreeFs`
+/// no longer recognised the prefix, the tree was never served, and the
+/// buffer came up as a brand-new empty file instead of a C++ header.
+///
+/// Taking the leading `Prefix`/`RootDir` components of a path the platform
+/// itself produced yields `/` on Unix and `C:\` on Windows, so the result is
+/// absolute under either convention by construction rather than by guess.
+fn fake_remote_root() -> PathBuf {
+    let anchor = std::env::temp_dir();
+    let mut root = PathBuf::new();
+    for component in anchor.components() {
+        match component {
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                root.push(component.as_os_str())
+            }
+            _ => break,
+        }
+    }
+    let root = root.join(REMOTE_PROJECT_DIR);
+    assert!(
+        root.is_absolute(),
+        "the fake remote root must be absolute on this platform, else the \
+         editor re-anchors it to the working directory and the fake tree is \
+         never consulted. Got: {}",
+        root.display()
+    );
+    root
+}
+
 /// A filesystem that behaves like an SSH host: the tree it serves lives under
-/// `/remote-cpp-project`, a path that does **not** exist on the machine
+/// [`fake_remote_root`], a path that does **not** exist on the machine
 /// running the test, and every operation is translated to a real temporary
 /// directory before being delegated to `StdFileSystem`.
 ///
@@ -138,17 +181,17 @@ fn test_h_header_in_pure_c_project_stays_c() {
 /// marks the backend as one whose sync calls are blocking round trips.
 struct RemoteTreeFs {
     inner: StdFileSystem,
+    /// Path prefix that exists only on the "remote host".
+    remote_root: PathBuf,
     /// The real directory backing the fake remote root.
     local_root: PathBuf,
 }
 
 impl RemoteTreeFs {
-    /// Path prefix that exists only on the "remote host".
-    const REMOTE_ROOT: &'static str = "/remote-cpp-project";
-
     fn new(local_root: PathBuf) -> Self {
         Self {
             inner: StdFileSystem,
+            remote_root: fake_remote_root(),
             local_root,
         }
     }
@@ -157,15 +200,15 @@ impl RemoteTreeFs {
     /// outside the fake root pass through unchanged, so the harness's own
     /// config and scratch files keep working.
     fn map(&self, path: &Path) -> PathBuf {
-        match path.strip_prefix(Self::REMOTE_ROOT) {
+        match path.strip_prefix(&self.remote_root) {
             Ok(rest) => self.local_root.join(rest),
             Err(_) => path.to_path_buf(),
         }
     }
 
     /// A path under the fake remote root for `name`.
-    fn remote_path(name: &str) -> PathBuf {
-        Path::new(Self::REMOTE_ROOT).join(name)
+    fn remote_path(&self, name: &str) -> PathBuf {
+        self.remote_root.join(name)
     }
 }
 
@@ -290,7 +333,7 @@ impl FileSystem for RemoteTreeFs {
 ///
 /// Before the `FileSystem` trait was threaded through language detection this
 /// rendered as C — the promotion probe read the local disk, which has no
-/// `/remote-cpp-project` at all, so it found no C++ sibling and quietly
+/// `<root>/remote-cpp-project` at all, so it found no C++ sibling and quietly
 /// declined to promote.
 #[test]
 fn test_remote_h_header_beside_cpp_source_highlights_as_cpp() {
@@ -300,6 +343,16 @@ fn test_remote_h_header_beside_cpp_source_highlights_as_cpp() {
     std::fs::write(backing.path().join("widget.cpp"), "#include \"widget.h\"\n").unwrap();
 
     let fs = Arc::new(RemoteTreeFs::new(backing.path().to_path_buf()));
+    let header = fs.remote_path("widget.h");
+    // The header exists only on the fake host: if `std::fs` can see it, the
+    // test would no longer be proving that detection went through the
+    // injected filesystem.
+    assert!(
+        !header.exists(),
+        "{} must not exist locally",
+        header.display()
+    );
+
     let mut harness = EditorTestHarness::create(
         120,
         30,
@@ -309,9 +362,7 @@ fn test_remote_h_header_beside_cpp_source_highlights_as_cpp() {
     )
     .unwrap();
 
-    harness
-        .open_file(&RemoteTreeFs::remote_path("widget.h"))
-        .unwrap();
+    harness.open_file(&header).unwrap();
     harness.render().unwrap();
 
     let status_bar = harness.get_status_bar();

--- a/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
@@ -1,0 +1,116 @@
+//! E2E: `.h` headers highlight with the grammar that detection actually
+//! resolved (issue #3009).
+//!
+//! `.h` is mapped to C by the default `[languages]` table, but the LSP-side
+//! detection already promotes a header to `cpp` when the surrounding tree
+//! smells like C++ (a sibling C++ source, an ancestor `compile_commands.json`).
+//! That promotion used to rename the buffer's language id only: the grammar,
+//! the status-bar label and every colour on screen still came from the C
+//! extension table. These tests open the *same header bytes* in two trees and
+//! assert on rendered output only.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use ratatui::style::Color;
+
+/// Same bytes in both trees. `namespace` / `class` / `virtual` are C++
+/// keywords and plain identifiers in C; `counter` is a plain identifier in
+/// both, so it is the per-buffer reference for "unhighlighted".
+const HEADER: &str = "\
+namespace ui {
+class Widget {
+public:
+    virtual void draw();
+};
+}
+int counter;
+";
+
+fn create_harness() -> EditorTestHarness {
+    EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_project_root()
+            .with_full_grammar_registry(),
+    )
+    .unwrap()
+}
+
+/// Foreground colour of the first cell of `text` on screen.
+fn fg_at(harness: &EditorTestHarness, text: &str) -> Color {
+    let (col, row) = harness
+        .find_text_on_screen(text)
+        .unwrap_or_else(|| panic!("'{text}' not found on screen"));
+    harness
+        .get_cell_style(col, row)
+        .and_then(|s| s.fg)
+        .unwrap_or_else(|| panic!("no fg style at '{text}' ({col},{row})"))
+}
+
+/// A header next to a C++ source is C++: the status bar says so and the C++
+/// keywords are painted with the keyword colour rather than plain foreground.
+#[test]
+fn test_h_header_beside_cpp_source_highlights_as_cpp() {
+    let mut harness = create_harness();
+    let dir = harness.project_dir().unwrap().join("cpp_tree");
+    std::fs::create_dir_all(&dir).unwrap();
+    let header = dir.join("widget.h");
+    std::fs::write(&header, HEADER).unwrap();
+    // The decisive C++ signal — a sibling translation unit.
+    std::fs::write(dir.join("widget.cpp"), "#include \"widget.h\"\n").unwrap();
+
+    harness.open_file(&header).unwrap();
+    harness.render().unwrap();
+
+    let status_bar = harness.get_status_bar();
+    assert!(
+        status_bar.contains("C++"),
+        "status bar should report C++ for a header in a C++ tree. Got: {status_bar}"
+    );
+
+    let plain = fg_at(&harness, "counter");
+    assert_ne!(
+        fg_at(&harness, "namespace"),
+        plain,
+        "`namespace` must render as a keyword, not plain foreground"
+    );
+    assert_ne!(
+        fg_at(&harness, "virtual"),
+        plain,
+        "`virtual` must render as a keyword, not plain foreground"
+    );
+}
+
+/// The same bytes in a plain C project keep the C grammar: `namespace` and
+/// `virtual` are ordinary identifiers there and must render unhighlighted.
+#[test]
+fn test_h_header_in_pure_c_project_stays_c() {
+    let mut harness = create_harness();
+    let dir = harness.project_dir().unwrap().join("c_tree");
+    std::fs::create_dir_all(&dir).unwrap();
+    let header = dir.join("widget.h");
+    std::fs::write(&header, HEADER).unwrap();
+    // Only C siblings — no C++ signal anywhere.
+    std::fs::write(dir.join("widget.c"), "#include \"widget.h\"\n").unwrap();
+
+    harness.open_file(&header).unwrap();
+    harness.render().unwrap();
+
+    let status_bar = harness.get_status_bar();
+    assert!(
+        !status_bar.contains("C++"),
+        "status bar must not report C++ for a header in a pure C tree. Got: {status_bar}"
+    );
+
+    let plain = fg_at(&harness, "counter");
+    assert_eq!(
+        fg_at(&harness, "namespace"),
+        plain,
+        "`namespace` is an ordinary identifier in C and must not be highlighted"
+    );
+    assert_eq!(
+        fg_at(&harness, "virtual"),
+        plain,
+        "`virtual` is an ordinary identifier in C and must not be highlighted"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3009_h_header_cpp.rs
@@ -10,7 +10,14 @@
 //! assert on rendered output only.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::model::filesystem::{
+    DirEntry, FileMetadata, FilePermissions, FileReader, FileSearchCursor, FileSearchOptions,
+    FileSystem, FileWriter, SearchMatch, StdFileSystem,
+};
 use ratatui::style::Color;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Same bytes in both trees. `namespace` / `class` / `virtual` are C++
 /// keywords and plain identifiers in C; `counter` is a plain identifier in
@@ -112,5 +119,216 @@ fn test_h_header_in_pure_c_project_stays_c() {
         fg_at(&harness, "virtual"),
         plain,
         "`virtual` is an ordinary identifier in C and must not be highlighted"
+    );
+}
+
+/// A filesystem that behaves like an SSH host: the tree it serves lives under
+/// `/remote-cpp-project`, a path that does **not** exist on the machine
+/// running the test, and every operation is translated to a real temporary
+/// directory before being delegated to `StdFileSystem`.
+///
+/// The translation is the whole point. It reproduces the one thing a plain
+/// tempdir fixture cannot: a file whose siblings are invisible to `std::fs`.
+/// The `.h` → C++ tree probe used to call `std::fs::read_dir` directly, so on
+/// a real SSH session it listed the *local* machine, found nothing, and
+/// silently left every header in a remote C++ tree highlighted as C. Against
+/// this filesystem the pre-fix probe behaves exactly as it did over SSH.
+///
+/// `remote_connection_info` also reports a connection string, which is what
+/// marks the backend as one whose sync calls are blocking round trips.
+struct RemoteTreeFs {
+    inner: StdFileSystem,
+    /// The real directory backing the fake remote root.
+    local_root: PathBuf,
+}
+
+impl RemoteTreeFs {
+    /// Path prefix that exists only on the "remote host".
+    const REMOTE_ROOT: &'static str = "/remote-cpp-project";
+
+    fn new(local_root: PathBuf) -> Self {
+        Self {
+            inner: StdFileSystem,
+            local_root,
+        }
+    }
+
+    /// Translate a remote path to the real directory serving it. Paths
+    /// outside the fake root pass through unchanged, so the harness's own
+    /// config and scratch files keep working.
+    fn map(&self, path: &Path) -> PathBuf {
+        match path.strip_prefix(Self::REMOTE_ROOT) {
+            Ok(rest) => self.local_root.join(rest),
+            Err(_) => path.to_path_buf(),
+        }
+    }
+
+    /// A path under the fake remote root for `name`.
+    fn remote_path(name: &str) -> PathBuf {
+        Path::new(Self::REMOTE_ROOT).join(name)
+    }
+}
+
+impl FileSystem for RemoteTreeFs {
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<DirEntry>> {
+        // Entries are reported back under the remote path, the way a real
+        // agent reports the host's own paths.
+        let entries = self.inner.read_dir(&self.map(path))?;
+        Ok(entries
+            .into_iter()
+            .map(|e| DirEntry::new(path.join(&e.name), e.name, e.entry_type))
+            .collect())
+    }
+
+    // `canonicalize` must stay in remote space — resolving to the local
+    // backing directory would hand the editor a path the "host" never had.
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.inner.canonicalize(&self.map(path))?;
+        Ok(path.to_path_buf())
+    }
+
+    fn remote_connection_info(&self) -> Option<&str> {
+        Some("user@build-host")
+    }
+
+    // ---- delegation, with path translation ----
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        self.inner.read_file(&self.map(path))
+    }
+    fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+        self.inner.read_range(&self.map(path), offset, len)
+    }
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        self.inner.write_file(&self.map(path), data)
+    }
+    fn create_file(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.create_file(&self.map(path))
+    }
+    fn open_file(&self, path: &Path) -> io::Result<Box<dyn FileReader>> {
+        self.inner.open_file(&self.map(path))
+    }
+    fn open_file_for_write(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_write(&self.map(path))
+    }
+    fn open_file_for_append(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_append(&self.map(path))
+    }
+    fn set_file_length(&self, path: &Path, len: u64) -> io::Result<()> {
+        self.inner.set_file_length(&self.map(path), len)
+    }
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.inner.rename(&self.map(from), &self.map(to))
+    }
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<u64> {
+        self.inner.copy(&self.map(from), &self.map(to))
+    }
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_file(&self.map(path))
+    }
+    fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_dir(&self.map(path))
+    }
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.metadata(&self.map(path))
+    }
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.symlink_metadata(&self.map(path))
+    }
+    fn is_dir(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_dir(&self.map(path))
+    }
+    fn is_file(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_file(&self.map(path))
+    }
+    fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()> {
+        self.inner.set_permissions(&self.map(path), permissions)
+    }
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir(&self.map(path))
+    }
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir_all(&self.map(path))
+    }
+    fn current_uid(&self) -> u32 {
+        self.inner.current_uid()
+    }
+    fn search_file(
+        &self,
+        path: &Path,
+        pattern: &str,
+        opts: &FileSearchOptions,
+        cursor: &mut FileSearchCursor,
+    ) -> io::Result<Vec<SearchMatch>> {
+        self.inner
+            .search_file(&self.map(path), pattern, opts, cursor)
+    }
+    fn sudo_write(
+        &self,
+        path: &Path,
+        data: &[u8],
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> io::Result<()> {
+        self.inner.sudo_write(&self.map(path), data, mode, uid, gid)
+    }
+    fn walk_files(
+        &self,
+        root: &Path,
+        skip_dirs: &[&str],
+        cancel: &std::sync::atomic::AtomicBool,
+        on_file: &mut dyn FnMut(&Path, &str) -> bool,
+    ) -> io::Result<()> {
+        self.inner
+            .walk_files(&self.map(root), skip_dirs, cancel, on_file)
+    }
+}
+
+/// The remote half of #3009: opening `widget.h` from an SSH host whose tree
+/// contains `widget.cpp` must highlight as C++ on screen, exactly as the
+/// local case does.
+///
+/// Before the `FileSystem` trait was threaded through language detection this
+/// rendered as C — the promotion probe read the local disk, which has no
+/// `/remote-cpp-project` at all, so it found no C++ sibling and quietly
+/// declined to promote.
+#[test]
+fn test_remote_h_header_beside_cpp_source_highlights_as_cpp() {
+    let backing = tempfile::tempdir().unwrap();
+    std::fs::write(backing.path().join("widget.h"), HEADER).unwrap();
+    // The decisive C++ signal — visible only through the remote filesystem.
+    std::fs::write(backing.path().join("widget.cpp"), "#include \"widget.h\"\n").unwrap();
+
+    let fs = Arc::new(RemoteTreeFs::new(backing.path().to_path_buf()));
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_full_grammar_registry()
+            .with_filesystem(fs),
+    )
+    .unwrap();
+
+    harness
+        .open_file(&RemoteTreeFs::remote_path("widget.h"))
+        .unwrap();
+    harness.render().unwrap();
+
+    let status_bar = harness.get_status_bar();
+    assert!(
+        status_bar.contains("C++"),
+        "status bar should report C++ for a header in a *remote* C++ tree. Got: {status_bar}"
+    );
+
+    let plain = fg_at(&harness, "counter");
+    assert_ne!(
+        fg_at(&harness, "namespace"),
+        plain,
+        "`namespace` must render as a keyword in a remote C++ tree"
+    );
+    assert_ne!(
+        fg_at(&harness, "virtual"),
+        plain,
+        "`virtual` must render as a keyword in a remote C++ tree"
     );
 }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -112,6 +112,7 @@ pub mod issue_2893_replace_all_many_matches;
 pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
 pub mod issue_3006_shift_select_at_buffer_edges;
+pub mod issue_3009_h_header_cpp;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
Fixes #3009.

Two commits: the first makes `.h` headers highlight as the language detection already chose, the second makes that detection ask the file's own filesystem so it works over SSH.

## What was happening

`.h` was unconditionally C, with no content or project-layout influence. The same bytes in `widget.h` and `widget.hpp` gave `C` and `C++` in the status bar respectively, and in the `.h` buffer `namespace`, `class`, `public`, `explicit`, `virtual`, `template`, `typename` all rendered in plain foreground instead of the keyword colour — `std::string` even split as `std:` + `:` rather than scoping `::`.

The interesting part is that a C++ promotion heuristic **already existed and never reached the screen**. `detect_language` (`services/lsp/manager.rs`) promotes `.h` to `cpp` when the surrounding tree smells like C++ — sibling C++ sources, or an ancestor `compile_commands.json` with a C++ marker. Measured against the unfixed build: a directory holding only `widget.h` and a sibling `widget.cpp` — precisely the signal that heuristic looks for — still opened the header as C.

`DetectedLanguage::from_path_with_fallback` was the reason. It computed `config_lang_id` from that promoting `detect_language`, then applied it through an `override_name` closure that touched `d.name` and nothing else, while `highlighter`, `ts_language` and `display_name` all came from `registry.find_by_path`, which resolves `.h` through the extension table (`config.rs`, `languages.c.extensions = ["c", "h"]`) and lands on C. So the LSP side could already believe a header was C++ while the grammar, the status-bar label and every colour on screen said C.

## Commit 1 — let the chosen language id pick the grammar

`primitives/detected_language.rs`. `override_name` is replaced by `DetectedLanguage::align_with_config_id`: when detection resolved a config id, that id wins and the grammar is re-resolved through `[languages.<id>].grammar`. If the grammar name resolves to the same catalog entry — aliases, the common case — or to nothing, the path-resolved grammar is left untouched. One hash lookup; no buffer scan and no extra filesystem access.

User config still overrides in both directions — `languages.cpp.extensions` including `"h"` continues to force C++ globally, and a config without a `cpp` language leaves `.h` as C.

## Commit 2 — ask the file's own filesystem

The probe deciding that promotion, `header_in_cpp_tree`, read the filesystem with `std::fs` directly — a standing violation of the `FileSystem` trait rule, carrying a `NOTE(remote-fs)` that said the fix needed threading `&dyn FileSystem` through `detect_language` and `DetectedLanguage::from_path`. Once commit 1 made the probe drive what the user sees, that became user-visible: on an SSH session the probe read the **local** filesystem, found nothing, and the promotion silently no-opped, so a `.h` in a remote C++ tree still highlighted as C.

The trait is now threaded through. All 11 non-test call sites of `from_path`/`from_path_with_fallback` were checked first: every one already holds the buffer it just loaded, so `buffer.filesystem()` answers at each and no call site needed an escape hatch. The parameter is a required `&dyn FileSystem` rather than an `Option` deliberately — an optional one would re-create exactly the failure being fixed, where a caller that omits it gets a silent "no" instead of a compile error.

### Remote round trips are budgeted, not assumed cheap

`RemoteFileSystem` implements the whole sync `FileSystem` surface over `AgentChannel::request_blocking` — `read_dir` → `ls`, `metadata` → `stat`, `read_range` → `read`, one blocking SSH round trip each, on the single-threaded editor loop. That file already documents the hazard for `$HOME` lookups: a blocking request there "would hang the whole single-threaded UI for the full request timeout."

Threading the trait naively would therefore have put **up to 13 serialized round trips on the file-open path**. Instead the probe carries a `ProbeBudget` derived from `fs.remote_connection_info()`:

* **Remote** — exactly one round trip, the sibling listing, which is the decisive signal and covers the ordinary `widget.h` / `widget.cpp` layout in this issue. The `compile_commands.json` ancestor walk is skipped.
* **Local** — unchanged: 11 directories, same 1 MiB cap.

The trade is explicit: a remote header under an `include/`-style tree with its sources elsewhere still reads as C. That is strictly better than today's unconditional no-op and does not buy highlighting with a frozen editor. The budget is a directory count rather than an `if is_remote` inside the loop, so the expensive case is unrepresentable rather than merely unreached.

### Two bugs the tests caught

* `"clang++"` does **not** contain the substring `"c++"` — the characters before `++` are `g`. The first fixture was unrealistic and a failing test said so.
* `FileSystem::read_range` is `read_exact`-shaped and errors on a short file, so a flat 1 MiB read would have made every normal-sized `compile_commands.json` read as "not C++". The clamp to `min(size, 1 MiB)` is load-bearing and has a test pinning it.

### Not included: `detect_workspace_root`

The old NOTE asked for it in the same pass. It is not a mechanical substitution: its three call sites sit inside LSP spawn/initialize, `LspManager` has no filesystem to thread, and `resolve_root_uri` walks *host* paths on purpose before applying `path_translation` for devcontainers — so "which filesystem" is a genuine design question there. The NOTE has been rewritten to state that accurately rather than implying it was covered.

## Tests

Commit 1: six unit tests in `detected_language.rs` (sibling promotion, pure-C project staying C, user config forcing `h` to C++, config without a `cpp` language, an alias resolving to the same entry, an unknown config grammar keeping the path-resolved highlighter) plus two e2e in `tests/e2e/issue_3009_h_header_cpp.rs`.

Commit 2, on a `FakeTree` fake filesystem (no shared in-memory double existed; it follows the delegation pattern in `tests/e2e/explorer_bugs.rs`): `test_h_header_promotion_reads_injected_filesystem_not_local_disk`, `test_h_header_promotion_ignores_local_disk_when_injected_fs_says_c`, `test_remote_probe_spends_one_op_and_skips_ancestor_walk`, `test_local_probe_still_walks_ancestors_for_compile_commands`, `test_small_compile_commands_is_read_despite_the_one_mib_cap`, `test_non_header_paths_touch_no_filesystem`, plus e2e `test_remote_h_header_beside_cpp_source_highlights_as_cpp`.

## Verification status

Commit 1: unit tests verified both directions — 6 passed with the fix; with the re-resolution neutralized, `test_h_header_beside_cpp_sibling_detects_cpp_grammar` failed with `left: "C" / right: "C++"` and the other five passed. Its two e2e tests were run only *with* the fix, so their fails-without direction is unverified.

Commit 2: `cargo test -p fresh-editor --lib -- detected_language detect_language jsonc_filenames workspace_root` → 31 passed, 0 failed. Reverting the sibling scan to `std::fs` makes the three key unit tests fail and restoring it makes them pass. The single new e2e test was also run individually (not the suite): it passes, and with the probe reverted to `std::fs` it fails with the status bar reading `C` instead of `C++`.

Clean on the committed tree: `cargo fmt --all --check`, `cargo check -p fresh-editor --all-targets`, `cargo clippy -p fresh-editor --all-targets` (zero warnings in touched files; the rest are pre-existing), and `cargo check --all-targets --features gui`. Full e2e suites were left to CI. No plugin API or config type changes, so no `.d.ts` or schema regeneration, and no new i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN