### PR TITLE
fix(render): clamp suggestions box to rows above the prompt on short terminals

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2973,11 +2973,19 @@ impl Editor {
             .min(crate::view::prompt::MAX_VISIBLE_SUGGESTIONS);
         let height = suggestion_count as u16 + 2 + hints_height;
 
+        // Clamp the suggestions box to the rows actually available above
+        // the prompt line: on a terminal shorter than the full suggestion
+        // list (plus chrome + hints), the saturating y anchored the box at
+        // row 0 but kept the unclamped height, letting the box (and the
+        // `Clear` behind it) extend past the buffer's last row and panic
+        // with "index outside of buffer".
+        let max_rows_above_prompt = prompt_area.y; // rows 0..=prompt_area.y-1
+        let box_height = (height - hints_height).min(max_rows_above_prompt);
         let suggestions_area = ratatui::layout::Rect {
             x: prompt_area.x,
-            y: prompt_area.y.saturating_sub(height),
+            y: prompt_area.y.saturating_sub(box_height),
             width,
-            height: height - hints_height,
+            height: box_height,
         };
 
         // Blank the buffer cells under the suggestions box only when the


### PR DESCRIPTION
## Problem

Opening a suggestions popup (Quick Open / command palette) in a short terminal panics:

```
thread 'main' panicked at ratatui-core-0.1.0/src/buffer/buffer.rs:250:13:
index outside of buffer: the area is Rect { x: 0, y: 0, width: 182, height: 10 } but index is (0, 10)
```

## Cause

`render_prompt_popups` anchors the suggestions box above the prompt line:

```rust
let height = suggestion_count as u16 + 2 + hints_height;   // up to 13 rows
let suggestions_area = Rect {
    y: prompt_area.y.saturating_sub(height),              // saturates to 0
    height: height - hints_height,                        // NOT clamped
    ...
};
```

On a 10-row terminal with the prompt line at y=9 and ≥9 suggestions, the box spans rows 0..12 — past the buffer's last row — and the `Clear` widget rendered into it indexes out of bounds.

## Repro

Terminal of ~10 rows, open Quick Open (`Ctrl+P`, or `M-x` under the emacs keymap) in a project with ≥9 commands/files. Panic on first paint of the popup.

## Fix

Clamp the box height to the rows actually available above the prompt line and anchor its top edge to the clamped height. Verified manually: Quick Open on a 10-row terminal now renders a clamped box instead of panicking.