### PR TITLE
fix(folding): stop a stale fold from swallowing a block header (#3031)

### DIFF
--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -132,6 +132,7 @@ impl Editor {
                 let buf = self.active_buffer();
                 let win = self.active_window_mut();
                 win.invalidate_layouts_for_buffer(buf);
+                win.prune_orphaned_folds(buf);
                 win.schedule_semantic_tokens_full_refresh(buf);
                 win.schedule_folding_ranges_refresh(buf);
             }
@@ -143,6 +144,7 @@ impl Editor {
                     let buf = self.active_buffer();
                     let win = self.active_window_mut();
                     win.invalidate_layouts_for_buffer(buf);
+                    win.prune_orphaned_folds(buf);
                     win.schedule_semantic_tokens_full_refresh(buf);
                     win.schedule_folding_ranges_refresh(buf);
                 }

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -847,9 +847,13 @@ fn create_fold(
         }
     });
 
-    buf_state
-        .folds
-        .add(&mut state.marker_list, start_byte, end_byte, placeholder);
+    buf_state.folds.add(
+        &state.buffer,
+        &mut state.marker_list,
+        start_byte,
+        end_byte,
+        placeholder,
+    );
 
     // If the viewport top is now inside the folded range, move it to the header.
     if buf_state.viewport.top_byte() >= start_byte && buf_state.viewport.top_byte() < end_byte {

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -154,6 +154,7 @@ impl Editor {
                                     .line_start_offset(end_line.saturating_add(1))
                                     .unwrap_or_else(|| state.buffer.len());
                                 buf_state.folds.add(
+                                    &state.buffer,
                                     &mut state.marker_list,
                                     start_byte,
                                     end_byte,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1785,6 +1785,7 @@ impl Window {
                     if vs.keyed_states.contains_key(&buffer_id) {
                         let buf_state = vs.ensure_buffer_state(buffer_id);
                         buf_state.folds.add(
+                            &state.buffer,
                             &mut state.marker_list,
                             start,
                             end,
@@ -1809,6 +1810,30 @@ impl Window {
                 }
             })
             .is_some()
+    }
+
+    /// Expand any fold on `buffer_id` whose header line the last edit took
+    /// away, across every view state hosting the buffer. Returns `true` when
+    /// a fold was retired, so the caller can flag a redraw.
+    ///
+    /// Runs from the edit path rather than the render path deliberately: the
+    /// folds are view state but the edit that orphans them is buffer state,
+    /// and retiring one changes what the buffer shows, so it belongs with the
+    /// edit that caused it (see [`FoldManager::prune_orphaned`]).
+    pub fn prune_orphaned_folds(&mut self, buffer_id: BufferId) -> bool {
+        self.buffers
+            .with_buffer_and_view_states(buffer_id, |state, vs_map| {
+                let mut pruned = false;
+                for vs in vs_map.values_mut() {
+                    if let Some(buf_state) = vs.keyed_states.get_mut(&buffer_id) {
+                        pruned |= buf_state
+                            .folds
+                            .prune_orphaned(&state.buffer, &mut state.marker_list);
+                    }
+                }
+                pruned
+            })
+            .unwrap_or(false)
     }
 
     /// Move every supplied split's primary cursor to `position` in

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1678,6 +1678,7 @@ impl crate::app::window::Window {
                                 .line_start_offset(end_line.saturating_add(1))
                                 .unwrap_or_else(|| state.buffer.len());
                             buf_state.folds.add(
+                                &state.buffer,
                                 &mut state.marker_list,
                                 start_byte,
                                 end_byte,

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -55,43 +55,61 @@ use super::Editor;
 ///   local external edit.
 /// - If still not found, return `None` so the caller drops the fold rather
 ///   than re-attaching it to unrelated content.
+///
+/// Whatever the route, a candidate that is blank is rejected (issue #3031).
+/// No fold-creation path puts a header on a blank line: indent folding
+/// refuses a blank header outright, and an LSP range starts on the
+/// construct it folds. A saved fold that resolves onto one is therefore
+/// stale — and restoring it is worse than dropping it, because the first
+/// hidden line is then the *real* block opener while the blank header row
+/// shows nothing but the placeholder, with no text and no line number to
+/// say a fold is there at all.
 fn resolve_fold_header_line(
     buffer: &crate::model::buffer::Buffer,
     saved_line: usize,
     header_text: Option<&str>,
 ) -> Option<usize> {
-    let Some(expected) = header_text else {
+    let line_text = |line: usize| -> Option<String> {
+        buffer.get_line(line).map(|bytes| {
+            String::from_utf8_lossy(&bytes)
+                .trim_end_matches('\n')
+                .trim_end_matches('\r')
+                .trim()
+                .to_string()
+        })
+    };
+    let candidate = match header_text {
         // Backward compatibility: no recorded text, trust the line number.
-        return Some(saved_line);
-    };
-    let expected_trimmed = expected.trim();
-    let line_matches = |line: usize| -> bool {
-        buffer
-            .get_line(line)
-            .map(|bytes| {
-                let text = String::from_utf8_lossy(&bytes);
-                text.trim_end_matches('\n').trim_end_matches('\r').trim() == expected_trimmed
-            })
-            .unwrap_or(false)
-    };
-    if line_matches(saved_line) {
-        return Some(saved_line);
-    }
-    // Search nearby (expanding outward) for the displaced header.
-    const SEARCH_WINDOW: usize = 32;
-    for delta in 1..=SEARCH_WINDOW {
-        let above = saved_line.checked_sub(delta);
-        if let Some(l) = above {
-            if line_matches(l) {
-                return Some(l);
+        None => Some(saved_line),
+        Some(expected) => {
+            let expected_trimmed = expected.trim();
+            let line_matches =
+                |line: usize| -> bool { line_text(line).as_deref() == Some(expected_trimmed) };
+            if line_matches(saved_line) {
+                Some(saved_line)
+            } else {
+                // Search nearby (expanding outward) for the displaced header.
+                const SEARCH_WINDOW: usize = 32;
+                let mut found = None;
+                for delta in 1..=SEARCH_WINDOW {
+                    let above = saved_line.checked_sub(delta);
+                    if let Some(l) = above {
+                        if line_matches(l) {
+                            found = Some(l);
+                            break;
+                        }
+                    }
+                    let below = saved_line.saturating_add(delta);
+                    if line_matches(below) {
+                        found = Some(below);
+                        break;
+                    }
+                }
+                found
             }
         }
-        let below = saved_line.saturating_add(delta);
-        if line_matches(below) {
-            return Some(below);
-        }
-    }
-    None
+    };
+    candidate.filter(|line| line_text(*line).is_some_and(|text| !text.is_empty()))
 }
 
 /// Workspace persistence state tracker
@@ -1636,8 +1654,8 @@ impl crate::app::window::Window {
                                 fold.header_text.as_deref(),
                             ) else {
                                 tracing::debug!(
-                                    "Dropping stale fold: header_line={} no longer matches stored \
-                             header_text after external edit",
+                                    "Dropping stale fold: header_line={} no longer resolves to a \
+                             usable header (text drift, or the line it lands on is blank)",
                                     fold.header_line,
                                 );
                                 continue;

--- a/crates/fresh-editor/src/view/folding.rs
+++ b/crates/fresh-editor/src/view/folding.rs
@@ -9,6 +9,12 @@ use crate::model::marker::{MarkerId, MarkerList};
 /// A collapsed fold range tracked by markers.
 #[derive(Debug, Clone)]
 pub struct FoldRange {
+    /// Marker at the first byte of the header line — the visible line that
+    /// owns the fold. Recorded at creation rather than re-derived from
+    /// `start_marker` on every query, so the fold keeps an identity for the
+    /// line it was collapsed on and [`FoldManager::prune_orphaned`] can tell
+    /// when that line is gone.
+    header_marker: MarkerId,
     /// Marker at the first hidden byte (start of line after header)
     start_marker: MarkerId,
     /// Marker at the end of the hidden range (start of line after fold end)
@@ -50,6 +56,17 @@ pub struct CollapsedFoldLineRange {
     pub header_text: Option<String>,
 }
 
+/// Whether the line starting at `line_start` has no non-whitespace content.
+///
+/// Shared by [`FoldManager::prune_orphaned`] and session restore, which
+/// enforce the same invariant from opposite ends: a blank line never owns a
+/// fold, whether it got there by an edit or by stale saved coordinates.
+fn header_line_is_blank(buffer: &Buffer, line_start: usize) -> bool {
+    let line_end = indent_folding::find_line_end_byte(buffer, line_start);
+    let bytes = buffer.slice_bytes(line_start..line_end);
+    indent_folding::slice_indent(&bytes, 1).1
+}
+
 /// Manages collapsed fold ranges for a buffer.
 #[derive(Debug, Clone)]
 pub struct FoldManager {
@@ -68,8 +85,16 @@ impl FoldManager {
     }
 
     /// Add a collapsed fold range.
+    ///
+    /// The header is the line immediately before the hidden range — that is
+    /// what every creation path (indent folding, LSP ranges, plugin
+    /// `addFold`) means by a fold's header — and it is pinned with its own
+    /// marker here so later edits can be told apart: one that merely moves
+    /// the header keeps the fold, one that deletes it retires the fold (see
+    /// [`Self::prune_orphaned`]).
     pub fn add(
         &mut self,
+        buffer: &Buffer,
         marker_list: &mut MarkerList,
         start: usize,
         end: usize,
@@ -79,11 +104,16 @@ impl FoldManager {
             return;
         }
 
-        // Both right gravity, like every `MarkerList::create` marker.
+        // All right gravity, like every `MarkerList::create` marker.
+        let header_marker = marker_list.create(indent_folding::find_line_start_byte(
+            buffer,
+            start.saturating_sub(1),
+        ));
         let start_marker = marker_list.create(start);
         let end_marker = marker_list.create(end);
 
         self.ranges.push(FoldRange {
+            header_marker,
             start_marker,
             end_marker,
             placeholder,
@@ -93,10 +123,67 @@ impl FoldManager {
     /// Remove all fold ranges and their markers.
     pub fn clear(&mut self, marker_list: &mut MarkerList) {
         for range in &self.ranges {
+            marker_list.delete(range.header_marker);
             marker_list.delete(range.start_marker);
             marker_list.delete(range.end_marker);
         }
         self.ranges.clear();
+    }
+
+    /// Retire folds whose header line no longer exists, expanding them.
+    ///
+    /// A collapsed fold is a statement about one line: "the block opening
+    /// here is folded away". Delete that line and the statement has no
+    /// subject left — but the markers on the *hidden* range survive the
+    /// edit (the interval tree clamps markers into a deletion rather than
+    /// dropping them), so without this the fold silently adopts whatever
+    /// line now precedes the body and keeps someone's code hidden under a
+    /// header they never folded (#3031).
+    ///
+    /// Two shapes of "the opener is gone", both retired:
+    ///
+    /// * the header line was deleted outright — its marker has collapsed
+    ///   into the hidden range's start, so the fold no longer has a visible
+    ///   line of its own;
+    /// * the header line survives but its text does not. A blank line can
+    ///   never own a fold — indent folding refuses a blank header outright,
+    ///   and an LSP range starts on the construct it folds — so a fold that
+    ///   ends up on one is tracking something that has been edited away.
+    ///
+    /// Returns true when anything was retired, so callers can flag a redraw.
+    pub fn prune_orphaned(&mut self, buffer: &Buffer, marker_list: &mut MarkerList) -> bool {
+        if self.ranges.is_empty() {
+            return false;
+        }
+
+        let mut to_delete = Vec::new();
+
+        self.ranges.retain(|range| {
+            let header_byte = marker_list.get_position(range.header_marker);
+            let start_byte = marker_list.get_position(range.start_marker);
+            let orphaned = match (header_byte, start_byte) {
+                // The header line was deleted: its marker has been clamped
+                // to (or past) the first hidden byte, so no visible line is
+                // left to own the fold.
+                (Some(header), Some(start)) => {
+                    header >= start || header_line_is_blank(buffer, header)
+                }
+                // A marker that no longer resolves cannot be re-anchored.
+                _ => true,
+            };
+            if orphaned {
+                to_delete.push((range.header_marker, range.start_marker, range.end_marker));
+            }
+            !orphaned
+        });
+
+        for (header, start, end) in &to_delete {
+            marker_list.delete(*header);
+            marker_list.delete(*start);
+            marker_list.delete(*end);
+        }
+
+        !to_delete.is_empty()
     }
 
     /// Remove any fold that contains the given byte position.
@@ -112,14 +199,15 @@ impl FoldManager {
                 return true;
             };
             if start_byte <= byte && byte < end_byte {
-                to_delete.push((range.start_marker, range.end_marker));
+                to_delete.push((range.header_marker, range.start_marker, range.end_marker));
                 false
             } else {
                 true
             }
         });
 
-        for (start, end) in &to_delete {
+        for (header, start, end) in &to_delete {
+            marker_list.delete(*header);
             marker_list.delete(*start);
             marker_list.delete(*end);
         }
@@ -155,11 +243,18 @@ impl FoldManager {
                 continue;
             }
 
-            let header_byte =
-                indent_folding::find_line_start_byte(buffer, start_byte.saturating_sub(1));
+            // The recorded header, not one re-derived from `start_byte`: the
+            // two agree while the fold is intact, and when they don't the
+            // fold is stale and `prune_orphaned` retires it.
+            let Some(header_byte) = marker_list.get_position(range.header_marker) else {
+                continue;
+            };
+            if header_byte >= start_byte {
+                continue;
+            }
 
             ranges.push(ResolvedFoldRange {
-                header_line: start_line - 1,
+                header_line: buffer.get_line_number(header_byte),
                 start_line,
                 end_line,
                 start_byte,
@@ -189,27 +284,26 @@ impl FoldManager {
     /// Returns true if a fold was removed.
     pub fn remove_by_header_byte(
         &mut self,
-        buffer: &Buffer,
+        _buffer: &Buffer,
         marker_list: &mut MarkerList,
         target_header_byte: usize,
     ) -> bool {
         let mut to_delete = Vec::new();
 
         self.ranges.retain(|range| {
-            let Some(start_byte) = marker_list.get_position(range.start_marker) else {
+            let Some(current_header) = marker_list.get_position(range.header_marker) else {
                 return true;
             };
-            let current_header =
-                indent_folding::find_line_start_byte(buffer, start_byte.saturating_sub(1));
             if current_header == target_header_byte {
-                to_delete.push((range.start_marker, range.end_marker));
+                to_delete.push((range.header_marker, range.start_marker, range.end_marker));
                 false
             } else {
                 true
             }
         });
 
-        for (start, end) in &to_delete {
+        for (header, start, end) in &to_delete {
+            marker_list.delete(*header);
             marker_list.delete(*start);
             marker_list.delete(*end);
         }

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -1258,7 +1258,13 @@ mod tests {
         let start = state.buffer.line_start_offset(1).unwrap();
         let end = state.buffer.line_start_offset(3).unwrap();
         let mut folds = FoldManager::new();
-        folds.add(&mut state.marker_list, start, end, Some("...".to_string()));
+        folds.add(
+            &state.buffer,
+            &mut state.marker_list,
+            start,
+            end,
+            Some("...".to_string()),
+        );
 
         let viewport = Viewport::new(40, 6);
         let gutter_width = state.margins.left_total_width();
@@ -1366,7 +1372,7 @@ mod tests {
         let start = state.buffer.line_start_offset(1).unwrap();
         let end = state.buffer.line_start_offset(2).unwrap();
         let mut folds = FoldManager::new();
-        folds.add(&mut state.marker_list, start, end, None);
+        folds.add(&state.buffer, &mut state.marker_list, start, end, None);
 
         let line1_byte = state.buffer.line_start_offset(1).unwrap();
         let view_lines = vec![ViewLine {

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -641,7 +641,24 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
         // Use the elegant pipeline's should_show_line_number function
         // This correctly handles: injected content, wrapped continuations, and source lines
-        let show_line_number = should_show_line_number(current_view_line);
+        let mut show_line_number = should_show_line_number(current_view_line);
+
+        // A collapsed fold's header row always owns a source line, even when
+        // that line is empty: the placeholder `apply_folding` appends then
+        // sits *in front of* the row's only source character (its newline),
+        // which reads to `should_show_line_number` as an injected row. Left
+        // alone it costs the row both its number and — because the fold
+        // indicator is keyed off `line_start_byte` — its `▸` arrow, so the
+        // hidden line looks like text the editor silently replaced with
+        // "..." rather than a fold anyone can see or click open (#3031).
+        if !show_line_number && !line_start_type.is_continuation() {
+            show_line_number = current_view_line.source_start_byte.is_some_and(|byte| {
+                decorations
+                    .fold_indicators
+                    .get(&byte)
+                    .is_some_and(|indicator| indicator.collapsed)
+            });
+        }
 
         // is_continuation means "don't show line number" for rendering purposes
         let is_continuation = !show_line_number;

--- a/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
@@ -25,6 +25,7 @@ use crate::common::fixtures::TestFixture;
 use crate::common::harness::{layout, EditorTestHarness, HarnessOptions};
 use fresh::config::Config;
 use fresh::config_io::DirectoryContext;
+use fresh::model::event::Event;
 use fresh::workspace::Workspace;
 use tempfile::TempDir;
 
@@ -70,6 +71,12 @@ fn line_byte_range(harness: &mut EditorTestHarness, line: usize) -> (usize, usiz
         .line_start_offset(line + 1)
         .unwrap_or_else(|| buffer.len());
     (start, end)
+}
+
+/// The full text of `line`, newline included.
+fn header_line_text(harness: &mut EditorTestHarness, line: usize) -> String {
+    let buffer = &mut harness.editor_mut().active_state_mut().buffer;
+    String::from_utf8_lossy(&buffer.get_line(line).expect("line exists")).to_string()
 }
 
 /// Age the session Fresh just wrote into the shape an older Fresh wrote:
@@ -244,6 +251,105 @@ fn test_collapsed_fold_on_blank_header_keeps_its_line_number_and_arrow() {
         "Issue #3031: the collapsed fold's header row lost its fold arrow, \
          leaving no way to see — or click open — the fold hiding \
          `debug {{`. Screen:\n{}",
+        screen
+    );
+}
+
+/// A collapsed fold is a claim about one line: "the block opening here is
+/// folded away". Delete that line and the claim has no subject — so the fold
+/// must retire and give the body back, rather than re-anchoring onto whatever
+/// line now precedes it and keeping the code hidden under a header nobody
+/// folded.
+#[test]
+fn test_deleting_the_fold_header_line_expands_the_fold() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let fixture = TestFixture::new("config.kdl", NIRI_CONFIG).unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    let buffer_id = harness.editor().active_buffer();
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .toggle_fold_at_line(buffer_id, DEBUG_HEADER_LINE);
+    harness.render().unwrap();
+    assert_eq!(
+        collapsed_fold_rows(&harness).len(),
+        1,
+        "Precondition: the `debug` block should be collapsed. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Delete the whole header line, newline included.
+    let (start, end) = line_byte_range(&mut harness, DEBUG_HEADER_LINE);
+    let deleted_text = header_line_text(&mut harness, DEBUG_HEADER_LINE);
+    let cursor_id = harness.editor().active_cursors().primary_id();
+    harness
+        .apply_event(Event::Delete {
+            range: start..end,
+            deleted_text,
+            cursor_id,
+        })
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("honor-xdg-activation-with-invalid-serial"),
+        "Deleting a collapsed fold's header line must expand the fold and \
+         give its body back; the body is still hidden. Screen:\n{}",
+        screen
+    );
+    assert!(
+        collapsed_fold_rows(&harness).is_empty(),
+        "The fold should be gone with its header, not re-anchored onto the \
+         line above. Screen:\n{}",
+        screen
+    );
+}
+
+/// Same claim, emptied rather than removed: the header line survives but its
+/// text is deleted. A blank line can never own a fold — indent folding
+/// refuses a blank header outright — so this retires the fold too.
+#[test]
+fn test_emptying_the_fold_header_line_expands_the_fold() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let fixture = TestFixture::new("config.kdl", NIRI_CONFIG).unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    let buffer_id = harness.editor().active_buffer();
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .toggle_fold_at_line(buffer_id, DEBUG_HEADER_LINE);
+    harness.render().unwrap();
+
+    // Delete the header line's text but leave its newline in place.
+    let (start, _) = line_byte_range(&mut harness, DEBUG_HEADER_LINE);
+    let text = header_line_text(&mut harness, DEBUG_HEADER_LINE);
+    let text_len = text.trim_end_matches('\n').len();
+    let cursor_id = harness.editor().active_cursors().primary_id();
+    harness
+        .apply_event(Event::Delete {
+            range: start..start + text_len,
+            deleted_text: text.trim_end_matches('\n').to_string(),
+            cursor_id,
+        })
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("honor-xdg-activation-with-invalid-serial"),
+        "Emptying a collapsed fold's header line must expand the fold: a \
+         blank line owns nothing. Screen:\n{}",
+        screen
+    );
+    assert!(
+        collapsed_fold_rows(&harness).is_empty(),
+        "No collapsed fold should survive on a blank header line. \
+         Screen:\n{}",
         screen
     );
 }

--- a/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
@@ -1,18 +1,28 @@
-//! E2E test for issue #3031: opening a Niri KDL config, the line
+//! E2E tests for issue #3031: opening a Niri KDL config, the line
 //! `debug {` renders as a bare `...` — as if the editor had swallowed the
 //! word. The file on disk is fine (`nano` shows it), and nothing about KDL
 //! is special here: what the reporter is looking at is a *collapsed fold*
 //! whose header landed on the blank line above `debug {`, so the block
 //! opener itself is inside the hidden range.
 //!
-//! How a fold gets there: a session file written before `header_text` was
-//! recorded (issue #1568) carries only line numbers, which restore trusts
-//! blindly. Edit the file between sessions and the saved header slides onto
-//! a blank line, putting the real block opener into the hidden range.
+//! Two independent defects conspire, and each gets a test here:
+//!
+//! 1. Session restore accepted a stale fold. A session file written before
+//!    `header_text` was recorded (issue #1568) carries only line numbers,
+//!    which restore trusts blindly. Edit the file between sessions and the
+//!    saved header slides onto a blank line, putting the real block opener
+//!    (`debug {`) into the folded — hidden — range.
+//!
+//! 2. Rendering then hid the evidence. The placeholder `apply_folding`
+//!    appends lands in front of a blank header row's only source character,
+//!    which reads as an injected row: no line number, and no `▸` arrow to
+//!    click. All that is left on screen is `...` where a line of the user's
+//!    config used to be.
 //!
 //! <https://github.com/sinelaw/fresh/issues/3031>
 
-use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crate::common::fixtures::TestFixture;
+use crate::common::harness::{layout, EditorTestHarness, HarnessOptions};
 use fresh::config::Config;
 use fresh::config_io::DirectoryContext;
 use fresh::workspace::Workspace;
@@ -50,6 +60,16 @@ fn collapsed_fold_rows(harness: &EditorTestHarness) -> Vec<usize> {
                 .unwrap_or(false)
         })
         .collect()
+}
+
+/// Byte range covering exactly `line` (its text plus its newline).
+fn line_byte_range(harness: &mut EditorTestHarness, line: usize) -> (usize, usize) {
+    let buffer = &mut harness.editor_mut().active_state_mut().buffer;
+    let start = buffer.line_start_offset(line).expect("line exists");
+    let end = buffer
+        .line_start_offset(line + 1)
+        .unwrap_or_else(|| buffer.len());
+    (start, end)
 }
 
 /// Age the session Fresh just wrote into the shape an older Fresh wrote:
@@ -174,4 +194,56 @@ fn test_stale_legacy_fold_on_blank_line_is_dropped_on_restore() {
             screen
         );
     }
+}
+
+/// Defence in depth for the same symptom: whatever put a collapsed fold on
+/// a blank header line (a stale session, marker drift after an edit, a
+/// plugin calling `addFold`), the header row must still say so — line
+/// number in the gutter and a `▸` to click — instead of showing a bare
+/// `...` that reads as vanished text.
+#[test]
+fn test_collapsed_fold_on_blank_header_keeps_its_line_number_and_arrow() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let fixture = TestFixture::new("config.kdl", NIRI_CONFIG).unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    // Plant a fold that hides exactly the `debug {` line, which makes the
+    // blank line above it the fold's header.
+    let (start, end) = line_byte_range(&mut harness, DEBUG_HEADER_LINE);
+    let buffer_id = harness.editor().active_buffer();
+    assert!(harness
+        .editor_mut()
+        .active_window_mut()
+        .add_fold(buffer_id, start, end, None));
+    harness.render().unwrap();
+
+    let header_row = layout::CONTENT_START_ROW + BLANK_LINE;
+    let row_text = harness.get_row_text(header_row as u16);
+    let screen = harness.screen_to_string();
+
+    assert!(
+        row_text.contains("..."),
+        "Precondition: the fold placeholder should render on the blank \
+         header row {}. Screen:\n{}",
+        header_row,
+        screen
+    );
+    assert!(
+        row_text.contains(&(BLANK_LINE + 1).to_string()),
+        "Issue #3031: the collapsed fold's header row lost its line \
+         number, so the hidden line reads as text the editor replaced with \
+         `...`. Row {} text: {:?}. Screen:\n{}",
+        header_row,
+        row_text,
+        screen
+    );
+    assert_eq!(
+        harness.get_cell(0, header_row as u16).as_deref(),
+        Some("▸"),
+        "Issue #3031: the collapsed fold's header row lost its fold arrow, \
+         leaving no way to see — or click open — the fold hiding \
+         `debug {{`. Screen:\n{}",
+        screen
+    );
 }

--- a/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs
@@ -1,0 +1,177 @@
+//! E2E test for issue #3031: opening a Niri KDL config, the line
+//! `debug {` renders as a bare `...` — as if the editor had swallowed the
+//! word. The file on disk is fine (`nano` shows it), and nothing about KDL
+//! is special here: what the reporter is looking at is a *collapsed fold*
+//! whose header landed on the blank line above `debug {`, so the block
+//! opener itself is inside the hidden range.
+//!
+//! How a fold gets there: a session file written before `header_text` was
+//! recorded (issue #1568) carries only line numbers, which restore trusts
+//! blindly. Edit the file between sessions and the saved header slides onto
+//! a blank line, putting the real block opener into the hidden range.
+//!
+//! <https://github.com/sinelaw/fresh/issues/3031>
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::workspace::Workspace;
+use tempfile::TempDir;
+
+/// A trimmed-down Niri config with the reporter's `debug` block. Line
+/// numbers below are 0-indexed: 7 is the blank line, 8 is `debug {`.
+const NIRI_CONFIG: &str = "\
+input {
+    keyboard {
+        xkb {
+            layout \"us\"
+        }
+    }
+}
+
+debug {
+  // Allows notification actions and window activation from Noctalia.
+  honor-xdg-activation-with-invalid-serial
+}
+";
+
+const BLANK_LINE: usize = 7;
+const DEBUG_HEADER_LINE: usize = 8;
+
+/// Rows carrying a collapsed-fold indicator in the gutter's first column.
+fn collapsed_fold_rows(harness: &EditorTestHarness) -> Vec<usize> {
+    let (start, end) = harness.content_area_rows();
+    (start..=end)
+        .filter(|row| {
+            harness
+                .get_cell(0, *row as u16)
+                .as_deref()
+                .map(|cell| cell == "▸")
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Age the session Fresh just wrote into the shape an older Fresh wrote:
+/// line numbers only, no `header_text` — the field only arrived with the
+/// issue #1568 fix, so every session file written before it looks like
+/// this. The header is also slid one line up, onto the blank line, which is
+/// where an external edit that dropped a line above the block leaves it.
+///
+/// Returns how many folds were aged, so the test can tell a real repro
+/// from a session that never recorded one.
+fn age_session_folds_to_blank_header(project_dir: &std::path::Path) -> usize {
+    let mut workspace = Workspace::load(project_dir)
+        .expect("session 1 wrote a workspace")
+        .expect("session 1 wrote a workspace");
+    let mut aged = 0;
+    for split_state in workspace.split_states.values_mut() {
+        for file_state in split_state.file_states.values_mut() {
+            for fold in file_state.folds.iter_mut() {
+                fold.header_text = None;
+                fold.header_line = BLANK_LINE;
+                fold.end_line = DEBUG_HEADER_LINE;
+                aged += 1;
+            }
+        }
+    }
+    workspace.save().expect("aged workspace is writable");
+    aged
+}
+
+/// A fold restored onto a blank line is stale by construction — no
+/// fold-creation path ever puts a header there — and restoring it hides the
+/// block opener that follows. It must be dropped, leaving `debug {` on
+/// screen.
+#[test]
+fn test_stale_legacy_fold_on_blank_line_is_dropped_on_restore() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("niri");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file_path = project_dir.join("config.kdl");
+    std::fs::write(&file_path, NIRI_CONFIG).unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // --- Session 1: fold the `debug` block so the session records a fold.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+        harness.open_file(&file_path).unwrap();
+        harness.render().unwrap();
+
+        let buffer_id = harness.editor().active_buffer();
+        harness
+            .editor_mut()
+            .active_window_mut()
+            .toggle_fold_at_line(buffer_id, DEBUG_HEADER_LINE);
+        harness.render().unwrap();
+
+        assert_eq!(
+            collapsed_fold_rows(&harness).len(),
+            1,
+            "Precondition: the `debug` block should be collapsed. Screen:\n{}",
+            harness.screen_to_string()
+        );
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // --- Between sessions: age the session file into the pre-#1568 shape
+    //     and slide its header onto the blank line above `debug {`.
+    let aged = age_session_folds_to_blank_header(&project_dir);
+    assert_eq!(
+        aged, 1,
+        "Precondition: session 1 must have persisted exactly the one fold \
+         this test ages"
+    );
+
+    // --- Session 2: restore. The stale fold must not swallow `debug {`.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let _ = harness.startup(true, &[]).unwrap();
+        harness.open_file(&file_path).unwrap();
+        harness.render().unwrap();
+
+        let screen = harness.screen_to_string();
+        assert!(
+            screen.contains("debug {"),
+            "Issue #3031: `debug {{` disappeared from the buffer — a stale \
+             fold restored onto the blank line above it hid the block \
+             opener behind a placeholder. Screen:\n{}",
+            screen
+        );
+        assert!(
+            collapsed_fold_rows(&harness).is_empty(),
+            "Issue #3031: the stale fold should have been dropped, not \
+             restored. Screen:\n{}",
+            screen
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -113,6 +113,7 @@ pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
 pub mod issue_3006_drag_beyond_text_area;
 pub mod issue_3006_shift_select_at_buffer_edges;
+pub mod issue_3031_stale_fold_hides_block_header;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;


### PR DESCRIPTION
**In one line:** `debug {` looked deleted because a collapsed fold had come to rest on the blank line above it and hidden it, and that blank header row rendered as a bare `...` with no line number or arrow — so a fold now keeps an identity for the line it was folded on, retires when that line is deleted, is never restored onto a blank line, and always renders a header row you can see and click.

Fixes #3031.

## What the reporter is actually seeing

Nothing about KDL is involved. Reproduced from the screenshot: line 60 (`debug {`) is inside a **collapsed fold whose header is the blank line above it**, so the block opener is the first *hidden* line. The header row — being blank — renders as nothing but the placeholder, with no line number and no `▸`, which is why it reads as "the editor replaced my text with `...`".

Reproduced manually in tmux, then in the tests below. Before:

```
▾ 7 │ }
    │  ...          ← lines 8 (blank) and 9 (`debug {`) are gone
 10 │   // Allows notification actions and window activation
```

Three defects, one per commit. The first two are how the reported state is reached and why it's invisible; the third is the same state reached by editing rather than by restore.

### 1. Session restore accepted a stale fold

`header_text` only started being recorded with #1568, so any session file written before that carries line numbers alone — and restore trusts them blindly. Edit the file between sessions and the saved header slides onto whatever now sits at that line number; land it on a blank line and the fold eats the real block opener.

No fold-creation path ever puts a header on a blank line (indent folding refuses a blank header outright; an LSP range starts on the construct it folds), so a resolved header that is blank is proof the coordinates are stale. Such folds are now dropped — on every resolution route, not just the text-matched one.

### 2. Rendering then hid the evidence

`apply_folding` appends its placeholder to the header line. On an *empty* header line those characters land in front of the row's only source character (its newline), which is exactly the shape `should_show_line_number` uses to recognise an injected row. The row loses its number and, with it, `line_start_byte` — the key the fold indicator is looked up by — so the arrow that would open the fold disappears too.

A row whose source byte owns a collapsed fold now keeps its number and its arrow, so such a fold is always visible and clickable however it arose.

### 3. Deleting the folded line left the fold behind

Same state, reached without any session restore. `FoldManager` kept markers only on the *hidden* range and re-derived the header per query as "whatever line precedes it", and the interval tree clamps markers into a deletion rather than dropping them — so deleting the opener left the fold alive, re-anchored onto the line above, still hiding code under a header nobody folded.

A fold now pins its header with its own marker at creation and retires when that line goes away: deleted outright (the marker collapses into the hidden range) or emptied of its text. The check runs from the edit path, beside the layout invalidation that already reacts to edits.

Worth stating for review: clearing a header line's text now expands its fold instead of leaving it collapsed under a blank row. That is the intent — the alternative is hidden content whose header says nothing — but it does mean an edit can expand a fold where previously only a toggle could.

## Tests

`crates/fresh-editor/tests/e2e/issue_3031_stale_fold_hides_block_header.rs`, all asserting only on rendered output:

- `test_stale_legacy_fold_on_blank_line_is_dropped_on_restore` — folds the `debug` block in session 1, ages the persisted fold into the pre-#1568 shape (no `header_text`, header slid onto the blank line), restores in session 2, and requires `debug {` back on screen with no fold left.
- `test_collapsed_fold_on_blank_header_keeps_its_line_number_and_arrow` — plants a fold that hides exactly the `debug {` line and requires the header row to still show its line number and `▸`.
- `test_deleting_the_fold_header_line_expands_the_fold` — folds the block, deletes the header line through the real edit path, and requires the body back on screen with no fold re-anchored above.
- `test_emptying_the_fold_header_line_expands_the_fold` — same, with the line emptied rather than removed.

Each fails without its commit's fix (verified by stashing the source changes) and passes with it. `cargo fmt`, `cargo clippy --all-targets`, `cargo check --all-targets` and `--features gui` are clean. Locally green: the `fold` e2e subset (65), the fold unit tests (14), `audit_mode` + `review_diff` (78 — the plugin that drives `addFold` hardest), `compose` (120) and `line_number` (19). Both behaviours were also confirmed by hand in tmux against the built binary.