### PR TITLE
feat(fresh-ui): styled pieces inside one text run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
 # Force LF line endings for the help manual — it's embedded at compile time
 # and CRLF causes literal <0D> display artifacts in the terminal.
 crates/fresh-editor/docs/fresh.txt text eol=lf
+
+# Force LF for the fresh-ui golden screens. They are recorded with LF and
+# compared against freshly rendered output, which is always LF — a CRLF
+# checkout on Windows makes every golden test fail on the line terminator
+# rather than on anything the picture shows.
+crates/fresh-ui/tests/golden/*.txt text eol=lf

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -167,11 +167,56 @@ pub struct BoxProps {
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct TextProps {
-    pub text: Rc<str>,
+    /// The run's content, in pieces. One piece for ordinary text; several when
+    /// parts of it are styled differently.
+    ///
+    /// The pieces are one logical string: measurement, wrapping and truncation
+    /// treat them as a unit, and a wrap point may fall inside a piece. That is
+    /// the difference between this and laying separate `TextRun`s side by side,
+    /// which wrap and truncate independently.
+    pub runs: Rc<[Run]>,
     pub wrap: bool,
     /// Where the text cursor sits within this run, in columns. Set by whatever
     /// is being edited; the library places it and the backend shows it.
     pub cursor: Option<u16>,
+}
+
+/// One piece of a text run, and the theme it paints in.
+///
+/// A piece with no theme of its own inherits the node's — so an unstyled run is
+/// a single piece with `theme: None`, and adding styling means splitting the
+/// content into more pieces rather than switching to a different mechanism.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Run {
+    pub text: Rc<str>,
+    pub theme: Option<crate::render::spec::ThemeKey>,
+}
+
+impl Run {
+    /// A piece that paints in the node's own theme.
+    pub fn plain(text: impl AsRef<str>) -> Run {
+        Run {
+            text: Rc::from(text.as_ref()),
+            theme: None,
+        }
+    }
+
+    /// A piece that paints in a theme of its own.
+    pub fn themed(text: impl AsRef<str>, theme: impl AsRef<str>) -> Run {
+        Run {
+            text: Rc::from(text.as_ref()),
+            theme: Some(crate::render::spec::ThemeKey(Some(Rc::from(
+                theme.as_ref(),
+            )))),
+        }
+    }
+}
+
+impl TextProps {
+    /// The whole content as one string — what measurement and wrapping work on.
+    pub fn plain(&self) -> String {
+        self.runs.iter().map(|r| &*r.text).collect()
+    }
 }
 
 /// What a viewport's scroll offset counts.
@@ -676,7 +721,26 @@ pub fn stack<M>() -> Node<M> {
 
 pub fn text<M>(s: impl AsRef<str>) -> Node<M> {
     Node::new(Desc::TextRun(TextProps {
-        text: Rc::from(s.as_ref()),
+        runs: Rc::from(vec![Run::plain(s)]),
+        wrap: false,
+        cursor: None,
+    }))
+}
+
+/// A text run whose pieces are styled independently.
+///
+/// One logical string: it wraps and measures as a whole, and a wrap point may
+/// fall inside a piece. Use this when the styling is *inside* the text —
+/// a match highlight, a mnemonic, inline code in a sentence. When the pieces
+/// are independently positioned instead, they are separate nodes in a `row()`,
+/// which is layout rather than styling.
+///
+/// ```ignore
+/// text_runs([Run::plain("Op"), Run::themed("e", "mnemonic"), Run::plain("n")])
+/// ```
+pub fn text_runs<M>(runs: impl IntoIterator<Item = Run>) -> Node<M> {
+    Node::new(Desc::TextRun(TextProps {
+        runs: Rc::from(runs.into_iter().collect::<Vec<_>>()),
         wrap: false,
         cursor: None,
     }))

--- a/crates/fresh-ui/src/diagnose.rs
+++ b/crates/fresh-ui/src/diagnose.rs
@@ -41,7 +41,7 @@ impl<M: 'static> Ui<M> {
     /// this is how a test reads what a component actually produced.
     pub fn text_of(&self, id: ElementId) -> Option<std::rc::Rc<str>> {
         match &crate::desc::resolve(&self.arena.get(id)?.desc).desc {
-            crate::desc::Desc::TextRun(p) => Some(p.text.clone()),
+            crate::desc::Desc::TextRun(p) => Some(std::rc::Rc::from(p.plain().as_str())),
             _ => None,
         }
     }

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -43,9 +43,9 @@ pub use behavior::Behavior;
 pub use component::{AnyComponent, Component};
 pub use desc::{
     col, focusable, gesture, host, host_leaf, layer, layout_reader, node_key, node_type, resolve,
-    row, shared_rc, stack, text, viewport, Align, Anchor, BoxProps, ComponentExt, Desc, Dir,
-    Dismiss, ElemType, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec, LayerProps,
-    LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Scrim, ScrollMode,
+    row, shared_rc, stack, text, text_runs, viewport, Align, Anchor, BoxProps, ComponentExt, Desc,
+    Dir, Dismiss, ElemType, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec, LayerProps,
+    LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Run, Scrim, ScrollMode,
     Sizing, TextProps, ViewportProps,
 };
 pub use element::ElementId;

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -124,6 +124,105 @@ pub fn wrap_text(text: &str, width: u16) -> Vec<String> {
     out
 }
 
+/// One painted fragment: a piece of a row, and the theme it paints in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Frag {
+    pub text: Rc<str>,
+    pub theme: Option<crate::render::spec::ThemeKey>,
+}
+
+/// Wrap a run's pieces as one logical string, reporting each output row as the
+/// fragments that compose it.
+///
+/// The pieces are concatenated, wrapped by the same [`wrap_text`] the unstyled
+/// path uses — so styled and unstyled text break identically — and the result
+/// is then cut back into fragments along the original piece boundaries. A wrap
+/// point inside a piece splits it; a row crossing three pieces is three
+/// fragments.
+pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: bool) -> Vec<Vec<Frag>> {
+    use unicode_width::UnicodeWidthStr;
+
+    let whole: String = runs.iter().map(|r| &*r.text).collect();
+    let rows: Vec<String> = if wrap {
+        wrap_text(&whole, width)
+    } else {
+        whole.split('\n').map(|s| s.to_string()).collect()
+    };
+
+    // Walk the pieces alongside the rows. Wrapping can drop a separator at a
+    // break, so rows are matched by content length rather than by byte offset
+    // into the original.
+    let mut piece = 0usize;
+    let mut used = 0usize; // chars of the current piece already emitted
+    let mut out: Vec<Vec<Frag>> = Vec::with_capacity(rows.len());
+
+    for row in &rows {
+        let mut frags: Vec<Frag> = Vec::new();
+        let mut want: usize = row.chars().count();
+        let mut at = 0usize; // chars of this row already taken
+
+        while want > 0 && piece < runs.len() {
+            let piece_chars: Vec<char> = runs[piece].text.chars().collect();
+            let left = piece_chars.len().saturating_sub(used);
+            if left == 0 {
+                piece += 1;
+                used = 0;
+                continue;
+            }
+            let take = left.min(want);
+            // Take the text from the *row*, not the piece: the row is what
+            // wrapping produced, and it is what must appear on screen.
+            let seg: String = row.chars().skip(at).take(take).collect();
+            if !seg.is_empty() {
+                frags.push(Frag {
+                    text: Rc::from(seg.as_str()),
+                    theme: runs[piece].theme.clone(),
+                });
+            }
+            at += take;
+            want -= take;
+            used += take;
+            if used >= piece_chars.len() {
+                piece += 1;
+                used = 0;
+            }
+        }
+
+        // A separator consumed by the wrap: step past it so the next row starts
+        // at the right place in the piece list.
+        if want == 0 && piece < runs.len() {
+            let piece_chars = runs[piece].text.chars().count();
+            if used < piece_chars {
+                let next: Option<char> = runs[piece].text.chars().nth(used);
+                if next == Some(' ') {
+                    used += 1;
+                    if used >= piece_chars {
+                        piece += 1;
+                        used = 0;
+                    }
+                }
+            }
+        }
+
+        if frags.is_empty() {
+            frags.push(Frag {
+                text: Rc::from(""),
+                theme: None,
+            });
+        }
+        out.push(frags);
+    }
+
+    let _ = UnicodeWidthStr::width("");
+    if out.is_empty() {
+        out.push(vec![Frag {
+            text: Rc::from(""),
+            theme: None,
+        }]);
+    }
+    out
+}
+
 /// Lay children out one on top of another, each honouring its own size
 /// request. What a node with no layout of its own does.
 fn stack_in(c: Constraints, cx: &mut dyn LayoutCx, align: Align, inset: Point) -> Size {
@@ -334,15 +433,15 @@ impl RenderObject for BoxRender {
 pub struct TextRender {
     pub props: TextProps,
     /// The wrapped rows, computed at measure time and reused by paint so the
-    /// two cannot disagree.
-    lines: Vec<Rc<str>>,
+    /// two cannot disagree. Each row is its fragments, in order.
+    rows: Vec<Vec<Frag>>,
 }
 
 impl TextRender {
     pub fn new(props: TextProps) -> Self {
         TextRender {
             props,
-            lines: Vec::new(),
+            rows: Vec::new(),
         }
     }
 }
@@ -350,26 +449,66 @@ impl TextRender {
 impl RenderObject for TextRender {
     fn layout(&mut self, c: Constraints, _cx: &mut dyn LayoutCx) -> Size {
         use unicode_width::UnicodeWidthStr;
-        let natural = UnicodeWidthStr::width(&*self.props.text) as u16;
+        // Measured as one string, whatever it is made of: the pieces are one
+        // logical run, so styling never changes where the text breaks.
+        let whole = self.props.plain();
+        let natural = UnicodeWidthStr::width(whole.as_str()) as u16;
         if self.props.wrap {
             let w = if c.min_w > 0 {
                 c.max_w
             } else {
                 c.max_w.min(natural.max(1))
             };
-            self.lines = wrap_text(&self.props.text, w)
-                .iter()
-                .map(|l| Rc::from(l.as_str()))
-                .collect();
-            c.constrain(Size::new(w, self.lines.len().min(u16::MAX as usize) as u16))
+            self.rows = wrap_runs(&self.props.runs, w, true);
+            c.constrain(Size::new(w, self.rows.len().min(u16::MAX as usize) as u16))
         } else {
-            self.lines = self.props.text.split('\n').map(Rc::from).collect();
-            c.constrain(Size::new(natural, self.lines.len().max(1) as u16))
+            self.rows = wrap_runs(&self.props.runs, 0, false);
+            c.constrain(Size::new(natural, self.rows.len().max(1) as u16))
         }
     }
 
     fn paint(&self, g: Geom, out: &mut DrawList) {
-        out.push(Draw::Lines(self.lines.clone()), g);
+        // An unstyled run is one item, exactly as before. A styled one emits an
+        // item per fragment, each carrying its own theme — so the display list
+        // keeps its one-theme-per-item contract and no backend has to learn
+        // about spans. `LayoutSpec::index` already maps a key to a *range* of
+        // items, so several items for one node is the existing model.
+        if self
+            .rows
+            .iter()
+            .all(|r| r.iter().all(|f| f.theme.is_none()))
+        {
+            let lines: Vec<Rc<str>> = self
+                .rows
+                .iter()
+                .map(|r| {
+                    r.first()
+                        .map(|f| f.text.clone())
+                        .unwrap_or_else(|| Rc::from(""))
+                })
+                .collect();
+            out.push(Draw::Lines(lines), g);
+        } else {
+            use unicode_width::UnicodeWidthStr;
+            for (i, row) in self.rows.iter().enumerate() {
+                let mut x = g.rect.x;
+                for frag in row {
+                    let w = UnicodeWidthStr::width(&*frag.text) as u16;
+                    if w == 0 {
+                        continue;
+                    }
+                    let rect = Rect::new(x, g.rect.y + i as i32, w, 1);
+                    let draw = Draw::Lines(vec![frag.text.clone()]);
+                    match &frag.theme {
+                        // A piece with its own theme names it; one without
+                        // inherits the node's, which is what `push_at` uses.
+                        Some(t) => out.push_themed(draw, rect, g.clip, t.clone()),
+                        None => out.push_at(draw, rect, g.clip),
+                    }
+                    x += w as i32;
+                }
+            }
+        }
         if let Some(col) = self.props.cursor {
             out.set_cursor(Point::new(g.rect.x + col as i32, g.rect.y));
         }

--- a/crates/fresh-ui/src/render/spec.rs
+++ b/crates/fresh-ui/src/render/spec.rs
@@ -167,12 +167,24 @@ impl DrawList {
     /// Draw over some other rectangle inside this node — a scrollbar down one
     /// edge, for instance.
     pub fn push_at(&mut self, draw: Draw, rect: Rect, clip: Rect) {
+        let theme = self.theme.clone();
+        self.push_themed(draw, rect, clip, theme);
+    }
+
+    /// Draw with a theme more specific than the one the framework assigned.
+    ///
+    /// Provenance is the framework's by default — an item takes the nearest
+    /// enclosing `theme(..)` tag. This is for the case where one node's output
+    /// is not uniform: a text run whose pieces are styled differently emits an
+    /// item per piece, each naming its own. The item still carries exactly one
+    /// theme, so nothing downstream changes.
+    pub fn push_themed(&mut self, draw: Draw, rect: Rect, clip: Rect, theme: ThemeKey) {
         self.items.push(Item {
             key: self.key.clone(),
             id: self.id,
             rect,
             clip,
-            theme: self.theme.clone(),
+            theme,
             draw,
         });
     }

--- a/crates/fresh-ui/tests/diagnose.rs
+++ b/crates/fresh-ui/tests/diagnose.rs
@@ -49,7 +49,9 @@ fn the_dump_names_the_type_key_state_build_count_and_cause() {
     assert!(dump.contains("state=Count(n=3)"), "live state\n{dump}");
     assert!(dump.contains("builds=2"), "rebuild counter\n{dump}");
     assert!(
-        dump.contains("cause=set_state") && dump.contains("tests/diagnose.rs:"),
+        // Not "tests/diagnose.rs": `file!()` spells the separator the host
+        // platform's way, and the claim here is that the site is named.
+        dump.contains("cause=set_state") && dump.contains("diagnose.rs:"),
         "the set_state site that marked it\n{dump}"
     );
     assert!(

--- a/crates/fresh-ui/tests/golden.rs
+++ b/crates/fresh-ui/tests/golden.rs
@@ -41,6 +41,11 @@ fn check(name: &str, session: &str) {
             path.display()
         )
     });
+    // A golden is a picture of a screen; its line terminator is not part of
+    // what it asserts. `.gitattributes` keeps these files LF, and normalising
+    // here means a stray CRLF checkout reports the frame that actually differs
+    // instead of failing every test on invisible bytes.
+    let expected = expected.replace("\r\n", "\n");
     if expected != session {
         panic!(
             "{name} differs from its recording.\n\

--- a/crates/fresh-ui/tests/paint.rs
+++ b/crates/fresh-ui/tests/paint.rs
@@ -230,3 +230,140 @@ fn theme_provenance_is_inherited_and_overridden() {
         .collect();
     assert_eq!(themes, vec!["outer".to_string(), "inner".to_string()]);
 }
+
+// -- styled runs -------------------------------------------------------------
+
+/// Rows of painted text, keyed by screen row.
+///
+/// Handles both shapes a text run can take: an unstyled run is one item whose
+/// `Lines` holds successive rows, and a styled one is an item per fragment,
+/// several of which may share a row.
+fn painted_rows(spec: &fresh_ui::LayoutSpec) -> Vec<String> {
+    let mut rows: std::collections::BTreeMap<i32, String> = Default::default();
+    for it in &spec.items {
+        if let Draw::Lines(lines) = &it.draw {
+            for (i, line) in lines.iter().enumerate() {
+                rows.entry(it.rect.y + i as i32).or_default().push_str(line);
+            }
+        }
+    }
+    rows.into_values().collect()
+}
+
+/// A run whose pieces are styled independently emits one item per piece, each
+/// carrying its own theme. The display list keeps its one-theme-per-item
+/// contract, so no backend has to learn about spans.
+#[test]
+fn a_styled_run_emits_one_item_per_piece() {
+    use fresh_ui::{text_runs, Run};
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        text_runs([
+            Run::plain("Op"),
+            Run::themed("e", "mnemonic"),
+            Run::plain("n"),
+        ]),
+        Size::new(20, 1),
+    );
+
+    let items: Vec<(String, String, i32, u16)> = spec
+        .items
+        .iter()
+        .filter_map(|it| match &it.draw {
+            Draw::Lines(l) => Some((
+                l.join(""),
+                it.theme.as_str().to_string(),
+                it.rect.x,
+                it.rect.w,
+            )),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        items,
+        vec![
+            ("Op".to_string(), String::new(), 0, 2),
+            ("e".to_string(), "mnemonic".to_string(), 2, 1),
+            ("n".to_string(), String::new(), 3, 1),
+        ],
+        "pieces should tile left to right, each with its own theme"
+    );
+}
+
+/// An unstyled run is still a single item — the common case pays nothing.
+#[test]
+fn an_unstyled_run_is_still_one_item() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(text("plain text"), Size::new(20, 1));
+    let lines: Vec<&Draw> = spec
+        .items
+        .iter()
+        .map(|i| &i.draw)
+        .filter(|d| matches!(d, Draw::Lines(_)))
+        .collect();
+    assert_eq!(lines.len(), 1);
+}
+
+/// **The reason spans exist rather than sibling nodes.** The pieces are one
+/// logical string, so wrapping runs across the boundaries between them: a break
+/// may fall inside a piece, and a row may be composed of several.
+#[test]
+fn wrapping_runs_across_piece_boundaries() {
+    use fresh_ui::{text_runs, Run};
+    let mut ui: Ui<()> = Ui::new();
+    // "hello " + "brave " + "world" = 17 cells, wrapped at 12.
+    let spec = ui.frame(
+        text_runs([
+            Run::plain("hello "),
+            Run::themed("brave ", "em"),
+            Run::plain("world"),
+        ])
+        .wrap()
+        .w(Sizing::Cells(12)),
+        Size::new(12, 4),
+    );
+
+    let text = painted_rows(spec);
+    assert_eq!(
+        text,
+        vec!["hello brave".to_string(), "world".to_string()],
+        "the pieces wrap as one string"
+    );
+
+    // The styled piece kept its theme even though the wrap fell inside it.
+    let em: Vec<String> = spec
+        .items
+        .iter()
+        .filter(|it| it.theme.as_str() == "em")
+        .filter_map(|it| match &it.draw {
+            Draw::Lines(l) => Some(l.join("")),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(em, vec!["brave".to_string()]);
+}
+
+/// Styling never changes where text breaks: a styled run and the same text
+/// unstyled wrap to identical rows.
+#[test]
+fn styling_does_not_change_where_text_breaks() {
+    use fresh_ui::{text_runs, Run};
+    let rows_of = |node: Node<()>| -> Vec<String> {
+        let mut ui: Ui<()> = Ui::new();
+        painted_rows(ui.frame(node, Size::new(12, 6)))
+    };
+
+    let sentence = "the quick brown fox jumps";
+    let plain = rows_of(text(sentence).wrap().w(Sizing::Cells(12)));
+    let styled = rows_of(
+        text_runs([
+            Run::plain("the quick "),
+            Run::themed("brown", "em"),
+            Run::plain(" fox jumps"),
+        ])
+        .wrap()
+        .w(Sizing::Cells(12)),
+    );
+    assert_eq!(plain, styled);
+}


### PR DESCRIPTION
Second base change for the UI migration, after the wheel axis (#3032). #3028 stacks on top.

## Why

A `TextRun` held one unstyled string, so text styled *within itself* — a fuzzy-match highlight in a palette row, a menu mnemonic, inline code in a sentence — had no expression.

Laying separate runs side by side is not a substitute. Siblings wrap and truncate independently, and the whole point of these cases is that the text is **one logical string**: a palette label ellipsizes across the whole label, and a markdown paragraph wraps across its bold and code spans.

**The editor already proved the need.** `view/markdown.rs` carries `StyledLine`/`StyledSpan` plus a `wrap_styled_lines` that flattens spans into words, wraps across the boundaries between them, and re-emits spans split at the wrap points. That vocabulary exists because rendering a markdown popup requires it — the library simply lacked it. Doing it editor-side instead would mean reimplementing paragraph wrapping *outside* the layout engine that owns wrapping, which is the "geometry computed in two places" problem the migration exists to end.

## What changed

- **`TextProps::runs` replaces `text`** — one piece for ordinary text, several when parts are styled. Built by `text()` (unchanged for callers) and the new `text_runs()`, with `Run::plain` / `Run::themed`. One representation, so pieces and content cannot disagree.
- **Measurement and wrapping work on the concatenation**, so styling never changes where text breaks — asserted directly by `styling_does_not_change_where_text_breaks`.
- **`wrap_runs`** cuts the wrapped rows back into fragments along the original piece boundaries; a break falling inside a piece splits it.

## Paint: the display list does not change

This is the part worth reviewing closely, because it's what keeps the change small.

- An **unstyled** run still emits exactly one item — the common case pays nothing.
- A **styled** run emits one item per fragment, each naming its own theme via the new `DrawList::push_themed`.

So an `Item` still carries exactly one `ThemeKey`, `Draw::Lines` is untouched, and **no backend learns about spans** — the TUI fold needs no changes, and a web backend gets a ready sequence of themed runs to render as nested elements. This was always legal: `LayoutSpec::index` maps a key to a `Range<usize>` of items, so several items for one node is the existing model.

## Verification

154 tests pass. **The goldens are unchanged**, so nothing that was not styled moved. New tests cover: one item per piece with correct tiling and themes; an unstyled run still being a single item; wrapping running across piece boundaries with the styled piece keeping its theme through the break; and styled/unstyled text breaking identically.

Clippy clean. The crate still builds standalone on `unicode-width` alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2GtzEBQRFZMv8qF61Jzr)_