### PR TITLE
fix(review diff): make the files sidebar scroll properly

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -253,8 +253,10 @@ interface ReviewState {
   // header; falls back to a ratio-derived estimate until the first
   // viewport_changed for that panel arrives.
   panelWidths: Record<string, number>;
-  // Last height in rows the host reported for each panel. The tree and
-  // list widgets need a row budget (`visibleRows`) to scroll within.
+  // Last height in rows the host reported for each panel. The panels'
+  // own list/tree windows are sized by the host; this is what
+  // `refreshViewportDimensions` reads for the diff pane's geometry, and
+  // what makes the side panels' relayout fire once per settled size.
   panelHeights: Record<string, number>;
   // Which comment the rail has selected (null = none). The rail is a
   // List widget: the host owns the selected *row*, the plugin owns which
@@ -2032,14 +2034,6 @@ let filesTree: FilesTree = {
     nodes: [], keys: [], fileByNodeKey: {}, indexByFileKey: {}, groupKeys: [],
 };
 
-/** Rows a side panel's list/tree can use: its height minus the header
- *  (and the filter field when it is showing). */
-function panelListRows(panel: 'files' | 'comments'): number {
-    const height = state.panelHeights[panel] ?? Math.max(8, state.viewportHeight - 6);
-    const chrome = 1 + (panel === 'files' ? 1 : 0); // header (+ filter field)
-    return Math.max(1, height - chrome);
-}
-
 /** The FILES panel spec: header, the filter field while `/` is open, and
  *  the file tree. */
 function buildFilesPanelSpec(): WidgetSpec {
@@ -2080,7 +2074,13 @@ function buildFilesPanelSpec(): WidgetSpec {
             nodes: filesTree.nodes,
             itemKeys: filesTree.keys,
             selectedIndex: selected,
-            visibleRows: panelListRows('files'),
+            // No `visibleRows`: the host sizes the tree to the panel's
+            // live height minus the rows its siblings occupy, and re-runs
+            // that on every resize. A plugin-side budget was a copy of the
+            // height taken from the last `viewport_changed`, and a grown
+            // panel kept the old, shorter window until some unrelated
+            // event happened to repaint it — the rows below the window
+            // stayed blank with files still to show.
             expandedKeys: filesTree.groupKeys,
             indentCols: FILES_TREE_INDENT,
             key: FILES_TREE_KEY,
@@ -2183,7 +2183,7 @@ function buildCommentsPanelSpec(): WidgetSpec {
             items: commentsList.items,
             itemKeys: commentsList.keys,
             selectedIndex: selected,
-            visibleRows: panelListRows('comments'),
+            // Host-auto-sized, like the FILES tree above.
             focusable: true,
             key: COMMENTS_LIST_KEY,
         }),
@@ -6646,7 +6646,14 @@ const REVIEW_LAYOUT = JSON.stringify({
         type: "split",
         direction: "h",
         ratio: FILES_PANEL_RATIO,
-        first: { type: "scrollable", id: "files" },
+        // Both side panels are widget panels whose list/tree owns its
+        // own scroll window, so the buffer under them is pinned
+        // (`scrollable: false`, as search_replace.ts does for the same
+        // reason). Left user-scrollable, a wheel that walked off the end
+        // of the tree fell through to the pane and scrolled the panel
+        // itself: the header slid off the top and a blank row appeared at
+        // the bottom, with no way to scroll it back.
+        first: { type: "scrollable", id: "files", scrollable: false },
         second: {
             type: "split",
             direction: "h",
@@ -6660,7 +6667,7 @@ const REVIEW_LAYOUT = JSON.stringify({
                 first: { type: "fixed", id: "sticky", height: 1 },
                 second: { type: "scrollable", id: "diff" },
             },
-            second: { type: "scrollable", id: "comments" },
+            second: { type: "scrollable", id: "comments", scrollable: false },
         },
     },
 });

--- a/crates/fresh-editor/src/app/chrome/mod.rs
+++ b/crates/fresh-editor/src/app/chrome/mod.rs
@@ -289,6 +289,11 @@ pub(crate) fn pointer_grab(ed: &Editor) -> Option<PointerGrab> {
     {
         return Some(PointerGrab::WidgetScrollbar);
     }
+    // Same grab for a scrollbar on a buffer-mounted widget panel; its
+    // tracks live on the editor rather than on a panel struct.
+    if ed.split_widget_scrollbar_drag.is_some() {
+        return Some(PointerGrab::WidgetScrollbar);
+    }
     let ms = &ed.active_window().mouse_state;
     if ms.dragging_scrollbar.is_some() {
         return Some(PointerGrab::VScrollbar);

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -151,6 +151,18 @@ impl Editor {
     ) -> AnyhowResult<()> {
         use crate::model::event::{CursorId, Event};
         use crossterm::event::KeyModifiers;
+
+        // A scrollbar painted over a buffer-mounted widget panel sits
+        // inside the split's content rect (the panel reserves the columns
+        // for it), so the press arrives here rather than through
+        // `handle_click_scrollbar`. Grab it before anything else: the bar
+        // overlaps the list's rightmost column, and a press there is a
+        // scroll, not a click on the row behind it.
+        if self.try_split_widget_scrollbar_press(col, row) {
+            self.focus_split(split_id, buffer_id);
+            return Ok(());
+        }
+
         // Build modifiers string for plugins
         let modifiers_str = if modifiers.contains(KeyModifiers::SHIFT) {
             "shift".to_string()

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -699,6 +699,10 @@ impl Editor {
             dock_width: None,
             dock_resizing: false,
             widget_text_drag: None,
+            split_widget_scrollbar_tracks: Vec::new(),
+            split_widget_scrollbar_mouse: Default::default(),
+            split_widget_scrollbar_drag: None,
+            widget_panel_render_heights: std::collections::HashMap::new(),
         };
 
         // The plugin per-window filesystem registry is populated on the first

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1408,6 +1408,26 @@ pub struct Editor {
     /// cleared on button-up. `anchor_flat` is the press position as a
     /// flat byte offset into the widget's shadow TextEdit value.
     pub(crate) widget_text_drag: Option<WidgetTextDrag>,
+    /// Screen-space scrollbar tracks painted over buffer-mounted widget
+    /// panels at the last draw, one per overflowing List/Tree, tagged
+    /// with the panel that owns it. Floating panels keep the same thing
+    /// on the panel struct; split-mounted ones have no such struct, so
+    /// the editor holds theirs. Refreshed on every draw — the mouse
+    /// hit-test reads it to start or continue a drag.
+    pub(crate) split_widget_scrollbar_tracks: Vec<(crate::widgets::PanelKey, WidgetScrollbarTrack)>,
+    /// Press/drag/release state for those tracks (the canonical
+    /// `ScrollbarMouse`, as the floating panels use).
+    pub(crate) split_widget_scrollbar_mouse: crate::view::ui::scrollbar::ScrollbarMouse,
+    /// Panel and list key of the split-mounted scrollbar being dragged.
+    pub(crate) split_widget_scrollbar_drag: Option<(crate::widgets::PanelKey, String)>,
+    /// Row budget each buffer-mounted widget panel was last rendered
+    /// against, so a panel whose split has since changed size can be
+    /// re-rendered once — and only once — against the new one. Comparing
+    /// against what was *rendered* (rather than against the previous
+    /// frame's viewport) is what keeps that a single repaint instead of a
+    /// per-frame one.
+    pub(crate) widget_panel_render_heights:
+        std::collections::HashMap<crate::widgets::PanelKey, u32>,
 }
 
 /// See [`Editor::widget_text_drag`].

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -276,6 +276,7 @@ impl Editor {
                 // so no grab can outlive its release even if its
                 // finalizer above was skipped.
                 self.release_widget_scrollbar();
+                self.release_split_widget_scrollbar();
                 self.widget_text_drag = None;
                 self.clear_active_window_drag_state();
 
@@ -980,7 +981,10 @@ impl Editor {
             // owns the input channel while it's up.
             PointerGrab::WidgetScrollbar => {
                 let _ = self.try_widget_scrollbar_drag(super::PanelSlot::Dock, row)
-                    || self.try_widget_scrollbar_drag(super::PanelSlot::Floating, row);
+                    || self.try_widget_scrollbar_drag(super::PanelSlot::Floating, row)
+                    // Buffer-mounted panels (review-diff sidebar, Search &
+                    // Replace) keep their tracks on the editor.
+                    || self.try_split_widget_scrollbar_drag(row);
             }
             // Vertical scrollbar drag: update scroll position.
             PointerGrab::VScrollbar => {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5145,6 +5145,7 @@ impl Editor {
         let panel_width = self.widget_panel_width(buffer_id);
         let avail_height = self.widget_panel_height(buffer_id);
         let out = self.render_panel_spec(&spec, &prev, &prev_focus, panel_width, avail_height);
+        self.record_widget_panel_render_height(&panel_key, avail_height);
         let focus_cursor = out.focus_cursor;
         // KNOWN LIMITATION (deliberate, recorded in the v2 review doc):
         // buffer-mounted panels consume only the base rows + hits —
@@ -5224,6 +5225,7 @@ impl Editor {
         let panel_width = self.widget_panel_width(buffer_id_for_width);
         let avail_height = self.widget_panel_height(buffer_id_for_width);
         let out = self.render_panel_spec(&spec, &prev, &prev_focus, panel_width, avail_height);
+        self.record_widget_panel_render_height(panel_key, avail_height);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         match self.widget_registry.update(

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -782,22 +782,6 @@ impl Editor {
             self.request_plugin_render();
         }
 
-        // A split that changed size takes any widget panel mounted in it
-        // with it: an auto-sized (`visible_rows: None`) list or tree was
-        // windowed to the old row budget, and this draw is the first place
-        // the panel's real rect is known (see
-        // `widget_panels_with_stale_height`). Re-render those panels here
-        // and ask for the frame that shows the result, rather than leaving
-        // a grown panel with blank rows under its short list until
-        // something else happens to repaint it.
-        let resized_panels = self.widget_panels_with_stale_height();
-        if !resized_panels.is_empty() {
-            for panel_key in &resized_panels {
-                self.rerender_widget_panel(panel_key);
-            }
-            self.request_plugin_render();
-        }
-
         // Update previous_viewports for next frame's comparison.
         // Take both `previous_viewports` and the split view-states from
         // the same `__win` borrow so the iterator and the inserts share
@@ -844,6 +828,25 @@ impl Editor {
         self.active_layout_mut().close_split_areas = close_split_areas;
         self.active_layout_mut().maximize_split_areas = maximize_split_areas;
         self.active_layout_mut().view_line_mappings = view_line_mappings;
+
+        // A split that changed size takes any widget panel mounted in it
+        // with it: an auto-sized (`visible_rows: None`) list or tree was
+        // windowed to the old row budget, and the rects published just
+        // above are the first place the panel's new geometry is known.
+        // Re-render those panels against it and ask for the frame that
+        // shows the result, rather than leaving a grown panel with blank
+        // rows under its short list until something else repaints it.
+        // Must stay below the `split_areas` assignment:
+        // `widget_panels_with_stale_height` reads this frame's rects, and
+        // against the previous frame's it would find nothing stale on the
+        // one frame that matters.
+        let restaled_panels = self.widget_panels_with_stale_height();
+        if !restaled_panels.is_empty() {
+            for panel_key in &restaled_panels {
+                self.rerender_widget_panel(panel_key);
+            }
+            self.request_plugin_render();
+        }
 
         // Widget panels mounted into splits render through the ordinary
         // buffer pipeline, which knows nothing about widget geometry —

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -782,6 +782,22 @@ impl Editor {
             self.request_plugin_render();
         }
 
+        // A split that changed size takes any widget panel mounted in it
+        // with it: an auto-sized (`visible_rows: None`) list or tree was
+        // windowed to the old row budget, and this draw is the first place
+        // the panel's real rect is known (see
+        // `widget_panels_with_stale_height`). Re-render those panels here
+        // and ask for the frame that shows the result, rather than leaving
+        // a grown panel with blank rows under its short list until
+        // something else happens to repaint it.
+        let resized_panels = self.widget_panels_with_stale_height();
+        if !resized_panels.is_empty() {
+            for panel_key in &resized_panels {
+                self.rerender_widget_panel(panel_key);
+            }
+            self.request_plugin_render();
+        }
+
         // Update previous_viewports for next frame's comparison.
         // Take both `previous_viewports` and the split view-states from
         // the same `__win` borrow so the iterator and the inserts share
@@ -4874,8 +4890,11 @@ impl Editor {
         use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
 
         // Collect paint jobs first so the layout/registry borrows end
-        // before the frame is written.
+        // before the frame is written. Each job also becomes a track the
+        // mouse hit-test can grab, so these bars drag like the floating
+        // panels' do instead of being decoration.
         let mut jobs: Vec<(ratatui::layout::Rect, ScrollbarState)> = Vec::new();
+        let mut tracks: Vec<(crate::widgets::PanelKey, super::WidgetScrollbarTrack)> = Vec::new();
         for (split_id, buffer_id, content_rect, _, _, _) in &self.active_layout().split_areas {
             let panels = self.widget_registry.panels_for_buffer(*buffer_id);
             if panels.is_empty() {
@@ -4943,31 +4962,51 @@ impl Editor {
                     // own just past the content rect, so paint into that one
                     // and the two coincide. Two tracks side by side is what
                     // the reserved columns looked like before.
+                    //
+                    // That column only exists when the split actually
+                    // draws a buffer scrollbar. A panel whose buffer is
+                    // non-scrollable (the self-managing widget panels:
+                    // Search & Replace, the review-diff sidebar) is laid
+                    // out to the full split width, so painting past the
+                    // content rect put the bar on the split divider — one
+                    // column outside the panel, where it was overwritten
+                    // and the list looked like it had no scrollbar at all.
                     let region_right = content_rect
                         .x
                         .saturating_add(gutter)
                         .saturating_add(b.col as u16)
                         .saturating_add(b.width.saturating_sub(1) as u16);
                     let panel_right = content_rect.x + content_rect.width.saturating_sub(1);
+                    let has_buffer_scrollbar_column = self.config.editor.show_vertical_scrollbar
+                        && !self.active_window().is_non_scrollable_buffer(*buffer_id);
                     let sb_x = if b.col != 0 {
                         region_right.min(panel_right)
-                    } else if self.config.editor.show_vertical_scrollbar {
+                    } else if has_buffer_scrollbar_column {
                         content_rect.x + content_rect.width
                     } else {
                         panel_right
                     };
-                    jobs.push((
-                        ratatui::layout::Rect {
-                            x: sb_x,
-                            y: y as u16,
-                            width: 1,
-                            height: h as u16,
+                    let rect = ratatui::layout::Rect {
+                        x: sb_x,
+                        y: y as u16,
+                        width: 1,
+                        height: h as u16,
+                    };
+                    jobs.push((rect, ScrollbarState::new(sc.total, sc.visible, sc.offset)));
+                    tracks.push((
+                        panel_key.clone(),
+                        super::WidgetScrollbarTrack {
+                            list_key: b.key.clone().unwrap_or_default(),
+                            rect,
+                            total: sc.total,
+                            visible: sc.visible,
+                            scroll: sc.offset,
                         },
-                        ScrollbarState::new(sc.total, sc.visible, sc.offset),
                     ));
                 }
             }
         }
+        self.split_widget_scrollbar_tracks = tracks;
         if jobs.is_empty() {
             return;
         }

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -768,6 +768,23 @@ impl Editor {
     /// the legacy fallback until it is). No padding is subtracted —
     /// the viewport height is already the buffer's usable rows.
     pub(super) fn widget_panel_height(&self, buffer_id: BufferId) -> Option<u32> {
+        // Prefer the rect the last draw actually gave this panel. The
+        // split view-state's viewport is a seed the layout pass computes,
+        // and for a buffer-group panel it can only be a guess: the group's
+        // inner tree is stashed out of the main split tree, so
+        // `apply_layout` finds no rect for those leaves and falls back to
+        // the whole editor height. Sizing a list to that overshoots the
+        // panel and clips its last rows.
+        let painted = self
+            .active_layout()
+            .split_areas
+            .iter()
+            .find(|(_, id, _, _, _, _)| *id == buffer_id)
+            .map(|(_, _, content_rect, _, _, _)| content_rect.height as u32)
+            .filter(|h| *h > 0);
+        if painted.is_some() {
+            return painted;
+        }
         self.windows
             .get(&self.active_window)
             .and_then(|w| w.buffers.splits())
@@ -777,6 +794,57 @@ impl Editor {
                     .find(|vs| vs.buffer_state(buffer_id).is_some() && vs.viewport.height > 0)
                     .map(|vs| vs.viewport.height as u32)
             })
+    }
+
+    /// Buffer-mounted widget panels whose split no longer matches the row
+    /// budget their auto-sized (`visible_rows: None`) lists and trees were
+    /// windowed to — a resize, a divider drag, a panel becoming visible.
+    ///
+    /// The comparison is against the height the panel was last *rendered*
+    /// against, not against the previous frame's viewport: a panel is then
+    /// repainted once per size change instead of once per frame, however
+    /// many frames the new size takes to settle.
+    pub(super) fn widget_panels_with_stale_height(&self) -> Vec<crate::widgets::PanelKey> {
+        self.widget_registry
+            .panel_keys()
+            .into_iter()
+            .filter(|key| {
+                let Some((buffer_id, _)) = self.widget_registry.buffer_and_spec_ref(key) else {
+                    return false;
+                };
+                // Floating and dock panels size themselves to their own
+                // frame (`floating_panel_inner_height`) and are re-rendered
+                // by the paths that move them; only the split-mounted ones
+                // take their budget from a split.
+                if Self::slot_for_panel_buffer(buffer_id).is_some() {
+                    return false;
+                }
+                match self.widget_panel_height(buffer_id) {
+                    Some(h) => self.widget_panel_render_heights.get(key) != Some(&h),
+                    None => false,
+                }
+            })
+            .collect()
+    }
+
+    /// Record the row budget `panel_key` was just rendered against. Called
+    /// from every path that renders a buffer-mounted panel, so
+    /// [`Self::widget_panels_with_stale_height`] can tell a panel that has
+    /// seen the current geometry from one that has not.
+    pub(super) fn record_widget_panel_render_height(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        avail_height: Option<u32>,
+    ) {
+        match avail_height {
+            Some(h) => {
+                self.widget_panel_render_heights
+                    .insert(panel_key.clone(), h);
+            }
+            None => {
+                self.widget_panel_render_heights.remove(panel_key);
+            }
+        }
     }
 
     /// Re-render an existing widget panel after an in-host state
@@ -793,6 +861,7 @@ impl Editor {
         // with 5 000 nodes that's a multi-MB deep clone per IPC, which
         // dominates the host's per-mutation cost during a streaming
         // search.
+        let rendered_height: Option<u32>;
         let (buffer_id, _is_floating, panel_width, out_pieces) = {
             let (buffer_id, spec) = match self.widget_registry.buffer_and_spec_ref(panel_key) {
                 Some(s) => s,
@@ -842,6 +911,7 @@ impl Editor {
                 Some(slot) => self.floating_panel_inner_height(slot),
                 None => self.widget_panel_height(buffer_id),
             };
+            rendered_height = avail_height;
             let theme_guard = self.theme.read().unwrap();
             let out = render_floating_spec(
                 focus_marker,
@@ -860,6 +930,7 @@ impl Editor {
             (buffer_id, is_floating, panel_width, out)
         };
         let _ = panel_width;
+        self.record_widget_panel_render_height(panel_key, rendered_height);
         let panel_slot = Self::slot_for_panel_buffer(buffer_id);
         let focus_cursor = out_pieces.focus_cursor;
         let entries = out_pieces.entries;
@@ -2450,6 +2521,69 @@ impl Editor {
             self.apply_widget_scroll(&panel_key, &key, off, t.visible);
         }
         true
+    }
+
+    /// Try to start a drag on a scrollbar painted over a *buffer-mounted*
+    /// widget panel (the review-diff sidebar, Search & Replace). Returns
+    /// true when the press landed on a track, so the caller skips the
+    /// click it would otherwise have delivered to the panel underneath.
+    ///
+    /// The floating-panel twin is [`Self::try_widget_scrollbar_press`];
+    /// the difference is only where the tracks live (on the editor here,
+    /// on the panel struct there).
+    pub(super) fn try_split_widget_scrollbar_press(&mut self, col: u16, row: u16) -> bool {
+        use crate::view::ui::scrollbar::ScrollbarState;
+        let Some((panel_key, track)) = self
+            .split_widget_scrollbar_tracks
+            .iter()
+            .find(|(_, t)| crate::view::ui::point_in_rect(t.rect, col, row))
+            .map(|(p, t)| (p.clone(), t.clone()))
+        else {
+            return false;
+        };
+        let state = ScrollbarState::new(track.total, track.visible, track.scroll);
+        let Some(new_offset) = self
+            .split_widget_scrollbar_mouse
+            .press(state, track.rect, col, row)
+        else {
+            return false;
+        };
+        self.split_widget_scrollbar_drag = Some((panel_key.clone(), track.list_key.clone()));
+        self.apply_widget_scroll(&panel_key, &track.list_key, new_offset, track.visible);
+        true
+    }
+
+    /// Continue an in-flight buffer-mounted scrollbar drag. Returns true
+    /// while one is active.
+    pub(super) fn try_split_widget_scrollbar_drag(&mut self, row: u16) -> bool {
+        use crate::view::ui::scrollbar::ScrollbarState;
+        let Some((panel_key, list_key)) = self.split_widget_scrollbar_drag.clone() else {
+            return false;
+        };
+        // Re-read the track: the panel re-renders as it scrolls, so its
+        // recorded geometry is the one from the latest draw.
+        let Some(track) = self
+            .split_widget_scrollbar_tracks
+            .iter()
+            .find(|(p, t)| *p == panel_key && t.list_key == list_key)
+            .map(|(_, t)| t.clone())
+        else {
+            return true;
+        };
+        let state = ScrollbarState::new(track.total, track.visible, track.scroll);
+        if let Some(off) = self
+            .split_widget_scrollbar_mouse
+            .drag(state, track.rect, row)
+        {
+            self.apply_widget_scroll(&panel_key, &list_key, off, track.visible);
+        }
+        true
+    }
+
+    /// End any in-flight buffer-mounted scrollbar drag.
+    pub(super) fn release_split_widget_scrollbar(&mut self) {
+        self.split_widget_scrollbar_mouse.release();
+        self.split_widget_scrollbar_drag = None;
     }
 
     /// End any in-flight floating-panel scrollbar drag.

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -103,6 +103,26 @@ pub(super) fn render_floating_spec(
 /// positionless wheel to pick which widget inside a panel absorbs
 /// the scroll. No kind matching here: the capability is the kind's
 /// declaration.
+/// Whether `spec` contains a `List`/`Tree` that omitted `visible_rows` —
+/// the widgets whose row window is the host's to size, and so the only
+/// ones a change of panel height can leave laid out wrongly.
+fn spec_has_auto_sized_list(spec: &fresh_core::api::WidgetSpec) -> bool {
+    use fresh_core::api::WidgetSpec;
+    if matches!(
+        spec,
+        WidgetSpec::List {
+            visible_rows: None,
+            ..
+        } | WidgetSpec::Tree {
+            visible_rows: None,
+            ..
+        }
+    ) {
+        return true;
+    }
+    spec.children().any(spec_has_auto_sized_list)
+}
+
 fn find_scrollable_widget_key(spec: &fresh_core::api::WidgetSpec) -> Option<String> {
     let meta = crate::widgets::kinds::behavior(spec).box_meta(spec);
     if meta.picker_scroll_target {
@@ -775,15 +795,8 @@ impl Editor {
         // `apply_layout` finds no rect for those leaves and falls back to
         // the whole editor height. Sizing a list to that overshoots the
         // panel and clips its last rows.
-        let painted = self
-            .active_layout()
-            .split_areas
-            .iter()
-            .find(|(_, id, _, _, _, _)| *id == buffer_id)
-            .map(|(_, _, content_rect, _, _, _)| content_rect.height as u32)
-            .filter(|h| *h > 0);
-        if painted.is_some() {
-            return painted;
+        if let Some(painted) = self.painted_panel_height(buffer_id) {
+            return Some(painted);
         }
         self.windows
             .get(&self.active_window)
@@ -796,20 +809,39 @@ impl Editor {
             })
     }
 
+    /// Height of the content rect the last draw gave `buffer_id`, or
+    /// `None` when it wasn't painted into a split at all (hidden panel,
+    /// a group slot pointing at some other buffer).
+    fn painted_panel_height(&self, buffer_id: BufferId) -> Option<u32> {
+        self.active_layout()
+            .split_areas
+            .iter()
+            .find(|(_, id, _, _, _, _)| *id == buffer_id)
+            .map(|(_, _, content_rect, _, _, _)| content_rect.height as u32)
+            .filter(|h| *h > 0)
+    }
+
     /// Buffer-mounted widget panels whose split no longer matches the row
     /// budget their auto-sized (`visible_rows: None`) lists and trees were
     /// windowed to — a resize, a divider drag, a panel becoming visible.
     ///
-    /// The comparison is against the height the panel was last *rendered*
-    /// against, not against the previous frame's viewport: a panel is then
-    /// repainted once per size change instead of once per frame, however
-    /// many frames the new size takes to settle.
+    /// Deliberately narrow, because the repaint it drives happens mid-draw:
+    ///
+    /// * only panels currently painted into a split (a panel whose buffer
+    ///   has been swapped out of its group's slot has no geometry to be
+    ///   stale against, and must not be rewritten underneath the plugin);
+    /// * only panels that actually *have* an auto-sized list or tree —
+    ///   a spec that pins every `visible_rows` lays out the same at any
+    ///   height, so repainting it would be work with no visible effect;
+    /// * and the comparison is against the height the panel was last
+    ///   *rendered* against, not the previous frame's viewport, so a panel
+    ///   is repainted once per size change rather than once per frame.
     pub(super) fn widget_panels_with_stale_height(&self) -> Vec<crate::widgets::PanelKey> {
         self.widget_registry
             .panel_keys()
             .into_iter()
             .filter(|key| {
-                let Some((buffer_id, _)) = self.widget_registry.buffer_and_spec_ref(key) else {
+                let Some((buffer_id, spec)) = self.widget_registry.buffer_and_spec_ref(key) else {
                     return false;
                 };
                 // Floating and dock panels size themselves to their own
@@ -819,10 +851,13 @@ impl Editor {
                 if Self::slot_for_panel_buffer(buffer_id).is_some() {
                     return false;
                 }
-                match self.widget_panel_height(buffer_id) {
-                    Some(h) => self.widget_panel_render_heights.get(key) != Some(&h),
-                    None => false,
+                if !spec_has_auto_sized_list(spec) {
+                    return false;
                 }
+                let Some(painted) = self.painted_panel_height(buffer_id) else {
+                    return false;
+                };
+                self.widget_panel_render_heights.get(key) != Some(&painted)
             })
             .collect()
     }
@@ -2533,10 +2568,29 @@ impl Editor {
     /// on the panel struct there).
     pub(super) fn try_split_widget_scrollbar_press(&mut self, col: u16, row: u16) -> bool {
         use crate::view::ui::scrollbar::ScrollbarState;
+        // Only tracks belonging to a keyed List/Tree: those are the ones
+        // `apply_widget_scroll` can move. A press claimed for anything else
+        // (a keyless box, an overflowing multi-line Text) would scroll
+        // nothing while still swallowing the click the panel underneath
+        // was owed.
         let Some((panel_key, track)) = self
             .split_widget_scrollbar_tracks
             .iter()
-            .find(|(_, t)| crate::view::ui::point_in_rect(t.rect, col, row))
+            .find(|(panel_key, t)| {
+                crate::view::ui::point_in_rect(t.rect, col, row)
+                    && self
+                        .widget_registry
+                        .buffer_and_spec_ref(panel_key)
+                        .is_some_and(|(_, spec)| {
+                            crate::widgets::find_widget_by_key(spec, &t.list_key).is_some_and(|w| {
+                                matches!(
+                                    w,
+                                    fresh_core::api::WidgetSpec::List { .. }
+                                        | fresh_core::api::WidgetSpec::Tree { .. }
+                                )
+                            })
+                        })
+            })
             .map(|(p, t)| (p.clone(), t.clone()))
         else {
             return false;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -2289,3 +2289,189 @@ fn test_normal_review_lays_out_every_file() {
         "both changed files' hunks belong in the stream. Screen:\n{screen}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// FILES sidebar: it owns its scroll window
+// ---------------------------------------------------------------------------
+
+/// A repo with `count` modified `.rs` files — enough of them that the
+/// FILES sidebar's tree cannot show them all at once.
+fn repo_with_many_modified_files(count: usize) -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+    for i in 0..count {
+        fs::write(
+            repo.path.join(format!("src/mod_{i:03}.rs")),
+            format!("pub fn f_{i}() {{}}\n"),
+        )
+        .unwrap();
+    }
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+    for i in 0..count {
+        fs::write(
+            repo.path.join(format!("src/mod_{i:03}.rs")),
+            format!("pub fn f_{i}() {{ /* CHANGED */ }}\n"),
+        )
+        .unwrap();
+    }
+    repo
+}
+
+/// The sidebar's file rows, read out of the left-hand column band the
+/// FILES panel occupies (the diff stream names files too, so the rest of
+/// the row has to be cut away before counting).
+fn sidebar_file_rows(screen: &str, sidebar_cols: usize) -> Vec<String> {
+    screen
+        .lines()
+        .map(|l| l.chars().take(sidebar_cols).collect::<String>())
+        .filter(|l| l.contains("mod_"))
+        .collect()
+}
+
+/// Show the FILES sidebar (the `F` toggle) and settle the frame.
+fn show_files_panel(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('F'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    harness.tick_and_render().unwrap();
+}
+
+/// Growing the terminal must grow the FILES tree with it. The row budget
+/// is the host's — the panel's live height minus its header and filter
+/// row — so the rows the resize added fill with files instead of staying
+/// blank while files are still unshown.
+#[test]
+fn test_files_panel_fills_its_height_after_a_resize() {
+    init_tracing_from_env();
+    let repo = repo_with_many_modified_files(60);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
+
+    let before = sidebar_file_rows(&harness.screen_to_string(), 20).len();
+    assert!(
+        before > 0,
+        "the sidebar should list files to begin with. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    harness.resize(120, 55).unwrap();
+    harness.tick_and_render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let after = sidebar_file_rows(&screen, 20).len();
+    assert!(
+        after >= before + 20,
+        "25 rows of new panel height should carry ~25 more files, not stay \
+         blank: {before} rows before the resize, {after} after. Screen:\n{screen}"
+    );
+}
+
+/// Wheeling past the end of the file tree must stop there. The panel
+/// buffer underneath is pinned (`scrollable: false`), so the wheel can't
+/// fall through to it and carry the panel's own header off the top —
+/// which left a blank row at the bottom that nothing could scroll back.
+#[test]
+fn test_files_panel_wheel_past_the_end_keeps_the_header() {
+    use crossterm::event::{MouseEvent, MouseEventKind};
+
+    init_tracing_from_env();
+    let repo = repo_with_many_modified_files(60);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
+
+    assert!(
+        harness.screen_to_string().contains("FILES"),
+        "the sidebar starts with its header on screen. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Well past the bottom of a 60-file tree, so the last events arrive
+    // with the tree already at its bound.
+    for _ in 0..60 {
+        harness
+            .send_mouse(MouseEvent {
+                kind: MouseEventKind::ScrollDown,
+                column: 5,
+                row: 10,
+                modifiers: KeyModifiers::NONE,
+            })
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("FILES"),
+        "the FILES header must survive a wheel that runs off the end of the \
+         tree — it scrolled off when the wheel fell through to the panel \
+         buffer. Screen:\n{screen}"
+    );
+}
+
+/// The sidebar's scrollbar is the tree's, and it is grabbable: a press on
+/// the track jumps the tree to that position. The bar is painted inside
+/// the panel (the panel reserves the columns for it) because the panel's
+/// buffer is pinned and so reserves no scrollbar column of its own.
+#[test]
+fn test_files_panel_scrollbar_press_scrolls_the_tree() {
+    init_tracing_from_env();
+    let repo = repo_with_many_modified_files(60);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    show_files_panel(&mut harness);
+
+    let screen = harness.screen_to_string();
+    // The panel's right edge: the column of the divider between the
+    // sidebar and the diff, on a row the sidebar is drawing files into.
+    let divider_col = screen
+        .lines()
+        .find(|l| l.chars().take(40).collect::<String>().contains("mod_"))
+        .and_then(|l| l.chars().position(|c| c == '\u{2502}'))
+        .expect("the sidebar is drawn next to the diff") as u16;
+    let track_col = divider_col - 1;
+
+    let before = sidebar_file_rows(&screen, 20);
+    assert!(!before.is_empty());
+
+    // Near the bottom of the track: the tree should jump toward the end
+    // of the list.
+    harness.mouse_click(track_col, 25).unwrap();
+    harness.tick_and_render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let after = sidebar_file_rows(&screen, 20);
+    assert_ne!(
+        before, after,
+        "pressing the sidebar's scrollbar should scroll its tree. \
+         Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -2880,3 +2880,58 @@ fn test_search_replace_positions_track_bulk_edits() {
         .wait_until(|h| cursor_sits_on(h, "ZZNEEDLE two"))
         .unwrap();
 }
+
+/// The results tree is auto-sized (it omits `visibleRows`), so growing
+/// the terminal has to grow the window it renders — the rows the resize
+/// added must fill with matches rather than stay blank while matches are
+/// still unshown. The repaint that does this reads the rects published by
+/// the draw it runs in; against the previous frame's it would find nothing
+/// stale on the one frame that matters, and this panel — unlike the
+/// review-diff sidebar — has no plugin-side relayout to cover for it.
+#[test]
+fn test_search_results_grow_with_the_panel_on_resize() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    for i in 0..40 {
+        fs::write(
+            project_root.join(format!("hit_{i:02}.txt")),
+            "NEEDLE_MARKER here\n",
+        )
+        .unwrap();
+    }
+
+    let start_file = project_root.join("hit_00.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("NEEDLE_MARKER").unwrap();
+
+    // The tree is windowing (40 matches, a panel that fits a handful).
+    harness
+        .wait_until(|h| h.screen_to_string().matches("NEEDLE_MARKER here").count() >= 2)
+        .unwrap();
+    let before = harness
+        .screen_to_string()
+        .matches("NEEDLE_MARKER here")
+        .count();
+
+    harness.resize(120, 60).unwrap();
+    harness.tick_and_render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let after = screen.matches("NEEDLE_MARKER here").count();
+    assert!(
+        after >= before + 5,
+        "the rows the resize added should carry more matches, not stay \
+         blank while 40 of them wait to be shown: {before} match rows \
+         before the resize, {after} after. Screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
Reviewing a range with many files (`HEAD~100..HEAD`, 373 files) left the
FILES sidebar half-empty and its scrollbar useless: rows below the file
list were blank with files still to show, wheeling past the end of the
tree slid the panel's own header off the top, and dragging the bar did
nothing at all.

Three causes, one per layer:

* The sidebar's tree pinned `visibleRows` to a copy of the panel height
  taken from the last `viewport_changed`. A panel that grew kept the old,
  shorter window until some unrelated event repainted it. The host sizes
  an omitted `visibleRows` to the panel's live height minus its chrome,
  so the budget is now the host's.
* Both side panels are widget panels that own their scroll window, but
  their buffers were left user-scrollable, so a wheel that ran off the
  end of the tree fell through to the pane and scrolled the panel itself
  — header off the top, blank row at the bottom, nothing to scroll back.
  They are pinned now (`scrollable: false`), as search_replace.ts already
  does for the same reason.
* The scrollbar a split-mounted widget panel paints was placed one column
  past the content rect, which only exists when the split draws a buffer
  scrollbar of its own. For a pinned panel that column is the split
  divider, so the bar was drawn outside the panel and lost. It now lands
  on the panel's own right edge, and the tracks are recorded at draw time
  so press and drag scroll the list — the same `ScrollbarMouse` path the
  floating panels use, which split-mounted panels never had.

A panel's row budget also has to survive a resize: the group's inner
split tree is stashed out of the main one, so the layout pass finds no
rect for those leaves and seeds them with the whole-editor height.
`widget_panel_height` now prefers the rect the last draw gave the panel,
and a panel whose split no longer matches the height it was rendered
against is re-rendered once, on the frame that establishes the new size.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MEjSG36HtE5jt1dgWyQGVt