### PR TITLE
Make a selection over empty lines visible (#2797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Features
 
+* **A selection that spans empty lines is visible** - every selected line break highlights the column it occupies (column 0 on an empty line), and whitespace inside a selection draws its `·` / `→` indicators even when the indicators are otherwise off (`whitespace_in_selection`, on by default) (#2797, reported by @akarinotomoshibi).
 * **Installing and updating Fresh** - the preferred install method for Linux is now a single self-contained, self-updating, statically linked (musl) binary - one install that works everywhere, instead of a dozen fragile packaging channels.
 * **LSP completions can offer auto-imports** - servers like rust-analyzer now suggest unimported symbols, and accepting one inserts the `use`/import line (#2603).
 * **The scripting API can manage the whole Orchestrator dock** - create, rename, move, archive, delete and list workspaces, including over SSH, not just create them.

--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
@@ -876,7 +876,7 @@
   <text x="559" y="122" fill="#ffffff" class="terminal" style="">&quot;</text>
   <rect x="567" y="108" width="9" height="18" fill="#000000"/>
   <text x="568" y="122" fill="#ffffff" class="terminal" style="">;</text>
-  <rect x="576" y="108" width="9" height="18" fill="#000000"/>
+  <rect x="576" y="108" width="9" height="18" fill="#323c5a"/>
   <rect x="585" y="108" width="9" height="18" fill="#000000"/>
   <rect x="594" y="108" width="9" height="18" fill="#000000"/>
   <rect x="603" y="108" width="9" height="18" fill="#000000"/>
@@ -953,9 +953,13 @@
   <text x="307" y="140" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="126" width="9" height="18" fill="#000000"/>
   <rect x="324" y="126" width="9" height="18" fill="#323c5a"/>
+  <text x="325" y="140" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="333" y="126" width="9" height="18" fill="#323c5a"/>
+  <text x="334" y="140" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="342" y="126" width="9" height="18" fill="#323c5a"/>
+  <text x="343" y="140" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="351" y="126" width="9" height="18" fill="#323c5a"/>
+  <text x="352" y="140" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="360" y="126" width="9" height="18" fill="#323c5a"/>
   <text x="361" y="140" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="369" y="126" width="9" height="18" fill="#323c5a"/>
@@ -2272,7 +2276,7 @@
   <rect x="486" y="324" width="9" height="18" fill="#000000"/>
   <rect x="495" y="324" width="9" height="18" fill="#000000"/>
   <text x="496" y="338" fill="#8be9fd" class="terminal" style="">{</text>
-  <rect x="504" y="324" width="9" height="18" fill="#000000"/>
+  <rect x="504" y="324" width="9" height="18" fill="#323c5a"/>
   <rect x="513" y="324" width="9" height="18" fill="#000000"/>
   <rect x="522" y="324" width="9" height="18" fill="#000000"/>
   <rect x="531" y="324" width="9" height="18" fill="#000000"/>
@@ -2358,9 +2362,13 @@
   <text x="307" y="356" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="342" width="9" height="18" fill="#000000"/>
   <rect x="324" y="342" width="9" height="18" fill="#323c5a"/>
+  <text x="325" y="356" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="333" y="342" width="9" height="18" fill="#323c5a"/>
+  <text x="334" y="356" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="342" y="342" width="9" height="18" fill="#323c5a"/>
+  <text x="343" y="356" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="351" y="342" width="9" height="18" fill="#323c5a"/>
+  <text x="352" y="356" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="360" y="342" width="9" height="18" fill="#323c5a"/>
   <text x="361" y="356" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="369" y="342" width="9" height="18" fill="#323c5a"/>
@@ -2398,7 +2406,7 @@
   <text x="514" y="356" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="342" width="9" height="18" fill="#000000"/>
   <text x="523" y="356" fill="#ffffff" class="terminal" style="">;</text>
-  <rect x="531" y="342" width="9" height="18" fill="#000000"/>
+  <rect x="531" y="342" width="9" height="18" fill="#323c5a"/>
   <rect x="540" y="342" width="9" height="18" fill="#000000"/>
   <rect x="549" y="342" width="9" height="18" fill="#000000"/>
   <rect x="558" y="342" width="9" height="18" fill="#000000"/>
@@ -2481,9 +2489,13 @@
   <text x="307" y="374" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="360" width="9" height="18" fill="#141414"/>
   <rect x="324" y="360" width="9" height="18" fill="#323c5a"/>
+  <text x="325" y="374" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="333" y="360" width="9" height="18" fill="#323c5a"/>
+  <text x="334" y="374" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="342" y="360" width="9" height="18" fill="#323c5a"/>
+  <text x="343" y="374" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="351" y="360" width="9" height="18" fill="#323c5a"/>
+  <text x="352" y="374" fill="#ffffff" class="terminal" style="">·</text>
   <rect x="360" y="360" width="9" height="18" fill="#323c5a"/>
   <text x="361" y="374" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="369" y="360" width="9" height="18" fill="#323c5a"/>
@@ -3378,92 +3390,91 @@
   <rect x="891" y="486" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="504" width="9" height="18" fill="#141414"/>
   <rect x="9" y="504" width="9" height="18" fill="#141414"/>
-  <text x="10" y="518" fill="#ffffff" class="terminal" style="">L</text>
+  <text x="10" y="518" fill="#ffffff" class="terminal" style="">T</text>
   <rect x="18" y="504" width="9" height="18" fill="#141414"/>
-  <text x="19" y="518" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="19" y="518" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="27" y="504" width="9" height="18" fill="#141414"/>
-  <text x="28" y="518" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="28" y="518" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="36" y="504" width="9" height="18" fill="#141414"/>
-  <text x="37" y="518" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="37" y="518" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="45" y="504" width="9" height="18" fill="#141414"/>
-  <text x="46" y="518" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="46" y="518" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="54" y="504" width="9" height="18" fill="#141414"/>
+  <text x="55" y="518" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="63" y="504" width="9" height="18" fill="#141414"/>
+  <text x="64" y="518" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="72" y="504" width="9" height="18" fill="#141414"/>
-  <text x="73" y="518" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="81" y="504" width="9" height="18" fill="#141414"/>
-  <text x="82" y="518" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="90" y="504" width="9" height="18" fill="#141414"/>
-  <text x="91" y="518" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="91" y="518" fill="#ffffff" class="terminal" style="">L</text>
   <rect x="99" y="504" width="9" height="18" fill="#141414"/>
-  <text x="100" y="518" fill="#ffffff" class="terminal" style="">/</text>
+  <text x="100" y="518" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="108" y="504" width="9" height="18" fill="#141414"/>
-  <text x="109" y="518" fill="#ffffff" class="terminal" style="">m</text>
+  <text x="109" y="518" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="117" y="504" width="9" height="18" fill="#141414"/>
   <text x="118" y="518" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="126" y="504" width="9" height="18" fill="#141414"/>
-  <text x="127" y="518" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="127" y="518" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="135" y="504" width="9" height="18" fill="#141414"/>
-  <text x="136" y="518" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="144" y="504" width="9" height="18" fill="#141414"/>
-  <text x="145" y="518" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="153" y="504" width="9" height="18" fill="#141414"/>
-  <text x="154" y="518" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="154" y="518" fill="#ffffff" class="terminal" style="">L</text>
   <rect x="162" y="504" width="9" height="18" fill="#141414"/>
-  <text x="163" y="518" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="163" y="518" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="171" y="504" width="9" height="18" fill="#141414"/>
   <rect x="180" y="504" width="9" height="18" fill="#141414"/>
+  <text x="181" y="518" fill="#ffffff" class="terminal" style="">6</text>
   <rect x="189" y="504" width="9" height="18" fill="#141414"/>
-  <text x="190" y="518" fill="#ffffff" class="terminal" style="">L</text>
+  <text x="190" y="518" fill="#ffffff" class="terminal" style="">,</text>
   <rect x="198" y="504" width="9" height="18" fill="#141414"/>
-  <text x="199" y="518" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="207" y="504" width="9" height="18" fill="#141414"/>
+  <text x="208" y="518" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="216" y="504" width="9" height="18" fill="#141414"/>
-  <text x="217" y="518" fill="#ffffff" class="terminal" style="">6</text>
+  <text x="217" y="518" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="225" y="504" width="9" height="18" fill="#141414"/>
-  <text x="226" y="518" fill="#ffffff" class="terminal" style="">,</text>
+  <text x="226" y="518" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="234" y="504" width="9" height="18" fill="#141414"/>
   <rect x="243" y="504" width="9" height="18" fill="#141414"/>
-  <text x="244" y="518" fill="#ffffff" class="terminal" style="">C</text>
+  <text x="244" y="518" fill="#ffffff" class="terminal" style="">1</text>
   <rect x="252" y="504" width="9" height="18" fill="#141414"/>
-  <text x="253" y="518" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="253" y="518" fill="#ffffff" class="terminal" style="">2</text>
   <rect x="261" y="504" width="9" height="18" fill="#141414"/>
-  <text x="262" y="518" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="270" y="504" width="9" height="18" fill="#141414"/>
   <rect x="279" y="504" width="9" height="18" fill="#141414"/>
-  <text x="280" y="518" fill="#ffffff" class="terminal" style="">1</text>
   <rect x="288" y="504" width="9" height="18" fill="#141414"/>
-  <text x="289" y="518" fill="#ffffff" class="terminal" style="">2</text>
   <rect x="297" y="504" width="9" height="18" fill="#141414"/>
+  <text x="298" y="518" fill="#ffffff" class="terminal" style="">E</text>
   <rect x="306" y="504" width="9" height="18" fill="#141414"/>
+  <text x="307" y="518" fill="#ffffff" class="terminal" style="">:</text>
   <rect x="315" y="504" width="9" height="18" fill="#141414"/>
+  <text x="316" y="518" fill="#ffffff" class="terminal" style="">1</text>
   <rect x="324" y="504" width="9" height="18" fill="#141414"/>
   <rect x="333" y="504" width="9" height="18" fill="#141414"/>
-  <text x="334" y="518" fill="#ffffff" class="terminal" style="">E</text>
   <rect x="342" y="504" width="9" height="18" fill="#141414"/>
-  <text x="343" y="518" fill="#ffffff" class="terminal" style="">:</text>
+  <text x="343" y="518" fill="#ffffff" class="terminal" style="">3</text>
   <rect x="351" y="504" width="9" height="18" fill="#141414"/>
-  <text x="352" y="518" fill="#ffffff" class="terminal" style="">1</text>
   <rect x="360" y="504" width="9" height="18" fill="#141414"/>
+  <text x="361" y="518" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="369" y="504" width="9" height="18" fill="#141414"/>
+  <text x="370" y="518" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="378" y="504" width="9" height="18" fill="#141414"/>
-  <text x="379" y="518" fill="#ffffff" class="terminal" style="">3</text>
+  <text x="379" y="518" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="387" y="504" width="9" height="18" fill="#141414"/>
+  <text x="388" y="518" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="396" y="504" width="9" height="18" fill="#141414"/>
-  <text x="397" y="518" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="397" y="518" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="405" y="504" width="9" height="18" fill="#141414"/>
-  <text x="406" y="518" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="406" y="518" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="414" y="504" width="9" height="18" fill="#141414"/>
-  <text x="415" y="518" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="415" y="518" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="423" y="504" width="9" height="18" fill="#141414"/>
-  <text x="424" y="518" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="432" y="504" width="9" height="18" fill="#141414"/>
-  <text x="433" y="518" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="441" y="504" width="9" height="18" fill="#141414"/>
-  <text x="442" y="518" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="442" y="518" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="450" y="504" width="9" height="18" fill="#141414"/>
-  <text x="451" y="518" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="451" y="518" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="459" y="504" width="9" height="18" fill="#141414"/>
+  <text x="460" y="518" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="468" y="504" width="9" height="18" fill="#141414"/>
   <rect x="477" y="504" width="9" height="18" fill="#141414"/>
   <rect x="486" y="504" width="9" height="18" fill="#141414"/>

--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
@@ -281,8 +281,8 @@
   <rect x="1026" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="1035" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="1044" y="18" width="9" height="18" fill="#1e1e23"/>
-  <text x="1045" y="32" fill="#8c8c8c" class="terminal" style="">□</text>
   <rect x="1053" y="18" width="9" height="18" fill="#1e1e23"/>
+  <text x="1054" y="32" fill="#8c8c8c" class="terminal" style="">□</text>
   <rect x="1062" y="18" width="9" height="18" fill="#1e1e23"/>
   <text x="1063" y="32" fill="#8c8c8c" class="terminal" style="">×</text>
   <rect x="1071" y="18" width="9" height="18" fill="#1e1e23"/>
@@ -297,208 +297,208 @@
   <rect x="54" y="36" width="9" height="18" fill="#7f7f7f"/>
   <text x="55" y="50" fill="#ffffff" class="terminal" style="">/</text>
   <rect x="63" y="36" width="9" height="18" fill="#000000"/>
-  <text x="64" y="50" fill="#e5e5e5" class="terminal" style="">/</text>
+  <text x="64" y="50" fill="#ffffff" class="terminal" style="">/</text>
   <rect x="72" y="36" width="9" height="18" fill="#000000"/>
   <rect x="81" y="36" width="9" height="18" fill="#000000"/>
-  <text x="82" y="50" fill="#e5e5e5" class="terminal" style="">F</text>
+  <text x="82" y="50" fill="#ffffff" class="terminal" style="">F</text>
   <rect x="90" y="36" width="9" height="18" fill="#000000"/>
-  <text x="91" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="91" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="99" y="36" width="9" height="18" fill="#000000"/>
-  <text x="100" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="100" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="108" y="36" width="9" height="18" fill="#000000"/>
-  <text x="109" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="109" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="117" y="36" width="9" height="18" fill="#000000"/>
   <rect x="126" y="36" width="9" height="18" fill="#000000"/>
-  <text x="127" y="50" fill="#e5e5e5" class="terminal" style="">1</text>
+  <text x="127" y="50" fill="#ffffff" class="terminal" style="">1</text>
   <rect x="135" y="36" width="9" height="18" fill="#000000"/>
   <rect x="144" y="36" width="9" height="18" fill="#000000"/>
-  <text x="145" y="50" fill="#e5e5e5" class="terminal" style="">-</text>
+  <text x="145" y="50" fill="#ffffff" class="terminal" style="">-</text>
   <rect x="153" y="36" width="9" height="18" fill="#000000"/>
   <rect x="162" y="36" width="9" height="18" fill="#000000"/>
-  <text x="163" y="50" fill="#e5e5e5" class="terminal" style="">C</text>
+  <text x="163" y="50" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="171" y="36" width="9" height="18" fill="#000000"/>
-  <text x="172" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="172" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="180" y="36" width="9" height="18" fill="#000000"/>
-  <text x="181" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="181" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="189" y="36" width="9" height="18" fill="#000000"/>
-  <text x="190" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="190" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="198" y="36" width="9" height="18" fill="#000000"/>
-  <text x="199" y="50" fill="#e5e5e5" class="terminal" style="">a</text>
+  <text x="199" y="50" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="207" y="36" width="9" height="18" fill="#000000"/>
-  <text x="208" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="208" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="216" y="36" width="9" height="18" fill="#000000"/>
-  <text x="217" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="217" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="225" y="36" width="9" height="18" fill="#000000"/>
-  <text x="226" y="50" fill="#e5e5e5" class="terminal" style="">s</text>
+  <text x="226" y="50" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="234" y="36" width="9" height="18" fill="#000000"/>
   <rect x="243" y="36" width="9" height="18" fill="#000000"/>
-  <text x="244" y="50" fill="#e5e5e5" class="terminal" style="">a</text>
+  <text x="244" y="50" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="252" y="36" width="9" height="18" fill="#000000"/>
   <rect x="261" y="36" width="9" height="18" fill="#000000"/>
-  <text x="262" y="50" fill="#e5e5e5" class="terminal" style="">v</text>
+  <text x="262" y="50" fill="#ffffff" class="terminal" style="">v</text>
   <rect x="270" y="36" width="9" height="18" fill="#000000"/>
-  <text x="271" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="271" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="279" y="36" width="9" height="18" fill="#000000"/>
-  <text x="280" y="50" fill="#e5e5e5" class="terminal" style="">r</text>
+  <text x="280" y="50" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="288" y="36" width="9" height="18" fill="#000000"/>
-  <text x="289" y="50" fill="#e5e5e5" class="terminal" style="">y</text>
+  <text x="289" y="50" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="297" y="36" width="9" height="18" fill="#000000"/>
   <rect x="306" y="36" width="9" height="18" fill="#000000"/>
-  <text x="307" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="307" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="315" y="36" width="9" height="18" fill="#000000"/>
-  <text x="316" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="316" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="324" y="36" width="9" height="18" fill="#000000"/>
-  <text x="325" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="325" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="333" y="36" width="9" height="18" fill="#000000"/>
-  <text x="334" y="50" fill="#e5e5e5" class="terminal" style="">g</text>
+  <text x="334" y="50" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="342" y="36" width="9" height="18" fill="#000000"/>
   <rect x="351" y="36" width="9" height="18" fill="#000000"/>
-  <text x="352" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="352" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="360" y="36" width="9" height="18" fill="#000000"/>
-  <text x="361" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="361" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="369" y="36" width="9" height="18" fill="#000000"/>
-  <text x="370" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="370" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="378" y="36" width="9" height="18" fill="#000000"/>
-  <text x="379" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="379" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="387" y="36" width="9" height="18" fill="#000000"/>
   <rect x="396" y="36" width="9" height="18" fill="#000000"/>
-  <text x="397" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="397" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="405" y="36" width="9" height="18" fill="#000000"/>
-  <text x="406" y="50" fill="#e5e5e5" class="terminal" style="">h</text>
+  <text x="406" y="50" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="414" y="36" width="9" height="18" fill="#000000"/>
-  <text x="415" y="50" fill="#e5e5e5" class="terminal" style="">a</text>
+  <text x="415" y="50" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="423" y="36" width="9" height="18" fill="#000000"/>
-  <text x="424" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="424" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="432" y="36" width="9" height="18" fill="#000000"/>
   <rect x="441" y="36" width="9" height="18" fill="#000000"/>
-  <text x="442" y="50" fill="#e5e5e5" class="terminal" style="">w</text>
+  <text x="442" y="50" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="450" y="36" width="9" height="18" fill="#000000"/>
-  <text x="451" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="451" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="459" y="36" width="9" height="18" fill="#000000"/>
-  <text x="460" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="460" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="468" y="36" width="9" height="18" fill="#000000"/>
-  <text x="469" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="469" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="477" y="36" width="9" height="18" fill="#000000"/>
   <rect x="486" y="36" width="9" height="18" fill="#000000"/>
-  <text x="487" y="50" fill="#e5e5e5" class="terminal" style="">r</text>
+  <text x="487" y="50" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="495" y="36" width="9" height="18" fill="#000000"/>
-  <text x="496" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="496" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="504" y="36" width="9" height="18" fill="#000000"/>
-  <text x="505" y="50" fill="#e5e5e5" class="terminal" style="">q</text>
+  <text x="505" y="50" fill="#ffffff" class="terminal" style="">q</text>
   <rect x="513" y="36" width="9" height="18" fill="#000000"/>
-  <text x="514" y="50" fill="#e5e5e5" class="terminal" style="">u</text>
+  <text x="514" y="50" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="522" y="36" width="9" height="18" fill="#000000"/>
-  <text x="523" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="523" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="531" y="36" width="9" height="18" fill="#000000"/>
-  <text x="532" y="50" fill="#e5e5e5" class="terminal" style="">r</text>
+  <text x="532" y="50" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="540" y="36" width="9" height="18" fill="#000000"/>
-  <text x="541" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="541" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="549" y="36" width="9" height="18" fill="#000000"/>
   <rect x="558" y="36" width="9" height="18" fill="#000000"/>
-  <text x="559" y="50" fill="#e5e5e5" class="terminal" style="">h</text>
+  <text x="559" y="50" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="567" y="36" width="9" height="18" fill="#000000"/>
-  <text x="568" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="568" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="576" y="36" width="9" height="18" fill="#000000"/>
-  <text x="577" y="50" fill="#e5e5e5" class="terminal" style="">r</text>
+  <text x="577" y="50" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="585" y="36" width="9" height="18" fill="#000000"/>
-  <text x="586" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="586" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="594" y="36" width="9" height="18" fill="#000000"/>
-  <text x="595" y="50" fill="#e5e5e5" class="terminal" style="">z</text>
+  <text x="595" y="50" fill="#ffffff" class="terminal" style="">z</text>
   <rect x="603" y="36" width="9" height="18" fill="#000000"/>
-  <text x="604" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="604" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="612" y="36" width="9" height="18" fill="#000000"/>
-  <text x="613" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="613" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="621" y="36" width="9" height="18" fill="#000000"/>
-  <text x="622" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="622" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="630" y="36" width="9" height="18" fill="#000000"/>
-  <text x="631" y="50" fill="#e5e5e5" class="terminal" style="">a</text>
+  <text x="631" y="50" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="639" y="36" width="9" height="18" fill="#000000"/>
-  <text x="640" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="640" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="648" y="36" width="9" height="18" fill="#000000"/>
   <rect x="657" y="36" width="9" height="18" fill="#000000"/>
-  <text x="658" y="50" fill="#e5e5e5" class="terminal" style="">s</text>
+  <text x="658" y="50" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="666" y="36" width="9" height="18" fill="#000000"/>
-  <text x="667" y="50" fill="#e5e5e5" class="terminal" style="">c</text>
+  <text x="667" y="50" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="675" y="36" width="9" height="18" fill="#000000"/>
-  <text x="676" y="50" fill="#e5e5e5" class="terminal" style="">r</text>
+  <text x="676" y="50" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="684" y="36" width="9" height="18" fill="#000000"/>
-  <text x="685" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="685" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="693" y="36" width="9" height="18" fill="#000000"/>
-  <text x="694" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="694" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="702" y="36" width="9" height="18" fill="#000000"/>
-  <text x="703" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="703" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="711" y="36" width="9" height="18" fill="#000000"/>
-  <text x="712" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="712" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="720" y="36" width="9" height="18" fill="#000000"/>
-  <text x="721" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="721" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="729" y="36" width="9" height="18" fill="#000000"/>
-  <text x="730" y="50" fill="#e5e5e5" class="terminal" style="">g</text>
+  <text x="730" y="50" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="738" y="36" width="9" height="18" fill="#000000"/>
   <rect x="747" y="36" width="9" height="18" fill="#000000"/>
-  <text x="748" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="748" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="756" y="36" width="9" height="18" fill="#000000"/>
-  <text x="757" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="757" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="765" y="36" width="9" height="18" fill="#000000"/>
   <rect x="774" y="36" width="9" height="18" fill="#000000"/>
-  <text x="775" y="50" fill="#e5e5e5" class="terminal" style="">s</text>
+  <text x="775" y="50" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="783" y="36" width="9" height="18" fill="#000000"/>
-  <text x="784" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="784" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="792" y="36" width="9" height="18" fill="#000000"/>
-  <text x="793" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="793" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="801" y="36" width="9" height="18" fill="#000000"/>
   <rect x="810" y="36" width="9" height="18" fill="#000000"/>
-  <text x="811" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="811" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="819" y="36" width="9" height="18" fill="#000000"/>
-  <text x="820" y="50" fill="#e5e5e5" class="terminal" style="">h</text>
+  <text x="820" y="50" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="828" y="36" width="9" height="18" fill="#000000"/>
-  <text x="829" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="829" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="837" y="36" width="9" height="18" fill="#000000"/>
   <rect x="846" y="36" width="9" height="18" fill="#000000"/>
-  <text x="847" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="847" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="855" y="36" width="9" height="18" fill="#000000"/>
-  <text x="856" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="856" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="864" y="36" width="9" height="18" fill="#000000"/>
-  <text x="865" y="50" fill="#e5e5e5" class="terminal" style="">d</text>
+  <text x="865" y="50" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="873" y="36" width="9" height="18" fill="#000000"/>
   <rect x="882" y="36" width="9" height="18" fill="#000000"/>
-  <text x="883" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="883" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="891" y="36" width="9" height="18" fill="#000000"/>
-  <text x="892" y="50" fill="#e5e5e5" class="terminal" style="">f</text>
+  <text x="892" y="50" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="900" y="36" width="9" height="18" fill="#000000"/>
   <rect x="909" y="36" width="9" height="18" fill="#000000"/>
-  <text x="910" y="50" fill="#e5e5e5" class="terminal" style="">i</text>
+  <text x="910" y="50" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="918" y="36" width="9" height="18" fill="#000000"/>
-  <text x="919" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="919" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="927" y="36" width="9" height="18" fill="#000000"/>
   <rect x="936" y="36" width="9" height="18" fill="#000000"/>
-  <text x="937" y="50" fill="#e5e5e5" class="terminal" style="">c</text>
+  <text x="937" y="50" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="945" y="36" width="9" height="18" fill="#000000"/>
-  <text x="946" y="50" fill="#e5e5e5" class="terminal" style="">o</text>
+  <text x="946" y="50" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="954" y="36" width="9" height="18" fill="#000000"/>
-  <text x="955" y="50" fill="#e5e5e5" class="terminal" style="">m</text>
+  <text x="955" y="50" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="963" y="36" width="9" height="18" fill="#000000"/>
-  <text x="964" y="50" fill="#e5e5e5" class="terminal" style="">p</text>
+  <text x="964" y="50" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="972" y="36" width="9" height="18" fill="#000000"/>
-  <text x="973" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="973" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="981" y="36" width="9" height="18" fill="#000000"/>
-  <text x="982" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="982" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="990" y="36" width="9" height="18" fill="#000000"/>
-  <text x="991" y="50" fill="#e5e5e5" class="terminal" style="">t</text>
+  <text x="991" y="50" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="999" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1000" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="1000" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="1008" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1009" y="50" fill="#e5e5e5" class="terminal" style="">l</text>
+  <text x="1009" y="50" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="1017" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1018" y="50" fill="#e5e5e5" class="terminal" style="">y</text>
+  <text x="1018" y="50" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="1026" y="36" width="9" height="18" fill="#000000"/>
   <rect x="1035" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1036" y="50" fill="#e5e5e5" class="terminal" style="">w</text>
+  <text x="1036" y="50" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="1044" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1045" y="50" fill="#e5e5e5" class="terminal" style="">h</text>
+  <text x="1045" y="50" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="1053" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1054" y="50" fill="#e5e5e5" class="terminal" style="">e</text>
+  <text x="1054" y="50" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="1062" y="36" width="9" height="18" fill="#000000"/>
-  <text x="1063" y="50" fill="#e5e5e5" class="terminal" style="">n</text>
+  <text x="1063" y="50" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="1071" y="36" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="54" width="9" height="18" fill="#000000"/>
   <text x="1" y="68" fill="#8c8c8c" class="terminal" style="">▾</text>
@@ -510,18 +510,18 @@
   <text x="37" y="68" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="45" y="54" width="9" height="18" fill="#000000"/>
   <rect x="54" y="54" width="9" height="18" fill="#000000"/>
-  <text x="55" y="68" fill="#00ffff" class="terminal" style="">f</text>
+  <text x="55" y="68" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="63" y="54" width="9" height="18" fill="#000000"/>
-  <text x="64" y="68" fill="#00ffff" class="terminal" style="">n</text>
+  <text x="64" y="68" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="72" y="54" width="9" height="18" fill="#000000"/>
   <rect x="81" y="54" width="9" height="18" fill="#000000"/>
-  <text x="82" y="68" fill="#ffff00" class="terminal" style="">m</text>
+  <text x="82" y="68" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="90" y="54" width="9" height="18" fill="#000000"/>
-  <text x="91" y="68" fill="#ffff00" class="terminal" style="">a</text>
+  <text x="91" y="68" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="99" y="54" width="9" height="18" fill="#000000"/>
-  <text x="100" y="68" fill="#ffff00" class="terminal" style="">i</text>
+  <text x="100" y="68" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="108" y="54" width="9" height="18" fill="#000000"/>
-  <text x="109" y="68" fill="#ffff00" class="terminal" style="">n</text>
+  <text x="109" y="68" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="117" y="54" width="9" height="18" fill="#000000"/>
   <text x="118" y="68" fill="#8be9fd" class="terminal" style="">(</text>
   <rect x="126" y="54" width="9" height="18" fill="#000000"/>
@@ -645,11 +645,11 @@
   <rect x="72" y="72" width="9" height="18" fill="#000000"/>
   <rect x="81" y="72" width="9" height="18" fill="#000000"/>
   <rect x="90" y="72" width="9" height="18" fill="#000000"/>
-  <text x="91" y="86" fill="#00ffff" class="terminal" style="">l</text>
+  <text x="91" y="86" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="99" y="72" width="9" height="18" fill="#000000"/>
-  <text x="100" y="86" fill="#00ffff" class="terminal" style="">e</text>
+  <text x="100" y="86" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="108" y="72" width="9" height="18" fill="#000000"/>
-  <text x="109" y="86" fill="#00ffff" class="terminal" style="">t</text>
+  <text x="109" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="117" y="72" width="9" height="18" fill="#000000"/>
   <rect x="126" y="72" width="9" height="18" fill="#000000"/>
   <text x="127" y="86" fill="#ffffff" class="terminal" style="">v</text>
@@ -766,89 +766,89 @@
   <text x="631" y="86" fill="#ffffff" class="terminal" style="">=</text>
   <rect x="639" y="72" width="9" height="18" fill="#000000"/>
   <rect x="648" y="72" width="9" height="18" fill="#000000"/>
-  <text x="649" y="86" fill="#00cd00" class="terminal" style="">&quot;</text>
+  <text x="649" y="86" fill="#ffffff" class="terminal" style="">&quot;</text>
   <rect x="657" y="72" width="9" height="18" fill="#000000"/>
-  <text x="658" y="86" fill="#00cd00" class="terminal" style="">T</text>
+  <text x="658" y="86" fill="#ffffff" class="terminal" style="">T</text>
   <rect x="666" y="72" width="9" height="18" fill="#000000"/>
-  <text x="667" y="86" fill="#00cd00" class="terminal" style="">h</text>
+  <text x="667" y="86" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="675" y="72" width="9" height="18" fill="#000000"/>
-  <text x="676" y="86" fill="#00cd00" class="terminal" style="">i</text>
+  <text x="676" y="86" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="684" y="72" width="9" height="18" fill="#000000"/>
-  <text x="685" y="86" fill="#00cd00" class="terminal" style="">s</text>
+  <text x="685" y="86" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="693" y="72" width="9" height="18" fill="#000000"/>
   <rect x="702" y="72" width="9" height="18" fill="#000000"/>
-  <text x="703" y="86" fill="#00cd00" class="terminal" style="">i</text>
+  <text x="703" y="86" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="711" y="72" width="9" height="18" fill="#000000"/>
-  <text x="712" y="86" fill="#00cd00" class="terminal" style="">s</text>
+  <text x="712" y="86" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="720" y="72" width="9" height="18" fill="#000000"/>
   <rect x="729" y="72" width="9" height="18" fill="#000000"/>
-  <text x="730" y="86" fill="#00cd00" class="terminal" style="">a</text>
+  <text x="730" y="86" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="738" y="72" width="9" height="18" fill="#000000"/>
   <rect x="747" y="72" width="9" height="18" fill="#000000"/>
-  <text x="748" y="86" fill="#00cd00" class="terminal" style="">s</text>
+  <text x="748" y="86" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="756" y="72" width="9" height="18" fill="#000000"/>
-  <text x="757" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="757" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="765" y="72" width="9" height="18" fill="#000000"/>
-  <text x="766" y="86" fill="#00cd00" class="terminal" style="">r</text>
+  <text x="766" y="86" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="774" y="72" width="9" height="18" fill="#000000"/>
-  <text x="775" y="86" fill="#00cd00" class="terminal" style="">i</text>
+  <text x="775" y="86" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="783" y="72" width="9" height="18" fill="#000000"/>
-  <text x="784" y="86" fill="#00cd00" class="terminal" style="">n</text>
+  <text x="784" y="86" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="792" y="72" width="9" height="18" fill="#000000"/>
-  <text x="793" y="86" fill="#00cd00" class="terminal" style="">g</text>
+  <text x="793" y="86" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="801" y="72" width="9" height="18" fill="#000000"/>
   <rect x="810" y="72" width="9" height="18" fill="#000000"/>
-  <text x="811" y="86" fill="#00cd00" class="terminal" style="">w</text>
+  <text x="811" y="86" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="819" y="72" width="9" height="18" fill="#000000"/>
-  <text x="820" y="86" fill="#00cd00" class="terminal" style="">i</text>
+  <text x="820" y="86" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="828" y="72" width="9" height="18" fill="#000000"/>
-  <text x="829" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="829" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="837" y="72" width="9" height="18" fill="#000000"/>
-  <text x="838" y="86" fill="#00cd00" class="terminal" style="">h</text>
+  <text x="838" y="86" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="846" y="72" width="9" height="18" fill="#000000"/>
   <rect x="855" y="72" width="9" height="18" fill="#000000"/>
-  <text x="856" y="86" fill="#00cd00" class="terminal" style="">a</text>
+  <text x="856" y="86" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="864" y="72" width="9" height="18" fill="#000000"/>
   <rect x="873" y="72" width="9" height="18" fill="#000000"/>
-  <text x="874" y="86" fill="#00cd00" class="terminal" style="">l</text>
+  <text x="874" y="86" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="882" y="72" width="9" height="18" fill="#000000"/>
-  <text x="883" y="86" fill="#00cd00" class="terminal" style="">o</text>
+  <text x="883" y="86" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="891" y="72" width="9" height="18" fill="#000000"/>
-  <text x="892" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="892" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="900" y="72" width="9" height="18" fill="#000000"/>
   <rect x="909" y="72" width="9" height="18" fill="#000000"/>
-  <text x="910" y="86" fill="#00cd00" class="terminal" style="">o</text>
+  <text x="910" y="86" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="918" y="72" width="9" height="18" fill="#000000"/>
-  <text x="919" y="86" fill="#00cd00" class="terminal" style="">f</text>
+  <text x="919" y="86" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="927" y="72" width="9" height="18" fill="#000000"/>
   <rect x="936" y="72" width="9" height="18" fill="#000000"/>
-  <text x="937" y="86" fill="#00cd00" class="terminal" style="">c</text>
+  <text x="937" y="86" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="945" y="72" width="9" height="18" fill="#000000"/>
-  <text x="946" y="86" fill="#00cd00" class="terminal" style="">o</text>
+  <text x="946" y="86" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="954" y="72" width="9" height="18" fill="#000000"/>
-  <text x="955" y="86" fill="#00cd00" class="terminal" style="">n</text>
+  <text x="955" y="86" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="963" y="72" width="9" height="18" fill="#000000"/>
-  <text x="964" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="964" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="972" y="72" width="9" height="18" fill="#000000"/>
-  <text x="973" y="86" fill="#00cd00" class="terminal" style="">e</text>
+  <text x="973" y="86" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="981" y="72" width="9" height="18" fill="#000000"/>
-  <text x="982" y="86" fill="#00cd00" class="terminal" style="">n</text>
+  <text x="982" y="86" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="990" y="72" width="9" height="18" fill="#000000"/>
-  <text x="991" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="991" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="999" y="72" width="9" height="18" fill="#000000"/>
   <rect x="1008" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1009" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="1009" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="1017" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1018" y="86" fill="#00cd00" class="terminal" style="">h</text>
+  <text x="1018" y="86" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="1026" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1027" y="86" fill="#00cd00" class="terminal" style="">a</text>
+  <text x="1027" y="86" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="1035" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1036" y="86" fill="#00cd00" class="terminal" style="">t</text>
+  <text x="1036" y="86" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="1044" y="72" width="9" height="18" fill="#000000"/>
   <rect x="1053" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1054" y="86" fill="#00cd00" class="terminal" style="">g</text>
+  <text x="1054" y="86" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="1062" y="72" width="9" height="18" fill="#000000"/>
-  <text x="1063" y="86" fill="#00cd00" class="terminal" style="">o</text>
+  <text x="1063" y="86" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="1071" y="72" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="90" width="9" height="18" fill="#000000"/>
   <rect x="9" y="90" width="9" height="18" fill="#000000"/>
@@ -863,33 +863,33 @@
   <rect x="72" y="90" width="9" height="18" fill="#000000"/>
   <rect x="81" y="90" width="9" height="18" fill="#000000"/>
   <rect x="90" y="90" width="9" height="18" fill="#000000"/>
-  <text x="91" y="104" fill="#ffff00" class="terminal" style="">p</text>
+  <text x="91" y="104" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="99" y="90" width="9" height="18" fill="#000000"/>
-  <text x="100" y="104" fill="#ffff00" class="terminal" style="">r</text>
+  <text x="100" y="104" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="108" y="90" width="9" height="18" fill="#000000"/>
-  <text x="109" y="104" fill="#ffff00" class="terminal" style="">i</text>
+  <text x="109" y="104" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="117" y="90" width="9" height="18" fill="#000000"/>
-  <text x="118" y="104" fill="#ffff00" class="terminal" style="">n</text>
+  <text x="118" y="104" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="126" y="90" width="9" height="18" fill="#000000"/>
-  <text x="127" y="104" fill="#ffff00" class="terminal" style="">t</text>
+  <text x="127" y="104" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="135" y="90" width="9" height="18" fill="#000000"/>
-  <text x="136" y="104" fill="#ffff00" class="terminal" style="">l</text>
+  <text x="136" y="104" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="144" y="90" width="9" height="18" fill="#000000"/>
-  <text x="145" y="104" fill="#ffff00" class="terminal" style="">n</text>
+  <text x="145" y="104" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="153" y="90" width="9" height="18" fill="#000000"/>
-  <text x="154" y="104" fill="#ffff00" class="terminal" style="">!</text>
+  <text x="154" y="104" fill="#ffffff" class="terminal" style="">!</text>
   <rect x="162" y="90" width="9" height="18" fill="#000000"/>
   <text x="163" y="104" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="171" y="90" width="9" height="18" fill="#000000"/>
-  <text x="172" y="104" fill="#00cd00" class="terminal" style="">&quot;</text>
+  <text x="172" y="104" fill="#ffffff" class="terminal" style="">&quot;</text>
   <rect x="180" y="90" width="9" height="18" fill="#000000"/>
   <text x="181" y="104" fill="#f1fa8c" class="terminal" style="">{</text>
   <rect x="189" y="90" width="9" height="18" fill="#000000"/>
   <text x="190" y="104" fill="#f1fa8c" class="terminal" style="">}</text>
   <rect x="198" y="90" width="9" height="18" fill="#000000"/>
-  <text x="199" y="104" fill="#00cd00" class="terminal" style="">&quot;</text>
+  <text x="199" y="104" fill="#ffffff" class="terminal" style="">&quot;</text>
   <rect x="207" y="90" width="9" height="18" fill="#000000"/>
-  <text x="208" y="104" fill="#d4d4d4" class="terminal" style="">,</text>
+  <text x="208" y="104" fill="#ffffff" class="terminal" style="">,</text>
   <rect x="216" y="90" width="9" height="18" fill="#000000"/>
   <rect x="225" y="90" width="9" height="18" fill="#000000"/>
   <text x="226" y="104" fill="#ffffff" class="terminal" style="">v</text>
@@ -1004,7 +1004,7 @@
   <rect x="720" y="90" width="9" height="18" fill="#000000"/>
   <text x="721" y="104" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="729" y="90" width="9" height="18" fill="#000000"/>
-  <text x="730" y="104" fill="#d4d4d4" class="terminal" style="">;</text>
+  <text x="730" y="104" fill="#ffffff" class="terminal" style="">;</text>
   <rect x="738" y="90" width="9" height="18" fill="#000000"/>
   <rect x="747" y="90" width="9" height="18" fill="#000000"/>
   <rect x="756" y="90" width="9" height="18" fill="#000000"/>
@@ -2685,99 +2685,99 @@
   <rect x="423" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="432" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="441" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="442" y="320" fill="#ffffff" class="terminal" style="">O</text>
   <rect x="450" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="451" y="320" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="459" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="460" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="468" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="469" y="320" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="477" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="486" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="487" y="320" fill="#ffffff" class="terminal" style="">O</text>
+  <text x="487" y="320" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="495" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="496" y="320" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="496" y="320" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="504" y="306" width="9" height="18" fill="#0064c8"/>
   <text x="505" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="513" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="514" y="320" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="522" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="523" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="531" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="532" y="320" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="532" y="320" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="540" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="541" y="320" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="541" y="320" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="549" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="550" y="320" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="550" y="320" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="558" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="559" y="320" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="567" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="568" y="320" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="568" y="320" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="576" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="577" y="320" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="585" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="586" y="320" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="586" y="320" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="594" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="595" y="320" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="595" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="603" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="604" y="320" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="604" y="320" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="612" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="613" y="320" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="613" y="320" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="621" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="630" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="631" y="320" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="631" y="320" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="639" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="640" y="320" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="640" y="320" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="648" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="649" y="320" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="649" y="320" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="657" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="658" y="320" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="658" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="666" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="675" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="676" y="320" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="676" y="320" fill="#ffffff" class="terminal" style="">(</text>
   <rect x="684" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="685" y="320" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="685" y="320" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="693" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="694" y="320" fill="#ffffff" class="terminal" style="">g</text>
+  <text x="694" y="320" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="702" y="306" width="9" height="18" fill="#0064c8"/>
   <text x="703" y="320" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="711" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="712" y="320" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="720" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="721" y="320" fill="#ffffff" class="terminal" style="">(</text>
   <rect x="729" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="730" y="320" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="730" y="320" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="738" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="739" y="320" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="739" y="320" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="747" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="748" y="320" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="748" y="320" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="756" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="757" y="320" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="757" y="320" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="765" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="766" y="320" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="774" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="775" y="320" fill="#ffffff" class="terminal" style="">b</text>
+  <text x="775" y="320" fill="#ffffff" class="terminal" style="">-</text>
   <rect x="783" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="784" y="320" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="784" y="320" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="792" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="793" y="320" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="793" y="320" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="801" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="802" y="320" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="810" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="811" y="320" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="811" y="320" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="819" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="820" y="320" fill="#ffffff" class="terminal" style="">-</text>
+  <text x="820" y="320" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="828" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="829" y="320" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="829" y="320" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="837" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="838" y="320" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="838" y="320" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="846" y="306" width="9" height="18" fill="#0064c8"/>
+  <text x="847" y="320" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="855" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="856" y="320" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="856" y="320" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="864" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="865" y="320" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="865" y="320" fill="#ffffff" class="terminal" style="">)</text>
   <rect x="873" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="874" y="320" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="882" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="883" y="320" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="891" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="892" y="320" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="900" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="901" y="320" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="909" y="306" width="9" height="18" fill="#0064c8"/>
-  <text x="910" y="320" fill="#ffffff" class="terminal" style="">)</text>
   <rect x="918" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="927" y="306" width="9" height="18" fill="#0064c8"/>
   <rect x="936" y="306" width="9" height="18" fill="#0064c8"/>
@@ -2802,8 +2802,7 @@
   <text x="1054" y="320" fill="#8c8c8c" class="terminal" style="">m</text>
   <rect x="1062" y="306" width="9" height="18" fill="#0064c8"/>
   <text x="1063" y="320" fill="#8c8c8c" class="terminal" style="">e</text>
-  <rect x="1071" y="306" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="320" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="306" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="324" width="9" height="18" fill="#000000"/>
   <text x="1" y="338" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="324" width="9" height="18" fill="#000000"/>
@@ -2872,65 +2871,65 @@
   <rect x="423" y="324" width="9" height="18" fill="#000000"/>
   <rect x="432" y="324" width="9" height="18" fill="#000000"/>
   <rect x="441" y="324" width="9" height="18" fill="#000000"/>
+  <text x="442" y="338" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="450" y="324" width="9" height="18" fill="#000000"/>
+  <text x="451" y="338" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="459" y="324" width="9" height="18" fill="#000000"/>
+  <text x="460" y="338" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="468" y="324" width="9" height="18" fill="#000000"/>
+  <text x="469" y="338" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="477" y="324" width="9" height="18" fill="#000000"/>
   <rect x="486" y="324" width="9" height="18" fill="#000000"/>
-  <text x="487" y="338" fill="#ffffff" class="terminal" style="">S</text>
+  <text x="487" y="338" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="495" y="324" width="9" height="18" fill="#000000"/>
-  <text x="496" y="338" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="496" y="338" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="504" y="324" width="9" height="18" fill="#000000"/>
-  <text x="505" y="338" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="505" y="338" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="513" y="324" width="9" height="18" fill="#000000"/>
-  <text x="514" y="338" fill="#ffffff" class="terminal" style="">w</text>
+  <text x="514" y="338" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="522" y="324" width="9" height="18" fill="#000000"/>
+  <text x="523" y="338" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="531" y="324" width="9" height="18" fill="#000000"/>
-  <text x="532" y="338" fill="#ffffff" class="terminal" style="">f</text>
+  <text x="532" y="338" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="540" y="324" width="9" height="18" fill="#000000"/>
-  <text x="541" y="338" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="541" y="338" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="549" y="324" width="9" height="18" fill="#000000"/>
   <text x="550" y="338" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="558" y="324" width="9" height="18" fill="#000000"/>
-  <text x="559" y="338" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="567" y="324" width="9" height="18" fill="#000000"/>
-  <text x="568" y="338" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="568" y="338" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="576" y="324" width="9" height="18" fill="#000000"/>
-  <text x="577" y="338" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="577" y="338" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="585" y="324" width="9" height="18" fill="#000000"/>
-  <text x="586" y="338" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="586" y="338" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="594" y="324" width="9" height="18" fill="#000000"/>
-  <text x="595" y="338" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="595" y="338" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="603" y="324" width="9" height="18" fill="#000000"/>
+  <text x="604" y="338" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="612" y="324" width="9" height="18" fill="#000000"/>
-  <text x="613" y="338" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="613" y="338" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="621" y="324" width="9" height="18" fill="#000000"/>
-  <text x="622" y="338" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="622" y="338" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="630" y="324" width="9" height="18" fill="#000000"/>
-  <text x="631" y="338" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="631" y="338" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="639" y="324" width="9" height="18" fill="#000000"/>
-  <text x="640" y="338" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="640" y="338" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="648" y="324" width="9" height="18" fill="#000000"/>
-  <text x="649" y="338" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="657" y="324" width="9" height="18" fill="#000000"/>
-  <text x="658" y="338" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="658" y="338" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="666" y="324" width="9" height="18" fill="#000000"/>
-  <text x="667" y="338" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="667" y="338" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="675" y="324" width="9" height="18" fill="#000000"/>
-  <text x="676" y="338" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="676" y="338" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="684" y="324" width="9" height="18" fill="#000000"/>
-  <text x="685" y="338" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="685" y="338" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="693" y="324" width="9" height="18" fill="#000000"/>
+  <text x="694" y="338" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="702" y="324" width="9" height="18" fill="#000000"/>
-  <text x="703" y="338" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="711" y="324" width="9" height="18" fill="#000000"/>
-  <text x="712" y="338" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="720" y="324" width="9" height="18" fill="#000000"/>
-  <text x="721" y="338" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="729" y="324" width="9" height="18" fill="#000000"/>
-  <text x="730" y="338" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="738" y="324" width="9" height="18" fill="#000000"/>
-  <text x="739" y="338" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="747" y="324" width="9" height="18" fill="#000000"/>
   <rect x="756" y="324" width="9" height="18" fill="#000000"/>
   <rect x="765" y="324" width="9" height="18" fill="#000000"/>
@@ -2974,8 +2973,7 @@
   <text x="1054" y="338" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="324" width="9" height="18" fill="#000000"/>
   <text x="1063" y="338" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="324" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="338" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="324" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="342" width="9" height="18" fill="#000000"/>
   <text x="1" y="356" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="342" width="9" height="18" fill="#000000"/>
@@ -3034,120 +3032,124 @@
   <rect x="297" y="342" width="9" height="18" fill="#000000"/>
   <rect x="306" y="342" width="9" height="18" fill="#000000"/>
   <rect x="315" y="342" width="9" height="18" fill="#000000"/>
+  <text x="316" y="356" fill="#8c8c8c" class="terminal" style="">A</text>
   <rect x="324" y="342" width="9" height="18" fill="#000000"/>
+  <text x="325" y="356" fill="#8c8c8c" class="terminal" style="">l</text>
   <rect x="333" y="342" width="9" height="18" fill="#000000"/>
+  <text x="334" y="356" fill="#8c8c8c" class="terminal" style="">t</text>
   <rect x="342" y="342" width="9" height="18" fill="#000000"/>
+  <text x="343" y="356" fill="#8c8c8c" class="terminal" style="">+</text>
   <rect x="351" y="342" width="9" height="18" fill="#000000"/>
+  <text x="352" y="356" fill="#8c8c8c" class="terminal" style="">S</text>
   <rect x="360" y="342" width="9" height="18" fill="#000000"/>
-  <text x="361" y="356" fill="#8c8c8c" class="terminal" style="">A</text>
+  <text x="361" y="356" fill="#8c8c8c" class="terminal" style="">h</text>
   <rect x="369" y="342" width="9" height="18" fill="#000000"/>
-  <text x="370" y="356" fill="#8c8c8c" class="terminal" style="">l</text>
+  <text x="370" y="356" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="378" y="342" width="9" height="18" fill="#000000"/>
-  <text x="379" y="356" fill="#8c8c8c" class="terminal" style="">t</text>
+  <text x="379" y="356" fill="#8c8c8c" class="terminal" style="">f</text>
   <rect x="387" y="342" width="9" height="18" fill="#000000"/>
-  <text x="388" y="356" fill="#8c8c8c" class="terminal" style="">+</text>
+  <text x="388" y="356" fill="#8c8c8c" class="terminal" style="">t</text>
   <rect x="396" y="342" width="9" height="18" fill="#000000"/>
-  <text x="397" y="356" fill="#8c8c8c" class="terminal" style="">S</text>
+  <text x="397" y="356" fill="#8c8c8c" class="terminal" style="">+</text>
   <rect x="405" y="342" width="9" height="18" fill="#000000"/>
-  <text x="406" y="356" fill="#8c8c8c" class="terminal" style="">h</text>
+  <text x="406" y="356" fill="#8c8c8c" class="terminal" style="">|</text>
   <rect x="414" y="342" width="9" height="18" fill="#000000"/>
-  <text x="415" y="356" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="423" y="342" width="9" height="18" fill="#000000"/>
-  <text x="424" y="356" fill="#8c8c8c" class="terminal" style="">f</text>
   <rect x="432" y="342" width="9" height="18" fill="#000000"/>
-  <text x="433" y="356" fill="#8c8c8c" class="terminal" style="">t</text>
   <rect x="441" y="342" width="9" height="18" fill="#000000"/>
-  <text x="442" y="356" fill="#8c8c8c" class="terminal" style="">+</text>
+  <text x="442" y="356" fill="#ffffff" class="terminal" style="">R</text>
   <rect x="450" y="342" width="9" height="18" fill="#000000"/>
-  <text x="451" y="356" fill="#8c8c8c" class="terminal" style="">|</text>
+  <text x="451" y="356" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="459" y="342" width="9" height="18" fill="#000000"/>
+  <text x="460" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="468" y="342" width="9" height="18" fill="#000000"/>
   <rect x="477" y="342" width="9" height="18" fill="#000000"/>
+  <text x="478" y="356" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="486" y="342" width="9" height="18" fill="#000000"/>
-  <text x="487" y="356" fill="#ffffff" class="terminal" style="">R</text>
+  <text x="487" y="356" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="495" y="342" width="9" height="18" fill="#000000"/>
-  <text x="496" y="356" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="496" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="504" y="342" width="9" height="18" fill="#000000"/>
-  <text x="505" y="356" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="505" y="356" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="513" y="342" width="9" height="18" fill="#000000"/>
+  <text x="514" y="356" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="522" y="342" width="9" height="18" fill="#000000"/>
-  <text x="523" y="356" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="531" y="342" width="9" height="18" fill="#000000"/>
-  <text x="532" y="356" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="532" y="356" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="540" y="342" width="9" height="18" fill="#000000"/>
-  <text x="541" y="356" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="541" y="356" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="549" y="342" width="9" height="18" fill="#000000"/>
-  <text x="550" y="356" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="550" y="356" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="558" y="342" width="9" height="18" fill="#000000"/>
-  <text x="559" y="356" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="559" y="356" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="567" y="342" width="9" height="18" fill="#000000"/>
+  <text x="568" y="356" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="576" y="342" width="9" height="18" fill="#000000"/>
-  <text x="577" y="356" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="577" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="585" y="342" width="9" height="18" fill="#000000"/>
-  <text x="586" y="356" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="586" y="356" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="594" y="342" width="9" height="18" fill="#000000"/>
-  <text x="595" y="356" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="603" y="342" width="9" height="18" fill="#000000"/>
-  <text x="604" y="356" fill="#ffffff" class="terminal" style="">m</text>
+  <text x="604" y="356" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="612" y="342" width="9" height="18" fill="#000000"/>
-  <text x="613" y="356" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="613" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="621" y="342" width="9" height="18" fill="#000000"/>
-  <text x="622" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="630" y="342" width="9" height="18" fill="#000000"/>
-  <text x="631" y="356" fill="#ffffff" class="terminal" style="">d</text>
+  <text x="631" y="356" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="639" y="342" width="9" height="18" fill="#000000"/>
+  <text x="640" y="356" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="648" y="342" width="9" height="18" fill="#000000"/>
-  <text x="649" y="356" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="649" y="356" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="657" y="342" width="9" height="18" fill="#000000"/>
-  <text x="658" y="356" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="658" y="356" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="666" y="342" width="9" height="18" fill="#000000"/>
+  <text x="667" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="675" y="342" width="9" height="18" fill="#000000"/>
-  <text x="676" y="356" fill="#ffffff" class="terminal" style="">b</text>
+  <text x="676" y="356" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="684" y="342" width="9" height="18" fill="#000000"/>
-  <text x="685" y="356" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="685" y="356" fill="#ffffff" class="terminal" style="">/</text>
   <rect x="693" y="342" width="9" height="18" fill="#000000"/>
-  <text x="694" y="356" fill="#ffffff" class="terminal" style="">f</text>
+  <text x="694" y="356" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="702" y="342" width="9" height="18" fill="#000000"/>
-  <text x="703" y="356" fill="#ffffff" class="terminal" style="">f</text>
+  <text x="703" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="711" y="342" width="9" height="18" fill="#000000"/>
-  <text x="712" y="356" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="712" y="356" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="720" y="342" width="9" height="18" fill="#000000"/>
-  <text x="721" y="356" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="721" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="729" y="342" width="9" height="18" fill="#000000"/>
-  <text x="730" y="356" fill="#ffffff" class="terminal" style="">/</text>
+  <text x="730" y="356" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="738" y="342" width="9" height="18" fill="#000000"/>
-  <text x="739" y="356" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="739" y="356" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="747" y="342" width="9" height="18" fill="#000000"/>
-  <text x="748" y="356" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="748" y="356" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="756" y="342" width="9" height="18" fill="#000000"/>
-  <text x="757" y="356" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="757" y="356" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="765" y="342" width="9" height="18" fill="#000000"/>
-  <text x="766" y="356" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="766" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="774" y="342" width="9" height="18" fill="#000000"/>
-  <text x="775" y="356" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="775" y="356" fill="#ffffff" class="terminal" style="">,</text>
   <rect x="783" y="342" width="9" height="18" fill="#000000"/>
-  <text x="784" y="356" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="792" y="342" width="9" height="18" fill="#000000"/>
-  <text x="793" y="356" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="793" y="356" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="801" y="342" width="9" height="18" fill="#000000"/>
-  <text x="802" y="356" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="802" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="810" y="342" width="9" height="18" fill="#000000"/>
-  <text x="811" y="356" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="811" y="356" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="819" y="342" width="9" height="18" fill="#000000"/>
-  <text x="820" y="356" fill="#ffffff" class="terminal" style="">,</text>
+  <text x="820" y="356" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="828" y="342" width="9" height="18" fill="#000000"/>
+  <text x="829" y="356" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="837" y="342" width="9" height="18" fill="#000000"/>
-  <text x="838" y="356" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="838" y="356" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="846" y="342" width="9" height="18" fill="#000000"/>
   <text x="847" y="356" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="855" y="342" width="9" height="18" fill="#000000"/>
-  <text x="856" y="356" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="864" y="342" width="9" height="18" fill="#000000"/>
-  <text x="865" y="356" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="865" y="356" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="873" y="342" width="9" height="18" fill="#000000"/>
-  <text x="874" y="356" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="874" y="356" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="882" y="342" width="9" height="18" fill="#000000"/>
-  <text x="883" y="356" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="883" y="356" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="891" y="342" width="9" height="18" fill="#000000"/>
   <text x="892" y="356" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="900" y="342" width="9" height="18" fill="#000000"/>
@@ -3178,8 +3180,7 @@
   <text x="1054" y="356" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="342" width="9" height="18" fill="#000000"/>
   <text x="1063" y="356" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="342" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="356" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="342" width="9" height="18" fill="#ffff00"/>
   <rect x="0" y="360" width="9" height="18" fill="#000000"/>
   <text x="1" y="374" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="360" width="9" height="18" fill="#000000"/>
@@ -3242,119 +3243,122 @@
   <rect x="297" y="360" width="9" height="18" fill="#000000"/>
   <rect x="306" y="360" width="9" height="18" fill="#000000"/>
   <rect x="315" y="360" width="9" height="18" fill="#000000"/>
+  <text x="316" y="374" fill="#8c8c8c" class="terminal" style="">A</text>
   <rect x="324" y="360" width="9" height="18" fill="#000000"/>
+  <text x="325" y="374" fill="#8c8c8c" class="terminal" style="">l</text>
   <rect x="333" y="360" width="9" height="18" fill="#000000"/>
+  <text x="334" y="374" fill="#8c8c8c" class="terminal" style="">t</text>
   <rect x="342" y="360" width="9" height="18" fill="#000000"/>
+  <text x="343" y="374" fill="#8c8c8c" class="terminal" style="">+</text>
   <rect x="351" y="360" width="9" height="18" fill="#000000"/>
+  <text x="352" y="374" fill="#8c8c8c" class="terminal" style="">A</text>
   <rect x="360" y="360" width="9" height="18" fill="#000000"/>
-  <text x="361" y="374" fill="#8c8c8c" class="terminal" style="">A</text>
   <rect x="369" y="360" width="9" height="18" fill="#000000"/>
-  <text x="370" y="374" fill="#8c8c8c" class="terminal" style="">l</text>
   <rect x="378" y="360" width="9" height="18" fill="#000000"/>
-  <text x="379" y="374" fill="#8c8c8c" class="terminal" style="">t</text>
   <rect x="387" y="360" width="9" height="18" fill="#000000"/>
-  <text x="388" y="374" fill="#8c8c8c" class="terminal" style="">+</text>
   <rect x="396" y="360" width="9" height="18" fill="#000000"/>
-  <text x="397" y="374" fill="#8c8c8c" class="terminal" style="">A</text>
   <rect x="405" y="360" width="9" height="18" fill="#000000"/>
   <rect x="414" y="360" width="9" height="18" fill="#000000"/>
   <rect x="423" y="360" width="9" height="18" fill="#000000"/>
   <rect x="432" y="360" width="9" height="18" fill="#000000"/>
   <rect x="441" y="360" width="9" height="18" fill="#000000"/>
+  <text x="442" y="374" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="450" y="360" width="9" height="18" fill="#000000"/>
+  <text x="451" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="459" y="360" width="9" height="18" fill="#000000"/>
+  <text x="460" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="468" y="360" width="9" height="18" fill="#000000"/>
+  <text x="469" y="374" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="477" y="360" width="9" height="18" fill="#000000"/>
+  <text x="478" y="374" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="486" y="360" width="9" height="18" fill="#000000"/>
-  <text x="487" y="374" fill="#ffffff" class="terminal" style="">S</text>
+  <text x="487" y="374" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="495" y="360" width="9" height="18" fill="#000000"/>
-  <text x="496" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="504" y="360" width="9" height="18" fill="#000000"/>
   <text x="505" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="513" y="360" width="9" height="18" fill="#000000"/>
-  <text x="514" y="374" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="514" y="374" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="522" y="360" width="9" height="18" fill="#000000"/>
-  <text x="523" y="374" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="523" y="374" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="531" y="360" width="9" height="18" fill="#000000"/>
-  <text x="532" y="374" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="540" y="360" width="9" height="18" fill="#000000"/>
+  <text x="541" y="374" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="549" y="360" width="9" height="18" fill="#000000"/>
-  <text x="550" y="374" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="550" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="558" y="360" width="9" height="18" fill="#000000"/>
-  <text x="559" y="374" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="559" y="374" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="567" y="360" width="9" height="18" fill="#000000"/>
-  <text x="568" y="374" fill="#ffffff" class="terminal" style="">d</text>
+  <text x="568" y="374" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="576" y="360" width="9" height="18" fill="#000000"/>
+  <text x="577" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="585" y="360" width="9" height="18" fill="#000000"/>
-  <text x="586" y="374" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="586" y="374" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="594" y="360" width="9" height="18" fill="#000000"/>
   <text x="595" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="603" y="360" width="9" height="18" fill="#000000"/>
-  <text x="604" y="374" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="612" y="360" width="9" height="18" fill="#000000"/>
-  <text x="613" y="374" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="613" y="374" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="621" y="360" width="9" height="18" fill="#000000"/>
-  <text x="622" y="374" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="622" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="630" y="360" width="9" height="18" fill="#000000"/>
-  <text x="631" y="374" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="631" y="374" fill="#ffffff" class="terminal" style="">x</text>
   <rect x="639" y="360" width="9" height="18" fill="#000000"/>
-  <text x="640" y="374" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="640" y="374" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="648" y="360" width="9" height="18" fill="#000000"/>
   <rect x="657" y="360" width="9" height="18" fill="#000000"/>
-  <text x="658" y="374" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="658" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="666" y="360" width="9" height="18" fill="#000000"/>
-  <text x="667" y="374" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="667" y="374" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="675" y="360" width="9" height="18" fill="#000000"/>
-  <text x="676" y="374" fill="#ffffff" class="terminal" style="">x</text>
+  <text x="676" y="374" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="684" y="360" width="9" height="18" fill="#000000"/>
-  <text x="685" y="374" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="685" y="374" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="693" y="360" width="9" height="18" fill="#000000"/>
+  <text x="694" y="374" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="702" y="360" width="9" height="18" fill="#000000"/>
-  <text x="703" y="374" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="703" y="374" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="711" y="360" width="9" height="18" fill="#000000"/>
-  <text x="712" y="374" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="720" y="360" width="9" height="18" fill="#000000"/>
-  <text x="721" y="374" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="721" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="729" y="360" width="9" height="18" fill="#000000"/>
-  <text x="730" y="374" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="730" y="374" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="738" y="360" width="9" height="18" fill="#000000"/>
-  <text x="739" y="374" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="739" y="374" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="747" y="360" width="9" height="18" fill="#000000"/>
-  <text x="748" y="374" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="756" y="360" width="9" height="18" fill="#000000"/>
+  <text x="757" y="374" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="765" y="360" width="9" height="18" fill="#000000"/>
-  <text x="766" y="374" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="766" y="374" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="774" y="360" width="9" height="18" fill="#000000"/>
-  <text x="775" y="374" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="775" y="374" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="783" y="360" width="9" height="18" fill="#000000"/>
-  <text x="784" y="374" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="784" y="374" fill="#ffffff" class="terminal" style="">-</text>
   <rect x="792" y="360" width="9" height="18" fill="#000000"/>
+  <text x="793" y="374" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="801" y="360" width="9" height="18" fill="#000000"/>
-  <text x="802" y="374" fill="#ffffff" class="terminal" style="">g</text>
+  <text x="802" y="374" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="810" y="360" width="9" height="18" fill="#000000"/>
-  <text x="811" y="374" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="811" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="819" y="360" width="9" height="18" fill="#000000"/>
-  <text x="820" y="374" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="820" y="374" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="828" y="360" width="9" height="18" fill="#000000"/>
-  <text x="829" y="374" fill="#ffffff" class="terminal" style="">-</text>
+  <text x="829" y="374" fill="#ffffff" class="terminal" style="">k</text>
   <rect x="837" y="360" width="9" height="18" fill="#000000"/>
-  <text x="838" y="374" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="838" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="846" y="360" width="9" height="18" fill="#000000"/>
-  <text x="847" y="374" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="847" y="374" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="855" y="360" width="9" height="18" fill="#000000"/>
-  <text x="856" y="374" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="864" y="360" width="9" height="18" fill="#000000"/>
-  <text x="865" y="374" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="865" y="374" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="873" y="360" width="9" height="18" fill="#000000"/>
-  <text x="874" y="374" fill="#ffffff" class="terminal" style="">k</text>
+  <text x="874" y="374" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="882" y="360" width="9" height="18" fill="#000000"/>
-  <text x="883" y="374" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="883" y="374" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="891" y="360" width="9" height="18" fill="#000000"/>
-  <text x="892" y="374" fill="#ffffff" class="terminal" style="">.</text>
+  <text x="892" y="374" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="900" y="360" width="9" height="18" fill="#000000"/>
-  <text x="901" y="374" fill="#ffffff" class="terminal" style="">.</text>
+  <text x="901" y="374" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="909" y="360" width="9" height="18" fill="#000000"/>
-  <text x="910" y="374" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="918" y="360" width="9" height="18" fill="#000000"/>
   <rect x="927" y="360" width="9" height="18" fill="#000000"/>
   <rect x="936" y="360" width="9" height="18" fill="#000000"/>
@@ -3386,8 +3390,7 @@
   <text x="1054" y="374" fill="#8c8c8c" class="terminal" style="">c</text>
   <rect x="1062" y="360" width="9" height="18" fill="#000000"/>
   <text x="1063" y="374" fill="#8c8c8c" class="terminal" style="">e</text>
-  <rect x="1071" y="360" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="374" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="360" width="9" height="18" fill="#505050"/>
   <rect x="0" y="378" width="9" height="18" fill="#000000"/>
   <text x="1" y="392" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="378" width="9" height="18" fill="#000000"/>
@@ -3435,14 +3438,14 @@
   <rect x="297" y="378" width="9" height="18" fill="#000000"/>
   <rect x="306" y="378" width="9" height="18" fill="#000000"/>
   <rect x="315" y="378" width="9" height="18" fill="#000000"/>
+  <text x="316" y="392" fill="#8c8c8c" class="terminal" style="">F</text>
   <rect x="324" y="378" width="9" height="18" fill="#000000"/>
+  <text x="325" y="392" fill="#8c8c8c" class="terminal" style="">1</text>
   <rect x="333" y="378" width="9" height="18" fill="#000000"/>
   <rect x="342" y="378" width="9" height="18" fill="#000000"/>
   <rect x="351" y="378" width="9" height="18" fill="#000000"/>
   <rect x="360" y="378" width="9" height="18" fill="#000000"/>
-  <text x="361" y="392" fill="#8c8c8c" class="terminal" style="">F</text>
   <rect x="369" y="378" width="9" height="18" fill="#000000"/>
-  <text x="370" y="392" fill="#8c8c8c" class="terminal" style="">1</text>
   <rect x="378" y="378" width="9" height="18" fill="#000000"/>
   <rect x="387" y="378" width="9" height="18" fill="#000000"/>
   <rect x="396" y="378" width="9" height="18" fill="#000000"/>
@@ -3451,47 +3454,47 @@
   <rect x="423" y="378" width="9" height="18" fill="#000000"/>
   <rect x="432" y="378" width="9" height="18" fill="#000000"/>
   <rect x="441" y="378" width="9" height="18" fill="#000000"/>
+  <text x="442" y="392" fill="#ffffff" class="terminal" style="">O</text>
   <rect x="450" y="378" width="9" height="18" fill="#000000"/>
+  <text x="451" y="392" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="459" y="378" width="9" height="18" fill="#000000"/>
+  <text x="460" y="392" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="468" y="378" width="9" height="18" fill="#000000"/>
+  <text x="469" y="392" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="477" y="378" width="9" height="18" fill="#000000"/>
   <rect x="486" y="378" width="9" height="18" fill="#000000"/>
-  <text x="487" y="392" fill="#ffffff" class="terminal" style="">O</text>
+  <text x="487" y="392" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="495" y="378" width="9" height="18" fill="#000000"/>
-  <text x="496" y="392" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="496" y="392" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="504" y="378" width="9" height="18" fill="#000000"/>
   <text x="505" y="392" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="513" y="378" width="9" height="18" fill="#000000"/>
-  <text x="514" y="392" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="522" y="378" width="9" height="18" fill="#000000"/>
+  <text x="523" y="392" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="531" y="378" width="9" height="18" fill="#000000"/>
-  <text x="532" y="392" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="532" y="392" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="540" y="378" width="9" height="18" fill="#000000"/>
-  <text x="541" y="392" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="541" y="392" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="549" y="378" width="9" height="18" fill="#000000"/>
-  <text x="550" y="392" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="550" y="392" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="558" y="378" width="9" height="18" fill="#000000"/>
   <rect x="567" y="378" width="9" height="18" fill="#000000"/>
-  <text x="568" y="392" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="568" y="392" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="576" y="378" width="9" height="18" fill="#000000"/>
-  <text x="577" y="392" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="577" y="392" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="585" y="378" width="9" height="18" fill="#000000"/>
-  <text x="586" y="392" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="586" y="392" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="594" y="378" width="9" height="18" fill="#000000"/>
-  <text x="595" y="392" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="595" y="392" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="603" y="378" width="9" height="18" fill="#000000"/>
+  <text x="604" y="392" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="612" y="378" width="9" height="18" fill="#000000"/>
-  <text x="613" y="392" fill="#ffffff" class="terminal" style="">m</text>
+  <text x="613" y="392" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="621" y="378" width="9" height="18" fill="#000000"/>
-  <text x="622" y="392" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="630" y="378" width="9" height="18" fill="#000000"/>
-  <text x="631" y="392" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="639" y="378" width="9" height="18" fill="#000000"/>
-  <text x="640" y="392" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="648" y="378" width="9" height="18" fill="#000000"/>
-  <text x="649" y="392" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="657" y="378" width="9" height="18" fill="#000000"/>
-  <text x="658" y="392" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="666" y="378" width="9" height="18" fill="#000000"/>
   <rect x="675" y="378" width="9" height="18" fill="#000000"/>
   <rect x="684" y="378" width="9" height="18" fill="#000000"/>
@@ -3544,8 +3547,7 @@
   <text x="1054" y="392" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="378" width="9" height="18" fill="#000000"/>
   <text x="1063" y="392" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="378" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="392" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="378" width="9" height="18" fill="#505050"/>
   <rect x="0" y="396" width="9" height="18" fill="#000000"/>
   <text x="1" y="410" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="396" width="9" height="18" fill="#000000"/>
@@ -3609,52 +3611,52 @@
   <rect x="423" y="396" width="9" height="18" fill="#000000"/>
   <rect x="432" y="396" width="9" height="18" fill="#000000"/>
   <rect x="441" y="396" width="9" height="18" fill="#000000"/>
+  <text x="442" y="410" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="450" y="396" width="9" height="18" fill="#000000"/>
+  <text x="451" y="410" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="459" y="396" width="9" height="18" fill="#000000"/>
+  <text x="460" y="410" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="468" y="396" width="9" height="18" fill="#000000"/>
+  <text x="469" y="410" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="477" y="396" width="9" height="18" fill="#000000"/>
+  <text x="478" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="486" y="396" width="9" height="18" fill="#000000"/>
-  <text x="487" y="410" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="495" y="396" width="9" height="18" fill="#000000"/>
-  <text x="496" y="410" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="496" y="410" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="504" y="396" width="9" height="18" fill="#000000"/>
-  <text x="505" y="410" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="505" y="410" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="513" y="396" width="9" height="18" fill="#000000"/>
-  <text x="514" y="410" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="514" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="522" y="396" width="9" height="18" fill="#000000"/>
-  <text x="523" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="531" y="396" width="9" height="18" fill="#000000"/>
+  <text x="532" y="410" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="540" y="396" width="9" height="18" fill="#000000"/>
-  <text x="541" y="410" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="541" y="410" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="549" y="396" width="9" height="18" fill="#000000"/>
-  <text x="550" y="410" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="550" y="410" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="558" y="396" width="9" height="18" fill="#000000"/>
-  <text x="559" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="567" y="396" width="9" height="18" fill="#000000"/>
+  <text x="568" y="410" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="576" y="396" width="9" height="18" fill="#000000"/>
-  <text x="577" y="410" fill="#ffffff" class="terminal" style="">g</text>
+  <text x="577" y="410" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="585" y="396" width="9" height="18" fill="#000000"/>
-  <text x="586" y="410" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="586" y="410" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="594" y="396" width="9" height="18" fill="#000000"/>
-  <text x="595" y="410" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="603" y="396" width="9" height="18" fill="#000000"/>
+  <text x="604" y="410" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="612" y="396" width="9" height="18" fill="#000000"/>
-  <text x="613" y="410" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="613" y="410" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="621" y="396" width="9" height="18" fill="#000000"/>
-  <text x="622" y="410" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="622" y="410" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="630" y="396" width="9" height="18" fill="#000000"/>
-  <text x="631" y="410" fill="#ffffff" class="terminal" style="">g</text>
+  <text x="631" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="639" y="396" width="9" height="18" fill="#000000"/>
+  <text x="640" y="410" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="648" y="396" width="9" height="18" fill="#000000"/>
-  <text x="649" y="410" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="657" y="396" width="9" height="18" fill="#000000"/>
-  <text x="658" y="410" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="666" y="396" width="9" height="18" fill="#000000"/>
-  <text x="667" y="410" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="675" y="396" width="9" height="18" fill="#000000"/>
-  <text x="676" y="410" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="684" y="396" width="9" height="18" fill="#000000"/>
-  <text x="685" y="410" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="693" y="396" width="9" height="18" fill="#000000"/>
   <rect x="702" y="396" width="9" height="18" fill="#000000"/>
   <rect x="711" y="396" width="9" height="18" fill="#000000"/>
@@ -3704,8 +3706,7 @@
   <text x="1054" y="410" fill="#8c8c8c" class="terminal" style="">o</text>
   <rect x="1062" y="396" width="9" height="18" fill="#000000"/>
   <text x="1063" y="410" fill="#8c8c8c" class="terminal" style="">g</text>
-  <rect x="1071" y="396" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="410" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="396" width="9" height="18" fill="#505050"/>
   <rect x="0" y="414" width="9" height="18" fill="#000000"/>
   <text x="1" y="428" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="414" width="9" height="18" fill="#000000"/>
@@ -3773,92 +3774,97 @@
   <rect x="423" y="414" width="9" height="18" fill="#000000"/>
   <rect x="432" y="414" width="9" height="18" fill="#000000"/>
   <rect x="441" y="414" width="9" height="18" fill="#000000"/>
+  <text x="442" y="428" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="450" y="414" width="9" height="18" fill="#000000"/>
+  <text x="451" y="428" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="459" y="414" width="9" height="18" fill="#000000"/>
+  <text x="460" y="428" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="468" y="414" width="9" height="18" fill="#000000"/>
+  <text x="469" y="428" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="477" y="414" width="9" height="18" fill="#000000"/>
   <rect x="486" y="414" width="9" height="18" fill="#000000"/>
-  <text x="487" y="428" fill="#ffffff" class="terminal" style="">S</text>
+  <text x="487" y="428" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="495" y="414" width="9" height="18" fill="#000000"/>
-  <text x="496" y="428" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="496" y="428" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="504" y="414" width="9" height="18" fill="#000000"/>
-  <text x="505" y="428" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="513" y="414" width="9" height="18" fill="#000000"/>
-  <text x="514" y="428" fill="#ffffff" class="terminal" style="">w</text>
+  <text x="514" y="428" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="522" y="414" width="9" height="18" fill="#000000"/>
+  <text x="523" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="531" y="414" width="9" height="18" fill="#000000"/>
-  <text x="532" y="428" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="532" y="428" fill="#ffffff" class="terminal" style="">d</text>
   <rect x="540" y="414" width="9" height="18" fill="#000000"/>
-  <text x="541" y="428" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="541" y="428" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="549" y="414" width="9" height="18" fill="#000000"/>
   <rect x="558" y="414" width="9" height="18" fill="#000000"/>
-  <text x="559" y="428" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="559" y="428" fill="#ffffff" class="terminal" style="">L</text>
   <rect x="567" y="414" width="9" height="18" fill="#000000"/>
-  <text x="568" y="428" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="568" y="428" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="576" y="414" width="9" height="18" fill="#000000"/>
-  <text x="577" y="428" fill="#ffffff" class="terminal" style="">d</text>
+  <text x="577" y="428" fill="#ffffff" class="terminal" style="">P</text>
   <rect x="585" y="414" width="9" height="18" fill="#000000"/>
-  <text x="586" y="428" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="594" y="414" width="9" height="18" fill="#000000"/>
+  <text x="595" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="603" y="414" width="9" height="18" fill="#000000"/>
-  <text x="604" y="428" fill="#ffffff" class="terminal" style="">L</text>
+  <text x="604" y="428" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="612" y="414" width="9" height="18" fill="#000000"/>
-  <text x="613" y="428" fill="#ffffff" class="terminal" style="">S</text>
+  <text x="613" y="428" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="621" y="414" width="9" height="18" fill="#000000"/>
-  <text x="622" y="428" fill="#ffffff" class="terminal" style="">P</text>
+  <text x="622" y="428" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="630" y="414" width="9" height="18" fill="#000000"/>
+  <text x="631" y="428" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="639" y="414" width="9" height="18" fill="#000000"/>
-  <text x="640" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="648" y="414" width="9" height="18" fill="#000000"/>
-  <text x="649" y="428" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="649" y="428" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="657" y="414" width="9" height="18" fill="#000000"/>
-  <text x="658" y="428" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="658" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="666" y="414" width="9" height="18" fill="#000000"/>
-  <text x="667" y="428" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="667" y="428" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="675" y="414" width="9" height="18" fill="#000000"/>
-  <text x="676" y="428" fill="#ffffff" class="terminal" style="">y</text>
+  <text x="676" y="428" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="684" y="414" width="9" height="18" fill="#000000"/>
+  <text x="685" y="428" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="693" y="414" width="9" height="18" fill="#000000"/>
-  <text x="694" y="428" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="702" y="414" width="9" height="18" fill="#000000"/>
-  <text x="703" y="428" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="703" y="428" fill="#ffffff" class="terminal" style="">(</text>
   <rect x="711" y="414" width="9" height="18" fill="#000000"/>
-  <text x="712" y="428" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="712" y="428" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="720" y="414" width="9" height="18" fill="#000000"/>
-  <text x="721" y="428" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="721" y="428" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="729" y="414" width="9" height="18" fill="#000000"/>
-  <text x="730" y="428" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="730" y="428" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="738" y="414" width="9" height="18" fill="#000000"/>
+  <text x="739" y="428" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="747" y="414" width="9" height="18" fill="#000000"/>
-  <text x="748" y="428" fill="#ffffff" class="terminal" style="">(</text>
   <rect x="756" y="414" width="9" height="18" fill="#000000"/>
-  <text x="757" y="428" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="757" y="428" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="765" y="414" width="9" height="18" fill="#000000"/>
-  <text x="766" y="428" fill="#ffffff" class="terminal" style="">y</text>
+  <text x="766" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="774" y="414" width="9" height="18" fill="#000000"/>
-  <text x="775" y="428" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="775" y="428" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="783" y="414" width="9" height="18" fill="#000000"/>
-  <text x="784" y="428" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="784" y="428" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="792" y="414" width="9" height="18" fill="#000000"/>
+  <text x="793" y="428" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="801" y="414" width="9" height="18" fill="#000000"/>
-  <text x="802" y="428" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="802" y="428" fill="#ffffff" class="terminal" style="">,</text>
   <rect x="810" y="414" width="9" height="18" fill="#000000"/>
-  <text x="811" y="428" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="819" y="414" width="9" height="18" fill="#000000"/>
-  <text x="820" y="428" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="820" y="428" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="828" y="414" width="9" height="18" fill="#000000"/>
-  <text x="829" y="428" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="829" y="428" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="837" y="414" width="9" height="18" fill="#000000"/>
-  <text x="838" y="428" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="838" y="428" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="846" y="414" width="9" height="18" fill="#000000"/>
-  <text x="847" y="428" fill="#ffffff" class="terminal" style="">,</text>
+  <text x="847" y="428" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="855" y="414" width="9" height="18" fill="#000000"/>
+  <text x="856" y="428" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="864" y="414" width="9" height="18" fill="#000000"/>
-  <text x="865" y="428" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="865" y="428" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="873" y="414" width="9" height="18" fill="#000000"/>
-  <text x="874" y="428" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="874" y="428" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="882" y="414" width="9" height="18" fill="#000000"/>
-  <text x="883" y="428" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="883" y="428" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="891" y="414" width="9" height="18" fill="#000000"/>
   <text x="892" y="428" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="900" y="414" width="9" height="18" fill="#000000"/>
@@ -3889,8 +3895,7 @@
   <text x="1054" y="428" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="414" width="9" height="18" fill="#000000"/>
   <text x="1063" y="428" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="414" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="428" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="414" width="9" height="18" fill="#505050"/>
   <rect x="0" y="432" width="9" height="18" fill="#000000"/>
   <text x="1" y="446" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="432" width="9" height="18" fill="#000000"/>
@@ -3964,92 +3969,96 @@
   <rect x="423" y="432" width="9" height="18" fill="#000000"/>
   <rect x="432" y="432" width="9" height="18" fill="#000000"/>
   <rect x="441" y="432" width="9" height="18" fill="#000000"/>
+  <text x="442" y="446" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="450" y="432" width="9" height="18" fill="#000000"/>
+  <text x="451" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="459" y="432" width="9" height="18" fill="#000000"/>
+  <text x="460" y="446" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="468" y="432" width="9" height="18" fill="#000000"/>
+  <text x="469" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="477" y="432" width="9" height="18" fill="#000000"/>
+  <text x="478" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="486" y="432" width="9" height="18" fill="#000000"/>
-  <text x="487" y="446" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="495" y="432" width="9" height="18" fill="#000000"/>
-  <text x="496" y="446" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="496" y="446" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="504" y="432" width="9" height="18" fill="#000000"/>
-  <text x="505" y="446" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="505" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="513" y="432" width="9" height="18" fill="#000000"/>
-  <text x="514" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="522" y="432" width="9" height="18" fill="#000000"/>
-  <text x="523" y="446" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="523" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="531" y="432" width="9" height="18" fill="#000000"/>
+  <text x="532" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="540" y="432" width="9" height="18" fill="#000000"/>
-  <text x="541" y="446" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="541" y="446" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="549" y="432" width="9" height="18" fill="#000000"/>
-  <text x="550" y="446" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="550" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="558" y="432" width="9" height="18" fill="#000000"/>
+  <text x="559" y="446" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="567" y="432" width="9" height="18" fill="#000000"/>
   <text x="568" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="576" y="432" width="9" height="18" fill="#000000"/>
-  <text x="577" y="446" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="577" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="585" y="432" width="9" height="18" fill="#000000"/>
-  <text x="586" y="446" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="594" y="432" width="9" height="18" fill="#000000"/>
   <text x="595" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="603" y="432" width="9" height="18" fill="#000000"/>
-  <text x="604" y="446" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="604" y="446" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="612" y="432" width="9" height="18" fill="#000000"/>
-  <text x="613" y="446" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="613" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="621" y="432" width="9" height="18" fill="#000000"/>
-  <text x="622" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="630" y="432" width="9" height="18" fill="#000000"/>
+  <text x="631" y="446" fill="#ffffff" class="terminal" style="">L</text>
   <rect x="639" y="432" width="9" height="18" fill="#000000"/>
-  <text x="640" y="446" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="640" y="446" fill="#ffffff" class="terminal" style="">S</text>
   <rect x="648" y="432" width="9" height="18" fill="#000000"/>
-  <text x="649" y="446" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="649" y="446" fill="#ffffff" class="terminal" style="">P</text>
   <rect x="657" y="432" width="9" height="18" fill="#000000"/>
-  <text x="658" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="666" y="432" width="9" height="18" fill="#000000"/>
+  <text x="667" y="446" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="675" y="432" width="9" height="18" fill="#000000"/>
-  <text x="676" y="446" fill="#ffffff" class="terminal" style="">L</text>
+  <text x="676" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="684" y="432" width="9" height="18" fill="#000000"/>
-  <text x="685" y="446" fill="#ffffff" class="terminal" style="">S</text>
+  <text x="685" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="693" y="432" width="9" height="18" fill="#000000"/>
-  <text x="694" y="446" fill="#ffffff" class="terminal" style="">P</text>
+  <text x="694" y="446" fill="#ffffff" class="terminal" style="">v</text>
   <rect x="702" y="432" width="9" height="18" fill="#000000"/>
+  <text x="703" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="711" y="432" width="9" height="18" fill="#000000"/>
-  <text x="712" y="446" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="712" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="720" y="432" width="9" height="18" fill="#000000"/>
-  <text x="721" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="729" y="432" width="9" height="18" fill="#000000"/>
-  <text x="730" y="446" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="730" y="446" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="738" y="432" width="9" height="18" fill="#000000"/>
-  <text x="739" y="446" fill="#ffffff" class="terminal" style="">v</text>
+  <text x="739" y="446" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="747" y="432" width="9" height="18" fill="#000000"/>
-  <text x="748" y="446" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="748" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="756" y="432" width="9" height="18" fill="#000000"/>
-  <text x="757" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="765" y="432" width="9" height="18" fill="#000000"/>
+  <text x="766" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="774" y="432" width="9" height="18" fill="#000000"/>
-  <text x="775" y="446" fill="#ffffff" class="terminal" style="">f</text>
+  <text x="775" y="446" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="783" y="432" width="9" height="18" fill="#000000"/>
-  <text x="784" y="446" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="784" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="792" y="432" width="9" height="18" fill="#000000"/>
-  <text x="793" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="801" y="432" width="9" height="18" fill="#000000"/>
+  <text x="802" y="446" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="810" y="432" width="9" height="18" fill="#000000"/>
-  <text x="811" y="446" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="811" y="446" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="819" y="432" width="9" height="18" fill="#000000"/>
-  <text x="820" y="446" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="820" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="828" y="432" width="9" height="18" fill="#000000"/>
-  <text x="829" y="446" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="829" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="837" y="432" width="9" height="18" fill="#000000"/>
+  <text x="838" y="446" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="846" y="432" width="9" height="18" fill="#000000"/>
-  <text x="847" y="446" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="847" y="446" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="855" y="432" width="9" height="18" fill="#000000"/>
-  <text x="856" y="446" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="856" y="446" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="864" y="432" width="9" height="18" fill="#000000"/>
-  <text x="865" y="446" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="873" y="432" width="9" height="18" fill="#000000"/>
-  <text x="874" y="446" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="874" y="446" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="882" y="432" width="9" height="18" fill="#000000"/>
-  <text x="883" y="446" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="883" y="446" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="891" y="432" width="9" height="18" fill="#000000"/>
   <text x="892" y="446" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="900" y="432" width="9" height="18" fill="#000000"/>
@@ -4080,8 +4089,7 @@
   <text x="1054" y="446" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="432" width="9" height="18" fill="#000000"/>
   <text x="1063" y="446" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="432" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="446" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="432" width="9" height="18" fill="#505050"/>
   <rect x="0" y="450" width="9" height="18" fill="#000000"/>
   <text x="1" y="464" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="450" width="9" height="18" fill="#000000"/>
@@ -4145,93 +4153,97 @@
   <rect x="423" y="450" width="9" height="18" fill="#000000"/>
   <rect x="432" y="450" width="9" height="18" fill="#000000"/>
   <rect x="441" y="450" width="9" height="18" fill="#000000"/>
+  <text x="442" y="464" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="450" y="450" width="9" height="18" fill="#000000"/>
+  <text x="451" y="464" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="459" y="450" width="9" height="18" fill="#000000"/>
+  <text x="460" y="464" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="468" y="450" width="9" height="18" fill="#000000"/>
+  <text x="469" y="464" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="477" y="450" width="9" height="18" fill="#000000"/>
   <rect x="486" y="450" width="9" height="18" fill="#000000"/>
-  <text x="487" y="464" fill="#ffffff" class="terminal" style="">C</text>
+  <text x="487" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="495" y="450" width="9" height="18" fill="#000000"/>
-  <text x="496" y="464" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="496" y="464" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="504" y="450" width="9" height="18" fill="#000000"/>
-  <text x="505" y="464" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="505" y="464" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="513" y="450" width="9" height="18" fill="#000000"/>
-  <text x="514" y="464" fill="#ffffff" class="terminal" style="">y</text>
   <rect x="522" y="450" width="9" height="18" fill="#000000"/>
+  <text x="523" y="464" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="531" y="450" width="9" height="18" fill="#000000"/>
-  <text x="532" y="464" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="532" y="464" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="540" y="450" width="9" height="18" fill="#000000"/>
-  <text x="541" y="464" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="541" y="464" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="549" y="450" width="9" height="18" fill="#000000"/>
-  <text x="550" y="464" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="550" y="464" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="558" y="450" width="9" height="18" fill="#000000"/>
+  <text x="559" y="464" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="567" y="450" width="9" height="18" fill="#000000"/>
-  <text x="568" y="464" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="568" y="464" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="576" y="450" width="9" height="18" fill="#000000"/>
-  <text x="577" y="464" fill="#ffffff" class="terminal" style="">b</text>
+  <text x="577" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="585" y="450" width="9" height="18" fill="#000000"/>
-  <text x="586" y="464" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="586" y="464" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="594" y="450" width="9" height="18" fill="#000000"/>
-  <text x="595" y="464" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="603" y="450" width="9" height="18" fill="#000000"/>
-  <text x="604" y="464" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="604" y="464" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="612" y="450" width="9" height="18" fill="#000000"/>
-  <text x="613" y="464" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="613" y="464" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="621" y="450" width="9" height="18" fill="#000000"/>
   <text x="622" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="630" y="450" width="9" height="18" fill="#000000"/>
-  <text x="631" y="464" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="631" y="464" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="639" y="450" width="9" height="18" fill="#000000"/>
   <rect x="648" y="450" width="9" height="18" fill="#000000"/>
-  <text x="649" y="464" fill="#ffffff" class="terminal" style="">p</text>
+  <text x="649" y="464" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="657" y="450" width="9" height="18" fill="#000000"/>
-  <text x="658" y="464" fill="#ffffff" class="terminal" style="">a</text>
+  <text x="658" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="666" y="450" width="9" height="18" fill="#000000"/>
-  <text x="667" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="675" y="450" width="9" height="18" fill="#000000"/>
-  <text x="676" y="464" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="676" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="684" y="450" width="9" height="18" fill="#000000"/>
+  <text x="685" y="464" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="693" y="450" width="9" height="18" fill="#000000"/>
-  <text x="694" y="464" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="694" y="464" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="702" y="450" width="9" height="18" fill="#000000"/>
-  <text x="703" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="711" y="450" width="9" height="18" fill="#000000"/>
+  <text x="712" y="464" fill="#ffffff" class="terminal" style="">c</text>
   <rect x="720" y="450" width="9" height="18" fill="#000000"/>
-  <text x="721" y="464" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="721" y="464" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="729" y="450" width="9" height="18" fill="#000000"/>
-  <text x="730" y="464" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="730" y="464" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="738" y="450" width="9" height="18" fill="#000000"/>
-  <text x="739" y="464" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="739" y="464" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="747" y="450" width="9" height="18" fill="#000000"/>
+  <text x="748" y="464" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="756" y="450" width="9" height="18" fill="#000000"/>
-  <text x="757" y="464" fill="#ffffff" class="terminal" style="">c</text>
+  <text x="757" y="464" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="765" y="450" width="9" height="18" fill="#000000"/>
-  <text x="766" y="464" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="766" y="464" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="774" y="450" width="9" height="18" fill="#000000"/>
-  <text x="775" y="464" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="783" y="450" width="9" height="18" fill="#000000"/>
-  <text x="784" y="464" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="784" y="464" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="792" y="450" width="9" height="18" fill="#000000"/>
-  <text x="793" y="464" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="793" y="464" fill="#ffffff" class="terminal" style="">u</text>
   <rect x="801" y="450" width="9" height="18" fill="#000000"/>
-  <text x="802" y="464" fill="#ffffff" class="terminal" style="">n</text>
+  <text x="802" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="810" y="450" width="9" height="18" fill="#000000"/>
-  <text x="811" y="464" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="811" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="819" y="450" width="9" height="18" fill="#000000"/>
+  <text x="820" y="464" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="828" y="450" width="9" height="18" fill="#000000"/>
-  <text x="829" y="464" fill="#ffffff" class="terminal" style="">b</text>
+  <text x="829" y="464" fill="#ffffff" class="terminal" style="">r</text>
   <rect x="837" y="450" width="9" height="18" fill="#000000"/>
-  <text x="838" y="464" fill="#ffffff" class="terminal" style="">u</text>
+  <text x="838" y="464" fill="#ffffff" class="terminal" style="">&apos;</text>
   <rect x="846" y="450" width="9" height="18" fill="#000000"/>
-  <text x="847" y="464" fill="#ffffff" class="terminal" style="">f</text>
+  <text x="847" y="464" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="855" y="450" width="9" height="18" fill="#000000"/>
-  <text x="856" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="864" y="450" width="9" height="18" fill="#000000"/>
-  <text x="865" y="464" fill="#ffffff" class="terminal" style="">e</text>
+  <text x="865" y="464" fill="#ffffff" class="terminal" style="">f</text>
   <rect x="873" y="450" width="9" height="18" fill="#000000"/>
-  <text x="874" y="464" fill="#ffffff" class="terminal" style="">r</text>
+  <text x="874" y="464" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="882" y="450" width="9" height="18" fill="#000000"/>
-  <text x="883" y="464" fill="#ffffff" class="terminal" style="">&apos;</text>
+  <text x="883" y="464" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="891" y="450" width="9" height="18" fill="#000000"/>
   <text x="892" y="464" fill="#ffffff" class="terminal" style="">.</text>
   <rect x="900" y="450" width="9" height="18" fill="#000000"/>
@@ -4262,8 +4274,7 @@
   <text x="1054" y="464" fill="#8c8c8c" class="terminal" style="">i</text>
   <rect x="1062" y="450" width="9" height="18" fill="#000000"/>
   <text x="1063" y="464" fill="#8c8c8c" class="terminal" style="">n</text>
-  <rect x="1071" y="450" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="464" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="450" width="9" height="18" fill="#505050"/>
   <rect x="0" y="468" width="9" height="18" fill="#000000"/>
   <text x="1" y="482" fill="#00ffff" class="terminal" style="">│</text>
   <rect x="9" y="468" width="9" height="18" fill="#000000"/>
@@ -4329,56 +4340,56 @@
   <rect x="423" y="468" width="9" height="18" fill="#000000"/>
   <rect x="432" y="468" width="9" height="18" fill="#000000"/>
   <rect x="441" y="468" width="9" height="18" fill="#000000"/>
+  <text x="442" y="482" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="450" y="468" width="9" height="18" fill="#000000"/>
+  <text x="451" y="482" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="459" y="468" width="9" height="18" fill="#000000"/>
+  <text x="460" y="482" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="468" y="468" width="9" height="18" fill="#000000"/>
+  <text x="469" y="482" fill="#ffffff" class="terminal" style="">s</text>
   <rect x="477" y="468" width="9" height="18" fill="#000000"/>
+  <text x="478" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="486" y="468" width="9" height="18" fill="#000000"/>
-  <text x="487" y="482" fill="#ffffff" class="terminal" style="">C</text>
   <rect x="495" y="468" width="9" height="18" fill="#000000"/>
-  <text x="496" y="482" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="496" y="482" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="504" y="468" width="9" height="18" fill="#000000"/>
-  <text x="505" y="482" fill="#ffffff" class="terminal" style="">o</text>
+  <text x="505" y="482" fill="#ffffff" class="terminal" style="">h</text>
   <rect x="513" y="468" width="9" height="18" fill="#000000"/>
-  <text x="514" y="482" fill="#ffffff" class="terminal" style="">s</text>
+  <text x="514" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="522" y="468" width="9" height="18" fill="#000000"/>
-  <text x="523" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="531" y="468" width="9" height="18" fill="#000000"/>
+  <text x="532" y="482" fill="#ffffff" class="terminal" style="">g</text>
   <rect x="540" y="468" width="9" height="18" fill="#000000"/>
-  <text x="541" y="482" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="541" y="482" fill="#ffffff" class="terminal" style="">i</text>
   <rect x="549" y="468" width="9" height="18" fill="#000000"/>
-  <text x="550" y="482" fill="#ffffff" class="terminal" style="">h</text>
+  <text x="550" y="482" fill="#ffffff" class="terminal" style="">t</text>
   <rect x="558" y="468" width="9" height="18" fill="#000000"/>
-  <text x="559" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="567" y="468" width="9" height="18" fill="#000000"/>
+  <text x="568" y="482" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="576" y="468" width="9" height="18" fill="#000000"/>
-  <text x="577" y="482" fill="#ffffff" class="terminal" style="">g</text>
+  <text x="577" y="482" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="585" y="468" width="9" height="18" fill="#000000"/>
-  <text x="586" y="482" fill="#ffffff" class="terminal" style="">i</text>
+  <text x="586" y="482" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="594" y="468" width="9" height="18" fill="#000000"/>
-  <text x="595" y="482" fill="#ffffff" class="terminal" style="">t</text>
+  <text x="595" y="482" fill="#ffffff" class="terminal" style="">m</text>
   <rect x="603" y="468" width="9" height="18" fill="#000000"/>
+  <text x="604" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="612" y="468" width="9" height="18" fill="#000000"/>
-  <text x="613" y="482" fill="#ffffff" class="terminal" style="">b</text>
   <rect x="621" y="468" width="9" height="18" fill="#000000"/>
-  <text x="622" y="482" fill="#ffffff" class="terminal" style="">l</text>
+  <text x="622" y="482" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="630" y="468" width="9" height="18" fill="#000000"/>
   <text x="631" y="482" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="639" y="468" width="9" height="18" fill="#000000"/>
-  <text x="640" y="482" fill="#ffffff" class="terminal" style="">m</text>
+  <text x="640" y="482" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="648" y="468" width="9" height="18" fill="#000000"/>
   <text x="649" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="657" y="468" width="9" height="18" fill="#000000"/>
+  <text x="658" y="482" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="666" y="468" width="9" height="18" fill="#000000"/>
-  <text x="667" y="482" fill="#ffffff" class="terminal" style="">p</text>
   <rect x="675" y="468" width="9" height="18" fill="#000000"/>
-  <text x="676" y="482" fill="#ffffff" class="terminal" style="">a</text>
   <rect x="684" y="468" width="9" height="18" fill="#000000"/>
-  <text x="685" y="482" fill="#ffffff" class="terminal" style="">n</text>
   <rect x="693" y="468" width="9" height="18" fill="#000000"/>
-  <text x="694" y="482" fill="#ffffff" class="terminal" style="">e</text>
   <rect x="702" y="468" width="9" height="18" fill="#000000"/>
-  <text x="703" y="482" fill="#ffffff" class="terminal" style="">l</text>
   <rect x="711" y="468" width="9" height="18" fill="#000000"/>
   <rect x="720" y="468" width="9" height="18" fill="#000000"/>
   <rect x="729" y="468" width="9" height="18" fill="#000000"/>
@@ -4428,8 +4439,7 @@
   <text x="1054" y="482" fill="#8c8c8c" class="terminal" style="">m</text>
   <rect x="1062" y="468" width="9" height="18" fill="#000000"/>
   <text x="1063" y="482" fill="#8c8c8c" class="terminal" style="">e</text>
-  <rect x="1071" y="468" width="9" height="18" fill="#000000"/>
-  <text x="1072" y="482" fill="#00ffff" class="terminal" style="">│</text>
+  <rect x="1071" y="468" width="9" height="18" fill="#505050"/>
   <rect x="0" y="486" width="9" height="18" fill="#000000"/>
   <text x="1" y="500" fill="#00ffff" class="terminal" style="">└</text>
   <rect x="9" y="486" width="9" height="18" fill="#000000"/>

--- a/crates/fresh-editor/locales/bg.json
+++ b/crates/fresh-editor/locales/bg.json
@@ -1451,6 +1451,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Вътрешни табулации",
   "settings.field.editor.whitespace_tabs_leading": "Начални табулации",
   "settings.field.editor.whitespace_tabs_trailing": "Крайни табулации",
+  "settings.field.editor.whitespace_in_selection": "Интервали в селекцията",
   "settings.help_default": "↑↓:Навигация  Tab:Следващ  Enter:Редактиране  /:Търсене  Esc:Затваряне",
   "settings.help_duallist": "↑↓:Избор  ←→:Колона  Shift+←→:Преместване  Shift+↑↓:Пренареждане  Esc:Готово",
   "settings.help_footer": "Tab:Следващ бутон  Enter:Активиране  Esc:Затваряне",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Vnitřní tabulátory",
   "settings.field.editor.whitespace_tabs_leading": "Úvodní tabulátory",
   "settings.field.editor.whitespace_tabs_trailing": "Koncové tabulátory",
+  "settings.field.editor.whitespace_in_selection": "Bílé znaky ve výběru",
   "settings.help_default": "↑↓:Navigace  Tab:Další  Enter:Upravit  /:Hledat  Esc:Zavřít",
   "settings.help_footer": "Tab:Další  Enter:Aktivovat  Esc:Zavřít",
   "settings.help_search": "Hledat, ↑↓:Navigace  Enter:Přejít  Esc:Zrušit",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Innere Tabs",
   "settings.field.editor.whitespace_tabs_leading": "Führende Tabs",
   "settings.field.editor.whitespace_tabs_trailing": "Nachfolgende Tabs",
+  "settings.field.editor.whitespace_in_selection": "Leerzeichen in Auswahl",
   "settings.help_default": "↑↓:Navigieren  Tab:Weiter  Enter:Bearbeiten  /:Suchen  Esc:Schließen",
   "settings.help_footer": "Tab:Weiter  Enter:Aktivieren  Esc:Schließen",
   "settings.help_search": "Suchen, ↑↓:Navigieren  Enter:Springen  Esc:Abbrechen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1463,6 +1463,7 @@
   "settings.field.editor.whitespace_tabs_leading": "Leading Tabs",
   "settings.field.editor.whitespace_tabs_inner": "Inner Tabs",
   "settings.field.editor.whitespace_tabs_trailing": "Trailing Tabs",
+  "settings.field.editor.whitespace_in_selection": "Whitespace In Selection",
   "shell.command_failed": "Command failed: %{error}",
   "shell.command_prompt": "Shell command: ",
   "shell.command_replace_prompt": "Shell command (replace): ",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Tabulaciones interiores",
   "settings.field.editor.whitespace_tabs_leading": "Tabulaciones iniciales",
   "settings.field.editor.whitespace_tabs_trailing": "Tabulaciones finales",
+  "settings.field.editor.whitespace_in_selection": "Espacios en blanco en la selección",
   "settings.help_default": "↑↓:Navegar  Tab:Siguiente  Enter:Editar  /:Buscar  Esc:Cerrar",
   "settings.help_footer": "Tab:Siguiente  Enter:Activar  Esc:Cerrar",
   "settings.help_search": "Buscar, ↑↓:Navegar  Enter:Ir  Esc:Cancelar",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Tabulations intérieures",
   "settings.field.editor.whitespace_tabs_leading": "Tabulations en début",
   "settings.field.editor.whitespace_tabs_trailing": "Tabulations en fin",
+  "settings.field.editor.whitespace_in_selection": "Espaces dans la sélection",
   "settings.help_default": "↑↓:Naviguer  Tab:Suivant  Entrée:Modifier  /:Rechercher  Échap:Fermer",
   "settings.help_footer": "Tab:Suivant  Entrée:Activer  Échap:Fermer",
   "settings.help_search": "Rechercher, ↑↓:Naviguer  Entrée:Aller  Échap:Annuler",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Tabulazioni interne",
   "settings.field.editor.whitespace_tabs_leading": "Tabulazioni iniziali",
   "settings.field.editor.whitespace_tabs_trailing": "Tabulazioni finali",
+  "settings.field.editor.whitespace_in_selection": "Spazi nella selezione",
   "settings.help_default": "↑↓:Naviga  Tab:Successivo  Invio:Modifica  /:Cerca  Esc:Chiudi",
   "settings.help_footer": "Tab:Successivo  Invio:Attiva  Esc:Chiudi",
   "settings.help_search": "Cerca, ↑↓:Naviga  Invio:Vai  Esc:Annulla",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "内部のタブ",
   "settings.field.editor.whitespace_tabs_leading": "先頭のタブ",
   "settings.field.editor.whitespace_tabs_trailing": "末尾のタブ",
+  "settings.field.editor.whitespace_in_selection": "選択範囲内の空白",
   "settings.help_default": "↑↓:移動  Tab:次へ  Enter:編集  /:検索  Esc:閉じる",
   "settings.help_footer": "Tab:次へ  Enter:実行  Esc:閉じる",
   "settings.help_search": "検索, ↑↓:移動  Enter:ジャンプ  Esc:キャンセル",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "내부 탭",
   "settings.field.editor.whitespace_tabs_leading": "선행 탭",
   "settings.field.editor.whitespace_tabs_trailing": "후행 탭",
+  "settings.field.editor.whitespace_in_selection": "선택 영역의 공백",
   "settings.help_default": "↑↓:이동  Tab:다음  Enter:편집  /:검색  Esc:닫기",
   "settings.help_footer": "Tab:다음  Enter:실행  Esc:닫기",
   "settings.help_search": "검색, ↑↓:이동  Enter:이동  Esc:취소",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Tabulações internas",
   "settings.field.editor.whitespace_tabs_leading": "Tabulações iniciais",
   "settings.field.editor.whitespace_tabs_trailing": "Tabulações finais",
+  "settings.field.editor.whitespace_in_selection": "Espaços em branco na seleção",
   "settings.help_default": "↑↓:Navegar  Tab:Próximo  Enter:Editar  /:Buscar  Esc:Fechar",
   "settings.help_footer": "Tab:Próximo  Enter:Ativar  Esc:Fechar",
   "settings.help_search": "Buscar, ↑↓:Navegar  Enter:Ir  Esc:Cancelar",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Внутренние табуляции",
   "settings.field.editor.whitespace_tabs_leading": "Начальные табуляции",
   "settings.field.editor.whitespace_tabs_trailing": "Конечные табуляции",
+  "settings.field.editor.whitespace_in_selection": "Пробелы в выделении",
   "settings.help_default": "↑↓:Навигация  Tab:Далее  Enter:Редактировать  /:Поиск  Esc:Закрыть",
   "settings.help_footer": "Tab:Далее  Enter:Активировать  Esc:Закрыть",
   "settings.help_search": "Поиск, ↑↓:Навигация  Enter:Перейти  Esc:Отмена",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "แท็บภายใน",
   "settings.field.editor.whitespace_tabs_leading": "แท็บนำหน้า",
   "settings.field.editor.whitespace_tabs_trailing": "แท็บต่อท้าย",
+  "settings.field.editor.whitespace_in_selection": "ช่องว่างในส่วนที่เลือก",
   "settings.help_default": "↑↓:นำทาง  Tab:ถัดไป  Enter:แก้ไข  /:ค้นหา  Esc:ปิด",
   "settings.help_footer": "Tab:ถัดไป  Enter:เปิดใช้งาน  Esc:ปิด",
   "settings.help_search": "ค้นหา, ↑↓:นำทาง  Enter:ไป  Esc:ยกเลิก",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Внутрішні табуляції",
   "settings.field.editor.whitespace_tabs_leading": "Початкові табуляції",
   "settings.field.editor.whitespace_tabs_trailing": "Кінцеві табуляції",
+  "settings.field.editor.whitespace_in_selection": "Пробіли у виділенні",
   "settings.help_default": "↑↓:Навігація  Tab:Далі  Enter:Редагувати  /:Пошук  Esc:Закрити",
   "settings.help_footer": "Tab:Далі  Enter:Активувати  Esc:Закрити",
   "settings.help_search": "Пошук, ↑↓:Навігація  Enter:Перейти  Esc:Скасувати",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "Tab bên trong",
   "settings.field.editor.whitespace_tabs_leading": "Tab đầu dòng",
   "settings.field.editor.whitespace_tabs_trailing": "Tab cuối dòng",
+  "settings.field.editor.whitespace_in_selection": "Khoảng trắng trong vùng chọn",
   "settings.help_default": "↑↓:Điều hướng  Tab:Tiếp theo  Enter:Chỉnh sửa  /:Tìm kiếm  Esc:Đóng",
   "settings.help_footer": "Tab:Nút tiếp theo  Enter:Kích hoạt  Esc:Đóng",
   "settings.help_search": "Gõ để tìm, ↑↓:Điều hướng  Enter:Nhảy  Esc:Hủy",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1397,6 +1397,7 @@
   "settings.field.editor.whitespace_tabs_inner": "行内制表符",
   "settings.field.editor.whitespace_tabs_leading": "行首制表符",
   "settings.field.editor.whitespace_tabs_trailing": "行尾制表符",
+  "settings.field.editor.whitespace_in_selection": "空白字符（选区内）",
   "settings.help_default": "↑↓:导航  Tab:下一个  Enter:编辑  /:搜索  Esc:关闭",
   "settings.help_footer": "Tab:下一个  Enter:激活  Esc:关闭",
   "settings.help_search": "搜索, ↑↓:导航  Enter:跳转  Esc:取消",

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -98,6 +98,7 @@
         "whitespace_tabs_trailing": true,
         "whitespace_newlines": false,
         "whitespace_carriage_returns": false,
+        "whitespace_in_selection": true,
         "use_tabs": false,
         "tab_size": 4,
         "auto_indent": true,
@@ -668,6 +669,12 @@
           "description": "Show carriage-return indicators (␍) for the CR half of CRLF line\nendings, next to the newline position. Stray CR bytes that are not\npart of the buffer's line ending always render as `<0D>` escapes.\nDefault: false",
           "type": "boolean",
           "default": false,
+          "x-section": "Whitespace"
+        },
+        "whitespace_in_selection": {
+          "description": "Show whitespace indicators (·, →) for whitespace *inside a\nselection*, even when the per-position settings above (or the\n`whitespace_show` master toggle) keep them hidden elsewhere. Makes the\nexact extent of a selection legible without turning indicators on for\nthe whole buffer.\nDefault: true",
+          "type": "boolean",
+          "default": true,
           "x-section": "Whitespace"
         },
         "use_tabs": {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1439,6 +1439,16 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Whitespace"))]
     pub whitespace_carriage_returns: bool,
 
+    /// Show whitespace indicators (·, →) for whitespace *inside a
+    /// selection*, even when the per-position settings above (or the
+    /// `whitespace_show` master toggle) keep them hidden elsewhere. Makes the
+    /// exact extent of a selection legible without turning indicators on for
+    /// the whole buffer.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Whitespace"))]
+    pub whitespace_in_selection: bool,
+
     // ===== Editing =====
     /// Whether pressing Tab inserts a tab character instead of spaces.
     /// This is the global default; individual languages can override it
@@ -2012,6 +2022,7 @@ impl Default for EditorConfig {
             whitespace_tabs_trailing: true,
             whitespace_newlines: false,
             whitespace_carriage_returns: false,
+            whitespace_in_selection: true,
         }
     }
 }
@@ -2916,6 +2927,11 @@ pub struct BufferConfig {
     /// Resolved whitespace indicator visibility
     pub whitespace: WhitespaceVisibility,
 
+    /// Whether whitespace inside a selection draws its indicators even when
+    /// `whitespace` keeps them hidden. Global (`editor.whitespace_in_selection`);
+    /// no per-language override, so it rides along resolution unchanged.
+    pub whitespace_in_selection: bool,
+
     /// Formatter command for this buffer
     pub formatter: Option<FormatterConfig>,
 
@@ -2966,6 +2982,7 @@ impl BufferConfig {
             line_wrap: editor.line_wrap,
             wrap_column: editor.wrap_column,
             whitespace,
+            whitespace_in_selection: editor.whitespace_in_selection,
             formatter: None,
             format_on_save: false,
             on_save: Vec::new(),

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -234,6 +234,7 @@ pub struct PartialEditorConfig {
     pub whitespace_tabs_trailing: Option<bool>,
     pub whitespace_newlines: Option<bool>,
     pub whitespace_carriage_returns: Option<bool>,
+    pub whitespace_in_selection: Option<bool>,
 }
 
 impl Merge for PartialEditorConfig {
@@ -369,6 +370,8 @@ impl Merge for PartialEditorConfig {
             .merge_from(&other.whitespace_newlines);
         self.whitespace_carriage_returns
             .merge_from(&other.whitespace_carriage_returns);
+        self.whitespace_in_selection
+            .merge_from(&other.whitespace_in_selection);
     }
 }
 
@@ -691,6 +694,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             whitespace_tabs_trailing: Some(cfg.whitespace_tabs_trailing),
             whitespace_newlines: Some(cfg.whitespace_newlines),
             whitespace_carriage_returns: Some(cfg.whitespace_carriage_returns),
+            whitespace_in_selection: Some(cfg.whitespace_in_selection),
         }
     }
 }
@@ -890,6 +894,9 @@ impl PartialEditorConfig {
             whitespace_carriage_returns: self
                 .whitespace_carriage_returns
                 .unwrap_or(defaults.whitespace_carriage_returns),
+            whitespace_in_selection: self
+                .whitespace_in_selection
+                .unwrap_or(defaults.whitespace_in_selection),
         }
     }
 }

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -95,6 +95,13 @@ pub struct BufferSettings {
     /// Set based on global + language config; can be toggled per-buffer by user
     pub whitespace: crate::config::WhitespaceVisibility,
 
+    /// Whether whitespace inside a selection draws its `·` / `→` indicators
+    /// even when `whitespace` hides them. Mirrors
+    /// `editor.whitespace_in_selection`; deliberately independent of the
+    /// per-buffer whitespace overrides, so hiding the indicators for a buffer
+    /// still leaves a selection's own whitespace legible.
+    pub whitespace_in_selection: bool,
+
     /// Whether pressing Tab should insert a tab character instead of spaces.
     /// Set based on language config; can be toggled per-buffer by user
     pub use_tabs: bool,
@@ -166,6 +173,7 @@ impl Default for BufferSettings {
     fn default() -> Self {
         Self {
             whitespace: crate::config::WhitespaceVisibility::default(),
+            whitespace_in_selection: true,
             use_tabs: false,
             use_tabs_override: None,
             whitespace_override: None,
@@ -206,6 +214,7 @@ impl BufferSettings {
             .virtual_space_override
             .unwrap_or(resolved.virtual_space);
         self.apply_whitespace_override(resolved.whitespace);
+        self.whitespace_in_selection = resolved.whitespace_in_selection;
         self.word_characters = resolved.word_characters.clone();
         self.indentation_guide = resolved.indentation_guide;
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -334,13 +334,35 @@ impl CellPass<'_, '_, '_> {
             };
             (guide_glyph, false)
         } else {
-            self.display_cell_text(ch, byte_pos, is_cursor, is_tab_start, &mut indicator_buf)
+            self.display_cell_text(
+                ch,
+                byte_pos,
+                is_cursor,
+                is_tab_start,
+                is_selected,
+                &mut indicator_buf,
+            )
         };
+        // A selected line break has nothing of its own to draw, which left a
+        // selection over empty lines invisible (issue #2797). Paint the one
+        // column the break occupies — column 0 on an empty line, just past the
+        // text otherwise — carrying the selection background from
+        // `resolve_cell_style`.
+        let selected_break_column = ch == '\n'
+            && display_char.is_empty()
+            && is_selected
+            && byte_pos.is_some_and(|bp| self.selection_sweep.contains_linear(bp));
+        let display_char = if selected_break_column {
+            " "
+        } else {
+            display_char
+        };
+
         // A newline cell normally renders as nothing; when it renders a
-        // line-ending indicator instead, remember how many cells landed so
-        // position bookkeeping (rendered_cols, the cursor-on-newline
-        // indicator) accounts for them.
-        if ch == '\n' && is_whitespace_indicator {
+        // line-ending indicator (or the selected-break column) instead,
+        // remember how many cells landed so position bookkeeping
+        // (rendered_cols, the cursor-on-newline indicator) accounts for them.
+        if ch == '\n' && (is_whitespace_indicator || selected_break_column) {
             self.newline_indicator_cols = display_char.chars().count();
         }
 
@@ -600,26 +622,36 @@ impl CellPass<'_, '_, '_> {
         byte_pos: Option<usize>,
         is_cursor: bool,
         is_tab_start: bool,
+        is_selected: bool,
         indicator_buf: &'buf mut [u8; 4],
     ) -> (&'buf str, bool) {
         let ws = &self.input.state.buffer_settings.whitespace;
+        // Selected whitespace draws its indicator regardless of the
+        // per-position settings (issue #2797): a selection over blank
+        // stretches is otherwise invisible. Line-ending indicators stay out of
+        // it — the selected line break gets its own highlighted column in
+        // `render_visible_cell`.
+        let ws_in_selection =
+            is_selected && self.input.state.buffer_settings.whitespace_in_selection;
         let ws_show_tab = is_tab_start
-            && ws_indicator_visible(
-                self.display_char_idx,
-                self.non_ws,
-                ws.tabs_leading,
-                ws.tabs_inner,
-                ws.tabs_trailing,
-            );
+            && (ws_in_selection
+                || ws_indicator_visible(
+                    self.display_char_idx,
+                    self.non_ws,
+                    ws.tabs_leading,
+                    ws.tabs_inner,
+                    ws.tabs_trailing,
+                ));
         let ws_show_space = ch == ' '
             && !is_tab_start
-            && ws_indicator_visible(
-                self.display_char_idx,
-                self.non_ws,
-                ws.spaces_leading,
-                ws.spaces_inner,
-                ws.spaces_trailing,
-            );
+            && (ws_in_selection
+                || ws_indicator_visible(
+                    self.display_char_idx,
+                    self.non_ws,
+                    ws.spaces_leading,
+                    ws.spaces_inner,
+                    ws.spaces_trailing,
+                ));
 
         if is_cursor && self.input.lsp_waiting && self.input.is_active {
             ("⋯", false)

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/selection_sweep.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/selection_sweep.rs
@@ -76,6 +76,32 @@ impl<'a> SelectionActiveSet<'a> {
         self.block_last_line = Some(gutter_num);
     }
 
+    /// Is this cell inside a *linear* selection range (block rects
+    /// excluded)?
+    ///
+    /// The selected-line-break column keys off this rather than
+    /// [`contains`](Self::contains): a block selection's rect can cover the
+    /// column a newline sits in without the line break itself being part of
+    /// the selection — copying the block wouldn't take it.
+    ///
+    /// Safe to call after [`contains`](Self::contains) for the same cell:
+    /// `range_cursor` only ever advances past ranges that ended before `bp`.
+    pub(super) fn contains_linear(&mut self, buffer_byte: usize) -> bool {
+        self.advance_ranges_to(buffer_byte);
+        self.ranges[self.range_cursor..]
+            .iter()
+            .take_while(|r| r.start <= buffer_byte)
+            .any(|r| r.end > buffer_byte)
+    }
+
+    /// Drop ranges that ended before `bp` — the cell loop scans the buffer
+    /// monotonically, so they can never match again.
+    fn advance_ranges_to(&mut self, bp: usize) {
+        while self.range_cursor < self.ranges.len() && self.ranges[self.range_cursor].end <= bp {
+            self.range_cursor += 1;
+        }
+    }
+
     /// Is this cell inside any selection?
     ///
     /// `buffer_byte` is the absolute byte position (used by the
@@ -87,16 +113,10 @@ impl<'a> SelectionActiveSet<'a> {
     /// the block-rect column-span check, matching how
     /// `block_rects` stores its column bounds).
     pub(super) fn contains(&mut self, buffer_byte: Option<usize>, cell_byte_index: usize) -> bool {
-        let linear = buffer_byte.is_some_and(|bp| {
-            while self.range_cursor < self.ranges.len() && self.ranges[self.range_cursor].end <= bp
-            {
-                self.range_cursor += 1;
-            }
-            self.ranges[self.range_cursor..]
-                .iter()
-                .take_while(|r| r.start <= bp)
-                .any(|r| r.end > bp)
-        });
+        let linear = match buffer_byte {
+            Some(bp) => self.contains_linear(bp),
+            None => false,
+        };
         let block = self.active_block.iter().any(|&i| {
             let (_, start_col, _, end_col) = self.blocks[i];
             cell_byte_index >= start_col && cell_byte_index <= end_col

--- a/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
+++ b/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
@@ -9,7 +9,7 @@ expression: "&screen_text"
 │      main.rs               │  3 │     let hello = "world";                                        
 │    Cargo.toml              │  4 │     let hello = "again";                                        
 │    README.md               │  5 │     let hello = "once more";                                    
-│                            │  6 │     println!("{}", hello);                                      
+│                            │  6 │ ····println!("{}", hello);                                      
 │                            │  7 │ }                                                               
 │                            │  8 │                                                                 
 │                            │  9 │ // Helper function                                              
@@ -21,8 +21,8 @@ expression: "&screen_text"
 │                            │ 15 │                                                                 
 │                            │ 16 │ // More code to enable scrolling                                
 │                            │▾17 │ fn long_function() {                                            
-│                            │ 18 │     println!("Line 1");                                         
-│                            │ 19 │     println!("Line 2");                                         
+│                            │ 18 │ ····println!("Line 1");                                         
+│                            │ 19 │ ····println!("Line 2");                                         
 │                            │ 20 │     println!("Line 3");                                         
 │                            │ 21 │     println!("Line 4");                                         
 │                            │ 22 │     println!("Line 5");                                         

--- a/crates/fresh-editor/tests/e2e/issue_2797_selection_visibility.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2797_selection_visibility.rs
@@ -1,0 +1,183 @@
+//! Issue #2797: a selection that covers empty lines (or line breaks in
+//! general) left no trace on screen — an all-empty-line selection looked
+//! exactly like no selection at all.
+//!
+//! Two rendered signals cover it, both observed here only through the
+//! rendered cells:
+//!
+//! * every selected line break paints one highlighted column at the
+//!   position the break occupies (column 0 on an empty line), and
+//! * whitespace inside a selection draws its `·` / `→` indicators even
+//!   when the whitespace indicators are otherwise off
+//!   (`editor.whitespace_in_selection`, on by default).
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+/// Screen row of buffer line `line_idx` (0-based) and the first content
+/// column, for a harness whose viewport is at the top of the buffer.
+fn content_origin(harness: &EditorTestHarness) -> (u16, u16) {
+    let gutter_width = harness.editor().active_state().margins.left_total_width() as u16;
+    let (content_first_row, _) = harness.content_area_rows();
+    (gutter_width, content_first_row as u16)
+}
+
+#[test]
+fn selected_empty_lines_show_a_highlighted_column() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    // Lines (0-based): 0 "aaa", 1 "bbb", 2 "", 3 "", 4 "", 5 "ccc"
+    harness
+        .load_buffer_from_text("aaa\nbbb\n\n\n\nccc\n")
+        .unwrap();
+
+    // Cursor to the start of line 2, then select lines 2 and 3 (both empty).
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..2 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    for _ in 0..2 {
+        harness
+            .send_key(KeyCode::Down, KeyModifiers::SHIFT)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let selection_bg = Some(harness.editor().theme().selection_bg);
+    let (col0, first_row) = content_origin(&harness);
+
+    for line_idx in [2u16, 3] {
+        let style = harness
+            .get_cell_style(col0, first_row + line_idx)
+            .expect("cell inside the viewport");
+        assert_eq!(
+            style.bg,
+            selection_bg,
+            "empty line {line_idx} is inside the selection, so its line break \
+             should paint a highlighted column at the start of the line\n{}",
+            harness.screen_to_string()
+        );
+    }
+
+    // Line 4 is empty too but outside the selection — it must stay clean.
+    let style = harness
+        .get_cell_style(col0, first_row + 4)
+        .expect("cell inside the viewport");
+    assert_ne!(
+        style.bg,
+        selection_bg,
+        "empty line 4 is outside the selection and must not be highlighted\n{}",
+        harness.screen_to_string()
+    );
+}
+
+#[test]
+fn selected_line_break_shows_a_highlighted_column_past_line_end() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text("aaa\nbbb\n").unwrap();
+
+    // Select line 0 including its line break.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+
+    let selection_bg = Some(harness.editor().theme().selection_bg);
+    let (col0, first_row) = content_origin(&harness);
+
+    let style = harness
+        .get_cell_style(col0 + 3, first_row)
+        .expect("cell inside the viewport");
+    assert_eq!(
+        style.bg,
+        selection_bg,
+        "the selected line break after \"aaa\" should paint one highlighted column\n{}",
+        harness.screen_to_string()
+    );
+
+    // One column further is past the line break — not selected.
+    let style = harness
+        .get_cell_style(col0 + 4, first_row)
+        .expect("cell inside the viewport");
+    assert_ne!(
+        style.bg, selection_bg,
+        "only the line break itself is highlighted, not the rest of the row"
+    );
+}
+
+#[test]
+fn whitespace_inside_selection_shows_indicators_by_default() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.load_buffer_from_text("ab  cd  ef\n").unwrap();
+    assert!(
+        !harness.config().editor.whitespace_spaces_inner,
+        "the space indicators are off by default; this test is about the \
+         in-selection override"
+    );
+
+    // Select "ab  cd" — the first pair of spaces is inside the selection,
+    // the second pair is not.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..6 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::SHIFT)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let (col0, row) = content_origin(&harness);
+    let screen = harness.screen_to_string();
+    for offset in [2u16, 3] {
+        assert_eq!(
+            harness.get_cell(col0 + offset, row).as_deref(),
+            Some("·"),
+            "space at column {offset} is inside the selection, so it should \
+             render a whitespace indicator\n{screen}"
+        );
+    }
+    for offset in [6u16, 7] {
+        assert_eq!(
+            harness.get_cell(col0 + offset, row).as_deref(),
+            Some(" "),
+            "space at column {offset} is outside the selection and the \
+             indicators are off, so it should stay blank\n{screen}"
+        );
+    }
+}
+
+#[test]
+fn whitespace_in_selection_can_be_turned_off() {
+    let mut config = Config::default();
+    config.editor.whitespace_in_selection = false;
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.load_buffer_from_text("ab  cd  ef\n").unwrap();
+
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..6 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::SHIFT)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let (col0, row) = content_origin(&harness);
+    for offset in [2u16, 3] {
+        assert_eq!(
+            harness.get_cell(col0 + offset, row).as_deref(),
+            Some(" "),
+            "with editor.whitespace_in_selection off, selected spaces keep \
+             rendering blank\n{}",
+            harness.screen_to_string()
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3006_drag_beyond_text_area.rs
@@ -70,12 +70,20 @@ fn drag_to(harness: &mut EditorTestHarness, col: u16, row: u16) {
     harness.render().unwrap();
 }
 
+/// The screen with the in-selection whitespace indicators folded back to
+/// spaces: `editor.whitespace_in_selection` draws `·` over a selected space,
+/// so a selected `LINE nnn` marker reads as `LINE·nnn` until it is undone.
+/// Each indicator occupies one cell, so columns are unaffected.
+fn screen_text(harness: &EditorTestHarness) -> String {
+    harness.screen_to_string().replace('·', " ")
+}
+
 /// The number of the topmost `LINE nnn` marker on screen. That marker is
 /// the buffer's first visible line, so this *is* the rendered scroll
 /// position — it changes the instant the viewport moves by one line and is
 /// identical frame-to-frame while it stays put.
 fn top_line(harness: &EditorTestHarness) -> u32 {
-    let screen = harness.screen_to_string();
+    let screen = screen_text(harness);
     screen
         .lines()
         .flat_map(|line| line.split("LINE ").skip(1))
@@ -101,7 +109,7 @@ fn selected_cells_in_row(harness: &EditorTestHarness, row: u16) -> usize {
 /// The `LINE nnn` marker rendered on screen `row`, or `None` for a row
 /// that carries no buffer line.
 fn line_number_at_row(harness: &EditorTestHarness, row: u16) -> Option<u32> {
-    let screen = harness.screen_to_string();
+    let screen = screen_text(harness);
     let rest = screen.lines().nth(row as usize)?.split("LINE ").nth(1)?;
     let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
     digits.parse::<u32>().ok()

--- a/crates/fresh-editor/tests/e2e/issue_3006_shift_select_at_buffer_edges.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3006_shift_select_at_buffer_edges.rs
@@ -26,11 +26,29 @@ fn open_fixture(harness: &mut EditorTestHarness, temp_dir: &TempDir) {
     harness.render().unwrap();
 }
 
+/// Locate `line` on screen, folding the in-selection whitespace indicators
+/// (`editor.whitespace_in_selection` draws `·` over a selected space) back to
+/// plain spaces first — a partly selected line renders a mix of the two, so a
+/// literal match would miss it. Each indicator occupies exactly one cell, so
+/// the column arithmetic is unaffected.
+fn find_line_on_screen(harness: &EditorTestHarness, line: &str) -> Option<(u16, u16)> {
+    harness
+        .screen_to_string()
+        .lines()
+        .enumerate()
+        .find_map(|(row, text)| {
+            let plain = text.replace('·', " ");
+            plain
+                .find(line)
+                .map(|byte_idx| (plain[..byte_idx].chars().count() as u16, row as u16))
+        })
+}
+
 /// Is the cell `offset` columns into the on-screen rendering of `line` painted
 /// with the theme's selection background?
 fn cell_is_selected(harness: &EditorTestHarness, line: &str, offset: u16) -> bool {
     let selection_bg = harness.editor().theme().selection_bg;
-    let (col, row) = harness.find_text_on_screen(line).unwrap_or_else(|| {
+    let (col, row) = find_line_on_screen(harness, line).unwrap_or_else(|| {
         panic!(
             "line {line:?} not on screen:\n{}",
             harness.screen_to_string()

--- a/crates/fresh-editor/tests/e2e/menu_bar.rs
+++ b/crates/fresh-editor/tests/e2e/menu_bar.rs
@@ -509,11 +509,13 @@ fn test_copy_with_formatting_submenu_activates_on_enter() {
         .unwrap();
     harness.render().unwrap();
 
-    // Verify text is selected (status bar should show selection)
+    // Verify text is selected: Ctrl+A selects the line, and selected
+    // whitespace draws its indicator (`editor.whitespace_in_selection`), so
+    // the space between the words renders as `·`.
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains("Hello World"),
-        "Text should be visible in the editor"
+        screen.contains("Hello·World"),
+        "Selected text should be visible in the editor:\n{screen}"
     );
 
     // Open Edit menu
@@ -567,9 +569,10 @@ fn test_copy_with_formatting_submenu_activates_on_enter() {
         "Menu should close after activating copy action. Screen:\n{}",
         screen_after
     );
-    // The editor content should still be visible
+    // The editor content should still be visible (still selected, so the
+    // space between the words keeps its `·` indicator).
     assert!(
-        screen_after.contains("Hello World"),
+        screen_after.contains("Hello·World"),
         "Editor content should still be visible after copy. Screen:\n{}",
         screen_after
     );

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -103,6 +103,7 @@ pub mod issue_2572_hover_through_panel;
 pub mod issue_2605_format_selection_range;
 pub mod issue_2761_git_commit_msg_state;
 pub mod issue_2796_key_release_duplicates;
+pub mod issue_2797_selection_visibility;
 #[cfg(feature = "plugins")]
 pub mod issue_2810_session_escape_flush;
 pub mod issue_2843_single_line_viewport;

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -74,6 +74,8 @@ Control visibility of space (`·`) and tab (`→`) characters. Configure indepen
 
 Line endings can be shown too: `whitespace_newlines` renders `↵` at the end of every line, and `whitespace_carriage_returns` renders `␍` for the CR half of CRLF (and Classic-Mac CR) line endings — so a CRLF file shows `␍↵` where an LF file shows `↵`. Both are off by default and follow the same master toggle.
 
+Inside a selection the indicators appear regardless of the settings above, so selected runs of spaces and tabs stay legible without turning indicators on for the whole buffer. Set `whitespace_in_selection` to `false` to switch that off; it is independent of the master toggle and of the per-buffer whitespace overrides.
+
 ## Inline Diagnostics
 
 Diagnostic messages can be displayed at the end of each line, right-aligned, with version-aware staleness dimming. Disabled by default — enable "diagnostics inline text" in the Settings UI or set `diagnostics_inline_text` in config.
@@ -108,6 +110,8 @@ Edit multiple locations simultaneously:
 | `Shift+Home/End` | Select to line start/end |
 | `Ctrl+Shift+Home/End` | Select to document start/end |
 | `Shift+PgUp/PgDn` | Select page up/down |
+
+Selected line breaks are drawn too: every line break inside the selection highlights the single column it occupies — column 0 on an empty line, just past the text otherwise — so a selection that spans blank lines is visible instead of leaving them looking untouched. Whitespace inside the selection also gets its `·` / `→` indicators (see [Whitespace Indicators](#whitespace-indicators)).
 
 ### Block Selection
 


### PR DESCRIPTION
Fixes #2797.

Selecting empty lines left the screen untouched: on a blank line the line break is the only thing selected, and the newline cell renders as nothing — so a selection over blank lines looked exactly like no selection at all. The reporter spent hours in the settings believing the selection had never been made.

## What changed

**1. Selected line breaks paint one highlighted column.** Every line break inside a *linear* selection now highlights the single column it occupies — column 0 on an empty line, just past the text otherwise (what VS Code shows). Block-selection rects are deliberately excluded: a rect can cover the newline's column without the break being part of what would be copied, so `SelectionActiveSet` grew a `contains_linear()` alongside `contains()`.

**2. Whitespace inside a selection shows its indicators.** Spaces and tabs inside a selection draw `·` / `→` even when the per-position settings (or the `whitespace_show` master toggle) keep them hidden elsewhere, so the extent of a selection over runs of blanks is legible without turning indicators on for the whole buffer. New `editor.whitespace_in_selection` setting, **on by default**, independent of the master toggle and of the per-buffer whitespace overrides. Line-ending indicators stay out of it — the break gets the highlighted column instead of a `↵`.

The flag rides along the existing buffer-config resolution (`BufferConfig::resolve` → `BufferSettings::apply_config`), so the renderer reads it per buffer with no new render plumbing.

## Tests

`tests/e2e/issue_2797_selection_visibility.rs` — four e2e tests that drive keys and assert only on rendered cells:

* selected empty lines carry `selection_bg` at column 0, and an empty line just outside the selection does not;
* a selected line break after text highlights exactly one column past the text;
* selected spaces render `·` while unselected spaces on the same line stay blank;
* `whitespace_in_selection = false` keeps selected spaces blank.

Three of the four fail on `master` (the fourth is the negative control for the config-off path). Verified by reverting `cells.rs` alone:

```
failures:
    selected_empty_lines_show_a_highlighted_column
    selected_line_break_shows_a_highlighted_column_past_line_end
    whitespace_inside_selection_shows_indicators_by_default
test result: FAILED. 1 passed; 3 failed
```

All four pass with the change. `cargo fmt --all` and `cargo clippy --all-targets` are clean; `config-schema.json` regenerated with `./scripts/gen_schema.sh`; the settings label added to all 15 locales; docs and CHANGELOG updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_014hm5DUeVUowDumVGH8oC1m)_