### PR TITLE
feat(fresh-ui): report whether a dispatch was claimed

### DIFF
--- a/crates/fresh-ui/src/focus/mod.rs
+++ b/crates/fresh-ui/src/focus/mod.rs
@@ -518,23 +518,28 @@ impl<M: 'static> Ui<M> {
     /// Keys travel the focus chain: the focused element, then each of its
     /// ancestors. Raw listeners run first; whatever they decline is resolved to
     /// an intent and offered to the same chain as an action.
-    pub(crate) fn dispatch_key(&mut self, k: KeyPress, out: &mut Vec<M>) {
+    /// Reports whether anything claimed the key, so a host with its own
+    /// pipeline behind this tree knows not to act on it as well.
+    pub(crate) fn dispatch_key(&mut self, k: KeyPress, out: &mut Vec<M>) -> bool {
         let chain: Vec<ElementId> = match self.focus {
             Some(f) => self.path_to(f),
             None => self.root.map(|r| vec![r]).unwrap_or_default(),
         };
         if self.propagate_key(&chain, k, out) {
-            return;
+            return true;
         }
         if let Some(intent) = self.resolve_intent(&chain, k) {
             if self.run_action(&chain, intent, k, out) {
-                return;
+                return true;
             }
             if self.default_for_intent(intent) {
-                return;
+                return true;
             }
         }
-        self.dismiss_for_key(k, out);
+        // A key that dismisses a layer is answered by that layer: Escape
+        // closing a menu is the menu's reply, not a key that also belongs to
+        // whatever is behind it.
+        self.dismiss_for_key(k, out)
     }
 
     fn propagate_key(&mut self, chain: &[ElementId], k: KeyPress, out: &mut Vec<M>) -> bool {

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -23,29 +23,83 @@ use crate::render::geom::Point;
 use crate::render::object::{Hit, RenderId};
 use crate::schedule::Ui;
 
+/// What one dispatch did.
+///
+/// Messages and *claim* are different answers. A handler claims an event with
+/// [`Event::stop`] and may return no message at all; another produces a message
+/// without claiming anything. A host routing between this tree and its own
+/// older pipeline needs to know which happened, and cannot infer it from the
+/// messages — so it is reported.
+pub struct Dispatch<M> {
+    /// What the handlers returned, in the order they ran.
+    pub msgs: Vec<M>,
+    /// Whether a node claimed the event, so nothing behind this tree should
+    /// also act on it.
+    pub claimed: bool,
+}
+
+impl<M> std::ops::Deref for Dispatch<M> {
+    type Target = [M];
+    fn deref(&self) -> &[M] {
+        &self.msgs
+    }
+}
+
+impl<M> IntoIterator for Dispatch<M> {
+    type Item = M;
+    type IntoIter = std::vec::IntoIter<M>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.msgs.into_iter()
+    }
+}
+
+impl<M: PartialEq> PartialEq<Vec<M>> for Dispatch<M> {
+    fn eq(&self, other: &Vec<M>) -> bool {
+        self.msgs == *other
+    }
+}
+
+impl<M: std::fmt::Debug> std::fmt::Debug for Dispatch<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dispatch")
+            .field("msgs", &self.msgs)
+            .field("claimed", &self.claimed)
+            .finish()
+    }
+}
+
 impl<M: 'static> Ui<M> {
-    /// Route one host input into the tree and collect the messages handlers
-    /// produced. Handlers run during this call; the tree is not rebuilt by it.
-    pub fn dispatch(&mut self, input: Input) -> Vec<M> {
+    /// Route one host input into the tree, reporting the messages handlers
+    /// produced and whether the event was claimed. Handlers run during this
+    /// call; the tree is not rebuilt by it.
+    pub fn dispatch(&mut self, input: Input) -> Dispatch<M> {
         let mut out = Vec::new();
+        let claimed = self.route_input(input, &mut out);
+        Dispatch { msgs: out, claimed }
+    }
+
+    /// The routing itself, reporting whether anything claimed the event.
+    fn route_input(&mut self, input: Input, out: &mut Vec<M>) -> bool {
         match input {
-            Input::Key(k) => self.dispatch_key(k, &mut out),
+            Input::Key(k) => self.dispatch_key(k, out),
             Input::Move { pos, mods } => {
                 if let Some(r) = self.scrollbar_drag {
+                    // A drag in progress owns the pointer.
                     self.scroll_to_pointer(r, pos.y);
-                    return out;
+                    return true;
                 }
                 let paths = self.route(pos);
-                self.update_hover(&paths, pos, mods, &mut out);
-                self.propagate_all(
+                self.update_hover(&paths, pos, mods, out);
+                let (claimed, _) = self.propagate_all(
                     &paths,
                     GestureKind::Move,
                     pos,
                     MouseButton::Left,
                     mods,
                     Wheel::NONE,
-                    &mut out,
+                    out,
                 );
+                claimed
             }
             Input::Press { pos, button, mods } => {
                 // A press on a viewport's scrollbar gutter drives its scroll
@@ -55,10 +109,20 @@ impl<M: 'static> Ui<M> {
                     if let Some(r) = self.scrollbar_hit(pos) {
                         self.scrollbar_drag = Some(r);
                         self.scroll_to_pointer(r, pos.y);
-                        return out;
+                        return true;
                     }
                 }
-                self.dismiss_for_pointer(pos, &mut out);
+                // Dismissal happens for any button; it *claims* only for the
+                // primary one.
+                //
+                // A left click outside a menu is spent closing it — that is
+                // the whole gesture. A right click outside is not: every
+                // platform closes the open menu and opens the new one from
+                // that same press, so consuming it would cost the user a
+                // click. Same rule a viewport applies to the wheel: act, and
+                // claim only when the act was the whole of it.
+                let dismissed = self.dismiss_for_pointer(pos, out);
+                let dismiss_claims = dismissed && button == MouseButton::Left;
                 let paths = self.route(pos);
                 // Every stacked path's target, so a click is derived per path:
                 // a transparent overlay and what is behind it were both
@@ -66,29 +130,30 @@ impl<M: 'static> Ui<M> {
                 let targets: Vec<ElementId> =
                     paths.iter().filter_map(|p| p.last().copied()).collect();
                 self.press = Some((targets, button));
-                self.propagate_all(
+                let (claimed, _) = self.propagate_all(
                     &paths,
                     GestureKind::Press,
                     pos,
                     button,
                     mods,
                     Wheel::NONE,
-                    &mut out,
+                    out,
                 );
+                claimed || dismiss_claims
             }
             Input::Release { pos, button, mods } => {
                 if self.scrollbar_drag.take().is_some() {
-                    return out;
+                    return true;
                 }
                 let paths = self.route(pos);
-                self.propagate_all(
+                let (mut claimed, _) = self.propagate_all(
                     &paths,
                     GestureKind::Release,
                     pos,
                     button,
                     mods,
                     Wheel::NONE,
-                    &mut out,
+                    out,
                 );
                 // A click is a press and a release over the same element, one
                 // per stacked path.
@@ -103,18 +168,20 @@ impl<M: 'static> Ui<M> {
                             .filter(|p| p.last().is_some_and(|t| pressed.contains(t)))
                             .cloned()
                             .collect();
-                        self.propagate_all(
+                        let (c, _) = self.propagate_all(
                             &click_paths,
                             kind,
                             pos,
                             button,
                             mods,
                             Wheel::NONE,
-                            &mut out,
+                            out,
                         );
+                        claimed |= c;
                     }
                 }
                 self.captured = None;
+                claimed
             }
             Input::Wheel {
                 pos,
@@ -131,7 +198,7 @@ impl<M: 'static> Ui<M> {
                     MouseButton::Left,
                     mods,
                     wheel,
-                    &mut out,
+                    out,
                 );
                 if !claimed && !prevented {
                     // Scroll chaining: the first viewport along the path whose
@@ -142,9 +209,9 @@ impl<M: 'static> Ui<M> {
                         self.scroll_chain(&p, wheel);
                     }
                 }
+                claimed
             }
         }
-        out
     }
 
     /// How far a wheel turned and along which axis, as one parameter — so the
@@ -587,7 +654,9 @@ impl<M: 'static> Ui<M> {
         }
     }
 
-    fn dismiss_for_pointer(&mut self, pos: Point, out: &mut Vec<M>) {
+    /// Reports whether any layer was dismissed.
+    fn dismiss_for_pointer(&mut self, pos: Point, out: &mut Vec<M>) -> bool {
+        let mut dismissed = false;
         let path = self.hit_test(pos);
         let layers: Vec<ElementId> = self
             .pending_layers
@@ -627,7 +696,11 @@ impl<M: 'static> Ui<M> {
                     out.push(m);
                 }
             }
+            // A layer that declared the dismissal was dismissed, whether or
+            // not it also had something to say about it.
+            dismissed = true;
         }
+        dismissed
     }
 
     pub(crate) fn dismiss_for_key(&mut self, k: KeyPress, out: &mut Vec<M>) -> bool {

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -57,6 +57,7 @@ pub use focus::{
     default_shortcuts, Directional, FocusDir, FocusEntry, FocusScope, Focusable, Intent,
     ReadingOrder, Shortcut, TraversalPolicy,
 };
+pub use hit::Dispatch;
 pub use key::{Key, KeyPath};
 pub use render::geom::{distribute, Constraints, Point, Rect, Size};
 pub use render::object::{

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -34,16 +34,21 @@ fn traced(name: &'static str, log: &Log, child: Node<()>) -> Node<()> {
 
 fn click(ui: &mut Ui<()>, x: i32, y: i32) -> Vec<()> {
     let pos = Point::new(x, y);
-    let mut out = ui.dispatch(Input::Press {
-        pos,
-        button: MouseButton::Left,
-        mods: Mods::NONE,
-    });
-    out.extend(ui.dispatch(Input::Release {
-        pos,
-        button: MouseButton::Left,
-        mods: Mods::NONE,
-    }));
+    let mut out = ui
+        .dispatch(Input::Press {
+            pos,
+            button: MouseButton::Left,
+            mods: Mods::NONE,
+        })
+        .msgs;
+    out.extend(
+        ui.dispatch(Input::Release {
+            pos,
+            button: MouseButton::Left,
+            mods: Mods::NONE,
+        })
+        .msgs,
+    );
     out
 }
 
@@ -543,4 +548,48 @@ fn a_wheel_listener_sees_the_axis() {
         *seen.borrow(),
         vec![(1, Axis::Vertical), (-2, Axis::Horizontal)]
     );
+}
+
+// -- what a dispatch reports -------------------------------------------------
+
+/// Claiming and saying something are different answers, and a host routing
+/// between this tree and an older pipeline of its own needs both.
+#[test]
+fn a_claim_is_reported_separately_from_the_messages() {
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        gesture(text("row")).on(
+            GestureKind::Press,
+            Rc::new(|e: &Event| {
+                // Claims, and has nothing to say about it.
+                e.stop();
+                None
+            }),
+        ),
+        FRAME,
+    );
+    let d = ui.dispatch(Input::Press {
+        pos: Point::new(1, 0),
+        button: MouseButton::Left,
+        mods: Mods::NONE,
+    });
+    assert!(d.msgs.is_empty(), "the handler returned no message");
+    assert!(d.claimed, "but it claimed the press");
+}
+
+/// And the converse: a message without a claim.
+#[test]
+fn a_message_without_a_claim_is_reported_as_unclaimed() {
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        gesture(text("row")).on(GestureKind::Press, Rc::new(|_: &Event| Some(()))),
+        FRAME,
+    );
+    let d = ui.dispatch(Input::Press {
+        pos: Point::new(1, 0),
+        button: MouseButton::Left,
+        mods: Mods::NONE,
+    });
+    assert_eq!(d.msgs.len(), 1);
+    assert!(!d.claimed, "producing a message is not claiming the event");
 }

--- a/crates/fresh-ui/tests/support/demo/mod.rs
+++ b/crates/fresh-ui/tests/support/demo/mod.rs
@@ -69,7 +69,7 @@ impl Demo {
 
     /// One turn of the loop: route an input, apply what came back, redraw.
     pub fn input(&mut self, input: Input) -> Vec<Msg> {
-        let mut msgs = self.ui.dispatch(input);
+        let mut msgs = self.ui.dispatch(input).msgs;
         msgs.extend(self.ui.take_messages());
         for m in msgs.clone() {
             update(&mut self.app, m);

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -28,21 +28,26 @@ enum Msg {
 
 fn click(ui: &mut Ui<Msg>, x: i32, y: i32) -> Vec<Msg> {
     let pos = Point::new(x, y);
-    let mut out = ui.dispatch(Input::Press {
-        pos,
-        button: MouseButton::Left,
-        mods: Mods::NONE,
-    });
-    out.extend(ui.dispatch(Input::Release {
-        pos,
-        button: MouseButton::Left,
-        mods: Mods::NONE,
-    }));
+    let mut out = ui
+        .dispatch(Input::Press {
+            pos,
+            button: MouseButton::Left,
+            mods: Mods::NONE,
+        })
+        .msgs;
+    out.extend(
+        ui.dispatch(Input::Release {
+            pos,
+            button: MouseButton::Left,
+            mods: Mods::NONE,
+        })
+        .msgs,
+    );
     out
 }
 
 fn key(ui: &mut Ui<Msg>, code: KeyCode) -> Vec<Msg> {
-    ui.dispatch(Input::Key(KeyPress::new(code)))
+    ui.dispatch(Input::Key(KeyPress::new(code))).msgs
 }
 
 fn texts(ui: &Ui<Msg>) -> Vec<String> {


### PR DESCRIPTION
Third base change for the UI migration. #3028 will stack on it.

## Why

`dispatch` returned only the messages handlers produced, so a host with its own pipeline behind the tree had to infer *"did anything take this?"* from *"did anything say anything?"*. Those are different answers — a handler claims with `Event::stop` and may return no message, and a handler can return a message without claiming anything.

The information already existed and was discarded: `propagate_all` computes `(claimed, prevented)` and only the messages came back out.

**This was found by a bug, not by inspection.** The editor migration had reached "message implies claimed", plus a `UiFact::Consumed` message whose only meaning was *"there is no message"* — and it had already produced a regression: a right-click outside an open context menu emitted a dismissal, which read as a claim, which skipped the pipeline that would have opened the new menu. Two right-clicks where one used to do.

## What changed

`dispatch` returns `Dispatch { msgs, claimed }`. It derefs to a slice, iterates, and compares equal to a `Vec`, so call sites that only wanted the messages are unchanged.

Two dismissal rules come with it, both now stated in the library rather than left for each caller to guess:

- **A key that dismisses a layer is answered by that layer.** Escape closing a menu is the menu's reply, not a key that also belongs to whatever is behind it — so it claims.
- **A pointer dismissal happens for any button but claims only for the primary one.** A left click outside a menu is spent closing it; that is the whole gesture. A right click outside is not — every platform closes the open menu and opens the new one from that same press, so consuming it costs the user a click.

That second rule is the same shape as one the library already applies to the wheel: *act, and claim only when the act was the whole of it.*

## Verification

156 tests pass, **goldens unchanged**, clippy clean. Two new tests pin the distinction directly: a handler that stops without returning a message reports `claimed`, and a handler that returns a message without stopping reports not-claimed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2GtzEBQRFZMv8qF61Jzr)_