### PR TITLE
fix(explorer): follow the active buffer when a tour opens the first step (#2988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * Comments inside fenced code blocks are no longer misdetected as Markdown syntax, and scrolling a large file in Compose mode is smooth on the first pass instead of only after it's been scrolled through once.
 * **Rendering**: the 256-color contrast pass no longer stalls large terminal windows or the Settings dialog, and a dimmed dialog no longer paints a fixed dark gray instead of following the active theme (#2982).
 * **Terminals**: a focused terminal keeps `Ctrl+B`/`Ctrl+E` for the shell instead of them toggling/focusing the File Explorer, and File Explorer keys (like Enter) no longer leak into a terminal's PTY sitting behind it.
-* **File Explorer**: the sidebar caret no longer blinks through modal dialogs.
+* **File Explorer**: the sidebar caret no longer blinks through modal dialogs. With `file_explorer.follow_active_buffer` on, the tree now also follows the first file a session opens — previously a code tour's opening step (or any first open into the empty `[No Name]` buffer) left the explorer parked at the root — and a follow request no longer gets thrown away when it arrives while the tree is still expanding for the previous one (#2988).
 * **Review Diff**: `PageDown`/`PageUp` no longer stalls with the cursor off-screen while paging over a collapsed file (#3029); a panel like the git-log commit view now word-wraps correctly no matter which split shows it.
 * **Editing near a fold, concealed span, or virtual line** no longer corrupts the rendered layout (wrong hidden text, row count, or scrollbar position) after certain edit sequences, or leaves it stuck stale after a file reload or undo past a bulk edit.
 

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -168,12 +168,7 @@ impl Window {
         let tabs_width = self.split_tabs_width(active_split);
         self.ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 
-        if self.file_explorer_visible
-            && self.resources.config.file_explorer.follow_active_buffer
-            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
-        {
-            self.sync_file_explorer_to_active_file();
-        }
+        self.follow_active_buffer_in_explorer();
 
         true
     }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -1709,13 +1709,17 @@ impl crate::app::window::Window {
         // `init_file_explorer`. Clear it *before* the expand-to-path sync below
         // so that sync can re-acquire it (it early-returns if it's still set).
         self.file_explorer_sync_in_progress = false;
+        // A follow request deferred while the build ran goes first: it names
+        // the file the user was actually sent to, which the active buffer may
+        // no longer be. It is re-gated on the way through (see
+        // `resume_deferred_file_explorer_expand`).
+        self.resume_deferred_file_explorer_expand();
         // Auto-expand to reveal the active file on first open (issue #1569),
-        // but only when this window is actually showing the explorer. A
-        // request deferred while the build ran wins: it names the file the
-        // user was actually sent to, which the active buffer may no longer be.
-        if self.file_explorer_sync_deferred.is_some() {
-            self.resume_deferred_file_explorer_expand();
-        } else if self.file_explorer_visible {
+        // but only when this window is actually showing the explorer. Skipped
+        // when the replay above already claimed the tree — this reveal is
+        // ungated, so running it on top would drag the selection off the file
+        // the deferred request was sent to.
+        if !self.file_explorer_sync_in_progress && self.file_explorer_visible {
             self.sync_file_explorer_to_active_file();
         }
     }
@@ -1733,6 +1737,16 @@ impl crate::app::window::Window {
     /// per-window for the same reason as `install_initialized_file_explorer`).
     pub(crate) fn install_expanded_file_explorer(&mut self, mut view: FileTreeView) {
         view.update_scroll_for_selection();
+        // A replay that would land exactly where this expand already did is
+        // pure churn — and not free churn: replaying hands the tree straight
+        // back out, so `self.file_explorer` returns to `None` and the sidebar
+        // paints blank until the second expand lands. One frame locally; over
+        // SSH the user watches it populate, blank, and populate again.
+        if self.file_explorer_sync_deferred.as_deref()
+            == view.get_selected_entry().map(|entry| entry.path.as_path())
+        {
+            self.file_explorer_sync_deferred = None;
+        }
         self.file_explorer = Some(view);
         self.file_explorer_sync_in_progress = false;
         self.resume_deferred_file_explorer_expand();
@@ -1747,11 +1761,18 @@ impl crate::app::window::Window {
     /// file and then hands the keyboard straight back to its own panel — a
     /// pathless virtual buffer — so re-reading would silently find nothing
     /// to reveal (issue #2988).
+    ///
+    /// The replay goes back through [`Window::follow_path_in_explorer`]
+    /// rather than straight to the spawn, because the gate it was queued
+    /// under can have gone false in the meantime: an expand takes seconds on
+    /// a remote filesystem, and the user is free to turn
+    /// `follow_active_buffer` off in Settings or take the keyboard into the
+    /// tree while it runs. Re-checking there keeps the gate at a single fork.
     fn resume_deferred_file_explorer_expand(&mut self) {
         let Some(target_path) = self.file_explorer_sync_deferred.take() else {
             return;
         };
-        self.expand_file_explorer_to_path(target_path);
+        self.follow_path_in_explorer(target_path);
     }
 
     /// Shift focus back to the editor pane (away from the file explorer)
@@ -1991,28 +2012,65 @@ impl crate::app::window::Window {
         self.set_status_message(msg);
     }
 
-    /// The single gate for `file_explorer.follow_active_buffer`.
+    /// Run the `file_explorer.follow_active_buffer` gate against whatever
+    /// file is active right now.
     ///
-    /// Every path that can make a *different file* the active one funnels
-    /// through here, so the gate cannot drift between call sites: the
-    /// buffer-switch path ([`Window::set_active_buffer`]) and the file-open
-    /// path that reuses the active scratch buffer in place — which changes
-    /// the active *file* without changing the active *buffer*, so it never
-    /// reaches `set_active_buffer` at all (issue #2988).
+    /// Called from the two paths that switch which file the user is looking
+    /// at without going through the explorer itself: the buffer-switch path
+    /// ([`Window::set_active_buffer`]) and the file-open path that reuses the
+    /// active scratch buffer in place — which changes the active *file*
+    /// without changing the active *buffer*, so it never reaches
+    /// `set_active_buffer` at all (issue #2988).
+    ///
+    /// Deliberately *not* a claim that every active-file change reaches here.
+    /// Two known ones do not, and their behaviour is unchanged: `Save As`
+    /// (`Editor::save_file_as_with_checks`) renames the active buffer's path
+    /// in place, and workspace restore opens files through
+    /// [`Window::open_file_no_focus`]. Adding either is a behaviour change,
+    /// not a refactor — check here before assuming the coverage is total.
+    pub(crate) fn follow_active_buffer_in_explorer(&mut self) {
+        let active_buf = self.active_buffer();
+        let Some(metadata) = self.buffer_metadata.get(&active_buf) else {
+            return;
+        };
+        let Some(target_path) = metadata.file_path().cloned() else {
+            return;
+        };
+        self.follow_path_in_explorer(target_path);
+    }
+
+    /// The single fork the `follow_active_buffer` gate is enforced at.
+    ///
+    /// Everything that follows the user around the tree — the live requests
+    /// from [`Window::follow_active_buffer_in_explorer`] and the deferred
+    /// ones replayed by [`Window::resume_deferred_file_explorer_expand`] —
+    /// passes its conditions here rather than re-deriving them, so a replay
+    /// cannot slip past a gate that has gone false since it was queued.
     ///
     /// Skipped while the explorer itself holds the keyboard: the user is
     /// navigating the tree, and yanking the selection to the editor's file
     /// under them would fight their own cursor.
-    pub(crate) fn follow_active_buffer_in_explorer(&mut self) {
-        if self.file_explorer_visible
-            && self.resources.config.file_explorer.follow_active_buffer
-            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
+    fn follow_path_in_explorer(&mut self, target_path: PathBuf) {
+        if !self.file_explorer_visible
+            || !self.resources.config.file_explorer.follow_active_buffer
+            || self.key_context == crate::input::keybindings::KeyContext::FileExplorer
+            || !target_path.starts_with(&self.root)
         {
-            self.sync_file_explorer_to_active_file();
+            tracing::trace!(
+                "follow_path_in_explorer: gate closed, not following {:?}",
+                target_path
+            );
+            return;
         }
+
+        self.expand_file_explorer_to_path(target_path);
     }
 
-    /// Expand this window's file-explorer tree to the active buffer's file.
+    /// Expand this window's file-explorer tree to the active buffer's file,
+    /// *ungated*: this is the explicit "show me where I am" reveal that
+    /// opening or focusing the sidebar performs (issue #1569), so it runs
+    /// even with `follow_active_buffer` off and with the tree focused.
+    ///
     /// No-op when the explorer isn't visible, the active buffer has no file
     /// behind it, or that file is outside the window's root.
     pub fn sync_file_explorer_to_active_file(&mut self) {
@@ -2045,19 +2103,31 @@ impl crate::app::window::Window {
     /// the first one forever, with nothing to retry it (issue #2988).
     fn expand_file_explorer_to_path(&mut self, target_path: PathBuf) {
         if !self.file_explorer_visible {
+            tracing::trace!(
+                "expand_file_explorer_to_path: sidebar hidden, dropping {:?}",
+                target_path
+            );
             return;
         }
 
         if self.file_explorer_sync_in_progress {
+            tracing::trace!(
+                "expand_file_explorer_to_path: expand in flight, deferring {:?}",
+                target_path
+            );
             self.file_explorer_sync_deferred = Some(target_path);
             return;
         }
 
         let Some(mut view) = self.file_explorer.take() else {
+            tracing::trace!(
+                "expand_file_explorer_to_path: no tree to expand, dropping {:?}",
+                target_path
+            );
             return;
         };
         tracing::trace!(
-            "sync_file_explorer_to_active_file: taking file_explorer for async expand to {:?}",
+            "expand_file_explorer_to_path: taking file_explorer for async expand to {:?}",
             target_path
         );
         let runtime_handle = self
@@ -2083,6 +2153,13 @@ impl crate::app::window::Window {
                 );
             });
         } else {
+            // No async plumbing on this window (headless/unit contexts). The
+            // tree goes back untouched; say so rather than losing the request
+            // without a trace.
+            tracing::trace!(
+                "expand_file_explorer_to_path: no runtime/bridge, dropping {:?}",
+                target_path
+            );
             self.file_explorer = Some(view);
         }
     }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -1710,8 +1710,12 @@ impl crate::app::window::Window {
         // so that sync can re-acquire it (it early-returns if it's still set).
         self.file_explorer_sync_in_progress = false;
         // Auto-expand to reveal the active file on first open (issue #1569),
-        // but only when this window is actually showing the explorer.
-        if self.file_explorer_visible {
+        // but only when this window is actually showing the explorer. A
+        // request deferred while the build ran wins: it names the file the
+        // user was actually sent to, which the active buffer may no longer be.
+        if self.file_explorer_sync_deferred.is_some() {
+            self.resume_deferred_file_explorer_expand();
+        } else if self.file_explorer_visible {
             self.sync_file_explorer_to_active_file();
         }
     }
@@ -1721,6 +1725,8 @@ impl crate::app::window::Window {
     /// collapses back to the editor rather than hanging blank forever.
     pub(crate) fn file_explorer_init_failed(&mut self) {
         self.file_explorer_sync_in_progress = false;
+        // Nothing to retry against: there is no tree to expand.
+        self.file_explorer_sync_deferred = None;
     }
 
     /// Install an async expand-to-path result onto *this* window (routed
@@ -1729,6 +1735,23 @@ impl crate::app::window::Window {
         view.update_scroll_for_selection();
         self.file_explorer = Some(view);
         self.file_explorer_sync_in_progress = false;
+        self.resume_deferred_file_explorer_expand();
+    }
+
+    /// Re-run the follow request that was deferred while an expand held the
+    /// tree, if there was one.
+    ///
+    /// The deferred *path* is replayed rather than re-read from the active
+    /// buffer: by the time an expand lands the active buffer is often no
+    /// longer a file at all. A code tour, for instance, opens the step's
+    /// file and then hands the keyboard straight back to its own panel — a
+    /// pathless virtual buffer — so re-reading would silently find nothing
+    /// to reveal (issue #2988).
+    fn resume_deferred_file_explorer_expand(&mut self) {
+        let Some(target_path) = self.file_explorer_sync_deferred.take() else {
+            return;
+        };
+        self.expand_file_explorer_to_path(target_path);
     }
 
     /// Shift focus back to the editor pane (away from the file explorer)
@@ -1968,17 +1991,32 @@ impl crate::app::window::Window {
         self.set_status_message(msg);
     }
 
-    /// Spawn an async expand-to-path of this window's file-explorer tree,
-    /// targeting the active buffer's file. No-op when the explorer isn't
-    /// visible, a sync is already running, or the target path is outside
-    /// the window's root.
+    /// The single gate for `file_explorer.follow_active_buffer`.
+    ///
+    /// Every path that can make a *different file* the active one funnels
+    /// through here, so the gate cannot drift between call sites: the
+    /// buffer-switch path ([`Window::set_active_buffer`]) and the file-open
+    /// path that reuses the active scratch buffer in place — which changes
+    /// the active *file* without changing the active *buffer*, so it never
+    /// reaches `set_active_buffer` at all (issue #2988).
+    ///
+    /// Skipped while the explorer itself holds the keyboard: the user is
+    /// navigating the tree, and yanking the selection to the editor's file
+    /// under them would fight their own cursor.
+    pub(crate) fn follow_active_buffer_in_explorer(&mut self) {
+        if self.file_explorer_visible
+            && self.resources.config.file_explorer.follow_active_buffer
+            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
+        {
+            self.sync_file_explorer_to_active_file();
+        }
+    }
+
+    /// Expand this window's file-explorer tree to the active buffer's file.
+    /// No-op when the explorer isn't visible, the active buffer has no file
+    /// behind it, or that file is outside the window's root.
     pub fn sync_file_explorer_to_active_file(&mut self) {
         if !self.file_explorer_visible {
-            return;
-        }
-
-        // Don't start a new sync if one is already in progress
-        if self.file_explorer_sync_in_progress {
             return;
         }
 
@@ -1992,6 +2030,26 @@ impl crate::app::window::Window {
         let target_path = file_path.clone();
 
         if !target_path.starts_with(&self.root) {
+            return;
+        }
+
+        self.expand_file_explorer_to_path(target_path);
+    }
+
+    /// Spawn the async expand-to-path that reveals and selects `target_path`.
+    ///
+    /// While an earlier expand holds the tree the request is *deferred*, not
+    /// dropped: whichever install lands next replays it (see
+    /// [`Window::resume_deferred_file_explorer_expand`]). Dropping it outright
+    /// meant any pair of opens fast enough to overlap left the tree parked on
+    /// the first one forever, with nothing to retry it (issue #2988).
+    fn expand_file_explorer_to_path(&mut self, target_path: PathBuf) {
+        if !self.file_explorer_visible {
+            return;
+        }
+
+        if self.file_explorer_sync_in_progress {
+            self.file_explorer_sync_deferred = Some(target_path);
             return;
         }
 

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -197,6 +197,15 @@ impl Editor {
                 "buffer_activated",
                 crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
             );
+
+            // The active *file* changed even though the active *buffer* did
+            // not, so `set_active_buffer` — where the follow-the-active-buffer
+            // sync normally hangs — was a no-op. Run the gate here too, or the
+            // very first file opened into a fresh session's scratch buffer
+            // never moves the explorer. Most visible when something opens that
+            // first file for you: a code tour's opening step left the tree
+            // parked at the root for the rest of the tour (issue #2988).
+            self.active_window_mut().follow_active_buffer_in_explorer();
         }
 
         // Use display_name from metadata for relative path display

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -692,6 +692,12 @@ pub struct Window {
     /// Whether a file-explorer rebuild is in flight (debounce flag).
     pub file_explorer_sync_in_progress: bool,
 
+    /// Path an expand-to-path request named while
+    /// `file_explorer_sync_in_progress` was already set. Replayed when the
+    /// in-flight expand lands, so an open that overlaps an earlier one still
+    /// reaches the tree (issue #2988).
+    pub file_explorer_sync_deferred: Option<PathBuf>,
+
     /// Width of the file-explorer panel.
     pub file_explorer_width: crate::config::ExplorerWidth,
 
@@ -2313,6 +2319,7 @@ impl Window {
             scroll_sync_manager: crate::view::scroll_sync::ScrollSyncManager::new(),
             file_explorer_visible: false,
             file_explorer_sync_in_progress: false,
+            file_explorer_sync_deferred: None,
             file_explorer_width: resources.config.file_explorer.width,
             file_explorer_side: resources.config.file_explorer.side,
             pending_file_explorer_show_hidden: None,

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3960,15 +3960,16 @@ fn test_file_explorer_duplicate_refreshes_git_decorations() {
 }
 
 /// Test that with `file_explorer.follow_active_buffer = true`, switching tabs
-/// re-syncs the file explorer to the newly active buffer's path — visibly
-/// expanding the directory containing that file.
+/// re-syncs the file explorer to the newly active buffer's path — moving the
+/// sidebar's *selection highlight* onto that file's row.
 ///
-/// Two files live in different subdirectories; both directories are
-/// initially collapsed. Opening file_b (after file_a was opened in-place
-/// over the empty buffer) syncs the explorer, expanding dir_b. Then
-/// `prev_buffer` switches the active tab back to file_a — with the sync
-/// hook in place, dir_a expands and file_a.txt becomes visible in the
-/// tree. Without the hook, dir_a stays collapsed and the wait times out.
+/// The highlight, rather than mere presence in the tree, is what this
+/// asserts, because presence cannot distinguish the two outcomes.
+/// `FileTree::expand_to_path` only ever expands ancestors and nothing on this
+/// path collapses one again, so a directory revealed once stays open for the
+/// rest of the session: "is `file_a.txt` in the tree?" answers yes from the
+/// moment file_a is first opened, whatever the tab bar does afterwards. The
+/// selection is the part that has to keep up with the active buffer.
 #[test]
 fn test_follow_active_buffer_syncs_explorer_on_tab_switch() {
     let mut config = Config::default();
@@ -3986,14 +3987,18 @@ fn test_follow_active_buffer_syncs_explorer_on_tab_switch() {
     // eligible (it is gated on `key_context != FileExplorer`).
     harness.editor_mut().toggle_file_explorer();
     harness.editor_mut().active_window_mut().focus_editor();
+    // Wait for the tree itself, not just the panel title: the sidebar draws
+    // its border and title the moment it becomes visible, while the initial
+    // build is still running. Opening a file in that window would queue its
+    // follow request behind the build instead of driving a sync of its own.
     harness
-        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .wait_until(|h| explorer_tree_contains(h, "dir_a"))
         .unwrap();
 
-    // Opening file_a replaces the initial `[No Name]` buffer in place, so
-    // `set_active_buffer` is a no-op and no sync fires. Opening file_b
-    // creates a new buffer; the sync triggered by that switch expands
-    // dir_b, leaving dir_a still collapsed.
+    // Opening file_a replaces the initial `[No Name]` buffer in place;
+    // opening file_b creates a new buffer. Both change which *file* is
+    // active, so both sync the explorer, and the highlight lands on
+    // file_b.txt.
     harness
         .editor_mut()
         .open_file(&project_root.join("dir_a/file_a.txt"))
@@ -4003,21 +4008,26 @@ fn test_follow_active_buffer_syncs_explorer_on_tab_switch() {
         .open_file(&project_root.join("dir_b/file_b.txt"))
         .unwrap();
     harness
-        .wait_until(|h| explorer_tree_contains(h, "file_b.txt"))
+        .wait_until(|h| explorer_row_highlighted(h, "file_b.txt"))
         .unwrap();
+
+    // Precondition: the highlight sits on file_b.txt, not on file_a.txt.
+    // That is what the tab switch has to change — unlike "file_a.txt is
+    // absent from the tree", which stops being true the moment opening
+    // file_a expands dir_a.
     assert!(
-        !explorer_tree_contains(&harness, "file_a.txt"),
-        "Precondition: dir_a should still be collapsed (file_a.txt not in \
-         the tree) before the tab switch.\nScreen:\n{}",
+        !explorer_row_highlighted(&harness, "file_a.txt"),
+        "Precondition: the sidebar's selection highlight should still be on \
+         file_b.txt before the tab switch.\nScreen:\n{}",
         harness.screen_to_string()
     );
 
-    // Switch the active tab back to file_a. With the sync hook in place,
-    // the explorer expands dir_a and file_a.txt becomes visible in the
-    // tree. Without it, dir_a stays collapsed and this wait times out.
+    // Switch the active tab back to file_a. With the sync hook in place the
+    // highlight follows onto file_a.txt's row. Without it, it stays parked
+    // on file_b.txt and this wait never completes.
     harness.editor_mut().prev_buffer();
     harness
-        .wait_until(|h| explorer_tree_contains(h, "file_a.txt"))
+        .wait_until(|h| explorer_row_highlighted(h, "file_a.txt"))
         .unwrap();
 }
 
@@ -4029,6 +4039,73 @@ fn explorer_tree_contains(harness: &EditorTestHarness, name: &str) -> bool {
         .screen_to_string()
         .lines()
         .any(|line| line.contains(name) && line.contains('│'))
+}
+
+/// The file-explorer sidebar's content rectangle, located from the panel's
+/// own border glyphs: `(first content column, one past the last content
+/// column, first content row, one past the last content row)`.
+///
+/// Derived from what the renderer drew rather than from config, and bounded
+/// on all four sides so that nothing outside the sidebar — the tab bar, the
+/// editor pane, the status line, each of which can echo a file name — can
+/// leak into an assertion about the tree.
+fn explorer_panel_rect(harness: &EditorTestHarness) -> Option<(u16, u16, u16, u16)> {
+    let area = harness.buffer().area;
+    let top = (0..area.height).find(|&y| harness.get_cell(0, y).as_deref() == Some("┌"))?;
+    let bottom =
+        ((top + 1)..area.height).find(|&y| harness.get_cell(0, y).as_deref() == Some("└"))?;
+    let right = (1..area.width).find(|&x| harness.get_cell(x, top).as_deref() == Some("┐"))?;
+    Some((1, right, top + 1, bottom))
+}
+
+/// The sidebar rows the renderer painted on a background other than the one
+/// the rest of the rows share — that is, the rows carrying the selection
+/// highlight.
+///
+/// Decided by majority vote over rendered cell backgrounds rather than by
+/// naming a theme color, so it holds for either highlight the explorer uses
+/// (`selection_bg` when the tree has the keyboard, `current_line_bg` when it
+/// does not) and under any theme.
+pub(crate) fn explorer_highlighted_rows(harness: &EditorTestHarness) -> Vec<String> {
+    let Some((x0, x1, y0, y1)) = explorer_panel_rect(harness) else {
+        return Vec::new();
+    };
+    let rows: Vec<(String, String)> = (y0..y1)
+        .map(|y| {
+            let text: String = (x0..x1).filter_map(|x| harness.get_cell(x, y)).collect();
+            // Debug-formatted so comparing backgrounds needs no color type.
+            let bg = format!("{:?}", harness.get_cell_style(x0, y).and_then(|s| s.bg));
+            (text, bg)
+        })
+        .collect();
+
+    let mut tally: Vec<(&str, usize)> = Vec::new();
+    for (_, bg) in &rows {
+        match tally.iter_mut().find(|(seen, _)| *seen == bg.as_str()) {
+            Some((_, count)) => *count += 1,
+            None => tally.push((bg.as_str(), 1)),
+        }
+    }
+    let Some(plain_bg) = tally
+        .iter()
+        .max_by_key(|(_, count)| *count)
+        .map(|(bg, _)| (*bg).to_string())
+    else {
+        return Vec::new();
+    };
+
+    rows.iter()
+        .filter(|(_, bg)| *bg != plain_bg)
+        .map(|(text, _)| text.trim().to_string())
+        .collect()
+}
+
+/// Whether the sidebar's selection highlight currently sits on the row for
+/// `name`. Rendered output only.
+pub(crate) fn explorer_row_highlighted(harness: &EditorTestHarness, name: &str) -> bool {
+    explorer_highlighted_rows(harness)
+        .iter()
+        .any(|row| row.contains(name))
 }
 
 /// Custom tree indicators (issue #1940) — the collapsed/expanded glyphs

--- a/crates/fresh-editor/tests/e2e/issue_2988_explorer_follow_tour.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2988_explorer_follow_tour.rs
@@ -128,8 +128,8 @@ fn explorer_shows(harness: &EditorTestHarness, name: &str) -> bool {
     explorer_panel_text(&harness.screen_to_string()).contains(name)
 }
 
-/// Open the explorer with the toggle key, then hand the keyboard back to the
-/// editor — the state the reported repro is in once the tour takes over.
+/// Open the explorer with the toggle key, exactly as the repro does, and
+/// leave the keyboard where `Ctrl+E` leaves it: in the tree.
 fn open_explorer(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
@@ -137,6 +137,18 @@ fn open_explorer(harness: &mut EditorTestHarness) {
     harness
         .wait_until(|h| h.screen_to_string().contains("File Explorer"))
         .unwrap();
+    harness.render().unwrap();
+}
+
+/// [`open_explorer`], then hand the keyboard back to the editor.
+///
+/// For the tests that drive opens straight through the editor rather than
+/// through keys: nothing in those would move focus out of the tree, so the
+/// follow gate (`key_context != FileExplorer`) would reject every request
+/// before it started. The tour test deliberately does *not* use this — see
+/// its own comment.
+fn open_explorer_and_focus_editor(harness: &mut EditorTestHarness) {
+    open_explorer(harness);
     harness.editor_mut().active_window_mut().focus_editor();
     harness.render().unwrap();
 }
@@ -149,6 +161,12 @@ fn open_explorer(harness: &mut EditorTestHarness) {
 /// Before the fix neither happened for step 1: no buffer switch, so no sync,
 /// so `step_one.rs` never appeared in the sidebar and this wait hangs until
 /// nextest kills the test.
+///
+/// The keyboard is left in the tree after `Ctrl+E`, the way the repro leaves
+/// it, and nothing here hands it back: the tour's own `focusSplit` is what
+/// drives `key_context`. That is on purpose — the issue suspected the
+/// `key_context != FileExplorer` guard of rejecting the tour's sync outright,
+/// and a test that pre-sets the context to `Normal` could never tell.
 #[test]
 fn test_explorer_follows_tour_steps() {
     let (_temp, project_root) = setup_tour_project();
@@ -229,7 +247,7 @@ fn test_overlapping_follow_requests_are_not_dropped() {
     fs::write(project_root.join("dir_b/file_b.txt"), "b").unwrap();
     fs::write(project_root.join("dir_c/file_c.txt"), "c").unwrap();
 
-    open_explorer(&mut harness);
+    open_explorer_and_focus_editor(&mut harness);
     assert!(
         !explorer_shows(&harness, "file_c.txt"),
         "Precondition: `dir_c/` should still be collapsed.\nScreen:\n{}",
@@ -274,7 +292,7 @@ fn test_deferred_follow_survives_a_pathless_active_buffer() {
     fs::write(project_root.join("dir_b/file_b.txt"), "b").unwrap();
     fs::write(project_root.join("seed.txt"), "seed").unwrap();
 
-    open_explorer(&mut harness);
+    open_explorer_and_focus_editor(&mut harness);
     assert!(
         !explorer_shows(&harness, "file_b.txt"),
         "Precondition: `dir_b/` should still be collapsed.\nScreen:\n{}",
@@ -303,5 +321,69 @@ fn test_deferred_follow_survives_a_pathless_active_buffer() {
 
     harness
         .wait_until(|h| explorer_shows(h, "file_b.txt"))
+        .unwrap();
+}
+
+/// A deferred follow request must re-pass the follow gate before it is
+/// replayed, because the gate can go false while the expand it queued behind
+/// is still running — seconds of it, on a remote filesystem.
+///
+/// Here the user takes the keyboard into the tree during that window.
+/// Following the active buffer is deliberately suppressed while the tree has
+/// focus (it would drag the selection out from under the user's own cursor),
+/// so the queued request has to be dropped, leaving the selection where the
+/// in-flight expand put it.
+///
+/// Before the fix the replay went straight to the spawn and re-checked only
+/// `file_explorer_visible`, so the stale request went through and yanked the
+/// selection onto `file_b` anyway: `file_a.txt` never carries the highlight
+/// and this wait hangs until nextest kills the test.
+///
+/// The opens are driven through the editor rather than through keys on
+/// purpose — sending a key drains the event loop, which would let the first
+/// expand land and dissolve the very overlap under test. Every assertion is
+/// still read off the rendered screen.
+#[test]
+fn test_deferred_follow_re_checks_the_gate_before_replaying() {
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = true;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    for dir in ["dir_a", "dir_b"] {
+        fs::create_dir_all(project_root.join(dir)).unwrap();
+    }
+    fs::write(project_root.join("dir_a/file_a.txt"), "a").unwrap();
+    fs::write(project_root.join("dir_b/file_b.txt"), "b").unwrap();
+
+    open_explorer_and_focus_editor(&mut harness);
+    // Let the initial tree build land, so the two opens below queue behind
+    // each other rather than behind the build.
+    harness.wait_until(|h| explorer_shows(h, "dir_a")).unwrap();
+
+    // No tick between these: file_b's request is deferred behind file_a's
+    // still-running expand.
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_a/file_a.txt"))
+        .unwrap();
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_b/file_b.txt"))
+        .unwrap();
+    // Park the editor on a pathless buffer. The sidebar's own "show me where
+    // I am" reveal, which focusing the tree performs, is deliberately ungated
+    // — with no active file it has nothing to reveal, so what the tree does
+    // next is down to the deferred request alone.
+    let _scratch = harness.editor_mut().new_buffer();
+    // The user takes the keyboard into the tree while the expand is still out.
+    harness.editor_mut().focus_file_explorer();
+
+    // file_a's expand lands, the deferred file_b request is dropped on the
+    // gate, and the highlight stays on the file the tree was already
+    // revealing.
+    harness
+        .wait_until(|h| crate::e2e::file_explorer::explorer_row_highlighted(h, "file_a.txt"))
         .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/issue_2988_explorer_follow_tour.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2988_explorer_follow_tour.rs
@@ -1,0 +1,307 @@
+//! E2E coverage for issue #2988: with `file_explorer.follow_active_buffer`
+//! on, the explorer must follow along when a code tour opens a step's file.
+//!
+//! Repro (manual, reproduced in tmux 160x40 against this repo):
+//!   1. Config `{ "file_explorer": { "follow_active_buffer": true } }`.
+//!   2. Open the file explorer (Ctrl+E).
+//!   3. Command palette -> `Tour: Load Definition...` -> `.fresh-tour.json`.
+//!   4. Expected: the explorer expands to reveal the first step's file, the
+//!      same way it does for quick-open or goto-definition.
+//!   5. Actual: the tree stays parked at the root. Stepping forward *does*
+//!      move it, which is the tell: the opening step is the one that lands
+//!      in the session's untouched scratch buffer.
+//!
+//! Two independent defects are covered here, one test each:
+//!
+//!   * A file opened into the fresh session's empty `[No Name]` buffer
+//!     replaces it *in place*: same buffer id, new file. `set_active_buffer`
+//!     — where the follow sync hangs — early-returns on "already active", so
+//!     nothing ever syncs. Every tour begins by opening a file, so its first
+//!     step hit this every single time.
+//!   * A sync request that arrives while an earlier expand is still in
+//!     flight used to be discarded, with nothing to retry it. Any pair of
+//!     opens fast enough to overlap left the tree on the first one.
+//!
+//! <https://github.com/sinelaw/fresh/issues/2988>
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A path as a JSON string literal — quotes and escapes included, so a
+/// Windows path interpolated into the manifest stays valid JSON.
+fn json_path(path: &Path) -> String {
+    serde_json::to_string(&path.display().to_string()).expect("path is UTF-8")
+}
+
+/// A two-step tour whose step files live in *different* collapsed
+/// subdirectories, so revealing either one requires the explorer to expand.
+fn tour_json(root: &Path) -> String {
+    let alpha = json_path(&root.join("alpha/step_one.rs"));
+    let beta = json_path(&root.join("beta/step_two.rs"));
+    format!(
+        r###"{{
+  "title": "Follow Tour",
+  "description": "Two steps in two directories",
+  "schema_version": "1.0",
+  "steps": [
+    {{
+      "step_id": 1,
+      "title": "First",
+      "file_path": {alpha},
+      "lines": [1, 2],
+      "explanation": "The first step."
+    }},
+    {{
+      "step_id": 2,
+      "title": "Second",
+      "file_path": {beta},
+      "lines": [1, 2],
+      "explanation": "The second step."
+    }}
+  ]
+}}"###
+    )
+}
+
+/// Project with the code-tour plugin, a manifest at the root, and the two
+/// step files buried one directory down.
+fn setup_tour_project() -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    // Canonicalize before it reaches the manifest: on macOS a tempdir is a
+    // symlink, and the editor stores the resolved path on the buffer, so an
+    // unresolved manifest path never matches a step's buffer.
+    let project_root = fs::canonicalize(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "code-tour");
+
+    fs::create_dir(project_root.join("alpha")).unwrap();
+    fs::create_dir(project_root.join("beta")).unwrap();
+    fs::write(
+        project_root.join("alpha/step_one.rs"),
+        "fn one() {}\nfn one_more() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project_root.join("beta/step_two.rs"),
+        "fn two() {}\nfn two_more() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project_root.join(".fresh-tour.json"),
+        tour_json(&project_root),
+    )
+    .unwrap();
+
+    (temp_dir, project_root)
+}
+
+/// The explorer sidebar's own columns, read off the rendered screen: every
+/// panel row starts with the sidebar's left border, and the sidebar ends at
+/// the first right-border glyph after it. Reading only these columns keeps
+/// the tab bar, the editor pane and the tour dock out of the assertions.
+fn explorer_panel_text(screen: &str) -> String {
+    screen
+        .lines()
+        .filter(|line| line.starts_with('┌') || line.starts_with('└') || line.starts_with('│'))
+        .map(|line| {
+            let mut it = line.char_indices();
+            let _left = it.next();
+            let end = it
+                .find(|(_, c)| matches!(c, '┐' | '┘' | '│'))
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(line.len());
+            line[..end].to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn explorer_shows(harness: &EditorTestHarness, name: &str) -> bool {
+    explorer_panel_text(&harness.screen_to_string()).contains(name)
+}
+
+/// Open the explorer with the toggle key, then hand the keyboard back to the
+/// editor — the state the reported repro is in once the tour takes over.
+fn open_explorer(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+    harness.editor_mut().active_window_mut().focus_editor();
+    harness.render().unwrap();
+}
+
+/// Loading a tour opens its first step's file — into the session's untouched
+/// scratch buffer, which is replaced in place rather than switched to. With
+/// `follow_active_buffer` on, the explorer must still expand to reveal it,
+/// and must keep up when the tour steps on to a file in another directory.
+///
+/// Before the fix neither happened for step 1: no buffer switch, so no sync,
+/// so `step_one.rs` never appeared in the sidebar and this wait hangs until
+/// nextest kills the test.
+#[test]
+fn test_explorer_follows_tour_steps() {
+    let (_temp, project_root) = setup_tour_project();
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = true;
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 40, config, project_root.clone())
+            .unwrap();
+    harness.render().unwrap();
+
+    open_explorer(&mut harness);
+
+    // Precondition: the step directories are collapsed, so neither step file
+    // is on screen before the tour runs.
+    assert!(
+        !explorer_shows(&harness, "step_one.rs") && !explorer_shows(&harness, "step_two.rs"),
+        "Precondition: `alpha/` and `beta/` should still be collapsed before \
+         the tour opens anything.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Load the tour the way the user does, through the palette.
+    harness
+        .run_palette_command("Tour: Load Definition")
+        .unwrap();
+    // Wait for the plugin's own file-pick prompt: the palette is still
+    // closing when the command fires, so any-prompt is not a sound wait.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("tour file path"))
+        .unwrap();
+    let manifest = project_root.join(".fresh-tour.json");
+    harness.type_text(&manifest.display().to_string()).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Step 1's file is revealed in the sidebar.
+    harness
+        .wait_until(|h| explorer_shows(h, "step_one.rs"))
+        .unwrap();
+
+    // The panel holds the keyboard once the step settles, so `n` advances
+    // the tour. Wait for the panel to say so before pressing it, or the key
+    // races the open → focus-handback chain and lands in the source file.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Step 1 of 2"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+
+    // Step 2 lives in a different directory, so the tree has to move again.
+    harness
+        .wait_until(|h| explorer_shows(h, "step_two.rs"))
+        .unwrap();
+}
+
+/// A follow request that overlaps an in-flight expand must not be lost.
+///
+/// Three opens back to back, with no editor tick in between, so the second
+/// one's expand is guaranteed to still be running when the third arrives.
+/// Before the fix the third request was discarded and nothing retried it:
+/// the tree stayed on the second file for good. Written without the tour
+/// because the race is not tour-specific — any burst of opens hits it.
+#[test]
+fn test_overlapping_follow_requests_are_not_dropped() {
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = true;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    for dir in ["dir_a", "dir_b", "dir_c"] {
+        fs::create_dir_all(project_root.join(dir)).unwrap();
+    }
+    fs::write(project_root.join("dir_a/file_a.txt"), "a").unwrap();
+    fs::write(project_root.join("dir_b/file_b.txt"), "b").unwrap();
+    fs::write(project_root.join("dir_c/file_c.txt"), "c").unwrap();
+
+    open_explorer(&mut harness);
+    assert!(
+        !explorer_shows(&harness, "file_c.txt"),
+        "Precondition: `dir_c/` should still be collapsed.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // No render/tick between these, so nothing can install an expand result
+    // in the gap: the third request necessarily overlaps the second's.
+    for file in ["dir_a/file_a.txt", "dir_b/file_b.txt", "dir_c/file_c.txt"] {
+        harness
+            .editor_mut()
+            .open_file(&project_root.join(file))
+            .unwrap();
+    }
+
+    harness
+        .wait_until(|h| explorer_shows(h, "file_c.txt"))
+        .unwrap();
+}
+
+/// A deferred follow request still names its own file once the active buffer
+/// has moved on to something with no file behind it.
+///
+/// This is the shape a code tour leaves behind: it opens the step's file and
+/// then hands the keyboard straight back to its own panel, a virtual buffer
+/// with no path. A retry that re-read "the active buffer's file" at that
+/// point would find nothing to reveal and quietly give up, so the deferred
+/// *path* is what gets replayed. Modelled here with a plain scratch buffer
+/// rather than a tour, because nothing about it is tour-specific.
+#[test]
+fn test_deferred_follow_survives_a_pathless_active_buffer() {
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = true;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    for dir in ["dir_a", "dir_b"] {
+        fs::create_dir_all(project_root.join(dir)).unwrap();
+    }
+    fs::write(project_root.join("dir_a/file_a.txt"), "a").unwrap();
+    fs::write(project_root.join("dir_b/file_b.txt"), "b").unwrap();
+    fs::write(project_root.join("seed.txt"), "seed").unwrap();
+
+    open_explorer(&mut harness);
+    assert!(
+        !explorer_shows(&harness, "file_b.txt"),
+        "Precondition: `dir_b/` should still be collapsed.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Consume the session's scratch buffer first, so both opens below are
+    // genuine buffer switches and each one really does request a follow.
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("seed.txt"))
+        .unwrap();
+
+    // Again no tick in between: file_b's request lands while file_a's expand
+    // still holds the tree, and the scratch buffer then takes over as the
+    // active buffer before that expand can install.
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_a/file_a.txt"))
+        .unwrap();
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_b/file_b.txt"))
+        .unwrap();
+    let _scratch = harness.editor_mut().new_buffer();
+
+    harness
+        .wait_until(|h| explorer_shows(h, "file_b.txt"))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -112,6 +112,7 @@ pub mod issue_2878_split_cursor_independence;
 pub mod issue_2893_replace_all_many_matches;
 pub mod issue_2953_search_replace_double_open;
 pub mod issue_2969_wheel_over_chrome;
+pub mod issue_2988_explorer_follow_tour;
 pub mod issue_3006_drag_beyond_text_area;
 pub mod issue_3006_shift_select_at_buffer_edges;
 pub mod issue_3031_stale_fold_hides_block_header;


### PR DESCRIPTION
Fixes #2988.

> **Verification status up front: local verification was not completed, and CI is the check.**
> The previous revision of this description claimed the `explorer` filter ran "212 passed, 0 failed". That claim is **withdrawn** — see [Correction](#correction-to-the-earlier-212-passed-0-failed-claim) below for why a single green run of that filter was not evidence of anything. **No regression-suite figure is claimed for this branch head.** The tests here are each verified to fail without the fix; none has been run against a build containing the fix. Full detail in [Verification status](#verification-status).

## What was wrong

With `file_explorer.follow_active_buffer` on, stepping through a code tour left the explorer parked at the root: the editor and the sidebar disagreed about where you were for the whole tour.

There are **two independent defects**. They are separate causes and are fixed (and tested) separately.

### 1. The active *file* can change without the active *buffer* changing — this is what made step 1 fail every time

A file opened into a session's untouched `[No Name]` buffer replaces it **in place**: same `BufferId`, new file. The follow sync hangs off `Window::set_active_buffer`, which early-returns on "the requested buffer is already active", so nothing ever synced.

Every tour begins by opening a file, so its opening step hit this deterministically, while later steps — genuine buffer switches — worked. That matches the asymmetry in the report exactly.

`open_file_with_kind` already had a branch for this case (it fires `buffer_activated` explicitly there because `set_active_buffer` was a no-op); the explorer follow was simply missing from it. The gate itself now lives in one place, `Window::follow_path_in_explorer`, reached from both the buffer-switch path and the in-place open path, so the two sites can't drift.

### 2. A follow request that overlaps an in-flight expand was dropped

This is the race in the issue's code lead, and it is real, but it is **not** what caused the reported first-step symptom. `sync_file_explorer_to_active_file` returned early when `file_explorer_sync_in_progress` was set, and nothing ever retried the discarded request. Any burst of opens fast enough to overlap left the tree on the first one.

Overlapping requests are now deferred and replayed when the in-flight expand lands. The deferred **path** is replayed rather than re-read from the active buffer, because by the time an expand lands the active buffer is frequently not a file at all — a tour opens the step's file and then hands the keyboard straight back to its own panel, a pathless virtual buffer, so a re-read would find nothing to reveal.

### The hypothesis I did *not* confirm

The issue also suggested the follow guard's `key_context` / visibility conditions might reject the tour's sync outright because the tour panel takes focus. **I checked this and it is not a cause.** Instrumenting the guard in a real session showed it evaluating `visible=true follow=true key_context=Normal` on the tour's open: `focus_split` resets `KeyContext::FileExplorer` to `Normal`, and the tour's `focusSplit` back to its panel runs *after* the open, not before. The gate is unchanged in what it admits.

---

## Review round

### Correction to the earlier "212 passed, 0 failed" claim

Withdrawn. I did observe one such run of the `explorer` filter at `7dc2c364c`, but a single green run of that filter proves nothing here, because **this change left a test inside it flaky**:

```
e2e::file_explorer::test_follow_active_buffer_syncs_explorer_on_tab_switch
at 7dc2c364c, 40 consecutive runs: 33 passed, 7 failed
```

A failing run fails on its precondition, exactly as reviewed:

```
Precondition: dir_a should still be collapsed (file_a.txt not in the tree) before the tab switch.
│▼ project_root                    │
│  ▼ dir_a                         │
│      file_a.txt                  │
│  ▼ dir_b                         │
│      file_b.txt                  │
```

So CI would have gone red about one run in six. The original figure was not fabricated — it is what one run printed — but reporting it as a clean regression run, of a filter this change had just made flaky, was not evidence that the suite was fine. No replacement figure is offered: **CI is the check.**

*(`cargo-nextest` is not installed in this environment. The runs quoted here are `cargo test` over the `e2e_tests` binary, with an external `timeout` standing in for nextest's slow-timeout — per CONTRIBUTING §3 the tests wait indefinitely, so "fails without the fix" surfaces as a timeout kill.)*

### The test is re-authored, not patched

Deleting the precondition would have made the test vacuous: its payoff step switches tabs back to `file_a` and waits for `file_a.txt` to appear in the tree, and `FileTree::expand_to_path` only ever expands ancestors — nothing on this path collapses one again — so once `dir_a` has been expanded, `file_a.txt` is in the tree for the rest of the session no matter what the tab bar does. The screen dump above shows precisely that: on a failing run the payoff condition was already satisfied *before* the tab switch.

`test_follow_active_buffer_syncs_explorer_on_tab_switch` now asserts on the sidebar's **selection highlight** instead. Presence in the tree is monotonic; the highlight is not. So "the highlight is on `file_b.txt` and not on `file_a.txt`" is a precondition that means something, and only the sync under test can satisfy the wait that follows the tab switch.

Mechanics, all rendered-output only (CONTRIBUTING §2):

* The sidebar's rectangle is derived from its own border glyphs, so the tab bar, the editor pane and the status line — all of which echo file names — are outside every assertion.
* The highlighted row is found by majority vote over rendered cell backgrounds rather than by naming a theme color, so it works for both highlights the explorer uses (`selection_bg` focused, `current_line_bg` blurred) under any theme.
* The setup now waits for the tree itself rather than for the panel title, which the sidebar draws while the initial build is still running. That ordering was the race.

Against the same source that made the old version fail 7 times in 40, the re-authored version ran **40/40 green**.

### The deferred replay now re-checks the gate it was queued under

`resume_deferred_file_explorer_expand` called the spawn directly, re-checking only `file_explorer_visible`. The other three conditions — `follow_active_buffer`, `key_context != FileExplorer`, and the target being under the window's root — were evaluated once at request time. The gap between deferral and replay is a whole async expand: milliseconds locally, seconds over SSH. Turn the setting off in Settings, or just click into the tree, while one is out, and the tree still jumped once more afterwards.

The gate now lives in `follow_path_in_explorer`, which both the live requests and the replay pass through, so neither can drift from the other (CONTRIBUTING §12). `sync_file_explorer_to_active_file` stays deliberately **ungated** — it is the explicit "show me where I am" reveal that opening or focusing the sidebar performs (#1569), which must still work with the setting off and the tree focused. Because the replay can now decline, the initial-build install runs that reveal as a fallback rather than as an `else` branch, and skips it only when the replay actually claimed the tree.

New test, `test_deferred_follow_re_checks_the_gate_before_replaying`: two overlapping opens with no tick in between, the editor parked on a pathless buffer so the ungated reveal has nothing to say, then the user takes the keyboard into the tree. The highlight must stay on the file the in-flight expand was already revealing. Against the code at `7dc2c364c` it **times out at 90 s** — the stale request goes through and yanks the selection onto `file_b`, so the wait never completes.

### Smaller review points

* **The doc comment overstated its invariant.** It claimed every path that can make a different file active funnels through the gate. It does not: `save_file_as_with_checks` renames the active buffer's path with no buffer switch, and workspace restore opens through `Window::open_file_no_focus`. I narrowed the wording rather than adding either as a call site — both would be behaviour changes, not refactors, and are out of scope here. The comment now names the two paths it covers *and* the two it doesn't.
* **Silently dropped requests.** An expand request can still be discarded three ways (sidebar hidden, no tree to take, no runtime behind the window), two of them with no trace at all — the same failure mode this PR exists to remove. Each now leaves a `tracing::trace!`.
* **SSH double-expand flicker.** Replaying a deferred path that the expand just landed on hands the tree straight back out, so the sidebar paints blank for the round trip — one frame locally, a visible populate → blank → populate over SSH. That replay is now skipped.
* **The tour test no longer pre-focuses the editor.** Setting `key_context` to `Normal` before loading the tour foreclosed the exact question the issue raised. The tour's own `focusSplit` drives it now; the test passes either way, and this version is the one that shows the `key_context` guard is not in the way.

---

## Verification status

Local runs were done from a dedicated git worktree with the shared build directory serialized under a lock covering both build and run, so no run executed another tree's artifacts.

**Observed on this branch head (`394c26d05`):**

| check | result |
|---|---|
| `cargo fmt --all` | clean — exit 0, no files modified |
| `cargo clippy --all-targets` | Finished in 2m48s, **0 errors**, and **no warning referencing any of the three touched files**. Because clippy compiles every target, this also covers `cargo check --all-targets`. |

**Observed against the pre-fix source (`7dc2c364c`), i.e. the fail-first evidence:**

| test | result |
|---|---|
| `test_follow_active_buffer_syncs_explorer_on_tab_switch`, old version, 40 runs | 33 passed, **7 failed** — flaky, screen dump above |
| the same test re-authored, 40 runs | **40 passed, 0 failed** |
| `test_deferred_follow_re_checks_the_gate_before_replaying` | **timed out at 90 s** — the expected failing state for a hang-when-absent reproducer (CONTRIBUTING §1/§3) |
| `test_explorer_follows_tour_steps`, with the `focus_editor()` line dropped | passed |
| `test_overlapping_follow_requests_are_not_dropped` | passed |
| `test_deferred_follow_survives_a_pathless_active_buffer` | passed |

**Not verified — CI is the check:**

* **No post-fix test run at all.** None of the five explorer/tour tests has been run against a build containing the gate fix. Local test running was stopped short: the build machine is shared and heavily contended, and with nextest absent a hang-when-absent reproducer has no external timeout, so runs were monopolising the shared lock. Every test here is verified to fail (or time out) *without* the fix; that it passes *with* it is for CI to confirm.
* **No regression-suite figure for this branch head.** The `explorer` filter has not been re-run since the review fixes.
* `test_follow_active_buffer_syncs_explorer_on_tab_switch` was not re-run against a build with the sync deliberately stubbed out. The evidence that its payoff is non-vacuous is the explicit precondition assertion plus the failing-run screen dump above, not a stub run.

## What was not exercised at all

* **Linux only.** Nothing here is platform-specific (no path-separator or case-sensitivity handling was added), but I did not build or run on macOS or Windows.
* **Remote (SSH) filesystems.** The change adds no filesystem access of its own — it reuses the existing `FileTreeView::expand_and_select_file` path — but it was only run against a local workspace. The gate re-check and the flicker fix are both motivated by remote latency, and neither was measured there.
* The `key_context != FileExplorer` gate is **unchanged in what it admits**, so a file opened while the explorer itself holds the keyboard still does not move the tree. That is the existing (deliberate) behaviour: the tree is taken out of the window for the duration of an expand, so syncing on every explorer keypress would freeze it under the user's cursor. What changed is only that a *deferred* request is now held to the same rule.
