### PR TITLE
feat(fresh-ui): a box can bound what its children paint and hit

### DIFF
--- a/crates/fresh-ui/README.md
+++ b/crates/fresh-ui/README.md
@@ -70,6 +70,13 @@ render tree (constraints down, sizes up, parents place children), and fold the
 result into a display list. Input runs the other way: hit-test the render tree,
 then capture → target → bubble along the resulting path.
 
+**Layout may over-constrain; paint and hit need not follow it out.** A child is
+normally clamped to the space its parent has left, but a floor it cannot
+satisfy — `min_w` / `min_h` — is a promise layout keeps even when keeping it
+places a sibling outside the parent. A node that says `clip(true)` bounds what
+its descendants may paint *and* hit to its content rect; `border()` implies it,
+because a frame its own content can paint over is not a frame.
+
 ## Subsystems
 
 | Area | What it does | Source |

--- a/crates/fresh-ui/examples/demo.rs
+++ b/crates/fresh-ui/examples/demo.rs
@@ -88,6 +88,30 @@ fn main() {
     demo.deliver_sync(42);
     show(&demo, "a result arrives from another thread", &mut step);
 
+    // The bound, in both directions. The sidebar panel has ten cells inside its
+    // frame and eleven cells of promises: a nine-cell name, a gap that will not
+    // close below one cell, and a one-cell slot. Watch the panel's right wall —
+    // `│clip-test │` becomes `│clip-test M` when nothing bounds the row.
+    demo.input(Input::Key(KeyPress::with(KeyCode::Char('p'), Mods::CTRL)));
+    demo.input(key(KeyCode::Char('c')));
+    demo.input(key(KeyCode::Char('l')));
+    demo.input(key(KeyCode::Enter));
+    show(
+        &demo,
+        "clip off: the slot lands on the panel's wall",
+        &mut step,
+    );
+
+    demo.input(Input::Key(KeyPress::with(KeyCode::Char('p'), Mods::CTRL)));
+    demo.input(key(KeyCode::Char('c')));
+    demo.input(key(KeyCode::Char('l')));
+    demo.input(key(KeyCode::Enter));
+    show(
+        &demo,
+        "clip on: the wall is whole and the slot is not drawn",
+        &mut step,
+    );
+
     let mut huge = Demo::with_app(support::demo::App::huge(1_000_000), Size::new(64, 16));
     huge.input(Input::Wheel {
         pos: Point::new(30, 6),

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -185,6 +185,14 @@ pub struct BoxProps {
     pub gap: u16,
     pub border: bool,
     pub align: Align,
+    /// Bound what descendants may paint and hit to this box's *content* rect —
+    /// inside the border ring and the padding.
+    ///
+    /// Off by default: a plain `row()` or `col()` is a layout grouping, and
+    /// clipping every one of them would cost a bound per node for no gain.
+    /// [`border`](Node::border) turns it on, because a frame its own content
+    /// can paint over is not a frame.
+    pub clip: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -972,8 +980,29 @@ impl<M> Node<M> {
         self
     }
 
+    /// Draw a box outline just inside this node's rectangle, and bound what is
+    /// inside it to the remaining content rect.
+    ///
+    /// The clip comes with the border on purpose. Content laid out in a
+    /// bordered box can still be given a rectangle that reaches the ring — an
+    /// unsatisfiable [`min_w`](Node::min_w) floor is the usual way — and
+    /// without a bound it paints over the frame, turning a corner into a
+    /// letter. Call [`clip(false)`](Node::clip) to keep the border and drop the
+    /// bound.
     pub fn border(mut self) -> Self {
-        self.box_props().border = true;
+        let p = self.box_props();
+        p.border = true;
+        p.clip = true;
+        self
+    }
+
+    /// Bound what descendants may paint and hit to this box's content rect.
+    ///
+    /// Implied by [`border`](Node::border); set it explicitly for an unbordered
+    /// box whose children must not escape — a pane in a split grid, a cell in a
+    /// table.
+    pub fn clip(mut self, on: bool) -> Self {
+        self.box_props().clip = on;
         self
     }
 

--- a/crates/fresh-ui/src/element.rs
+++ b/crates/fresh-ui/src/element.rs
@@ -814,6 +814,7 @@ impl<M: 'static> Ui<M> {
             return;
         };
         let clips = obj.clips();
+        let clip_inset = obj.clip_inset();
         let out_of_flow = obj.out_of_flow();
         let reads_window = obj.reads_window();
         let raw_input = obj.takes_raw_input();
@@ -830,6 +831,7 @@ impl<M: 'static> Ui<M> {
             min_h: 0,
             pointer: None,
             clips,
+            clip_inset,
             out_of_flow,
             reads_window,
             raw_input,
@@ -857,6 +859,7 @@ impl<M: 'static> Ui<M> {
             .desc
             .sync_render(Some(obj.as_mut()));
         let clips = obj.clips();
+        let clip_inset = obj.clip_inset();
         let out_of_flow = obj.out_of_flow();
         let reads_window = obj.reads_window();
         let raw_input = obj.takes_raw_input();
@@ -865,6 +868,7 @@ impl<M: 'static> Ui<M> {
         if let Some(n) = self.render.get_mut(r) {
             n.obj = Some(obj);
             n.clips = clips;
+            n.clip_inset = clip_inset;
             n.out_of_flow = out_of_flow;
             n.reads_window = reads_window;
             n.raw_input = raw_input;

--- a/crates/fresh-ui/src/render/geom.rs
+++ b/crates/fresh-ui/src/render/geom.rs
@@ -224,6 +224,22 @@ impl Rect {
         }
     }
 
+    /// Shrink by `dx` cells on the left and right and `dy` on the top and
+    /// bottom. A rectangle too small to give that up collapses to `ZERO`
+    /// rather than wrapping around into a large one.
+    pub fn deflate(&self, dx: u16, dy: u16) -> Rect {
+        let (dx, dy) = (dx as i32, dy as i32);
+        if self.w as i32 <= 2 * dx || self.h as i32 <= 2 * dy {
+            return Rect::ZERO;
+        }
+        Rect {
+            x: self.x + dx,
+            y: self.y + dy,
+            w: (self.w as i32 - 2 * dx) as u16,
+            h: (self.h as i32 - 2 * dy) as u16,
+        }
+    }
+
     pub fn translate(&self, dx: i32, dy: i32) -> Rect {
         Rect {
             x: self.x + dx,
@@ -266,4 +282,73 @@ pub fn distribute(total: u16, weights: &[u16]) -> Vec<u16> {
         left -= 1;
     }
     out
+}
+
+#[cfg(test)]
+mod rect_tests {
+    use super::Rect;
+
+    #[test]
+    fn deflate_shrinks_on_every_side() {
+        let r = Rect {
+            x: 2,
+            y: 3,
+            w: 10,
+            h: 6,
+        };
+        assert_eq!(
+            r.deflate(1, 1),
+            Rect {
+                x: 3,
+                y: 4,
+                w: 8,
+                h: 4
+            }
+        );
+        assert_eq!(
+            r.deflate(2, 0),
+            Rect {
+                x: 4,
+                y: 3,
+                w: 6,
+                h: 6
+            }
+        );
+        assert_eq!(r.deflate(0, 0), r);
+    }
+
+    /// The case a border hits at the small end: a box two cells wide has no
+    /// inside. Answering `ZERO` keeps that honest — the arithmetic done in
+    /// `u16` would have wrapped `0 - 2` around to 65534 and turned "no room"
+    /// into "unbounded".
+    #[test]
+    fn deflate_past_the_middle_collapses_rather_than_wrapping() {
+        let r = Rect {
+            x: 0,
+            y: 0,
+            w: 2,
+            h: 2,
+        };
+        assert_eq!(r.deflate(1, 1), Rect::ZERO);
+        assert_eq!(
+            Rect {
+                x: 0,
+                y: 0,
+                w: 3,
+                h: 1
+            }
+            .deflate(1, 1),
+            Rect::ZERO
+        );
+        assert_eq!(
+            Rect {
+                x: 5,
+                y: 5,
+                w: 1,
+                h: 40
+            }
+            .deflate(3, 0),
+            Rect::ZERO
+        );
+    }
 }

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -690,11 +690,12 @@ impl<M: 'static> Ui<M> {
     // -- positioning ---------------------------------------------------------
 
     pub(crate) fn arrange(&mut self, r: RenderId, origin: Point, clip: Rect) {
-        let (size, clips, translate, scroll, kids, dirty, was, cached) = {
+        let (size, clips, clip_inset, translate, scroll, kids, dirty, was, cached) = {
             let Some(n) = self.render.get(r) else { return };
             (
                 n.data.size,
                 n.clips,
+                n.clip_inset,
                 n.data.translate,
                 n.data.scroll,
                 n.children.clone(),
@@ -720,7 +721,14 @@ impl<M: 'static> Ui<M> {
             n.data.child_arrange_dirty = false;
         }
         let start = self.pending_layers.len();
-        let child_clip = if clips { clip.intersect(rect) } else { clip };
+        // A clipping node bounds its descendants at its *content* rect, not at
+        // its outer edge: a bordered box owns the ring it drew, so content that
+        // reaches it has escaped rather than arrived.
+        let child_clip = if clips {
+            clip.intersect(rect.deflate(clip_inset.0, clip_inset.1))
+        } else {
+            clip
+        };
         let sc = if clips && translate {
             scroll
         } else {

--- a/crates/fresh-ui/src/render/object.rs
+++ b/crates/fresh-ui/src/render/object.rs
@@ -186,6 +186,17 @@ pub trait RenderObject {
         false
     }
 
+    /// How far inside this node's own rectangle the bound sits, when
+    /// [`clips`](Self::clips) is true: `(x, y)` cells on each side.
+    ///
+    /// A viewport bounds its descendants at its edge and answers `(0, 0)`. A
+    /// bordered box bounds them at the *inside* of its frame, because the ring
+    /// is the box's own paint and content that reaches it has escaped. Ignored
+    /// entirely when `clips()` is false.
+    fn clip_inset(&self) -> (u16, u16) {
+        (0, 0)
+    }
+
     /// Whether this node draws a scrollbar in its gutter — so the framework can
     /// route a press or drag there to the scroll offset. A viewport with a
     /// scrollbar says yes; nothing else does.
@@ -262,6 +273,9 @@ pub(crate) struct RenderNode {
     /// Cached from the object so the framework can ask while the object itself
     /// is checked out for `layout`.
     pub clips: bool,
+    /// `(x, y)` inset of the clip bound inside `rect`; see
+    /// [`RenderObject::clip_inset`]. Meaningful only when `clips` is set.
+    pub clip_inset: (u16, u16),
     pub out_of_flow: bool,
     pub reads_window: bool,
     pub raw_input: bool,

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -267,6 +267,21 @@ pub struct BoxRender {
 }
 
 impl RenderObject for BoxRender {
+    fn clips(&self) -> bool {
+        self.props.clip
+    }
+
+    /// The bound sits inside the border ring and the padding — the same inset
+    /// `layout` uses to place children, so the clip and the content rect are
+    /// the same rectangle by construction rather than by two copies of the sum.
+    fn clip_inset(&self) -> (u16, u16) {
+        let border = u16::from(self.props.border);
+        (
+            self.props.pad.x.saturating_add(border),
+            self.props.pad.y.saturating_add(border),
+        )
+    }
+
     fn layout(&mut self, c: Constraints, cx: &mut dyn LayoutCx) -> Size {
         let p = &self.props;
         let border = u16::from(p.border);

--- a/crates/fresh-ui/tests/golden/context_modal.txt
+++ b/crates/fresh-ui/tests/golden/context_modal.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it┌─────────┐                   #3
-            │»[ ] route │Toggle░░░│                   #4
-            │»[ ] wire u│Delete…  │                   #5
-            │           └─────────┘
+┌──────────┐│»[ ] route │Toggle░░░│                   #4
+│clip-test ││»[ ] wire u│Delete…  │                   #5
+└──────────┘│           └─────────┘
             │
             │
             │
@@ -20,9 +20,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it┌─────────┐                   #3
-            │»[ ] route │Toggle   │                   #4
-            │»[ ] wire u│Delete…░░│                   #5
-            │           └─────────┘
+┌──────────┐│»[ ] route │Toggle   │                   #4
+│clip-test ││»[ ] wire u│Delete…░░│                   #5
+└──────────┘│           └─────────┘
             │
             │
             │
@@ -68,9 +68,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/deleting.txt
+++ b/crates/fresh-ui/tests/golden/deleting.txt
@@ -20,9 +20,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
-            │
+┌──────────┐│»[ ] wire up focus                       #5
+│clip-test ││
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/divider.txt
+++ b/crates/fresh-ui/tests/golden/divider.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │
@@ -20,9 +20,9 @@ Filter              │new task…                      Add
 (o) All░░░░░░░░░░░░░│ ribbon: click the text, it falls t
 ( ) Open            │»[x] build the reconciler        #2
 ( ) Done            │»[ ] lay it out                  #3
-                    │»[ ] route the pointer           #4
-                    │»[ ] wire up focus               #5
-                    │
+┌──────────┐        │»[ ] route the pointer           #4
+│clip-test │        │»[ ] wire up focus               #5
+└──────────┘        │
                     │
                     │
                     │
@@ -36,9 +36,9 @@ Filter  │new task…                                  Add
 (o) All░│ ribbon: click the text, it falls through · las
 ( ) Open│»[x] build the reconciler                    #2
 ( ) Done│»[ ] lay it out                              #3
-        │»[ ] route the pointer                       #4
-        │»[ ] wire up focus                           #5
-        │
+┌──────┐│»[ ] route the pointer                       #4
+│clip-t││»[ ] wire up focus                           #5
+└──────┘│
         │
         │
         │
@@ -52,9 +52,9 @@ Filter  │new task…                                  Add
 (o) All░│ ribbon: click the text, it falls through · las
 ( ) Open│»[x] build the reconciler                    #2
 ( ) Done│»[ ] lay it out                              #3
-        │»[ ] route the pointer                       #4
-        │»[ ] wire up focus                           #5
-        │
+┌──────┐│»[ ] route the pointer                       #4
+│clip-t││»[ ] wire up focus                           #5
+└──────┘│
         │
         │
         │

--- a/crates/fresh-ui/tests/golden/filtering.txt
+++ b/crates/fresh-ui/tests/golden/filtering.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 ( ) All     │ ribbon: click the text, it falls through ·
 (o) Open░░░░│»[ ] route the pointer                   #4
 ( ) Done    │»[ ] wire up focus                       #5
-            │
-            │
-            │
+┌──────────┐│
+│clip-test ││
+└──────────┘│
             │
             │
             │
@@ -20,9 +20,9 @@ Filter      │new task…                              Add
 ( ) All     │ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 (o) Done░░░░│
-            │
-            │
-            │
+┌──────────┐│
+│clip-test ││
+└──────────┘│
             │
             │
             │
@@ -36,9 +36,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/menu.txt
+++ b/crates/fresh-ui/tests/golden/menu.txt
@@ -4,9 +4,9 @@
 │New task│░░│ ribbon: click the text, it falls through ·
 │Quit    │  │»[x] build the reconciler                #2
 └────────┘  │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │
@@ -20,9 +20,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/million.txt
+++ b/crates/fresh-ui/tests/golden/million.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[ ] task 1                             #2│
 ( ) Done    │»[ ] task 2                             #3│
-            │»[x] task 3                             #4│
-            │»[ ] task 4                             #5│
-            │»[ ] task 5                             #6│
+┌──────────┐│»[x] task 3                             #4│
+│clip-test ││»[ ] task 4                             #5│
+└──────────┘│»[ ] task 5                             #6│
             │»[x] task 6                             #7│
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
@@ -20,9 +20,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[ ] task 1                             #2│
 ( ) Done    │»[ ] task 2                             #3│
-            │»[x] task 3                             #4│
-            │»[ ] task 4                             #5│
-            │»[ ] task 5                             #6│
+┌──────────┐│»[x] task 3                             #4│
+│clip-test ││»[ ] task 4                             #5│
+└──────────┘│»[ ] task 5                             #6│
             │»[x] task 6                             #7│
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
@@ -36,9 +36,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[ ] task 1                             #2│
 ( ) Done    │»[ ] task 2                             #3│
-            │»[x] task 3                             #4│
-            │»[ ] task 4                             #5│
-            │»[ ] task 5                             #6│
+┌──────────┐│»[x] task 3                             #4│
+│clip-test ││»[ ] task 4                             #5│
+└──────────┘│»[ ] task 5                             #6│
             │»[x] task 6                             #7│
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
@@ -52,9 +52,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[ ] task 1                             #2│
 ( ) Done    │»[ ] task 2                             #3│
-            │»[x] task 3                             #4│
-            │»[ ] task 4                             #5│
-            │»[ ] task 5                             #6│
+┌──────────┐│»[x] task 3                             #4│
+│clip-test ││»[ ] task 4                             #5│
+└──────────┘│»[ ] task 5                             #6│
             │»[x] task 6                             #7│
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│

--- a/crates/fresh-ui/tests/golden/opening.txt
+++ b/crates/fresh-ui/tests/golden/opening.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/palette.txt
+++ b/crates/fresh-ui/tests/golden/palette.txt
@@ -4,12 +4,12 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x┌──────────────────────┐              #2
 ( ) Done    │»[ │command…▪▪▪▪▪▪▪▪▪▪▪▪▪▪│              #3
-            │»[ │Toggle theme░░░░░░░░░░│              #4
-            │»[ │Toggle preview        │              #5
+┌──────────┐│»[ │Toggle theme░░░░░░░░░░│              #4
+│clip-test ││»[ │Toggle preview        │              #5
+└──────────┘│   │Toggle clipping       │
             │   │Clear done            │
             │   │Sync                  │
             │   └──────────────────────┘
-            │
             │
             │
 5 tasks · light · synced 0 · ready
@@ -19,10 +19,10 @@ Filter      │new task…                              Add
 Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
-( ) Done    │»[ ] lay it out                          #3
-            │»[ ┌──────────────────────┐              #4
-            │»[ │p▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪│              #5
-            │   │Toggle preview░░░░░░░░│
+( ) Done    │»[ ┌──────────────────────┐              #3
+┌──────────┐│»[ │p▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪│              #4
+│clip-test ││»[ │Toggle preview░░░░░░░░│              #5
+└──────────┘│   │Toggle clipping       │
             │   └──────────────────────┘
             │
             │
@@ -36,11 +36,11 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ┌──────────────────────┐              #3
-            │»[ │t▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪│              #4
-            │»[ │Toggle theme░░░░░░░░░░│              #5
-            │   │Toggle preview        │
+┌──────────┐│»[ │t▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪│              #4
+│clip-test ││»[ │Toggle theme░░░░░░░░░░│              #5
+└──────────┘│   │Toggle preview        │
+            │   │Toggle clipping       │
             │   └──────────────────────┘
-            │
             │
             │
             │
@@ -52,9 +52,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │▸[x] build the reconciler                #2
 ( ) Done    │▸[ ] lay it out                          #3
-            │▸[ ] route the pointer                   #4
-            │▸[ ] wire up focus                       #5
-            │
+┌──────────┐│▸[ ] route the pointer                   #4
+│clip-test ││▸[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/resize.txt
+++ b/crates/fresh-ui/tests/golden/resize.txt
@@ -4,9 +4,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │
@@ -20,8 +20,8 @@ Filter      │new task…    Add
 (o) All░░░░░│ ribbon: click th
 ( ) Open    │»[x] build the re
 ( ) Done    │»[ ] lay it out
-            │»[ ] route the po
-            │»[ ] wire up focu
+┌──────────┐│»[ ] route the po
+└──────────┘│»[ ] wire up focu
 5 tasks · light · synced 0 · r
 
 === at 90x6
@@ -38,9 +38,9 @@ Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │

--- a/crates/fresh-ui/tests/golden/typing.txt
+++ b/crates/fresh-ui/tests/golden/typing.txt
@@ -4,9 +4,9 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │
@@ -20,9 +20,9 @@ Filter      │ship it▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪�
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│
             │
             │
             │
@@ -36,9 +36,9 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │»[ ] ship it                             #6
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│»[ ] ship it                             #6
             │
             │
             │
@@ -52,9 +52,9 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
 (o) All░░░░░│ ribbon: click the text, it falls through ·
 ( ) Open    │»[x] build the reconciler                #2
 ( ) Done    │»[ ] lay it out                          #3
-            │»[ ] route the pointer                   #4
-            │»[ ] wire up focus                       #5
-            │»[ ] ship it                             #6
+┌──────────┐│»[ ] route the pointer                   #4
+│clip-test ││»[ ] wire up focus                       #5
+└──────────┘│»[ ] ship it                             #6
             │
             │
             │

--- a/crates/fresh-ui/tests/paint.rs
+++ b/crates/fresh-ui/tests/paint.rs
@@ -712,3 +712,139 @@ fn a_layer_inside_a_layer_places_against_where_its_parent_landed() {
          rectangle the outer one was finally given"
     );
 }
+
+// ── clipping ───────────────────────────────────────────────────────────────
+
+/// A row whose fixed children cannot fit, where one of them carries an
+/// unsatisfiable `min_w` floor. Ordinary over-wide children are clamped to the
+/// space left, so they never escape; a floor is a promise layout keeps even
+/// when keeping it puts a sibling outside the parent. That is the one way
+/// content reaches a box's own frame, and it is not exotic — a name, a gap
+/// that will not close, and a status slot is the shape of a file-tree row.
+fn overflowing_row<M: 'static>() -> Node<M> {
+    row().h(Sizing::Cells(1)).children([
+        text("a-name!").w(Sizing::Cells(7)),
+        row().flex(1).min_w(1),
+        text("M").w(Sizing::Cells(1)),
+    ])
+}
+
+/// The escape, with nothing to stop it: the slot lands on the frame's column.
+#[test]
+fn a_min_w_floor_can_place_a_child_outside_its_parent() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col()
+            .w(Sizing::Cells(10))
+            .border()
+            .clip(false)
+            .child(overflowing_row()),
+        Size { w: 20, h: 4 },
+    );
+    let slot = spec
+        .items
+        .iter()
+        .find(|i| matches!(&i.draw, Draw::Lines(l) if l.first().map(|s| &**s) == Some("M")))
+        .expect("the slot paints");
+    assert_eq!(
+        slot.visible_rect(),
+        Rect {
+            x: 9,
+            y: 1,
+            w: 1,
+            h: 1
+        },
+        "x=9 is the border's own column: unbounded, the slot overwrites the frame"
+    );
+}
+
+/// The same description, bounded — which is the default, because `border()`
+/// turns the bound on. The slot keeps the rectangle layout gave it and paints
+/// nothing, so the frame survives.
+#[test]
+fn a_bordered_box_bounds_what_its_children_paint() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().w(Sizing::Cells(10)).border().child(overflowing_row()),
+        Size { w: 20, h: 4 },
+    );
+    assert!(
+        !spec
+            .items
+            .iter()
+            .any(|i| matches!(&i.draw, Draw::Lines(l) if l.first().map(|s| &**s) == Some("M"))),
+        "fully bounded away, so it is not in the display list at all"
+    );
+    // And nothing else reached the ring either.
+    for i in &spec.items {
+        if matches!(&i.draw, Draw::Lines(_)) {
+            let v = i.visible_rect();
+            assert!(v.x >= 1 && v.right() <= 9, "{v:?} escaped the content rect");
+        }
+    }
+}
+
+/// The bound is the *content* rect. A box that clips without a border still
+/// subtracts its padding, because padding is the box's own space too.
+#[test]
+fn the_bound_is_the_content_rect_not_the_outer_edge() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col()
+            .w(Sizing::Cells(10))
+            .h(Sizing::Cells(4))
+            .clip(true)
+            .pad(2, 1)
+            .child(overflowing_row()),
+        Size { w: 20, h: 6 },
+    );
+    for i in &spec.items {
+        let v = i.visible_rect();
+        if matches!(&i.draw, Draw::Lines(_)) && !v.is_empty() {
+            assert!(
+                v.x >= 2 && v.right() <= 8 && v.y >= 1,
+                "{v:?} escaped the padding"
+            );
+        }
+    }
+}
+
+/// Off by default, so a plain grouping box keeps whatever overflow behaviour
+/// its caller was relying on.
+#[test]
+fn a_plain_box_does_not_bound_its_children() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col().w(Sizing::Cells(8)).child(overflowing_row()),
+        Size { w: 20, h: 4 },
+    );
+    let slot = spec
+        .items
+        .iter()
+        .find(|i| matches!(&i.draw, Draw::Lines(l) if l.first().map(|s| &**s) == Some("M")))
+        .expect("the slot paints");
+    assert_eq!(slot.visible_rect().x, 8, "one past the box's own 8 cells");
+}
+
+/// A box too small to hold its own frame bounds its children to nothing,
+/// rather than to a rectangle that wrapped around into a large one.
+#[test]
+fn a_box_smaller_than_its_own_frame_bounds_to_nothing() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        col()
+            .w(Sizing::Cells(2))
+            .h(Sizing::Cells(2))
+            .border()
+            .child(text("xxxx").w(Sizing::Cells(4))),
+        Size { w: 20, h: 4 },
+    );
+    for i in &spec.items {
+        if matches!(&i.draw, Draw::Lines(_)) {
+            assert!(
+                i.visible_rect().is_empty(),
+                "a 2x2 frame has no inside for text to paint in"
+            );
+        }
+    }
+}

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use fresh_ui::Axis;
 use fresh_ui::{
-    col, gesture, stack, text, viewport, BuildCx, Component, ComponentExt, Event, GestureKind,
+    col, gesture, row, stack, text, viewport, BuildCx, Component, ComponentExt, Event, GestureKind,
     Input, Mods, MouseButton, Node, Point, PointerMode, Size, Sizing, Ui,
 };
 
@@ -701,5 +701,52 @@ fn an_opaque_child_of_a_transparent_strip_still_absorbs() {
         log.borrow().iter().any(|s| s.starts_with("button")),
         "on the button: {:?}",
         log.borrow()
+    );
+}
+
+/// A bound is a statement about input as well as paint. The same over-constrained
+/// row as in `paint.rs`: the status slot is placed on the frame's own column, so
+/// without a bound a press there reaches the slot instead of the box that drew
+/// the frame — a resize grip losing its column to a one-cell label.
+#[test]
+fn a_bound_keeps_a_press_from_reaching_what_was_clipped_away() {
+    let log: Log = Rc::default();
+    let mut ui: Ui<()> = Ui::new();
+    let build =
+        |log: &Log, clip: bool| {
+            col().w(Sizing::Cells(10)).border().clip(clip).child(
+                row().h(Sizing::Cells(1)).children([
+                    text("a-name!").w(Sizing::Cells(7)),
+                    row().flex(1).min_w(1),
+                    traced("slot", log, text("M").w(Sizing::Cells(1))),
+                ]),
+            )
+        };
+
+    // Unbounded, x=9 is the slot's.
+    ui.frame(build(&log, false), FRAME);
+    click(&mut ui, 9, 1);
+    assert!(
+        log.borrow().iter().any(|s| s.starts_with("slot")),
+        "without a bound the escaped cell is the slot's"
+    );
+
+    // Bounded — the default under `border()` — it is not.
+    log.borrow_mut().clear();
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(build(&log, true), FRAME);
+    click(&mut ui, 9, 1);
+    assert!(
+        log.borrow().is_empty(),
+        "a bounded child takes no input outside the bound: {:?}",
+        log.borrow()
+    );
+
+    // And the cells it legitimately occupies still answer.
+    log.borrow_mut().clear();
+    click(&mut ui, 3, 1);
+    assert!(
+        log.borrow().is_empty(),
+        "the name's cells are not the slot's"
     );
 }

--- a/crates/fresh-ui/tests/support/demo/model.rs
+++ b/crates/fresh-ui/tests/support/demo/model.rs
@@ -112,6 +112,10 @@ pub struct App {
     pub resizing: bool,
     pub theme: Rc<Theme>,
     pub preview: bool,
+    /// Whether the overflow panel bounds its children. On by default, because
+    /// `border()` turns it on; the palette's "Toggle clipping" turns it off so
+    /// the escape is visible.
+    pub clip: bool,
     /// The row a context menu is open for, and where it was raised.
     pub context: Option<(usize, Point)>,
     /// The task a delete confirmation is open for.
@@ -127,7 +131,13 @@ pub struct App {
     pub sync_slot: super::view::SyncSlot,
 }
 
-pub const COMMANDS: [&str; 4] = ["Toggle theme", "Toggle preview", "Clear done", "Sync"];
+pub const COMMANDS: [&str; 5] = [
+    "Toggle theme",
+    "Toggle preview",
+    "Toggle clipping",
+    "Clear done",
+    "Sync",
+];
 
 impl Default for App {
     fn default() -> Self {
@@ -211,6 +221,7 @@ impl App {
             resizing: false,
             theme: Rc::new(LIGHT),
             preview: false,
+            clip: true,
             context: None,
             confirm: None,
             palette: None,
@@ -385,11 +396,18 @@ pub fn update(app: &mut App, msg: Msg) {
                     app.status = format!("preview {}", app.preview);
                 }
                 Some(2) => {
+                    app.clip = !app.clip;
+                    app.status = format!(
+                        "clip {} — watch the panel's right wall",
+                        if app.clip { "on" } else { "off" }
+                    );
+                }
+                Some(3) => {
                     Rc::make_mut(&mut app.tasks).retain(|t| !t.done);
                     app.selected = 0;
                     app.status = "cleared done".into();
                 }
-                Some(3) => app.status = "syncing…".into(),
+                Some(4) => app.status = "syncing…".into(),
                 _ => {}
             }
         }

--- a/crates/fresh-ui/tests/support/demo/view.rs
+++ b/crates/fresh-ui/tests/support/demo/view.rs
@@ -114,7 +114,37 @@ fn sidebar(app: &App) -> Node<Msg> {
                 })
             })
             .node(),
+        overflow_panel(app),
     ])
+}
+
+/// A bordered panel whose content cannot fit, so a bound has something to do.
+///
+/// Ten cells inside the frame; eleven cells of promises. A nine-cell name, a
+/// gap that will not close below one cell, and a one-cell slot. An
+/// over-wide child is normally clamped to what remains and never escapes — but
+/// `min_w` is a floor layout keeps *even when keeping it puts the slot outside
+/// the parent*, and outside the parent is the column the border is drawn on.
+///
+/// **"Toggle clipping"** in the palette (Ctrl-P) turns the bound off and on.
+/// With it on — the default, because `border()` implies it — the wall survives
+/// and the slot is simply not drawn: `│clip-test │`. With it off, the slot is
+/// placed on the wall's column and paints over it: `│clip-test M`.
+fn overflow_panel(app: &App) -> Node<Msg> {
+    col()
+        .border()
+        .clip(app.clip)
+        .theme("sidebar")
+        .h(Sizing::Cells(3))
+        // A width of its own, not the sidebar's: ten cells inside the frame,
+        // for eleven cells of promises. Dragging the grip then moves the panel
+        // without changing what it is demonstrating.
+        .w(Sizing::Cells(12))
+        .child(row().h(Sizing::Cells(1)).children([
+            text("clip-test").w(Sizing::Cells(9)),
+            row().flex(1).min_w(1),
+            text("M").w(Sizing::Cells(1)).theme("sidebar.title"),
+        ]))
 }
 
 /// A one-cell column that resizes the sidebar. Pressing it captures the


### PR DESCRIPTION
Second base PR for the `fresh-editor` → `fresh-ui` migration, after #3092. One
library change, found the same way the last three were: by migrating a real
surface and hitting something the tree could not say.

## The escape

Layout may over-constrain. A child is normally clamped to the space its parent
has left, so it never escapes — but a `min_w`/`min_h` floor (added in #3092) is
a promise layout keeps **even when keeping it places a sibling outside the
parent**.

That is the one route by which content reaches a box's own frame, and the shape
that triggers it is ordinary. A name, a gap that will not close below one cell,
and a status slot — a file-tree row:

```rust
col().w(Cells(10)).border().child(
    row().children([
        text("a-name!").w(Cells(7)),
        row().flex(1).min_w(1),   // the gap holds its cell
        text("M").w(Cells(1)),    // …so the slot goes to x=9
    ]),
)
```

Eight cells of room, nine cells of promises. The slot is placed on the column
holding `│` — and on the top row, `┐`. Nothing stopped it, so the panel
silently lost a corner to a letter.

## Why nothing stopped it

`Item.clip` and the whole propagation already existed. `Viewport` was simply the
only node that ever opted in — and it bounds at its **outer edge**, which is the
wrong rectangle for a frame: the ring is the box's own paint, so content that
reaches it has escaped rather than arrived.

## The change

- `BoxProps.clip`, set by `.clip(bool)` and implied by `.border()`.
- `RenderObject::clip_inset` beside `clips`, for *where* the bound sits. A
  viewport keeps answering `(0, 0)`; a box answers border-plus-padding — the
  same inset `layout` uses to place children, read from the same props, so the
  bound and the content rect cannot drift into two copies of one sum.
- `Rect::deflate`, which is where a `2×2` box would otherwise have wrapped
  `0 - 2` around in `u16` and turned "no room inside" into "unbounded".

`border()` implying the bound is the opinionated part. A frame its own content
can paint over is not a frame, and every caller drawing one wants it;
`.clip(false)` after `.border()` declines. Bare `row()`/`col()` stay unbounded —
they are layout groupings, and a bound per node would cost something for
nothing.

The bound covers **hit-testing** too, which `clips` always promised: a cell a
child was clipped out of is no longer that child's to answer. That is the half
that matters for the resize grip the file explorer draws on its border column.

## Tests

`tests/paint.rs` pins both directions from one shared over-constrained row —
the escape with `clip(false)`, the frame surviving with the default — plus the
padding case, the unbounded default, and the `2×2` collapse. `tests/pointer.rs`
pins the input half. `Rect::deflate` has unit tests at the wrap boundary.

Whole `fresh-ui` suite green; `fresh-editor`'s 3426 lib tests pass unchanged, so
nothing in the editor was relying on content escaping a bordered box.

## Three suspected gaps that were not gaps

Recorded because the migration doc listed them as open, and they are now closed
rather than deferred:

| Suspected | Actually |
|---|---|
| Inline styled spans (was "blocks M3/M5") | `text_runs` — one logical string, styled pieces, wraps as a unit |
| Modal focus containment | `Modality::Exclusive` + `FocusScope` |
| Content shaped by its own extent (a rule, a divider, a full-height grip glyph) | `layout_reader` — the builder runs during layout with the constraints |

Still genuinely absent, and deliberately **not** in this PR: markers on
`Draw::Scrollbar`, for the plugin overview-ruler API. The library already owns
`scrollbar_thumb` so every backend renders the bar identically, and marks belong
next to it — but the editor's projection carries ranges, priorities and three
coordinate bases, and picking the wrong coordinate space here would bake a bad
API in with no consumer to correct it. It blocks M9, which is last; it should be
designed against the real projection rather than guessed at now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws2GtzEBQRFZMv8qF61Jzr)_