### PR TITLE
fix(search-replace): survive a second invocation while the panel is opening

### DIFF
--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -1395,7 +1395,40 @@ async function performSearch(pattern: string, silent?: boolean): Promise<SearchR
 // Panel lifecycle
 // =============================================================================
 
+/** In-flight `openPanel` run, if any (#2953).
+ *
+ * `openPanel` awaits the host round-trip that creates the panel's virtual
+ * buffer, and only learns the buffer id when that resolves. A second
+ * invocation arriving inside that await — pressing `Alt+A` twice, or the
+ * keymap and the palette firing together — used to see the half-built
+ * `panel` object, take the "already open" branch and render the widget tree
+ * into `resultsBufferId === 0`. The host has no buffer 0, so the mount
+ * failed, the panel stayed bound to the bogus id and every later update
+ * failed too: a panel with no search field, no replace field and no footer,
+ * which never repaired itself.
+ *
+ * Opens are therefore serialized. A concurrent caller waits for the run
+ * ahead of it and then applies its own intent (prefill, scope) to the
+ * finished panel, so pressing the key twice ends up exactly where pressing
+ * it twice slowly does. */
+let openPanelInFlight: Promise<void> | null = null;
+
 async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
+  // Wait out any open already in progress (a chain of them, if the user
+  // leaned on the key), then take the baton.
+  while (openPanelInFlight) {
+    await openPanelInFlight;
+  }
+  const run = openPanelInner(opts);
+  openPanelInFlight = run;
+  try {
+    await run;
+  } finally {
+    if (openPanelInFlight === run) openPanelInFlight = null;
+  }
+}
+
+async function openPanelInner(opts?: { allFiles?: boolean }): Promise<void> {
   // Try to pre-fill search from editor selection
   let prefill = "";
   let sourceBufferPath = "";
@@ -1437,43 +1470,21 @@ async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
 
   const sourceSplitId = editor.getActiveSplitId();
 
-  panel = {
-    resultsBufferId: 0,
-    sourceSplitId,
-    resultsSplitId: 0,
-    searchResults: [],
-    fileGroups: [],
-    searchPattern: prefill,
-    replaceText: "",
-    fileGlob: "",
-    focusPanel: "query",
-    queryField: "search",
-    optionIndex: 0,
-    matchIndex: 0,
-    caseSensitive: false,
-    useRegex: false,
-    wholeWords: false,
-    allFiles,
-    sourceBufferPath,
-    sourceBufferRelPath,
-    sourceBufferId,
-    viewportWidth: DEFAULT_WIDTH,
-    busy: false,
-    searchPerformed: false,
-    truncated: false,
-    cursorPos: prefill.length,
-    scrollOffset: 0,
-    expandedFileKeys: new Set<string>(),
-    knownFileKeys: new Set<string>(),
-    widgetPanel: null,
-  };
-
   try {
+    // Create the buffer *before* publishing `panel`. Everything that reads
+    // the module-level `panel` — the `resize` hook, `after_file_open`,
+    // `updatePanelContent` — would otherwise be able to observe a panel
+    // whose `resultsBufferId` is still the 0 placeholder and render the
+    // widget tree into a buffer that does not exist (#2953). Assigning only
+    // once the real id is in hand makes that state unrepresentable rather
+    // than merely guarded against.
     const result = await editor.createVirtualBufferInSplit({
       name: "*Search/Replace*",
       mode: "search-replace-list",
       readOnly: true,
-      entries: buildPanelEntries(),
+      // The panel's content is painted by `updatePanelContent()` below, as
+      // a widget tree; the buffer starts empty for the one frame in between.
+      entries: [],
       ratio: 0.6,
       panelId: "search-replace-panel",
       // Opt into the Utility Dock (issue #1796 / Section 2 of
@@ -1490,12 +1501,40 @@ async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
       // search inputs off-screen, revealing empty space below (#2434).
       scrollable: false,
     });
-    panel.resultsBufferId = result.bufferId;
-    panel.resultsSplitId = result.splitId ?? editor.getActiveSplitId();
+
+    panel = {
+      resultsBufferId: result.bufferId,
+      sourceSplitId,
+      resultsSplitId: result.splitId ?? editor.getActiveSplitId(),
+      searchResults: [],
+      fileGroups: [],
+      searchPattern: prefill,
+      replaceText: "",
+      fileGlob: "",
+      focusPanel: "query",
+      queryField: "search",
+      optionIndex: 0,
+      matchIndex: 0,
+      caseSensitive: false,
+      useRegex: false,
+      wholeWords: false,
+      allFiles,
+      sourceBufferPath,
+      sourceBufferRelPath,
+      sourceBufferId,
+      // Now we have the split, so the real width is available.
+      viewportWidth: getViewportWidth(),
+      busy: false,
+      searchPerformed: false,
+      truncated: false,
+      cursorPos: prefill.length,
+      scrollOffset: 0,
+      expandedFileKeys: new Set<string>(),
+      knownFileKeys: new Set<string>(),
+      widgetPanel: null,
+    };
     editor.debug(`Search/Replace: panel opened, bufferId=${result.bufferId}, splitId=${result.splitId}`);
 
-    // Now we have the split, refresh width
-    panel.viewportWidth = getViewportWidth();
     updatePanelContent();
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1126,6 +1126,28 @@ impl EditorTestHarness {
         Ok(())
     }
 
+    /// Deliver a key **without** draining the async work it kicks off.
+    ///
+    /// [`Self::send_key`] settles all plugin work before returning, which is
+    /// what most tests want — but it also makes every plugin command look
+    /// atomic, so a test can never express "the user pressed the key again
+    /// before the first press finished". Real frames don't wait: the editor
+    /// pumps input and plugin completions on the same loop, so two presses a
+    /// few milliseconds apart both reach the plugin thread while the first
+    /// command is still awaiting a host round-trip.
+    ///
+    /// Use this to reproduce re-entrancy bugs (e.g. #2953, opening the
+    /// Search & Replace panel twice), then settle with `wait_until` /
+    /// `wait_for_async_quiescence` and assert on the rendered screen.
+    pub fn send_key_without_drain(
+        &mut self,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+    ) -> AnyhowResult<()> {
+        self.editor.handle_key(code, modifiers)?;
+        Ok(())
+    }
+
     /// Send the same key press multiple times without rendering after each one
     /// This is optimized for tests that need to send many keys in a row (e.g., scrolling)
     /// Only renders once at the end, which is much faster than calling send_key() in a loop

--- a/crates/fresh-editor/tests/e2e/issue_2953_search_replace_double_open.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2953_search_replace_double_open.rs
@@ -1,0 +1,142 @@
+//! E2E: invoking Search & Replace twice while the panel is still opening
+//! must still produce a fully rendered panel (issue #2953).
+//!
+//! `openPanel` in `plugins/search_replace.ts` awaits the host round-trip that
+//! creates the panel's virtual buffer, so a second `Alt+A` arriving inside
+//! that await used to see the half-built panel object, take the "already
+//! open" branch, and mount the widget tree against `resultsBufferId === 0`.
+//! The host has no buffer 0, so the mount failed, the panel stayed bound to
+//! the bogus id, and every later update failed too — leaving a panel with no
+//! search field, no replace field, no files field, no toggles and no footer,
+//! with the terminal cursor stranded in the bottom-right chrome.
+//!
+//! The reproduction needs two key presses that are *not* separated by a
+//! plugin drain, which is what `send_key_without_drain` is for: the normal
+//! `send_key` settles all plugin work before returning and so can never
+//! express "the user pressed the key again before the first press finished".
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+/// Project directory with the search_replace plugin and a file to search.
+fn setup_project() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "search_replace");
+
+    fs::write(
+        project_root.join("alpha.txt"),
+        "hello world\nfoo bar\nhello again\n",
+    )
+    .unwrap();
+
+    (temp_dir, project_root)
+}
+
+/// Assert the panel's control rows are all on screen. Any one of them
+/// missing is the #2953 symptom.
+fn assert_panel_fully_rendered(harness: &EditorTestHarness) {
+    let screen = harness.screen_to_string();
+    for label in ["Search:", "Replace:", "Files:", "Matches"] {
+        assert!(
+            screen.contains(label),
+            "Search & Replace panel is missing the '{label}' row — the widget \
+             tree carrying the inputs was never painted. Screen:\n{screen}"
+        );
+    }
+}
+
+/// Two `Alt+A` presses delivered before the first open finishes must leave a
+/// complete panel with the caret in the search field.
+#[test]
+fn test_double_invocation_while_opening_still_renders_panel() {
+    let (_temp_dir, project_root) = setup_project();
+    let start_file = project_root.join("alpha.txt");
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    // Both presses reach the plugin thread before any of the work they queue
+    // is drained — the second lands inside the first's `await`.
+    harness
+        .send_key_without_drain(KeyCode::Char('a'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .send_key_without_drain(KeyCode::Char('a'), KeyModifiers::ALT)
+        .unwrap();
+
+    // Semantic wait: the search input row is the thing the bug removes.
+    // Without the fix this never appears and the test is killed externally.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+    // Let the second invocation land too — it must not undo the first.
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    assert_panel_fully_rendered(&harness);
+
+    // The caret belongs in the search field, not in the bottom-right chrome.
+    let (search_col, search_row) = harness
+        .find_text_on_screen("Search:")
+        .expect("search label on screen");
+    let cursor = harness
+        .render_observing_cursor()
+        .unwrap()
+        .expect("a visible terminal cursor");
+    assert_eq!(
+        cursor.1, search_row,
+        "caret should sit on the search input row ({search_row}), got {cursor:?}"
+    );
+    assert!(
+        cursor.0 > search_col,
+        "caret should sit after the 'Search:' label (col > {search_col}), got {cursor:?}"
+    );
+
+    // And the panel still works: typing goes into the search field.
+    harness.type_text("hello").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("hello"))
+        .unwrap();
+    assert_panel_fully_rendered(&harness);
+}
+
+/// Control: a single invocation renders the same complete panel. Guards
+/// against a re-entrancy guard that swallows the *first* open too.
+#[test]
+fn test_single_invocation_renders_panel() {
+    let (_temp_dir, project_root) = setup_project();
+    let start_file = project_root.join("alpha.txt");
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    assert_panel_fully_rendered(&harness);
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -108,6 +108,7 @@ pub mod issue_2843_single_line_viewport;
 pub mod issue_2876_prompt_input_hscroll;
 pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
+pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;


### PR DESCRIPTION
Addresses the failure mode found while investigating #2953.

## Scope, stated up front

The issue reports that the cursor "sometimes" does not jump to the search input. **That intermittency was not reproduced**: a single invocation put the caret in the search field 45/45 times across `Alt+A` and the palette, idle and under `nproc*4` load, with and without a prefill selection and on reopen.

What *was* reproduced, 11/11 and deterministically, is a neighbouring failure with the same visible symptom: invoking the command twice before the panel finishes opening leaves the panel with **no input row at all** — no `Search:`, `Replace:` or `Files:` field, no toggle row, no footer, only the `Matches` separator — and it never repairs. The caret ends up in the bottom-right chrome because there is nothing to put it in. This PR fixes that. Whether it is the reporter's case is unknown, and the issue should stay open until they can say whether their "sometimes" involved a second invocation.

## What was happening

From a failing run's log:

```
INFO  ... Created virtual buffer '*Search/Replace*' with mode 'search-replace-list' in split (id=BufferId(2))
ERROR ... Failed to render mounted widget panel search_replace:1 into BufferId(0): Buffer not found
ERROR ... Failed to render updated widget panel search_replace:1: Buffer not found
```

`openPanel` is `async` with no re-entrancy guard. It assigned the module-level `panel` object — with `resultsBufferId: 0` — and only then awaited `createVirtualBufferInSplit`, which is what fills the real id in. A second invocation arriving inside that await saw a truthy `panel`, took the early-return branch, and called `updatePanelContent()` while the id was still `0`, mounting the widget panel against `BufferId(0)`. The panel stays bound there, so the update that follows the real buffer's creation fails too, and the widget tree carrying the inputs is never painted.

## The change

`plugins/search_replace.ts`:

1. `openPanel` becomes a serializing wrapper over `openPanelInner`, keyed on a module-level in-flight promise. A second invocation waits out the first and then applies its own prefill and scope to the finished panel — coalesced, not dropped, so invoking it again with a fresh selection still does what the user asked.
2. The module-level `panel` is assigned only *after* `createVirtualBufferInSplit` resolves, with the real buffer id already in it. `resultsBufferId === 0` is now unobservable, which closes the same hole for the `resize` and `after_file_open` hooks. The buffer is created with `entries: []` since `updatePanelContent()` paints it immediately afterwards.

## Deliberately not done: a host-side guard

Making the invalid mount unrepresentable was considered and rejected for now. `mountWidgetPanel` is fire-and-forget over the plugin IPC channel — it returns "queued", not "mounted" — and the plugin-side `WidgetPanel` latches `mounted = true` regardless. A host that rejected a mount into a non-existent buffer therefore could not tell the plugin, so rejection would swap one wedged panel for one silently-missing panel with an identical user-visible symptom, and no test asserting on rendered output could distinguish them. Doing it properly means `PluginCommand::MountWidgetPanel` carrying a validated buffer handle instead of a raw `BufferId`, plus an ack channel for retry — a plugin-API change rippling into `fresh-core`, the QuickJS backend, the generated `.d.ts` and every widget-panel plugin. Worth doing separately if this class recurs. (`BufferId(0)` is genuinely never a real buffer — ids start at 1 and the host already uses 0 as a "none" fallback at `plugin_dispatch.rs:5188`.)

## Tests

`tests/e2e/issue_2953_search_replace_double_open.rs`: `test_double_invocation_while_opening_still_renders_panel` and `test_single_invocation_renders_panel` as a control. Assertions are on rendered output only — the `Search:` / `Replace:` / `Files:` / `Matches` rows and the terminal cursor's position relative to the `Search:` label. Semantic waits only; without the fix the first wait never satisfies, which is the "fails or times out" form the guidelines allow.

This needed one harness addition: `EditorTestHarness::send_key_without_drain`. The existing `send_key` drains all plugin work before returning, which makes every plugin command atomic and cannot express the race at all.

## Verification status — please read

**This change was not verified locally.** The repro was not re-run against the fix and the new tests were never executed, in either direction, per an instruction to leave e2e runs to CI. No pass or fail is claimed. CI is the first real check of the fix and of the tests.

The diagnosis above *is* measured — the 11/11 repro and the log lines come from the unfixed build — but the fix itself rests on reading the code.

Ran and clean: `cargo fmt --all`, `cargo check --all-targets` (two pre-existing warnings only), `cargo clippy --all-targets` (no new lints; harness warnings are pre-existing ones whose line numbers shifted), and `plugins/check-types.sh` with **zero** errors in `search_replace.ts` — the remaining errors are the pre-existing set in `lib/widgets.ts`, `vi_mode.ts` and others, untouched here. No plugin API or config type changes, so no `.d.ts` or schema regeneration; no new i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN

---
_Generated by [Claude Code](https://claude.ai/code/session_014RASTj1HKSpMtmL2ZpjJAN)_