### PR TITLE
fresh-ui: say where the out-of-flow half of the display list begins

### DIFF
--- a/crates/fresh-ui/README.md
+++ b/crates/fresh-ui/README.md
@@ -108,6 +108,17 @@ the display list — the shape a real host renderer takes — and depends on
 crossterm only as a dev-dependency, so the library itself keeps its single
 runtime dependency.
 
+It folds in **two passes**, split at `LayoutSpec::layers_from`, and draws a band
+of its own in between (press <kbd>F2</kbd> to toggle it). That is the shape a
+host takes while it still paints some surfaces itself: its own drawing belongs
+over the tree's in-flow content and under the tree's layers. Only the library
+can say where one half ends and the other begins — a scrim carries no key, and
+a layer need not carry one either (`widgets::Dropdown`'s does not), so a
+backend deriving the split from the key index would put both on the wrong side.
+Open the palette, a menu or the confirm modal over the band to see the
+ordering, and the modal's scrim dimming the band along with everything else
+beneath it.
+
 ## Tests
 
 ```text

--- a/crates/fresh-ui/examples/interactive.rs
+++ b/crates/fresh-ui/examples/interactive.rs
@@ -9,8 +9,14 @@
 //!
 //! Quit with Ctrl-Q. The library itself has no terminal dependency; crossterm
 //! is a dev-dependency, so it is compiled only for examples and tests. This
-//! file is an ordinary backend — a fold over `LayoutSpec::items` — and is the
+//! file is an ordinary backend — a fold over the display list — and is the
 //! shape a real host renderer takes.
+//!
+//! It folds in **two passes**, split at `LayoutSpec::layers_from`, with a band
+//! of its own drawn in between (F2). That is the shape a host takes while it
+//! is still painting some surfaces itself: its own drawing has to land over
+//! the tree's in-flow content and under the tree's layers, and only the
+//! library can say where one ends and the other begins.
 
 #[path = "../tests/support/mod.rs"]
 mod support;
@@ -37,10 +43,13 @@ fn main() -> io::Result<()> {
     let (w, h) = terminal::size()?;
     // A long list, so the task viewport overflows and shows a scrollbar.
     let mut demo = Demo::with_app(App::seeded(250), Size::new(w, h));
-    let redraw = |term: &mut Terminal, demo: &Demo| -> io::Result<()> {
-        term.draw(demo.ui.spec(), demo.app.theme.name == "dark")
+    // Stands in for a host's own painter, drawn between the display list's two
+    // halves. See `Terminal::banner`.
+    let mut banner = true;
+    let redraw = |term: &mut Terminal, demo: &Demo, banner: bool| -> io::Result<()> {
+        term.draw(demo.ui.spec(), demo.app.theme.name == "dark", banner)
     };
-    redraw(&mut term, &demo)?;
+    redraw(&mut term, &demo, banner)?;
 
     loop {
         if demo.app.quit {
@@ -56,6 +65,11 @@ fn main() -> io::Result<()> {
                     if k.code == CtKey::Char('q') && k.modifiers.contains(KeyModifiers::CONTROL) {
                         break;
                     }
+                    if k.code == CtKey::F(2) {
+                        banner = !banner;
+                        redraw(&mut term, &demo, banner)?;
+                        continue;
+                    }
                     if let Some(press) = translate_key(k.code, k.modifiers) {
                         demo.input(Input::Key(press));
                     }
@@ -68,10 +82,10 @@ fn main() -> io::Result<()> {
                 CtEvent::Resize(w, h) => demo.resize(Size::new(w, h)),
                 _ => continue,
             }
-            redraw(&mut term, &demo)?;
+            redraw(&mut term, &demo, banner)?;
         } else if demo.ui.needs_frame() {
             demo.pump();
-            redraw(&mut term, &demo)?;
+            redraw(&mut term, &demo, banner)?;
         }
     }
 
@@ -205,7 +219,7 @@ impl Terminal {
         })
     }
 
-    fn draw(&mut self, spec: &fresh_ui::LayoutSpec, dark: bool) -> io::Result<()> {
+    fn draw(&mut self, spec: &fresh_ui::LayoutSpec, dark: bool, banner: bool) -> io::Result<()> {
         let (w, h) = terminal::size()?;
         if (w, h) != (self.w, self.h) {
             self.w = w;
@@ -222,11 +236,48 @@ impl Terminal {
         self.shadows.clear();
 
         let frame = Rect::new(0, 0, self.w, self.h);
-        for item in &spec.items {
+
+        // **Two passes over one list.** A backend that draws content the tree
+        // does not own — a host mid-migration, still painting some of its own
+        // surfaces — needs to slot that drawing *between* the tree's in-flow
+        // content and its layers: over the first, under the second. That is
+        // what `LayoutSpec::layers_from` is for, and the banner below stands in
+        // for the host's own painter so the ordering is visible rather than
+        // asserted.
+        //
+        // Nothing outside the library can work the split out for itself: a
+        // scrim carries no key, and a layer need not carry one either (the
+        // `Dropdown` in this very demo does not), so an index-derived guess
+        // puts both on the wrong side.
+        for item in spec.in_flow() {
             self.paint(item, frame, &r);
         }
+        if banner {
+            self.banner(frame, &r);
+        }
+        for item in spec.layers() {
+            self.paint(item, frame, &r);
+        }
+
         self.cast_shadows(frame, &r);
         self.flush(spec)
+    }
+
+    /// A band the *backend* paints, owned by nothing in the tree.
+    ///
+    /// Press F2 to toggle it, then open a menu, the palette or the confirm
+    /// modal over it: the tree's in-flow content goes under the band, and
+    /// every layer — the modal's dim scrim included — goes over it. Fold the
+    /// whole list in one pass instead and the band covers the layers, which is
+    /// the bug this split exists to prevent.
+    fn banner(&mut self, frame: Rect, roles: &Roles) {
+        let y = frame.h as i32 / 2;
+        let text = "  host-painted band (F2) — in-flow content under, layers over  ";
+        let (fg, bg) = (c(roles.status_fg), c(roles.status_bg));
+        self.fill(Rect::new(0, y, frame.w, 1), ' ', fg, bg, frame);
+        for (i, ch) in text.chars().enumerate() {
+            self.put(i as i32, y, ch, fg, bg, frame);
+        }
     }
 
     fn paint(&mut self, item: &fresh_ui::Item, frame: Rect, roles: &Roles) {
@@ -255,6 +306,10 @@ impl Terminal {
             Draw::Scrim(Scrim::Dim) => self.dim(frame, roles),
             Draw::Border => self.border(r, fg, bg, clip),
             Draw::Lines(lines) => {
+                // Clipped to the item's own rect as well as its inherited one:
+                // an item declares how much room it has, and a run longer than
+                // that would otherwise paint through whatever encloses it.
+                let clip = clip.intersect(r);
                 for (i, line) in lines.iter().enumerate() {
                     let y = r.y + i as i32;
                     for (j, ch) in line.chars().enumerate() {

--- a/crates/fresh-ui/src/render/paint.rs
+++ b/crates/fresh-ui/src/render/paint.rs
@@ -21,6 +21,11 @@ impl<M: 'static> Ui<M> {
         spec.frame = frame;
         if let Some(root) = self.render_root {
             self.paint_render(root, &mut spec);
+            // Everything from here on came out of a layer. Recorded before the
+            // loop rather than derived after it, because a scrim carries no key
+            // and an unkeyed layer leaves no index entry — nothing outside can
+            // tell the two halves apart. See `LayoutSpec::layers_from`.
+            spec.layers_from = spec.items.len();
             // Layers paint above the content they were declared in, in the
             // order the arrange walk found them.
             for i in 0..self.pending_layers.len() {
@@ -44,6 +49,9 @@ impl<M: 'static> Ui<M> {
                 // emitting it would make the backend draw and then overdraw.
                 spec.items.clear();
                 spec.index.clear();
+                // The in-flow half is gone with it, so the whole list is now
+                // out of flow.
+                spec.layers_from = 0;
             }
             spec.items.push(Item {
                 key: None,

--- a/crates/fresh-ui/src/render/spec.rs
+++ b/crates/fresh-ui/src/render/spec.rs
@@ -20,6 +20,21 @@ pub struct LayoutSpec {
     pub frame: Size,
     /// Paint order *is* list order.
     pub items: Vec<Item>,
+    /// Where the out-of-flow half begins.
+    ///
+    /// Layers paint after the tree they were declared in, so every item a
+    /// `Layer` produced — including a scrim, which belongs to no keyed
+    /// subtree — sits in one contiguous tail starting here. `items.len()` when
+    /// no layer painted.
+    ///
+    /// A backend that draws content of its own *between* in-flow and
+    /// out-of-flow content needs this: a host mid-migration paints its own
+    /// surfaces between the two, and one covering the other is exactly what
+    /// the split decides. Deriving it from the outside is not possible — a
+    /// layer need not be keyed (`widgets::Dropdown` is not) and a scrim never
+    /// is — which is why the library reports it rather than leaving each
+    /// backend to guess.
+    pub layers_from: usize,
     /// Key to the range of items its subtree produced. Used for hit-testing
     /// shortcuts, for patching a retained backend, and by tests.
     pub index: Vec<(Key, Range<usize>)>,
@@ -30,7 +45,18 @@ impl LayoutSpec {
     pub fn clear(&mut self) {
         self.items.clear();
         self.index.clear();
+        self.layers_from = 0;
         self.cursor = None;
+    }
+
+    /// The in-flow half: everything the tree itself painted.
+    pub fn in_flow(&self) -> &[Item] {
+        &self.items[..self.layers_from.min(self.items.len())]
+    }
+
+    /// The out-of-flow half: everything the layers painted, scrims included.
+    pub fn layers(&self) -> &[Item] {
+        &self.items[self.layers_from.min(self.items.len())..]
     }
 
     /// The items a keyed subtree produced.

--- a/crates/fresh-ui/tests/paint.rs
+++ b/crates/fresh-ui/tests/paint.rs
@@ -367,3 +367,174 @@ fn styling_does_not_change_where_text_breaks() {
     );
     assert_eq!(plain, styled);
 }
+
+// -- the in-flow / out-of-flow split -----------------------------------------
+
+/// **What `layers_from` is for.** A backend that draws content of its own
+/// between the tree's in-flow half and its layers — a host mid-migration
+/// painting surfaces the tree does not own yet — has to know where one ends
+/// and the other begins. Everything before the mark is the tree; everything
+/// from it on is a layer.
+#[test]
+fn layers_from_marks_where_the_out_of_flow_half_begins() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().children([
+            text("behind one"),
+            text("behind two"),
+            layer()
+                .anchor(Anchor::Screen(Align::Center))
+                .child(text("front")),
+        ]),
+        FRAME,
+    );
+    assert_eq!(spec.layers_from, 2);
+    assert_eq!(spec.in_flow().len(), 2);
+    assert_eq!(spec.layers().len(), 1);
+    assert!(matches!(&spec.layers()[0].draw, Draw::Lines(l) if &*l[0] == "front"));
+}
+
+/// With no layer at all the whole list is in flow, and the out-of-flow half is
+/// empty rather than absent — a backend's second pass simply finds nothing.
+#[test]
+fn a_frame_with_no_layers_is_all_in_flow() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(col().children([text("a"), text("b")]), FRAME);
+    assert_eq!(spec.layers_from, spec.items.len());
+    assert!(spec.layers().is_empty());
+    assert_eq!(spec.in_flow().len(), spec.items.len());
+}
+
+/// **The case nothing outside the library can get right.** A scrim belongs to
+/// no keyed subtree — it carries no key at all — and it is pushed *before* the
+/// layer's own items. A backend deriving the split from the key index would
+/// put it on the wrong side and paint the dimming under the content it is
+/// meant to dim.
+#[test]
+fn a_scrim_belongs_to_the_out_of_flow_half() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().children([
+            text("behind"),
+            layer()
+                .key("modal")
+                .anchor(Anchor::Screen(Align::Center))
+                .scrim(Some(Scrim::Dim))
+                .child(text("front")),
+        ]),
+        FRAME,
+    );
+    assert!(
+        spec.layers()
+            .iter()
+            .any(|i| matches!(i.draw, Draw::Scrim(Scrim::Dim))),
+        "the scrim is out of flow: {:?}",
+        spec.items.iter().map(|i| &i.draw).collect::<Vec<_>>()
+    );
+    assert!(
+        spec.in_flow()
+            .iter()
+            .all(|i| !matches!(i.draw, Draw::Scrim(_))),
+        "and nothing in flow is one"
+    );
+    assert!(
+        spec.layers()[0].key.is_none(),
+        "and it is unkeyed, which is why the index cannot classify it"
+    );
+}
+
+/// **The other case.** A layer need not be keyed — `widgets::Dropdown`'s is
+/// not — so it produces no index entry, and a backend deriving the split from
+/// the index would treat its whole pop-over as in-flow content.
+#[test]
+fn an_unkeyed_layer_is_still_out_of_flow() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().children([
+            text("behind"),
+            layer()
+                .anchor(Anchor::Screen(Align::Center))
+                .child(text("front")),
+        ]),
+        FRAME,
+    );
+    assert!(spec.index.is_empty(), "nothing here is keyed");
+    assert_eq!(spec.layers().len(), 1, "and the split still knows");
+}
+
+/// An opaque scrim erases the in-flow half, so the whole list is out of flow
+/// and the mark has to move with it — otherwise it points past the end.
+#[test]
+fn an_opaque_scrim_leaves_nothing_in_flow() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().children([
+            text("behind one"),
+            text("behind two"),
+            layer()
+                .anchor(Anchor::Screen(Align::Center))
+                .modality(Modality::Exclusive)
+                .scrim(Some(Scrim::Opaque))
+                .child(text("on top")),
+        ]),
+        FRAME,
+    );
+    assert_eq!(spec.layers_from, 0);
+    assert!(spec.in_flow().is_empty());
+    assert_eq!(spec.layers().len(), spec.items.len());
+}
+
+/// The two halves partition the list: nothing is dropped and nothing is
+/// counted twice, which is what makes a two-pass backend equivalent to a
+/// one-pass one.
+#[test]
+fn the_two_halves_partition_the_list() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().children([
+            text("behind"),
+            layer()
+                .key("a")
+                .anchor(Anchor::Screen(Align::Start))
+                .scrim(Some(Scrim::Dim))
+                .child(text("one")),
+            layer()
+                .key("b")
+                .anchor(Anchor::Screen(Align::End))
+                .child(text("two")),
+        ]),
+        FRAME,
+    );
+    assert_eq!(spec.in_flow().len() + spec.layers().len(), spec.items.len());
+    assert!(spec.layers_from <= spec.items.len());
+}
+
+/// **An item declares how much room it has.** Layout gives a constrained node
+/// the width it was allowed, not the width its content wants — so a backend
+/// that ignores the rect and simply writes the string paints through whatever
+/// encloses it. The clipping fix is in the backends (`tests/support/screen.rs`
+/// and `examples/interactive.rs`); this pins the fact they have to honour.
+#[test]
+fn a_constrained_run_reports_the_rect_it_was_given_not_the_one_it_wanted() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col()
+            .w(Sizing::Cells(6))
+            .child(text("0123456789").w(Sizing::Cells(4))),
+        Size { w: 12, h: 3 },
+    );
+    let item = spec
+        .items
+        .iter()
+        .find(|i| matches!(i.draw, Draw::Lines(_)))
+        .expect("a text item");
+    assert_eq!(item.rect.w, 4, "four columns is what it was given");
+    let Draw::Lines(lines) = &item.draw else {
+        unreachable!()
+    };
+    assert_eq!(
+        &*lines[0], "0123456789",
+        "and the run is longer than that, which is the backend's problem to \
+         clip rather than the library's to hide"
+    );
+}

--- a/crates/fresh-ui/tests/support/screen.rs
+++ b/crates/fresh-ui/tests/support/screen.rs
@@ -102,6 +102,10 @@ fn draw(s: &mut Screen, item: &Item, frame: Rect, fill_char: &impl Fn(&str) -> O
         Draw::Scrim(Scrim::Dim) => fill(s, frame, '·', frame),
         Draw::Border => border(s, r, clip),
         Draw::Lines(lines) => {
+            // Clipped to the item's own rect as well as its inherited one: an
+            // item declares how much room it has, and a run longer than that
+            // would otherwise paint straight through whatever encloses it.
+            let clip = clip.intersect(r);
             for (i, line) in lines.iter().enumerate() {
                 let y = r.y + i as i32;
                 for (j, ch) in line.chars().enumerate() {

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -551,3 +551,29 @@ fn a_scrollbar_sits_in_a_gutter_the_content_does_not_cover() {
     });
     assert!(!overlap, "content must not cover the scrollbar gutter");
 }
+
+/// **A backend clips a run to the item's own rectangle.** Layout gives a
+/// constrained node the width it was *allowed*, not the width its content
+/// wants, so a `Draw::Lines` run can be longer than the rect that carries it.
+/// A backend that writes the string and honours only the inherited clip paints
+/// straight through whatever encloses the node — a menu row through its own
+/// border, a status segment through the segment beside it.
+///
+/// The reference backend in `support::screen` is the contract; the interactive
+/// example's fold does the same.
+#[test]
+fn a_run_longer_than_its_item_is_clipped_to_it() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col()
+            .w(Sizing::Cells(6))
+            .child(fresh_ui::text("0123456789").w(Sizing::Cells(4))),
+        Size { w: 8, h: 2 },
+    );
+    let screen = support::screen::render(spec);
+    assert_eq!(
+        screen.line(0),
+        "0123    ",
+        "four columns were given, four were painted"
+    );
+}


### PR DESCRIPTION
Base PR for the editor UI migration (#3028), which stacks on top. `fresh-ui` only — no editor changes.

## Why

A backend that draws content the tree does not own has to slot that drawing **between** the tree's in-flow content and its layers: over the first, under the second. A host mid-migration is exactly that shape — some surfaces have moved into the tree, the rest are still painted by its own code — and getting the order wrong means a menu under a status bar, or a modal's scrim dimming everything except the thing it is meant to dim.

Nothing outside the library can work the split out for itself. The obvious derivation is `LayoutSpec::index`, and it is wrong twice over:

- **A scrim carries no key** *and* is pushed **before** its layer's own items (`paint_layer`), so an index-derived boundary puts it on the in-flow side.
- **A layer need not be keyed at all.** `widgets::Dropdown`'s is not, so its whole pop-over produces no index entry and reads as in-flow content.

Either one lands on the wrong side, silently. The editor branch had been deriving exactly this from a hand-maintained list of key families — which is what goal 2 ("no hand-specified exceptions") forbids, and it was already broken for both cases above.

## What

**`LayoutSpec::layers_from`** — the index of the first item a layer produced, recorded in `flush_paint` before the layer loop, with `in_flow()` and `layers()` as the two halves. An opaque scrim clears the in-flow half, so the mark moves to `0` with it rather than pointing past the end.

This is the same diagnosis that produced `Dispatch::claimed` in #3046: the library already computes it and throws it away.

**Backends clip `Draw::Lines` to the item's own rect.** Both in-repo backends (`tests/support/screen.rs`, `examples/interactive.rs`) drew a run at its item's origin while honouring only the *inherited* clip, so a run longer than the rect it was given painted straight through whatever enclosed it — a row through its own border. Layout hands a constrained node the width it was *allowed*, not the width its content wants, so this is reachable from ordinary descriptions.

**The interactive example folds in two passes** to exercise the split, with a band of its own drawn in between (<kbd>F2</kbd>) standing in for a host's own painter.

## Verification

Driven live under tmux, not just asserted:

| Case | Result |
|---|---|
| Keyed layer (command palette) over the band | lands on top ✓ |
| **Unkeyed** layer (`Dropdown` File menu) over the band | lands on top ✓ — the case an index-derived split misclassifies |
| Confirm modal + `Scrim::Dim` | modal on top, and the band **dimmed** along with everything else beneath it ✓ |
| In-flow content (task list) | goes under the band ✓ |
| <kbd>F2</kbd> toggle | band appears/disappears, nothing else moves ✓ |

Verified the scrim case by colour, not just glyphs: with the modal closed the band row is `fg 231 / bg 25` (its own status colours); with it open the row carries no colour of its own and inherits the dimmed scrim palette.

Seven new tests in `tests/paint.rs` and `tests/widgets.rs` cover the mark, the empty case, the scrim, the unkeyed layer, the opaque-scrim reset, the partition property, and the clipping. All existing tests pass and **the goldens are unchanged**, so nothing that was already correct moved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2GtzEBQRFZMv8qF61Jzr)_