### PR TITLE
fix(ci): build liblzma into the macOS binaries instead of linking Homebrew's

### DIFF
--- a/.github/workflows/gui-builds.yml
+++ b/.github/workflows/gui-builds.yml
@@ -58,6 +58,10 @@ jobs:
 
       - name: Build GUI binary
         shell: bash
+        env:
+          # See release.yml: keeps the runner's Homebrew liblzma (and the
+          # distro's liblzma.so.5) out of a binary we hand to users.
+          LZMA_API_STATIC: 1
         run: |
           if [ "${{ matrix.cross }}" = "true" ] && [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
@@ -66,6 +70,19 @@ jobs:
             export RUSTFLAGS="-C target-feature=+crt-static"
           fi
           cargo build --release --features gui --target ${{ matrix.target }}
+
+      - name: Verify macOS binary links only system libraries
+        if: runner.os == 'macOS'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          deps=$(otool -L "target/${TARGET}/release/fresh" | tail -n +2 | awk '{print $1}')
+          echo "$deps"
+          if external=$(echo "$deps" | grep -v -E '^(/usr/lib/|/System/Library/)'); then
+            echo "::error::binary depends on non-system libraries:"
+            echo "$external"
+            exit 1
+          fi
 
       # ── Windows: single exe ──────────────────────────────────────────
       - name: Package GUI (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,12 @@ jobs:
         # never match (SC2193).
         env:
           TARGET: ${{ matrix.target }}
+          # Compile liblzma from the vendored xz source instead of linking
+          # whatever `pkg-config` turns up. Without this, `lzma-sys` links the
+          # runner's Homebrew liblzma on macOS arm64 (and the distro's
+          # liblzma.so.5 on Linux), so the published binary carries a
+          # dependency on a library the user's machine has no reason to have.
+          LZMA_API_STATIC: 1
         run: |
           if [ "${{ matrix.cross }}" = "true" ] && [ "$TARGET" = "aarch64-unknown-linux-gnu" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
@@ -153,6 +159,22 @@ jobs:
           # Default features include embed-plugins; plugins (and themes via build.rs)
           # are compiled into the binary, so we ship a single self-contained executable.
           cargo build --release --target ${{ matrix.target }}
+
+      # Checks the artifact rather than trusting the build flag above: a
+      # released binary must load nothing but the OS's own libraries, or it
+      # dies at startup on every machine that lacks the missing library.
+      - name: Verify macOS binary links only system libraries
+        if: runner.os == 'macOS'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          deps=$(otool -L "target/${TARGET}/release/fresh" | tail -n +2 | awk '{print $1}')
+          echo "$deps"
+          if external=$(echo "$deps" | grep -v -E '^(/usr/lib/|/System/Library/)'); then
+            echo "::error::binary depends on non-system libraries:"
+            echo "$external"
+            exit 1
+          fi
 
       - name: Create archive (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## The bug

The `fresh-editor-aarch64-apple-darwin` binary on the releases page does not start on a Mac without Homebrew (#3055):

```
dyld[1654]: Library not loaded: /opt/homebrew/opt/xz/lib/liblzma.5.dylib
```

Confirmed against the current release — its load commands are all system libraries except one:

```
LC_LOAD_DYLIB /opt/homebrew/opt/xz/lib/liblzma.5.dylib   cur=14.3.0 compat=14.0.0
LC_LOAD_DYLIB /usr/lib/libiconv.2.dylib
LC_LOAD_DYLIB /usr/lib/libSystem.B.dylib
… plus AppKit / CoreGraphics / Foundation / CoreFoundation / Security / libobjc
```

Three symbols are involved: `lzma_code`, `lzma_end`, `lzma_stream_decoder`.

## Why

`fresh-update`'s `archive` feature pulls `xz2` → `lzma-sys`, whose build script compiles the vendored xz source **only when `pkg-config` fails** to find a system liblzma. The macOS arm64 runner has Homebrew's `xz` installed, so the probe succeeds and the linker records a path that exists on the runner and on no user's machine.

The `x86_64-apple-darwin` binary escaped by accident: it is cross-compiled, the `pkg-config` crate refuses to probe across architectures, and it has been getting the static build all along — its load commands reference nothing outside `/usr/lib`.

## The change

* `LZMA_API_STATIC: 1` on the build steps of `release.yml` and `gui-builds.yml`, so liblzma always comes from the vendored xz source regardless of what is installed on the runner. Linux gnu builds shed their `liblzma.so.5` dependency as a side effect, which is what an archive whose claim is "unpack it and run it" should have been doing anyway. Set on the CI steps rather than in `Cargo.toml`, so distro/Nix builds keep using their own system liblzma.
* A post-build check on each macOS job: `otool -L` on the artifact must show nothing outside `/usr/lib` and `/System/Library`, so a dependency that leaks in from the runner's installed software fails the build instead of the user's first launch.

## Testing

* `actionlint -shellcheck shellcheck` with `SHELLCHECK_OPTS=-S warning` (the same invocation as the `actionlint` CI job): clean.
* The verification snippet was exercised against captured `otool -L` output from both the broken arm64 binary (fails, printing the Homebrew path) and a clean one (passes).
* The build itself only runs on a tag push, so the real check is the next release; the artifact check above is what makes that safe to trust.

Workarounds for anyone hitting this on an already-published binary are in #3055.