### PR TITLE
Update 0.4.10 changelog for fixes merged since #3037

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * **Toggle Line Numbers** in a Compose/Page View buffer no longer writes a setting the user never chose, leaving no way to turn numbers off while composing.
   * Vi's `:set number` / `:set nonumber` are honoured again on a buffer carrying a per-buffer pin, where they had become a silent no-op that still reported success.
 * **Rulers**: the column guide is drawn on the column it names rather than one cell to its right, and it stays visible where it crosses full-width characters instead of leaving a hole in the bar (#2928, reported by @dhanoosu).
-* **Daemon mode**: resizing a terminal attached with `fresh -a` no longer smears the last-painted colour across the blank cells.
+* **Daemon mode**: resizing a terminal attached with `fresh -a` no longer smears the last-painted colour across the blank cells - seen as a purple/theme-coloured screen fill when dragging a Windows Terminal window between monitors over SSH (#2723, reported by @amirhosseindavoody).
 
 ### Internals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Whitespace indicators**
   * Indicators inside a selection are drawn in a subdued colour of their own (`whitespace_indicator_selected_fg`, derived from the selection background when a theme doesn't set it) instead of taking the selected text's full-contrast foreground, where they were louder than the code around them.
   * **Toggle Whitespace Indicators (Current Buffer)** now marks every space when switched on, so it does something visible in a space-indented file — with the default settings (spaces off, tabs on) both halves of the toggle looked identical. Tab and line-ending indicators still follow the configuration.
+* **Line numbers**
+  * A per-buffer line-number toggle survives a tab switch in Page View instead of reappearing for one frame and then vanishing on the next keypress (#2931, reported by @mygirleatsmayo).
+  * **Toggle Line Numbers** in a Compose/Page View buffer no longer writes a setting the user never chose, leaving no way to turn numbers off while composing.
+  * Vi's `:set number` / `:set nonumber` are honoured again on a buffer carrying a per-buffer pin, where they had become a silent no-op that still reported success.
+* **Rulers**: the column guide is drawn on the column it names rather than one cell to its right, and it stays visible where it crosses full-width characters instead of leaving a hole in the bar (#2928, reported by @dhanoosu).
+* **Daemon mode**: resizing a terminal attached with `fresh -a` no longer smears the last-painted colour across the blank cells.
 
 ### Internals
 


### PR DESCRIPTION
Follow-up to #3037, covering the 15 commits merged into `master` since that entry landed.

## Summary

Adds three user-facing threads that weren't yet in the `## 0.4.10` section:

- **Line numbers** — a per-buffer pin surviving a tab switch in Page View, the global toggle no longer writing a setting the user never chose while composing, and vi's `:set number` honoured again on a pinned buffer (#2931).
- **Rulers** — the column guide drawn on the column it names rather than one cell right, and staying visible where it crosses full-width characters (#2928).
- **Daemon mode** — resizing a terminal attached with `fresh -a` no longer smears the last-painted colour across blank cells.

The whitespace-indicator, occurrence-highlight (#3011), explorer-follow (#2988) and diff hunk-header (#3021) entries were already added to the section alongside their own merges, so they're left as-is.

`crates/fresh-ui` work (#3046 and the rest of the widget-library arc) stays in the Internals rollup — it's still a standalone sub-crate that `fresh-editor` does not depend on, so nothing user-visible ships from it yet.

## Test plan

- [x] `## 0.4.9` and every older section still diff byte-identical against `git show v0.4.9:CHANGELOG.md` — the only changes are inside `## 0.4.10`.
- [x] Every `#NNNN` cited traces to a fixing commit in `v0.4.9..HEAD`; #2928 and #2931 confirmed against their commits.
- [x] Cross-checked every issue reference appearing in commit bodies but absent from the section — each is either already shipped in 0.4.9 (#2969), a PR number whose underlying issue is cited (#3041→#3021, #3043→#3011, #3044→#2988, #3015→#3014), an internal-only PR (#3008, #3024, #3046), or incidental historical context (#1239, #1568, #1569, #2029, #2587, #2689, #2953).
- [x] No attribution to `sinelaw` or `claude`; no Web UI mentions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UWwbFNBGA6C1hV9j3fcNCz)_