### PR TITLE
fix(pkg): upgrades, reachable actions, reopen, arrow-nav and URL-installed rows

### DIFF
--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -1976,7 +1976,6 @@ type FocusTarget =
 
 interface PkgManagerState {
   isOpen: boolean;
-  bufferId: number | null;
   splitId: number | null;
   sourceBufferId: number | null;
   filter: "all" | "installed" | "plugins" | "themes" | "languages" | "bundles";
@@ -2007,7 +2006,6 @@ interface PkgManagerState {
 
 const pkgState: PkgManagerState = {
   isOpen: false,
-  bufferId: null,
   splitId: null,
   sourceBufferId: null,
   filter: "all",
@@ -2686,11 +2684,21 @@ function updatePkgManagerView(): void {
  */
 async function openPackageManager(): Promise<void> {
   if (pkgState.isOpen) {
-    // Already open, just focus it
-    if (pkgState.bufferId !== null) {
-      editor.showBuffer(pkgState.bufferId);
+    // Adopt the group we already own and bring it to the front, rather
+    // than stacking a second one. This used to key off `pkgState
+    // .bufferId`, which nothing ever assigned (the buffer-group
+    // migration left it null), so re-running the command while the
+    // manager was open did nothing at all.
+    const listBufferId = pkgState.panelBuffers["list"];
+    if (typeof listBufferId === "number" && bufferExists(listBufferId)) {
+      editor.showBuffer(listBufferId);
+      return;
     }
-    return;
+    // The group is gone without us hearing about it. Drop the dead
+    // handles and open a new one instead of returning to a UI that no
+    // longer exists.
+    unmountPkgPanels();
+    resetPkgManagerState();
   }
 
   // Store current buffer
@@ -2760,38 +2768,85 @@ async function openPackageManager(): Promise<void> {
   });
 }
 
+/** Whether `bufferId` is still a live buffer. */
+function bufferExists(bufferId: number): boolean {
+  return editor.listBuffers().some((b) => b.id === bufferId);
+}
+
+/**
+ * Unmount the widget panels the manager owns.
+ *
+ * The host keys panels by (plugin, panel id) and is never told that a
+ * panel's buffer went away, so a panel that is merely dropped on the
+ * plugin side stays registered against a dead buffer for the rest of
+ * the session. Closing the buffer group is not an unmount; only this
+ * is.
+ */
+function unmountPkgPanels(): void {
+  pkgState.listPanel?.unmount();
+  pkgState.footerPanel?.unmount();
+  pkgState.listPanel = null;
+  pkgState.footerPanel = null;
+  pkgListRowCache = [];
+}
+
+/** Drop every handle into a package-manager UI that no longer exists. */
+function resetPkgManagerState(): void {
+  pkgState.isOpen = false;
+  pkgState.groupId = null;
+  pkgState.panelBuffers = {};
+  pkgState.splitId = null;
+  pkgState.sourceBufferId = null;
+  pkgState.error = null;
+}
+
 /**
  * Close the package manager
  */
 function closePackageManager(): void {
   if (!pkgState.isOpen) return;
 
-  // Close the buffer group if using the new system
-  if (pkgState.groupId !== null) {
-    editor.closeBufferGroup(pkgState.groupId);
-    pkgState.groupId = null;
-    pkgState.panelBuffers = {};
-  } else if (pkgState.bufferId !== null) {
-    editor.closeBuffer(pkgState.bufferId);
+  const groupId = pkgState.groupId;
+  const sourceBufferId = pkgState.sourceBufferId;
+  const splitId = pkgState.splitId;
+
+  // Unmount before the buffers go, and clear the state before the
+  // close fires `buffer_closed` for each panel — by then there is
+  // nothing left for `pkg_buffer_closed` to tear down, so the two
+  // teardown routes can't trip over each other.
+  unmountPkgPanels();
+  resetPkgManagerState();
+
+  if (groupId !== null) {
+    editor.closeBufferGroup(groupId);
   }
 
   // Restore previous buffer if possible
-  if (pkgState.sourceBufferId !== null && pkgState.splitId !== null) {
-    editor.showBuffer(pkgState.sourceBufferId);
+  if (sourceBufferId !== null && splitId !== null) {
+    editor.showBuffer(sourceBufferId);
   }
-
-  // Reset state. The buffer group's close will tear down the panel
-  // buffers and (implicitly) the widget panels rendering into them;
-  // we just null the handles so any stray render call after close
-  // is a no-op.
-  pkgState.isOpen = false;
-  pkgState.bufferId = null;
-  pkgState.splitId = null;
-  pkgState.sourceBufferId = null;
-  pkgState.listPanel = null;
-  pkgState.footerPanel = null;
-  pkgListRowCache = [];
 }
+
+/**
+ * Tear down when a panel buffer is closed by the editor rather than by
+ * `pkg_back_or_close`: the group tab's ×, File → Close Buffer, or a
+ * split going away.
+ *
+ * Without this the state stays "open" pointing at dead buffer ids, and
+ * because the open path then takes its adopt branch, `Package:
+ * Packages` never opens again for the rest of the session.
+ */
+function pkg_buffer_closed(data: { buffer_id: number }): void {
+  if (!pkgState.isOpen) return;
+  const isOurs = Object.values(pkgState.panelBuffers).some(
+    (id) => id === data.buffer_id,
+  );
+  if (!isOurs) return;
+  unmountPkgPanels();
+  resetPkgManagerState();
+}
+registerHandler("pkg_buffer_closed", pkg_buffer_closed);
+editor.on("buffer_closed", "pkg_buffer_closed");
 
 /**
  * Get all focusable elements in order for Tab navigation

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -682,7 +682,11 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
         }
 
         packages.push({
-          name: entry.name,
+          // The manifest names the package; the directory is only
+          // where it happens to live. They match for anything the
+          // installer put there, but the manifest is what a registry
+          // entry would be keyed by, so prefer it.
+          name: manifest?.name || entry.name,
           path: pkgPath,
           type,
           source,
@@ -698,6 +702,23 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
   }
 
   return packages;
+}
+
+/**
+ * Every installed package, of every kind.
+ *
+ * The manager's commands used to look at plugins and themes only, so a
+ * language pack or bundle — which `Package: Install from URL` installs
+ * just as readily — was listed in the browser but invisible to Update,
+ * Remove, Update All and the lockfile.
+ */
+function getAllInstalledPackages(): InstalledPackage[] {
+  return [
+    ...getInstalledPackages("plugin"),
+    ...getInstalledPackages("theme"),
+    ...getInstalledPackages("language"),
+    ...getInstalledPackages("bundle"),
+  ];
 }
 
 /**
@@ -949,8 +970,12 @@ function swapInstalledDir(
     : fsLocal.copyPath(stagingDir, targetDir);
 
   if (!placed) {
+    // A directory copy that fails part-way still leaves what it managed
+    // to write. Clear it: a half-copied package left at the install
+    // path is scanned as an installed one and shows up in the browser
+    // as if the install had worked.
+    fsLocal.removePath(targetDir);
     if (hadExisting) {
-      fsLocal.removePath(targetDir);
       fsLocal.renamePath(backupDir, targetDir);
     }
     return false;
@@ -1823,9 +1848,7 @@ async function removePackage(pkg: InstalledPackage): Promise<boolean> {
  * Update all packages
  */
 async function updateAllPackages(): Promise<void> {
-  const plugins = getInstalledPackages("plugin");
-  const themes = getInstalledPackages("theme");
-  const all = [...plugins, ...themes];
+  const all = getAllInstalledPackages();
 
   if (all.length === 0) {
     editor.setStatus("No packages installed");
@@ -1861,9 +1884,7 @@ async function updateAllPackages(): Promise<void> {
 async function generateLockfile(): Promise<void> {
   editor.setStatus("Generating lockfile...");
 
-  const plugins = getInstalledPackages("plugin");
-  const themes = getInstalledPackages("theme");
-  const all = [...plugins, ...themes];
+  const all = getAllInstalledPackages();
 
   const lockfile: Lockfile = {
     lockfile_version: 1,
@@ -2612,7 +2633,11 @@ function buildPkgDetailEntries(): TextPropertyEntry[] {
   if (selectedItem) {
     entries.push({ text: selectedItem.name + "\n", properties: { type: "detail-title" } });
     entries.push({ text: "─".repeat(Math.min(selectedItem.name.length + 2, 50)) + "\n", properties: { type: "detail-sep" } });
-    let metaLine = `v${selectedItem.version}`;
+    // The kind is on the row for available packages (the `[P]`/`[T]`
+    // tag) but nowhere for installed ones, so state it here — it is
+    // read straight off the manifest, which every installed package
+    // has whether or not a registry lists it.
+    let metaLine = `${selectedItem.packageType} • v${selectedItem.version}`;
     if (selectedItem.updateAvailable && selectedItem.latestVersion) {
       metaLine += ` → v${selectedItem.latestVersion}`;
     }
@@ -3040,12 +3065,39 @@ async function runPackageAction(
 ): Promise<boolean> {
   pkgState.error = null;
   lastPackageError = null;
+  const selectedName = getFilteredItems()[pkgState.selectedIndex]?.name;
   const ok = await run();
   if (!ok) {
     pkgState.error = lastPackageError ?? "Action failed";
   }
   pkgState.items = buildPackageList();
+  // Keep the selection on the same package. The list is ordered
+  // installed-first, so installing one moves it up past every
+  // available entry and a positional index would land on something
+  // else. A package that is gone (uninstalled) leaves the index where
+  // it was, which `updatePkgManagerView` clamps into range.
+  if (selectedName !== undefined) {
+    const idx = getFilteredItems().findIndex((i) => i.name === selectedName);
+    if (idx >= 0) {
+      pkgState.selectedIndex = idx;
+    }
+  }
   return ok;
+}
+
+/**
+ * Re-read what is installed and repaint, if the browser is open.
+ *
+ * Installs and removals started from outside the browser's own action
+ * buttons — `Package: Install from URL`, the registry finder, the
+ * Update / Remove finders — otherwise leave it showing the package set
+ * from when it was opened, so a package just installed from a URL
+ * doesn't appear until the browser is closed and reopened.
+ */
+function refreshPackageManagerIfOpen(): void {
+  if (!pkgState.isOpen) return;
+  pkgState.items = buildPackageList();
+  updatePkgManagerView();
 }
 
 async function pkg_activate() : Promise<void> {
@@ -3203,6 +3255,7 @@ const registryFinder = new Finder<[string, RegistryEntry]>(editor, {
   maxResults: 100,
   onSelect: async ([name, entry]) => {
     await installPackage(entry.repository, name, "plugin");
+    refreshPackageManagerIfOpen();
   }
 });
 
@@ -3292,11 +3345,22 @@ editor.on("prompt_confirmed", async (args) => {
   if (args.prompt_type !== "pkg-install-url") return true;
 
   const url = args.input.trim();
-  if (url) {
-    await installPackage(url);
-  } else {
+  if (!url) {
     editor.setStatus("No URL or path provided");
+    return true;
   }
+
+  // The handler's promise is detached from here on, so it carries its
+  // own catch: an unhandled rejection is fatal to the plugin runtime.
+  try {
+    await installPackage(url);
+  } catch (e) {
+    packageFailure(`Install failed: ${e}`);
+  }
+  // A package installed from a URL is an installed package like any
+  // other; if the browser is open it belongs in the list now, not
+  // after a close and reopen.
+  refreshPackageManagerIfOpen();
 
   return true;
 });
@@ -3314,6 +3378,7 @@ registerHandler("pkg_list", pkg_list);
  */
 async function pkg_update_all() : Promise<void> {
   await updateAllPackages();
+  refreshPackageManagerIfOpen();
 }
 registerHandler("pkg_update_all", pkg_update_all);
 
@@ -3321,9 +3386,7 @@ registerHandler("pkg_update_all", pkg_update_all);
  * Update a specific package
  */
 function pkg_update() : void {
-  const plugins = getInstalledPackages("plugin");
-  const themes = getInstalledPackages("theme");
-  const all = [...plugins, ...themes];
+  const all = getAllInstalledPackages();
 
   if (all.length === 0) {
     editor.setStatus("No packages installed");
@@ -3340,6 +3403,7 @@ function pkg_update() : void {
     preview: false,
     onSelect: async (pkg) => {
       await updatePackage(pkg);
+      refreshPackageManagerIfOpen();
     }
   });
 
@@ -3357,9 +3421,7 @@ registerHandler("pkg_update", pkg_update);
  * Remove a package
  */
 function pkg_remove() : void {
-  const plugins = getInstalledPackages("plugin");
-  const themes = getInstalledPackages("theme");
-  const all = [...plugins, ...themes];
+  const all = getAllInstalledPackages();
 
   if (all.length === 0) {
     editor.setStatus("No packages installed");
@@ -3376,6 +3438,7 @@ function pkg_remove() : void {
     preview: false,
     onSelect: async (pkg) => {
       await removePackage(pkg);
+      refreshPackageManagerIfOpen();
     }
   });
 
@@ -3401,9 +3464,7 @@ registerHandler("pkg_sync", pkg_sync);
  * Show outdated packages
  */
 async function pkg_outdated() : Promise<void> {
-  const plugins = getInstalledPackages("plugin");
-  const themes = getInstalledPackages("theme");
-  const all = [...plugins, ...themes];
+  const all = getAllInstalledPackages();
 
   if (all.length === 0) {
     editor.setStatus("No packages installed");
@@ -3414,7 +3475,17 @@ async function pkg_outdated() : Promise<void> {
 
   const outdated: Array<{ pkg: InstalledPackage; behind: number }> = [];
 
+  let skipped = 0;
   for (const pkg of all) {
+    // Only a plain-repo install has a .git to count commits against. A
+    // monorepo-subpath or local-directory install is a copy, so git
+    // here reports nothing and the package would silently look up to
+    // date; those are updated by re-installing (see `updatePackage`).
+    if (!fsLocal.fileExists(editor.pathJoin(pkg.path, ".git"))) {
+      skipped++;
+      continue;
+    }
+
     // Fetch latest
     await gitCommand(["-C", `${pkg.path}`, "fetch"]);
 
@@ -3430,7 +3501,11 @@ async function pkg_outdated() : Promise<void> {
   }
 
   if (outdated.length === 0) {
-    editor.setStatus("All packages are up to date");
+    editor.setStatus(
+      skipped > 0
+        ? `All git-tracked packages are up to date (${skipped} installed by copy — use Update to re-install)`
+        : "All packages are up to date",
+    );
     return;
   }
 
@@ -3444,6 +3519,7 @@ async function pkg_outdated() : Promise<void> {
     preview: false,
     onSelect: async (item) => {
       await updatePackage(item.pkg);
+      refreshPackageManagerIfOpen();
     }
   });
 

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -223,6 +223,13 @@ interface InstalledPackage {
   manifest?: PackageManifest;
   /** Original local path if installed from a local directory */
   localSource?: string;
+  /**
+   * URL or path this package was installed from, as recorded in
+   * `.fresh-source.json`. This is what an update re-fetches: unlike
+   * `source` (a git remote, which monorepo-subpath and local-directory
+   * installs don't have) it is written by every install path.
+   */
+  installedFrom?: string;
 }
 
 interface LockfileEntry {
@@ -296,6 +303,29 @@ async function gitCommand(args: string[]): Promise<{ exit_code: number; stdout: 
   ];
   const result = await editor.spawnProcess("git", gitArgs);
   return result;
+}
+
+/**
+ * Turn a failed git invocation's stderr into one line worth showing.
+ *
+ * Prefers git's first `fatal:` / `error:` line over the first line of
+ * output: git opens with progress noise ("Cloning into '/tmp/...'...")
+ * and trails off into advice ("...and the repository exists."), and
+ * this text is what the package browser shows the user when an install
+ * or update fails.
+ */
+function gitErrorMessage(stderr: string, fallback: string): string {
+  if (stderr.includes("Could not resolve host")) return "Network error";
+  if (stderr.includes("not found") || stderr.includes("404")) return "Repository not found";
+  if (stderr.includes("Authentication") || stderr.includes("403")) {
+    return "Access denied (repository may be private)";
+  }
+  const lines = stderr.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  for (const line of lines) {
+    const match = line.match(/^(?:fatal|error):\s*(.+)$/);
+    if (match) return match[1];
+  }
+  return lines[0] || fallback;
 }
 
 /**
@@ -627,14 +657,29 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
           }
         }
 
-        // Check for .fresh-source.json (local path or monorepo installs)
-        if (!source) {
-          const freshSourcePath = editor.pathJoin(pkgPath, ".fresh-source.json");
-          const freshSource = readJsonFile<{ local_path?: string; original_url?: string }>(freshSourcePath);
-          if (freshSource?.local_path) {
-            localSource = freshSource.local_path;
-            source = freshSource.original_url || freshSource.local_path;
-          }
+        // Every install path writes .fresh-source.json; read it whatever
+        // the git remote said, because the marker is the only record a
+        // monorepo-subpath or local-directory install leaves behind (they
+        // are copies, so they have no .git at all).
+        const freshSourcePath = editor.pathJoin(pkgPath, ".fresh-source.json");
+        const freshSource = readJsonFile<{
+          local_path?: string;
+          original_url?: string;
+          url?: string;
+          repository?: string;
+          subpath?: string;
+          installed_from?: string;
+        }>(freshSourcePath);
+        if (freshSource?.local_path) {
+          localSource = freshSource.local_path;
+        }
+        const installedFrom = freshSource?.installed_from
+          || freshSource?.original_url
+          || freshSource?.url
+          || freshSource?.local_path
+          || undefined;
+        if (!source && installedFrom) {
+          source = installedFrom;
         }
 
         packages.push({
@@ -645,6 +690,7 @@ function getInstalledPackages(type: "plugin" | "theme" | "language" | "bundle"):
           version: manifest?.version || "unknown",
           manifest: manifest ?? undefined,
           localSource,
+          installedFrom,
         });
       }
     }
@@ -941,6 +987,26 @@ function installedStatus(
 }
 
 /**
+ * The most recent install / update / uninstall failure.
+ *
+ * Progress messages belong on the status bar, but a failure the user
+ * has to act on must not vanish the next time anything else writes
+ * there — the package browser reads this to show the failure in its
+ * own panel. Cleared by `runPackageAction` when a new action starts.
+ */
+let lastPackageError: string | null = null;
+
+/**
+ * Report a failed package operation: to the status bar as before, and
+ * into `lastPackageError` so the browser UI can surface it too.
+ */
+function packageFailure(message: string): false {
+  lastPackageError = message;
+  editor.setStatus(message);
+  return false;
+}
+
+/**
  * Install a package from a git URL, direct file URL, or local path.
  *
  * Supports:
@@ -1008,14 +1074,14 @@ async function installFromDirectFile(
       : result.exit_code > 0
       ? `HTTP ${result.exit_code}`
       : result.stderr.split("\n")[0] || "Download failed";
-    editor.setStatus(`Failed to download ${packageName}: ${errorMsg}`);
+    packageFailure(`Failed to download ${packageName}: ${errorMsg}`);
     fsLocal.removePath(tempFile);
     return false;
   }
 
   const content = fsLocal.readFile(tempFile);
   if (!content) {
-    editor.setStatus(`Failed to read downloaded file`);
+    packageFailure(`Failed to read downloaded file`);
     fsLocal.removePath(tempFile);
     return false;
   }
@@ -1024,7 +1090,7 @@ async function installFromDirectFile(
   try {
     parsed = JSON.parse(content) as Record<string, unknown>;
   } catch (e) {
-    editor.setStatus(`Downloaded file is not valid JSON: ${e}`);
+    packageFailure(`Downloaded file is not valid JSON: ${e}`);
     fsLocal.removePath(tempFile);
     return false;
   }
@@ -1043,7 +1109,7 @@ async function installFromDirectFile(
   );
 
   if (!looksLikeTheme) {
-    editor.setStatus(
+    packageFailure(
       `Unrecognized file format at ${url} - direct file install currently supports Fresh theme JSON only`
     );
     fsLocal.removePath(tempFile);
@@ -1070,14 +1136,14 @@ async function installFromDirectFile(
     `fresh-pkg-theme-${hashString(url)}-${Date.now()}`,
   );
   if (!ensureDir(stagingDir)) {
-    editor.setStatus(`Failed to create staging directory ${stagingDir}`);
+    packageFailure(`Failed to create staging directory ${stagingDir}`);
     fsLocal.removePath(tempFile);
     return false;
   }
 
   const themeFileName = "theme.json";
   if (!fsLocal.writeFile(editor.pathJoin(stagingDir, themeFileName), content)) {
-    editor.setStatus(`Failed to write theme file`);
+    packageFailure(`Failed to write theme file`);
     fsLocal.removePath(tempFile);
     fsLocal.removePath(stagingDir);
     return false;
@@ -1093,7 +1159,7 @@ async function installFromDirectFile(
     },
   };
   if (!await writeJsonFile(editor.pathJoin(stagingDir, "package.json"), manifest)) {
-    editor.setStatus(`Failed to write package manifest`);
+    packageFailure(`Failed to write package manifest`);
     fsLocal.removePath(tempFile);
     fsLocal.removePath(stagingDir);
     return false;
@@ -1107,7 +1173,7 @@ async function installFromDirectFile(
 
   ensureDir(THEMES_PACKAGES_DIR);
   if (!swapInstalledDir(stagingDir, THEMES_PACKAGES_DIR, safeName, true)) {
-    editor.setStatus(`Failed to install ${safeName}: could not replace ${targetDir}`);
+    packageFailure(`Failed to install ${safeName}: could not replace ${targetDir}`);
     fsLocal.removePath(tempFile);
     fsLocal.removePath(stagingDir);
     return false;
@@ -1142,12 +1208,8 @@ async function installFromRepo(
   const result = await gitCommand(cloneArgs);
 
   if (result.exit_code !== 0) {
-    const errorMsg = result.stderr.includes("not found") || result.stderr.includes("404")
-      ? "Repository not found"
-      : result.stderr.includes("Authentication") || result.stderr.includes("403")
-      ? "Access denied (repository may be private)"
-      : result.stderr.split("\n")[0] || "Clone failed";
-    editor.setStatus(`Failed to install ${packageName}: ${errorMsg}`);
+    const errorMsg = gitErrorMessage(result.stderr, "Clone failed");
+    packageFailure(`Failed to install ${packageName}: ${errorMsg}`);
     return false;
   }
 
@@ -1163,7 +1225,7 @@ async function installFromRepo(
   const validation = validatePackage(tempDir, packageName);
   if (!validation.valid) {
     editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
-    editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
+    packageFailure(`Failed to install ${packageName}: ${validation.error}`);
     // Clean up
     fsLocal.removePath(tempDir);
     return false;
@@ -1207,7 +1269,7 @@ async function installFromRepo(
   // Ensure correct directory exists and move from temp
   ensureDir(correctPackagesDir);
   if (!swapInstalledDir(tempDir, correctPackagesDir, packageName, true)) {
-    editor.setStatus(`Failed to install ${packageName}: could not move package to target directory`);
+    packageFailure(`Failed to install ${packageName}: could not move package to target directory`);
     fsLocal.removePath(tempDir);
     return false;
   }
@@ -1264,21 +1326,21 @@ async function installFromLocalPath(
 
   // Check if source exists
   if (!fsLocal.fileExists(sourcePath)) {
-    editor.setStatus(`Local path not found: ${sourcePath}`);
+    packageFailure(`Local path not found: ${sourcePath}`);
     return false;
   }
 
   // Check if it's a directory (by checking for package.json)
   const manifestPath = editor.pathJoin(sourcePath, "package.json");
   if (!fsLocal.fileExists(manifestPath)) {
-    editor.setStatus(`Not a valid package (no package.json): ${sourcePath}`);
+    packageFailure(`Not a valid package (no package.json): ${sourcePath}`);
     return false;
   }
 
   // Read manifest FIRST to determine actual package type and name
   const manifest = readJsonFile<PackageManifest>(manifestPath);
   if (!manifest) {
-    editor.setStatus(`Invalid package.json in ${sourcePath}`);
+    packageFailure(`Invalid package.json in ${sourcePath}`);
     return false;
   }
 
@@ -1310,7 +1372,7 @@ async function installFromLocalPath(
   );
   editor.setStatus(`Copying from ${sourcePath}...`);
   if (!fsLocal.copyPath(sourcePath, stagingDir)) {
-    editor.setStatus(`Failed to copy package from ${sourcePath}`);
+    packageFailure(`Failed to copy package from ${sourcePath}`);
     return false;
   }
 
@@ -1318,7 +1380,7 @@ async function installFromLocalPath(
   const validation = validatePackage(stagingDir, packageName);
   if (!validation.valid) {
     editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
-    editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
+    packageFailure(`Failed to install ${packageName}: ${validation.error}`);
     // Clean up the invalid package
     fsLocal.removePath(stagingDir);
     return false;
@@ -1338,7 +1400,7 @@ async function installFromLocalPath(
     await unloadPluginsUnder(correctTargetDir);
   }
   if (!swapInstalledDir(stagingDir, correctPackagesDir, packageName, true)) {
-    editor.setStatus(`Failed to install ${packageName}: could not move package to target directory`);
+    packageFailure(`Failed to install ${packageName}: could not move package to target directory`);
     fsLocal.removePath(stagingDir);
     return false;
   }
@@ -1394,12 +1456,8 @@ async function installFromMonorepo(
 
     const cloneResult = await gitCommand(cloneArgs);
     if (cloneResult.exit_code !== 0) {
-      const errorMsg = cloneResult.stderr.includes("not found") || cloneResult.stderr.includes("404")
-        ? "Repository not found"
-        : cloneResult.stderr.includes("Authentication") || cloneResult.stderr.includes("403")
-        ? "Access denied (repository may be private)"
-        : cloneResult.stderr.split("\n")[0] || "Clone failed";
-      editor.setStatus(`Failed to clone repository: ${errorMsg}`);
+      const errorMsg = gitErrorMessage(cloneResult.stderr, "Clone failed");
+      packageFailure(`Failed to clone repository: ${errorMsg}`);
       return false;
     }
 
@@ -1411,7 +1469,7 @@ async function installFromMonorepo(
     // Verify subpath exists
     const subpathDir = editor.pathJoin(tempDir, parsed.subpath!);
     if (!fsLocal.fileExists(subpathDir)) {
-      editor.setStatus(`Subpath '${parsed.subpath}' not found in repository`);
+      packageFailure(`Subpath '${parsed.subpath}' not found in repository`);
       fsLocal.removePath(tempDir);
       return false;
     }
@@ -1420,7 +1478,7 @@ async function installFromMonorepo(
     const validation = validatePackage(subpathDir, packageName);
     if (!validation.valid) {
       editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
-      editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
+      packageFailure(`Failed to install ${packageName}: ${validation.error}`);
       fsLocal.removePath(tempDir);
       return false;
     }
@@ -1468,7 +1526,7 @@ async function installFromMonorepo(
     // Copy subdirectory to correct target
     editor.setStatus(`Installing ${packageName} from ${parsed.subpath}...`);
     if (!swapInstalledDir(subpathDir, correctPackagesDir, packageName, false)) {
-      editor.setStatus(`Failed to copy package from ${parsed.subpath}`);
+      packageFailure(`Failed to copy package from ${parsed.subpath}`);
       fsLocal.removePath(tempDir);
       return false;
     }
@@ -1696,117 +1754,40 @@ async function findMatchingSemver(pkgPath: string, spec: string): Promise<string
 }
 
 /**
- * Update a package
+ * Where an installed package can be re-fetched from, or `null` when
+ * nothing recorded a source.
+ *
+ * The `.fresh-source.json` marker comes first because every install
+ * path writes it; the git remote is the fallback for plain-repo
+ * installs made before the marker existed.
  */
-async function updatePackage(pkg: InstalledPackage): Promise<boolean> {
-  editor.setStatus(`Updating ${pkg.name}...`);
-
-  const result = await gitCommand(["-C", `${pkg.path}`, "pull", "--ff-only"]);
-
-  if (result.exit_code === 0) {
-    if (result.stdout.includes("Already up to date")) {
-      editor.setStatus(`${pkg.name} is already up to date`);
-    } else {
-      // Reload the plugin to apply changes
-      // Use listPlugins to find the correct runtime plugin name
-      if (pkg.type === "plugin") {
-        const loadedPlugins = await editor.listPlugins();
-        const plugin = loadedPlugins.find((p: { path: string }) => p.path.startsWith(pkg.path));
-        if (plugin) {
-          await editor.reloadPlugin(plugin.name);
-        }
-      } else if (pkg.type === "theme") {
-        editor.reloadThemes();
-      }
-      editor.setStatus(`Updated and reloaded ${pkg.name}`);
-    }
-    return true;
-  } else {
-    const errorMsg = result.stderr.includes("Could not resolve host")
-      ? "Network error"
-      : result.stderr.includes("Authentication") || result.stderr.includes("403")
-      ? "Authentication failed"
-      : result.stderr.split("\n")[0] || "Update failed";
-    editor.setStatus(`Failed to update ${pkg.name}: ${errorMsg}`);
-    return false;
-  }
+function updateSource(pkg: InstalledPackage): string | null {
+  return pkg.installedFrom || pkg.source || null;
 }
 
 /**
- * Reinstall a package from its original local path.
- * Removes the installed copy and re-copies from the source directory.
+ * Update a package by re-running its install from the source it came
+ * from.
+ *
+ * This used to be `git -C <pkgdir> pull --ff-only`, which only means
+ * anything for a plain-repo install, where the clone itself became the
+ * installed directory. A monorepo install is a copy of a subdirectory
+ * taken out of a throwaway clone and a local install is a copy of a
+ * directory: neither has a `.git`, so the pull failed and those
+ * packages could never be updated at all. Re-installing works for every
+ * kind, and inherits the install path's guarantees — it validates the
+ * new copy before touching the old one, unloads before replacing, and
+ * reloads afterwards.
  */
-async function reinstallPackage(pkg: InstalledPackage): Promise<boolean> {
-  if (!pkg.localSource) {
-    editor.setStatus(`Cannot reinstall ${pkg.name}: no local source path`);
+async function updatePackage(pkg: InstalledPackage): Promise<boolean> {
+  const source = updateSource(pkg);
+  if (!source) {
+    packageFailure(`Cannot update ${pkg.name}: no recorded install source`);
     return false;
   }
 
-  const sourcePath = pkg.localSource;
-
-  if (!fsLocal.fileExists(sourcePath)) {
-    editor.setStatus(`Source path no longer exists: ${sourcePath}`);
-    return false;
-  }
-
-  editor.setStatus(`Reinstalling ${pkg.name} from ${sourcePath}...`);
-
-  // Unload plugin first if applicable
-  if (pkg.type === "plugin") {
-    const loadedPlugins = await editor.listPlugins();
-    const plugin = loadedPlugins.find((p: { path: string }) => p.path.startsWith(pkg.path));
-    if (plugin) {
-      await editor.unloadPlugin(plugin.name).catch(() => {});
-    }
-  }
-
-  // Remove old copy
-  if (!fsLocal.removePath(pkg.path)) {
-    editor.setStatus(`Failed to remove old copy of ${pkg.name}`);
-    return false;
-  }
-
-  // Re-copy from source
-  if (!fsLocal.copyPath(sourcePath, pkg.path)) {
-    editor.setStatus(`Failed to copy from source: ${sourcePath}`);
-    return false;
-  }
-
-  // Re-write the .fresh-source.json marker
-  const sourceInfo = {
-    local_path: sourcePath,
-    original_url: pkg.source,
-    installed_at: new Date().toISOString()
-  };
-  await writeJsonFile(editor.pathJoin(pkg.path, ".fresh-source.json"), sourceInfo);
-
-  // Re-read manifest for validation and reload
-  const validation = validatePackage(pkg.path, pkg.name);
-  if (!validation.valid) {
-    editor.setStatus(`Reinstalled ${pkg.name} but package is invalid: ${validation.error}`);
-    return false;
-  }
-
-  const manifest = validation.manifest;
-
-  // Reload
-  if (manifest?.type === "plugin" && validation.entryPath) {
-    await editor.loadPlugin(validation.entryPath);
-    editor.setStatus(`Reinstalled and activated ${pkg.name}`);
-  } else if (manifest?.type === "theme") {
-    editor.reloadThemes();
-    editor.setStatus(`Reinstalled theme ${pkg.name}`);
-  } else if (manifest?.type === "language") {
-    await loadLanguagePack(pkg.path, manifest);
-    editor.setStatus(`Reinstalled language pack ${pkg.name}`);
-  } else if (manifest?.type === "bundle") {
-    await loadBundle(pkg.path, manifest);
-    editor.setStatus(`Reinstalled bundle ${pkg.name}`);
-  } else {
-    editor.setStatus(`Reinstalled ${pkg.name}`);
-  }
-
-  return true;
+  editor.setStatus(`Updating ${pkg.name} from ${source}...`);
+  return await installPackage(source, pkg.name);
 }
 
 /**
@@ -1834,7 +1815,7 @@ async function removePackage(pkg: InstalledPackage): Promise<boolean> {
     editor.setStatus(`Removed ${pkg.name}`);
     return true;
   } else {
-    editor.setStatus(`Failed to remove ${pkg.name}`);
+    packageFailure(`Failed to remove ${pkg.name}`);
     return false;
   }
 }
@@ -1858,27 +1839,17 @@ async function updateAllPackages(): Promise<void> {
   for (const pkg of all) {
     editor.setStatus(`Updating ${pkg.name} (${updated + failed + 1}/${all.length})...`);
 
-    if (pkg.localSource) {
-      // Local packages: reinstall from source path
-      const ok = await reinstallPackage(pkg);
-      if (ok) {
-        updated++;
-      } else {
-        failed++;
-      }
+    // One path for every kind of install — see `updatePackage`. A
+    // re-install always replaces, so there is no "unchanged" outcome
+    // to report any more.
+    if (await updatePackage(pkg)) {
+      updated++;
     } else {
-      const result = await gitCommand(["-C", `${pkg.path}`, "pull", "--ff-only"]);
-      if (result.exit_code === 0) {
-        if (!result.stdout.includes("Already up to date")) {
-          updated++;
-        }
-      } else {
-        failed++;
-      }
+      failed++;
     }
   }
 
-  editor.setStatus(`Update complete: ${updated} updated, ${all.length - updated - failed} unchanged, ${failed} failed`);
+  editor.setStatus(`Update complete: ${updated} updated, ${failed} failed`);
 }
 
 // =============================================================================
@@ -2010,6 +1981,10 @@ interface PkgManagerState {
   sourceBufferId: number | null;
   filter: "all" | "installed" | "plugins" | "themes" | "languages" | "bundles";
   searchQuery: string;
+  /** Last failed action, shown in the detail panel. The status bar is
+   * overwritten by any other code path, so a failure the user has to
+   * act on gets its own place in this UI. */
+  error: string | null;
   items: PackageListItem[];
   selectedIndex: number;
   focus: FocusTarget;  // What element has Tab focus
@@ -2037,6 +2012,7 @@ const pkgState: PkgManagerState = {
   sourceBufferId: null,
   filter: "all",
   searchQuery: "",
+  error: null,
   items: [],
   selectedIndex: 0,
   focus: { type: "list" },
@@ -2147,10 +2123,44 @@ editor.defineMode(
 );
 
 /**
+ * Compare two dotted version strings numerically, component by
+ * component: negative when `a` sorts before `b`, positive after, zero
+ * when equal. A leading `v` is ignored and non-numeric components
+ * compare as 0, which is enough to answer "is the registry's version
+ * newer than the one on disk" without pulling in a semver parser.
+ */
+function compareVersions(a: string, b: string): number {
+  const parts = (v: string) => v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
+  const av = parts(a);
+  const bv = parts(b);
+  for (let i = 0; i < Math.max(av.length, bv.length); i++) {
+    const diff = (av[i] ?? 0) - (bv[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
  * Build package list from installed and registry data
  */
 function buildPackageList(): PackageListItem[] {
   const items: PackageListItem[] = [];
+
+  // Registry entries, keyed by package name, loaded up front so the
+  // installed rows below can consult them too — an installed package
+  // the registry knows about carries its `latest_version`, which is
+  // the one thing that lets `updateAvailable` be answered honestly.
+  const registrySynced = isRegistrySynced();
+  const registryEntries = new Map<string, RegistryEntry>();
+  const pluginRegistry = registrySynced ? loadRegistry("plugins") : null;
+  const themeRegistry = registrySynced ? loadRegistry("themes") : null;
+  const languageRegistry = registrySynced ? loadRegistry("languages") : null;
+  for (const registry of [pluginRegistry, themeRegistry, languageRegistry]) {
+    if (!registry) continue;
+    for (const [name, entry] of Object.entries(registry.packages)) {
+      registryEntries.set(name, entry);
+    }
+  }
 
   // Get installed packages
   const installedPlugins = getInstalledPackages("plugin");
@@ -2161,26 +2171,35 @@ function buildPackageList(): PackageListItem[] {
 
   for (const pkg of [...installedPlugins, ...installedThemes, ...installedLanguages, ...installedBundles]) {
     installedMap.set(pkg.name, pkg);
+    const entry = registryEntries.get(pkg.name);
+    // An update is "available" when the registry names a version newer
+    // than the one on disk. Packages the registry doesn't list have
+    // nothing to compare against — they still get an Update action,
+    // which re-installs from their recorded source.
+    const latestVersion = entry?.latest_version;
+    const updateAvailable = latestVersion !== undefined
+      && pkg.version !== "unknown"
+      && compareVersions(latestVersion, pkg.version) > 0;
     items.push({
       type: "installed",
       name: pkg.name,
-      description: pkg.manifest?.description || "No description",
+      description: pkg.manifest?.description || entry?.description || "No description",
       version: pkg.version,
       installed: true,
-      updateAvailable: false, // TODO: Check for updates
-      author: pkg.manifest?.author,
-      license: pkg.manifest?.license,
+      updateAvailable,
+      latestVersion,
+      author: pkg.manifest?.author || entry?.author,
+      license: pkg.manifest?.license || entry?.license,
       repository: pkg.source,
+      keywords: pkg.manifest?.keywords || entry?.keywords,
       packageType: pkg.type,
       installedPackage: pkg,
+      registryEntry: entry,
     });
   }
 
   // Get available packages from registry
-  if (isRegistrySynced()) {
-    const pluginRegistry = loadRegistry("plugins");
-    const themeRegistry = loadRegistry("themes");
-
+  if (pluginRegistry && themeRegistry && languageRegistry) {
     for (const [name, entry] of Object.entries(pluginRegistry.packages)) {
       if (!installedMap.has(name)) {
         items.push({
@@ -2226,7 +2245,6 @@ function buildPackageList(): PackageListItem[] {
     }
 
     // Add language packages from registry
-    const languageRegistry = loadRegistry("languages");
     for (const [name, entry] of Object.entries(languageRegistry.packages)) {
       if (!installedMap.has(name)) {
         items.push({
@@ -2334,10 +2352,16 @@ function getActionButtons(): string[] {
   const item = items[pkgState.selectedIndex];
 
   if (item.installed) {
-    if (item.installedPackage?.localSource) {
-      return ["Reinstall", "Uninstall"];
-    }
-    return item.updateAvailable ? ["Update", "Uninstall"] : ["Uninstall"];
+    // "Update" is offered whenever we know where the package came
+    // from, not only when a newer version has been detected: an
+    // update is a re-install from the recorded source, which is also
+    // what the old "Reinstall" button did, so the two collapse into
+    // one action. Gating it on `updateAvailable` is what used to make
+    // it unreachable — that flag is only knowable for packages the
+    // registry lists a version for.
+    const canUpdate = item.installedPackage !== undefined
+      && updateSource(item.installedPackage) !== null;
+    return canUpdate ? ["Update", "Uninstall"] : ["Uninstall"];
   } else {
     return ["Install"];
   }
@@ -2581,6 +2605,9 @@ function buildPkgDetailEntries(): TextPropertyEntry[] {
     entries.push({ text: selectedItem.name + "\n", properties: { type: "detail-title" } });
     entries.push({ text: "─".repeat(Math.min(selectedItem.name.length + 2, 50)) + "\n", properties: { type: "detail-sep" } });
     let metaLine = `v${selectedItem.version}`;
+    if (selectedItem.updateAvailable && selectedItem.latestVersion) {
+      metaLine += ` → v${selectedItem.latestVersion}`;
+    }
     if (selectedItem.author) metaLine += ` • ${selectedItem.author}`;
     if (selectedItem.license) metaLine += ` • ${selectedItem.license}`;
     entries.push({ text: metaLine + "\n", properties: { type: "detail-meta" } });
@@ -2599,6 +2626,16 @@ function buildPkgDetailEntries(): TextPropertyEntry[] {
       let displayUrl = selectedItem.repository.replace(/^https?:\/\//, "").replace(/\.git$/, "");
       if (displayUrl.length > 50) displayUrl = displayUrl.slice(0, 47) + "...";
       entries.push({ text: displayUrl + "\n", properties: { type: "detail-url" } });
+      entries.push({ text: "\n", properties: { type: "blank" } });
+    }
+    if (pkgState.error) {
+      for (const line of wrapText(pkgState.error, 50)) {
+        entries.push({
+          text: line + "\n",
+          properties: { type: "detail-error" },
+          style: { fg: "diagnostics.error" },
+        });
+      }
       entries.push({ text: "\n", properties: { type: "blank" } });
     }
     const actions = getActionButtons();
@@ -2665,6 +2702,7 @@ async function openPackageManager(): Promise<void> {
   pkgState.searchQuery = "";
   pkgState.selectedIndex = 0;
   pkgState.focus = { type: "list" };
+  pkgState.error = null;
 
   // Build package list immediately with installed packages and cached registry
   pkgState.items = buildPackageList();
@@ -2833,6 +2871,8 @@ editor.on("widget_event", (data) => {
     if (itemIdx === pkgState.selectedIndex) return;
     pkgState.selectedIndex = itemIdx;
     pkgState.focus = { type: "list" };
+    // The error belongs to the package it happened on.
+    pkgState.error = null;
     // Re-render header/detail to reflect the new selection;
     // the list itself is already updated by the host (we don't
     // need to call renderPkgList again).
@@ -2871,6 +2911,24 @@ function pkg_prev_button() : void {
 }
 registerHandler("pkg_prev_button", pkg_prev_button);
 
+/**
+ * Run one of the browser's package actions, refreshing the list
+ * afterwards and keeping any failure on screen in the detail panel.
+ * The action's own progress messages still go to the status bar.
+ */
+async function runPackageAction(
+  run: () => Promise<boolean>,
+): Promise<boolean> {
+  pkgState.error = null;
+  lastPackageError = null;
+  const ok = await run();
+  if (!ok) {
+    pkgState.error = lastPackageError ?? "Action failed";
+  }
+  pkgState.items = buildPackageList();
+  return ok;
+}
+
 async function pkg_activate() : Promise<void> {
   if (!pkgState.isOpen) return;
 
@@ -2881,6 +2939,7 @@ async function pkg_activate() : Promise<void> {
     const filters = ["all", "installed", "plugins", "themes", "languages", "bundles"] as const;
     pkgState.filter = filters[focus.index];
     pkgState.selectedIndex = 0;
+    pkgState.error = null;
     pkgState.items = buildPackageList();
     updatePkgManagerView();
     return;
@@ -2926,24 +2985,25 @@ async function pkg_activate() : Promise<void> {
     const actions = getActionButtons();
     const actionName = actions[focus.index];
 
-    if (actionName === "Reinstall" && item.installedPackage) {
-      await reinstallPackage(item.installedPackage);
-      pkgState.items = buildPackageList();
+    const installedPackage = item.installedPackage;
+    if (actionName === "Update" && installedPackage) {
+      await runPackageAction(() => updatePackage(installedPackage));
       updatePkgManagerView();
-    } else if (actionName === "Update" && item.installedPackage) {
-      await updatePackage(item.installedPackage);
-      pkgState.items = buildPackageList();
-      updatePkgManagerView();
-    } else if (actionName === "Uninstall" && item.installedPackage) {
-      await removePackage(item.installedPackage);
-      pkgState.items = buildPackageList();
+    } else if (actionName === "Uninstall" && installedPackage) {
+      await runPackageAction(() => removePackage(installedPackage));
       const newItems = getFilteredItems();
       pkgState.selectedIndex = Math.min(pkgState.selectedIndex, Math.max(0, newItems.length - 1));
       pkgState.focus = { type: "list" };
       updatePkgManagerView();
-    } else if (actionName === "Install" && item.registryEntry) {
-      await installPackage(item.registryEntry.repository, item.name, item.packageType);
-      pkgState.items = buildPackageList();
+    } else if (actionName === "Install") {
+      const installUrl = item.registryEntry?.repository ?? item.repository;
+      if (installUrl) {
+        await runPackageAction(() =>
+          installPackage(installUrl, item.name, item.packageType)
+        );
+      } else {
+        pkgState.error = `Cannot install ${item.name}: no source URL`;
+      }
       updatePkgManagerView();
     }
   }
@@ -3160,11 +3220,7 @@ function pkg_update() : void {
     }),
     preview: false,
     onSelect: async (pkg) => {
-      if (pkg.localSource) {
-        await reinstallPackage(pkg);
-      } else {
-        await updatePackage(pkg);
-      }
+      await updatePackage(pkg);
     }
   });
 

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -2,7 +2,6 @@
 
 import {
   hintBar,
-  key,
   list,
   parseHintString,
   WidgetPanel,
@@ -2591,6 +2590,17 @@ function renderPkgList(): void {
       key: "pkg-list",
     }),
   );
+  // The spec's `selectedIndex` only takes effect on the first mount:
+  // `updateWidgetPanel` preserves the host's instance state by design,
+  // so every later render leaves the widget's selection wherever it
+  // was. State it explicitly instead. Without this, a panel that
+  // mounted before the registry finished loading — an empty list, so
+  // selection -1 — kept that -1 once the packages arrived, and the
+  // first two arrow presses went into catching the widget up rather
+  // than moving the selection.
+  if (rowSel >= 0) {
+    pkgState.listPanel.setSelectedIndex("pkg-list", rowSel);
+  }
 }
 
 function buildPkgDetailEntries(): TextPropertyEntry[] {
@@ -2667,6 +2677,13 @@ function renderPkgFooter(): void {
 
 function updatePkgManagerView(): void {
   if (pkgState.groupId === null) return;
+  // The item set changes under the selection — the background registry
+  // sync lands, a filter narrows it, a package is uninstalled — so pin
+  // it back into range before anything renders against it.
+  const itemCount = getFilteredItems().length;
+  pkgState.selectedIndex = itemCount === 0
+    ? 0
+    : Math.min(pkgState.selectedIndex, itemCount - 1);
   // Header + detail still flow through the legacy `setPanelContent`
   // path — their UI shape (filter/sync/search inputs in the header,
   // action buttons in the detail) spans cross-panel focus, which
@@ -2714,7 +2731,10 @@ async function openPackageManager(): Promise<void> {
 
   // Build package list immediately with installed packages and cached registry
   pkgState.items = buildPackageList();
-  pkgState.isLoading = false;
+  // With nothing installed and no cached registry the first paint has
+  // no rows at all. Say so, rather than claiming "No packages found"
+  // while the background sync below is still fetching them.
+  pkgState.isLoading = !isRegistrySynced();
 
   // Create buffer group with layout:
   // vertical: [header(fixed 4), horizontal: [list, detail], footer(fixed 1)]
@@ -2760,12 +2780,24 @@ async function openPackageManager(): Promise<void> {
 
   // Sync registry in background and update view when done
   // User can still interact with installed packages during sync
-  syncRegistry().then(() => {
-    if (pkgState.isOpen) {
-      pkgState.items = buildPackageList();
-      updatePkgManagerView();
-    }
-  });
+  syncRegistry()
+    .then(() => {
+      if (pkgState.isOpen) {
+        pkgState.isLoading = false;
+        pkgState.items = buildPackageList();
+        updatePkgManagerView();
+      }
+    })
+    // Detached, so it needs its own catch: an unhandled rejection here
+    // takes down the plugin runtime, and the browser is perfectly
+    // usable for installed packages without the registry.
+    .catch((e) => {
+      editor.warn(`[pkg] Background registry sync failed: ${e}`);
+      if (pkgState.isOpen) {
+        pkgState.isLoading = false;
+        updatePkgManagerView();
+      }
+    });
 }
 
 /** Whether `bufferId` is still a live buffer. */
@@ -2892,21 +2924,43 @@ function getCurrentFocusIndex(): number {
 }
 
 // Navigation commands
+
+/**
+ * Move the list selection by `delta` packages.
+ *
+ * The plugin owns the selection and pushes it to the List widget
+ * (`renderPkgList`), rather than forwarding the arrow key and adopting
+ * whichever row the host lands on. That indirection is what made Down
+ * look dead: the widget's rows include non-selectable section headers
+ * and a spacer, and its instance state survives every re-render, so a
+ * key press could move the widget's highlight without moving
+ * `pkgState.selectedIndex` at all. Counting in packages makes one
+ * press move the selection by exactly one package, every time.
+ */
+function moveSelection(delta: number): void {
+  pkgState.focus = { type: "list" };
+  const items = getFilteredItems();
+  if (items.length === 0) return;
+  const next = Math.min(
+    items.length - 1,
+    Math.max(0, pkgState.selectedIndex + delta),
+  );
+  if (next === pkgState.selectedIndex) return;
+  pkgState.selectedIndex = next;
+  // The error belongs to the package it happened on.
+  pkgState.error = null;
+  updatePkgManagerView();
+}
+
 function pkg_nav_up(): void {
   if (!pkgState.isOpen) return;
-  // Always snap focus back to the list and let the host move the
-  // List widget's selection. The resulting `widget_event "select"`
-  // updates `pkgState.selectedIndex` and refreshes the detail
-  // panel — see the `widget_event` listener installed below.
-  pkgState.focus = { type: "list" };
-  pkgState.listPanel?.command(key("Up"));
+  moveSelection(-1);
 }
 registerHandler("pkg_nav_up", pkg_nav_up);
 
 function pkg_nav_down(): void {
   if (!pkgState.isOpen) return;
-  pkgState.focus = { type: "list" };
-  pkgState.listPanel?.command(key("Down"));
+  moveSelection(1);
 }
 registerHandler("pkg_nav_down", pkg_nav_down);
 
@@ -2922,7 +2976,17 @@ editor.on("widget_event", (data) => {
       typeof data.payload?.index === "number" ? data.payload.index : -1;
     if (rowIdx < 0) return;
     const itemIdx = selectedRowToItemIndex(rowIdx);
-    if (itemIdx < 0) return; // selection landed on a section header
+    if (itemIdx < 0) {
+      // A click landed on a section header or the blank spacer between
+      // sections. Those aren't packages, so put the highlight back on
+      // the selected one instead of leaving it parked on a row the
+      // detail panel has nothing to say about.
+      const rowSel = itemIndexToRow(pkgState.selectedIndex);
+      if (rowSel >= 0) {
+        pkgState.listPanel?.setSelectedIndex("pkg-list", rowSel);
+      }
+      return;
+    }
     if (itemIdx === pkgState.selectedIndex) return;
     pkgState.selectedIndex = itemIdx;
     pkgState.focus = { type: "list" };

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -837,6 +837,110 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
 }
 
 /**
+ * Read the `version` recorded in an installed package's manifest, or
+ * `null` when the directory holds no readable manifest. Used to name
+ * the version an upgrade replaced.
+ */
+function installedVersion(packageDir: string): string | null {
+  const manifest = readJsonFile<PackageManifest>(
+    editor.pathJoin(packageDir, "package.json"),
+  );
+  return manifest?.version || null;
+}
+
+/**
+ * Unload every plugin running out of `packageDir`.
+ *
+ * Must run before an installed directory is replaced: deleting files
+ * under a loaded plugin leaves the old copy running for the rest of
+ * the session. Matches by path prefix rather than by package name
+ * (the runtime plugin name comes from the entry file), and unloads
+ * every match so a bundle's several plugins all come down.
+ */
+async function unloadPluginsUnder(packageDir: string): Promise<void> {
+  const loadedPlugins = await editor.listPlugins();
+  for (const plugin of loadedPlugins) {
+    if (plugin.path.startsWith(packageDir)) {
+      await editor.unloadPlugin(plugin.name).catch(() => {});
+    }
+  }
+}
+
+/**
+ * Move a freshly fetched, already-validated package into its install
+ * directory, replacing any copy already there.
+ *
+ * Callers validate the staging copy first and unload anything running
+ * out of the target, so by the time this runs the replacement is known
+ * good. The existing copy is renamed aside and only deleted once the
+ * new one is in place; a failed swap puts it back, so an upgrade can
+ * never leave the user without a working install. The backup name
+ * starts with a dot so `getInstalledPackages` never sees it as a
+ * package of its own.
+ *
+ * `move` renames the staging directory in (the git-clone paths, whose
+ * staging lives under the temp dir); otherwise it is copied, leaving
+ * the source intact (local-path installs).
+ */
+function swapInstalledDir(
+  stagingDir: string,
+  packagesDir: string,
+  packageName: string,
+  move: boolean,
+): boolean {
+  const targetDir = editor.pathJoin(packagesDir, packageName);
+  const backupDir = editor.pathJoin(
+    packagesDir,
+    `.${packageName}.replaced-${Date.now()}`,
+  );
+
+  const hadExisting = fsLocal.fileExists(targetDir);
+  if (hadExisting && !fsLocal.renamePath(targetDir, backupDir)) {
+    return false;
+  }
+
+  const placed = move
+    ? fsLocal.renamePath(stagingDir, targetDir)
+    : fsLocal.copyPath(stagingDir, targetDir);
+
+  if (!placed) {
+    if (hadExisting) {
+      fsLocal.removePath(targetDir);
+      fsLocal.renamePath(backupDir, targetDir);
+    }
+    return false;
+  }
+
+  if (hadExisting) {
+    fsLocal.removePath(backupDir);
+  }
+  return true;
+}
+
+/**
+ * Status line for a finished install. `previousVersion` is `null` for a
+ * first install and the replaced version otherwise, so an upgrade reads
+ * as one ("Upgraded file-diff 1.0.0 → 1.1.0"). Re-running an install at
+ * the version already on disk is a deliberate forced refresh (the
+ * source may have moved without the version changing), reported as a
+ * reinstall rather than silently doing nothing.
+ */
+function installedStatus(
+  action: string,
+  packageName: string,
+  previousVersion: string | null,
+  version: string,
+): string {
+  if (previousVersion === null) {
+    return `${action} ${packageName} v${version}`;
+  }
+  if (previousVersion === version) {
+    return `Reinstalled ${packageName} v${version}`;
+  }
+  return `Upgraded ${packageName} ${previousVersion} → ${version}`;
+}
+
+/**
  * Install a package from a git URL, direct file URL, or local path.
  *
  * Supports:
@@ -952,52 +1056,68 @@ async function installFromDirectFile(
   // Sanitize for use as a directory name.
   const safeName = packageName.replace(/[^a-zA-Z0-9_.-]/g, "-");
   const targetDir = editor.pathJoin(THEMES_PACKAGES_DIR, safeName);
+  // Remembered before anything is replaced so the finished install can
+  // report an upgrade; `null` when this is a first install.
+  const previousVersion = fsLocal.fileExists(targetDir)
+    ? installedVersion(targetDir)
+    : null;
 
-  if (fsLocal.fileExists(targetDir)) {
-    editor.setStatus(`Package '${safeName}' is already installed`);
-    fsLocal.removePath(tempFile);
-    return false;
-  }
-
-  ensureDir(THEMES_PACKAGES_DIR);
-  if (!ensureDir(targetDir)) {
-    editor.setStatus(`Failed to create package directory ${targetDir}`);
+  // Stage the whole package in the temp dir first. Only once it is
+  // complete does `swapInstalledDir` touch the installed copy, so a
+  // half-written theme can never replace a working one.
+  const stagingDir = editor.pathJoin(
+    editor.getTempDir(),
+    `fresh-pkg-theme-${hashString(url)}-${Date.now()}`,
+  );
+  if (!ensureDir(stagingDir)) {
+    editor.setStatus(`Failed to create staging directory ${stagingDir}`);
     fsLocal.removePath(tempFile);
     return false;
   }
 
   const themeFileName = "theme.json";
-  if (!fsLocal.writeFile(editor.pathJoin(targetDir, themeFileName), content)) {
+  if (!fsLocal.writeFile(editor.pathJoin(stagingDir, themeFileName), content)) {
     editor.setStatus(`Failed to write theme file`);
     fsLocal.removePath(tempFile);
-    fsLocal.removePath(targetDir);
+    fsLocal.removePath(stagingDir);
     return false;
   }
 
   const manifest: PackageManifest = {
     name: safeName,
-    version: "1.0.0",
+    version: previousVersion ?? "1.0.0",
     description: `Theme installed from ${url}`,
     type: "theme",
     fresh: {
       themes: [{ file: themeFileName, name: themeName ?? safeName }],
     },
   };
-  if (!await writeJsonFile(editor.pathJoin(targetDir, "package.json"), manifest)) {
+  if (!await writeJsonFile(editor.pathJoin(stagingDir, "package.json"), manifest)) {
     editor.setStatus(`Failed to write package manifest`);
     fsLocal.removePath(tempFile);
-    fsLocal.removePath(targetDir);
+    fsLocal.removePath(stagingDir);
     return false;
   }
 
-  await writeJsonFile(editor.pathJoin(targetDir, ".fresh-source.json"), {
+  await writeJsonFile(editor.pathJoin(stagingDir, ".fresh-source.json"), {
     url,
+    installed_from: url,
     installed_at: new Date().toISOString(),
   });
 
+  ensureDir(THEMES_PACKAGES_DIR);
+  if (!swapInstalledDir(stagingDir, THEMES_PACKAGES_DIR, safeName, true)) {
+    editor.setStatus(`Failed to install ${safeName}: could not replace ${targetDir}`);
+    fsLocal.removePath(tempFile);
+    fsLocal.removePath(stagingDir);
+    return false;
+  }
+
   fsLocal.removePath(tempFile);
   editor.reloadThemes();
-  editor.setStatus(`Installed theme ${themeName ?? safeName}`);
+  editor.setStatus(
+    installedStatus("Installed theme", themeName ?? safeName, previousVersion, manifest.version),
+  );
   return true;
 }
 
@@ -1062,38 +1182,55 @@ async function installFromRepo(
                            : LANGUAGES_PACKAGES_DIR;
   const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
-  // Check if already installed in correct location
-  if (fsLocal.fileExists(correctTargetDir)) {
-    editor.setStatus(`Package '${packageName}' is already installed`);
-    fsLocal.removePath(tempDir);
-    return false;
+  // An existing installation is an upgrade, not a dead end. The clone
+  // above is already fetched and validated, so replacing the old copy
+  // from here can only fail on a filesystem error — a bad download
+  // returned long before this point, leaving the install untouched.
+  const previousVersion = fsLocal.fileExists(correctTargetDir)
+    ? installedVersion(correctTargetDir)
+    : null;
+
+  // Record where this came from so the package manager can re-install
+  // it later without re-deriving the URL from the clone's git remote.
+  await writeJsonFile(editor.pathJoin(tempDir, ".fresh-source.json"), {
+    repository: repoUrl,
+    installed_from: repoUrl,
+    installed_at: new Date().toISOString()
+  });
+
+  if (previousVersion !== null) {
+    // Unload before replacing: files deleted under a loaded plugin
+    // leave the old copy running for the rest of the session.
+    await unloadPluginsUnder(correctTargetDir);
   }
 
   // Ensure correct directory exists and move from temp
   ensureDir(correctPackagesDir);
-  if (!fsLocal.renamePath(tempDir, correctTargetDir)) {
+  if (!swapInstalledDir(tempDir, correctPackagesDir, packageName, true)) {
     editor.setStatus(`Failed to install ${packageName}: could not move package to target directory`);
     fsLocal.removePath(tempDir);
     return false;
   }
+
+  const newVersion = manifest?.version ?? "unknown";
 
   // Dynamically load plugins, reload themes, load language packs, or load bundles
   if (manifest?.type === "plugin" && validation.entryPath) {
     // Update entry path to new location
     const newEntryPath = validation.entryPath.replace(tempDir, correctTargetDir);
     await editor.loadPlugin(newEntryPath);
-    editor.setStatus(`Installed and activated ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+    editor.setStatus(installedStatus("Installed and activated", packageName, previousVersion, newVersion));
   } else if (manifest?.type === "theme") {
     editor.reloadThemes();
-    editor.setStatus(`Installed theme ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+    editor.setStatus(installedStatus("Installed theme", packageName, previousVersion, newVersion));
   } else if (manifest?.type === "language") {
     await loadLanguagePack(correctTargetDir, manifest);
-    editor.setStatus(`Installed language pack ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+    editor.setStatus(installedStatus("Installed language pack", packageName, previousVersion, newVersion));
   } else if (manifest?.type === "bundle") {
     await loadBundle(correctTargetDir, manifest);
-    editor.setStatus(`Installed bundle ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+    editor.setStatus(installedStatus("Installed bundle", packageName, previousVersion, newVersion));
   } else {
-    editor.setStatus(`Installed ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+    editor.setStatus(installedStatus("Installed", packageName, previousVersion, newVersion));
   }
   return true;
 }
@@ -1156,29 +1293,34 @@ async function installFromLocalPath(
                            : LANGUAGES_PACKAGES_DIR;
   const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
-  // Check if already installed in correct location
-  if (fsLocal.fileExists(correctTargetDir)) {
-    editor.setStatus(`Package '${packageName}' is already installed`);
-    return false;
-  }
+  // An existing installation is an upgrade, not a dead end.
+  const previousVersion = fsLocal.fileExists(correctTargetDir)
+    ? installedVersion(correctTargetDir)
+    : null;
 
   // Ensure correct directory exists
   ensureDir(correctPackagesDir);
 
-  // Copy the directory to correct target
+  // Copy into a staging directory and validate there, so a source that
+  // turns out not to be a valid package never touches an installation
+  // that already works.
+  const stagingDir = editor.pathJoin(
+    editor.getTempDir(),
+    `fresh-pkg-local-${hashString(sourcePath)}-${Date.now()}`,
+  );
   editor.setStatus(`Copying from ${sourcePath}...`);
-  if (!fsLocal.copyPath(sourcePath, correctTargetDir)) {
+  if (!fsLocal.copyPath(sourcePath, stagingDir)) {
     editor.setStatus(`Failed to copy package from ${sourcePath}`);
     return false;
   }
 
   // Validate package structure
-  const validation = validatePackage(correctTargetDir, packageName);
+  const validation = validatePackage(stagingDir, packageName);
   if (!validation.valid) {
     editor.warn(`[pkg] Invalid package '${packageName}': ${validation.error}`);
     editor.setStatus(`Failed to install ${packageName}: ${validation.error}`);
     // Clean up the invalid package
-    fsLocal.removePath(correctTargetDir);
+    fsLocal.removePath(stagingDir);
     return false;
   }
 
@@ -1188,23 +1330,39 @@ async function installFromLocalPath(
     original_url: parsed.subpath ? `${parsed.repoUrl}#${parsed.subpath}` : parsed.repoUrl,
     installed_at: new Date().toISOString()
   };
-  await writeJsonFile(editor.pathJoin(correctTargetDir, ".fresh-source.json"), sourceInfo);
+  await writeJsonFile(editor.pathJoin(stagingDir, ".fresh-source.json"), sourceInfo);
+
+  if (previousVersion !== null) {
+    // Unload before replacing: files deleted under a loaded plugin
+    // leave the old copy running for the rest of the session.
+    await unloadPluginsUnder(correctTargetDir);
+  }
+  if (!swapInstalledDir(stagingDir, correctPackagesDir, packageName, true)) {
+    editor.setStatus(`Failed to install ${packageName}: could not move package to target directory`);
+    fsLocal.removePath(stagingDir);
+    return false;
+  }
+
+  const newVersion = manifest.version || "unknown";
+  // The validated entry path points into the staging directory; the
+  // package now lives at its install path.
+  const entryPath = validation.entryPath?.replace(stagingDir, correctTargetDir);
 
   // Dynamically load plugins, reload themes, load language packs, or load bundles
-  if (manifest.type === "plugin" && validation.entryPath) {
-    await editor.loadPlugin(validation.entryPath);
-    editor.setStatus(`Installed and activated ${packageName} v${manifest.version || "unknown"}`);
+  if (manifest.type === "plugin" && entryPath) {
+    await editor.loadPlugin(entryPath);
+    editor.setStatus(installedStatus("Installed and activated", packageName, previousVersion, newVersion));
   } else if (manifest.type === "theme") {
     editor.reloadThemes();
-    editor.setStatus(`Installed theme ${packageName} v${manifest.version || "unknown"}`);
+    editor.setStatus(installedStatus("Installed theme", packageName, previousVersion, newVersion));
   } else if (manifest.type === "language") {
     await loadLanguagePack(correctTargetDir, manifest);
-    editor.setStatus(`Installed language pack ${packageName} v${manifest.version || "unknown"}`);
+    editor.setStatus(installedStatus("Installed language pack", packageName, previousVersion, newVersion));
   } else if (manifest.type === "bundle") {
     await loadBundle(correctTargetDir, manifest);
-    editor.setStatus(`Installed bundle ${packageName} v${manifest.version || "unknown"}`);
+    editor.setStatus(installedStatus("Installed bundle", packageName, previousVersion, newVersion));
   } else {
-    editor.setStatus(`Installed ${packageName} v${manifest.version || "unknown"}`);
+    editor.setStatus(installedStatus("Installed", packageName, previousVersion, newVersion));
   }
   return true;
 }
@@ -1280,50 +1438,60 @@ async function installFromMonorepo(
                              : LANGUAGES_PACKAGES_DIR;
     const correctTargetDir = editor.pathJoin(correctPackagesDir, packageName);
 
-    // Check if already installed
-    if (fsLocal.fileExists(correctTargetDir)) {
-      editor.setStatus(`Package '${packageName}' is already installed`);
-      fsLocal.removePath(tempDir);
-      return false;
-    }
+    // An existing installation is an upgrade, not a dead end. The
+    // subdirectory in the clone is already fetched and validated, so
+    // the old copy only goes once the replacement is known good.
+    const previousVersion = fsLocal.fileExists(correctTargetDir)
+      ? installedVersion(correctTargetDir)
+      : null;
 
     // Ensure correct directory exists
     ensureDir(correctPackagesDir);
 
-    // Copy subdirectory to correct target
-    editor.setStatus(`Installing ${packageName} from ${parsed.subpath}...`);
-    if (!fsLocal.copyPath(subpathDir, correctTargetDir)) {
-      editor.setStatus(`Failed to copy package from ${parsed.subpath}`);
-      fsLocal.removePath(tempDir);
-      return false;
-    }
-
-    // Store the original monorepo URL in a .fresh-source file
+    // Store the original monorepo URL in a .fresh-source file. Written
+    // into the clone before the swap so the marker lands with the files
+    // it describes.
     const sourceInfo = {
       repository: parsed.repoUrl,
       subpath: parsed.subpath,
       installed_from: `${parsed.repoUrl}#${parsed.subpath}`,
       installed_at: new Date().toISOString()
     };
-    await writeJsonFile(editor.pathJoin(correctTargetDir, ".fresh-source.json"), sourceInfo);
+    await writeJsonFile(editor.pathJoin(subpathDir, ".fresh-source.json"), sourceInfo);
+
+    if (previousVersion !== null) {
+      // Unload before replacing: files deleted under a loaded plugin
+      // leave the old copy running for the rest of the session.
+      await unloadPluginsUnder(correctTargetDir);
+    }
+
+    // Copy subdirectory to correct target
+    editor.setStatus(`Installing ${packageName} from ${parsed.subpath}...`);
+    if (!swapInstalledDir(subpathDir, correctPackagesDir, packageName, false)) {
+      editor.setStatus(`Failed to copy package from ${parsed.subpath}`);
+      fsLocal.removePath(tempDir);
+      return false;
+    }
+
+    const newVersion = manifest?.version ?? "unknown";
 
     // Dynamically load plugins, reload themes, load language packs, or load bundles
     if (manifest?.type === "plugin" && validation.entryPath) {
       // Update entry path to new location
       const newEntryPath = validation.entryPath.replace(subpathDir, correctTargetDir);
       await editor.loadPlugin(newEntryPath);
-      editor.setStatus(`Installed and activated ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+      editor.setStatus(installedStatus("Installed and activated", packageName, previousVersion, newVersion));
     } else if (manifest?.type === "theme") {
       editor.reloadThemes();
-      editor.setStatus(`Installed theme ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+      editor.setStatus(installedStatus("Installed theme", packageName, previousVersion, newVersion));
     } else if (manifest?.type === "language") {
       await loadLanguagePack(correctTargetDir, manifest);
-      editor.setStatus(`Installed language pack ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+      editor.setStatus(installedStatus("Installed language pack", packageName, previousVersion, newVersion));
     } else if (manifest?.type === "bundle") {
       await loadBundle(correctTargetDir, manifest);
-      editor.setStatus(`Installed bundle ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+      editor.setStatus(installedStatus("Installed bundle", packageName, previousVersion, newVersion));
     } else {
-      editor.setStatus(`Installed ${packageName}${manifest ? ` v${manifest.version}` : ""}`);
+      editor.setStatus(installedStatus("Installed", packageName, previousVersion, newVersion));
     }
     return true;
   } finally {

--- a/crates/fresh-editor/tests/e2e/plugins/package_manager.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/package_manager.rs
@@ -1730,3 +1730,518 @@ globalThis.uninstall_test_hello = function() { editor.setStatus("Hello from unin
         screen
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for the package manager's upgrade / browser behaviour.
+//
+// Each of these reproduces one defect: without the corresponding fix in
+// `plugins/pkg.ts` the assertion fails, or the semantic wait never settles.
+// They all drive the palette and the browser with real keys and assert on
+// rendered output only.
+// ---------------------------------------------------------------------------
+
+/// Everything a package-manager UI test needs: an isolated config dir, a
+/// project repo carrying the `pkg` plugin, and a package index on disk so
+/// the registry sync never reaches the network.
+struct PkgUiEnv {
+    _temp_dir: tempfile::TempDir,
+    dir_context: fresh::config_io::DirectoryContext,
+    repo: GitTestRepo,
+    packages_dir: std::path::PathBuf,
+}
+
+/// Build the shared setup. `registry_packages` is the JSON object body for
+/// the index's `packages` map — `{}` for a registry that lists nothing, so
+/// the browser shows only what is installed.
+fn setup_pkg_ui_env(registry_packages: &str) -> PkgUiEnv {
+    use fresh::config_io::DirectoryContext;
+    use tempfile::TempDir;
+
+    init_tracing_from_env();
+
+    let temp_dir = TempDir::new().unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "pkg");
+
+    let packages_dir = dir_context.config_dir.join("plugins").join("packages");
+    fs::create_dir_all(&packages_dir).unwrap();
+
+    // `193934da` is the pkg plugin's hash of the default registry URL, which
+    // is what the default config points at. Seeding the index means
+    // `isRegistrySynced()` is true on the first paint; the git repo with no
+    // remote makes the background `git pull` exit immediately instead of
+    // going to the network.
+    let fake_registry_dir = packages_dir.join(".index").join("193934da");
+    fs::create_dir_all(&fake_registry_dir).unwrap();
+    fs::write(
+        fake_registry_dir.join("plugins.json"),
+        format!(
+            r#"{{"schema_version": 1, "updated": "2026-01-01T00:00:00Z", "packages": {}}}"#,
+            registry_packages
+        ),
+    )
+    .unwrap();
+    git_init_commit(&fake_registry_dir);
+
+    PkgUiEnv {
+        _temp_dir: temp_dir,
+        dir_context,
+        repo,
+        packages_dir,
+    }
+}
+
+/// `git init` + commit everything in `dir`, with no remote configured.
+fn git_init_commit(dir: &std::path::Path) {
+    for args in [
+        vec!["init"],
+        vec!["add", "."],
+        vec![
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "user.name=T",
+            "commit",
+            "-m",
+            "init",
+        ],
+    ] {
+        std::process::Command::new("git")
+            .args(&args)
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("git {:?} failed in {:?}: {}", args, dir, e));
+    }
+}
+
+/// Write a one-file plugin package into `dir`, registering `command_name` so
+/// the palette can show which version of the code is actually running.
+fn write_plugin_package(
+    dir: &std::path::Path,
+    name: &str,
+    version: &str,
+    description: &str,
+    command_name: &str,
+) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("main.ts"),
+        format!(
+            r#"
+/// <reference path="./lib/fresh.d.ts" />
+const editor = getEditor();
+globalThis.pkg_e2e_cmd = function() {{ editor.setStatus("{name} ran"); }};
+editor.registerCommand("{command_name}", "e2e probe command", "pkg_e2e_cmd", null);
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("package.json"),
+        format!(
+            r#"{{
+    "name": "{name}",
+    "version": "{version}",
+    "description": "{description}",
+    "type": "plugin",
+    "fresh": {{ "entry": "main.ts" }}
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+/// Run a command from the palette by name.
+fn run_palette_command(harness: &mut EditorTestHarness, command: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text(command).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(command))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+}
+
+/// Drive `Package: Install from URL` with `url`.
+fn install_from_url(harness: &mut EditorTestHarness, url: &str) {
+    run_palette_command(harness, "Package: Install from URL");
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Git URL or local path"))
+        .unwrap();
+    harness.type_text(url).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+}
+
+/// Text unique to the package browser being on screen (the filter bar).
+const PKG_BROWSER_MARKER: &str = "Bundles";
+
+/// `Package: Install from URL` must upgrade a package that is already
+/// installed, rather than refusing with "already installed", and the running
+/// session must pick up the new code — not just the files on disk.
+#[test]
+#[cfg_attr(windows, ignore)] // file:// URLs don't work reliably on Windows
+fn test_pkg_install_from_url_upgrades_installed_package() {
+    let env = setup_pkg_ui_env("{}");
+
+    // A monorepo-subpath source: the install path that has no `.git` of its
+    // own, so it is also the one an update can't reach with `git pull`.
+    let monorepo = GitTestRepo::new();
+    let pkg_dir = monorepo.path.join("plugin-alpha");
+    write_plugin_package(
+        &pkg_dir,
+        "plugin-alpha",
+        "1.0.0",
+        "Alpha plugin",
+        "Alpha Version One",
+    );
+    monorepo.git_add_all();
+    monorepo.git_commit("alpha 1.0.0");
+
+    let original_dir = env.repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        35,
+        Default::default(),
+        env.repo.path.clone(),
+        env.dir_context.clone(),
+    )
+    .unwrap();
+
+    let url = format!("file://{}#plugin-alpha", monorepo.path.display());
+
+    install_from_url(&mut harness, &url);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Installed and activated"))
+        .unwrap();
+    assert!(
+        harness.screen_to_string().contains("1.0.0"),
+        "First install should report v1.0.0. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Publish a newer version, with a different command name so the palette
+    // can tell which copy of the code the session is running.
+    write_plugin_package(
+        &pkg_dir,
+        "plugin-alpha",
+        "1.1.0",
+        "Alpha plugin",
+        "Alpha Version Two",
+    );
+    monorepo.git_add_all();
+    monorepo.git_commit("alpha 1.1.0");
+
+    install_from_url(&mut harness, &url);
+
+    // Without the fix this reports "Package 'plugin-alpha' is already
+    // installed" and the wait never settles.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Upgraded"))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("plugin-alpha") && screen.contains("1.0.0") && screen.contains("1.1.0"),
+        "Upgrade should name both versions. Screen:\n{}",
+        screen
+    );
+
+    // The session must be running the new code: the new command is
+    // registered and the old one is gone (it would still be there if the
+    // old copy had been left loaded while its files were replaced).
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Alpha Version").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Alpha Version Two"))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Alpha Version One"),
+        "The replaced version's command should be gone after the upgrade. Screen:\n{}",
+        screen
+    );
+}
+
+/// An installed package must offer a working Update action in the browser,
+/// including one installed from a monorepo subpath — which has no `.git`, so
+/// the old `git pull` implementation could never have updated it.
+#[test]
+#[cfg_attr(windows, ignore)] // file:// URLs don't work reliably on Windows
+fn test_pkg_browser_update_action_reachable_and_updates() {
+    let env = setup_pkg_ui_env("{}");
+
+    let monorepo = GitTestRepo::new();
+    let pkg_dir = monorepo.path.join("plugin-alpha");
+    write_plugin_package(
+        &pkg_dir,
+        "plugin-alpha",
+        "1.0.0",
+        "Alpha plugin",
+        "Alpha Version One",
+    );
+    monorepo.git_add_all();
+    monorepo.git_commit("alpha 1.0.0");
+
+    let original_dir = env.repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        35,
+        Default::default(),
+        env.repo.path.clone(),
+        env.dir_context.clone(),
+    )
+    .unwrap();
+
+    let url = format!("file://{}#plugin-alpha", monorepo.path.display());
+    install_from_url(&mut harness, &url);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Installed and activated"))
+        .unwrap();
+
+    run_palette_command(&mut harness, "Package: Packages");
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(PKG_BROWSER_MARKER) && s.contains("INSTALLED (1)")
+        })
+        .unwrap();
+
+    // Enter on the list moves focus to the selected package's actions.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Uninstall"))
+        .unwrap();
+
+    // Without the fix the only action offered is Uninstall: `updateAvailable`
+    // is hardcoded false and Reinstall needs a local_path this install never
+    // wrote.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Update"),
+        "An installed package with a recorded source should offer Update. Screen:\n{}",
+        screen
+    );
+
+    // Publish a newer version and activate the focused Update button.
+    write_plugin_package(
+        &pkg_dir,
+        "plugin-alpha",
+        "1.1.0",
+        "Alpha plugin",
+        "Alpha Version One",
+    );
+    monorepo.git_add_all();
+    monorepo.git_commit("alpha 1.1.0");
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("1.1.0"))
+        .unwrap();
+}
+
+/// Closing the browser through the editor's own Close Buffer command — not
+/// the plugin's Esc handler — must leave `Package: Packages` able to open it
+/// again.
+#[test]
+fn test_pkg_browser_reopens_after_close_buffer() {
+    let env = setup_pkg_ui_env("{}");
+
+    let original_dir = env.repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        35,
+        Default::default(),
+        env.repo.path.clone(),
+        env.dir_context.clone(),
+    )
+    .unwrap();
+
+    run_palette_command(&mut harness, "Package: Packages");
+    harness
+        .wait_until(|h| h.screen_to_string().contains(PKG_BROWSER_MARKER))
+        .unwrap();
+
+    run_palette_command(&mut harness, "Close Buffer");
+    harness
+        .wait_until(|h| !h.screen_to_string().contains(PKG_BROWSER_MARKER))
+        .unwrap();
+
+    // Without the fix the plugin still believes it is open and this second
+    // open is a no-op, so the browser never comes back.
+    run_palette_command(&mut harness, "Package: Packages");
+    harness
+        .wait_until(|h| h.screen_to_string().contains(PKG_BROWSER_MARKER))
+        .unwrap();
+}
+
+/// The first Down must move the selection, including on an open where the
+/// list was still empty when the panel mounted — the registry had not
+/// finished loading yet.
+#[test]
+#[cfg_attr(windows, ignore)] // file:// URLs don't work reliably on Windows
+fn test_pkg_browser_arrow_down_moves_selection_on_first_press() {
+    use fresh::config_io::DirectoryContext;
+    use tempfile::TempDir;
+
+    init_tracing_from_env();
+
+    let temp_dir = TempDir::new().unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // A registry served from a local git repo, and deliberately *not*
+    // pre-synced: with no index and no cache on disk, the browser's first
+    // paint has no rows at all and the packages only arrive when the
+    // background sync lands. That ordering is what used to leave the list
+    // widget's selection out of step with the plugin's.
+    let registry = GitTestRepo::new();
+    fs::write(
+        registry.path.join("plugins.json"),
+        r#"{
+            "schema_version": 1,
+            "updated": "2026-01-01T00:00:00Z",
+            "packages": {
+                "aaa-plugin": {
+                    "description": "Detail shows Alpha",
+                    "repository": "https://example.invalid/aaa"
+                },
+                "zzz-plugin": {
+                    "description": "Detail shows Zulu",
+                    "repository": "https://example.invalid/zzz"
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    registry.git_add_all();
+    registry.git_commit("registry");
+
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "pkg");
+    fs::create_dir_all(dir_context.config_dir.join("plugins").join("packages")).unwrap();
+
+    let config = fresh::config::Config {
+        packages: fresh::config::PackagesConfig {
+            sources: vec![format!("file://{}", registry.path.display())],
+        },
+        ..Default::default()
+    };
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        35,
+        config,
+        repo.path.clone(),
+        dir_context.clone(),
+    )
+    .unwrap();
+
+    run_palette_command(&mut harness, "Package: Packages");
+
+    // Only the detail panel renders a package's description, so these
+    // strings say which package the selection is on.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Detail shows Alpha"))
+        .unwrap();
+
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+
+    // Without the fix the first presses go into catching the list widget up
+    // with the plugin's selection, so the detail panel doesn't move.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Detail shows Zulu"))
+        .unwrap();
+}
+
+/// A package installed from a URL while the browser is open must appear in
+/// it, without closing and reopening.
+#[test]
+#[cfg_attr(windows, ignore)] // file:// URLs don't work reliably on Windows
+fn test_pkg_url_installed_package_appears_in_open_browser() {
+    let env = setup_pkg_ui_env("{}");
+
+    let monorepo = GitTestRepo::new();
+    write_plugin_package(
+        &monorepo.path.join("plugin-gamma"),
+        "plugin-gamma",
+        "1.0.0",
+        "Gamma plugin",
+        "Gamma Command",
+    );
+    monorepo.git_add_all();
+    monorepo.git_commit("gamma 1.0.0");
+
+    let original_dir = env.repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        35,
+        Default::default(),
+        env.repo.path.clone(),
+        env.dir_context.clone(),
+    )
+    .unwrap();
+
+    run_palette_command(&mut harness, "Package: Packages");
+    harness
+        .wait_until(|h| h.screen_to_string().contains(PKG_BROWSER_MARKER))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("plugin-gamma"),
+        "Nothing is installed yet. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    let url = format!("file://{}#plugin-gamma", monorepo.path.display());
+    install_from_url(&mut harness, &url);
+
+    // Without the fix the browser keeps the package set it was opened with,
+    // so the new package never shows up here.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("INSTALLED (1)"))
+        .unwrap();
+    assert!(
+        harness.screen_to_string().contains("plugin-gamma"),
+        "The newly installed package should be listed. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    assert!(
+        env.packages_dir.join("plugin-gamma").exists(),
+        "The package should also be on disk at {:?}",
+        env.packages_dir.join("plugin-gamma")
+    );
+}


### PR DESCRIPTION
Five separable defects in the package manager (`crates/fresh-editor/plugins/pkg.ts`), one commit each, plus a commit adding an e2e regression test per defect.

## 1. `Package: Install from URL` couldn't upgrade — 652bce7

All four install paths hard-refused when the target directory existed (`Package 'X' is already installed`), so a user wanting a newer version had no route through the command at all.

Each path now treats an existing install as an upgrade, keeping and extending the ordering property the old code had: the replacement is fetched and passed through `validatePackage` **before** the installed copy is touched. `installFromLocalPath` used to copy straight over the target and validate afterwards; it now stages under the temp dir, which is what makes that guarantee hold for local sources too.

Replacing goes through one helper, `swapInstalledDir`: rename the old directory aside, put the new one in place, delete the backup only then — restoring it if the swap fails. The backup name is dot-prefixed so the package scan can't mistake it for a package. Anything running out of the target is unloaded first (every loaded plugin whose path sits under the directory, so a bundle's several plugins all come down); deleting files under a loaded plugin is what leaves the old code running for the rest of the session.

`.fresh-source.json` is rewritten on every install. Plain-repo installs now write one too (`repository` / `installed_from`), which they previously did not.

**A reinstall at the version already on disk is a forced refresh, not a no-op.** A branch or a local directory can move without the manifest version changing, and a user asking to install again is asking for the current source. It reports as `Reinstalled X v1.0.0`; a version change reports `Upgraded X 1.0.0 → 1.1.0`.

## 2. Update and Reinstall were unreachable, and update was wrong — e8c4b9d

Three things: `updateAvailable` was hardcoded `false` at every construction site; `Reinstall` required a `local_path` only `installFromLocalPath` writes; and `updatePackage` was `git -C <pkgdir> pull --ff-only`, which only means anything for a plain-repo install where the clone *became* the installed directory. Monorepo-subpath and local-directory installs are copies with no `.git`, so the pull failed outright.

Update and Reinstall **collapse into one action**: an update re-runs the install from the recorded source. That is what Reinstall did for local packages and what a monorepo install needs, and since (1) made `installPackage` an upgrade, that one call validates before replacing, unloads before deleting and reloads afterwards, for every kind. `reinstallPackage` and the git-pull branch in `updateAllPackages` are gone — both did a subset of this.

The action is offered whenever a source is known rather than when a newer version has been detected. Gating it on "is there an update" is what made it unreachable, and it isn't knowable for a package the registry doesn't list. `updateAvailable` is now computed for real (registry `latest_version` compared numerically against the manifest) and drives **display only** — the `↑` marker and a `v0.9.0 → v1.0.0` line. A locally-newer build no longer claims an update is waiting.

Failures from these actions now surface in the browser's own detail panel, not only on the status bar which any other code path overwrites.

## 3. Closing and reopening the browser didn't work — 6444d96

Closing the group by any route other than the plugin's Esc handler — the tab's ×, File → Close Buffer, a split going away — left `pkgState.isOpen` true. `openPackageManager` then took its "already open, just focus it" branch, which reads `pkgState.bufferId`; **nothing has assigned that since the buffer-group migration**, so the branch fell through and did nothing. `Package: Packages` was dead for the rest of the session.

The plugin now hears about it via a `buffer_closed` handler, and the adopt branch is real: it brings the existing group to the front by its live list-panel buffer, and if that buffer has gone it drops the stale handles and opens a new group.

It was also the missed unmount, as suspected: closing a buffer group is not an unmount. The host keys panels by (plugin, panel id) and is never told the buffer went away, so every open leaked its list and footer panels against dead buffer ids — visible in the log as `pkg:1`/`pkg:2` still mounted while `pkg:3`/`pkg:4` came up on the next open. `closePackageManager` now unmounts both panels first.

## 4. Arrow-down intermittently didn't move — 433fd71

The variable was **whether the registry index was already on disk when the browser opened**.

The list panel mounts with whatever `buildPackageList()` returns at that instant. With nothing installed and no cached registry that is nothing, so the panel mounted with the List widget's selection at `-1`. Every later render goes through `updateWidgetPanel`, which preserves the host's instance state by design and ignores the spec's `selectedIndex` — so when the background sync landed, the widget still selected `-1` while `pkgState.selectedIndex` said `0`. `pkg_nav_down` forwarded the key and let the host move from there, and the rows it moved through are not all packages: `-1` → the `AVAILABLE (n)` section header (which the select handler ignores) → the first package (already the plugin's selection). Two presses spent catching up, detail panel unmoved. With a warm cache the first paint had rows and Down worked — hence intermittent.

The plugin now owns the selection: `renderPkgList` states the intended row on every render, `pkg_nav_up`/`pkg_nav_down` move by one *package* (headers and the spacer can't absorb a press), `updatePkgManagerView` pins the selection into range, and a click on a header row puts the highlight back. Initial focus is therefore deterministic regardless of load order.

Found alongside in the same path: the detached `syncRegistry()` had no `.catch()` (an unhandled rejection is fatal to the plugin runtime), and an open with nothing to show claimed "No packages found" while the sync was still in flight — it now says "Loading...".

## 5. URL-installed packages were second-class — fa66030

Installing while the browser was open did nothing to the browser (the list is built at open and rebuilt only by its own action buttons), so a package just installed from the URL prompt was absent until close-and-reopen; same for the registry and Update/Remove finders. Rows said nothing about package kind. The name came from the directory rather than the manifest. And Update / Remove / Update All / Show Outdated / the lockfile listed plugins and themes only, so a language pack or bundle was in the browser but invisible to all of them.

`Package: Show Outdated` also ran `git fetch` / `rev-list` in every installed directory; copy-installs silently counted as up to date. They're now skipped explicitly and reported as such.

## Heads-up: an upstream packaging bug this uncovered

`sinelaw/fresh-plugins`' `amp/lib/fresh.d.ts` is an **absolute symlink into its author's home directory** (`/home/noam/repos/fresh/...`). Copying it fails on any other machine, so `amp` cannot be installed from the registry at all. Not fixed here — it needs a change in that repo.

It did expose a real defect on our side, now fixed: a directory copy that failed part-way left what it had written at the install path, and the next scan reported that half-package as installed. `swapInstalledDir` clears the partial target (still restoring the previous copy when there was one).

## Tests — 57fddb2

One e2e test per defect, in the existing `tests/e2e/plugins/package_manager.rs`. They drive the palette and the browser with real keys and assert on rendered output only, per CONTRIBUTING. Where a package name would also land in a status message, the assertion uses something only the browser renders — the `INSTALLED (1)` section header, or a description, which only the detail panel draws — so a stale browser cannot satisfy it.

Isolation follows the file's existing pattern: a per-test temp config dir via `DirectoryContext::for_testing`, registry sources served from local git repos, and a seeded index whose git repo has no remote, so nothing reaches the network.

Each was run against `master`'s `pkg.ts` to confirm it actually reproduces (124 = hung on a semantic wait and was killed externally; 101 = assertion failed):

| test | on this branch | on master's pkg.ts |
|---|---|---|
| `..._install_from_url_upgrades_installed_package` | pass | **124** — `Upgraded` never appears |
| `..._browser_update_action_reachable_and_updates` | pass | **101** — browser offers only `Uninstall` |
| `..._browser_reopens_after_close_buffer` | pass | **124** — the browser never reopens |
| `..._browser_arrow_down_moves_selection_on_first_press` | pass | **124** — detail panel doesn't move |
| `..._url_installed_package_appears_in_open_browser` | pass | **124** — no `INSTALLED` section appears |

## Manual verification

The fixes were also driven by hand in a live editor over tmux, which is how the causes were found:

- **Upgrades** end-to-end against `https://github.com/sinelaw/fresh-plugins#file-diff` and local clones of it, through **all four** install paths (monorepo subpath, local path, plain repo, direct-file theme). Each time the palette was checked for the new version's command label, confirming the **running session** picked up the new code rather than just the files on disk.
- **Safety property**: a deliberately broken source left the previous install loaded and intact, with the reason shown in the panel.
- **Reopen**: Esc-close and reopen; tab-×-close and reopen (the permanently-broken case); and re-running the command while open now focuses the existing group keeping its selection.
- **Arrow nav**: both with a warm registry and with the index and cache deleted and nothing installed.
- **Non-registry package**: a plugin published only at a URL renders with name, kind, version, author, licence, description, tags and source URL, updates from its recorded source, uninstalls, and appears the moment it is installed while the browser is open.

`cargo check --all-targets` and `cargo fmt --all -- --check` pass. Plugin type-check is at master's exact baseline — the one pre-existing `fresh?.main` error in `pkg.ts`, unchanged, and no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfjhZo1ELYpvKj98mwmHGT
