### PR TITLE
fix(diff): cover the whole hunk-header row with the diff wash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * Deleting the line a fold was folded on now expands the fold instead of leaving a dangling marker.
 * **Search & Replace** no longer opens with every input field missing when invoked a second time while the panel is still opening (#3019).
 * **Git Log**: diff colours in the commit detail panel no longer drift off their rows for commits containing non-ASCII text (#3014).
+* **Diff files**: a hunk header's coloured bar now covers the whole row - the enclosing-section name `git diff` appends after the closing `@@` no longer sits in an uncoloured gap (#3021).
 * **Markdown**
   * Heading marks appear on the scrollbar as soon as a file opens, not only after scrolling past them, and stay stable and limited to top-level headings (#2990).
   * Compose mode no longer frames the paragraph after a fenced code block as code when the buffer opens or scrolls into view mid-document (#3001).

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -696,7 +696,8 @@ fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<Pr
     (line_end, line_byte_len, prepared)
 }
 
-/// Streaming span sink that keeps a washed row's background hole-free.
+/// Streaming span sink that fills the *unclaimed* gaps of a washed row
+/// with that row's wash.
 ///
 /// The diff categories (`Inserted` / `Deleted` / `Changed`) are the
 /// ones whose `bg_extends_to_line_end()` is set: the renderer treats
@@ -709,20 +710,31 @@ fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<Pr
 /// the trailing fill past end-of-line, with the section name sitting in
 /// a hole.
 ///
-/// So the guarantee is enforced per row rather than per scope: when the
-/// row's *first* span starts at the row start and carries a wash, any
-/// byte range of the row that no later span claims is emitted with that
-/// same category. Rows whose leading span is not a wash (ordinary code)
-/// pass through untouched. Filler spans merge with their neighbours in
-/// `merge_adjacent_spans`, and the wash categories resolve to the
-/// editor foreground, so filling changes background only.
+/// So the rule is applied per row rather than per scope: when the span
+/// covering the row start carries a wash, every byte range of the row
+/// that *no span claims* is emitted with that same category. Rows whose
+/// covering span at the row start is not a wash — every row of ordinary
+/// source, and the non-wash rows of a diff — pass through untouched.
+/// Filler spans merge with their neighbours in `merge_adjacent_spans`,
+/// and the wash categories resolve to the editor foreground, so filling
+/// changes background only.
+///
+/// The guarantee stops at "unclaimed": a span that *does* claim a range
+/// inside a washed row keeps its own category, background or none, so
+/// the bar still breaks across it. That is reachable — syntect's `Diff`
+/// grammar matches `meta.diff.header.to-file` mid-row, so a section
+/// name shaped like `- foo ====` inside a hunk header is scoped as a
+/// file header — but not by anything `git diff` emits, so the sink is
+/// deliberately not scope-aware. See
+/// `test_diff_hunk_header_inner_span_is_a_known_wash_hole`.
 struct RowWash<F: FnMut(usize, usize, HighlightCategory)> {
     row_start: usize,
     row_end: usize,
-    /// The wash to fill gaps with; `None` until the first span decides,
-    /// and stays `None` for rows that carry no wash.
+    /// The wash to fill gaps with; `None` until the span covering
+    /// `row_start` decides, and stays `None` for rows carrying no wash.
     wash: Option<HighlightCategory>,
-    /// Whether the leading span has been seen (so `wash` is decided).
+    /// Whether the span covering `row_start` has been seen (so `wash`
+    /// is decided).
     decided: bool,
     /// End of the highest byte range emitted so far.
     covered: usize,
@@ -742,9 +754,14 @@ impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
     }
 
     fn emit(&mut self, start: usize, end: usize, category: HighlightCategory) {
-        if !self.decided {
+        // Decide from the span that *covers* `row_start`, not from
+        // whichever span happens to arrive first: an empty leading
+        // segment (`start == end == row_start`) must not decide the
+        // row, so the rule does not depend on the producer skipping
+        // zero-length ranges.
+        if !self.decided && end > self.row_start {
             self.decided = true;
-            if start == self.row_start && category.bg_extends_to_line_end() {
+            if start <= self.row_start && category.bg_extends_to_line_end() {
                 self.wash = Some(category);
             }
         }
@@ -977,8 +994,9 @@ impl TextMateEngine {
     /// Parse one line advancing the composite `snapshot` (host parser +
     /// optional embedded-language child parser). This is the single
     /// per-line entry point for all parse paths, so embedded regions
-    /// behave identically under cold start, forward extension, and
-    /// partial update.
+    /// behave identically under cold start, forward extension and
+    /// partial update — and under `structure_lines_in`, which advances
+    /// the same snapshot but discards the spans.
     ///
     /// Line classification is driven purely by the host grammar's scope
     /// stack (no second lexer that could disagree with what the host
@@ -999,10 +1017,10 @@ impl TextMateEngine {
     /// region ends. Content lines therefore cost one extra (trivial)
     /// host `parse_line` on top of the child parse.
     ///
-    /// Spans leave this function through `RowWash`, which closes
-    /// bg-less holes on rows the grammar washes edge to edge (see its
-    /// docs) — a `@@` hunk header whose trailing section name is
-    /// scoped separately would otherwise punch a hole in the bar.
+    /// Spans leave this function through `RowWash`, which fills the
+    /// unclaimed gaps of rows the grammar washes (see its docs) — a
+    /// `@@` hunk header whose trailing section name is left outside
+    /// `meta.diff.range` would otherwise punch a hole in the bar.
     fn parse_snapshot_line(
         &mut self,
         snapshot: &mut ParseSnapshot,
@@ -3743,6 +3761,80 @@ mod tests {
             assert_eq!(headers_checked, 2, "both hunk headers should be examined");
         } else {
             panic!("Expected TextMate engine for .diff file");
+        }
+    }
+
+    /// Pins the known limitation of the `RowWash` gap fill: it fills
+    /// only the byte ranges of a washed row that *no* span claims. A
+    /// span that does claim its range keeps its own (bg-less)
+    /// category, so the bar still breaks across it.
+    ///
+    /// This is reachable with the shipped `Diff` grammar because its
+    /// `meta.diff.header.to-file` rule is not `^`-anchored: a
+    /// hunk-header section name shaped like `- foo ====` is scoped as
+    /// a file header mid-row and maps to `Type`, which carries no
+    /// background (asserted below). `git diff` never emits a
+    /// section name of that shape, so the algorithm is deliberately
+    /// left as is rather than made scope-aware. If that ever changes,
+    /// this test and the `RowWash` doc comment are what to update.
+    #[test]
+    fn test_diff_hunk_header_inner_span_is_a_known_wash_hole() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        const RANGE: &str = "@@ -2,6 +2,8 @@";
+        const SECTION: &str = " - foo ====";
+        let content = format!(
+            "--- a/file.rs\n\
+             +++ b/file.rs\n\
+             {RANGE}{SECTION}\n\
+             context\n"
+        );
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+
+        let HighlightEngine::TextMate(ref mut tm) = engine else {
+            panic!("Expected TextMate engine for .diff file");
+        };
+        let spans = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+        let span_at = |byte_pos: usize| {
+            spans
+                .iter()
+                .find(|s| s.range.start <= byte_pos && s.range.end > byte_pos)
+        };
+        let bg_at = |byte_pos: usize| span_at(byte_pos).and_then(|s| s.bg);
+
+        let header_start = content.find(RANGE).expect("header line present");
+        // The `@@ … @@` run is washed, as issue #3021 requires.
+        for byte_pos in header_start..header_start + RANGE.len() {
+            assert_eq!(
+                bg_at(byte_pos),
+                Some(theme.diff_modify_bg),
+                "byte {byte_pos} of `{RANGE}` should carry diff_modify_bg",
+            );
+        }
+        // …but the section name is *claimed* by a non-wash span, so the
+        // gap fill does not reach it. Documented limitation, not a
+        // shape `git diff` produces.
+        for byte_pos in header_start + RANGE.len()..header_start + RANGE.len() + SECTION.len() {
+            let span = span_at(byte_pos);
+            // `Type` is what `meta.diff.header.*` maps to in
+            // `scope_to_category` — i.e. the run really is claimed by
+            // the unanchored to-file header rule, not merely unstyled.
+            assert_eq!(
+                span.and_then(|s| s.category),
+                Some(HighlightCategory::Type),
+                "byte {byte_pos} of `{SECTION}` should be claimed by the \
+                 `meta.diff.header.*` rule",
+            );
+            assert_ne!(
+                bg_at(byte_pos),
+                Some(theme.diff_modify_bg),
+                "byte {byte_pos} of `{SECTION}` is claimed, so the gap fill \
+                 does not reach it; if it now carries the wash, the \
+                 limitation was fixed — update this test and the `RowWash` docs",
+            );
         }
     }
 

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -696,6 +696,78 @@ fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<Pr
     (line_end, line_byte_len, prepared)
 }
 
+/// Streaming span sink that keeps a washed row's background hole-free.
+///
+/// The diff categories (`Inserted` / `Deleted` / `Changed`) are the
+/// ones whose `bg_extends_to_line_end()` is set: the renderer treats
+/// them as a whole-row wash rather than as styling of the scoped
+/// text. Syntect's `Diff` grammar mostly cooperates — a `+`/`-` row is
+/// one span covering the row — but a hunk header is not: it scopes
+/// `@@ -1,2 +3,4 @@` under `meta.diff.range` and leaves the enclosing
+/// section name `git diff` appends after the closing `@@` outside that
+/// scope entirely, so the bar stopped at the `@@` and resumed only in
+/// the trailing fill past end-of-line, with the section name sitting in
+/// a hole.
+///
+/// So the guarantee is enforced per row rather than per scope: when the
+/// row's *first* span starts at the row start and carries a wash, any
+/// byte range of the row that no later span claims is emitted with that
+/// same category. Rows whose leading span is not a wash (ordinary code)
+/// pass through untouched. Filler spans merge with their neighbours in
+/// `merge_adjacent_spans`, and the wash categories resolve to the
+/// editor foreground, so filling changes background only.
+struct RowWash<F: FnMut(usize, usize, HighlightCategory)> {
+    row_start: usize,
+    row_end: usize,
+    /// The wash to fill gaps with; `None` until the first span decides,
+    /// and stays `None` for rows that carry no wash.
+    wash: Option<HighlightCategory>,
+    /// Whether the leading span has been seen (so `wash` is decided).
+    decided: bool,
+    /// End of the highest byte range emitted so far.
+    covered: usize,
+    inner: F,
+}
+
+impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
+    fn new(row_start: usize, row_end: usize, inner: F) -> Self {
+        Self {
+            row_start,
+            row_end,
+            wash: None,
+            decided: false,
+            covered: row_start,
+            inner,
+        }
+    }
+
+    fn emit(&mut self, start: usize, end: usize, category: HighlightCategory) {
+        if !self.decided {
+            self.decided = true;
+            if start == self.row_start && category.bg_extends_to_line_end() {
+                self.wash = Some(category);
+            }
+        }
+        if let Some(wash) = self.wash {
+            if start > self.covered {
+                (self.inner)(self.covered, start, wash);
+            }
+        }
+        self.covered = self.covered.max(end);
+        (self.inner)(start, end, category);
+    }
+
+    /// Emit the trailing filler, if any. Must be called once the row's
+    /// spans have all been emitted.
+    fn finish(mut self) {
+        if let Some(wash) = self.wash {
+            if self.covered < self.row_end {
+                (self.inner)(self.covered, self.row_end, wash);
+            }
+        }
+    }
+}
+
 impl TextMateEngine {
     /// Create a new TextMate engine for the given syntax
     pub fn new(syntax_set: Arc<SyntaxSet>, syntax_index: usize) -> Self {
@@ -926,7 +998,33 @@ impl TextMateEngine {
     /// it is in a cheap "raw" context — because only it knows where the
     /// region ends. Content lines therefore cost one extra (trivial)
     /// host `parse_line` on top of the child parse.
+    ///
+    /// Spans leave this function through `RowWash`, which closes
+    /// bg-less holes on rows the grammar washes edge to edge (see its
+    /// docs) — a `@@` hunk header whose trailing section name is
+    /// scoped separately would otherwise punch a hole in the bar.
     fn parse_snapshot_line(
+        &mut self,
+        snapshot: &mut ParseSnapshot,
+        prepared: &PreparedLine,
+        current_offset: usize,
+        on_span: impl FnMut(usize, usize, HighlightCategory),
+    ) -> bool {
+        let mut wash = RowWash::new(
+            current_offset,
+            current_offset + prepared.line_content_len,
+            on_span,
+        );
+        let parsed =
+            self.parse_snapshot_line_spans(snapshot, prepared, current_offset, |s, e, c| {
+                wash.emit(s, e, c)
+            });
+        wash.finish();
+        parsed
+    }
+
+    /// `parse_snapshot_line` without the row-wash gap filling; see there.
+    fn parse_snapshot_line_spans(
         &mut self,
         snapshot: &mut ParseSnapshot,
         prepared: &PreparedLine,
@@ -3575,6 +3673,74 @@ mod tests {
                 }
                 line_start = line_end + 1;
             }
+        } else {
+            panic!("Expected TextMate engine for .diff file");
+        }
+    }
+
+    /// Reproduce <https://github.com/sinelaw/fresh/issues/3021>: the
+    /// enclosing-section name `git diff` appends after a hunk header's
+    /// closing `@@` is scoped outside `meta.diff.range`, so the
+    /// `diff_modify_bg` bar stopped at the `@@` and left the section
+    /// name in a bg-less hole. The whole `@@` row must carry
+    /// `theme.diff_modify_bg`, exactly as
+    /// `test_diff_inserted_line_is_fully_covered` requires of `+` rows.
+    #[test]
+    fn test_diff_hunk_header_line_is_fully_covered() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        // Two hunk headers: one with a section name (the reported case)
+        // and one bare, so the bare form is covered against regressions
+        // from the gap fill.
+        let content = concat!(
+            "diff --git a/file.rs b/file.rs\n",
+            "index aaa..bbb 100644\n",
+            "--- a/file.rs\n",
+            "+++ b/file.rs\n",
+            "@@ -2,6 +2,8 @@ fn keep_one(&self) -> usize {\n",
+            " context\n",
+            "+added\n",
+            "@@ -40,3 +42,4 @@\n",
+            " more context\n",
+        );
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        if let HighlightEngine::TextMate(ref mut tm) = engine {
+            let spans = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+
+            let bytes = content.as_bytes();
+            let mut line_start = 0;
+            let mut headers_checked = 0;
+            while line_start < bytes.len() {
+                let mut line_end = line_start;
+                while line_end < bytes.len() && bytes[line_end] != b'\n' {
+                    line_end += 1;
+                }
+                if content[line_start..line_end].starts_with("@@ ") {
+                    headers_checked += 1;
+                    for byte_pos in line_start..line_end {
+                        let span = spans
+                            .iter()
+                            .find(|s| s.range.start <= byte_pos && s.range.end > byte_pos);
+                        let bg = span.and_then(|s| s.bg);
+                        assert_eq!(
+                            bg,
+                            Some(theme.diff_modify_bg),
+                            "byte {} (`{}`) of `@@` line starting at {} should carry \
+                             diff_modify_bg; got span={:?}",
+                            byte_pos,
+                            content[byte_pos..byte_pos + 1].escape_debug(),
+                            line_start,
+                            span,
+                        );
+                    }
+                }
+                line_start = line_end + 1;
+            }
+            assert_eq!(headers_checked, 2, "both hunk headers should be examined");
         } else {
             panic!("Expected TextMate engine for .diff file");
         }

--- a/crates/fresh-editor/tests/e2e/issue_3021_diff_hunk_header_bg.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3021_diff_hunk_header_bg.rs
@@ -72,14 +72,13 @@ fn test_diff_hunk_header_row_has_no_background_gap() {
     let file_path = temp_dir.path().join("hunk.diff");
     std::fs::write(&file_path, diff_content()).unwrap();
 
-    let mut harness = EditorTestHarness::create(
-        120,
-        24,
-        HarnessOptions::new()
-            .with_full_grammar_registry()
-            .without_empty_plugins_dir(),
-    )
-    .unwrap();
+    // Plugin loading stays disabled (the `HarnessOptions` default): the
+    // wash comes from core syntect highlighting, and plugin overlays
+    // paint above the syntax background, so a decorating plugin could
+    // mask the very defect this asserts on.
+    let mut harness =
+        EditorTestHarness::create(120, 24, HarnessOptions::new().with_full_grammar_registry())
+            .unwrap();
     harness.open_file(&file_path).unwrap();
     harness.render().unwrap();
     harness.wait_for_screen_contains("keep_one").unwrap();

--- a/crates/fresh-editor/tests/e2e/issue_3021_diff_hunk_header_bg.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3021_diff_hunk_header_bg.rs
@@ -1,0 +1,119 @@
+//! Regression test for <https://github.com/sinelaw/fresh/issues/3021>:
+//!
+//! In a `.diff` buffer the hunk header's `diff_modify_bg` bar stopped at
+//! the closing `@@`, so the enclosing-section name `git diff` appends
+//! after it (`@@ -2,6 +2,8 @@ fn keep_one(…)`) sat in a bg-less hole and
+//! the bar resumed only past end-of-line. `git diff` puts that section
+//! name on nearly every real hunk header, so most hunk bars showed the
+//! gap in practice.
+//!
+//! Asserted purely from the rendered screen: the background of every
+//! cell of the hunk-header row's text, compared against the background
+//! of the `@@` marker itself and against an ordinary context row.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use tempfile::TempDir;
+
+/// The hunk header carries a section name after the closing `@@` — the
+/// span that had no background. It is deliberately not the first line of
+/// the file, so the cursor line (line 1) never overlaps the row under
+/// test and can't tint its background.
+const HUNK_HEADER: &str = "@@ -2,6 +2,8 @@ fn keep_one(&self) -> usize {";
+const CONTEXT_LINE: &str = " context stays plain";
+
+fn diff_content() -> String {
+    format!(
+        "diff --git a/file.rs b/file.rs\n\
+         index 1111111..2222222 100644\n\
+         --- a/file.rs\n\
+         +++ b/file.rs\n\
+         {HUNK_HEADER}\n\
+         {CONTEXT_LINE}\n\
+         +added line\n"
+    )
+}
+
+/// Row index of the first screen row whose text contains `needle`, plus
+/// the column the needle starts at.
+fn find_row(harness: &EditorTestHarness, needle: &str) -> (u16, u16) {
+    let buf = harness.buffer();
+    for y in 0..buf.area.height {
+        let mut row = String::new();
+        for x in 0..buf.area.width {
+            row.push_str(buf[(x, y)].symbol());
+        }
+        if let Some(byte_idx) = row.find(needle) {
+            // The screen rows are built one cell per column, and the
+            // fixture is ASCII, so the byte index is the column.
+            return (y, byte_idx as u16);
+        }
+    }
+    panic!(
+        "never found `{needle}` on screen:\n{}",
+        harness_dump(harness)
+    );
+}
+
+fn harness_dump(harness: &EditorTestHarness) -> String {
+    let buf = harness.buffer();
+    let mut out = String::new();
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            out.push_str(buf[(x, y)].symbol());
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn test_diff_hunk_header_row_has_no_background_gap() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("hunk.diff");
+    std::fs::write(&file_path, diff_content()).unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        24,
+        HarnessOptions::new()
+            .with_full_grammar_registry()
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+    harness.wait_for_screen_contains("keep_one").unwrap();
+
+    let (header_row, header_col) = find_row(&harness, HUNK_HEADER);
+    let (context_row, context_col) = find_row(&harness, CONTEXT_LINE.trim_end());
+
+    let marker_bg = harness
+        .get_cell_style(header_col, header_row)
+        .and_then(|s| s.bg);
+    let context_bg = harness
+        .get_cell_style(context_col, context_row)
+        .and_then(|s| s.bg);
+
+    // Guard against a vacuous pass: if the hunk header carried no wash at
+    // all, "every cell matches the marker cell" would hold trivially.
+    assert_ne!(
+        marker_bg, context_bg,
+        "the `@@` marker at ({header_col}, {header_row}) should carry the \
+         diff_modify_bg wash, distinct from a context row's background \
+         {context_bg:?}",
+    );
+
+    for offset in 0..HUNK_HEADER.chars().count() as u16 {
+        let x = header_col + offset;
+        let bg = harness.get_cell_style(x, header_row).and_then(|s| s.bg);
+        let ch = harness.buffer()[(x, header_row)].symbol().to_string();
+        assert_eq!(
+            bg,
+            marker_bg,
+            "column {x} (`{ch}`) of the hunk header row should carry the \
+             same diff background as the `@@` marker ({marker_bg:?}); saw \
+             {bg:?}\n{}",
+            harness_dump(&harness),
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -114,6 +114,7 @@ pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
 pub mod issue_3006_drag_beyond_text_area;
 pub mod issue_3006_shift_select_at_buffer_edges;
+pub mod issue_3021_diff_hunk_header_bg;
 pub mod issue_3031_stale_fold_hides_block_header;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_779_after_eof_shade;


### PR DESCRIPTION
Fixes #3021.

## The bug

`git diff` appends the enclosing section name after a hunk header's closing `@@`. Syntect's bundled `Diff` grammar scopes that trailing text *outside* `meta.diff.range`, so it carries no diff scope at all. Because the renderer treats the diff categories (`Inserted` / `Deleted` / `Changed`) as a whole-row background wash, the `editor.diff_modify_bg` bar stopped at the `@@`, skipped the section name, and resumed only in the past-end-of-line tail fill:

```
@@ -2,6 +2,8 @@ keep one
|<-- diff_modify_bg -->|<- none ->|<-- diff_modify_bg -->|
```

I confirmed the reporter's diagnosis before fixing: a probe over the spans `HighlightEngine::highlight_viewport` returns for a `.diff` buffer showed the hunk-header row producing exactly one span, `69..84` = `` `@@ -2,6 +2,8 @@` `` with `bg: Some(diff_modify_bg)`, and **no span at all** over `84..93` = `" keep one"`. So this is not an inner scope outranking the outer one — there is no diff scope on those bytes to find.

PR #3015 did not cause and did not fix this; it removed the `git_log` detail-panel overlay that used to paint over the whole hunk row, which had been hiding the gap in that one view.

## The fix

Because the scope stack has nothing to offer on those bytes, the rule is applied per *row* rather than per scope. A new `RowWash` span sink wraps `TextMateEngine::parse_snapshot_line`, the single per-line entry point — shared by the cold-start, forward-extension and partial-update parse paths, and by `structure_lines_in`, which advances the same snapshot but discards the spans (so the sink is inert there).

The rule: when the span **covering the row start** carries a category whose `bg_extends_to_line_end()` is set, every byte range of the row that **no span claims** is emitted with that same category. Rows whose covering span at the row start is not a wash pass through untouched.

Two things that rule is deliberately *not*:

* **Not "everything except ordinary code".** The pass-through is structural — the row's leading span carries no wash — not a diff-buffer vs. source-buffer distinction. Counterexample in the other direction: `crates/fresh-editor/src/grammars/git-commit.sublime-syntax:57` scopes a diffstat line's `+++---` run as `markup.inserted.git-commit` → `Inserted`, a wash category, in a **non-diff** buffer. Behaviour there is genuinely unchanged, but only because that rule requires `\S+ \| \d+` to match first, so the wash span is never the row's *leading* one.
* **Not hole-free — only unclaimed-gap-free.** A span that *does* claim a range inside a washed row keeps its own category, background or none, so the bar still breaks across it. That is reachable with the shipped `Diff` grammar: its `meta.diff.header.to-file` rule is not `^`-anchored, so a hunk-header section name shaped like `- foo ====` is scoped as a file header mid-row, maps to `Type`, and carries no background. `git diff` does not emit section names of that shape, so the sink is deliberately not made scope-aware; the case is pinned by a test and stated in the `RowWash` doc comment.

Two notes on scope of impact:

* Filling changes **background only**. The diff categories resolve to `theme.editor_fg` for foreground, which is exactly what the previously-unscoped section name already rendered with.
* The filler spans are the same category as their neighbour, so `merge_adjacent_spans` collapses them; the cache ends up with one span per hunk-header row rather than more. No extra allocation per line — `RowWash` is a streaming sink, not a buffer.

## An alternative, for the maintainer to weigh

A reviewer raised a different root-cause fix: a local `Diff` grammar override (the repo already ships grammar overrides under `crates/fresh-editor/src/grammars/`) changing the hunk-header match to `^(@@)\s*(.+?)\s*(@@).*(?m:$)\n?`. That would be contained to one file instead of touching the shared span pipeline. It would have to leave the trailing text **unscoped inside** `meta.diff.range.unified` — scoping it `entity.name.section` maps to `Keyword` (`highlight_engine.rs:70`) and loses the background again. The current approach was judged sound and at the right layer, so it is kept here; recording the alternative so it can be weighed rather than rediscovered.

## Tests

1. `test_diff_hunk_header_line_is_fully_covered` (unit, `primitives/highlight_engine.rs`) — mirrors the existing `test_diff_inserted_line_is_fully_covered`: every byte of every `@@` row must resolve to a span carrying `theme.diff_modify_bg`. Covers both a header with a section name and a bare one.
   * without the fix: `FAILED` (``… of `@@` line … should carry diff_modify_bg; got span=None``)
   * with the fix: `ok`
2. `test_diff_hunk_header_row_has_no_background_gap` (e2e, `tests/e2e/issue_3021_diff_hunk_header_bg.rs`) — opens a `.diff` file in a per-test `TempDir`, renders, and asserts **only on rendered cells**: every column of the hunk-header row carries the same background as the `@@` marker cell. It also asserts the marker's background differs from a context row's, so the test cannot pass vacuously if the wash disappeared entirely.
   * without the fix: `FAILED` — ``column 21 (` `) of the hunk header row should carry the same diff background as the `@@` marker (Some(Rgb(60, 55, 0))); saw Some(Rgb(0, 0, 0))``
   * with the fix: `ok`
3. `test_diff_hunk_header_inner_span_is_a_known_wash_hole` (unit, new in the review round) — pins the limitation above: on `@@ -2,6 +2,8 @@ - foo ====` the `@@ … @@` run carries `diff_modify_bg`, while the section name is claimed by a `meta.diff.header.*` span (asserted as `HighlightCategory::Type`) and therefore does **not**. It is a characterization test: if the gap fill is ever made scope-aware, it is the test to update, together with the `RowWash` docs.

Tests 1 and 2 were verified to fail without the change and pass with it, by building the same tree twice with only the `RowWash` wiring removed. Test 3 characterizes existing behaviour, so there is no "fails before" for it; what it pins was verified directly by probing the spans (see below).

The e2e test runs with the harness's **default** plugin isolation (an empty plugins dir). An earlier revision passed `.without_empty_plugins_dir()`, which *enables* plugin loading; nothing in the test needs plugins, and the syntax background slots *below* plugin overlays by design (`view/ui/split_rendering/char_style.rs:146-151`: "Slots BELOW overlays … so an `addOverlay` from a plugin can still paint over the diff colour"), so a future decorating plugin could have masked the defect under test.

No timers or sleeps: the e2e test uses the harness's `wait_for_screen_contains`, and its fixture lives under its own `TempDir`, so it is parallel-safe.

## Verification status — read this before trusting any number above

**Local verification of the review round (commit `a1912d6`) was NOT completed. CI is the check for that commit.** No local suite was run to completion against it, and nothing here should be read as claiming one passed.

What was actually observed, and when:

**First round (commit `bf9c306`) — run locally to completion:**

* `cargo fmt --all` — clean. `cargo check --all-targets` — exit 0. `cargo clippy --all-targets` — exit 0.
* `cargo test -p fresh-editor --lib` — 3376 passed, 0 failed.
* e2e subsets on the `e2e_tests` binary (filters `syntax_highlighting` (160), `markdown` (148), `language_textmate`, `folding`, `issue_2405`, `issue_779`) — all passing.

**Review round (commit `a1912d6`) — only these partial observations:**

* `cargo test -p fresh-editor --test e2e_tests -- issue_3021` → `test result: ok. 1 passed; 0 failed`, run *before* the plugin-isolation change. That is the pre-change baseline, not a re-run after it.
* A direct span probe on `@@ -2,6 +2,8 @@ - foo ====` confirming the claimed-span limitation: `28..43 "@@ -2,6 +2,8 @@" bg=Some(Rgb(40,38,30))`, `43..54 " - foo ====" bg=None`.
* `rustfmt --check` on both edited files — clean, so `cargo fmt --all` is a no-op for them.

**Never run against `a1912d6`:** the unit tests (including the new one), the e2e test with plugin isolation restored, `cargo check --all-targets`, `cargo clippy --all-targets`. These are left to CI.

## Other things I did not verify

* **Not verified on a real truecolor terminal via tmux.** The intended verification is the e2e assertion on rendered cell backgrounds plus the span-level unit tests; both read the same colours the terminal would receive.
* **Windows and the `gui` feature set unchecked.** This change is in backend-independent highlighting code and touches no platform or GUI path, but `cargo check --all-targets --features gui` was not run.
* The `Diff` grammar ships as a binary packdump, so the claim that its `meta.diff.header.to-file` rule is unanchored is inferred from observed behaviour (the span starts mid-row), not read off the grammar source.
* One flake seen in the first round and **not** caused by this change: `e2e::folding::test_folding_preserves_syntax_highlighting_after_skip` failed once under `--test-threads=4` on a cursor-line background, then passed on rerun and 3/3 in isolation. It exercises a `.rs` buffer, which produces no diff categories at all, so `RowWash` is inert there.