### PR TITLE
Make Emacs keybinding support complete, and fix chord handling in the keybinding editor

### DIFF
--- a/crates/fresh-editor/keymaps/emacs.json
+++ b/crates/fresh-editor/keymaps/emacs.json
@@ -1,23 +1,26 @@
 {
-  "inherits": null,
+  "inherits": "default",
+  "comment": "Emacs keymap. Inherits the default keymap so every context (settings, completion, terminal, search prompt, dock, file explorer, LSP, multi-cursor, ...) keeps a working set of keys, then overrides the ones Emacs users reach for. Only the Emacs-specific bindings live here; anything not listed behaves like the default keymap.",
   "bindings": [
     {
-      "comment": "M-x - execute extended command (command palette)",
+      "comment": "M-x - execute extended command. Overrides the default Alt+X menu mnemonic. Bound to `quick_open` rather than the identical `command_palette` so the status bar's palette hint (which looks up `quick_open`) names M-x.",
       "key": "x",
       "modifiers": ["alt"],
-      "action": "command_palette",
+      "action": "quick_open",
       "args": {},
       "when": "global"
     },
     {
-      "key": "F10",
-      "modifiers": [],
-      "action": "menu_activate",
+      "comment": "C-p is previous-line, everywhere — not the default global palette shortcut, which would leave the status bar advertising a key that moves the cursor instead.",
+      "key": "p",
+      "modifiers": ["ctrl"],
+      "action": "noop",
       "args": {},
       "when": "global"
     },
+
     {
-      "comment": "Emacs movement - C-f/b/n/p",
+      "comment": "Character/line movement - C-f/C-b/C-n/C-p, C-a/C-e",
       "key": "f",
       "modifiers": ["ctrl"],
       "action": "move_right",
@@ -60,7 +63,24 @@
       "when": "normal"
     },
     {
-      "comment": "Word movement - M-f/b and Ctrl+arrows",
+      "comment": "Home behaves like C-a (true beginning of line), not the default smart-home",
+      "key": "Home",
+      "modifiers": [],
+      "action": "move_line_start",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "M-m - back-to-indentation",
+      "key": "m",
+      "modifiers": ["alt"],
+      "action": "smart_home",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "Word movement - M-f/M-b and Ctrl+arrows",
       "key": "f",
       "modifiers": ["alt"],
       "action": "move_word_right",
@@ -75,21 +95,114 @@
       "when": "normal"
     },
     {
-      "key": "Left",
-      "modifiers": ["ctrl"],
-      "action": "move_word_left",
-      "args": {},
-      "when": "normal"
-    },
-    {
       "key": "Right",
       "modifiers": ["ctrl"],
       "action": "move_word_right",
       "args": {},
       "when": "normal"
     },
+
     {
-      "comment": "Clipboard - C-w (kill), M-w (copy), C-y (yank)",
+      "comment": "M-< / M-> - beginning/end of buffer. Bound on the shifted character itself: a terminal sends Alt+Shift+, as ESC '<', so `key: \",\"` never matches. The alt+shift variant covers terminals (kitty protocol) that do report Shift alongside the shifted glyph.",
+      "key": "<",
+      "modifiers": ["alt"],
+      "action": "move_document_start",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "<",
+      "modifiers": ["alt", "shift"],
+      "action": "move_document_start",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": ">",
+      "modifiers": ["alt"],
+      "action": "move_document_end",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": ">",
+      "modifiers": ["alt", "shift"],
+      "action": "move_document_end",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "M-{ / M-} - backward/forward paragraph",
+      "key": "{",
+      "modifiers": ["alt"],
+      "action": "move_to_paragraph_up",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "{",
+      "modifiers": ["alt", "shift"],
+      "action": "move_to_paragraph_up",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "}",
+      "modifiers": ["alt"],
+      "action": "move_to_paragraph_down",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "}",
+      "modifiers": ["alt", "shift"],
+      "action": "move_to_paragraph_down",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "C-v / M-v - page down/up",
+      "key": "v",
+      "modifiers": ["ctrl"],
+      "action": "move_page_down",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "v",
+      "modifiers": ["alt"],
+      "action": "move_page_up",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "Scrolling without moving the cursor - Alt+arrows",
+      "key": "Up",
+      "modifiers": ["alt"],
+      "action": "scroll_up",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "Down",
+      "modifiers": ["alt"],
+      "action": "scroll_down",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-l - recenter",
+      "key": "l",
+      "modifiers": ["ctrl"],
+      "action": "recenter",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "Clipboard - C-w (kill region), M-w (copy region), C-y (yank)",
       "key": "w",
       "modifiers": ["ctrl"],
       "action": "cut",
@@ -110,59 +223,189 @@
       "args": {},
       "when": "normal"
     },
+
     {
-      "comment": "C-g - keyboard quit",
+      "comment": "C-SPC - set mark (start selection)",
+      "key": " ",
+      "modifiers": ["ctrl"],
+      "action": "set_mark",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-g - keyboard quit: drops extra cursors and cancels mark mode",
       "key": "g",
       "modifiers": ["ctrl"],
       "action": "remove_secondary_cursors",
       "args": {},
       "when": "normal"
     },
+
     {
-      "key": "g",
+      "comment": "C-d - delete char forward, M-d - kill word forward, M-DEL - kill word backward",
+      "key": "d",
       "modifiers": ["ctrl"],
-      "action": "prompt_cancel",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "g",
-      "modifiers": ["ctrl"],
-      "action": "popup_cancel",
-      "args": {},
-      "when": "popup"
-    },
-    {
-      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke). Scoped to non-modal contexts so a user-overridden alt+t in normal/fileExplorer still wins at the same precedence level.",
-      "key": "t",
-      "modifiers": ["alt"],
-      "action": "popup_focus",
+      "action": "delete_forward",
       "args": {},
       "when": "normal"
     },
     {
-      "key": "t",
+      "key": "d",
       "modifiers": ["alt"],
-      "action": "popup_focus",
+      "action": "delete_word_forward",
       "args": {},
-      "when": "fileExplorer"
+      "when": "normal"
     },
     {
-      "key": "g",
+      "key": "Backspace",
+      "modifiers": ["alt"],
+      "action": "delete_word_backward",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-k - kill to end of line (Emacs kill-line), not the whole line",
+      "key": "k",
       "modifiers": ["ctrl"],
-      "action": "focus_editor",
+      "action": "delete_to_line_end",
       "args": {},
-      "when": "file_explorer"
+      "when": "normal"
     },
     {
-      "key": "g",
+      "comment": "C-S-DEL - kill whole line. On the Delete key: `normalize_key` folds Shift off Backspace, so Ctrl+Shift+Backspace would be unreachable behind Ctrl+Backspace.",
+      "key": "Delete",
+      "modifiers": ["ctrl", "shift"],
+      "action": "delete_line",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-t - transpose chars, C-o - open line",
+      "key": "t",
       "modifiers": ["ctrl"],
-      "action": "menu_close",
+      "action": "transpose_chars",
       "args": {},
-      "when": "menu"
+      "when": "normal"
     },
     {
-      "comment": "C-x prefix commands (chords)",
+      "key": "o",
+      "modifiers": ["ctrl"],
+      "action": "open_line",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "M-; - comment-dwim",
+      "key": ";",
+      "modifiers": ["alt"],
+      "action": "toggle_comment",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "M-/ - dabbrev-expand (overrides the default Alt+/ live grep, which stays on the palette and the Search menu)",
+      "key": "/",
+      "modifiers": ["alt"],
+      "action": "dabbrev_expand",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "M-TAB (C-M-i) - completion at point",
+      "key": "Tab",
+      "modifiers": ["alt"],
+      "action": "lsp_completion",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "M-. / M-, - xref find definition / pop back",
+      "key": ".",
+      "modifiers": ["alt"],
+      "action": "lsp_goto_definition",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": ",",
+      "modifiers": ["alt"],
+      "action": "navigate_back",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "Undo - C-/ (and its C-_ / C-7 terminal spellings)",
+      "key": "/",
+      "modifiers": ["ctrl"],
+      "action": "undo",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "-",
+      "modifiers": ["ctrl"],
+      "action": "undo",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "Redo - M-_ . Emacs has no redo; this mirrors C-_ so the editor's redo stays reachable (C-y is yank here).",
+      "key": "_",
+      "modifiers": ["alt"],
+      "action": "redo",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "C-s - isearch forward (opens the search prompt), C-r - search backwards",
+      "key": "s",
+      "modifiers": ["ctrl"],
+      "action": "search",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "r",
+      "modifiers": ["ctrl"],
+      "action": "find_previous",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-s / C-r repeat the search while the search prompt is open (isearch style)",
+      "key": "s",
+      "modifiers": ["ctrl"],
+      "action": "find_next",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "key": "r",
+      "modifiers": ["ctrl"],
+      "action": "find_previous",
+      "args": {},
+      "when": "searchPrompt"
+    },
+    {
+      "comment": "M-% - query replace. Bound on the shifted character; see the M-< note above.",
+      "key": "%",
+      "modifiers": ["alt"],
+      "action": "query_replace",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "%",
+      "modifiers": ["alt", "shift"],
+      "action": "query_replace",
+      "args": {},
+      "when": "normal"
+    },
+
+    {
+      "comment": "C-x C-s - save buffer",
       "keys": [
         {"key": "x", "modifiers": ["ctrl"]},
         {"key": "s", "modifiers": ["ctrl"]}
@@ -172,6 +415,27 @@
       "when": "normal"
     },
     {
+      "comment": "C-x s - save some buffers",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "s", "modifiers": []}
+      ],
+      "action": "save_all",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x C-w - write file (save as)",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "w", "modifiers": ["ctrl"]}
+      ],
+      "action": "save_as",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x C-f - find file",
       "keys": [
         {"key": "x", "modifiers": ["ctrl"]},
         {"key": "f", "modifiers": ["ctrl"]}
@@ -181,6 +445,7 @@
       "when": "normal"
     },
     {
+      "comment": "C-x C-c - save buffers and quit",
       "keys": [
         {"key": "x", "modifiers": ["ctrl"]},
         {"key": "c", "modifiers": ["ctrl"]}
@@ -196,6 +461,74 @@
         {"key": "k", "modifiers": []}
       ],
       "action": "close",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x b / C-x C-b - switch to buffer / list buffers",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "b", "modifiers": []}
+      ],
+      "action": "quick_open_buffers",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "b", "modifiers": ["ctrl"]}
+      ],
+      "action": "quick_open_buffers",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x Right / C-x Left - next / previous buffer",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "Right", "modifiers": []}
+      ],
+      "action": "next_buffer",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "Left", "modifiers": []}
+      ],
+      "action": "prev_buffer",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x u - undo",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "u", "modifiers": []}
+      ],
+      "action": "undo",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x h - mark whole buffer (select all)",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "h", "modifiers": []}
+      ],
+      "action": "select_all",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "C-x d - dired (file explorer)",
+      "keys": [
+        {"key": "x", "modifiers": ["ctrl"]},
+        {"key": "d", "modifiers": []}
+      ],
+      "action": "toggle_file_explorer",
       "args": {},
       "when": "normal"
     },
@@ -240,7 +573,7 @@
       "when": "normal"
     },
     {
-      "comment": "M-g g - goto line",
+      "comment": "M-g g / M-g M-g - goto line",
       "keys": [
         {"key": "g", "modifiers": ["alt"]},
         {"key": "g", "modifiers": []}
@@ -250,352 +583,20 @@
       "when": "normal"
     },
     {
-      "comment": "M-d - kill word forward",
-      "key": "d",
-      "modifiers": ["alt"],
-      "action": "delete_word_forward",
+      "keys": [
+        {"key": "g", "modifiers": ["alt"]},
+        {"key": "g", "modifiers": ["alt"]}
+      ],
+      "action": "goto_line",
       "args": {},
       "when": "normal"
     },
+
     {
-      "comment": "M-Backspace - kill word backward",
-      "key": "Backspace",
-      "modifiers": ["alt"],
-      "action": "delete_word_backward",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "M-< - beginning of buffer",
-      "key": ",",
-      "modifiers": ["alt", "shift"],
-      "action": "move_document_start",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "M-> - end of buffer",
-      "key": ".",
-      "modifiers": ["alt", "shift"],
-      "action": "move_document_end",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "M-% - query replace",
-      "key": "5",
-      "modifiers": ["alt", "shift"],
-      "action": "query_replace",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-t - transpose chars",
-      "key": "t",
+      "comment": "Minibuffer (prompt) - Emacs line editing",
+      "key": "g",
       "modifiers": ["ctrl"],
-      "action": "transpose_chars",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-o - open line (insert newline, stay on line)",
-      "key": "o",
-      "modifiers": ["ctrl"],
-      "action": "open_line",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-l - recenter (scroll cursor to center)",
-      "key": "l",
-      "modifiers": ["ctrl"],
-      "action": "recenter",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-SPC - set mark (start selection)",
-      "key": " ",
-      "modifiers": ["ctrl"],
-      "action": "set_mark",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Arrow keys still work",
-      "key": "Left",
-      "modifiers": [],
-      "action": "move_left",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Right",
-      "modifiers": [],
-      "action": "move_right",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Up",
-      "modifiers": [],
-      "action": "move_up",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Down",
-      "modifiers": [],
-      "action": "move_down",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Shift+arrows for selection",
-      "key": "Left",
-      "modifiers": ["shift"],
-      "action": "select_left",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Right",
-      "modifiers": ["shift"],
-      "action": "select_right",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Up",
-      "modifiers": ["shift"],
-      "action": "select_up",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Down",
-      "modifiers": ["shift"],
-      "action": "select_down",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Scrolling - Alt+arrows",
-      "key": "Up",
-      "modifiers": ["alt"],
-      "action": "scroll_up",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Down",
-      "modifiers": ["alt"],
-      "action": "scroll_down",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-v/M-v - page down/up",
-      "key": "v",
-      "modifiers": ["ctrl"],
-      "action": "move_page_down",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "v",
-      "modifiers": ["alt"],
-      "action": "move_page_up",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-s - isearch forward",
-      "key": "s",
-      "modifiers": ["ctrl"],
-      "action": "search",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-d - delete char forward",
-      "key": "d",
-      "modifiers": ["ctrl"],
-      "action": "delete_forward",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "C-k - kill line",
-      "key": "k",
-      "modifiers": ["ctrl"],
-      "action": "delete_line",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Basic editing",
-      "key": "Backspace",
-      "modifiers": [],
-      "action": "delete_backward",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Delete",
-      "modifiers": [],
-      "action": "delete_forward",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Enter",
-      "modifiers": [],
-      "action": "insert_newline",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Tab",
-      "modifiers": [],
-      "action": "insert_tab",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Home/End keys",
-      "key": "Home",
-      "modifiers": [],
-      "action": "move_line_start",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "End",
-      "modifiers": [],
-      "action": "move_line_end",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "Home",
-      "modifiers": ["ctrl"],
-      "action": "move_document_start",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "End",
-      "modifiers": ["ctrl"],
-      "action": "move_document_end",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "PageUp",
-      "modifiers": [],
-      "action": "move_page_up",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "key": "PageDown",
-      "modifiers": [],
-      "action": "move_page_down",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Undo - C-/ or C-_",
-      "key": "/",
-      "modifiers": ["ctrl"],
-      "action": "undo",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Escape - cancel/quit",
-      "key": "Escape",
-      "modifiers": [],
-      "action": "remove_secondary_cursors",
-      "args": {},
-      "when": "normal"
-    },
-    {
-      "comment": "Prompt context bindings",
-      "key": "Enter",
-      "modifiers": [],
-      "action": "prompt_confirm",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Escape",
-      "modifiers": [],
       "action": "prompt_cancel",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Backspace",
-      "modifiers": [],
-      "action": "prompt_backspace",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Left",
-      "modifiers": [],
-      "action": "prompt_move_left",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Right",
-      "modifiers": [],
-      "action": "prompt_move_right",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Up",
-      "modifiers": [],
-      "action": "prompt_select_prev",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Down",
-      "modifiers": [],
-      "action": "prompt_select_next",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Home",
-      "modifiers": [],
-      "action": "prompt_move_start",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "End",
-      "modifiers": [],
-      "action": "prompt_move_end",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "Tab",
-      "modifiers": [],
-      "action": "prompt_accept_suggestion",
-      "args": {},
-      "when": "prompt"
-    },
-    {
-      "key": "y",
-      "modifiers": ["ctrl"],
-      "action": "prompt_paste",
       "args": {},
       "when": "prompt"
     },
@@ -614,35 +615,92 @@
       "when": "prompt"
     },
     {
-      "comment": "Popup context bindings",
-      "key": "Enter",
-      "modifiers": [],
-      "action": "popup_confirm",
+      "key": "f",
+      "modifiers": ["ctrl"],
+      "action": "prompt_move_right",
       "args": {},
-      "when": "popup"
+      "when": "prompt"
     },
     {
-      "key": "Escape",
-      "modifiers": [],
-      "action": "popup_cancel",
+      "key": "b",
+      "modifiers": ["ctrl"],
+      "action": "prompt_move_left",
       "args": {},
-      "when": "popup"
+      "when": "prompt"
     },
     {
-      "key": "Up",
-      "modifiers": [],
-      "action": "popup_select_prev",
+      "key": "f",
+      "modifiers": ["alt"],
+      "action": "prompt_move_word_right",
       "args": {},
-      "when": "popup"
+      "when": "prompt"
     },
     {
-      "key": "Down",
-      "modifiers": [],
-      "action": "popup_select_next",
+      "key": "b",
+      "modifiers": ["alt"],
+      "action": "prompt_move_word_left",
       "args": {},
-      "when": "popup"
+      "when": "prompt"
     },
     {
+      "key": "n",
+      "modifiers": ["ctrl"],
+      "action": "prompt_select_next",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "p",
+      "modifiers": ["ctrl"],
+      "action": "prompt_select_prev",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "d",
+      "modifiers": ["ctrl"],
+      "action": "prompt_delete",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "d",
+      "modifiers": ["alt"],
+      "action": "prompt_delete_word_forward",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "Backspace",
+      "modifiers": ["alt"],
+      "action": "prompt_delete_word_backward",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "k",
+      "modifiers": ["ctrl"],
+      "action": "prompt_delete_to_line_end",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "w",
+      "modifiers": ["ctrl"],
+      "action": "prompt_cut",
+      "args": {},
+      "when": "prompt"
+    },
+    {
+      "key": "y",
+      "modifiers": ["ctrl"],
+      "action": "prompt_paste",
+      "args": {},
+      "when": "prompt"
+    },
+
+    {
+      "comment": "Popups - C-n/C-p to move, C-g to dismiss",
       "key": "n",
       "modifiers": ["ctrl"],
       "action": "popup_select_next",
@@ -657,154 +715,101 @@
       "when": "popup"
     },
     {
-      "comment": "File explorer context",
-      "key": "Escape",
-      "modifiers": [],
-      "action": "focus_editor",
+      "key": "g",
+      "modifiers": ["ctrl"],
+      "action": "popup_cancel",
       "args": {},
-      "when": "file_explorer"
+      "when": "popup"
+    },
+
+    {
+      "comment": "Completion popup - C-n/C-p to move, C-g to dismiss",
+      "key": "n",
+      "modifiers": ["ctrl"],
+      "action": "popup_select_next",
+      "args": {},
+      "when": "completion"
     },
     {
-      "key": "Up",
-      "modifiers": [],
-      "action": "file_explorer_up",
+      "key": "p",
+      "modifiers": ["ctrl"],
+      "action": "popup_select_prev",
       "args": {},
-      "when": "file_explorer"
+      "when": "completion"
     },
     {
-      "key": "Down",
-      "modifiers": [],
-      "action": "file_explorer_down",
+      "key": "g",
+      "modifiers": ["ctrl"],
+      "action": "completion_dismiss",
       "args": {},
-      "when": "file_explorer"
+      "when": "completion"
     },
+
     {
-      "key": "Enter",
-      "modifiers": [],
-      "action": "file_explorer_open",
-      "args": {},
-      "when": "file_explorer"
-    },
-    {
-      "key": "Right",
-      "modifiers": [],
-      "action": "file_explorer_expand",
-      "args": {},
-      "when": "file_explorer"
-    },
-    {
-      "key": "Left",
-      "modifiers": [],
-      "action": "file_explorer_collapse",
-      "args": {},
-      "when": "file_explorer"
-    },
-    {
-      "comment": "Menu context",
-      "key": "Escape",
-      "modifiers": [],
-      "action": "menu_close",
-      "args": {},
-      "when": "menu"
-    },
-    {
-      "key": "Enter",
-      "modifiers": [],
-      "action": "menu_execute",
-      "args": {},
-      "when": "menu"
-    },
-    {
-      "key": "Up",
-      "modifiers": [],
-      "action": "menu_up",
-      "args": {},
-      "when": "menu"
-    },
-    {
-      "key": "Down",
-      "modifiers": [],
+      "comment": "Menus - C-n/C-p/C-f/C-b to move, C-g to close",
+      "key": "n",
+      "modifiers": ["ctrl"],
       "action": "menu_down",
       "args": {},
       "when": "menu"
     },
     {
-      "key": "Left",
-      "modifiers": [],
-      "action": "menu_left",
+      "key": "p",
+      "modifiers": ["ctrl"],
+      "action": "menu_up",
       "args": {},
       "when": "menu"
     },
     {
-      "key": "Right",
-      "modifiers": [],
+      "key": "f",
+      "modifiers": ["ctrl"],
       "action": "menu_right",
       "args": {},
       "when": "menu"
     },
     {
-      "comment": "Play last recorded macro (F4)",
-      "key": "F4",
-      "modifiers": [],
-      "action": "play_last_macro",
+      "key": "b",
+      "modifiers": ["ctrl"],
+      "action": "menu_left",
       "args": {},
-      "when": "normal"
+      "when": "menu"
     },
     {
-      "comment": "Open the Remote Indicator menu (Local / SSH / Container actions)",
-      "key": "F6",
-      "modifiers": [],
-      "action": "show_remote_indicator_menu",
+      "key": "g",
+      "modifiers": ["ctrl"],
+      "action": "menu_close",
       "args": {},
-      "when": "global"
+      "when": "menu"
+    },
+
+    {
+      "comment": "File explorer - C-n/C-p to move, C-g / Esc back to the editor",
+      "key": "n",
+      "modifiers": ["ctrl"],
+      "action": "file_explorer_down",
+      "args": {},
+      "when": "file_explorer"
     },
     {
-      "comment": "Composite buffer context - Close view (q)",
-      "key": "q",
-      "modifiers": [],
-      "action": "close",
+      "key": "p",
+      "modifiers": ["ctrl"],
+      "action": "file_explorer_up",
       "args": {},
-      "when": "compositeBuffer"
+      "when": "file_explorer"
     },
     {
-      "comment": "Composite buffer context - Close view (Esc)",
+      "key": "g",
+      "modifiers": ["ctrl"],
+      "action": "focus_editor",
+      "args": {},
+      "when": "file_explorer"
+    },
+    {
       "key": "Escape",
       "modifiers": [],
-      "action": "close",
+      "action": "focus_editor",
       "args": {},
-      "when": "compositeBuffer"
-    },
-    {
-      "comment": "Composite buffer context - Next hunk (n)",
-      "key": "n",
-      "modifiers": [],
-      "action": "composite_next_hunk",
-      "args": {},
-      "when": "compositeBuffer"
-    },
-    {
-      "comment": "Composite buffer context - Previous hunk (p)",
-      "key": "p",
-      "modifiers": [],
-      "action": "composite_prev_hunk",
-      "args": {},
-      "when": "compositeBuffer"
-    },
-    {
-      "comment": "Composite buffer context - Next hunk (])",
-      "key": "]",
-      "modifiers": [],
-      "action": "composite_next_hunk",
-      "args": {},
-      "when": "compositeBuffer"
-    },
-    {
-      "comment": "Composite buffer context - Previous hunk ([)",
-      "key": "[",
-      "modifiers": [],
-      "action": "composite_prev_hunk",
-      "args": {},
-      "when": "compositeBuffer"
+      "when": "file_explorer"
     }
   ]
 }

--- a/crates/fresh-editor/keymaps/emacs.json
+++ b/crates/fresh-editor/keymaps/emacs.json
@@ -335,7 +335,7 @@
     },
 
     {
-      "comment": "Undo - C-/ (and its C-_ / C-7 terminal spellings)",
+      "comment": "Undo - C-/ and C-_ . `ctrl+-` picks up the `ctrl+_` alias `terminal_key_equivalents` adds for legacy terminals; the explicit `ctrl+shift+-`/`ctrl+shift+_` entries cover terminals (kitty protocol) that report Shift alongside the shifted glyph.",
       "key": "/",
       "modifiers": ["ctrl"],
       "action": "undo",
@@ -350,9 +350,23 @@
       "when": "normal"
     },
     {
-      "comment": "Redo - M-_ . Emacs has no redo; this mirrors C-_ so the editor's redo stays reachable (C-y is yank here).",
+      "key": "_",
+      "modifiers": ["ctrl", "shift"],
+      "action": "undo",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "comment": "Redo - M-_ . Emacs has no redo; this mirrors C-_ so the editor's redo stays reachable (C-y is yank here). Both Alt spellings, as above.",
       "key": "_",
       "modifiers": ["alt"],
+      "action": "redo",
+      "args": {},
+      "when": "normal"
+    },
+    {
+      "key": "_",
+      "modifiers": ["alt", "shift"],
       "action": "redo",
       "args": {},
       "when": "normal"

--- a/crates/fresh-editor/src/app/action_dispatch.rs
+++ b/crates/fresh-editor/src/app/action_dispatch.rs
@@ -10,6 +10,7 @@
 
 use super::*;
 use anyhow::Result as AnyhowResult;
+use crossterm::event::KeyModifiers as KM;
 use rust_i18n::t;
 
 impl Editor {
@@ -1897,6 +1898,80 @@ impl Editor {
                     self.update_prompt_suggestions();
                 }
             }
+
+            // Prompt navigation and editing.
+            //
+            // These are the actions the `prompt` section of every keymap binds.
+            // The prompt owns its editing logic in `Prompt`'s `InputHandler`
+            // (suggestion sync, theme preview, plugin selection hooks, …), and
+            // the handler runs *before* keybinding resolution — so a key it
+            // handles itself never reaches its binding, and until now a key it
+            // ignored resolved to an action with no dispatch arm at all and did
+            // nothing. That left every `prompt` binding on a non-default key
+            // silently dead (Emacs `C-b`/`C-n`/`C-g`, say).
+            //
+            // Each action is defined as "the same thing this key does", and
+            // re-enters the prompt's handler with that key, so there is one
+            // implementation of each operation rather than a second copy here
+            // that would drift.
+            Action::PromptCancel => self.dispatch_prompt_key_for_action(KeyCode::Esc, KM::NONE),
+            Action::PromptBackspace => {
+                self.dispatch_prompt_key_for_action(KeyCode::Backspace, KM::NONE)
+            }
+            Action::PromptDelete => self.dispatch_prompt_key_for_action(KeyCode::Delete, KM::NONE),
+            Action::PromptMoveLeft => self.dispatch_prompt_key_for_action(KeyCode::Left, KM::NONE),
+            Action::PromptMoveRight => {
+                self.dispatch_prompt_key_for_action(KeyCode::Right, KM::NONE)
+            }
+            Action::PromptMoveStart => self.dispatch_prompt_key_for_action(KeyCode::Home, KM::NONE),
+            Action::PromptMoveEnd => self.dispatch_prompt_key_for_action(KeyCode::End, KM::NONE),
+            Action::PromptSelectPrev => self.dispatch_prompt_key_for_action(KeyCode::Up, KM::NONE),
+            Action::PromptSelectNext => {
+                self.dispatch_prompt_key_for_action(KeyCode::Down, KM::NONE)
+            }
+            Action::PromptPageUp => self.dispatch_prompt_key_for_action(KeyCode::PageUp, KM::NONE),
+            Action::PromptPageDown => {
+                self.dispatch_prompt_key_for_action(KeyCode::PageDown, KM::NONE)
+            }
+            Action::PromptAcceptSuggestion => {
+                self.dispatch_prompt_key_for_action(KeyCode::Tab, KM::NONE)
+            }
+            Action::PromptMoveWordLeft => {
+                self.dispatch_prompt_key_for_action(KeyCode::Left, KM::CONTROL)
+            }
+            Action::PromptMoveWordRight => {
+                self.dispatch_prompt_key_for_action(KeyCode::Right, KM::CONTROL)
+            }
+            Action::PromptDeleteWordBackward => {
+                self.dispatch_prompt_key_for_action(KeyCode::Backspace, KM::CONTROL)
+            }
+            Action::PromptDeleteWordForward => {
+                self.dispatch_prompt_key_for_action(KeyCode::Delete, KM::CONTROL)
+            }
+            Action::PromptDeleteToLineEnd => {
+                self.dispatch_prompt_key_for_action(KeyCode::Char('k'), KM::CONTROL)
+            }
+            Action::PromptSelectAll => {
+                self.dispatch_prompt_key_for_action(KeyCode::Char('a'), KM::CONTROL)
+            }
+            Action::PromptMoveLeftSelecting => {
+                self.dispatch_prompt_key_for_action(KeyCode::Left, KM::SHIFT)
+            }
+            Action::PromptMoveRightSelecting => {
+                self.dispatch_prompt_key_for_action(KeyCode::Right, KM::SHIFT)
+            }
+            Action::PromptMoveHomeSelecting => {
+                self.dispatch_prompt_key_for_action(KeyCode::Home, KM::SHIFT)
+            }
+            Action::PromptMoveEndSelecting => {
+                self.dispatch_prompt_key_for_action(KeyCode::End, KM::SHIFT)
+            }
+            Action::PromptSelectWordLeft => {
+                self.dispatch_prompt_key_for_action(KeyCode::Left, KM::CONTROL | KM::SHIFT)
+            }
+            Action::PromptSelectWordRight => {
+                self.dispatch_prompt_key_for_action(KeyCode::Right, KM::CONTROL | KM::SHIFT)
+            }
             _ => {
                 // TODO: Why do we have this catch-all? It seems like actions should either:
                 // 1. Be handled explicitly above (like InsertChar, PopupConfirm, etc.)
@@ -2053,5 +2128,36 @@ impl Editor {
             buffer_id
         );
         Ok(())
+    }
+
+    /// Run one of the `prompt_*` actions by re-entering the prompt's own
+    /// input handler with the key that means the same thing.
+    ///
+    /// The prompt keeps its editing logic in `Prompt`'s `InputHandler` and runs
+    /// it ahead of keybinding resolution, so an action arm that reimplemented
+    /// (say) suggestion navigation would be a second copy of the sync, theme
+    /// preview and plugin-notification behaviour, free to drift from the one
+    /// the arrow keys use. Delegating keeps exactly one implementation.
+    ///
+    /// A no-op when no prompt is open — an action bound in the `prompt`
+    /// context can still be reached from elsewhere.
+    fn dispatch_prompt_key_for_action(
+        &mut self,
+        code: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
+    ) {
+        use crate::input::handler::{InputContext, InputHandler};
+        let mut ctx = InputContext::new();
+        let event = crossterm::event::KeyEvent::new(code, modifiers);
+        let handled = match self.active_window_mut().prompt.as_mut() {
+            Some(prompt) => {
+                prompt.handle_key_event(&event, &mut ctx);
+                true
+            }
+            None => false,
+        };
+        if handled {
+            self.process_deferred_actions(ctx);
+        }
     }
 }

--- a/crates/fresh-editor/src/app/chrome/menu.rs
+++ b/crates/fresh-editor/src/app/chrome/menu.rs
@@ -123,6 +123,23 @@ impl ChromeComponent for Menu {
         event: &crossterm::event::KeyEvent,
     ) -> Option<AnyhowResult<crate::input::handler::InputResult>> {
         use crate::input::handler::{InputContext, InputHandler};
+        // A `menu`-context binding is consulted first. `MenuInputHandler` is
+        // capture-all — its final arm consumes every key it doesn't recognise —
+        // so without this the `menu` section of every keymap is decorative:
+        // nothing a user or a keymap binds there can ever fire (Emacs `C-n` /
+        // `C-g` in an open menu did nothing at all).
+        //
+        // Narrowly scoped to the menu's own actions, so a binding that means
+        // something else keeps whatever route it has today, and the handler
+        // still owns navigation, mnemonics and dismissal for every key the
+        // keymap leaves alone.
+        if let Some(action) = self.menu_action_binding(ed, event) {
+            return Some(
+                ed.handle_action(action)
+                    .map(|_| crate::input::handler::InputResult::Consumed),
+            );
+        }
+
         // An open menu is capture-all: navigation, mnemonics and
         // dismissal all belong to `MenuInputHandler` while its layer
         // is up.
@@ -141,6 +158,37 @@ impl ChromeComponent for Menu {
         };
         ed.process_deferred_actions(ctx);
         Some(Ok(result))
+    }
+}
+
+impl Menu {
+    /// The menu action this key resolves to in the `menu` context, if any.
+    ///
+    /// Only the menu's own navigation and dismissal actions qualify, so this
+    /// can change which menu operation a key performs and nothing else.
+    /// `menu_open` is deliberately excluded: the mnemonics it powers are the
+    /// handler's business, and re-opening a menu from inside one is not a
+    /// menu-navigation step.
+    fn menu_action_binding(
+        &self,
+        ed: &Editor,
+        event: &crossterm::event::KeyEvent,
+    ) -> Option<crate::input::keybindings::Action> {
+        use crate::input::keybindings::{Action, KeyContext};
+        if ed.get_key_context() != KeyContext::Menu {
+            return None;
+        }
+        let action = ed.keybindings.read().ok()?.resolve(event, KeyContext::Menu);
+        matches!(
+            action,
+            Action::MenuUp
+                | Action::MenuDown
+                | Action::MenuLeft
+                | Action::MenuRight
+                | Action::MenuExecute
+                | Action::MenuClose
+        )
+        .then_some(action)
     }
 }
 

--- a/crates/fresh-editor/src/app/chrome/prompt.rs
+++ b/crates/fresh-editor/src/app/chrome/prompt.rs
@@ -384,6 +384,26 @@ impl Editor {
             return Some(result);
         }
 
+        // A `prompt`-context binding outranks the prompt widget's own
+        // hardcoded key handling. `Prompt`'s `InputHandler` owns a handful of
+        // Ctrl keys outright (Ctrl+A select-all, Ctrl+Y redo-input, …) and runs
+        // ahead of keybinding resolution, so no keymap and no user config could
+        // reach those keys — an Emacs user cannot get `C-a` to mean
+        // beginning-of-line in the minibuffer, however they bind it.
+        //
+        // Narrowly scoped on purpose: only a resolved `prompt_*` action is
+        // taken here, so a binding that means something else entirely (the file
+        // browser's Alt toggles, Ctrl+P for quick-open) keeps its existing
+        // route through the rungs below. The actions themselves re-enter this
+        // same handler with their canonical key, so nothing here recurses.
+        if let Some(action) = self.prompt_action_binding(event) {
+            return Some(
+                self.handle_action(action)
+                    .map(|_| InputResult::Consumed)
+                    .unwrap_or(InputResult::Consumed),
+            );
+        }
+
         if let Some(ref mut prompt) = self.active_window_mut().prompt {
             let result = prompt.dispatch_input(event, &mut ctx);
             // Only return and process deferred actions if the prompt
@@ -397,6 +417,61 @@ impl Editor {
             }
         }
         None
+    }
+
+    /// The `prompt_*` action this key resolves to in the prompt's own key
+    /// context, if any.
+    ///
+    /// Only the prompt's navigation and editing actions qualify — the set with
+    /// a dispatch arm that delegates back to the prompt widget. Anything else
+    /// the key might resolve to is left to the normal walk, so this can only
+    /// ever change which of the *prompt's own* operations a key performs.
+    fn prompt_action_binding(
+        &self,
+        event: &crossterm::event::KeyEvent,
+    ) -> Option<crate::input::keybindings::Action> {
+        use crate::input::keybindings::Action;
+        let context = self.get_key_context();
+        if !matches!(
+            context,
+            crate::input::keybindings::KeyContext::Prompt
+                | crate::input::keybindings::KeyContext::SearchPrompt
+        ) {
+            return None;
+        }
+        let action = self.keybindings.read().ok()?.resolve(event, context);
+        matches!(
+            action,
+            Action::PromptCancel
+                | Action::PromptBackspace
+                | Action::PromptDelete
+                | Action::PromptMoveLeft
+                | Action::PromptMoveRight
+                | Action::PromptMoveStart
+                | Action::PromptMoveEnd
+                | Action::PromptSelectPrev
+                | Action::PromptSelectNext
+                | Action::PromptPageUp
+                | Action::PromptPageDown
+                | Action::PromptAcceptSuggestion
+                | Action::PromptMoveWordLeft
+                | Action::PromptMoveWordRight
+                | Action::PromptDeleteWordBackward
+                | Action::PromptDeleteWordForward
+                | Action::PromptDeleteToLineEnd
+                | Action::PromptSelectAll
+                | Action::PromptMoveLeftSelecting
+                | Action::PromptMoveRightSelecting
+                | Action::PromptMoveHomeSelecting
+                | Action::PromptMoveEndSelecting
+                | Action::PromptSelectWordLeft
+                | Action::PromptSelectWordRight
+                | Action::PromptCopy
+                | Action::PromptCut
+                | Action::PromptPaste
+                | Action::PromptConfirm
+        )
+        .then_some(action)
     }
 
     /// Hit-test (col, row) against the suggestions popup. Returns the index

--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -265,6 +265,7 @@ impl KeybindingEditor {
                         key_code: *key_code,
                         modifiers: *modifiers,
                         is_chord: false,
+                        chord_keys: Vec::new(),
                         plugin_name: Some(section.clone()),
                         command_name: None,
                         original_config: None,
@@ -288,6 +289,7 @@ impl KeybindingEditor {
                     key_code: KeyCode::Null,
                     modifiers: KeyModifiers::NONE,
                     is_chord: false,
+                    chord_keys: Vec::new(),
                     plugin_name: None,
                     command_name: None,
                     original_config: None,
@@ -312,6 +314,7 @@ impl KeybindingEditor {
                         key_code: KeyCode::Null,
                         modifiers: KeyModifiers::NONE,
                         is_chord: false,
+                        chord_keys: Vec::new(),
                         plugin_name,
                         command_name: Some(cmd.get_localized_name()),
                         original_config: None,
@@ -390,6 +393,7 @@ impl KeybindingEditor {
                 key_code: KeyCode::Null,
                 modifiers: KeyModifiers::NONE,
                 is_chord: true,
+                chord_keys: kb.keys.clone(),
                 plugin_name: None,
                 command_name: None,
                 original_config,
@@ -415,6 +419,7 @@ impl KeybindingEditor {
                 key_code,
                 modifiers,
                 is_chord: false,
+                chord_keys: Vec::new(),
                 plugin_name: None,
                 command_name: None,
                 original_config,
@@ -445,10 +450,13 @@ impl KeybindingEditor {
             actions.push(format!("menu_open:{}", name));
         }
 
-        // Keybinding maps: the four built-ins plus user-defined.
-        let mut keymaps: Vec<String> = ["default", "emacs", "vscode", "macos"]
-            .map(String::from)
-            .to_vec();
+        // Keybinding maps: every built-in plus user-defined. Sourced from
+        // `KeybindingMapName::BUILTIN_OPTIONS` so the dropdown can't drift
+        // out of sync with the settings picker (it used to omit `macos-gui`).
+        let mut keymaps: Vec<String> = crate::config::KeybindingMapName::BUILTIN_OPTIONS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
         keymaps.extend(config.keybinding_maps.keys().cloned());
         keymaps.sort();
         keymaps.dedup();
@@ -858,6 +866,9 @@ impl KeybindingEditor {
             kb.action == config_kb.action
                 && kb.key == config_kb.key
                 && kb.modifiers == config_kb.modifiers
+                // Chords carry an empty key/modifiers pair — compare the
+                // sequence too, or any two of them look like the same binding.
+                && kb.keys == config_kb.keys
                 && kb.when == config_kb.when
         });
         if let Some(pos) = found_in_adds {
@@ -881,7 +892,11 @@ impl KeybindingEditor {
         let binding = &self.bindings[idx];
         let action_name = binding.action.clone();
 
-        // Build a noop custom override for the same key+context.
+        // Build a noop custom override for the same key+context. A chord is
+        // written back as its `keys` sequence — a chord has no single
+        // key/modifiers pair, and emitting an empty one produced a binding
+        // the resolver drops, so the keymap chord stayed live (the editor
+        // reported it disabled and nothing changed).
         let noop_kb = Keybinding {
             key: if binding.is_chord {
                 String::new()
@@ -893,7 +908,7 @@ impl KeybindingEditor {
             } else {
                 modifiers_to_config_names(binding.modifiers)
             },
-            keys: Vec::new(),
+            keys: binding.chord_keys.clone(),
             action: "noop".to_string(),
             args: HashMap::new(),
             when: if binding.context.is_empty() {
@@ -915,6 +930,7 @@ impl KeybindingEditor {
             key_code: self.bindings[idx].key_code,
             modifiers: self.bindings[idx].modifiers,
             is_chord: self.bindings[idx].is_chord,
+            chord_keys: self.bindings[idx].chord_keys.clone(),
             plugin_name: self.bindings[idx].plugin_name.clone(),
             command_name: None,
             original_config: None,
@@ -943,6 +959,7 @@ impl KeybindingEditor {
             key_code: KeyCode::Null,
             modifiers: KeyModifiers::NONE,
             is_chord: false,
+            chord_keys: Vec::new(),
             plugin_name: None,
             command_name: None,
             original_config: None,
@@ -963,7 +980,7 @@ impl KeybindingEditor {
             } else {
                 modifiers_to_config_names(binding.modifiers)
             },
-            keys: Vec::new(),
+            keys: binding.chord_keys.clone(),
             action,
             args,
             when: if binding.context.is_empty() {
@@ -979,7 +996,11 @@ impl KeybindingEditor {
     pub fn apply_edit_dialog(&mut self) -> Option<String> {
         let dialog = self.edit_dialog.take()?;
 
-        if dialog.key_code.is_none() || dialog.action_text.is_empty() {
+        // A chord keeps its sequence in `chord_keys` and leaves `key_code`
+        // empty, so "has a key" means either of the two.
+        if (dialog.key_code.is_none() && dialog.chord_keys.is_empty())
+            || dialog.action_text.is_empty()
+        {
             self.edit_dialog = Some(dialog);
             return Some(t!("keybinding_editor.error_key_action_required").to_string());
         }
@@ -1003,10 +1024,26 @@ impl KeybindingEditor {
             return Some(err_msg);
         }
 
-        let key_code = dialog.key_code.unwrap();
+        // The user re-recorded a key only if `key_code` is set; otherwise this
+        // is a chord being re-pointed at a different action, and the sequence
+        // must survive the round-trip (writing `key_code_to_config_name` of a
+        // placeholder produced the unparseable `"key": "Null"`).
+        let chord_keys = if dialog.key_code.is_some() {
+            Vec::new()
+        } else {
+            dialog.chord_keys.clone()
+        };
+        let is_chord = !chord_keys.is_empty();
+        let key_code = dialog.key_code.unwrap_or(KeyCode::Null);
         let modifiers = dialog.modifiers;
-        let key_name = key_code_to_config_name(key_code);
-        let modifier_names = modifiers_to_config_names(modifiers);
+        let (key_name, modifier_names) = if is_chord {
+            (String::new(), Vec::new())
+        } else {
+            (
+                key_code_to_config_name(key_code),
+                modifiers_to_config_names(modifiers),
+            )
+        };
 
         // Split the qualified form (e.g. `menu_open:File`) into bare action +
         // args so the written Keybinding actually parses back to the right
@@ -1016,7 +1053,7 @@ impl KeybindingEditor {
         let new_binding = Keybinding {
             key: key_name,
             modifiers: modifier_names,
-            keys: Vec::new(),
+            keys: chord_keys.clone(),
             action: bare_action.clone(),
             args: args.clone(),
             when: Some(dialog.context.clone()),
@@ -1027,7 +1064,11 @@ impl KeybindingEditor {
         self.has_changes = true;
 
         // Update display
-        let key_display = format_keybinding(&key_code, &modifiers);
+        let key_display = if is_chord {
+            format_chord_keys(&chord_keys)
+        } else {
+            format_keybinding(&key_code, &modifiers)
+        };
         let action_display =
             KeybindingResolver::format_action_from_str_with_args(&bare_action, &args);
 
@@ -1046,7 +1087,8 @@ impl KeybindingEditor {
             source: BindingSource::Custom,
             key_code,
             modifiers,
-            is_chord: false,
+            is_chord,
+            chord_keys,
             plugin_name: preserved_plugin_name,
             command_name: None,
             original_config: None,
@@ -1134,7 +1176,20 @@ mod tests {
     use crate::input::buffer_mode::ModeRegistry;
 
     fn make_editor(extra_menus: &[&str]) -> KeybindingEditor {
-        let config = Config::default();
+        make_editor_with_config(Config::default(), extra_menus)
+    }
+
+    /// An editor over the `emacs` keymap — the only built-in keymap with
+    /// chord bindings, so the chord paths below need it explicitly.
+    fn make_emacs_editor() -> KeybindingEditor {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        make_editor_with_config(config, &[])
+    }
+
+    fn make_editor_with_config(config: Config, extra_menus: &[&str]) -> KeybindingEditor {
         let resolver = KeybindingResolver::new(&config);
         let mode_registry = ModeRegistry::new();
         let cmd_registry = CommandRegistry::new();
@@ -1192,7 +1247,7 @@ mod tests {
     #[test]
     fn dropdown_lists_builtin_keybinding_maps() {
         let editor = make_editor(&[]);
-        for map in ["default", "emacs", "vscode", "macos"] {
+        for map in crate::config::KeybindingMapName::BUILTIN_OPTIONS {
             let qualified = format!("switch_keybinding_map:{}", map);
             assert!(
                 editor.available_actions.contains(&qualified),
@@ -1246,6 +1301,7 @@ mod tests {
             key_code: KeyCode::Char('f'),
             modifiers: KeyModifiers::ALT,
             is_chord: false,
+            chord_keys: Vec::new(),
             plugin_name: None,
             command_name: None,
             original_config: None,
@@ -1258,5 +1314,129 @@ mod tests {
             "the variant name must land in args.name, got {:?}",
             kb.args
         );
+    }
+
+    /// The display row showing binding `idx`.
+    fn select_row(editor: &KeybindingEditor, idx: usize) -> usize {
+        editor
+            .display_rows
+            .iter()
+            .position(|r| matches!(r, DisplayRow::Binding(i) if *i == idx))
+            .expect("the binding has a visible row")
+    }
+
+    /// The `Ctrl+X Ctrl+S` row in the emacs keymap.
+    fn emacs_save_chord(editor: &KeybindingEditor) -> usize {
+        editor
+            .bindings
+            .iter()
+            .position(|b| b.is_chord && b.action == "save")
+            .expect("the emacs keymap binds save to the C-x C-s chord")
+    }
+
+    #[test]
+    fn chord_rows_keep_their_key_sequence() {
+        let editor = make_emacs_editor();
+        let idx = emacs_save_chord(&editor);
+        let keys = &editor.bindings[idx].chord_keys;
+        assert_eq!(
+            keys.len(),
+            2,
+            "a chord row must carry its full sequence, got {:?}",
+            keys
+        );
+        assert_eq!(keys[0].key, "x");
+        assert_eq!(keys[1].key, "s");
+    }
+
+    #[test]
+    fn disabling_a_chord_writes_a_chord_shaped_noop() {
+        // Regression: the noop override was written with an empty `key` and
+        // no `keys`, so the resolver dropped it as an invalid binding — the
+        // editor said "disabled" and C-x C-s kept saving.
+        let mut editor = make_emacs_editor();
+        let idx = emacs_save_chord(&editor);
+        editor.selected = select_row(&editor, idx);
+        assert_eq!(editor.delete_selected(), DeleteResult::KeymapOverridden);
+
+        let noop = editor
+            .get_custom_bindings()
+            .into_iter()
+            .find(|kb| kb.action == "noop")
+            .expect("deleting a keymap binding queues a noop override");
+        assert!(
+            noop.key.is_empty(),
+            "a chord override has no single key, got {:?}",
+            noop.key
+        );
+        assert_eq!(
+            noop.keys.iter().map(|k| k.key.as_str()).collect::<Vec<_>>(),
+            vec!["x", "s"],
+            "the override must name the chord it disables"
+        );
+    }
+
+    #[test]
+    fn editing_a_chord_without_re_recording_keeps_the_chord() {
+        // Regression: the dialog seeded `key_code` with the chord's
+        // placeholder `KeyCode::Null`, so saving wrote `"key": "Null"` and
+        // destroyed the binding.
+        let mut editor = make_emacs_editor();
+        let idx = emacs_save_chord(&editor);
+        editor.edit_dialog = Some(EditBindingState::new_edit(idx, &editor.bindings[idx]));
+        assert!(
+            editor.apply_edit_dialog().is_none(),
+            "the edit must validate"
+        );
+
+        let written = editor
+            .get_custom_bindings()
+            .into_iter()
+            .find(|kb| kb.action == "save")
+            .expect("applying the dialog queues the edited binding");
+        assert!(
+            written.key.is_empty(),
+            "a preserved chord must not be written as a single key, got {:?}",
+            written.key
+        );
+        assert_eq!(
+            written
+                .keys
+                .iter()
+                .map(|k| k.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["x", "s"],
+        );
+        assert!(
+            editor.bindings[idx].is_chord,
+            "the row stays a chord after the edit"
+        );
+    }
+
+    #[test]
+    fn dropdown_context_options_cover_every_keymap_context() {
+        // Contexts that appear in the built-in keymaps must be pickable in
+        // the add/edit dialog, otherwise those bindings can't be authored.
+        let dialog = EditBindingState::new_add();
+        for ctx in [
+            "global",
+            "normal",
+            "prompt",
+            "searchPrompt",
+            "popup",
+            "completion",
+            "file_explorer",
+            "dock",
+            "menu",
+            "terminal",
+            "settings",
+            "compositeBuffer",
+        ] {
+            assert!(
+                dialog.context_options.iter().any(|c| c == ctx),
+                "context `{}` missing from the dialog dropdown",
+                ctx
+            );
+        }
     }
 }

--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -210,14 +210,23 @@ impl KeybindingEditor {
         let mut bindings = Vec::new();
         let mut seen: HashMap<(String, String), usize> = HashMap::new(); // (key_display, context) -> index
 
-        // First, load bindings from the active keymap
+        // First, load bindings from the active keymap. `resolve_keymap`
+        // returns the inheritance chain parent-first, and the resolver takes
+        // the last write for a given key+context — so a keymap that overrides
+        // an inherited binding must *replace* the parent's row here, not add a
+        // second one. Otherwise `emacs` (which inherits `default`) listed both
+        // "Ctrl+S → Save file" and "Ctrl+S → Find", only one of which fires.
         let map_bindings = config.resolve_keymap(&config.active_keybinding_map);
         for kb in &map_bindings {
             if let Some(entry) = Self::keybinding_to_resolved(kb, BindingSource::Keymap, resolver) {
                 let key = (entry.key_display.clone(), entry.context.clone());
-                let idx = bindings.len();
-                seen.insert(key, idx);
-                bindings.push(entry);
+                if let Some(&existing_idx) = seen.get(&key) {
+                    bindings[existing_idx] = entry;
+                } else {
+                    let idx = bindings.len();
+                    seen.insert(key, idx);
+                    bindings.push(entry);
+                }
             }
         }
 
@@ -1410,6 +1419,25 @@ mod tests {
         assert!(
             editor.bindings[idx].is_chord,
             "the row stays a chord after the edit"
+        );
+    }
+
+    #[test]
+    fn an_overriding_keymap_replaces_the_inherited_row() {
+        // `emacs` inherits `default` and rebinds Ctrl+S from Save to Find.
+        // Only the winning action may be listed, or the editor advertises a
+        // binding that never fires.
+        let editor = make_emacs_editor();
+        let ctrl_s: Vec<&str> = editor
+            .bindings
+            .iter()
+            .filter(|b| b.key_display == "Ctrl+S" && b.context == "normal")
+            .map(|b| b.action.as_str())
+            .collect();
+        assert_eq!(
+            ctrl_s,
+            vec!["search"],
+            "Ctrl+S must list only the emacs action, not the inherited one"
         );
     }
 

--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -1,6 +1,8 @@
 //! KeybindingEditor - the main editor state and logic.
 
-use super::helpers::{format_chord_keys, key_code_to_config_name, modifiers_to_config_names};
+use super::helpers::{
+    canonical_context, format_chord_keys, key_code_to_config_name, modifiers_to_config_names,
+};
 use super::types::*;
 use crate::config::{Config, Keybinding};
 use crate::input::command_registry::CommandRegistry;
@@ -376,7 +378,13 @@ impl KeybindingEditor {
         source: BindingSource,
         _resolver: &KeybindingResolver,
     ) -> Option<ResolvedBinding> {
-        let context = kb.when.as_deref().unwrap_or("normal").to_string();
+        // Canonicalise the `when` spelling. `KeyContext` accepts aliases
+        // (`file_explorer` / `fileExplorer`, `search_prompt` / `searchPrompt`,
+        // `composite_buffer` / `compositeBuffer`) and `default.json` uses both,
+        // so a raw string here would split one context into two: two rows for
+        // the same key, and an edit dialog whose dropdown can't find the
+        // context it was opened on — silently reassigning it on save.
+        let context = canonical_context(kb.when.as_deref().unwrap_or("normal"));
 
         // Store the qualified form (e.g. `menu_open:File`) on ResolvedBinding
         // so the dropdown round-trips faithfully and "still-bound" checks
@@ -773,17 +781,15 @@ impl KeybindingEditor {
 
     /// Cycle context filter
     pub fn cycle_context_filter(&mut self) {
-        let mut contexts = vec![
-            ContextFilter::All,
-            ContextFilter::Specific("global".to_string()),
-            ContextFilter::Specific("normal".to_string()),
-            ContextFilter::Specific("prompt".to_string()),
-            ContextFilter::Specific("popup".to_string()),
-            ContextFilter::Specific("completion".to_string()),
-            ContextFilter::Specific("file_explorer".to_string()),
-            ContextFilter::Specific("menu".to_string()),
-            ContextFilter::Specific("terminal".to_string()),
-        ];
+        // Canonical spellings, matching `ResolvedBinding::context` — the filter
+        // compares the two directly, so `file_explorer` here would select
+        // nothing now that rows carry `fileExplorer`.
+        let mut contexts = vec![ContextFilter::All];
+        contexts.extend(
+            EditBindingState::base_context_options()
+                .into_iter()
+                .map(ContextFilter::Specific),
+        );
         // Add mode contexts dynamically
         for mode_ctx in &self.mode_contexts {
             contexts.push(ContextFilter::Specific(mode_ctx.clone()));
@@ -1426,12 +1432,18 @@ mod tests {
     fn an_overriding_keymap_replaces_the_inherited_row() {
         // `emacs` inherits `default` and rebinds Ctrl+S from Save to Find.
         // Only the winning action may be listed, or the editor advertises a
-        // binding that never fires.
+        // binding that never fires. Matched on the parsed key rather than
+        // `key_display`, which renders as "⌃S" on macOS and "Ctrl+S" elsewhere.
         let editor = make_emacs_editor();
         let ctrl_s: Vec<&str> = editor
             .bindings
             .iter()
-            .filter(|b| b.key_display == "Ctrl+S" && b.context == "normal")
+            .filter(|b| {
+                !b.is_chord
+                    && b.key_code == KeyCode::Char('s')
+                    && b.modifiers == KeyModifiers::CONTROL
+                    && b.context == "normal"
+            })
             .map(|b| b.action.as_str())
             .collect();
         assert_eq!(
@@ -1443,28 +1455,41 @@ mod tests {
 
     #[test]
     fn dropdown_context_options_cover_every_keymap_context() {
-        // Contexts that appear in the built-in keymaps must be pickable in
-        // the add/edit dialog, otherwise those bindings can't be authored.
+        // Every context the built-in keymaps actually use must be pickable in
+        // the add/edit dialog: a binding whose context isn't offered can't be
+        // authored, and editing one falls back to "normal" — silently
+        // reassigning it on save. Read off the keymaps rather than a hand
+        // written list, which is how four of them went missing.
         let dialog = EditBindingState::new_add();
-        for ctx in [
-            "global",
-            "normal",
-            "prompt",
-            "searchPrompt",
-            "popup",
-            "completion",
-            "file_explorer",
-            "dock",
-            "menu",
-            "terminal",
-            "settings",
-            "compositeBuffer",
-        ] {
-            assert!(
-                dialog.context_options.iter().any(|c| c == ctx),
-                "context `{}` missing from the dialog dropdown",
-                ctx
-            );
+        let config = Config::default();
+        for map_name in crate::config::KeybindingMapName::BUILTIN_OPTIONS {
+            for kb in config.resolve_keymap(map_name) {
+                let ctx = canonical_context(kb.when.as_deref().unwrap_or("normal"));
+                assert!(
+                    dialog.context_options.contains(&ctx),
+                    "keymap `{}` binds `{}` in context `{}`, which the dialog \
+                     dropdown does not offer",
+                    map_name,
+                    kb.action,
+                    ctx,
+                );
+            }
         }
+    }
+
+    #[test]
+    fn context_spellings_are_folded_together() {
+        // `default.json` writes both `fileExplorer` and `file_explorer`. Rows
+        // must land on one canonical spelling, or the same context shows up
+        // twice and the dropdown can't match either.
+        let editor = make_editor(&[]);
+        assert!(
+            editor.bindings.iter().all(|b| b.context != "file_explorer"),
+            "the alias spelling must be folded into `fileExplorer`"
+        );
+        assert!(
+            editor.bindings.iter().any(|b| b.context == "fileExplorer"),
+            "file-explorer bindings should still be listed"
+        );
     }
 }

--- a/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
@@ -1,8 +1,21 @@
 //! Helper/utility functions for the keybinding editor.
 
 use crate::config::KeyPress;
-use crate::input::keybindings::{format_keybinding, KeybindingResolver};
+use crate::input::keybindings::{format_keybinding, KeyContext, KeybindingResolver};
 use crossterm::event::{KeyCode, KeyModifiers};
+
+/// The canonical spelling of a `when` clause.
+///
+/// `KeyContext::from_when_clause` accepts aliases — `file_explorer` and
+/// `fileExplorer` are the same context, and the built-in keymaps use both — so
+/// anything that groups or matches rows by their context string has to fold
+/// them together first. An unrecognised clause (a plugin `mode:` context, or a
+/// typo) is passed through unchanged so it still round-trips.
+pub fn canonical_context(when: &str) -> String {
+    KeyContext::from_when_clause(when)
+        .map(|ctx| ctx.to_when_clause())
+        .unwrap_or_else(|| when.to_string())
+}
 
 /// Format chord keys for display
 pub fn format_chord_keys(keys: &[KeyPress]) -> String {

--- a/crates/fresh-editor/src/app/keybinding_editor/types.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/types.rs
@@ -1,6 +1,6 @@
 //! Data types for the keybinding editor.
 
-use crate::config::Keybinding;
+use crate::config::{KeyPress, Keybinding};
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::Rect;
 
@@ -49,6 +49,11 @@ pub struct ResolvedBinding {
     pub modifiers: KeyModifiers,
     /// Whether this is a chord (multi-key) binding
     pub is_chord: bool,
+    /// The key sequence, for chord bindings (empty otherwise). Kept so the
+    /// editor can write a chord back to config: a chord has no single
+    /// `key_code`/`modifiers` to reconstruct it from, and dropping this is
+    /// what made "delete" and "edit" silently destroy chord bindings.
+    pub chord_keys: Vec<KeyPress>,
     /// Plugin name this binding belongs to (None = builtin)
     pub plugin_name: Option<String>,
     /// Human-friendly command name from the CommandRegistry (e.g., "Titlecase").
@@ -112,6 +117,11 @@ pub struct EditBindingState {
     /// When true, the next keypress in the key field is captured raw
     /// (including Esc, Tab, Enter). Resets to false after one capture.
     pub capturing_special: bool,
+    /// Key sequence of the chord being edited, empty when the dialog holds a
+    /// single-key binding. Cleared as soon as the user records a new key, so
+    /// saving without re-recording keeps the chord intact instead of writing
+    /// a keyless binding.
+    pub chord_keys: Vec<KeyPress>,
 }
 
 impl EditBindingState {
@@ -120,11 +130,15 @@ impl EditBindingState {
             "global".to_string(),
             "normal".to_string(),
             "prompt".to_string(),
+            "searchPrompt".to_string(),
             "popup".to_string(),
             "completion".to_string(),
             "file_explorer".to_string(),
+            "dock".to_string(),
             "menu".to_string(),
             "terminal".to_string(),
+            "settings".to_string(),
+            "compositeBuffer".to_string(),
         ]
     }
 
@@ -155,6 +169,7 @@ impl EditBindingState {
             autocomplete_visible: false,
             action_error: None,
             capturing_special: false,
+            chord_keys: Vec::new(),
         }
     }
 
@@ -176,7 +191,14 @@ impl EditBindingState {
 
         Self {
             mode: EditMode::RecordingKey,
-            key_code: Some(binding.key_code),
+            // A chord has no single key code to seed the field with; keep the
+            // sequence in `chord_keys` instead and leave `key_code` empty so
+            // saving without re-recording round-trips the chord unchanged.
+            key_code: if binding.is_chord {
+                None
+            } else {
+                Some(binding.key_code)
+            },
             modifiers: binding.modifiers,
             key_display: binding.key_display.clone(),
             action_text: binding.action.clone(),
@@ -194,6 +216,7 @@ impl EditBindingState {
             autocomplete_visible: false,
             action_error: None,
             capturing_special: false,
+            chord_keys: binding.chord_keys.clone(),
         }
     }
 }

--- a/crates/fresh-editor/src/app/keybinding_editor/types.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/types.rs
@@ -125,7 +125,7 @@ pub struct EditBindingState {
 }
 
 impl EditBindingState {
-    fn base_context_options() -> Vec<String> {
+    pub(crate) fn base_context_options() -> Vec<String> {
         vec![
             "global".to_string(),
             "normal".to_string(),
@@ -133,7 +133,7 @@ impl EditBindingState {
             "searchPrompt".to_string(),
             "popup".to_string(),
             "completion".to_string(),
-            "file_explorer".to_string(),
+            "fileExplorer".to_string(),
             "dock".to_string(),
             "menu".to_string(),
             "terminal".to_string(),

--- a/crates/fresh-editor/src/app/keybinding_editor_actions.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor_actions.rs
@@ -80,6 +80,10 @@ impl Editor {
                 !(kb.action == remove.action
                     && kb.key == remove.key
                     && kb.modifiers == remove.modifiers
+                    // Chords carry an empty key/modifiers pair, so without
+                    // this every custom chord for the same action+context
+                    // would match and be dropped together.
+                    && kb.keys == remove.keys
                     && kb.when == remove.when)
             });
         }

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2588,7 +2588,7 @@ pub struct FileBrowserConfig {
 }
 
 /// A single key in a sequence
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct KeyPress {
     /// Key name (e.g., "a", "Enter", "F1")
     pub key: String,

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -1627,6 +1627,14 @@ pub struct KeybindingResolver {
     /// Plugin default chord bindings (for mode chord bindings from defineMode)
     plugin_chord_defaults: HashMap<KeyContext, HashMap<Vec<(KeyCode, KeyModifiers)>, Action>>,
 
+    /// Entries of `default_bindings` that were not written by the keymap
+    /// itself but synthesized by [`terminal_key_equivalents`] (e.g. the
+    /// `Ctrl+7` alias a `Ctrl+/` binding registers). An explicit binding
+    /// outranks such an alias no matter which order they load in, so a
+    /// child keymap that rebinds `Ctrl+/` also takes over `Ctrl+7`
+    /// instead of leaving the parent's action stranded on the alias.
+    default_binding_aliases: std::collections::HashSet<(KeyContext, (KeyCode, KeyModifiers))>,
+
     /// Plugin modes that want unbound keys to fall through to Normal
     /// bindings (motion, selection, copy). Populated by `defineMode` when
     /// `inheritNormalBindings: true`.
@@ -1682,6 +1690,7 @@ impl KeybindingResolver {
             chord_bindings: HashMap::new(),
             default_chord_bindings: HashMap::new(),
             plugin_chord_defaults: HashMap::new(),
+            default_binding_aliases: std::collections::HashSet::new(),
             inheriting_modes: std::collections::HashSet::new(),
             menu_mnemonics_enabled: config.editor.menu_bar_mnemonics,
         };
@@ -1783,18 +1792,32 @@ impl KeybindingResolver {
         action: Action,
         key_name: &str,
     ) {
-        let context_bindings = self.default_bindings.entry(context.clone()).or_default();
-
-        // Insert the primary binding
-        context_bindings.insert((key_code, modifiers), action.clone());
+        // Insert the primary binding. It is explicit, so it also reclaims
+        // the slot from any alias a previously loaded binding synthesized
+        // for it (a parent keymap's `Ctrl+/` registers `Ctrl+7`; a child
+        // rebinding `Ctrl+/` must take `Ctrl+7` with it).
+        self.default_bindings
+            .entry(context.clone())
+            .or_default()
+            .insert((key_code, modifiers), action.clone());
+        self.default_binding_aliases
+            .remove(&(context.clone(), (key_code, modifiers)));
 
         // Get terminal key equivalents and add them as aliases
         let equivalents = terminal_key_equivalents(key_code, modifiers);
         for (equiv_key, equiv_mods) in equivalents {
-            // Check if this equivalent is already bound
-            if let Some(existing_action) = context_bindings.get(&(equiv_key, equiv_mods)) {
+            let slot = (context.clone(), (equiv_key, equiv_mods));
+            // An *explicit* binding for the equivalent chord wins; another
+            // alias does not, so the newer binding's alias replaces it.
+            let existing_explicit = self
+                .default_bindings
+                .get(&context)
+                .and_then(|m| m.get(&(equiv_key, equiv_mods)))
+                .filter(|_| !self.default_binding_aliases.contains(&slot))
+                .cloned();
+            if let Some(existing_action) = existing_explicit {
                 // Only warn if bound to a DIFFERENT action
-                if existing_action != &action {
+                if existing_action != action {
                     let equiv_name = format!("{:?}", equiv_key);
                     tracing::warn!(
                         "Terminal key equivalent conflict in {:?} context: {} (equivalent of {}) \
@@ -1810,8 +1833,12 @@ impl KeybindingResolver {
                 }
                 // Don't override explicit bindings with auto-generated equivalents
             } else {
-                // Add the equivalent binding
-                context_bindings.insert((equiv_key, equiv_mods), action.clone());
+                // Add (or refresh) the equivalent binding
+                self.default_bindings
+                    .entry(context.clone())
+                    .or_default()
+                    .insert((equiv_key, equiv_mods), action.clone());
+                self.default_binding_aliases.insert(slot);
             }
         }
     }
@@ -4363,6 +4390,178 @@ mod tests {
     /// be dead because a broader binding shadows its chord. This is what
     /// keeps the resolver's precedence rule and the keymap data honest with
     /// each other (the old global-first order shipped four dead entries).
+    /// A keymap that rebinds a chord must take its terminal-equivalent
+    /// spelling with it. `default` binds Ctrl+/ (which also registers the
+    /// Ctrl+7 alias many terminals send); `emacs` rebinds Ctrl+/ to Undo, so
+    /// Ctrl+7 must be Undo too — otherwise the same physical keypress means
+    /// Undo or Toggle Comment depending on the terminal.
+    #[test]
+    fn child_keymap_override_claims_the_terminal_equivalent() {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        let resolver = KeybindingResolver::new(&config);
+
+        for key in ['/', '7'] {
+            let event = KeyEvent::new(KeyCode::Char(key), KeyModifiers::CONTROL);
+            assert_eq!(
+                resolver.resolve(&event, KeyContext::Normal),
+                Action::Undo,
+                "Ctrl+{} must resolve to the emacs binding, not default's",
+                key
+            );
+        }
+        // Same for the Ctrl+Space / Ctrl+@ pair: default binds it to LSP
+        // completion, emacs to set-mark.
+        for key in [' ', '@'] {
+            let event = KeyEvent::new(KeyCode::Char(key), KeyModifiers::CONTROL);
+            assert_eq!(
+                resolver.resolve(&event, KeyContext::Normal),
+                Action::SetMark,
+                "Ctrl+{:?} must resolve to the emacs binding, not default's",
+                key
+            );
+        }
+    }
+
+    /// The emacs keymap inherits `default`, so every context the editor can
+    /// put the keyboard into keeps a working set of keys. Before this it was
+    /// the one built-in map with `inherits: null` and left whole contexts
+    /// (completion, search prompt, terminal, dock, settings) unbound.
+    #[test]
+    fn emacs_keymap_inherits_the_default_contexts() {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        let resolver = KeybindingResolver::new(&config);
+
+        let cases: &[(KeyContext, KeyCode, KeyModifiers, Action)] = &[
+            (
+                KeyContext::Completion,
+                KeyCode::Tab,
+                KeyModifiers::NONE,
+                Action::CompletionAccept,
+            ),
+            (
+                KeyContext::SearchPrompt,
+                KeyCode::Char('c'),
+                KeyModifiers::ALT,
+                Action::ToggleSearchCaseSensitive,
+            ),
+            (
+                KeyContext::Terminal,
+                KeyCode::Char(']'),
+                KeyModifiers::CONTROL,
+                Action::TerminalEscape,
+            ),
+            (
+                KeyContext::Normal,
+                KeyCode::Char(']'),
+                KeyModifiers::CONTROL,
+                Action::GoToMatchingBracket,
+            ),
+            (
+                KeyContext::Normal,
+                KeyCode::Down,
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+                Action::AddCursorBelow,
+            ),
+        ];
+        for (context, code, modifiers, expected) in cases {
+            let event = KeyEvent::new(*code, *modifiers);
+            assert_eq!(
+                &resolver.resolve(&event, context.clone()),
+                expected,
+                "emacs keymap lost the inherited {:?} binding for {:?}+{:?}",
+                context,
+                modifiers,
+                code
+            );
+        }
+    }
+
+    /// The Emacs bindings whose key was previously spelled as the *unshifted*
+    /// character plus a `shift` modifier (`M-<` as `alt+shift+,`). A terminal
+    /// sends `ESC <`, so those entries never matched and the commands were
+    /// dead. Guard the shifted spelling that actually fires.
+    #[test]
+    fn emacs_shifted_symbol_bindings_resolve() {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        let resolver = KeybindingResolver::new(&config);
+
+        let cases: &[(char, Action)] = &[
+            ('<', Action::MoveDocumentStart),
+            ('>', Action::MoveDocumentEnd),
+            ('%', Action::QueryReplace),
+        ];
+        for (ch, expected) in cases {
+            let event = KeyEvent::new(KeyCode::Char(*ch), KeyModifiers::ALT);
+            assert_eq!(
+                &resolver.resolve(&event, KeyContext::Normal),
+                expected,
+                "M-{} must fire",
+                ch
+            );
+        }
+    }
+
+    /// Emacs `C-k` is kill-line: it kills from point to end of line. Binding
+    /// it to `delete_line` threw away the text *before* the cursor too.
+    #[test]
+    fn emacs_ctrl_k_kills_to_end_of_line() {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        let resolver = KeybindingResolver::new(&config);
+        let event = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL);
+        assert_eq!(
+            resolver.resolve(&event, KeyContext::Normal),
+            Action::DeleteToLineEnd
+        );
+    }
+
+    /// The `C-x` prefix commands an Emacs user reaches for first.
+    #[test]
+    fn emacs_ctrl_x_chords_are_bound() {
+        let config = Config {
+            active_keybinding_map: "emacs".into(),
+            ..Config::default()
+        };
+        let resolver = KeybindingResolver::new(&config);
+        let ctrl_x = [(KeyCode::Char('x'), KeyModifiers::CONTROL)];
+
+        let cases: &[(KeyCode, KeyModifiers, Action)] = &[
+            (KeyCode::Char('s'), KeyModifiers::CONTROL, Action::Save),
+            (KeyCode::Char('f'), KeyModifiers::CONTROL, Action::Open),
+            (KeyCode::Char('w'), KeyModifiers::CONTROL, Action::SaveAs),
+            (KeyCode::Char('s'), KeyModifiers::NONE, Action::SaveAll),
+            (KeyCode::Char('u'), KeyModifiers::NONE, Action::Undo),
+            (KeyCode::Char('h'), KeyModifiers::NONE, Action::SelectAll),
+            (
+                KeyCode::Char('b'),
+                KeyModifiers::NONE,
+                Action::QuickOpenBuffers,
+            ),
+        ];
+        for (code, modifiers, expected) in cases {
+            let event = KeyEvent::new(*code, *modifiers);
+            assert_eq!(
+                resolver.resolve_chord(&ctrl_x, &event, KeyContext::Normal),
+                ChordResolution::Complete(expected.clone()),
+                "C-x {:?}+{:?} must run {:?}",
+                modifiers,
+                code,
+                expected
+            );
+        }
+    }
+
     #[test]
     fn test_builtin_keymap_bindings_are_reachable() {
         for map_name in crate::config::KeybindingMapName::BUILTIN_OPTIONS {

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -4385,11 +4385,6 @@ mod tests {
         );
     }
 
-    /// Reachability guard for issue #2941: every binding shipped in every
-    /// built-in keymap must actually fire in its own context — no entry may
-    /// be dead because a broader binding shadows its chord. This is what
-    /// keeps the resolver's precedence rule and the keymap data honest with
-    /// each other (the old global-first order shipped four dead entries).
     /// A keymap that rebinds a chord must take its terminal-equivalent
     /// spelling with it. `default` binds Ctrl+/ (which also registers the
     /// Ctrl+7 alias many terminals send); `emacs` rebinds Ctrl+/ to Undo, so
@@ -4498,14 +4493,41 @@ mod tests {
             ('<', Action::MoveDocumentStart),
             ('>', Action::MoveDocumentEnd),
             ('%', Action::QueryReplace),
+            ('_', Action::Redo),
         ];
         for (ch, expected) in cases {
-            let event = KeyEvent::new(KeyCode::Char(*ch), KeyModifiers::ALT);
+            for modifiers in [
+                KeyModifiers::ALT,
+                // Terminals on the kitty protocol report Shift alongside the
+                // shifted glyph; legacy ones send the glyph alone.
+                KeyModifiers::ALT | KeyModifiers::SHIFT,
+            ] {
+                let event = KeyEvent::new(KeyCode::Char(*ch), modifiers);
+                assert_eq!(
+                    &resolver.resolve(&event, KeyContext::Normal),
+                    expected,
+                    "M-{} must fire with modifiers {:?}",
+                    ch,
+                    modifiers
+                );
+            }
+        }
+
+        // Undo's three terminal spellings: C-/ , C-_ (as ctrl+- plus the alias
+        // `terminal_key_equivalents` derives) and the kitty ctrl+shift+_ form.
+        for (ch, modifiers) in [
+            ('/', KeyModifiers::CONTROL),
+            ('-', KeyModifiers::CONTROL),
+            ('_', KeyModifiers::CONTROL),
+            ('_', KeyModifiers::CONTROL | KeyModifiers::SHIFT),
+        ] {
+            let event = KeyEvent::new(KeyCode::Char(ch), modifiers);
             assert_eq!(
-                &resolver.resolve(&event, KeyContext::Normal),
-                expected,
-                "M-{} must fire",
-                ch
+                resolver.resolve(&event, KeyContext::Normal),
+                Action::Undo,
+                "C-{} ({:?}) must undo",
+                ch,
+                modifiers
             );
         }
     }
@@ -4562,6 +4584,11 @@ mod tests {
         }
     }
 
+    /// Reachability guard for issue #2941: every binding shipped in every
+    /// built-in keymap must actually fire in its own context — no entry may
+    /// be dead because a broader binding shadows its chord. This is what
+    /// keeps the resolver's precedence rule and the keymap data honest with
+    /// each other (the old global-first order shipped four dead entries).
     #[test]
     fn test_builtin_keymap_bindings_are_reachable() {
         for map_name in crate::config::KeybindingMapName::BUILTIN_OPTIONS {

--- a/crates/fresh-editor/src/view/keybinding_editor.rs
+++ b/crates/fresh-editor/src/view/keybinding_editor.rs
@@ -1452,6 +1452,9 @@ fn handle_edit_dialog_input(
                 let (norm_code, norm_mods) = normalize_key(event.code, event.modifiers);
                 dialog.key_code = Some(norm_code);
                 dialog.modifiers = norm_mods;
+                // A recorded key replaces whatever the row held — including a
+                // chord sequence, which must not linger and win at save time.
+                dialog.chord_keys.clear();
                 dialog.key_display = format_keybinding(&norm_code, &norm_mods);
                 dialog.conflicts = editor.find_conflicts(norm_code, norm_mods, &dialog.context);
                 dialog.capturing_special = false;

--- a/crates/fresh-editor/tests/e2e/emacs_keymap.rs
+++ b/crates/fresh-editor/tests/e2e/emacs_keymap.rs
@@ -1,0 +1,122 @@
+//! End-to-end coverage for the Emacs keymap itself — the keys, not the
+//! actions behind them. Everything here drives real keystrokes through the
+//! `emacs` map and asserts on what lands on screen.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+fn emacs_harness() -> EditorTestHarness {
+    let config = Config {
+        active_keybinding_map: "emacs".into(),
+        ..Default::default()
+    };
+    EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_preserved_keybinding_map(),
+    )
+    .unwrap()
+}
+
+fn key(harness: &mut EditorTestHarness, code: KeyCode, modifiers: KeyModifiers) {
+    harness.send_key(code, modifiers).unwrap();
+    harness.render().unwrap();
+}
+
+fn ctrl(harness: &mut EditorTestHarness, c: char) {
+    key(harness, KeyCode::Char(c), KeyModifiers::CONTROL);
+}
+
+fn alt(harness: &mut EditorTestHarness, c: char) {
+    key(harness, KeyCode::Char(c), KeyModifiers::ALT);
+}
+
+/// `C-k` is Emacs `kill-line`: it kills from point to end of line. It used to
+/// be bound to `delete_line`, which also threw away the text *before* point.
+#[test]
+fn ctrl_k_kills_only_to_end_of_line() {
+    let mut harness = emacs_harness();
+    harness.type_text("alpha beta gamma").unwrap();
+    harness.render().unwrap();
+
+    // C-a to line start, then C-f five times to sit just after "alpha".
+    ctrl(&mut harness, 'a');
+    for _ in 0..5 {
+        ctrl(&mut harness, 'f');
+    }
+    ctrl(&mut harness, 'k');
+
+    harness.assert_screen_contains("alpha");
+    harness.assert_screen_not_contains("beta");
+}
+
+/// `M-<` / `M->` move to the ends of the buffer. Both were dead: the keymap
+/// spelled them as the *unshifted* character plus a `shift` modifier, but a
+/// terminal sends `ESC <`, i.e. the shifted glyph with Alt.
+#[test]
+fn meta_angle_brackets_jump_to_buffer_ends() {
+    let mut harness = emacs_harness();
+    harness.type_text("one\ntwo\nthree").unwrap();
+    harness.render().unwrap();
+
+    alt(&mut harness, '<');
+    harness.type_text("TOP").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("TOPone");
+
+    alt(&mut harness, '>');
+    harness.type_text("END").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("threeEND");
+}
+
+/// `C-x h` is `mark-whole-buffer`. Typing then replaces everything, which is
+/// how the selection becomes visible on screen.
+#[test]
+fn ctrl_x_h_marks_the_whole_buffer() {
+    let mut harness = emacs_harness();
+    harness.type_text("alpha\nbeta").unwrap();
+    harness.render().unwrap();
+
+    ctrl(&mut harness, 'x');
+    key(&mut harness, KeyCode::Char('h'), KeyModifiers::NONE);
+    harness.type_text("Z").unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("Z");
+    harness.assert_screen_not_contains("alpha");
+    harness.assert_screen_not_contains("beta");
+}
+
+/// `C-x u` is undo — one of the `C-x` commands the map didn't carry.
+#[test]
+fn ctrl_x_u_undoes() {
+    let mut harness = emacs_harness();
+    harness.type_text("keep").unwrap();
+    harness.render().unwrap();
+    harness.type_text("DROP").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("keepDROP");
+
+    ctrl(&mut harness, 'x');
+    key(&mut harness, KeyCode::Char('u'), KeyModifiers::NONE);
+    harness.assert_screen_not_contains("DROP");
+}
+
+/// The Emacs map inherits `default`, so keys it has no opinion about still
+/// work. `M-u` (upcase-word) is one of them — before the keymap inherited,
+/// it did nothing at all.
+#[test]
+fn inherited_default_bindings_still_fire() {
+    let mut harness = emacs_harness();
+    harness.type_text("alpha beta").unwrap();
+    harness.render().unwrap();
+
+    ctrl(&mut harness, 'a');
+    alt(&mut harness, 'u');
+
+    harness.assert_screen_contains("ALPHA beta");
+}

--- a/crates/fresh-editor/tests/e2e/emacs_keymap.rs
+++ b/crates/fresh-editor/tests/e2e/emacs_keymap.rs
@@ -120,3 +120,122 @@ fn inherited_default_bindings_still_fire() {
 
     harness.assert_screen_contains("ALPHA beta");
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Minibuffer and menu: a keymap binding has to actually reach them.
+//
+// Both surfaces run their own input handler ahead of keybinding resolution —
+// the menu's is capture-all — so a `prompt` or `menu` binding on anything but
+// the handler's own hardcoded keys used to do nothing at all.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Open the goto-line prompt with `M-g g`.
+fn open_goto_line(harness: &mut EditorTestHarness) {
+    key(harness, KeyCode::Char('g'), KeyModifiers::ALT);
+    key(harness, KeyCode::Char('g'), KeyModifiers::NONE);
+}
+
+#[test]
+fn minibuffer_ctrl_b_and_ctrl_f_move_the_caret() {
+    let mut harness = emacs_harness();
+    open_goto_line(&mut harness);
+    harness.type_text("123").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("123");
+
+    // C-b twice, then a digit: it lands between "1" and "2".
+    ctrl(&mut harness, 'b');
+    ctrl(&mut harness, 'b');
+    harness.type_text("9").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("192");
+
+    // C-f moves back over the "2"; the next digit lands after it.
+    ctrl(&mut harness, 'f');
+    harness.type_text("7").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("1927");
+}
+
+#[test]
+fn minibuffer_ctrl_a_is_beginning_of_line_not_select_all() {
+    // The prompt widget hardcodes Ctrl+A to select-all and runs before
+    // keybinding resolution, so the Emacs binding could never win. Typing
+    // after C-a proves which one did: beginning-of-line keeps the text.
+    let mut harness = emacs_harness();
+    open_goto_line(&mut harness);
+    harness.type_text("123").unwrap();
+    harness.render().unwrap();
+
+    ctrl(&mut harness, 'a');
+    harness.type_text("X").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("X123");
+}
+
+#[test]
+fn minibuffer_ctrl_g_cancels() {
+    let mut harness = emacs_harness();
+    open_goto_line(&mut harness);
+    harness.type_text("123").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("123");
+
+    ctrl(&mut harness, 'g');
+    harness.assert_screen_not_contains("Go to line");
+}
+
+#[test]
+fn menu_ctrl_n_moves_the_highlight() {
+    // The menu handler consumes every key it doesn't recognise, so `menu`
+    // bindings never fired. Proven by what Enter runs: with C-n working, the
+    // second File item (Open File…) opens its prompt; without it, Enter runs
+    // the first item and makes a new buffer instead.
+    let mut harness = emacs_harness();
+    key(&mut harness, KeyCode::F(10), KeyModifiers::NONE);
+    harness.assert_screen_contains("Open File");
+
+    ctrl(&mut harness, 'n');
+    key(&mut harness, KeyCode::Enter, KeyModifiers::NONE);
+    harness.assert_screen_contains("Open file");
+}
+
+#[test]
+fn menu_ctrl_g_closes_the_menu() {
+    let mut harness = emacs_harness();
+    key(&mut harness, KeyCode::F(10), KeyModifiers::NONE);
+    harness.assert_screen_contains("Open File");
+
+    ctrl(&mut harness, 'g');
+    harness.assert_screen_not_contains("Open File");
+}
+
+/// The precedence change must not disturb the default keymap, which binds
+/// `prompt` Ctrl+A to `prompt_select_all` — the same thing the widget does.
+#[test]
+fn default_keymap_minibuffer_ctrl_a_still_selects_all() {
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new()
+            .with_config(Config {
+                active_keybinding_map: "default".into(),
+                ..Default::default()
+            })
+            .with_preserved_keybinding_map(),
+    )
+    .unwrap();
+
+    // Ctrl+G is goto-line in the default keymap.
+    key(&mut harness, KeyCode::Char('g'), KeyModifiers::CONTROL);
+    harness.type_text("123").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("123");
+
+    // Select-all, so the next character replaces the whole line.
+    key(&mut harness, KeyCode::Char('a'), KeyModifiers::CONTROL);
+    harness.type_text("X").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_not_contains("123");
+    harness.assert_screen_contains("X");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -38,6 +38,7 @@ pub mod dock_panel_routing;
 pub mod dock_switch_wipes_outgoing_window;
 pub mod document_model;
 pub mod emacs_actions;
+pub mod emacs_keymap;
 pub mod encoding;
 pub mod explorer_bugs;
 pub mod explorer_context_menu;

--- a/docs/features/emacs-keymap.md
+++ b/docs/features/emacs-keymap.md
@@ -1,0 +1,115 @@
+# Emacs Keymap
+
+Fresh ships an Emacs keymap. Turn it on from **View → Keybinding Style → Emacs**,
+or set it in `config.json`:
+
+```json
+{
+  "active_keybinding_map": "emacs"
+}
+```
+
+The keymap inherits `default`, so every key Emacs has no opinion about — the
+settings editor, the completion popup, the integrated terminal, the dock, the
+multi-cursor and bookmark keys — keeps working exactly as it does out of the
+box. What follows is what the Emacs keymap changes.
+
+## Movement
+
+| Key | Command |
+|-----|---------|
+| `C-f` / `C-b` | forward / backward char |
+| `C-n` / `C-p` | next / previous line |
+| `C-a` / `C-e` | beginning / end of line |
+| `M-f` / `M-b` | forward / backward word |
+| `M-m` | back to indentation |
+| `M-<` / `M->` | beginning / end of buffer |
+| `M-{` / `M-}` | backward / forward paragraph |
+| `C-v` / `M-v` | scroll down / up a page |
+| `C-l` | recenter |
+| `M-g g`, `M-g M-g` | goto line |
+
+## Editing
+
+| Key | Command |
+|-----|---------|
+| `C-d` | delete char forward |
+| `M-d` / `M-DEL` | kill word forward / backward |
+| `C-k` | kill to end of line |
+| `C-S-DEL` | kill whole line |
+| `C-t` | transpose chars |
+| `C-o` | open line |
+| `M-;` | comment / uncomment |
+| `M-/` | dabbrev expand |
+| `M-u` / `M-l` | upcase / downcase |
+| `C-/`, `C-_`, `C-x u` | undo |
+| `M-_` | redo |
+
+## Mark and kill ring
+
+| Key | Command |
+|-----|---------|
+| `C-SPC` | set mark |
+| `C-w` / `M-w` | kill / copy region |
+| `C-y` | yank |
+| `C-g` | keyboard quit — cancels the mark and drops extra cursors |
+| `C-x h` | mark whole buffer |
+
+Once the mark is set, plain movement extends the region, as in Emacs.
+
+`C-w`, `M-w` and `C-y` use the system clipboard. Fresh has no kill ring, so
+`C-k` does not push the killed text onto it — text killed with `C-k` comes back
+with undo, not with `C-y`.
+
+## Search and replace
+
+| Key | Command |
+|-----|---------|
+| `C-s` | search forward (opens the search prompt) |
+| `C-s` / `C-r` in the prompt | repeat forward / backward |
+| `C-r` | search backward |
+| `M-%` | query replace |
+
+## Files, buffers and windows (`C-x`)
+
+| Key | Command |
+|-----|---------|
+| `C-x C-f` | find file |
+| `C-x C-s` | save buffer |
+| `C-x s` | save all buffers |
+| `C-x C-w` | write file (save as) |
+| `C-x k` | kill buffer |
+| `C-x b`, `C-x C-b` | switch buffer |
+| `C-x <right>` / `C-x <left>` | next / previous buffer |
+| `C-x d` | file explorer (dired) |
+| `C-x o` | other window |
+| `C-x 0` | delete window |
+| `C-x 2` / `C-x 3` | split below / right |
+| `C-x C-c` | quit |
+
+## Minibuffer, popups and menus
+
+`M-x` opens the command palette. Inside any prompt, `C-a`/`C-e`, `C-f`/`C-b`,
+`M-f`/`M-b`, `C-d`, `M-d`, `M-DEL`, `C-k`, `C-w`, `C-y` and `C-g` do what they
+do in the Emacs minibuffer, and `C-n`/`C-p` move through the completion list.
+`C-n`/`C-p` also move in popups, menus and the file explorer, and `C-g` closes
+them.
+
+## LSP
+
+| Key | Command |
+|-----|---------|
+| `M-.` | go to definition |
+| `M-,` | back to where you jumped from |
+| `M-TAB` (`C-M-i`) | completion at point |
+
+## Differences from GNU Emacs
+
+- No kill ring — see the note above.
+- `C-x` is a prefix, so it is not cut; `C-c` is *not* a prefix and copies.
+- `C-q` quits (Fresh convention) rather than `quoted-insert`.
+- `M-x` is the command palette, which also does file, buffer and line jumps.
+- Emacs has no redo; Fresh's is on `M-_`.
+
+Anything here can be rebound in the [keybinding editor](./keybinding-editor.md)
+or in the `keybindings` array of your config.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,4 +16,5 @@
 - [Devcontainers](./devcontainer.md) - Attach to a project's devcontainer
 - [Daemon Mode](./session-persistence.md) - Detach and reattach to a background daemon (formerly "Session Persistence")
 - [Keybinding Editor](./keybinding-editor.md) - Visual keybinding browser and editor
+- [Emacs Keymap](./emacs-keymap.md) - The Emacs keybinding style, key by key
 - [Dashboard](./dashboard.md) - Startup dashboard with weather, git, PRs, disk

--- a/docs/features/keybinding-editor.md
+++ b/docs/features/keybinding-editor.md
@@ -57,7 +57,7 @@ When adding or editing a binding, a dialog appears with three fields:
 
 1. **Key** — Press the desired key combination. The dialog starts in key recording mode. To bind a special key like **Esc**, **Tab**, or **Enter**, press **Enter** on the key field first to enter recording, then press the key you want to bind; press **Escape** to cancel recording.
 2. **Action** — Type an action name. An autocomplete popup shows matching actions as you type. Use `↑`/`↓` to navigate suggestions and `Tab` or `Enter` to accept. Only valid action names are accepted.
-3. **Context** — Use `←`/`→` to cycle through available contexts (global, normal, prompt, popup, file\_explorer, menu, terminal).
+3. **Context** — Use `←`/`→` to cycle through available contexts (global, normal, prompt, searchPrompt, popup, completion, file\_explorer, dock, menu, terminal, settings, compositeBuffer).
 
 Use `Tab` to move between fields. The dialog shows a read-only description of the selected action and warns about conflicting bindings.
 
@@ -73,10 +73,21 @@ If you try to close the editor with unsaved changes, a confirmation dialog offer
 
 Fresh uses a layered keybinding system:
 
-1. **Keymap** — A named set of default bindings (e.g., `default`, `emacs`, `macos`). Set via `"keymap"` in your config.
+1. **Keymap** — A named set of default bindings (`default`, `emacs`, `vscode`, `macos`, `macos-gui`). Set via `"active_keybinding_map"` in your config.
 2. **Custom bindings** — User overrides defined in the `"keybindings"` array of your config file. These take precedence over keymap bindings.
 
-Custom bindings added through the editor are appended to the `keybindings` array. To switch the base keymap, use **View → Keybinding Style** or set `"keymap"` in your config file.
+Custom bindings added through the editor are appended to the `keybindings` array. To switch the base keymap, use **View → Keybinding Style** or set `"active_keybinding_map"` in your config file:
+
+```json
+{
+  "active_keybinding_map": "emacs"
+}
+```
+
+Every built-in keymap other than `default` inherits from another one and
+overrides only the keys it cares about, so anything a keymap doesn't mention
+behaves like its parent. `vscode`, `macos`, and `emacs` inherit `default`;
+`macos-gui` inherits `macos`.
 
 ### Binding Format
 
@@ -109,13 +120,43 @@ Each binding in `config.json` has this structure:
 | `global` | Always active, regardless of focus |
 | `normal` | When the text editor is focused |
 | `prompt` | When an input prompt is active |
+| `searchPrompt` | When the find/replace prompt is active — a narrowing of `prompt`, adding the match-mode toggles |
 | `popup` | When a popup (completion, hover) is open |
+| `completion` | When the completion popup is open — takes precedence over `popup` |
 | `file_explorer` | When the file explorer has focus |
+| `dock` | When the utility dock has focus |
 | `menu` | When a menu is open |
 | `terminal` | When the integrated terminal has focus |
+| `settings` | When the settings editor is open |
+| `compositeBuffer` | When a composite (diff / git log) view is focused |
 
 When the same key is bound in more than one applicable context, the most
 specific context wins: a `normal` or `prompt` binding outranks a `global` one
 for the same key. `global` is the fallback that applies wherever no narrower
 binding claims the key. Your custom bindings always outrank keymap defaults,
 whatever context either uses.
+
+### Chord (multi-key) bindings
+
+A binding can be a *sequence* of keypresses instead of a single one — Emacs's
+`C-x C-s` is one. Use `keys` instead of `key`/`modifiers`:
+
+```json
+{
+  "keybindings": [
+    {
+      "keys": [
+        { "key": "x", "modifiers": ["ctrl"] },
+        { "key": "s", "modifiers": ["ctrl"] }
+      ],
+      "action": "save",
+      "when": "normal"
+    }
+  ]
+}
+```
+
+The keybinding editor lists chords (shown as `Ctrl+X Ctrl+S`), and `d` disables
+one the same way it disables any other keymap binding. Recording a *new* chord
+from the editor's add/edit dialog is not supported yet — the key field captures
+a single combination — so write those in `config.json` by hand.


### PR DESCRIPTION
Emacs mode was partial in a way that's easy to miss from the keymap file alone. I drove it interactively under tmux and fixed what turned up — which included two surfaces where *no* keymap's bindings could reach at all.

## The keymap

**The `emacs` keymap was the only built-in with `inherits: null`.** It wasn't a set of Emacs overrides — it was the entire binding table. 139 actions the default keymap binds had no key at all under it, and whole contexts were empty:

| Context | Under `emacs`, before |
|---|---|
| `completion` | no bindings — the completion popup could not be accepted or dismissed |
| `searchPrompt` | no bindings — the on-screen `Case Sensitive` / `Whole Word` / `Regex` toggles were unreachable by keyboard |
| `terminal` | no bindings — no escape key out of the integrated terminal |
| `dock` | no bindings |

Also unbound anywhere: `select_all`, `redo`, `toggle_comment`, `find_next`/`find_previous`, `save_as`, `save_all`, every LSP command, every multi-cursor command, bookmarks, live grep. (The settings editor turned out fine — it installs its own dispatcher and doesn't go through the resolver.)

**Three bindings the map did ship were dead.** `M-<`, `M->` and `M-%` were spelled as the *unshifted* character plus a `shift` modifier — `{"key": ",", "modifiers": ["alt","shift"]}`. A terminal sends `ESC <`, so none of the three ever matched. Confirmed under tmux: `M-f` moved, `M->` did nothing.

**`C-k` killed the whole line.** Bound to `delete_line`, so with point after `alpha` in `alpha beta gamma`, `C-k` deleted `alpha` too. Emacs `kill-line` kills from point to end of line.

`emacs.json` now **inherits `default`** and carries only Emacs-specific overrides (106 entries → 101, but 58 of the old ones were byte-identical duplicates of `default`). Anything the map has no opinion about behaves like the rest of the editor. The shifted symbols are bound on the glyph the terminal actually sends, `C-k` is `delete_to_line_end` (`C-S-DEL` kills the whole line), and the commands an Emacs user reaches for first are filled in: `C-x u/h/b/s/d`, `C-x C-w`, `C-x <left>`/`<right>`, `C-r`, `M-;`, `M-/`, `M-m`, `M-{`/`M-}`, `M-.`/`M-,`, `M-TAB`, `M-_`, Emacs line editing plus `C-n`/`C-p` in the minibuffer, popups, menus and the file explorer, and `C-s`/`C-r` to repeat the search isearch-style.

## Two surfaces no keymap could reach

Found by pressing the keys, not by reading the code — the resolver was innocent in both cases.

**Most `prompt_*` actions had no dispatch arm.** `Prompt`'s `InputHandler` does the real work and runs ahead of keybinding resolution, so the only `prompt` bindings that ever appeared to work were the ones sitting on a key the widget already handled itself. Everything else resolved to an action nothing implemented and silently did nothing: in the goto-line prompt, `C-b` `C-b` then `9` gave `129`, not `192`, and `C-g` didn't cancel. Each action is now defined as "the same thing this key does" and re-enters the prompt's handler with that key, so suggestion sync, theme preview and the plugin selection hooks keep one implementation rather than gaining a second copy free to drift.

**`MenuInputHandler` is capture-all** — its final arm consumes every key it doesn't recognise, so no `menu` binding could reach the menu even though the actions behind them were dispatched. `F10` `C-n` `Enter` ran *New File*: the highlight had never moved. `C-g` didn't close the menu.

The prompt widget also hardcodes a few Ctrl keys outright (`Ctrl+A` select-all, `Ctrl+Y` redo-input) that no binding could displace — `C-a` could not be made to mean beginning-of-line in the minibuffer however it was bound. Both surfaces now consult their own key context before their handler runs, taking the result only when it's one of that surface's own actions: a binding can change which prompt or menu operation a key performs, and nothing else. The default keymap is unaffected — its `prompt` bindings name the same operations the widget already performed, and that's pinned by a test.

## Two bugs that only appear once a keymap has a parent

- **A child's binding didn't take its terminal-equivalent spelling with it.** `default` binds `Ctrl+/`, which also registers the `Ctrl+7` alias many terminals send; `emacs` rebinding `Ctrl+/` to Undo left `Ctrl+7` on the parent's Toggle Comment — one physical keypress meaning two different things depending on the terminal. The resolver now tracks which entries are synthesized aliases so a later explicit binding reclaims them. Same for `Ctrl+Space` / `Ctrl+@`.
- **The keybinding editor listed both the inherited and the overriding row** for a rebound key, advertising "Ctrl+S → Save file" under a map where Ctrl+S searches. Overriding rows now replace rather than append.

## Keybinding editor

**Chords were listed but couldn't be acted on.** `ResolvedBinding` kept only a `key_code`/`modifiers` pair, which a chord has no meaningful value for, so both write paths lost the sequence:

- Deleting `C-x C-s` wrote `{"action": "noop", "when": "normal"}` — no key. The resolver drops that as invalid, so the editor said *"Keymap binding disabled (noop override added)"* and `C-x C-s` kept saving.
- Editing it wrote `{"key": "Null", "action": "save"}` — unparseable, and the chord gone.

Emacs is the only built-in keymap with chords, so this is what an Emacs user hits the moment they try to rebind `C-x C-s`. Chords now carry their sequence through delete and edit; the edit dialog can hold a chord with no recorded key (recording one replaces the chord); removal matching compares `keys`, so deleting one custom chord no longer drops every other chord for the same action and context.

**Context spelling was split in two.** `KeyContext` treats `file_explorer` and `fileExplorer` as one context and `default.json` uses both, but the editor kept the raw `when` string — so the dedup above could be defeated by writing the other spelling, and the edit dialog couldn't find `fileExplorer` in its dropdown, falling back to index 1 and silently reassigning the binding to `prompt` on save. Rows now carry the canonical spelling, and the context *filter* cycle (which compares against that string, and was itself missing four contexts) comes from the same list as the dropdown. The dropdown was missing `searchPrompt`, `dock`, `settings` and `compositeBuffer` — bindings for those contexts couldn't be authored at all — and the keymap dropdown omitted `macos-gui`.

## Docs

New [Emacs Keymap](docs/features/emacs-keymap.md) reference, including the honest list of differences from GNU Emacs. `keybinding-editor.md` said the config key was `"keymap"`; it is `"active_keybinding_map"`, and `"keymap"` silently did nothing. Also documented keymap inheritance, the full context list, and the `keys` chord format.

## Known limitations, documented rather than fixed

- **No kill ring.** `C-w`/`M-w`/`C-y` use the system clipboard; text killed with `C-k` comes back with undo, not `C-y`.
- **`C-c` copies** rather than acting as a prefix — no `C-c` chords exist, so making it a dead prefix would be worse.
- **The editor can't *record* a new chord** — the key field captures one combination. Disabling and re-pointing an existing chord works; authoring a new one is a config-file edit. Called out in the docs.

## Testing

Four commits, each passing `cargo check --all-targets`, `cargo fmt` and `cargo clippy` (no new warnings — 304 before and after), and `cargo test --lib` (3408).

11 e2e tests in `tests/e2e/emacs_keymap.rs` drive real keystrokes and assert only on rendered output: `C-k` semantics, `M-<`/`M->`, `C-x h`, `C-x u`, an inherited `default` binding still firing, `C-b`/`C-f` in the minibuffer, `C-a` as beginning-of-line, `C-g` cancelling, `C-n` and `C-g` in the menu, and the default keymap's `Ctrl+A` still selecting all. The first five were verified to fail against the old keymap and pass with the new one, by reverting `emacs.json` alone.

Unit tests cover what isn't visible on screen: the keybinding-editor chord invariants (each verified to fail with its fix reverted), context folding, the alias-reclaim rule, keymap context inheritance, the shifted-symbol resolutions, `C-k`, and the `C-x` chord table. The dropdown-coverage test reads the contexts off the built-in keymaps rather than repeating a list, which is how four went missing.

The repo's own `test_builtin_keymap_bindings_are_reachable` guard caught a first attempt at binding kill-whole-line to `C-S-Backspace` (`normalize_key` folds Shift off Backspace, so it was shadowed) — moved to `C-S-DEL`, which is what Emacs uses anyway.

### One unrelated flake

`e2e::occurrence_highlight::test_zero_width_block_selection_keeps_word_highlight` failed on ubuntu in the first run and on macOS in the second, passing on the other platform each time, and passes on both in the current run. It also passed 40/40 locally at 16 threads. Nothing in this diff touches occurrence highlighting, block selection, or the default keymap that test uses. Not addressed here — I couldn't reproduce it, and guessing at a fix seemed worse than saying so.