### PR TITLE
fix(review-diff): page over collapsed files instead of through them

### DIFF
--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -129,7 +129,12 @@ impl crate::app::window::Window {
         };
 
         let old_pos = viewport_pos(self)?;
-        self.handle_scroll_event(delta);
+        // Scroll *this* leaf: `split_id` is the effective active split, which
+        // for a grouped buffer's inner panel is not the split manager's
+        // active leaf. Scrolling the latter left the panel's viewport where
+        // it was, so this always fell through to the logical-line fallback
+        // below — fold-blind, so a page landed inside a collapsed body.
+        self.handle_scroll_event_for_split(split_id, delta);
         let new_pos = viewport_pos(self)?;
 
         if new_pos == old_pos {
@@ -147,12 +152,7 @@ impl crate::app::window::Window {
         // start (landing the cursor there would re-introduce the overshoot
         // / jump-to-top bugs).
         let target_byte = {
-            let buffer_id = self
-                .buffers
-                .splits()
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .buffer_for_split(split_id)?;
+            let buffer_id = self.buffer_for_leaf(split_id)?;
             self.buffers
                 .with_buffer_and_split(buffer_id, split_id, |state, vs| {
                     let soft_breaks = state.collect_soft_break_positions();

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -4124,16 +4124,48 @@ impl Window {
         }
     }
 
-    /// Handle scroll events using the active split's viewport.
+    /// The buffer a leaf currently shows.
+    ///
+    /// `SplitManager::buffer_for_split` only knows the leaves in the main
+    /// split tree, so it answers `None` for a grouped buffer's inner panel
+    /// (a Review Diff pane, say) — the leaf still owns a `SplitViewState`,
+    /// it just isn't a node of the tree. Fall back to that view state's own
+    /// active buffer, which is what `effective_active_pair` treats as
+    /// authoritative for those leaves.
+    pub(crate) fn buffer_for_leaf(&self, leaf_id: LeafId) -> Option<BufferId> {
+        let (mgr, vs_map) = self.buffers.splits()?;
+        mgr.buffer_for_split(leaf_id)
+            .or_else(|| vs_map.get(&leaf_id).map(|vs| vs.active_buffer))
+    }
+
+    /// Handle scroll events using the focused split's viewport.
     ///
     /// View events (like `Scroll`) target SplitViewState rather than
     /// EditorState so scroll limits are correct when view transforms
     /// inject extra rows.
     pub(crate) fn handle_scroll_event(&mut self, line_offset: isize) {
-        let Some((mgr, _)) = self.buffers.splits() else {
+        // Guard before resolving the split: `effective_active_pair` asserts
+        // a populated split layout, which this entry point never did.
+        if self.buffers.splits().is_none() {
             return;
-        };
-        let active_split = mgr.active_split();
+        }
+        // The *effective* active split, not the split manager's: when the
+        // focus sits on an inner panel of a grouped buffer, the tree's
+        // active leaf is the group host and scrolling it moves a viewport
+        // the user isn't looking at while the panel stays put.
+        self.handle_scroll_event_for_split(self.effective_active_split(), line_offset);
+    }
+
+    /// Body of [`Self::handle_scroll_event`], for a caller that already
+    /// resolved which leaf it means to scroll.
+    pub(crate) fn handle_scroll_event_for_split(
+        &mut self,
+        active_split: LeafId,
+        line_offset: isize,
+    ) {
+        if self.buffers.splits().is_none() {
+            return;
+        }
 
         if let Some(group) = self
             .scroll_sync_manager
@@ -4160,8 +4192,7 @@ impl Window {
         };
 
         for split_id in splits_to_scroll {
-            let (mgr, _) = self.buffers.splits().expect("splits checked above");
-            let Some(buffer_id) = mgr.buffer_for_split(split_id) else {
+            let Some(buffer_id) = self.buffer_for_leaf(split_id) else {
                 continue;
             };
 

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -66,6 +66,7 @@ pub mod plugin_keybinding_execution;
 pub mod plugin_snapshot_scaling;
 pub mod plugin_text_property_freshness;
 pub mod plugins_dir_in_working_dir;
+pub mod review_diff_collapsed_paging;
 pub mod review_diff_cursor_and_layout;
 pub mod review_diff_hunk_parity;
 pub mod review_diff_layout_bench;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_collapsed_paging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_collapsed_paging.rs
@@ -1,0 +1,132 @@
+//! Paging over a collapsed file in the Review Diff unified stream
+//! (issue #3029).
+//!
+//! A collapsed file draws one header row, so a page of scrolling has to
+//! step over its whole body for free. When the page motion spends its
+//! budget on the hidden rows instead, the view stops moving — and the
+//! cursor walks off into content nobody can see — for as many presses as
+//! the collapsed file has hidden rows.
+
+use crate::common::git_test_helper::GitTestRepo;
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+fn setup_audit_mode_plugin(repo: &GitTestRepo) {
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin(&plugins_dir, "audit_mode");
+    copy_plugin_lib(&plugins_dir);
+}
+
+fn open_review_diff(harness: &mut EditorTestHarness) {
+    harness.run_palette_command("Review Diff").unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("next hunk") && !screen.contains("Generating Review")
+        })
+        .unwrap();
+}
+
+/// A repo whose working tree rewrites every line of every file, so file
+/// `f` contributes roughly `2 * lines[f]` rows to the unified stream.
+fn repo_with_rewritten_files(lines: &[usize]) -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    for (f, count) in lines.iter().enumerate() {
+        let body: String = (0..*count)
+            .map(|l| format!("fn original_{f:02}_{l}() {{ let x = {l}; }}\n"))
+            .collect();
+        repo.create_file(&format!("src/file{f:02}.rs"), &body);
+    }
+    repo.git_add_all();
+    repo.git_commit("baseline");
+    for (f, count) in lines.iter().enumerate() {
+        let body: String = (0..*count)
+            .map(|l| format!("fn changed_{f:02}_{l}() {{ let y = {l}; }}\n"))
+            .collect();
+        repo.create_file(&format!("src/file{f:02}.rs"), &body);
+    }
+    repo
+}
+
+fn press(harness: &mut EditorTestHarness, code: KeyCode) {
+    harness.send_key(code, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+}
+
+/// Paging towards a collapsed file has to walk *over* it, not through it.
+/// `src/file02.rs` here is forty times longer than its neighbours, so a
+/// fold-blind page motion parks the view at its header for dozens of
+/// presses while the cursor crawls through rows the renderer never draws.
+#[test]
+fn test_paging_steps_over_a_collapsed_file() {
+    init_tracing_from_env();
+    // file00 / file01 lead in, file02 is the big body to collapse, and
+    // file03 is the landing zone just past it.
+    let repo = repo_with_rewritten_files(&[20, 20, 800, 20]);
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("original_00_0"))
+        .unwrap();
+
+    // `.` walks file to file; Enter on a file header is its disclosure
+    // toggle. Collapse file02, then come back to the top of the stream.
+    for _ in 0..2 {
+        press(&mut harness, KeyCode::Char('.'));
+    }
+    press(&mut harness, KeyCode::Enter);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("\u{25b8} src/file02.rs"))
+        .unwrap();
+    for _ in 0..2 {
+        press(&mut harness, KeyCode::Char(','));
+    }
+    harness
+        .wait_until(|h| h.screen_to_string().contains("original_00_0"))
+        .unwrap();
+
+    // file00 and file01 draw ~40 diff rows each and the collapsed file02
+    // draws one, so file03's content is well under 150 rendered rows away
+    // — a handful of pages on a 40-row terminal. The cap is deliberately
+    // loose; the fold-blind motion needs ~60 presses to cross file02's
+    // 1600 hidden rows.
+    const CAP: usize = 30;
+    let mut down = 0;
+    while !harness.screen_to_string().contains("_03_") {
+        assert!(
+            down < CAP,
+            "PageDown never reached src/file03.rs past the collapsed \
+             src/file02.rs — {CAP} presses were spent inside its hidden \
+             body. Screen:\n{}",
+            harness.screen_to_string()
+        );
+        press(&mut harness, KeyCode::PageDown);
+        down += 1;
+    }
+
+    // And back: PageUp has to step over the same fold in one press too.
+    let mut up = 0;
+    while !harness.screen_to_string().contains("original_00_0") {
+        assert!(
+            up < CAP,
+            "PageUp never got back above the collapsed src/file02.rs — \
+             {CAP} presses were spent inside its hidden body. Screen:\n{}",
+            harness.screen_to_string()
+        );
+        press(&mut harness, KeyCode::PageUp);
+        up += 1;
+    }
+}


### PR DESCRIPTION
Fixes #3029.

## Symptom

In Review Diff, paging down towards a collapsed file wedges the view: the same frame is redrawn press after press, the cursor is nowhere on screen, and `Ln` keeps climbing by a page each time. The stall lasts for as many presses as the collapsed file has hidden rows — on a `HEAD~100..HEAD` review with a ~3000-row file collapsed, ~80 presses of nothing.

Reproduced by hand in tmux against `HEAD~100..HEAD` before touching any code, then again after the fix: the same key sequence that used to freeze now steps over all six collapsed files in a single press, in both directions.

## Cause

`handle_page_motion` scrolls the viewport a page of *drawn* rows — a fold-aware walk that steps over a collapsed body for free — and then lands the cursor at the new viewport top. It resolves the leaf to move correctly (`effective_active_split`), but delegates the actual scroll to `handle_scroll_event`, which targets the split manager's active leaf instead.

For a grouped buffer those two differ. The review panel is an inner leaf of the group, not a node of the split tree, so the scroll moved the group host's viewport while the panel's stayed exactly where it was. Seeing no movement, `handle_page_motion` concluded the buffer was already at its edge and returned `None`, falling back to the plain logical-line cursor page-down — which counts lines whether or not the renderer draws them. The cursor walks into the collapsed body, the viewport has nowhere to follow it, and the screen stops.

Without folds the two motions look identical (every logical line is a drawn row), which is why this only shows up once something is collapsed.

## Change

* `handle_page_motion` scrolls the leaf it already resolved, via a new `handle_scroll_event_for_split`.
* `handle_scroll_event` keeps its old signature but now resolves `effective_active_split()` rather than the tree's active leaf, so `Ctrl+Up` / `Ctrl+Down` in a panel hit the same fix (they had the identical mismatch). Its early return for a window with no split layout is preserved — `effective_active_pair` asserts one.
* `buffer_for_leaf` resolves the buffer for a leaf: `SplitManager::buffer_for_split` only knows tree nodes, so it answers `None` for an inner panel; the fallback reads the leaf's own `SplitViewState::active_buffer`, which `effective_active_pair` already treats as authoritative.

Left alone deliberately: `handle_set_viewport_event` and `handle_recenter_event` resolve their leaf the same old way and would have the same blind spot for inner panels. Neither is reachable from a review panel by a keybinding I could find, so there's no reproducer to write a test against and no fix worth making without one.

## Tests

`crates/fresh-editor/tests/e2e/plugins/review_diff_collapsed_paging.rs` drives keys and asserts only on rendered output: it opens a review whose `src/file02.rs` is forty times longer than its neighbours, collapses it with `Enter` on the file header, returns to the top of the stream, and requires PageDown to reach `src/file03.rs`'s content — and PageUp to get back above the fold — within 30 presses. The fold-blind motion needs ~60 to cross that file's 1600 hidden rows; the fixed motion needs about four.

Verified failing on the parent commit (`PageDown never reached src/file03.rs past the collapsed src/file02.rs — 30 presses were spent inside its hidden body`) and passing with the change.

Also run: `cargo fmt`, `cargo clippy --all-targets` (no new warnings), `cargo check --all-targets --features gui`, `cargo test -p fresh-editor --lib` (3375 passed), and the e2e suites covering paging, scrolling, viewports, review diff / audit mode, splits, composites and folds (697 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EM6V5VanwxUpmnhqtxjy8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01EM6V5VanwxUpmnhqtxjy8R)_