### PR TITLE
fresh-ui: a stale boundary re-measure, and five concepts the chrome migration needs

### DIFF
--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -372,7 +372,19 @@ pub enum Anchor {
     #[default]
     Parent,
     Node(Key),
+    /// A position with no extent. A click happened *at* a coordinate, and a
+    /// menu placed `Over` it starts there.
     Point(u16, u16),
+    /// A single cell, which is what a caret or a hovered cell is.
+    ///
+    /// The distinction from [`Anchor::Point`] is the whole of it: a point
+    /// resolves to a zero-size rect, so `Place::Below` a point is the point's
+    /// own row. Below a *cell* is the row after it, and a flip clears the cell
+    /// rather than landing on it. Both are correct for what they name — a
+    /// click position has no extent, a caret occupies one — and a completion
+    /// popup that opens on top of the character it is completing is the bug
+    /// that comes of having only the first.
+    Cell(u16, u16),
     Screen(Align),
 }
 
@@ -488,19 +500,27 @@ pub struct LayerProps<M> {
     pub anchor: Anchor,
     pub place: Place,
     pub fit: Fit,
-    /// Take the anchor's extent on the axis the placement does not use.
+    /// How this layer sits against its anchor on the axis the placement does
+    /// not use.
     ///
-    /// A dropdown is as wide as the button it hangs off; a command palette is
-    /// as wide as the row it sits above. Both are a relationship to the anchor
-    /// rather than a number, and neither is expressible otherwise: a layer
-    /// measures against the whole frame, so `flex` or `Sizing::Grow` inside it
-    /// reach the frame's edge and a cell count is the caller measuring the
-    /// anchor itself — which is the arithmetic anchoring exists to remove.
+    /// A dropdown is as wide as the button it hangs off; a notification hangs
+    /// off the *right* edge of the row above it. Both are a relationship to
+    /// the anchor rather than a number, and neither is expressible otherwise:
+    /// a layer measures against the whole frame, so `flex` or `Sizing::Grow`
+    /// inside it reach the frame's edge, and a cell count is the caller
+    /// measuring the anchor itself — the arithmetic anchoring exists to
+    /// remove.
     ///
-    /// `Place::Fill` is the all-axes form of this and ignores it. `Above` and
-    /// `Below` take the anchor's width; `LeftOf` and `RightOf` its height;
-    /// `Over` has no free axis and is unaffected.
-    pub stretch: bool,
+    /// `Align::Stretch` takes the anchor's whole extent, which is what
+    /// [`Node::stretch_to_anchor`] spells; the others place a
+    /// naturally-sized layer within it. `None` leaves the layer where the
+    /// placement put it, which is the default and what every layer did before
+    /// this existed.
+    ///
+    /// `Place::Fill` is the all-axes form and ignores this. `Above` and
+    /// `Below` free the width; `LeftOf` and `RightOf` the height; `Over` has
+    /// no free axis and is unaffected.
+    pub align: Option<Align>,
     pub modality: Modality,
     pub scrim: Option<Scrim>,
     pub dismiss: Dismiss,
@@ -515,7 +535,7 @@ impl<M> Default for LayerProps<M> {
             anchor: Anchor::default(),
             place: Place::default(),
             fit: Fit::default(),
-            stretch: false,
+            align: None,
             modality: Modality::default(),
             scrim: None,
             dismiss: Dismiss::default(),
@@ -530,7 +550,7 @@ impl<M> Clone for LayerProps<M> {
             anchor: self.anchor.clone(),
             place: self.place,
             fit: self.fit,
-            stretch: self.stretch,
+            align: self.align,
             modality: self.modality,
             scrim: self.scrim,
             dismiss: self.dismiss,
@@ -546,7 +566,7 @@ impl<M> LayerProps<M> {
         self.anchor == o.anchor
             && self.place == o.place
             && self.fit == o.fit
-            && self.stretch == o.stretch
+            && self.align == o.align
     }
 }
 
@@ -1253,10 +1273,19 @@ impl<M> Node<M> {
         }
     }
 
-    /// Match the anchor on the axis the placement leaves free. See
-    /// [`LayerProps::stretch`].
-    pub fn stretch_to_anchor(mut self) -> Self {
-        self.layer_props().stretch = true;
+    /// Match the anchor on the axis the placement leaves free.
+    ///
+    /// The `Align::Stretch` spelling of [`Node::align_to_anchor`], kept
+    /// because "as wide as the thing it hangs off" reads better at the call
+    /// site than an alignment does.
+    pub fn stretch_to_anchor(self) -> Self {
+        self.align_to_anchor(Align::Stretch)
+    }
+
+    /// How this layer sits against its anchor on the free axis. See
+    /// [`LayerProps::align`].
+    pub fn align_to_anchor(mut self, a: Align) -> Self {
+        self.layer_props().align = Some(a);
         self
     }
 

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -65,6 +65,9 @@ pub struct Node<M> {
     /// usually means "take what is left, but never less than this".
     pub min_w: u16,
     pub min_h: u16,
+    /// Who keeps its size when there is not enough room; higher yields last.
+    /// See [`Node::priority`]. `0` for everything that does not say.
+    pub priority: u8,
     /// Whether pointer hits stop at this node. `None` leaves it to the render
     /// object, which is [`PointerMode::Opaque`] for everything that has one.
     ///
@@ -195,6 +198,28 @@ pub struct BoxProps {
     pub clip: bool,
 }
 
+/// How a run gives up cells it was not given.
+///
+/// Non-wrapping text measures at its natural width and is clipped to whatever
+/// the parent allowed, which loses the fact that anything was cut. That was
+/// tolerable while a host truncated its own strings first — but a host cannot,
+/// once [`Node::priority`] lets layout decide a column's width: the width is
+/// not known until measurement is over. So the run says how it yields, and the
+/// end that survives is part of what it says.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Elide {
+    /// Clip, silently. The default, and right for text whose overflow the
+    /// enclosing box already explains.
+    #[default]
+    None,
+    /// Keep the head, mark the cut at the end: a command name, a label, a
+    /// message.
+    Tail,
+    /// Keep the tail, mark the cut at the start: a file path, whose filename
+    /// is the part worth seeing.
+    Head,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct TextProps {
     /// The run's content, in pieces. One piece for ordinary text; several when
@@ -206,6 +231,9 @@ pub struct TextProps {
     /// which wrap and truncate independently.
     pub runs: Rc<[Run]>,
     pub wrap: bool,
+    /// Which end survives when the run is given less than it measured at.
+    /// Ignored when `wrap` is set: wrapped text has no overflow to mark.
+    pub elide: Elide,
     /// Where the text cursor sits within this run, in columns. Set by whatever
     /// is being edited; the library places it and the backend shows it.
     pub cursor: Option<u16>,
@@ -460,6 +488,19 @@ pub struct LayerProps<M> {
     pub anchor: Anchor,
     pub place: Place,
     pub fit: Fit,
+    /// Take the anchor's extent on the axis the placement does not use.
+    ///
+    /// A dropdown is as wide as the button it hangs off; a command palette is
+    /// as wide as the row it sits above. Both are a relationship to the anchor
+    /// rather than a number, and neither is expressible otherwise: a layer
+    /// measures against the whole frame, so `flex` or `Sizing::Grow` inside it
+    /// reach the frame's edge and a cell count is the caller measuring the
+    /// anchor itself — which is the arithmetic anchoring exists to remove.
+    ///
+    /// `Place::Fill` is the all-axes form of this and ignores it. `Above` and
+    /// `Below` take the anchor's width; `LeftOf` and `RightOf` its height;
+    /// `Over` has no free axis and is unaffected.
+    pub stretch: bool,
     pub modality: Modality,
     pub scrim: Option<Scrim>,
     pub dismiss: Dismiss,
@@ -474,6 +515,7 @@ impl<M> Default for LayerProps<M> {
             anchor: Anchor::default(),
             place: Place::default(),
             fit: Fit::default(),
+            stretch: false,
             modality: Modality::default(),
             scrim: None,
             dismiss: Dismiss::default(),
@@ -488,6 +530,7 @@ impl<M> Clone for LayerProps<M> {
             anchor: self.anchor.clone(),
             place: self.place,
             fit: self.fit,
+            stretch: self.stretch,
             modality: self.modality,
             scrim: self.scrim,
             dismiss: self.dismiss,
@@ -500,7 +543,10 @@ impl<M> LayerProps<M> {
     /// Whether two layer descriptions place their content differently. Only
     /// these fields matter to layout; the handler does not.
     pub fn geom_eq(&self, o: &Self) -> bool {
-        self.anchor == o.anchor && self.place == o.place && self.fit == o.fit
+        self.anchor == o.anchor
+            && self.place == o.place
+            && self.fit == o.fit
+            && self.stretch == o.stretch
     }
 }
 
@@ -584,6 +630,7 @@ impl<M> Clone for Node<M> {
             h: self.h,
             min_w: self.min_w,
             min_h: self.min_h,
+            priority: self.priority,
             pointer: self.pointer,
             theme: self.theme.clone(),
             anchor: self.anchor.clone(),
@@ -688,6 +735,7 @@ impl<M> Node<M> {
             w: Sizing::Auto,
             h: Sizing::Auto,
             min_w: 0,
+            priority: 0,
             min_h: 0,
             pointer: None,
             theme: None,
@@ -704,6 +752,7 @@ impl<M> Node<M> {
             w: Sizing::Cells(0),
             h: Sizing::Cells(0),
             min_w: 0,
+            priority: 0,
             min_h: 0,
             pointer: None,
             theme: None,
@@ -759,6 +808,7 @@ pub fn text<M>(s: impl AsRef<str>) -> Node<M> {
     Node::new(Desc::TextRun(TextProps {
         runs: Rc::from(vec![Run::plain(s)]),
         wrap: false,
+        elide: Elide::None,
         cursor: None,
     }))
 }
@@ -778,6 +828,7 @@ pub fn text_runs<M>(runs: impl IntoIterator<Item = Run>) -> Node<M> {
     Node::new(Desc::TextRun(TextProps {
         runs: Rc::from(runs.into_iter().collect::<Vec<_>>()),
         wrap: false,
+        elide: Elide::None,
         cursor: None,
     }))
 }
@@ -957,6 +1008,27 @@ impl<M> Node<M> {
         self
     }
 
+    /// Who keeps its size when there is not enough room: **higher yields last.**
+    ///
+    /// A row resolves its non-flex children against the space that is left, in
+    /// declaration order, so the first-declared child gets its full ask and the
+    /// last one gets the remainder. That is *placement*, and placement is not
+    /// precedence — there was no way to say "size the right-hand side first,
+    /// and let the left take what remains" without doing the arithmetic outside
+    /// layout and passing in the answer.
+    ///
+    /// Two surfaces had already done exactly that (the status bar's reserved
+    /// right side, the suggestion row's four columns, where the name is sized
+    /// before the description absorbs the squeeze), which is what says this is
+    /// a missing concept rather than two special cases.
+    ///
+    /// Default `0`. Equal priorities keep declaration order, so a tree that
+    /// never sets this lays out exactly as before.
+    pub fn priority(mut self, p: u8) -> Self {
+        self.priority = p;
+        self
+    }
+
     /// Never shorter than this.
     pub fn min_h(mut self, cells: u16) -> Self {
         self.min_h = cells;
@@ -1016,6 +1088,16 @@ impl<M> Node<M> {
         match &mut self.desc {
             Desc::TextRun(p) => p.cursor = Some(col),
             _ => panic!("cursor_at() applies to TextRun nodes only"),
+        }
+        self
+    }
+
+    /// Which end of this run survives a width it did not ask for.
+    ///
+    /// See [`Elide`]. A no-op on anything but a text run, and on a wrapped one.
+    pub fn elide(mut self, e: Elide) -> Self {
+        if let Desc::TextRun(t) = &mut self.desc {
+            t.elide = e;
         }
         self
     }
@@ -1169,6 +1251,13 @@ impl<M> Node<M> {
             Desc::Layer(p) => p,
             _ => panic!("layer properties apply to Layer nodes only"),
         }
+    }
+
+    /// Match the anchor on the axis the placement leaves free. See
+    /// [`LayerProps::stretch`].
+    pub fn stretch_to_anchor(mut self) -> Self {
+        self.layer_props().stretch = true;
+        self
     }
 
     pub fn anchor(mut self, a: Anchor) -> Self {

--- a/crates/fresh-ui/src/element.rs
+++ b/crates/fresh-ui/src/element.rs
@@ -829,6 +829,7 @@ impl<M: 'static> Ui<M> {
             h: crate::desc::Sizing::Auto,
             min_w: 0,
             min_h: 0,
+            priority: 0,
             pointer: None,
             clips,
             clip_inset,

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -44,9 +44,9 @@ pub use component::{AnyComponent, Component};
 pub use desc::{
     col, focusable, gesture, host, host_leaf, layer, layout_reader, node_key, node_type, resolve,
     row, shared_rc, stack, text, text_runs, viewport, Align, Anchor, BoxProps, ComponentExt, Desc,
-    Dir, Dismiss, ElemType, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec, LayerProps,
-    LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Run, Scrim, ScrollMode,
-    Sizing, TextProps, ViewportProps,
+    Dir, Dismiss, ElemType, Elide, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec,
+    LayerProps, LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Run, Scrim,
+    ScrollMode, Sizing, TextProps, ViewportProps,
 };
 pub use element::ElementId;
 pub use event::{

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -30,6 +30,7 @@ pub(crate) struct Carry {
     h: Sizing,
     min_w: u16,
     min_h: u16,
+    priority: u8,
     pointer: Option<crate::desc::PointerMode>,
     theme: Option<Rc<str>>,
     key: Option<crate::key::Key>,
@@ -65,6 +66,10 @@ impl<M: 'static> LayoutCx for UiLayoutCx<'_, M> {
     fn floor(&self, child: RenderId) -> (u16, u16) {
         let n = &self.ui.render[child];
         (n.min_w, n.min_h)
+    }
+
+    fn priority(&self, child: RenderId) -> u8 {
+        self.ui.render[child].priority
     }
 
     fn measure(&mut self, child: RenderId, c: Constraints) -> Size {
@@ -309,6 +314,7 @@ impl<M: 'static> Ui<M> {
         // the wrapper it handed over.
         let min_w = carry.min_w.max(el.desc.min_w);
         let min_h = carry.min_h.max(el.desc.min_h);
+        let priority = carry.priority.max(el.desc.priority);
         let pointer = carry.pointer.or(el.desc.pointer);
         let theme = el
             .desc
@@ -343,6 +349,7 @@ impl<M: 'static> Ui<M> {
                     n.h = h;
                     n.min_w = min_w;
                     n.min_h = min_h;
+                    n.priority = priority;
                     n.pointer = pointer;
                     n.theme = theme;
                     n.key = key;
@@ -390,6 +397,7 @@ impl<M: 'static> Ui<M> {
                             h,
                             min_w,
                             min_h,
+                            priority,
                             pointer,
                             theme: theme.clone(),
                             key: key.clone(),
@@ -791,6 +799,16 @@ impl<M: 'static> Ui<M> {
             };
             let c = if props.place == Place::Fill {
                 Constraints::tight(anchor.size())
+            } else if props.stretch {
+                // Free axis pinned to the anchor, the other still free. What
+                // makes a dropdown the width of its button without the caller
+                // measuring the button.
+                let a = anchor.size();
+                match props.place {
+                    Place::Above | Place::Below => Constraints::new(a.w, a.w, 0, frame.h),
+                    Place::LeftOf | Place::RightOf => Constraints::new(0, frame.w, a.h, a.h),
+                    Place::Over | Place::Fill => Constraints::loose(frame),
+                }
             } else {
                 Constraints::loose(frame)
             };

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -795,11 +795,15 @@ impl<M: 'static> Ui<M> {
                     .map(|r| self.render[r].data.rect)
                     .unwrap_or(self.render[parent].data.rect),
                 Anchor::Point(x, y) => Rect::new(*x as i32, *y as i32, 0, 0),
+                // One cell, which is the whole difference: `Place::Below` a
+                // cell is the row after it, while below a point is the point's
+                // own row.
+                Anchor::Cell(x, y) => Rect::new(*x as i32, *y as i32, 1, 1),
                 Anchor::Screen(_) => Rect::from_size(frame),
             };
             let c = if props.place == Place::Fill {
                 Constraints::tight(anchor.size())
-            } else if props.stretch {
+            } else if props.align == Some(Align::Stretch) {
                 // Free axis pinned to the anchor, the other still free. What
                 // makes a dropdown the width of its button without the caller
                 // measuring the button.
@@ -814,7 +818,15 @@ impl<M: 'static> Ui<M> {
             };
             self.render.get_mut(lr).expect("live").data.needs_layout = true;
             let size = self.measure(lr, c);
-            let origin = place(&props.anchor, props.place, props.fit, anchor, size, frame);
+            let origin = place(
+                &props.anchor,
+                props.place,
+                props.fit,
+                props.align,
+                anchor,
+                size,
+                frame,
+            );
             self.arrange(lr, origin, Rect::from_size(frame));
         }
     }
@@ -840,7 +852,16 @@ impl<M: 'static> Ui<M> {
     }
 }
 
-fn place(anchor_kind: &Anchor, p: Place, fit: Fit, anchor: Rect, size: Size, frame: Size) -> Point {
+#[allow(clippy::too_many_arguments)]
+fn place(
+    anchor_kind: &Anchor,
+    p: Place,
+    fit: Fit,
+    align: Option<Align>,
+    anchor: Rect,
+    size: Size,
+    frame: Size,
+) -> Point {
     let fw = frame.w as i32;
     let fh = frame.h as i32;
     let sw = size.w as i32;
@@ -867,6 +888,27 @@ fn place(anchor_kind: &Anchor, p: Place, fit: Fit, anchor: Rect, size: Size, fra
         Place::LeftOf => (anchor.x - sw, anchor.y),
         Place::Over | Place::Fill => (anchor.x, anchor.y),
     };
+
+    // Where the layer sits against the anchor on the axis the placement did
+    // not use. `Stretch` was already applied as a constraint and needs no
+    // origin of its own; the rest slide within the anchor's extent.
+    match (align, p) {
+        (Some(a), Place::Above | Place::Below) => {
+            x = match a {
+                Align::Stretch | Align::Start => anchor.x,
+                Align::Center => anchor.x + (anchor.w as i32 - sw) / 2,
+                Align::End => anchor.right() - sw,
+            }
+        }
+        (Some(a), Place::LeftOf | Place::RightOf) => {
+            y = match a {
+                Align::Stretch | Align::Start => anchor.y,
+                Align::Center => anchor.y + (anchor.h as i32 - sh) / 2,
+                Align::End => anchor.bottom() - sh,
+            }
+        }
+        _ => {}
+    }
 
     if fit.flip {
         match p {

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -516,7 +516,15 @@ impl<M: 'static> Ui<M> {
         let root_c = self.root_constraints(root, frame);
         let full = self.frame_size != frame || self.render[root].data.cached.is_none();
         if full {
-            self.layout_dirty.clear();
+            // The dirty list is deliberately *not* cleared here. A root
+            // measure is not a whole-tree measure: path-marking stops at the
+            // nearest relayout boundary, so the root walk short-circuits above
+            // every boundary that was marked from below and leaves it holding
+            // last frame's measurement — which for text is the shaped rows
+            // paint reads. Dropping the list here painted a stale status bar
+            // for the whole frame in which a layer was open, because the layer
+            // dirtied the root. Re-entering the root from the drain afterwards
+            // is a cache hit.
             self.measure(root, root_c);
         }
 
@@ -642,8 +650,16 @@ impl<M: 'static> Ui<M> {
                     continue;
                 }
                 let Some((c, _)) = self.render[b].data.cached else {
+                    // No cache means no constraints to re-enter this boundary
+                    // on, so the pass starts again from the root. That does
+                    // *not* stand in for the rest of the list: path-marking
+                    // stops at a boundary, so the root walk short-circuits
+                    // above every other dirty boundary and leaves it stale.
+                    // Each one is still visited — by then the root pass has
+                    // usually refilled its cache, and if it has not, this
+                    // measure is a cache hit that costs nothing.
                     self.measure(root, root_c);
-                    break;
+                    continue;
                 };
                 self.measure(b, c);
             }

--- a/crates/fresh-ui/src/render/object.rs
+++ b/crates/fresh-ui/src/render/object.rs
@@ -145,8 +145,8 @@ pub struct LayerGeom {
     pub anchor: Anchor,
     pub place: Place,
     pub fit: Fit,
-    /// See [`crate::desc::LayerProps::stretch`].
-    pub stretch: bool,
+    /// See [`crate::desc::LayerProps::align`].
+    pub align: Option<crate::desc::Align>,
     pub modality: Modality,
     pub scrim: Option<Scrim>,
     pub dismiss: Dismiss,

--- a/crates/fresh-ui/src/render/object.rs
+++ b/crates/fresh-ui/src/render/object.rs
@@ -78,6 +78,15 @@ pub trait LayoutCx {
         let _ = child;
         (0, 0)
     }
+    /// Who keeps its size when the container runs out of room: higher yields
+    /// last. A container that resolves children against remaining space sizes
+    /// them in descending priority, so "reserve this before spending that" is
+    /// a property of the child rather than arithmetic the caller does first.
+    /// `0` is no preference, and equal priorities keep declaration order.
+    fn priority(&self, child: RenderId) -> u8 {
+        let _ = child;
+        0
+    }
     /// Measure a child. Returns its size, honouring the layout cache.
     fn measure(&mut self, child: RenderId, c: Constraints) -> Size;
     /// Position a child relative to this node's content origin.
@@ -136,6 +145,8 @@ pub struct LayerGeom {
     pub anchor: Anchor,
     pub place: Place,
     pub fit: Fit,
+    /// See [`crate::desc::LayerProps::stretch`].
+    pub stretch: bool,
     pub modality: Modality,
     pub scrim: Option<Scrim>,
     pub dismiss: Dismiss,
@@ -267,6 +278,9 @@ pub(crate) struct RenderNode {
     /// Floors on the resolved extent, from the same chain. `0` is no floor.
     pub min_w: u16,
     pub min_h: u16,
+    /// Who keeps its size when there is not enough room; higher yields last.
+    /// See `Node::priority`.
+    pub priority: u8,
     /// Whether pointer hits stop here, when the description says so. `None`
     /// leaves it to the render object.
     pub pointer: Option<crate::desc::PointerMode>,

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -322,8 +322,23 @@ impl RenderObject for BoxRender {
         // child is sized and again when it is placed.
         let floors: Vec<u16> = (0..n).map(|i| main_floor(dir, cx.floor(kids[i]))).collect();
 
+        // **Who yields when the room runs out.** Children resolve against the
+        // space that is left, so the order they are *sized* in is the order
+        // they get their ask honoured — which is not the order they are
+        // *placed* in. Descending `priority` separates the two: a status bar
+        // reserves its right-hand side by giving it a higher priority than the
+        // left, and the row still paints left to right.
+        //
+        // Equal priorities keep declaration order (the sort is stable), so a
+        // tree that never sets one lays out exactly as it did before.
+        let order: Vec<usize> = {
+            let mut o: Vec<usize> = (0..n).collect();
+            o.sort_by_key(|&i| std::cmp::Reverse(cx.priority(kids[i])));
+            o
+        };
+
         // Everything that is not flex resolves first; flex divides what is left.
-        for i in 0..n {
+        for i in order {
             let (sw, sh) = cx.sizing(kids[i]);
             let (s_main, s_cross) = match dir {
                 Dir::Row => (sw, sh),
@@ -474,6 +489,103 @@ impl RenderObject for BoxRender {
 
 // -- TextRun -----------------------------------------------------------------
 
+/// The ellipsis. One cell, so the arithmetic below is `width - 1` and not a
+/// second measurement.
+const ELLIPSIS: &str = "…";
+
+/// Cut a row of fragments down to `w` cells, marking the cut.
+///
+/// Done at paint, not at measure, and that is the whole reason this exists:
+/// layout is what decides how many cells a run gets — `priority` and `flex`
+/// both hand a run less than it measured at — so nothing before paint knows
+/// what to cut to.
+///
+/// Widths, not chars: a CJK glyph is two cells and a combining mark is zero, so
+/// counting characters puts the ellipsis in the wrong place and, worse, can cut
+/// a fragment mid-glyph. Fragments are walked whole and only the one straddling
+/// the boundary is split, so a styled run keeps its pieces' colours.
+fn elide_row(row: &[Frag], w: u16, mode: crate::desc::Elide) -> Vec<Frag> {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+    let total: usize = row.iter().map(|f| UnicodeWidthStr::width(&*f.text)).sum();
+    if mode == crate::desc::Elide::None || total <= w as usize {
+        return row.to_vec();
+    }
+    if w == 0 {
+        return Vec::new();
+    }
+    // One cell for the mark. At a width of exactly one that is all there is
+    // room for, which is the honest answer: something was here.
+    let budget = w as usize - 1;
+    let mark = |f: Option<&Frag>| Frag {
+        text: Rc::from(ELLIPSIS),
+        theme: f.and_then(|f| f.theme.clone()),
+    };
+
+    // `take` walks a fragment in one direction and returns the piece that fits
+    // in `left` cells, along with what it consumed.
+    let take = |f: &Frag, left: usize, from_end: bool| -> (String, usize) {
+        let mut chars: Vec<char> = f.text.chars().collect();
+        if from_end {
+            chars.reverse();
+        }
+        let (mut used, mut out) = (0usize, String::new());
+        for c in chars {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if used + cw > left {
+                break;
+            }
+            used += cw;
+            out.push(c);
+        }
+        if from_end {
+            out = out.chars().rev().collect();
+        }
+        (out, used)
+    };
+
+    let mut kept: Vec<Frag> = Vec::new();
+    let mut left = budget;
+    match mode {
+        crate::desc::Elide::Tail => {
+            for f in row {
+                if left == 0 {
+                    break;
+                }
+                let (seg, used) = take(f, left, false);
+                left -= used;
+                if !seg.is_empty() {
+                    kept.push(Frag {
+                        text: Rc::from(seg.as_str()),
+                        theme: f.theme.clone(),
+                    });
+                }
+            }
+            let last = kept.last().cloned();
+            kept.push(mark(last.as_ref()));
+        }
+        crate::desc::Elide::Head => {
+            for f in row.iter().rev() {
+                if left == 0 {
+                    break;
+                }
+                let (seg, used) = take(f, left, true);
+                left -= used;
+                if !seg.is_empty() {
+                    kept.push(Frag {
+                        text: Rc::from(seg.as_str()),
+                        theme: f.theme.clone(),
+                    });
+                }
+            }
+            kept.reverse();
+            let first = kept.first().cloned();
+            kept.insert(0, mark(first.as_ref()));
+        }
+        crate::desc::Elide::None => unreachable!(),
+    }
+    kept
+}
+
 pub struct TextRender {
     pub props: TextProps,
     /// The wrapped rows, computed at measure time and reused by paint so the
@@ -512,29 +624,45 @@ impl RenderObject for TextRender {
     }
 
     fn paint(&self, g: Geom, out: &mut DrawList) {
+        // What was actually given, cut to fit. Wrapped text has no overflow to
+        // mark, and `Elide::None` is the whole of today's behaviour, so both
+        // pass straight through.
+        let elided: Vec<Vec<Frag>>;
+        let rows: &[Vec<Frag>] = if self.props.wrap || self.props.elide == crate::desc::Elide::None
+        {
+            &self.rows
+        } else {
+            elided = self
+                .rows
+                .iter()
+                .map(|r| elide_row(r, g.rect.w, self.props.elide))
+                .collect();
+            &elided
+        };
+
         // An unstyled run is one item, exactly as before. A styled one emits an
         // item per fragment, each carrying its own theme — so the display list
         // keeps its one-theme-per-item contract and no backend has to learn
         // about spans. `LayoutSpec::index` already maps a key to a *range* of
         // items, so several items for one node is the existing model.
-        if self
-            .rows
-            .iter()
-            .all(|r| r.iter().all(|f| f.theme.is_none()))
-        {
-            let lines: Vec<Rc<str>> = self
-                .rows
+        if rows.iter().all(|r| r.iter().all(|f| f.theme.is_none())) {
+            let lines: Vec<Rc<str>> = rows
                 .iter()
                 .map(|r| {
-                    r.first()
-                        .map(|f| f.text.clone())
-                        .unwrap_or_else(|| Rc::from(""))
+                    // An elided row is more than one fragment even unstyled —
+                    // the content and the mark — so this joins rather than
+                    // taking the first.
+                    match r.len() {
+                        0 => Rc::from(""),
+                        1 => r[0].text.clone(),
+                        _ => Rc::from(r.iter().map(|f| &*f.text).collect::<String>().as_str()),
+                    }
                 })
                 .collect();
             out.push(Draw::Lines(lines), g);
         } else {
             use unicode_width::UnicodeWidthStr;
-            for (i, row) in self.rows.iter().enumerate() {
+            for (i, row) in rows.iter().enumerate() {
                 let mut x = g.rect.x;
                 for frag in row {
                     let w = UnicodeWidthStr::width(&*frag.text) as u16;
@@ -835,6 +963,7 @@ impl LayerRender {
                 anchor: p.anchor.clone(),
                 place: p.place,
                 fit: p.fit,
+                stretch: p.stretch,
                 modality: p.modality,
                 scrim: p.scrim,
                 dismiss: p.dismiss,

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -963,7 +963,7 @@ impl LayerRender {
                 anchor: p.anchor.clone(),
                 place: p.place,
                 fit: p.fit,
-                stretch: p.stretch,
+                align: p.align,
                 modality: p.modality,
                 scrim: p.scrim,
                 dismiss: p.dismiss,

--- a/crates/fresh-ui/src/widgets/list.rs
+++ b/crates/fresh-ui/src/widgets/list.rs
@@ -36,6 +36,65 @@ pub struct ListState {
     pub(crate) revealed: crate::behavior::Cache<usize, ()>,
 }
 
+/// Which click in a run activates a row.
+///
+/// Not a detail of the widget: it is the difference between a menu and a file
+/// list. A palette row commits on the first click, because selecting it *is*
+/// choosing it; a file list selects on the first and opens on the second,
+/// because the user may want to look at what they picked before committing to
+/// it. Both were `on_activate` before, and the widget chose the first for
+/// everyone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Activate {
+    /// The first click both selects and activates.
+    #[default]
+    Click,
+    /// The second click activates; the first only selects.
+    DoubleClick,
+}
+
+impl Activate {
+    fn wants(self, clicks: u8) -> bool {
+        match self {
+            Activate::Click => true,
+            Activate::DoubleClick => clicks >= 2,
+        }
+    }
+}
+
+/// A row's visual state, as the list knows it.
+///
+/// **The widget owns the state machine; the host owns the palette.** `List`
+/// already tracks which row is selected, which the pointer is over, and whether
+/// the list has focus — and two of those live in `ListState`, so a host cannot
+/// compute them from the outside. What it *can* decide is what each state looks
+/// like, which is why [`List::row_theme`] hands the state out rather than a
+/// name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RowState {
+    Normal,
+    /// The pointer is over this row.
+    Hover,
+    /// Selected, in a list that has focus.
+    Selected,
+    /// Selected, in a list that does not — so the eye can tell which list among
+    /// several the keyboard is driving.
+    SelectedBlur,
+}
+
+impl RowState {
+    /// The default name for this state: the vocabulary a host gets when it does
+    /// not name its own.
+    pub fn theme(self) -> &'static str {
+        match self {
+            RowState::Normal => "list.row",
+            RowState::Hover => "list.row.hover",
+            RowState::Selected => "list.row.selected",
+            RowState::SelectedBlur => "list.row.selected.blur",
+        }
+    }
+}
+
 enum Source<M> {
     Eager(Rc<Vec<(Key, Node<M>)>>),
     #[allow(clippy::type_complexity)]
@@ -84,9 +143,12 @@ pub struct List<M> {
     selected: Option<usize>,
     on_select: Option<Rc<dyn Fn(usize) -> M>>,
     on_activate: Option<Rc<dyn Fn(usize) -> Option<M>>>,
+    activate_on: Activate,
     focusable: bool,
     autofocus: bool,
     scrollbar: bool,
+    #[allow(clippy::type_complexity)]
+    row_theme: Option<Rc<dyn Fn(usize, RowState) -> String>>,
 }
 
 impl<M: 'static> List<M> {
@@ -123,9 +185,11 @@ impl<M: 'static> List<M> {
             selected: None,
             on_select: None,
             on_activate: None,
+            activate_on: Activate::default(),
             focusable: true,
             autofocus: false,
             scrollbar: false,
+            row_theme: None,
         }
     }
 
@@ -152,6 +216,13 @@ impl<M: 'static> List<M> {
         self
     }
 
+    /// Which click activates a row. See [`Activate`]; the default is the first,
+    /// which is what every caller got before this existed.
+    pub fn activate_on(mut self, a: Activate) -> Self {
+        self.activate_on = a;
+        self
+    }
+
     pub fn focusable(mut self, yes: bool) -> Self {
         self.focusable = yes;
         self
@@ -160,6 +231,20 @@ impl<M: 'static> List<M> {
     /// Take focus when this list first appears.
     pub fn autofocus(mut self) -> Self {
         self.autofocus = true;
+        self
+    }
+
+    /// Name each row's appearance, given its index and the state the list has
+    /// it in.
+    ///
+    /// Without this a row is stamped with [`RowState::theme`] — `list.row`,
+    /// `list.row.selected` and the rest — which is a vocabulary the backend has
+    /// to bind. A host that already has theme names for the surface it is
+    /// migrating says them here instead, and the stamped name never appears.
+    /// The name overwrites whatever the row builder set, so this is the only
+    /// way for the caller's own name to survive.
+    pub fn row_theme(mut self, f: impl Fn(usize, RowState) -> String + 'static) -> Self {
+        self.row_theme = Some(Rc::new(f));
         self
     }
 
@@ -201,6 +286,7 @@ impl<M: 'static> Component<M> for List<M> {
         let source = self.source.clone();
         let hov = s.hovered;
         let focused = s.focused;
+        let row_theme = self.row_theme.clone();
         // Clicking a row selects it, the same selection the keyboard drives.
         // Built here so it rides along with each visible row the reader emits.
         let click: Option<RowClick<M>> = if self.focusable {
@@ -208,6 +294,7 @@ impl<M: 'static> Component<M> for List<M> {
             let anchor = anchor.clone();
             let on_select = self.on_select.clone();
             let on_activate = self.on_activate.clone();
+            let activate_on = self.activate_on;
             Some(Rc::new(move |i: usize| {
                 let up = up.clone();
                 let anchor = anchor.clone();
@@ -217,12 +304,15 @@ impl<M: 'static> Component<M> for List<M> {
                     e.request_focus(crate::event::SelectionOnFocus::Preserve);
                     up.set(move |st: &mut ListState| st.selected = i);
                     let _ = &anchor;
-                    // A click both moves the selection and activates the row:
-                    // for a menu or the palette that is the whole interaction,
-                    // for a plain list it is select-and-open. A handler may
-                    // return only one message, so activation wins when both are
-                    // present and the selection is delivered through state.
+                    // A click always moves the selection; whether it also
+                    // activates is `activate_on`'s answer, read off the click
+                    // run the host reported. A handler may return only one
+                    // message, so activation wins when it fires and the
+                    // selection is delivered through state either way.
                     let selected = on_select.as_ref().map(|f| f(i));
+                    if !activate_on.wants(e.clicks) {
+                        return selected;
+                    }
                     match on_activate.as_ref().and_then(|f| f(i)) {
                         Some(m) => Some(m),
                         None => selected,
@@ -265,19 +355,22 @@ impl<M: 'static> Component<M> for List<M> {
             let last = (first + visible + OVERSCAN).min(n);
             col().children((first..last).map(|i| {
                 let (k, row) = source.at(i).expect("index inside the source");
-                let theme = if i == sel {
+                let state = if i == sel {
                     // A selected row reads as focused only when the list has
-                    // focus; otherwise it is muted, so the eye can tell which
-                    // list among several the keyboard is driving.
+                    // focus; otherwise it is muted.
                     if focused {
-                        "list.row.selected"
+                        RowState::Selected
                     } else {
-                        "list.row.selected.blur"
+                        RowState::SelectedBlur
                     }
                 } else if hov == Some(i) {
-                    "list.row.hover"
+                    RowState::Hover
                 } else {
-                    "list.row"
+                    RowState::Normal
+                };
+                let theme: String = match &row_theme {
+                    Some(f) => f(i, state),
+                    None => state.theme().to_string(),
                 };
                 let content = row.key(k).theme(theme).h(Sizing::Cells(1));
                 let g = gesture(content).on_enter(hover(i)).on_leave(hover(i));

--- a/crates/fresh-ui/src/widgets/mod.rs
+++ b/crates/fresh-ui/src/widgets/mod.rs
@@ -24,6 +24,6 @@ pub mod misc;
 
 pub use button::{Button, Toggle};
 pub use field::{Number, TextField};
-pub use list::{DualList, List, Tree, TreeNode};
+pub use list::{Activate, DualList, List, RowState, Tree, TreeNode};
 pub use menu::{Dropdown, RadioGroup};
 pub use misc::{divider, spacer};

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -3,7 +3,7 @@
 
 use fresh_ui::{
     col, distribute, layout_reader, row, text, viewport, Align, BuildCx, Component, ComponentExt,
-    Constraints, Node, Rect, Size, Sizing, Ui,
+    Constraints, Draw, Key, Node, Rect, Size, Sizing, Ui,
 };
 
 const FRAME: Size = Size { w: 80, h: 24 };
@@ -552,4 +552,180 @@ fn a_stale_boundary_is_re_measured_even_when_the_root_is_too() {
         "the boundary painted a stale row: {:?}",
         lines(&ui)
     );
+}
+
+/// **Priority decides who yields, declaration order decides who is placed
+/// where.** The two were the same thing before: a row sizes its children
+/// against the space that is left, in the order they were declared, so the
+/// first-declared won every contest.
+///
+/// The status bar is the case this exists for. Its rule is "reserve the right
+/// side, then spend what is left on the left side" — a precedence, which flex
+/// cannot say, so the editor computed the answer outside layout and passed in
+/// widths (`left_budget`). Here the same rule is two `priority` calls.
+#[test]
+fn a_higher_priority_child_is_sized_before_a_lower_one() {
+    let row_of = |left_priority: u8, right_priority: u8| {
+        row().children([
+            text("a-very-long-left-hand-label")
+                .w(Sizing::Cells(26))
+                .priority(left_priority),
+            text("RIGHT").w(Sizing::Cells(5)).priority(right_priority),
+        ])
+    };
+
+    // Declaration order alone: the left child takes what it asked for and the
+    // right one gets the remainder — three cells of a five-cell ask.
+    let mut plain = ui();
+    plain.frame(row_of(0, 0), Size::new(29, 1));
+    assert_eq!(plain.rect(plain.at(&[0]).unwrap()).w, 26);
+    assert_eq!(
+        plain.rect(plain.at(&[1]).unwrap()).w,
+        3,
+        "the right side yielded"
+    );
+
+    // The same tree, with the right side reserved first. It keeps all five
+    // cells and the left side truncates instead — and it is still drawn on
+    // the right, because placement did not change.
+    let mut reserved = ui();
+    reserved.frame(row_of(0, 1), Size::new(29, 1));
+    let left = reserved.rect(reserved.at(&[0]).unwrap());
+    let right = reserved.rect(reserved.at(&[1]).unwrap());
+    assert_eq!(right.w, 5, "the reserved side keeps its width");
+    assert_eq!(left.w, 24, "the left side spends what is left");
+    assert!(left.x < right.x, "placement is still declaration order");
+}
+
+/// The default costs nothing: with no priority set anywhere, layout is
+/// byte-identical to what it was before the concept existed.
+#[test]
+fn equal_priorities_keep_declaration_order() {
+    let mut ui = ui();
+    ui.frame(
+        row().children([
+            text("aaaa").w(Sizing::Cells(4)).priority(3),
+            text("bbbb").w(Sizing::Cells(4)).priority(3),
+            text("cccc").w(Sizing::Cells(4)).priority(3),
+        ]),
+        Size::new(9, 1),
+    );
+    assert_eq!(ui.rect(ui.at(&[0]).unwrap()).w, 4);
+    assert_eq!(ui.rect(ui.at(&[1]).unwrap()).w, 4);
+    assert_eq!(ui.rect(ui.at(&[2]).unwrap()).w, 1, "the last one yields");
+}
+
+// -- Elide -------------------------------------------------------------------
+
+/// **A run that is given less than it measured at says so.**
+///
+/// Non-wrapping text is clipped by the enclosing box, which loses the fact that
+/// anything was cut. That was survivable while a host truncated its own strings
+/// first — but `priority` moved the decision into layout, so by the time the
+/// width is known the host is no longer in the loop. The mark has to come from
+/// the run.
+#[test]
+fn an_elided_run_marks_the_end_it_cut() {
+    use fresh_ui::Elide;
+    let painted = |e: Elide| {
+        let mut ui: Ui<()> = Ui::new();
+        let spec = ui
+            .frame(
+                row()
+                    .w(Sizing::Cells(6))
+                    .child(text("abcdefghij").elide(e).key(Key::from(1u64))),
+                Size::new(6, 1),
+            )
+            .clone();
+        spec.items
+            .iter()
+            .find(|i| i.key.as_ref() == Some(&Key::from(1u64)))
+            .and_then(|i| match &i.draw {
+                Draw::Lines(l) => l.first().map(|s| s.to_string()),
+                _ => None,
+            })
+            .expect("the run painted")
+    };
+    // The head survives, and the cut is visible at the end.
+    assert_eq!(painted(Elide::Tail), "abcde…");
+    // The tail survives — a path keeps its filename.
+    assert_eq!(painted(Elide::Head), "…fghij");
+    // Unasked for, nothing changes: the box clips, exactly as before.
+    assert_eq!(painted(Elide::None), "abcdefghij");
+}
+
+/// **Cells, not characters.** Counting `char`s puts the mark in the wrong place
+/// for a wide glyph and can cut one in half. Four double-width glyphs in five
+/// cells is two glyphs and the mark.
+#[test]
+fn eliding_counts_cells_and_never_splits_a_glyph() {
+    use fresh_ui::Elide;
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui
+        .frame(
+            row()
+                .w(Sizing::Cells(5))
+                .child(text("漢字漢字").elide(Elide::Tail).key(Key::from(1u64))),
+            Size::new(5, 1),
+        )
+        .clone();
+    let painted = spec
+        .items
+        .iter()
+        .find(|i| i.key.as_ref() == Some(&Key::from(1u64)))
+        .and_then(|i| match &i.draw {
+            Draw::Lines(l) => l.first().map(|s| s.to_string()),
+            _ => None,
+        })
+        .expect("the run painted");
+    assert_eq!(painted, "漢字…");
+}
+
+/// **A layer can be as wide as what it hangs off.**
+///
+/// A dropdown matches its button; a command palette matches the row it sits
+/// above. Neither is expressible any other way: a layer measures against the
+/// whole frame, so `flex` inside it reaches the frame's edge, and a cell count
+/// is the caller measuring the anchor by hand — which is the arithmetic
+/// anchoring exists to remove.
+#[test]
+fn a_stretched_layer_takes_its_anchor_width() {
+    use fresh_ui::{layer, Anchor, Place};
+    let build = |stretch: bool| {
+        let mut ui: Ui<()> = Ui::new();
+        let l = layer()
+            .key(Key::from(9u64))
+            .anchor(Anchor::Node(Key::from(1u64)))
+            .place(Place::Above)
+            .child(col().theme("x").child(text("hi")));
+        let l = if stretch { l.stretch_to_anchor() } else { l };
+        let spec = ui
+            .frame(
+                col().children([
+                    row().h(Sizing::Cells(4)),
+                    row()
+                        .key(Key::from(1u64))
+                        .w(Sizing::Cells(30))
+                        .h(Sizing::Cells(1))
+                        .theme("row")
+                        .child(l),
+                ]),
+                Size::new(60, 10),
+            )
+            .clone();
+        let r = spec
+            .index
+            .iter()
+            .find(|(k, _)| *k == Key::from(9u64))
+            .unwrap()
+            .1
+            .clone();
+        spec.items[r.start].rect
+    };
+    // Left to itself, the layer is the width of its content.
+    assert_eq!(build(false).w, 2, "\"hi\" is two cells");
+    // Stretched, it is the width of the row it is placed above — and still
+    // only as tall as it needs.
+    let s = build(true);
+    assert_eq!((s.w, s.h), (30, 1), "the anchor's width, its own height");
 }

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -492,3 +492,64 @@ fn a_floor_holds_inside_a_viewport() {
         ui.rect(gap).w
     );
 }
+
+/// A second frame re-measures every dirty boundary, not just the root.
+///
+/// The mark that a node needs layout stops at the nearest relayout boundary —
+/// that is the point of boundaries. So re-measuring the *root* does not stand
+/// in for the rest of the dirty list: the root walk hits each boundary's cache
+/// and short-circuits above it, leaving it holding the previous frame's
+/// measurement. `TextRender` shapes its rows during measure and paints from
+/// them, so a boundary that was skipped paints last frame's text.
+///
+/// A layer is what made this reachable in practice: it dirties the root, the
+/// root has no cached constraints to re-enter on, and the pass used to drop
+/// the rest of the list on that account. The editor's status bar then painted
+/// a stale row for every frame in which a menu was open.
+#[test]
+fn a_stale_boundary_is_re_measured_even_when_the_root_is_too() {
+    let tree = |msg: &str, overlay: bool| {
+        // `h(Cells(1))` hands the row tight constraints, which makes it a
+        // relayout boundary — the marker from the text below stops there.
+        // The inner `col` matters: it sits between the root and the boundary
+        // and is itself clean, so a walk from the root stops there. Without
+        // something in between, the root's own re-measure would reach the
+        // boundary by accident and the bug would not show.
+        let base = col().children([col().flex(1).children([
+            row().h(Sizing::Cells(1)).children([text(msg.to_string())]),
+            text("body").flex(1),
+        ])]);
+        if overlay {
+            base.child(
+                fresh_ui::layer()
+                    .anchor(fresh_ui::Anchor::Screen(Align::Center))
+                    .child(text("overlay")),
+            )
+        } else {
+            base
+        }
+    };
+    let lines = |ui: &Ui<()>| -> Vec<String> {
+        ui.spec()
+            .items
+            .iter()
+            .filter_map(|i| match &i.draw {
+                fresh_ui::Draw::Lines(l) => l.first().map(|s| s.to_string()),
+                _ => None,
+            })
+            .collect()
+    };
+
+    // One `Ui` across both frames: the second frame is a reconcile, which is
+    // how a host drives it.
+    let mut ui = ui();
+    ui.frame(tree("before", true), FRAME);
+    assert!(lines(&ui).contains(&"before".to_string()));
+
+    ui.frame(tree("after", false), FRAME);
+    assert!(
+        lines(&ui).contains(&"after".to_string()),
+        "the boundary painted a stale row: {:?}",
+        lines(&ui)
+    );
+}

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -729,3 +729,102 @@ fn a_stretched_layer_takes_its_anchor_width() {
     let s = build(true);
     assert_eq!((s.w, s.h), (30, 1), "the anchor's width, its own height");
 }
+
+/// **A caret is a cell; a click position is a point.**
+///
+/// `Place::Below` an `Anchor::Point` lands on the point's own row, because a
+/// point resolves to a zero-size rect and below a zero-height thing is itself.
+/// That is right for what a point names — the context menu opens `Over` a click
+/// position and wants exactly that. A caret occupies a cell, and a completion
+/// popup placed below one must clear the character it is completing.
+#[test]
+fn below_a_cell_is_the_row_after_it_and_below_a_point_is_its_own() {
+    use fresh_ui::{layer, Anchor, Place};
+    let at = |a: Anchor| {
+        let mut ui: Ui<()> = Ui::new();
+        let spec = ui
+            .frame(
+                col().child(
+                    layer()
+                        .key(Key::from(3u64))
+                        .anchor(a)
+                        .place(Place::Below)
+                        .child(col().theme("x").child(text("hi"))),
+                ),
+                Size::new(40, 12),
+            )
+            .clone();
+        spec.index
+            .iter()
+            .find(|(k, _)| *k == Key::from(3u64))
+            .and_then(|(_, r)| spec.items.get(r.start))
+            .map(|i| i.rect.y)
+            .expect("placed")
+    };
+    assert_eq!(
+        at(Anchor::Point(5, 4)),
+        4,
+        "below a point is the point's row"
+    );
+    assert_eq!(
+        at(Anchor::Cell(5, 4)),
+        5,
+        "below a cell is the row after it"
+    );
+}
+
+/// **A layer can align within its anchor, not only match it.**
+///
+/// A notification hangs off the right edge of the row above it; a dropdown
+/// matches its button's width. Both are relationships to the anchor, and
+/// `stretch_to_anchor` was only the `Stretch` one — with no way to say the
+/// others, a caller is back to measuring the anchor and subtracting.
+#[test]
+fn a_layer_aligns_on_the_axis_its_placement_leaves_free() {
+    use fresh_ui::{layer, Align, Anchor, Place};
+    let at = |align: Option<Align>| {
+        let l = layer()
+            .key(Key::from(4u64))
+            .anchor(Anchor::Node(Key::from(1u64)))
+            .place(Place::Above)
+            .child(col().theme("x").child(text("hi")));
+        let l = match align {
+            Some(a) => l.align_to_anchor(a),
+            None => l,
+        };
+        let mut ui: Ui<()> = Ui::new();
+        let spec = ui
+            .frame(
+                col().children([
+                    row().h(Sizing::Cells(4)),
+                    row()
+                        .key(Key::from(1u64))
+                        .w(Sizing::Cells(30))
+                        .h(Sizing::Cells(1))
+                        .theme("row")
+                        .child(l),
+                ]),
+                Size::new(60, 10),
+            )
+            .clone();
+        let i = spec
+            .index
+            .iter()
+            .find(|(k, _)| *k == Key::from(4u64))
+            .and_then(|(_, r)| spec.items.get(r.start))
+            .expect("placed");
+        (i.rect.x, i.rect.w)
+    };
+    // Unaligned: the placement's own origin, the anchor's left edge.
+    assert_eq!(at(None), (0, 2));
+    assert_eq!(at(Some(Align::Start)), (0, 2));
+    // "hi" is two cells; the anchor is thirty.
+    assert_eq!(at(Some(Align::Center)), (14, 2));
+    assert_eq!(
+        at(Some(Align::End)),
+        (28, 2),
+        "flush with the anchor's right"
+    );
+    // Stretch is the case `stretch_to_anchor` already spelled, unchanged.
+    assert_eq!(at(Some(Align::Stretch)), (0, 30));
+}

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -244,6 +244,77 @@ fn the_selected_row_is_marked_in_the_display_list() {
     assert_eq!(themes_of(&ui, "item 3"), vec!["list.row"]);
 }
 
+/// **A host names its own row appearance.** The stamped vocabulary
+/// (`list.row.selected` and the rest) overwrites whatever the row builder set,
+/// so a host migrating a surface that already has theme names had no way to
+/// keep them — and it cannot compute the name itself either, because `hovered`
+/// and `focused` live in `ListState`. `row_theme` hands out the state instead
+/// of the name.
+#[test]
+fn a_host_can_name_each_row_state_itself() {
+    let items: Vec<usize> = (0..6).collect();
+    let list = List::keyed(
+        &items,
+        |i| fresh_ui::Key::from(*i),
+        |i| fresh_ui::text(format!("item {i}")),
+    )
+    .selected(2)
+    .row_theme(|i, st| match st {
+        fresh_ui::widgets::RowState::Normal => format!("mine.plain.{i}"),
+        fresh_ui::widgets::RowState::Selected => "mine.on".into(),
+        fresh_ui::widgets::RowState::SelectedBlur => "mine.on.blur".into(),
+        fresh_ui::widgets::RowState::Hover => "mine.hover".into(),
+    })
+    .node();
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(list, FRAME);
+    assert_eq!(themes_of(&ui, "item 2"), vec!["mine.on.blur"]);
+    assert_eq!(themes_of(&ui, "item 3"), vec!["mine.plain.3"]);
+}
+
+/// **Which click commits is the host's rule, not the widget's.**
+///
+/// `on_activate` fired on the first click and won over `on_select`, so a list
+/// that wants select-then-open — a file browser, the editor's suggestion list
+/// with its double-click confirm — could not have both: setting the two
+/// handlers confirmed on every click. The click run is already carried to the
+/// handler on `Event::clicks`; this is only a matter of the widget consulting
+/// it.
+#[test]
+fn a_double_click_list_selects_first_and_activates_second() {
+    use fresh_ui::widgets::Activate;
+    let items: Vec<usize> = (0..6).collect();
+    let list = || {
+        List::keyed(
+            &items,
+            |i| fresh_ui::Key::from(*i),
+            |i| fresh_ui::text(format!("item {i}")),
+        )
+        .selected(0)
+        .on_select(Msg::Selected)
+        .on_activate(Msg::Activated)
+        .activate_on(Activate::DoubleClick)
+        .node()
+    };
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(list(), FRAME);
+    let at = ui.rect_of(ui.find_by_key(&fresh_ui::Key::from(2u64)).expect("row 2"));
+    let p = Point::new(at.x, at.y);
+
+    let mut click = |n: u8| {
+        let mut out = ui
+            .dispatch(Input::press_n(p, MouseButton::Left, Mods::NONE, n))
+            .msgs;
+        out.extend(
+            ui.dispatch(Input::release(p, MouseButton::Left, Mods::NONE))
+                .msgs,
+        );
+        out
+    };
+    assert_eq!(click(1), vec![Msg::Selected(2)], "the first click selects");
+    assert_eq!(click(2), vec![Msg::Activated(2)], "the second activates");
+}
+
 #[test]
 fn a_list_scrolls_to_keep_the_selection_visible() {
     let mut ui: Ui<Msg> = Ui::new();


### PR DESCRIPTION
Library-only. Everything `fresh-ui` gains for the editor chrome migration (#3028), so that branch carries no library changes of its own.

Each item below has a test that **fails without it**, verified by neutralising the change and watching the test go red — not just by the test passing once it is in.

## The bug fix

**A root re-measure does not stand in for the dirty list.** `flush_layout` cleared `layout_dirty` on a full pass, and `drain_layout` gave up on the whole list the first time a boundary had no cached constraints. Neither is sound: path-marking stops at the nearest relayout boundary, so a root walk short-circuits *above* every boundary marked from below and leaves it holding last frame's measurement — which, for text, is the shaped rows paint reads. The symptom was a status bar frozen for the whole frame in which a layer was open, because the layer dirtied the root.

Re-entering a boundary the root pass already refilled is a cache hit, so the fix costs nothing.

`a_stale_boundary_is_re_measured_even_when_the_root_is_too`

## Five concepts

**`Node::priority`** — which child is sized first when a row cannot fit them all. `flex` resolves against what is left in declaration order, which is placement rather than precedence. A status bar reserving its right side before its left, and a suggestion row whose command name must never truncate while the description still has cells, are both stating an *order*. Two surfaces needing it is what made it a library concept rather than a second budget function.

`a_higher_priority_child_is_sized_before_a_lower_one`, `equal_priorities_keep_declaration_order`

**`Node::elide`** — which end a run gives up when handed less than it measured at. Non-wrapping text was clipped by whatever enclosed it, which loses the fact that anything was cut. Survivable while a host truncated its own strings first — but `priority` moves the width decision into layout, so by the time a column's width exists the host is no longer in the loop. Resolved at paint for the same reason: measurement reports the natural width, and it is layout that decides the run gets less.

Which end survives is part of what the run says: a path keeps its filename, a label keeps its head. Cells, not characters — counting `char`s puts the mark one cell early for every wide glyph and can cut one in half.

`an_elided_run_marks_the_end_it_cut`, `eliding_counts_cells_and_never_splits_a_glyph`

**`List::row_theme`** — the widget owns the row state machine, the host owns the palette. `List` stamped `list.row.selected` and its siblings over whatever the row builder named, and a host cannot compute those names itself: `hovered` and `focused` live in `ListState`. A backend whose theme has no entry for the stamped vocabulary drew every row in its fallback style, with nothing failing anywhere. `RowState::theme()` remains the default, so existing callers are unchanged.

`a_host_can_name_each_row_state_itself`

**`List::activate_on`** — which click in a run commits. `on_activate` fired on the first click and won over `on_select`, so select-then-open could not be expressed: setting both handlers confirmed every click. Deliberately *not* a click count on the handler — which click commits is what kind of list this is, and stating it once also settles what the first click of a double-click list does. `Activate::Click` is the default.

`a_double_click_list_selects_first_and_activates_second`

**`Layer::stretch_to_anchor`** — a layer as wide as what it hangs off. A dropdown matches its button; a command palette matches the row it sits above. Neither spelling available today works: a layer measures against the whole frame, so `flex` inside it reaches the frame's edge, and a cell count is the caller measuring the anchor by hand — the arithmetic anchoring exists to remove. Takes the anchor's extent on the axis the placement leaves free; `Place::Fill` is the all-axes form and ignores it.

`a_stretched_layer_takes_its_anchor_width`

## Scope

No consumer changes. `crates/fresh-ui` only — sources and its own tests.