### PR TITLE
fix(review diff): pin git's patch format so local diff config can't blank the review (#3066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * **A remote workspace's buffers load off the editor loop.**
 * **Opening a C# file can no longer run project code** - `dotnet restore` is now gated behind Workspace Trust (#2063, reported by @z3moo).
 * **git-gutter works with an external difftool** - it now forces git's own diff format (#2721, by @asukaminato0721).
-* **Review Diff works with an external difftool** - range, working-tree, stash, and single-file reviews now force Git's native patch format instead of mistaking tools such as `difft` for an empty diff (#3066, by @asukaminato0721).
+* **Review Diff works with an external difftool** - range, working-tree, and stash reviews now force Git's native patch format instead of mistaking tools such as `difft` for an empty diff (#3066, by @asukaminato0721).
 * **No blank frame at the horizontal scroll bound** (by @ttenneb).
 * **Modal dialogs are no longer clipped**, and worktree trust isn't re-asked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * **A remote workspace's buffers load off the editor loop.**
 * **Opening a C# file can no longer run project code** - `dotnet restore` is now gated behind Workspace Trust (#2063, reported by @z3moo).
 * **git-gutter works with an external difftool** - it now forces git's own diff format (#2721, by @asukaminato0721).
+* **Review Diff works with an external difftool** - range, working-tree, stash, and single-file reviews now force Git's native patch format instead of mistaking tools such as `difft` for an empty diff.
 * **No blank frame at the horizontal scroll bound** (by @ttenneb).
 * **Modal dialogs are no longer clipped**, and worktree trust isn't re-asked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
   * **A remote workspace's buffers load off the editor loop.**
 * **Opening a C# file can no longer run project code** - `dotnet restore` is now gated behind Workspace Trust (#2063, reported by @z3moo).
 * **git-gutter works with an external difftool** - it now forces git's own diff format (#2721, by @asukaminato0721).
-* **Review Diff works with an external difftool** - range, working-tree, stash, and single-file reviews now force Git's native patch format instead of mistaking tools such as `difft` for an empty diff.
+* **Review Diff works with an external difftool** - range, working-tree, stash, and single-file reviews now force Git's native patch format instead of mistaking tools such as `difft` for an empty diff (#3066, by @asukaminato0721).
 * **No blank frame at the horizontal scroll bound** (by @ttenneb).
 * **Modal dialogs are no longer clipped**, and worktree trust isn't re-asked.
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -830,7 +830,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Staged diffs
     if (hasStaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--cached", "--unified=3"], cwd);
+        const result = await editor.spawnProcess("git", ["diff", "--no-ext-diff", "--cached", "--unified=3"], cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'staged'));
         }
@@ -838,7 +838,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Unstaged diffs
     if (hasUnstaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--unified=3"], cwd);
+        const result = await editor.spawnProcess("git", ["diff", "--no-ext-diff", "--unified=3"], cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'unstaged'));
         }
@@ -847,7 +847,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
     // Untracked file diffs
     for (const f of untrackedFiles) {
         const result = await editor.spawnProcess("git", [
-            "diff", "--no-index", "--unified=3", "/dev/null", f.path
+            "diff", "--no-ext-diff", "--no-index", "--unified=3", "/dev/null", f.path
         ], cwd);
         if (result.stdout.trim()) {
             const hunks = parseDiffOutput(result.stdout, 'untracked');
@@ -6874,7 +6874,10 @@ function parseRangeInput(input: string): ReviewRange | null {
  * still works; untracked / staged categories are meaningless here.
  */
 async function fetchRangeDiff(range: ReviewRange): Promise<{ hunks: Hunk[]; files: FileEntry[] }> {
-    const args = range.command || ["diff", "--unified=3", `${range.from}..${range.to}`];
+    // This output is parsed as a unified patch below. A user-level
+    // `diff.external` setting (for example `difft`) changes the output format,
+    // so force Git's native formatter just as git-gutter does.
+    const args = range.command || ["diff", "--no-ext-diff", "--unified=3", `${range.from}..${range.to}`];
     const cwd = gitCwd();
     const result = await editor.spawnProcess("git", args, cwd);
     if (result.exit_code !== 0) {
@@ -7027,7 +7030,7 @@ editor.on("prompt_confirmed", (args) => {
         from: ref,
         to: ref,
         label: ref,
-        command: ["stash", "show", "-p", "--unified=3", ref],
+        command: ["stash", "show", "-p", "--no-ext-diff", "--unified=3", ref],
     });
     return true;
 });
@@ -7230,12 +7233,12 @@ async function side_by_side_diff_current_file() {
     let diffOutput: string;
     if (isUntracked) {
         // For untracked files, use --no-index to diff against /dev/null
-        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "--no-index", "--unified=3", "--", "/dev/null", filePath]);
+        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "--no-ext-diff", "--no-index", "--unified=3", "--", "/dev/null", filePath]);
         // git diff --no-index exits with 1 when there are differences, which is expected
         diffOutput = result.stdout || "";
     } else {
         // For tracked files, use normal diff against HEAD
-        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "HEAD", "--unified=3", "--", filePath]);
+        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "--no-ext-diff", "HEAD", "--unified=3", "--", filePath]);
         if (result.exit_code !== 0) {
             editor.setStatus(editor.t("status.failed_git_diff"));
             return;

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -817,6 +817,50 @@ async function getGitStatus(): Promise<GitStatusResult> {
 }
 
 /**
+ * Restore git's default `a/` / `b/` path prefixes. Written as `-c` overrides
+ * rather than `--src-prefix=`/`--dst-prefix=`: `git stash show` garbles those
+ * two, while `-c` behaves the same for every sub-command.
+ */
+const DIFF_PREFIX_CONFIG = [
+    "-c", "diff.noprefix=false",
+    "-c", "diff.mnemonicPrefix=false",
+    "-c", "diff.srcPrefix=a/",
+    "-c", "diff.dstPrefix=b/",
+];
+
+/**
+ * Build the `git` argv for a diff-producing sub-command whose stdout
+ * `parseDiffOutput` parses and `buildHunkPatch` rebuilds for `git apply`.
+ * Each knob neutralised here is one a user may legitimately have set, and any
+ * one alone leaves the parser with zero hunks: `diff.external` swaps in a
+ * tool's own format, textconv diffs converted text (so hunk line numbers stop
+ * addressing the real file), `color.diff=always` wraps every line in escapes,
+ * and the prefix settings break the `a/`/`b/` paths it matches on.
+ */
+function diffArgs(subcommand: string[], ...rest: string[]): string[] {
+    return [
+        ...DIFF_PREFIX_CONFIG,
+        ...subcommand,
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        ...rest,
+    ];
+}
+
+/**
+ * Route an already-assembled git argv through `diffArgs`, splitting it at its
+ * first option so the leading sub-command words (`diff`, `stash show`, …) stay
+ * in front. Lets callers that build the argv dynamically inherit the format
+ * pinning instead of each having to repeat the flag list.
+ */
+function withDiffArgs(command: string[]): string[] {
+    const firstOption = command.findIndex(a => a.startsWith("-"));
+    const cut = firstOption === -1 ? command.length : firstOption;
+    return diffArgs(command.slice(0, cut), ...command.slice(cut));
+}
+
+/**
  * Fetch unified diffs for the given file entries.
  * Groups by category to minimize git invocations.
  */
@@ -830,7 +874,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Staged diffs
     if (hasStaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--no-ext-diff", "--cached", "--unified=3"], cwd);
+        const result = await editor.spawnProcess("git", diffArgs(["diff"], "--cached", "--unified=3"), cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'staged'));
         }
@@ -838,7 +882,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Unstaged diffs
     if (hasUnstaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--no-ext-diff", "--unified=3"], cwd);
+        const result = await editor.spawnProcess("git", diffArgs(["diff"], "--unified=3"), cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'unstaged'));
         }
@@ -846,9 +890,11 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Untracked file diffs
     for (const f of untrackedFiles) {
-        const result = await editor.spawnProcess("git", [
-            "diff", "--no-ext-diff", "--no-index", "--unified=3", "/dev/null", f.path
-        ], cwd);
+        const result = await editor.spawnProcess(
+            "git",
+            diffArgs(["diff"], "--no-index", "--unified=3", "/dev/null", f.path),
+            cwd,
+        );
         if (result.stdout.trim()) {
             const hunks = parseDiffOutput(result.stdout, 'untracked');
             for (const h of hunks) {
@@ -6874,10 +6920,10 @@ function parseRangeInput(input: string): ReviewRange | null {
  * still works; untracked / staged categories are meaningless here.
  */
 async function fetchRangeDiff(range: ReviewRange): Promise<{ hunks: Hunk[]; files: FileEntry[] }> {
-    // This output is parsed as a unified patch below. A user-level
-    // `diff.external` setting (for example `difft`) changes the output format,
-    // so force Git's native formatter just as git-gutter does.
-    const args = range.command || ["diff", "--no-ext-diff", "--unified=3", `${range.from}..${range.to}`];
+    // The pinning flags go on *after* the override so every `range.command`
+    // inherits them; a source that spells out its own argv (the stash review)
+    // otherwise has to remember the whole list for itself.
+    const args = withDiffArgs(range.command || ["diff", "--unified=3", `${range.from}..${range.to}`]);
     const cwd = gitCwd();
     const result = await editor.spawnProcess("git", args, cwd);
     if (result.exit_code !== 0) {
@@ -7030,7 +7076,7 @@ editor.on("prompt_confirmed", (args) => {
         from: ref,
         to: ref,
         label: ref,
-        command: ["stash", "show", "-p", "--no-ext-diff", "--unified=3", ref],
+        command: ["stash", "show", "-p", "--unified=3", ref],
     });
     return true;
 });
@@ -7233,12 +7279,12 @@ async function side_by_side_diff_current_file() {
     let diffOutput: string;
     if (isUntracked) {
         // For untracked files, use --no-index to diff against /dev/null
-        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "--no-ext-diff", "--no-index", "--unified=3", "--", "/dev/null", filePath]);
+        const result = await editor.spawnProcess("git", ["-C", gitRoot, ...diffArgs(["diff"], "--no-index", "--unified=3", "--", "/dev/null", filePath)]);
         // git diff --no-index exits with 1 when there are differences, which is expected
         diffOutput = result.stdout || "";
     } else {
         // For tracked files, use normal diff against HEAD
-        const result = await editor.spawnProcess("git", ["-C", gitRoot, "diff", "--no-ext-diff", "HEAD", "--unified=3", "--", filePath]);
+        const result = await editor.spawnProcess("git", ["-C", gitRoot, ...diffArgs(["diff"], "HEAD", "--unified=3", "--", filePath)]);
         if (result.exit_code !== 0) {
             editor.setStatus(editor.t("status.failed_git_diff"));
             return;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -2153,11 +2153,13 @@ fn open_review_range_head(harness: &mut EditorTestHarness) {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
     harness.wait_for_prompt_closed().unwrap();
+    // Gate on the review toolbar, not on the range label or the "Generating"
+    // status. `bootstrapRangeReview` opens the panels only after the diff has
+    // been fetched and parsed, so the toolbar's appearance already implies a
+    // settled stream -- and unlike a status message, no code path can clobber
+    // it and no translation can reword it out from under the wait.
     harness
-        .wait_until(|h| {
-            let s = h.screen_to_string();
-            s.contains("HEAD~..HEAD") && !s.contains("Generating Review")
-        })
+        .wait_until(|h| h.screen_to_string().contains("next hunk"))
         .unwrap();
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -2077,6 +2077,45 @@ fn open_review_range_head(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
+/// A configured external diff driver may emit side-by-side text instead of a
+/// unified patch. Review Range parses Git's patch output, so it must bypass
+/// `diff.external` rather than mistaking the unparseable output for no changes.
+#[test]
+#[cfg(unix)]
+fn test_range_review_ignores_external_diff_and_pager() {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    repo.create_file("src/main.rs", "fn main() {}\n");
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    repo.create_file(
+        "src/main.rs",
+        "fn main() {\n    // RANGE_EXTERNAL_DIFF_MARKER\n}\n",
+    );
+    repo.git_add_all();
+    repo.git_commit("second commit");
+    repo.setup_external_diff_and_pager();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    open_review_range_head(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("RANGE_EXTERNAL_DIFF_MARKER"),
+        "Review Range should render Git's native patch even when diff.external is configured. Screen:\n{screen}"
+    );
+}
+
 /// A big range (the reported case: `HEAD~100..HEAD`) used to open on a
 /// list of file headers and *no diff at all*. Above a line threshold the
 /// stream rendered exactly one file, and the one it picked came from the

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -178,6 +178,23 @@ fn marker_new_line_number(screen: &str, marker: &str) -> Option<u32> {
     gutter.split_whitespace().last()?.parse().ok()
 }
 
+/// Stash the working tree so `Review Stash` has something to show. Reverts the
+/// tree as a side effect, which is what makes the stash the only diff source.
+#[cfg(unix)]
+fn git_stash(repo: &GitTestRepo) {
+    use crate::common::git_test_helper::git_command;
+
+    let output = git_command(&repo.path)
+        .args(["stash", "push", "-m", "review-stash-fixture"])
+        .output()
+        .expect("run git stash");
+    assert!(
+        output.status.success(),
+        "git stash failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // BUG-1: CompositeInputRouter dead code — side-by-side vim keys broken
 // ---------------------------------------------------------------------------
@@ -2260,6 +2277,64 @@ fn test_review_diff_ignores_external_diff_and_format_settings() {
         Some(2),
         "Review Diff should number the marker by the real file, not by textconv \
          output. Screen:\n{screen}"
+    );
+}
+
+/// The stash review is the only caller that reaches `git` through the
+/// `range.command` override, so it is the only test that exercises splicing the
+/// format flags into a multi-word sub-command (`stash show`). It is also where
+/// the choice of `-c diff.srcPrefix=` over `--src-prefix=` is load-bearing:
+/// `git stash show` mangles the latter, which would strip the `a/`/`b/` paths
+/// the diff parser matches on.
+#[test]
+#[cfg(unix)]
+fn test_stash_review_ignores_external_diff_and_format_settings() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    repo.create_file("src/main.rs", "fn main() {}\n");
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    repo.create_file(
+        "src/main.rs",
+        "fn main() {\n    // STASH_EXTERNAL_DIFF_MARKER\n}\n",
+    );
+    git_stash(&repo);
+    configure_hostile_diff_output(&repo);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    harness.run_palette_command("Review Stash").unwrap();
+    // The ref prompt opens prefilled with `stash@{0}`, which is the entry we
+    // just pushed, so confirm it as-is.
+    harness.wait_for_prompt().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("next hunk"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("STASH_EXTERNAL_DIFF_MARKER"),
+        "Review Stash should render Git's native patch even when diff.external, \
+         colour and prefix settings are configured. Screen:\n{screen}"
+    );
+    assert_eq!(
+        marker_new_line_number(&screen, "STASH_EXTERNAL_DIFF_MARKER"),
+        Some(2),
+        "Review Stash should number the marker by the real file. Screen:\n{screen}"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -94,6 +94,47 @@ fn start_server(config: Config) {
     (repo, main_rs)
 }
 
+/// Switch on the git settings that rewrite `git diff`'s output. Each is
+/// something a real user's config may carry, and each on its own is enough to
+/// leave Review Diff's parser with zero hunks: an external driver prints its
+/// own format, a textconv filter diffs converted text, forced colour wraps
+/// every line in escapes, and the prefix settings strip the `a/`/`b/` paths
+/// the parser matches on.
+#[cfg(unix)]
+fn configure_hostile_diff_output(repo: &GitTestRepo) {
+    use crate::common::git_test_helper::git_command;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Stand-ins for `difft` (diff.external) and `delta` (core.pager).
+    repo.setup_external_diff_and_pager();
+
+    // A textconv driver that collapses every `.rs` file to the same text, so
+    // an unsuppressed filter makes the change vanish rather than merely
+    // reformatting it.
+    let textconv = repo.create_file("textconv.sh", "#!/bin/sh\nprintf 'TEXTCONV\\n'\n");
+    fs::set_permissions(&textconv, fs::Permissions::from_mode(0o755))
+        .expect("make textconv script executable");
+    repo.create_file(".gitattributes", "*.rs diff=fresh-test\n");
+    let textconv = textconv.to_string_lossy().into_owned();
+
+    for (key, value) in [
+        ("diff.fresh-test.textconv", textconv.as_str()),
+        ("color.diff", "always"),
+        ("diff.noprefix", "true"),
+        ("diff.mnemonicPrefix", "true"),
+    ] {
+        let output = git_command(&repo.path)
+            .args(["config", "--local", key, value])
+            .output()
+            .expect("run git config");
+        assert!(
+            output.status.success(),
+            "git config {key} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // BUG-1: CompositeInputRouter dead code — side-by-side vim keys broken
 // ---------------------------------------------------------------------------
@@ -2077,12 +2118,12 @@ fn open_review_range_head(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
-/// A configured external diff driver may emit side-by-side text instead of a
-/// unified patch. Review Range parses Git's patch output, so it must bypass
-/// `diff.external` rather than mistaking the unparseable output for no changes.
+/// Review Range parses Git's patch output, so it has to pin the output format
+/// instead of mistaking a user's reformatted (or empty) diff for no changes.
 #[test]
 #[cfg(unix)]
-fn test_range_review_ignores_external_diff_and_pager() {
+fn test_range_review_ignores_external_diff_and_format_settings() {
+    init_tracing_from_env();
     let repo = GitTestRepo::new();
     setup_audit_mode_plugin(&repo);
 
@@ -2096,7 +2137,7 @@ fn test_range_review_ignores_external_diff_and_pager() {
     );
     repo.git_add_all();
     repo.git_commit("second commit");
-    repo.setup_external_diff_and_pager();
+    configure_hostile_diff_output(&repo);
 
     let mut harness = EditorTestHarness::with_config_and_working_dir(
         120,
@@ -2112,7 +2153,48 @@ fn test_range_review_ignores_external_diff_and_pager() {
     let screen = harness.screen_to_string();
     assert!(
         screen.contains("RANGE_EXTERNAL_DIFF_MARKER"),
-        "Review Range should render Git's native patch even when diff.external is configured. Screen:\n{screen}"
+        "Review Range should render Git's native patch even when diff.external, \
+         a textconv filter, colour and prefix settings are configured. Screen:\n{screen}"
+    );
+}
+
+/// The same for the working-tree review, which fetches its hunks through a
+/// different set of `git diff` invocations (staged / unstaged / untracked) and
+/// so needs the format pinned independently of the range path.
+#[test]
+#[cfg(unix)]
+fn test_review_diff_ignores_external_diff_and_format_settings() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    repo.create_file("src/main.rs", "fn main() {}\n");
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    // Leave the change in the working tree: this is the unstaged path.
+    repo.create_file(
+        "src/main.rs",
+        "fn main() {\n    // WORKTREE_EXTERNAL_DIFF_MARKER\n}\n",
+    );
+    configure_hostile_diff_output(&repo);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    let screen = open_review_diff(&mut harness);
+
+    assert!(
+        screen.contains("WORKTREE_EXTERNAL_DIFF_MARKER"),
+        "Review Diff should render Git's native patch for the working tree even \
+         when diff.external, a textconv filter, colour and prefix settings are \
+         configured. Screen:\n{screen}"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -96,28 +96,54 @@ fn start_server(config: Config) {
 
 /// Switch on the git settings that rewrite `git diff`'s output. Each is
 /// something a real user's config may carry, and each on its own is enough to
-/// leave Review Diff's parser with zero hunks: an external driver prints its
-/// own format, a textconv filter diffs converted text, forced colour wraps
-/// every line in escapes, and the prefix settings strip the `a/`/`b/` paths
-/// the parser matches on.
+/// stop Review Diff's parser producing usable hunks: an external driver prints
+/// its own format, a textconv filter diffs converted text, forced colour wraps
+/// every line in escapes, and the prefix settings strip the `a/`/`b/` paths the
+/// parser matches on.
+///
+/// `core.pager` is deliberately not configured: git only starts a pager when
+/// stdout is a tty, and `editor.spawnProcess` reads through a pipe, so a pager
+/// shim could never run and would protect nothing.
 #[cfg(unix)]
 fn configure_hostile_diff_output(repo: &GitTestRepo) {
     use crate::common::git_test_helper::git_command;
     use std::os::unix::fs::PermissionsExt;
 
-    // Stand-ins for `difft` (diff.external) and `delta` (core.pager).
-    repo.setup_external_diff_and_pager();
+    // Everything the fixture installs lives under `.git/`, which git never
+    // reports as untracked. In the working tree these files would show up as
+    // untracked hunks inside the very panel the assertions read, competing for
+    // the rows the marker has to be visible on.
+    let shim = |name: &str, body: &str| -> String {
+        let path = repo.create_file(name, body);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .expect("make diff shim executable");
+        path.to_string_lossy().into_owned()
+    };
 
-    // A textconv driver that collapses every `.rs` file to the same text, so
-    // an unsuppressed filter makes the change vanish rather than merely
-    // reformatting it.
-    let textconv = repo.create_file("textconv.sh", "#!/bin/sh\nprintf 'TEXTCONV\\n'\n");
-    fs::set_permissions(&textconv, fs::Permissions::from_mode(0o755))
-        .expect("make textconv script executable");
-    repo.create_file(".gitattributes", "*.rs diff=fresh-test\n");
-    let textconv = textconv.to_string_lossy().into_owned();
+    // A `difft`-style driver: side-by-side text where a patch is expected.
+    let external = shim(
+        ".git/difft",
+        "#!/bin/sh\nprintf '%s\\n' 'src/main.rs --- Rust' '1 fn main() | 1 fn main()'\n",
+    );
+
+    // The textconv filter *keeps* the difference and prepends two header
+    // lines, so an unsuppressed filter yields a perfectly parseable patch
+    // whose hunk line numbers are all off by two. A filter that erased the
+    // change instead would make git emit an empty diff, and the test would
+    // then fail for "no hunks" without ever exercising the line-number
+    // corruption `--no-textconv` exists to prevent -- the corruption that
+    // feeds `buildHunkPatch` and then `git apply`.
+    let textconv = shim(
+        ".git/textconv.sh",
+        "#!/bin/sh\nprintf 'HDR1\\nHDR2\\n'; cat \"$1\"\n",
+    );
+
+    // `.git/info/attributes` binds the driver exactly as a tracked
+    // `.gitattributes` would, without adding a file to the working tree.
+    repo.create_file(".git/info/attributes", "*.rs diff=fresh-test\n");
 
     for (key, value) in [
+        ("diff.external", external.as_str()),
         ("diff.fresh-test.textconv", textconv.as_str()),
         ("color.diff", "always"),
         ("diff.noprefix", "true"),
@@ -133,6 +159,23 @@ fn configure_hostile_diff_output(repo: &GitTestRepo) {
             String::from_utf8_lossy(&output.stderr)
         );
     }
+}
+
+/// The new-file line number the review panel prints in its gutter for the row
+/// carrying `marker`.
+///
+/// A row reads `<old> <new> +<content>`, drawn to the right of the file-list
+/// divider, so this scans back from the diff prefix rather than assuming a
+/// column: the rightmost `+` before the marker is the diff prefix, and the
+/// last whitespace-separated token in front of it is the new-file number.
+/// Added lines leave the old-number field blank, which is why the last token
+/// is unambiguous.
+#[cfg(unix)]
+fn marker_new_line_number(screen: &str, marker: &str) -> Option<u32> {
+    let row = screen.lines().find(|l| l.contains(marker))?;
+    let (before_marker, _) = row.split_once(marker)?;
+    let (gutter, _) = before_marker.rsplit_once('+')?;
+    gutter.split_whitespace().last()?.parse().ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -2156,6 +2199,16 @@ fn test_range_review_ignores_external_diff_and_format_settings() {
         "Review Range should render Git's native patch even when diff.external, \
          a textconv filter, colour and prefix settings are configured. Screen:\n{screen}"
     );
+    // The marker is the second line of the new file. Under the textconv filter
+    // git would diff two header lines' worth of extra content and report it as
+    // line 4, which parses cleanly and renders the marker just the same -- the
+    // line number is the only thing that gives the corruption away.
+    assert_eq!(
+        marker_new_line_number(&screen, "RANGE_EXTERNAL_DIFF_MARKER"),
+        Some(2),
+        "Review Range should number the marker by the real file, not by \
+         textconv output. Screen:\n{screen}"
+    );
 }
 
 /// The same for the working-tree review, which fetches its hunks through a
@@ -2195,6 +2248,16 @@ fn test_review_diff_ignores_external_diff_and_format_settings() {
         "Review Diff should render Git's native patch for the working tree even \
          when diff.external, a textconv filter, colour and prefix settings are \
          configured. Screen:\n{screen}"
+    );
+    // See the range test: with textconv left on, the patch still parses and the
+    // marker still renders, but every line number is shifted by the filter's
+    // two header lines -- and those numbers are what `buildHunkPatch` hands to
+    // `git apply` when staging or discarding the hunk.
+    assert_eq!(
+        marker_new_line_number(&screen, "WORKTREE_EXTERNAL_DIFF_MARKER"),
+        Some(2),
+        "Review Diff should number the marker by the real file, not by textconv \
+         output. Screen:\n{screen}"
     );
 }
 


### PR DESCRIPTION
## Summary

**Motivation.** Review Diff shells out to `git diff` and parses the unified patch it gets back, then rebuilds `a/`…`b/` patches to feed `git apply`. Each of those invocations inherited whatever the user's git config does to diff output, so a perfectly dirty working tree could render as **"No changes"**. Four settings cause this independently:

| setting | effect on the parser |
|---|---|
| `diff.external` | output replaced by the tool's, nothing parseable |
| textconv filter | both sides converted, so hunk line numbers no longer address the real file — `git apply` then gets a patch that cannot land |
| `color.diff = always` | every line wrapped in ANSI escapes |
| `diff.noprefix` / `diff.mnemonicPrefix` | strips or renames the `a/`/`b/` prefixes the parser matches on |

`--no-ext-diff` alone only covered the first row.

**Goal.** Pin the patch format on every diff the reviewer parses, in one place rather than seven.

**Contents.**
- A single `diffArgs()` helper, with all 7 call sites routed through it: working tree (staged / unstaged / untracked), range, stash, and both side-by-side paths.
- The flags are spliced in *after* the `range.command ||` fallback so command overrides inherit them — the stash path previously needed a hand-patched argv for exactly this reason.
- Prefixes are pinned with `-c diff.srcPrefix=` / `diff.dstPrefix=` plus `noprefix=false` / `mnemonicPrefix=false`, **not** `--src-prefix=` / `--dst-prefix=`. `git stash show` garbles the latter two — it emits a truncated prefix, and which side is mangled depends on argument order — so passing them there would have broken stash review instead of protecting it. The `-c` form also predates `--default-prefix`, so it keeps working on older git.
- Regression tests configure a hostile git (external diff + textconv + forced colour + prefix-less headers) and cover both the range and the working-tree path.

---

fix #3066 

same as https://github.com/sinelaw/fresh/pull/2791
