### PR TITLE
feat(fresh-ui): give the wheel an axis

### DIFF
--- a/crates/fresh-ui/examples/demo.rs
+++ b/crates/fresh-ui/examples/demo.rs
@@ -6,6 +6,7 @@
 
 #[path = "../tests/support/mod.rs"]
 mod support;
+use fresh_ui::Axis;
 use fresh_ui::{Input, KeyCode, KeyPress, Mods, MouseButton, Point, Size};
 use support::demo::Demo;
 
@@ -107,6 +108,7 @@ fn main() {
     huge.input(Input::Wheel {
         pos: Point::new(30, 6),
         delta: 400_000,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     println!("── one million rows ───────────────────────────────────────────");

--- a/crates/fresh-ui/examples/interactive.rs
+++ b/crates/fresh-ui/examples/interactive.rs
@@ -25,6 +25,7 @@ use crossterm::event::{
 use crossterm::style::{Color, Print, SetBackgroundColor, SetForegroundColor};
 use crossterm::{cursor, execute, queue, terminal};
 
+use fresh_ui::Axis;
 use fresh_ui::{
     Draw, Input, KeyCode, KeyPress, Mods, MouseButton, Point, Rect, Scrim, Size, ThemeKey,
 };
@@ -138,11 +139,13 @@ fn translate_mouse(m: event::MouseEvent) -> Option<Input> {
         MouseEventKind::ScrollDown => Input::Wheel {
             pos,
             delta: 1,
+            axis: Axis::Vertical,
             mods,
         },
         MouseEventKind::ScrollUp => Input::Wheel {
             pos,
             delta: -1,
+            axis: Axis::Vertical,
             mods,
         },
         _ => return None,

--- a/crates/fresh-ui/src/event.rs
+++ b/crates/fresh-ui/src/event.rs
@@ -147,9 +147,24 @@ pub enum Input {
     Wheel {
         pos: Point,
         delta: i32,
+        /// Which way the notches run. Terminals report one axis per event and
+        /// browsers report two deltas; both resolve to this.
+        axis: Axis,
         mods: Mods,
     },
     Key(KeyPress),
+}
+
+/// Which way a wheel turns, and which way an offset moves.
+///
+/// The scroll model has always been two-dimensional — a `Viewport`'s offset
+/// and its maximum are both points — so this is the axis that was already
+/// implied by the geometry, named so input can address it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub enum Axis {
+    #[default]
+    Vertical,
+    Horizontal,
 }
 
 impl Input {
@@ -196,8 +211,10 @@ pub struct Event {
     pub local: Point,
     pub button: MouseButton,
     pub mods: Mods,
-    /// Wheel notches; negative is up.
+    /// Wheel notches; negative is up (or left).
     pub delta: i32,
+    /// Which axis `delta` moves along. `Vertical` for everything else.
+    pub axis: Axis,
     pub key: Option<KeyPress>,
     /// On a focus event, what the acquisition asked the target to do with its
     /// selection.
@@ -223,6 +240,7 @@ impl Event {
             button: MouseButton::Left,
             mods: Mods::NONE,
             delta: 0,
+            axis: Axis::Vertical,
             key: None,
             selection: SelectionOnFocus::None,
             target: at,

--- a/crates/fresh-ui/src/focus/mod.rs
+++ b/crates/fresh-ui/src/focus/mod.rs
@@ -126,7 +126,7 @@ use std::rc::Rc;
 use crate::desc::{resolve, Desc, Modality};
 use crate::element::ElementId;
 use crate::event::{
-    Ctl, Event, Flow, GestureKind, KeyPress, Mods, MouseButton, Phase, SelectionOnFocus,
+    Axis, Ctl, Event, Flow, GestureKind, KeyPress, Mods, MouseButton, Phase, SelectionOnFocus,
 };
 use crate::render::geom::Point;
 use crate::schedule::{DirtyCause, Ui};
@@ -265,6 +265,7 @@ impl<M: 'static> Ui<M> {
             button: MouseButton::Left,
             mods: key.map(|k| k.mods).unwrap_or(Mods::NONE),
             delta: 0,
+            axis: Axis::Vertical,
             key,
             selection: SelectionOnFocus::None,
             target: id,

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -16,7 +16,8 @@ use std::rc::Rc;
 use crate::desc::{resolve, Desc, ElemType};
 use crate::element::ElementId;
 use crate::event::{
-    Ctl, Event, Flow, GestureKind, Input, KeyPress, Mods, MouseButton, Phase, SelectionOnFocus,
+    Axis, Ctl, Event, Flow, GestureKind, Input, KeyPress, Mods, MouseButton, Phase,
+    SelectionOnFocus,
 };
 use crate::render::geom::Point;
 use crate::render::object::{Hit, RenderId};
@@ -42,7 +43,7 @@ impl<M: 'static> Ui<M> {
                     pos,
                     MouseButton::Left,
                     mods,
-                    0,
+                    Wheel::NONE,
                     &mut out,
                 );
             }
@@ -65,14 +66,30 @@ impl<M: 'static> Ui<M> {
                 let targets: Vec<ElementId> =
                     paths.iter().filter_map(|p| p.last().copied()).collect();
                 self.press = Some((targets, button));
-                self.propagate_all(&paths, GestureKind::Press, pos, button, mods, 0, &mut out);
+                self.propagate_all(
+                    &paths,
+                    GestureKind::Press,
+                    pos,
+                    button,
+                    mods,
+                    Wheel::NONE,
+                    &mut out,
+                );
             }
             Input::Release { pos, button, mods } => {
                 if self.scrollbar_drag.take().is_some() {
                     return out;
                 }
                 let paths = self.route(pos);
-                self.propagate_all(&paths, GestureKind::Release, pos, button, mods, 0, &mut out);
+                self.propagate_all(
+                    &paths,
+                    GestureKind::Release,
+                    pos,
+                    button,
+                    mods,
+                    Wheel::NONE,
+                    &mut out,
+                );
                 // A click is a press and a release over the same element, one
                 // per stacked path.
                 if let Some((pressed, b)) = self.press.take() {
@@ -86,12 +103,26 @@ impl<M: 'static> Ui<M> {
                             .filter(|p| p.last().is_some_and(|t| pressed.contains(t)))
                             .cloned()
                             .collect();
-                        self.propagate_all(&click_paths, kind, pos, button, mods, 0, &mut out);
+                        self.propagate_all(
+                            &click_paths,
+                            kind,
+                            pos,
+                            button,
+                            mods,
+                            Wheel::NONE,
+                            &mut out,
+                        );
                     }
                 }
                 self.captured = None;
             }
-            Input::Wheel { pos, delta, mods } => {
+            Input::Wheel {
+                pos,
+                delta,
+                axis,
+                mods,
+            } => {
+                let wheel = Wheel { delta, axis };
                 let paths = self.route(pos);
                 let (claimed, prevented) = self.propagate_all(
                     &paths,
@@ -99,7 +130,7 @@ impl<M: 'static> Ui<M> {
                     pos,
                     MouseButton::Left,
                     mods,
-                    delta,
+                    wheel,
                     &mut out,
                 );
                 if !claimed && !prevented {
@@ -108,7 +139,7 @@ impl<M: 'static> Ui<M> {
                     // not claim, so the wheel continues outward.
                     if let Some(p) = paths.first() {
                         let p = p.clone();
-                        self.scroll_chain(&p, delta);
+                        self.scroll_chain(&p, wheel);
                     }
                 }
             }
@@ -116,6 +147,8 @@ impl<M: 'static> Ui<M> {
         out
     }
 
+    /// How far a wheel turned and along which axis, as one parameter — so the
+    /// gestures that are not wheels pass [`Wheel::NONE`] rather than a bare zero.
     /// Run the stacked paths in order until one claims the event. A
     /// transparent region is why there is more than one.
     #[allow(clippy::too_many_arguments)]
@@ -126,12 +159,12 @@ impl<M: 'static> Ui<M> {
         pos: Point,
         button: MouseButton,
         mods: Mods,
-        delta: i32,
+        wheel: Wheel,
         out: &mut Vec<M>,
     ) -> (bool, bool) {
         let mut prevented = false;
         for path in paths {
-            let (claimed, p) = self.propagate(path, kind, pos, button, mods, delta, None, out);
+            let (claimed, p) = self.propagate(path, kind, pos, button, mods, wheel, None, out);
             prevented |= p;
             if claimed {
                 return (true, prevented);
@@ -304,7 +337,7 @@ impl<M: 'static> Ui<M> {
         pos: Point,
         button: MouseButton,
         mods: Mods,
-        delta: i32,
+        wheel: Wheel,
         key: Option<KeyPress>,
         out: &mut Vec<M>,
     ) -> (bool, bool) {
@@ -331,7 +364,8 @@ impl<M: 'static> Ui<M> {
                     local: Point::new(pos.x - rect.x, pos.y - rect.y),
                     button,
                     mods,
-                    delta,
+                    delta: wheel.delta,
+                    axis: wheel.axis,
                     key,
                     selection: SelectionOnFocus::None,
                     target: self.retarget(target, n),
@@ -447,6 +481,7 @@ impl<M: 'static> Ui<M> {
             button: MouseButton::Left,
             mods,
             delta: 0,
+            axis: Axis::Vertical,
             key: None,
             selection: SelectionOnFocus::None,
             target: n,
@@ -511,7 +546,7 @@ impl<M: 'static> Ui<M> {
         self.mark_render_dirty(r);
     }
 
-    fn scroll_chain(&mut self, path: &[ElementId], delta: i32) {
+    fn scroll_chain(&mut self, path: &[ElementId], wheel: Wheel) {
         for &n in path.iter().rev() {
             let Some(r) = self.render_for(n) else {
                 continue;
@@ -525,10 +560,17 @@ impl<M: 'static> Ui<M> {
             if !clips {
                 continue;
             }
-            let next = (scroll.y + delta).clamp(0, max.y.max(0));
-            if next != scroll.y {
+            let (at, limit) = match wheel.axis {
+                Axis::Vertical => (scroll.y, max.y),
+                Axis::Horizontal => (scroll.x, max.x),
+            };
+            let next = (at + wheel.delta).clamp(0, limit.max(0));
+            if next != at {
                 if let Some(node) = self.render.get_mut(r) {
-                    node.data.scroll.y = next;
+                    match wheel.axis {
+                        Axis::Vertical => node.data.scroll.y = next,
+                        Axis::Horizontal => node.data.scroll.x = next,
+                    }
                 }
                 self.mark_render_dirty(r);
                 return;
@@ -573,6 +615,7 @@ impl<M: 'static> Ui<M> {
                     button: MouseButton::Left,
                     mods: Mods::NONE,
                     delta: 0,
+                    axis: Axis::Vertical,
                     key: None,
                     selection: SelectionOnFocus::None,
                     target: lid,
@@ -614,6 +657,7 @@ impl<M: 'static> Ui<M> {
                     button: MouseButton::Left,
                     mods: k.mods,
                     delta: 0,
+                    axis: Axis::Vertical,
                     key: Some(k),
                     selection: SelectionOnFocus::None,
                     target: lid,
@@ -629,4 +673,22 @@ impl<M: 'static> Ui<M> {
         }
         any
     }
+}
+
+/// How far a wheel turned, and along which axis.
+///
+/// One parameter rather than two, so the gestures that are not wheels pass
+/// [`Wheel::NONE`] instead of a bare zero whose meaning has to be inferred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct Wheel {
+    pub delta: i32,
+    pub axis: Axis,
+}
+
+impl Wheel {
+    /// No wheel movement: what a press, release or click carries.
+    pub const NONE: Wheel = Wheel {
+        delta: 0,
+        axis: Axis::Vertical,
+    };
 }

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -50,7 +50,8 @@ pub use desc::{
 };
 pub use element::ElementId;
 pub use event::{
-    Event, Flow, GestureKind, Input, KeyCode, KeyPress, Mods, MouseButton, Phase, SelectionOnFocus,
+    Axis, Event, Flow, GestureKind, Input, KeyCode, KeyPress, Mods, MouseButton, Phase,
+    SelectionOnFocus,
 };
 pub use focus::{
     default_shortcuts, Directional, FocusDir, FocusEntry, FocusScope, Focusable, Intent,

--- a/crates/fresh-ui/tests/golden.rs
+++ b/crates/fresh-ui/tests/golden.rs
@@ -16,6 +16,7 @@
 use std::path::PathBuf;
 
 mod support;
+use fresh_ui::Axis;
 use fresh_ui::{Input, KeyCode, KeyPress, Mods, MouseButton, Point, Size};
 use support::demo::{App, Demo, Msg};
 
@@ -119,9 +120,14 @@ impl Session {
     }
 
     fn wheel(&mut self, x: i32, y: i32, delta: i32) -> &mut Self {
+        self.wheel_on(x, y, delta, Axis::Vertical)
+    }
+
+    fn wheel_on(&mut self, x: i32, y: i32, delta: i32, axis: Axis) -> &mut Self {
         self.feed(Input::Wheel {
             pos: Point::new(x, y),
             delta,
+            axis,
             mods: Mods::NONE,
         });
         self
@@ -261,6 +267,7 @@ fn the_display_list_stays_bounded_over_a_million_rows() {
     demo.input(Input::Wheel {
         pos: Point::new(30, 6),
         delta: 700_000,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     assert!(

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use fresh_ui::Axis;
 use fresh_ui::{
     col, gesture, stack, text, viewport, BuildCx, Component, ComponentExt, Event, GestureKind,
     Input, Mods, MouseButton, Node, Point, PointerMode, Size, Sizing, Ui,
@@ -256,6 +257,7 @@ fn a_viewport_at_its_bound_lets_the_wheel_through() {
     ui.dispatch(Input::Wheel {
         pos: over_inner,
         delta: 1,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     ui.tick();
@@ -266,6 +268,7 @@ fn a_viewport_at_its_bound_lets_the_wheel_through() {
     ui.dispatch(Input::Wheel {
         pos: over_inner,
         delta: 1,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     ui.tick();
@@ -278,6 +281,7 @@ fn a_viewport_at_its_bound_lets_the_wheel_through() {
     ui.dispatch(Input::Wheel {
         pos: over_inner,
         delta: 1,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     ui.tick();
@@ -307,6 +311,7 @@ fn preventing_the_default_suppresses_scrolling_without_claiming() {
     ui.dispatch(Input::Wheel {
         pos: Point::new(1, 1),
         delta: 1,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     ui.tick();
@@ -437,5 +442,105 @@ fn pressing_and_dragging_the_scrollbar_gutter_scrolls_the_viewport() {
         ui.scroll(vp).0.y,
         0,
         "a bare move after release does not scroll"
+    );
+}
+
+/// The chain honours the axis it is given — and the built-in `Viewport` has
+/// nothing to move along `x`.
+///
+/// The scroll model has always been two-dimensional: a viewport's offset and
+/// its maximum are both points, and the maximum's `x` is computed. But a
+/// viewport lays its child out under `Constraints::new(0, w, ..)`, bounding the
+/// child to the window's own width, so the content can never be wider than the
+/// window and that maximum is always zero. `Viewport` is a vertical scroller by
+/// construction.
+///
+/// That is deliberate and unchanged here. What this test pins is the boundary:
+/// the routing understands both axes, so a horizontally scrollable viewport
+/// would work the day one exists — and until then a horizontal wheel reaching a
+/// viewport correctly does nothing rather than scrolling the wrong way.
+#[test]
+fn a_viewport_has_no_horizontal_extent_to_scroll() {
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        viewport(text("x".repeat(60)))
+            .w(Sizing::Cells(10))
+            .h(Sizing::Cells(1)),
+        FRAME,
+    );
+    let vp = ui.root().unwrap();
+    let (offset, content) = ui.scroll(vp);
+    assert_eq!(offset, Point::new(0, 0));
+    assert!(
+        content.w <= 10,
+        "the child is bounded to the window's width, so there is no overflow \
+         to scroll: content {content:?}"
+    );
+
+    ui.dispatch(Input::Wheel {
+        pos: Point::new(2, 0),
+        delta: 3,
+        axis: Axis::Horizontal,
+        mods: Mods::NONE,
+    });
+    assert_eq!(
+        ui.scroll(vp).0,
+        Point::new(0, 0),
+        "nothing to scroll, and in particular the vertical offset is untouched"
+    );
+}
+
+/// A vertical wheel still scrolls, and leaves `x` alone.
+#[test]
+fn a_vertical_wheel_moves_only_y() {
+    let mut ui: Ui<()> = Ui::new();
+    let rows: Vec<Node<()>> = (0..40).map(|i| text(format!("row {i}"))).collect();
+    ui.frame(
+        viewport(col().children(rows))
+            .w(Sizing::Cells(10))
+            .h(Sizing::Cells(4)),
+        FRAME,
+    );
+    let vp = ui.root().unwrap();
+
+    ui.dispatch(Input::Wheel {
+        pos: Point::new(2, 2),
+        delta: 2,
+        axis: Axis::Vertical,
+        mods: Mods::NONE,
+    });
+    assert_eq!(ui.scroll(vp).0, Point::new(0, 2));
+}
+
+/// A `Wheel` listener can tell the axes apart, so a widget that handles its own
+/// scrolling is not forced to guess.
+#[test]
+fn a_wheel_listener_sees_the_axis() {
+    let seen: Rc<RefCell<Vec<(i32, Axis)>>> = Rc::new(RefCell::new(Vec::new()));
+    let s = seen.clone();
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        gesture(text("row")).on(
+            GestureKind::Wheel,
+            Rc::new(move |e: &Event| {
+                s.borrow_mut().push((e.delta, e.axis));
+                e.stop();
+                None
+            }),
+        ),
+        FRAME,
+    );
+
+    for (delta, axis) in [(1, Axis::Vertical), (-2, Axis::Horizontal)] {
+        ui.dispatch(Input::Wheel {
+            pos: Point::new(1, 0),
+            delta,
+            axis,
+            mods: Mods::NONE,
+        });
+    }
+    assert_eq!(
+        *seen.borrow(),
+        vec![(1, Axis::Vertical), (-2, Axis::Horizontal)]
     );
 }

--- a/crates/fresh-ui/tests/properties.rs
+++ b/crates/fresh-ui/tests/properties.rs
@@ -7,6 +7,7 @@
 use proptest::prelude::*;
 
 mod support;
+use fresh_ui::Axis;
 use fresh_ui::{
     col, distribute, row, text, Input, Key, KeyCode, KeyPress, Mods, MouseButton, Node, Point,
     Rect, Size, Sizing, Ui,
@@ -339,6 +340,7 @@ fn apply(demo: &mut Demo, act: &Act) {
             demo.input(Input::Wheel {
                 pos: Point::new(30, 6),
                 delta: *d as i32,
+                axis: Axis::Vertical,
                 mods: m,
             });
         }

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -4,6 +4,7 @@
 //! read the messages and the display list. Nothing reaches into the framework.
 
 mod support;
+use fresh_ui::Axis;
 use fresh_ui::{
     col, Button, ComponentExt, Draw, Dropdown, Input, KeyCode, KeyPress, List, Mods, MouseButton,
     Node, Number, Point, RadioGroup, Size, Sizing, TextField, Toggle, Tree, TreeNode, Ui,
@@ -286,6 +287,7 @@ fn a_million_row_list_does_a_screenful_of_work_per_frame() {
     ui.dispatch(Input::Wheel {
         pos: Point::new(1, 1),
         delta: 40,
+        axis: Axis::Vertical,
         mods: Mods::NONE,
     });
     ui.tick();


### PR DESCRIPTION
Base of a two-PR stack. #3028 (the fresh-editor UI migration) is stacked on top of this.

## Why

The scroll model has always been two-dimensional — a viewport's offset and its maximum are both `Point`s, and `ViewportProps::scroll` is a pair — but nothing could address the horizontal one. `Input::Wheel` carried a bare scalar and `scroll_chain` only ever moved `y`. The axis was implied by the geometry everywhere except where it could be driven.

This surfaced while writing the editor-side input adapter for the migration: translating a horizontal wheel had no target, so the adapter had to decline it and leave it on the legacy path. Rather than encode that gap as an editor workaround — which is the class of thing the migration exists to remove — it is closed here, in the library, before anything depends on it.

## What changed

- `Axis::{Vertical, Horizontal}`, carried on `Input::Wheel` and on the `Event` a `Wheel` listener receives, so a widget that scrolls itself can tell the two apart instead of guessing.
- `scroll_chain` moves and clamps the axis it was given.
- The wheel travels through propagation as one parameter (`Wheel { delta, axis }`) rather than two, so the gestures that are *not* wheels pass `Wheel::NONE` instead of a bare `0` whose meaning had to be inferred at each call site.

## What this deliberately does not do

It does not make the built-in `Viewport` scroll sideways. A viewport lays its child out under `Constraints::new(0, w, ..)`, bounding it to the window's own width, so content can never overflow horizontally and that maximum stays zero — `Viewport` is a vertical scroller by construction, and remains one here.

A horizontally scrollable viewport is a separate feature, and nothing needs it yet: a host leaf that scrolls its own content (an editor buffer) does that itself and only needs the axis to reach its handler intact. `a_viewport_has_no_horizontal_extent_to_scroll` pins that boundary, so if someone later builds a horizontal viewport, the test says what changed.

## Verification

`tests/pointer.rs` covers all three cases: a `Wheel` listener sees the axis; a vertical wheel still moves only `y`; a horizontal wheel over a viewport correctly does nothing rather than scrolling the wrong way.

Full suite green — 150 tests, goldens included, so no rendered output moved. The crate still builds standalone with `unicode-width` as its only runtime dependency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2GtzEBQRFZMv8qF61Jzr)_