### PR TITLE
fix(rulers): draw the column guide on the column it names, and keep it visible over wide text (#2928)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -589,12 +589,12 @@
           "x-section": "Display"
         },
         "rulers": {
-          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nColumns are 1-based, matching the status bar: a ruler at 80 marks the\n80th character of a line — the last column text may occupy.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
+          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nColumns are 1-based *display* columns — screen cells, not characters:\na ruler at 80 marks the 80th display column, the last one text may\noccupy. A tab advances to the next tab stop and a full-width character\n(CJK, most emoji) takes two cells, so on lines containing either, the\nruler column is not the character count the status bar reports; for\nplain ASCII text the two numbers agree.\nValues below 1 are not valid columns and are ignored.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint",
-            "minimum": 0
+            "minimum": 1
           },
           "default": [],
           "x-section": "Display"

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -589,7 +589,7 @@
           "x-section": "Display"
         },
         "rulers": {
-          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
+          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nColumns are 1-based, matching the status bar: a ruler at 80 marks the\n80th character of a line — the last column text may occupy.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
           "type": "array",
           "items": {
             "type": "integer",

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -589,7 +589,7 @@
           "x-section": "Display"
         },
         "rulers": {
-          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nColumns are 1-based *display* columns — screen cells, not characters:\na ruler at 80 marks the 80th display column, the last one text may\noccupy. A tab advances to the next tab stop and a full-width character\n(CJK, most emoji) takes two cells, so on lines containing either, the\nruler column is not the character count the status bar reports; for\nplain ASCII text the two numbers agree.\nValues below 1 are not valid columns and are ignored.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
+          "description": "Vertical ruler lines at specific column positions.\nDraws subtle vertical lines to help with line length conventions.\nColumns are 1-based *display* columns — screen cells, not characters:\na ruler at 80 marks the 80th display column, the last one text may\noccupy. A tab advances to the next tab stop and a full-width character\n(CJK, most emoji) takes two cells, so on lines containing either, the\nruler column is not the character count the status bar reports; for\nplain ASCII text the two numbers agree.\nIf the column falls inside a full-width character, the guide marks that\ncharacter's first cell, so it stays visible on lines of CJK text.\nValues below 1 are not valid columns and are ignored.\nExample: [80, 120] draws rulers at columns 80 and 120.\nDefault: [] (no rulers)",
           "type": "array",
           "items": {
             "type": "integer",

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1340,6 +1340,8 @@ pub struct EditorConfig {
     /// (CJK, most emoji) takes two cells, so on lines containing either, the
     /// ruler column is not the character count the status bar reports; for
     /// plain ASCII text the two numbers agree.
+    /// If the column falls inside a full-width character, the guide marks that
+    /// character's first cell, so it stays visible on lines of CJK text.
     /// Values below 1 are not valid columns and are ignored.
     /// Example: [80, 120] draws rulers at columns 80 and 120.
     /// Default: [] (no rulers)

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1334,12 +1334,17 @@ pub struct EditorConfig {
 
     /// Vertical ruler lines at specific column positions.
     /// Draws subtle vertical lines to help with line length conventions.
-    /// Columns are 1-based, matching the status bar: a ruler at 80 marks the
-    /// 80th character of a line — the last column text may occupy.
+    /// Columns are 1-based *display* columns — screen cells, not characters:
+    /// a ruler at 80 marks the 80th display column, the last one text may
+    /// occupy. A tab advances to the next tab stop and a full-width character
+    /// (CJK, most emoji) takes two cells, so on lines containing either, the
+    /// ruler column is not the character count the status bar reports; for
+    /// plain ASCII text the two numbers agree.
+    /// Values below 1 are not valid columns and are ignored.
     /// Example: [80, 120] draws rulers at columns 80 and 120.
     /// Default: [] (no rulers)
     #[serde(default)]
-    #[schemars(extend("x-section" = "Display"))]
+    #[schemars(extend("x-section" = "Display"), inner(range(min = 1)))]
     pub rulers: Vec<usize>,
 
     /// Vertical indentation guide rendering mode.

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1334,6 +1334,8 @@ pub struct EditorConfig {
 
     /// Vertical ruler lines at specific column positions.
     /// Draws subtle vertical lines to help with line length conventions.
+    /// Columns are 1-based, matching the status bar: a ruler at 80 marks the
+    /// 80th character of a line — the last column text may occupy.
     /// Example: [80, 120] draws rulers at columns 80 and 120.
     /// Default: [] (no rulers)
     #[serde(default)]

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -715,7 +715,15 @@ pub(crate) fn draw_buffer_in_split(
     // show the ruler only on written lines, leaving the rest of the pane blank
     // and the guide looking truncated (#2631).
     if !rulers.is_empty() {
-        let ruler_cols: Vec<u16> = rulers.iter().map(|&r| r as u16).collect();
+        // Ruler columns are 1-based — the same numbering the status bar shows
+        // and the "Add Ruler" prompt accepts (it rejects 0). Screen offsets
+        // within the content area are 0-based, so a ruler at column N marks
+        // the cell holding the Nth character (#2928). Values of 0 are not
+        // valid rulers and are skipped rather than wrapping around.
+        let ruler_cols: Vec<u16> = rulers
+            .iter()
+            .filter_map(|&r| u16::try_from(r.checked_sub(1)?).ok())
+            .collect();
         render_ruler_bg(
             buf,
             &ruler_cols,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -719,7 +719,9 @@ pub(crate) fn draw_buffer_in_split(
         // Ruler" prompt accepts (it rejects 0), counted in screen cells, so a
         // tab spans to the next tab stop and a full-width character takes two
         // (#2928). `render_ruler_bg` owns the conversion to the 0-based screen
-        // offsets it paints, and skips values below 1.
+        // offsets it paints, skips values below 1, and snaps a column landing
+        // inside a full-width grapheme onto that grapheme's leading cell so
+        // the guide stays visible on CJK lines.
         render_ruler_bg(
             buf,
             rulers,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -715,18 +715,14 @@ pub(crate) fn draw_buffer_in_split(
     // show the ruler only on written lines, leaving the rest of the pane blank
     // and the guide looking truncated (#2631).
     if !rulers.is_empty() {
-        // Ruler columns are 1-based — the same numbering the status bar shows
-        // and the "Add Ruler" prompt accepts (it rejects 0). Screen offsets
-        // within the content area are 0-based, so a ruler at column N marks
-        // the cell holding the Nth character (#2928). Values of 0 are not
-        // valid rulers and are skipped rather than wrapping around.
-        let ruler_cols: Vec<u16> = rulers
-            .iter()
-            .filter_map(|&r| u16::try_from(r.checked_sub(1)?).ok())
-            .collect();
+        // `rulers` are 1-based *display* columns — the numbering the "Add
+        // Ruler" prompt accepts (it rejects 0), counted in screen cells, so a
+        // tab spans to the next tab stop and a full-width character takes two
+        // (#2928). `render_ruler_bg` owns the conversion to the 0-based screen
+        // offsets it paints, and skips values below 1.
         render_ruler_bg(
             buf,
-            &ruler_cols,
+            rulers,
             theme.ruler_bg,
             render_area,
             gutter_width,

--- a/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
@@ -70,9 +70,15 @@ pub(super) fn render_cursor_column_bg(
 /// Render vertical rulers as a subtle background color tint.
 /// Unlike `render_column_guides` which draws │ characters (for compose guides),
 /// this preserves the existing text content and only adjusts the background color.
+///
+/// `columns` holds ruler columns exactly as configured: **1-based** display
+/// columns, so a ruler at N tints the cell holding the Nth display column of
+/// the line (#2928). The 1-based -> 0-based conversion lives here rather than
+/// at the call site so a caller cannot reintroduce the off-by-one; values
+/// below 1 are not valid columns and are skipped.
 pub(super) fn render_ruler_bg(
     buf: &mut ratatui::buffer::Buffer,
-    columns: &[u16],
+    columns: &[usize],
     color: Color,
     render_area: Rect,
     gutter_width: usize,
@@ -80,11 +86,24 @@ pub(super) fn render_ruler_bg(
     left_column: usize,
 ) {
     let guide_height = content_height.min(render_area.height as usize);
-    for &col in columns {
-        let Some(scrolled_col) = (col as usize).checked_sub(left_column) else {
+    let content_x = render_area.x + gutter_width as u16;
+    for &column in columns {
+        // 1-based -> 0-based; `0` (and anything scrolled off the left edge)
+        // is not a column this pane can draw.
+        let Some(col) = column.checked_sub(1) else {
             continue;
         };
-        let guide_x = render_area.x + gutter_width as u16 + scrolled_col as u16;
+        let Some(scrolled_col) = col.checked_sub(left_column) else {
+            continue;
+        };
+        // A ruler far off the right edge must stay off-screen rather than
+        // wrap around when narrowed to the buffer's `u16` coordinates.
+        let Some(guide_x) = u16::try_from(scrolled_col)
+            .ok()
+            .and_then(|c| content_x.checked_add(c))
+        else {
+            continue;
+        };
         if guide_x < render_area.x + render_area.width {
             for row in 0..guide_height {
                 let cell = &mut buf[(guide_x, render_area.y + row as u16)];

--- a/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
@@ -76,6 +76,15 @@ pub(super) fn render_cursor_column_bg(
 /// the line (#2928). The 1-based -> 0-based conversion lives here rather than
 /// at the call site so a caller cannot reintroduce the off-by-one; values
 /// below 1 are not valid columns and are skipped.
+///
+/// When a ruler column falls on the *trailing* half of a double-width
+/// grapheme, the tint is moved onto that grapheme's leading cell. A background
+/// set on a continuation cell never reaches the terminal — `Buffer::diff`
+/// computes `to_skip` from the preceding symbol's width and gates every update
+/// on `to_skip == 0` — so without this the guide silently disappeared on rows
+/// of full-width text while still rendering on the blank rows above and below
+/// (#2928). Snapping keeps the bar continuous and keeps it pointing at the
+/// character that actually occupies the column.
 pub(super) fn render_ruler_bg(
     buf: &mut ratatui::buffer::Buffer,
     columns: &[usize],
@@ -85,6 +94,8 @@ pub(super) fn render_ruler_bg(
     content_height: usize,
     left_column: usize,
 ) {
+    use unicode_width::UnicodeWidthStr;
+
     let guide_height = content_height.min(render_area.height as usize);
     let content_x = render_area.x + gutter_width as u16;
     for &column in columns {
@@ -106,8 +117,19 @@ pub(super) fn render_ruler_bg(
         };
         if guide_x < render_area.x + render_area.width {
             for row in 0..guide_height {
-                let cell = &mut buf[(guide_x, render_area.y + row as u16)];
-                cell.set_bg(color);
+                let y = render_area.y + row as u16;
+                // Snap per row, not per column: whether the ruler lands inside
+                // a wide grapheme depends on that row's text. Only one cell
+                // back needs checking because no terminal grapheme is wider
+                // than two cells.
+                let x = if guide_x > content_x
+                    && buf[(guide_x - 1, y)].symbol().width() > 1
+                {
+                    guide_x - 1
+                } else {
+                    guide_x
+                };
+                buf[(x, y)].set_bg(color);
             }
         }
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
@@ -122,9 +122,7 @@ pub(super) fn render_ruler_bg(
                 // a wide grapheme depends on that row's text. Only one cell
                 // back needs checking because no terminal grapheme is wider
                 // than two cells.
-                let x = if guide_x > content_x
-                    && buf[(guide_x - 1, y)].symbol().width() > 1
-                {
+                let x = if guide_x > content_x && buf[(guide_x - 1, y)].symbol().width() > 1 {
                     guide_x - 1
                 } else {
                     guide_x

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -791,26 +791,235 @@ fn test_ruler_counts_display_columns_not_characters() {
     );
 }
 
-/// Documents a **known limitation** (pre-existing, not introduced by #2928):
-/// rulers address display columns and are not snapped to grapheme
-/// boundaries, so over full-width text an *even* ruler column falls on the
-/// trailing half of a double-width cell.
+/// A line of repeated full-width graphemes, for the pair of tests below.
+/// Every `你` spans two display columns, so leading cells are the **odd**
+/// display columns (1, 3, 5 …) and continuation cells are the **even** ones.
+fn wide_line() -> String {
+    "你".repeat(50)
+}
+
+/// Control for the test that follows: a ruler on the *leading* cell of a
+/// double-width grapheme has always rendered.
 ///
-/// `你` occupies display columns 1-2, so a ruler at 2 tints the continuation
-/// cell — which ratatui has `reset()` to a blank. The tint is present in the
-/// frame buffer (asserted below), but `Buffer::diff` skips the cells covered
-/// by a preceding wide symbol, so it is not guaranteed to reach the terminal.
+/// On `wide_line()` the 2nd `你` covers display columns 3-4, so a ruler at 3
+/// sits on the cell that carries the symbol and the tint is emitted.
 ///
-/// The assertion here is deliberately a description of today's behaviour, not
-/// a statement that it is desirable; fixing it means snapping rulers to the
-/// grapheme that covers the column, which is out of scope for #2928.
+/// Note what these assertions read: `EditorTestHarness::buffer()` returns
+/// `Terminal::backend().buffer()`, and `TestBackend::draw` only writes the
+/// cells `Buffer::diff` chose to emit. So this is the *emitted* screen, not
+/// the frame buffer — which is exactly the distinction the next test needs.
 #[test]
-fn test_ruler_on_even_column_over_wide_characters() {
+fn test_ruler_on_leading_cell_of_wide_grapheme_renders() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![3];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&wide_line()).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 3)],
+        "a ruler on the leading cell of a wide grapheme must be visible, \
+         got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("你"),
+        "display column 3 is the leading cell of the 2nd `你`"
+    );
+}
+
+/// Regression: a ruler whose display column lands on the *continuation* cell
+/// of a double-width grapheme must still be visible.
+///
+/// On `wide_line()` the 2nd `你` covers display columns 3-4, so a ruler at 4
+/// addresses the continuation cell. Setting a background there is a no-op the
+/// user never sees: `Buffer::diff` sets `to_skip = symbol.width() - 1` after a
+/// wide symbol and gates every update on `to_skip == 0`, so the cell is never
+/// emitted. Before the fix this test found **no tinted cell at all** — the
+/// guide silently vanished on wide text.
+///
+/// The ruler now marks the leading cell of the grapheme that occupies the
+/// column, so it stays visible and still points at the character sitting at
+/// that column.
+#[test]
+fn test_ruler_on_trailing_cell_of_wide_grapheme_still_renders() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![4];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&wide_line()).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 3)],
+        "a ruler at column 4 falls inside the `你` covering columns 3-4 and \
+         must be painted on its leading cell (column 3) to be visible at all, \
+         got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("你"),
+        "the tinted cell must be the one carrying the grapheme's symbol"
+    );
+}
+
+/// The same snap, but with the column arithmetic exercised somewhere other
+/// than a uniform row: two ASCII cells then full-width text.
+///
+/// `ab你你你` lays out as `a`=1, `b`=2, then `你` on 3-4, 5-6, 7-8. A ruler at
+/// 6 is the continuation cell of the `你` covering 5-6, so it must snap to 5.
+///
+/// Deliberately configured with **only** the column that needs snapping. An
+/// earlier draft of this test set `rulers = [5, 6]`; because the ruler at 5
+/// already rendered, the row still had exactly one tinted cell at column 5
+/// before the fix and the test passed vacuously. With `[6]` alone the pre-fix
+/// row has no tinted cell at all.
+#[test]
+fn test_ruler_snaps_to_leading_cell_on_mixed_line() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![6];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text("ab你你你").unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 5)],
+        "a ruler at 6 belongs to the `你` covering columns 5-6 and must mark \
+         its leading cell at column 5, got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("你"),
+        "column 5 is the leading cell of the 2nd `你` on `ab你你你`"
+    );
+}
+
+/// The user-visible symptom, in the shape it was reported: a ruler bar that
+/// runs cleanly down the blank rows of a pane but **vanishes where a line of
+/// full-width text crosses it**.
+///
+/// This form needs no claim about terminal emission at all — it compares the
+/// same ruler across rows of a single frame. Before the fix the blank rows
+/// carried a tinted cell and the CJK row carried **none**, so the bar had a
+/// hole in it exactly where the text was.
+///
+/// Note precisely what is asserted, because it is not "the bar is perfectly
+/// straight". Snapping to the covering grapheme's leading cell means that on a
+/// row where the ruler falls inside a full-width character the tint sits one
+/// cell to the left of where it sits on blank rows. That is the deliberate
+/// trade of this fix — a guide one cell left is legible, a guide that is not
+/// emitted at all is not — and it is what the config docs now describe. The
+/// invariant is therefore: **every row shows the guide**, within one cell of
+/// the nominal column.
+///
+/// Measured on this fixture: blank rows tint screen x 25, the wide-text row
+/// tints 24 (the leading half of the `你`-class grapheme covering display
+/// columns 19-20). Before the fix the wide-text row tinted nothing.
+#[test]
+fn test_ruler_bar_is_continuous_across_wide_text_rows() {
+    let mut config = Config::default();
+    // Column 20 is even, so on a line of `你好世界…` starting at column 1 it
+    // lands on the continuation cell of the 10th grapheme (columns 19-20).
+    config.editor.rulers = vec![20];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    // Blank rows above and below the wide-text row are the control: whatever
+    // the ruler does there is what "correct" looks like.
+    //
+    // The wide line is kept to 20 graphemes / 40 display columns so it fits
+    // the content area without wrapping. An earlier draft used 80 graphemes;
+    // at 160 display columns that line wrapped, the row below it was a
+    // *continuation* of the same wide line rather than the blank line 3, and
+    // the control assertion below caught it.
+    let text = format!("\n\n{}\n\n", "你好世界".repeat(5));
+    let _fixture = harness.load_buffer_from_text(&text).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    // Buffer lines: 0 blank, 1 blank, 2 wide text, 3 blank.
+    let blank_row = content_first_row as u16;
+    let wide_row = content_first_row as u16 + 2;
+    let blank_row_below = content_first_row as u16 + 3;
+
+    let on_blank = ruler_cells_in_row(&harness, blank_row, 80);
+    let on_wide = ruler_cells_in_row(&harness, wide_row, 80);
+    let on_blank_below = ruler_cells_in_row(&harness, blank_row_below, 80);
+
+    // Control first: establish what an uninterrupted bar looks like.
+    assert_eq!(
+        on_blank.len(),
+        1,
+        "control: a blank row must carry exactly one ruler cell, got {on_blank:?}"
+    );
+    assert_eq!(
+        on_blank_below, on_blank,
+        "control: the blank row below must match the blank row above"
+    );
+
+    // The symptom: before the fix this row carried no tinted cell at all, so
+    // the bar had a hole in it exactly where the wide text was.
+    assert_eq!(
+        on_wide.len(),
+        1,
+        "the ruler must still be visible on the row of full-width text; \
+         before the fix this row carried no tinted cell at all. blank rows \
+         -> {on_blank:?}, wide-text row -> {on_wide:?}"
+    );
+
+    // It may sit one cell left of the nominal column, because it snaps to the
+    // leading cell of the grapheme covering that column. It must not drift
+    // further than that.
+    let nominal = on_blank[0];
+    assert!(
+        on_wide[0] == nominal || on_wide[0] + 1 == nominal,
+        "the guide may snap at most one cell left onto the covering \
+         grapheme, but sat at {} against a nominal {nominal}",
+        on_wide[0]
+    );
+
+    // And it must land on a cell that actually carries a symbol — the whole
+    // point is that a tint on a continuation cell is never emitted.
+    let glyph = harness.get_cell(on_wide[0], wide_row);
+    assert!(
+        glyph.as_deref().is_some_and(|g| g.chars().next().is_some_and(
+            |c| ('\u{4e00}'..='\u{9fff}').contains(&c)
+        )),
+        "the tinted cell on the wide row must carry the CJK grapheme's \
+         symbol, got {glyph:?}"
+    );
+}
+
+/// A combining sequence is *not* affected by the same class of problem, and
+/// this test pins that rather than leaving it to assumption.
+///
+/// `e` + U+0301 is one grapheme of display width 1, so it occupies a single
+/// cell and has no continuation cell for a ruler to be lost on. The ruler
+/// lands on it directly and nothing snaps.
+#[test]
+fn test_ruler_on_combining_sequence_needs_no_snap() {
     let mut config = Config::default();
     config.editor.rulers = vec![2];
 
     let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
-    let _fixture = harness.load_buffer_from_text("你好世界").unwrap();
+    // "ae\u{0301}c" -> `a`, `é` (e + combining acute), `c` on columns 1, 2, 3.
+    let _fixture = harness.load_buffer_from_text("ae\u{0301}c").unwrap();
     harness.render().unwrap();
 
     let (content_first_row, _) = harness.content_area_rows();
@@ -820,11 +1029,12 @@ fn test_ruler_on_even_column_over_wide_characters() {
     assert_eq!(
         marked,
         vec![ruler_x(&harness, 2)],
-        "the ruler at column 2 tints display column 2, got {marked:?}"
+        "a width-1 combining sequence has no continuation cell, so the ruler \
+         stays on display column 2, got {marked:?}"
     );
-    assert_ne!(
+    assert_eq!(
         harness.get_cell(marked[0], row).as_deref(),
-        Some("你"),
-        "column 2 is the trailing half of `你`, not the cell carrying its symbol"
+        Some("e\u{0301}"),
+        "column 2 holds the whole combining sequence in one cell"
     );
 }

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -584,6 +584,39 @@ fn test_add_ruler_zero_column() {
     }
 }
 
+/// A `0` reaching the renderer through the *config* (rather than the "Add
+/// Ruler" prompt, which rejects it) is not a valid 1-based column and must be
+/// dropped, leaving the other rulers untouched.
+///
+/// Before #2928 the renderer treated config values as 0-based screen offsets,
+/// so `[0, 10]` tinted two cells: the first content column and the 11th. Now
+/// only column 10 is drawn.
+#[test]
+fn test_config_ruler_zero_column_is_skipped() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![0, 10];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&marker_line(40)).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 10)],
+        "only the ruler at column 10 should be tinted; 0 is not a valid \
+         1-based column, got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("A"),
+        "the surviving ruler must still mark the 10th character"
+    );
+}
+
 /// Regression (#2928): a ruler at column N must mark the cell holding the
 /// N-th character, not the one after it. Ruler columns are 1-based (the
 /// "Add Ruler" prompt rejects 0, and the status bar numbers columns from 1),
@@ -696,9 +729,14 @@ fn test_ruler_tracks_its_character_when_scrolled_horizontally() {
     );
 }
 
-/// Double-width characters: the ruler counts display columns, so a ruler at
-/// column 3 lands on the start of the second CJK character (which occupies
-/// display columns 3 and 4) rather than inside the first one's trailing cell.
+/// Double-width characters: the ruler counts *display* columns, not
+/// characters. `你好世界` puts `你` on display columns 1-2 and `好` on 3-4, so
+/// a ruler at column 3 tints the cell holding `好`.
+///
+/// Nothing snaps a ruler to a grapheme boundary — column 3 simply happens to
+/// be the leading half of a double-width cell here. See
+/// `test_ruler_on_even_column_over_wide_characters` for what an odd column
+/// does.
 #[test]
 fn test_ruler_column_with_wide_characters() {
     let mut config = Config::default();
@@ -717,5 +755,76 @@ fn test_ruler_column_with_wide_characters() {
         harness.get_cell(marked[0], row).as_deref(),
         Some("好"),
         "the ruler should sit on the character starting at display column 3"
+    );
+}
+
+/// Pins the documented coordinate space: ruler columns are *display* columns
+/// (screen cells), not the grapheme count the status bar reports.
+///
+/// With `tab_size = 4` the two leading tabs of `\t\tab…` cover display columns
+/// 1-8, so display column 10 holds `b` — the *fourth* character of the line.
+/// A ruler at 10 therefore marks `b`, which is what the config docs must say;
+/// "matching the status bar" would have promised the 10th character instead.
+#[test]
+fn test_ruler_counts_display_columns_not_characters() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![10];
+    config.editor.tab_size = 4;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text("\t\tabcdefghij").unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 10)],
+        "the ruler should tint display column 10, got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("b"),
+        "display column 10 is the 4th character of `\\t\\tab…` at tab_size 4"
+    );
+}
+
+/// Documents a **known limitation** (pre-existing, not introduced by #2928):
+/// rulers address display columns and are not snapped to grapheme
+/// boundaries, so over full-width text an *even* ruler column falls on the
+/// trailing half of a double-width cell.
+///
+/// `你` occupies display columns 1-2, so a ruler at 2 tints the continuation
+/// cell — which ratatui has `reset()` to a blank. The tint is present in the
+/// frame buffer (asserted below), but `Buffer::diff` skips the cells covered
+/// by a preceding wide symbol, so it is not guaranteed to reach the terminal.
+///
+/// The assertion here is deliberately a description of today's behaviour, not
+/// a statement that it is desirable; fixing it means snapping rulers to the
+/// grapheme that covers the column, which is out of scope for #2928.
+#[test]
+fn test_ruler_on_even_column_over_wide_characters() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![2];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text("你好世界").unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(
+        marked,
+        vec![ruler_x(&harness, 2)],
+        "the ruler at column 2 tints display column 2, got {marked:?}"
+    );
+    assert_ne!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("你"),
+        "column 2 is the trailing half of `你`, not the cell carrying its symbol"
     );
 }

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -29,6 +29,36 @@ fn has_ruler_bg(harness: &EditorTestHarness, x: u16, y: u16) -> bool {
         .unwrap_or(false)
 }
 
+/// Screen x of the cell a ruler at 1-based `column` must mark: the cell that
+/// holds the `column`-th character of the line, i.e. `column - 1` cells after
+/// the gutter.
+fn ruler_x(harness: &EditorTestHarness, column: u16) -> u16 {
+    gutter_width(harness) + column - 1
+}
+
+/// All screen x positions on `row` that carry the ruler background.
+fn ruler_cells_in_row(harness: &EditorTestHarness, row: u16, width: u16) -> Vec<u16> {
+    (0..width)
+        .filter(|&x| has_ruler_bg(harness, x, row))
+        .collect()
+}
+
+/// A line whose every 10th character is a letter marker:
+/// `123456789A123456789B…` — so the `n`-th group's letter sits at column
+/// `n * 10`, letting a test name the character a ruler is expected to mark.
+fn marker_line(columns: usize) -> String {
+    (1..=columns)
+        .map(|col| {
+            if col % 10 == 0 {
+                // 10 -> 'A', 20 -> 'B', ...
+                char::from(b'A' + ((col / 10 - 1) % 26) as u8)
+            } else {
+                char::from(b'0' + (col % 10) as u8)
+            }
+        })
+        .collect()
+}
+
 /// Helper to run a command from the command palette.
 fn run_command(harness: &mut EditorTestHarness, command_name: &str) {
     harness
@@ -58,24 +88,24 @@ fn test_rulers_render_at_correct_columns() {
 
     // Ruler at column 10 should have ruler bg
     assert!(
-        has_ruler_bg(&harness, gutter_width(&harness) + 10, row),
+        has_ruler_bg(&harness, ruler_x(&harness, 10), row),
         "Ruler bg should appear at column 10"
     );
 
     // Ruler at column 20 should have ruler bg
     assert!(
-        has_ruler_bg(&harness, gutter_width(&harness) + 20, row),
+        has_ruler_bg(&harness, ruler_x(&harness, 20), row),
         "Ruler bg should appear at column 20"
     );
 
     // Column 15 should NOT have ruler bg
     assert!(
-        !has_ruler_bg(&harness, gutter_width(&harness) + 15, row),
+        !has_ruler_bg(&harness, ruler_x(&harness, 15), row),
         "Column 15 should not have ruler bg"
     );
 
     // Rulers should preserve text content (not overwrite with │)
-    let cell_10 = harness.get_cell(gutter_width(&harness) + 10, row);
+    let cell_10 = harness.get_cell(ruler_x(&harness, 10), row);
     assert_eq!(
         cell_10.as_deref(),
         Some("X"),
@@ -95,11 +125,11 @@ fn test_rulers_span_full_height() {
     harness.render().unwrap();
 
     let (content_first_row, content_last_row) = harness.content_area_rows();
-    let ruler_x = gutter_width(&harness) + 10;
+    let ruler_screen_x = ruler_x(&harness, 10);
 
     for row in content_first_row..=content_last_row {
         assert!(
-            has_ruler_bg(&harness, ruler_x, row as u16),
+            has_ruler_bg(&harness, ruler_screen_x, row as u16),
             "Ruler bg should appear on row {row}"
         );
     }
@@ -122,13 +152,13 @@ fn test_rulers_span_full_height_short_buffer() {
     harness.render().unwrap();
 
     let (content_first_row, content_last_row) = harness.content_area_rows();
-    let ruler_x = gutter_width(&harness) + 10;
+    let ruler_screen_x = ruler_x(&harness, 10);
 
     // The ruler must appear on every content row, including the empty rows
     // below the last line of text.
     for row in content_first_row..=content_last_row {
         assert!(
-            has_ruler_bg(&harness, ruler_x, row as u16),
+            has_ruler_bg(&harness, ruler_screen_x, row as u16),
             "Ruler bg should appear on row {row} (short buffer, {content_first_row}..={content_last_row})"
         );
     }
@@ -150,7 +180,7 @@ fn test_rulers_horizontal_scroll() {
     let row = content_first_row as u16;
 
     // Initially ruler at column 5 should be visible at screen x = gutter + 5
-    let ruler_screen_x = gutter_width(&harness) + 5;
+    let ruler_screen_x = ruler_x(&harness, 5);
     assert!(
         has_ruler_bg(&harness, ruler_screen_x, row),
         "Ruler at col 5 should be visible initially"
@@ -216,11 +246,11 @@ fn test_no_rulers_on_virtual_buffer() {
     let row = content_first_row as u16;
 
     assert!(
-        !has_ruler_bg(&harness, gutter_width(&harness) + 10, row),
+        !has_ruler_bg(&harness, ruler_x(&harness, 10), row),
         "Virtual buffer should not paint a ruler at column 10"
     );
     assert!(
-        !has_ruler_bg(&harness, gutter_width(&harness) + 20, row),
+        !has_ruler_bg(&harness, ruler_x(&harness, 20), row),
         "Virtual buffer should not paint a ruler at column 20"
     );
 }
@@ -236,9 +266,9 @@ fn test_ruler_uses_theme_color() {
     harness.render().unwrap();
 
     let (content_first_row, _) = harness.content_area_rows();
-    let ruler_x = gutter_width(&harness) + 10;
+    let ruler_screen_x = ruler_x(&harness, 10);
 
-    let style = harness.get_cell_style(ruler_x, content_first_row as u16);
+    let style = harness.get_cell_style(ruler_screen_x, content_first_row as u16);
     assert!(style.is_some(), "Ruler cell should have a style");
 
     let style = style.unwrap();
@@ -270,10 +300,10 @@ fn test_per_buffer_ruler_independence() {
 
     let (content_first_row, _) = harness.content_area_rows();
     let row = content_first_row as u16;
-    let ruler_x = gutter_width(&harness) + 15;
+    let ruler_screen_x = ruler_x(&harness, 15);
 
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "File1 should have a ruler at column 15"
     );
 
@@ -282,7 +312,7 @@ fn test_per_buffer_ruler_independence() {
     harness.render().unwrap();
 
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "File2 should also have rulers initialized from config"
     );
 
@@ -293,7 +323,7 @@ fn test_per_buffer_ruler_independence() {
     harness.render().unwrap();
 
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "File1 should still have ruler after switching back"
     );
 }
@@ -307,11 +337,11 @@ fn test_add_ruler_command() {
 
     let (content_first_row, _) = harness.content_area_rows();
     let row = content_first_row as u16;
-    let ruler_x = gutter_width(&harness) + 25;
+    let ruler_screen_x = ruler_x(&harness, 25);
 
     // Before: no ruler at column 25
     assert!(
-        !has_ruler_bg(&harness, ruler_x, row),
+        !has_ruler_bg(&harness, ruler_screen_x, row),
         "No ruler should exist at column 25 initially"
     );
 
@@ -327,7 +357,7 @@ fn test_add_ruler_command() {
 
     // Verify ruler now exists at column 25
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "Ruler should appear at column 25 after Add Ruler command"
     );
 }
@@ -344,8 +374,8 @@ fn test_remove_ruler_command() {
 
     let (content_first_row, _) = harness.content_area_rows();
     let row = content_first_row as u16;
-    let ruler_x_10 = gutter_width(&harness) + 10;
-    let ruler_x_20 = gutter_width(&harness) + 20;
+    let ruler_x_10 = ruler_x(&harness, 10);
+    let ruler_x_20 = ruler_x(&harness, 20);
 
     // Verify both rulers exist
     assert!(
@@ -392,8 +422,8 @@ fn test_remove_ruler_selects_specific() {
 
     let (content_first_row, _) = harness.content_area_rows();
     let row = content_first_row as u16;
-    let ruler_x_10 = gutter_width(&harness) + 10;
-    let ruler_x_20 = gutter_width(&harness) + 20;
+    let ruler_x_10 = ruler_x(&harness, 10);
+    let ruler_x_20 = ruler_x(&harness, 20);
 
     // Both rulers exist
     assert!(has_ruler_bg(&harness, ruler_x_10, row));
@@ -473,11 +503,11 @@ fn test_add_then_remove_ruler_bad_then_good_input() {
 
     let (content_first_row, _) = harness.content_area_rows();
     let row = content_first_row as u16;
-    let ruler_x = gutter_width(&harness) + 80;
+    let ruler_screen_x = ruler_x(&harness, 80);
 
     // Step 1: Add a ruler at column 80 via command palette
     assert!(
-        !has_ruler_bg(&harness, ruler_x, row),
+        !has_ruler_bg(&harness, ruler_screen_x, row),
         "No ruler at column 80 before adding"
     );
 
@@ -490,7 +520,7 @@ fn test_add_then_remove_ruler_bad_then_good_input() {
 
     // Verify the ruler renders at column 80
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "Ruler should render at column 80 after adding"
     );
 
@@ -509,7 +539,7 @@ fn test_add_then_remove_ruler_bad_then_good_input() {
     harness.render().unwrap();
 
     assert!(
-        has_ruler_bg(&harness, ruler_x, row),
+        has_ruler_bg(&harness, ruler_screen_x, row),
         "Ruler at 80 should still exist after rejected remove with '32'"
     );
 
@@ -524,7 +554,7 @@ fn test_add_then_remove_ruler_bad_then_good_input() {
 
     // Ruler at 80 should now be gone
     assert!(
-        !has_ruler_bg(&harness, ruler_x, row),
+        !has_ruler_bg(&harness, ruler_screen_x, row),
         "Ruler at 80 should be removed after correct input"
     );
 }
@@ -552,4 +582,140 @@ fn test_add_ruler_zero_column() {
             "No ruler should exist after adding column 0"
         );
     }
+}
+
+/// Regression (#2928): a ruler at column N must mark the cell holding the
+/// N-th character, not the one after it. Ruler columns are 1-based (the
+/// "Add Ruler" prompt rejects 0, and the status bar numbers columns from 1),
+/// so a ruler at 80 is the "line must not exceed 80 characters" guide.
+///
+/// Before the fix the tinted cell was one to the right: on a line whose 80th
+/// character is `H`, the tint landed on the `1` that starts the next group.
+#[test]
+fn test_ruler_marks_configured_column_not_the_next_one() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![80];
+
+    let mut harness = EditorTestHarness::with_config(120, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&marker_line(100)).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 120);
+    assert_eq!(
+        marked.len(),
+        1,
+        "exactly one cell should carry the ruler tint, got {marked:?}"
+    );
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("H"),
+        "the ruler at column 80 must tint the 80th character ('H'), \
+         not its neighbour"
+    );
+}
+
+/// The ruler column must not depend on the length of the line it crosses:
+/// a line shorter than the ruler column, and an empty line, keep the guide in
+/// the same screen column as the line that reaches past it.
+#[test]
+fn test_ruler_column_is_stable_on_short_and_empty_lines() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![80];
+
+    let mut harness = EditorTestHarness::with_config(120, 24, config).unwrap();
+    let text = format!("{}\nshort\n\ntail", marker_line(100));
+    let _fixture = harness.load_buffer_from_text(&text).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let long_row = content_first_row as u16;
+
+    let marked_long = ruler_cells_in_row(&harness, long_row, 120);
+    assert_eq!(marked_long.len(), 1, "long line: got {marked_long:?}");
+    assert_eq!(
+        harness.get_cell(marked_long[0], long_row).as_deref(),
+        Some("H"),
+        "the ruler must tint the 80th character of the long line"
+    );
+
+    for (offset, what) in [(1u16, "short line"), (2, "empty line"), (3, "last line")] {
+        let row = long_row + offset;
+        let marked = ruler_cells_in_row(&harness, row, 120);
+        assert_eq!(
+            marked, marked_long,
+            "{what}: ruler should stay in the same screen column"
+        );
+    }
+}
+
+/// With horizontal scrolling the ruler must keep marking the same buffer
+/// column: it scrolls with the text rather than staying put or drifting by one.
+#[test]
+fn test_ruler_tracks_its_character_when_scrolled_horizontally() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![40];
+    config.editor.line_wrap = false;
+
+    let mut harness = EditorTestHarness::with_config(60, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text(&marker_line(100)).unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let before = ruler_cells_in_row(&harness, row, 60);
+    assert_eq!(before.len(), 1, "unscrolled: got {before:?}");
+    assert_eq!(
+        harness.get_cell(before[0], row).as_deref(),
+        Some("D"),
+        "the ruler at column 40 must tint the 40th character ('D')"
+    );
+
+    // Walk the cursor past the right edge of the viewport so the content
+    // scrolls horizontally, while keeping column 40 on screen.
+    for _ in 0..60 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let after = ruler_cells_in_row(&harness, row, 60);
+    assert_eq!(after.len(), 1, "scrolled: got {after:?}");
+    assert!(
+        after[0] < before[0],
+        "the view should have scrolled horizontally (ruler at {after:?}, was {before:?})"
+    );
+    assert_eq!(
+        harness.get_cell(after[0], row).as_deref(),
+        Some("D"),
+        "after scrolling, the ruler must still tint the 40th character ('D')"
+    );
+}
+
+/// Double-width characters: the ruler counts display columns, so a ruler at
+/// column 3 lands on the start of the second CJK character (which occupies
+/// display columns 3 and 4) rather than inside the first one's trailing cell.
+#[test]
+fn test_ruler_column_with_wide_characters() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![3];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    let _fixture = harness.load_buffer_from_text("你好世界").unwrap();
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    let marked = ruler_cells_in_row(&harness, row, 80);
+    assert_eq!(marked.len(), 1, "got {marked:?}");
+    assert_eq!(
+        harness.get_cell(marked[0], row).as_deref(),
+        Some("好"),
+        "the ruler should sit on the character starting at display column 3"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -998,9 +998,10 @@ fn test_ruler_bar_is_continuous_across_wide_text_rows() {
     // point is that a tint on a continuation cell is never emitted.
     let glyph = harness.get_cell(on_wide[0], wide_row);
     assert!(
-        glyph.as_deref().is_some_and(|g| g.chars().next().is_some_and(
-            |c| ('\u{4e00}'..='\u{9fff}').contains(&c)
-        )),
+        glyph.as_deref().is_some_and(|g| g
+            .chars()
+            .next()
+            .is_some_and(|c| ('\u{4e00}'..='\u{9fff}').contains(&c))),
         "the tinted cell on the wide row must carry the CJK grapheme's \
          symbol, got {glyph:?}"
     );

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -20,7 +20,7 @@ Add column rulers at any position via "Add Ruler" from the command palette. Usef
 
 Ruler columns are 1-based *display* columns — screen cells, not characters: a ruler at 80 highlights the 80th display column, the last one the text may occupy. A tab advances to the next tab stop and a full-width character (CJK, most emoji) takes two cells, so on lines containing either, the ruler column is not the character count the status bar reports; for plain ASCII text the two numbers agree. Values below 1 are not valid columns and are ignored.
 
-Known limitation: on a line of full-width characters a ruler at an even column falls on the trailing half of a double-width cell, where the tint may not be visible.
+When a ruler column falls inside a full-width character — for example a ruler at an even column on a line of CJK text — the guide marks that character's first cell, so it stays visible and still points at the character occupying the column. On such a row the bar can therefore sit one cell to the left of where it runs on the rows above and below.
 
 ## Indentation Guides
 

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -18,7 +18,9 @@ Some keybindings may not work or may differ on your system due to differences in
 
 Add column rulers at any position via "Add Ruler" from the command palette. Useful for enforcing line length limits. Remove with "Remove Ruler". Rulers are per-buffer. The `rulers` config setting can also set default rulers (e.g. `[80, 120]`).
 
-Ruler columns are 1-based, like the column shown in the status bar: a ruler at 80 highlights the 80th character of a line — the last column the text may occupy.
+Ruler columns are 1-based *display* columns — screen cells, not characters: a ruler at 80 highlights the 80th display column, the last one the text may occupy. A tab advances to the next tab stop and a full-width character (CJK, most emoji) takes two cells, so on lines containing either, the ruler column is not the character count the status bar reports; for plain ASCII text the two numbers agree. Values below 1 are not valid columns and are ignored.
+
+Known limitation: on a line of full-width characters a ruler at an even column falls on the trailing half of a double-width cell, where the tint may not be visible.
 
 ## Indentation Guides
 

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -18,6 +18,8 @@ Some keybindings may not work or may differ on your system due to differences in
 
 Add column rulers at any position via "Add Ruler" from the command palette. Useful for enforcing line length limits. Remove with "Remove Ruler". Rulers are per-buffer. The `rulers` config setting can also set default rulers (e.g. `[80, 120]`).
 
+Ruler columns are 1-based, like the column shown in the status bar: a ruler at 80 highlights the 80th character of a line — the last column the text may occupy.
+
 ## Indentation Guides
 
 Enable vertical indentation guides in the Settings UI. The default is off; choose to draw every indentation level, or only the innermost guide for the cursor's current block. The glyph (default `▏`) is also configurable there.


### PR DESCRIPTION
## How to reproduce

Three separate behaviours change. Each can be checked by eye in a terminal.

### 1. The off-by-one

1. Set `~/.config/fresh/config.json` to `{ "editor": { "rulers": [80] } }`.
2. Create a file with one 100-character line where every 10th character is a letter marker: `123456789A123456789B…123456789J`, so `H` sits at column 80.
3. Open it and look at which cell carries the ruler tint.

**After the fix the tint is on `H`, the 80th column. Before the fix it was on the `1` immediately after `H` — column 81**, so a line ending exactly at column 80 already looked like it had crossed the guide.

### 2. The guide vanishing over full-width text

1. Set `{ "editor": { "rulers": [20] } }`.
2. Create a file whose line is `你好世界` repeated five times. Each grapheme is two columns wide, so column 20 falls on the trailing half of the 10th grapheme.
3. Open it and compare the ruler bar on that row against the blank rows above and below it.

**After the fix the bar is continuous, with the tint on the glyph `好`. Before the fix that row had no ruler tint at all** — the bar ran down the blank rows and disappeared exactly where the CJK line crossed it, which is the hole visible in the reporter's screenshot.

### 3. A `0` in a hand-written config

1. Set `{ "editor": { "rulers": [0, 10] } }`.
2. Open any file and count the tinted cells on a line.

**After the fix exactly one cell is tinted, at column 10. Before the fix two were tinted** — column 10 and the first content column, because `0` was taken as a 0-based offset.

---

Fixes both halves of the ruler placement problem in #2928 (reported by @dhanoosu), plus a related disappearing-guide bug the reporter photographed.

## 1. The off-by-one

With `editor.rulers: [80]`, the tinted cell was column **81**. A line ending exactly at the 80th column already looked like it had crossed the guide, so the ruler could not be used as a strict line-length marker.

Ruler columns are 1-based everywhere the user meets them: the "Add Ruler" prompt rejects `0`, and the config docs say "[80, 120] draws rulers at columns 80 and 120". The renderer used the configured value directly as a 0-based offset. The conversion now lives inside `render_ruler_bg` — the one function that maps a ruler column onto a screen cell — so a future caller cannot reintroduce the off-by-one by passing raw offsets.

**Behaviour change worth a release note:** every existing ruler moves one cell left. Stored configs keep parsing and need no migration, but the guide visibly shifts for anyone with `rulers` set.

## 2. The guide vanishing over full-width text

A ruler column is a *display* column, and nothing snapped it to a grapheme boundary. When it landed on the trailing half of a double-width character, the tint went onto a continuation cell — and `Buffer::diff` never emits those (`to_skip = symbol.width() - 1`, every update gated on `to_skip == 0`). The guide silently disappeared on rows of CJK text while still rendering on the blank rows above and below: a bar with a hole in it.

### Reproduced in a terminal before changing the renderer

Debug build of this branch, `rulers = [20]`, a line of `你好世界` repeated five times (each grapheme two columns, so column 20 is the continuation half of the 10th), driven under tmux and captured with `tmux capture-pane -e -p`, decoding SGR backgrounds per cell:

| | blank rows (3, 4, 6–23) | CJK row (5) |
|---|---|---|
| **before** | ruler bg at terminal column 26 | **no ruler background anywhere** |
| **after** | ruler bg at column 26 | ruler bg at column 25, on the glyph `好` |

Across the whole pane the ruler colour `rgb(50,50,50)` occurs **20 times before and 21 after** — one added cell, precisely the one that was missing.

On the two extra light cells visible in the reported screenshot: I checked rather than assumed, and they are **not** ruler background. The pane contains yellow `rgb(255,255,0)` and cyan `rgb(0,255,255)` cells from other UI, unrelated to this bug and unchanged by the fix.

### The fix, and why this semantic

A ruler now snaps onto the **leading cell of the grapheme occupying its column**. Weighed against the alternatives: a guide one cell to the left is legible, whereas a guide that is never emitted is not; and the leading cell is the one that actually carries the character sitting at that column, which is what "the last column text may occupy" is meant to point at. Applied per row inside `render_ruler_bg`, because whether a column falls inside a wide grapheme depends on that row's text. Only one cell back is inspected, since no terminal grapheme exceeds two cells.

**The consequence is deliberate, and documented rather than hidden:** on a row where the ruler falls inside a full-width character, the bar sits one cell left of where it runs on the rows around it. The `rulers` doc comment, `plugins/config-schema.json`, `docs/features/editing.md` and the render-site comment all say this now, and the "known limitation" note that previously described this as unfixed is **gone from all of them**.

## 3. Coordinate space, and a `0` in a hand-written config

Rulers address display columns — screen cells, not characters. A tab advances to the next tab stop and a full-width character takes two cells, so on such lines the ruler column is not the grapheme count the status bar reports; for plain ASCII the two agree. An earlier revision of this branch claimed the ruler "marks the 80th character, matching the status bar" — wrong for tabbed or non-ASCII lines, and corrected in all four places it had been copied to.

`0` is not a valid 1-based column and is now skipped. **Correcting an earlier claim in this description:** master did not wrap to column 65535 — it treated the value as a 0-based offset and drew at the first content column. Skipping it is a real behaviour change and now has its own test; the pre-existing `test_add_ruler_zero_column` only covered the prompt's rejection. The schema also declared `"minimum": 0`, contradicting the documented semantics; the field now carries `#[schemars(inner(range(min = 1)))]`.

## Test coverage

All in `crates/fresh-editor/tests/e2e/vertical_rulers.rs`, asserting only on rendered cells (each scans the row rather than hard-coding a position). Note that `EditorTestHarness::buffer()` returns `Terminal::backend().buffer()`, and `TestBackend::draw` writes only the cells `Buffer::diff` chose to emit — so these assertions read the *emitted* screen, which is what makes the disappearing-guide bug observable at all.

* `test_ruler_on_trailing_cell_of_wide_grapheme_still_renders` — the core regression; fails pre-fix with `got []`.
* `test_ruler_bar_is_continuous_across_wide_text_rows` — the reported symptom, comparing the wide-text row against the blank rows of the same frame, so it needs no claim about emission.
* `test_ruler_snaps_to_leading_cell_on_mixed_line` — ASCII then wide, exercising the arithmetic off a uniform row.
* `test_ruler_on_leading_cell_of_wide_grapheme_renders` — control; this case always worked.
* `test_ruler_on_combining_sequence_needs_no_snap` — pins that a width-1 combining sequence has no continuation cell and is unaffected.
* `test_ruler_marks_configured_column_not_the_next_one`, `test_ruler_counts_display_columns_not_characters`, `test_config_ruler_zero_column_is_skipped`, plus stability/scroll cases.

Two of these were rewritten after their first run said something I had not expected, and both corrections are recorded in the docstrings so the next reader does not repeat them:

* the mixed-line test originally set `rulers = [5, 6]` and **passed vacuously**, because the ruler at 5 already rendered and left the row with exactly one tinted cell either way;
* the bar-continuity test originally used an 80-grapheme line, which **wrapped**, so the "blank row below" was really a continuation of the wide line — its own control assertion caught that before it could mislead.

## Verified vs. left to CI

**Verified locally against this exact tree**, with each cargo invocation bounded by `timeout` and serialised on the machine's shared build lock:

* `vertical_rulers` filter **before** the renderer change: **23 passed, 3 failed** — the three new snapping tests, two of them with `got []`.
* The same filter **after**: **26 passed, 0 failed**.
* The tmux capture above, from a debug binary built from this worktree.

**Not run, and not claimed:** `cargo clippy`, the wider test suite, and the schema generator. `plugins/config-schema.json` is **hand-edited** to what the generator is expected to emit; if the schema-drift check fails, that file is the cause and the generator output should replace it. (CI's `schema` job has since passed, so the hand-edit matched.)

`cargo fmt` was **not** run before the first push and CI's `fmt` job caught it, in both `post_pass.rs` and `vertical_rulers.rs`; commit `3eb4ec00a` applies rustfmt to both. No behavioural change.

One caveat worth recording: this machine shares a single `CARGO_TARGET_DIR` across several worktrees, and I caught it serving artifacts from another branch — a build of this tree failed on a `PluginCommand` variant that does not exist in it, and one test run reported the ruler theme colour as `rgb(20,20,20)` with the #2928 fix apparently absent. Every result quoted above comes from a run where all workspace sources were re-stamped first, so the binary was genuinely built from this tree; results that could not be shown to be clean have been discarded rather than reported.

## Part 2 of the issue (thin line glyph) — intentionally not included

The issue also asks whether the ruler could be a `│` glyph like the indentation guides. That is a design decision rather than a defect fix: indentation guides only ever replace *leading whitespace*, so a glyph there costs nothing, whereas a ruler crosses real text. A glyph-based ruler must decide what to do when a character already occupies the cell — overwrite it (hides code), fall back to a tint (two visual languages for one feature), or draw only past end-of-line (broken-looking on exactly the long lines the reporter cares about). Once chosen it wants a `ruler_style`-shaped setting, a theme fg key, schema, docs and tests. Happy to follow up with whichever variant you prefer.