### PR TITLE
test: deflake the three e2e tests that failed on CI

### DIFF
--- a/crates/fresh-editor/tests/e2e/crash_repro.rs
+++ b/crates/fresh-editor/tests/e2e/crash_repro.rs
@@ -788,7 +788,13 @@ fn test_review_diff_typing_after_open_does_not_panic() {
         .unwrap();
     harness.wait_for_prompt_closed().unwrap();
     harness
-        .wait_until(|h| h.screen_to_string().contains("next hunk"))
+        // The toolbar renders before the stream body: also wait for the
+        // "Generating Review Diff Stream..." status to clear, so what follows
+        // acts on a settled review rather than a half-drawn one.
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("next hunk") && !s.contains("Generating Review")
+        })
         .unwrap();
 
     // Switch back to the regular file tab (Ctrl+PageUp = prev buffer)

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -242,12 +242,33 @@ fn heading_marks_survive_exploring_the_document() {
     let initial = marker_rows(&harness);
 
     // Page down through the document so later sections enter the viewport,
-    // letting the plugin's marks settle after each page.
+    // settling the frame after each page rather than waiting for the whole
+    // async pipeline to fall silent.
+    //
+    // This loop is the only place in the file that settles per iteration, and
+    // it is the one test in the file that timed out on CI. Quiescence is
+    // bounded but not cheap: it needs several consecutive no-work ticks at
+    // 50ms apiece, and with the plugin re-decorating every newly visible page
+    // it measured over a second per call on a loaded runner — 13 calls, ~19s,
+    // against ~8s for the whole test unloaded — and gives up only after 30s
+    // when the pipeline never goes quiet.
+    //
+    // The property under test survives without the per-page settle: every
+    // page's `lines_changed` batch is queued by the scroll whether or not this
+    // thread waits for it, and a whole-namespace republish — the bug this test
+    // exists for — is still visible in the set the final settle below hands to
+    // the comparison.
+    //
+    // Not "wait for the screen to change", though: a PageDown at the end of
+    // the document is a no-op, and this sweep runs twelve pages over a
+    // document only about thirteen deep, so that wait would be one viewport
+    // row away from never resolving. A settled frame is true whether or not
+    // the page moved.
     for _ in 0..12 {
         harness
             .send_key(KeyCode::PageDown, KeyModifiers::NONE)
             .unwrap();
-        harness.wait_for_async_quiescence(4).unwrap();
+        harness.wait_until_stable(|_| true).unwrap();
     }
     harness.wait_for_async_quiescence(8).unwrap();
 

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2008,15 +2008,17 @@ fn test_review_diff_scrolling_many_files() {
         .unwrap();
     harness.wait_for_prompt_closed().unwrap();
 
-    // Wait for review diff to load — toolbar's "next hunk" hint marks the
-    // unified-stream layout as ready.
+    // Wait for review diff to load. The toolbar's "next hunk" hint marks the
+    // unified-stream layout as up, but it is painted before the stream body is
+    // written, so the "Generating Review Diff Stream..." status clearing is
+    // what says the diff itself has landed.
     harness
         .wait_until(|h| {
             let screen = h.screen_to_string();
             if screen.contains("TypeError") || screen.contains("Error:") {
                 panic!("Error loading review diff. Screen:\n{}", screen);
             }
-            screen.contains("next hunk")
+            screen.contains("next hunk") && !screen.contains("Generating Review")
         })
         .unwrap();
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -62,7 +62,12 @@ fn open_review_diff(harness: &mut EditorTestHarness) {
             if s.contains("TypeError") || s.contains("Error:") {
                 panic!("Error loading review diff. Screen:\n{}", s);
             }
-            s.contains("next hunk")
+            // The toolbar is painted near the start of `openReviewPanels`,
+            // before the stream body is written and before the "Generating
+            // Review Diff Stream..." status is replaced. Waiting for it alone
+            // resolves on a frame whose diff area is still blank — and every
+            // line-staging assertion below reads that area.
+            s.contains("next hunk") && !s.contains("Generating Review")
         })
         .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -2334,15 +2334,20 @@ fn test_stash_review_ignores_external_diff_and_format_settings() {
 
     harness.run_palette_command("Review Diff: Stash").unwrap();
     // The ref prompt opens prefilled with `stash@{0}`, which is the entry we
-    // just pushed, so confirm it as-is.
-    harness.wait_for_prompt().unwrap();
+    // just pushed, so confirm it as-is. Waiting for *a* prompt would not gate
+    // on it: the palette this command was picked from is itself a prompt and
+    // is still up when the Enter above is dispatched, so `wait_for_prompt`
+    // resolves on the palette and the Enter below can land on it instead of
+    // the ref picker (CONTRIBUTING.md Code §16). The picker's own label
+    // (`prompt.review_stash`) can only be on screen once it is open.
+    harness
+        .wait_for_screen_contains("Review stash (e.g. stash@{0})")
+        .unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
     harness.wait_for_prompt_closed().unwrap();
-    harness
-        .wait_until(|h| h.screen_to_string().contains("next hunk"))
-        .unwrap();
+    wait_for_review_ready(&mut harness);
 
     let screen = harness.screen_to_string();
     assert!(

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -79,13 +79,56 @@ fn enter_search_and_replace(harness: &mut EditorTestHarness, search: &str, repla
     harness.render().unwrap();
 }
 
+/// Wait until the panel's streaming search has *finished*, not merely
+/// produced its first results.
+///
+/// The match count is not that gate. `buildMatchStatsEntries` prints
+/// "(N matches / M files)" from `panel.searchResults` as the pump appends to
+/// it, while `panel.busy` is still true — and `doReplaceAll` refuses to run
+/// while it is: it sets "Search still running — please wait, then try again."
+/// and *drops* the keystroke rather than queueing it. So a Replace All fired
+/// on the count alone can be swallowed, and the wait for the confirmation
+/// prompt that follows then never resolves — a 180s nextest timeout with no
+/// failed assertion to point at, which is how
+/// `test_search_replace_current_file_unnamed_buffer` failed on CI.
+///
+/// The end of the search is visible on the status line: `performSearch` sets
+/// "Found N matches" (or "No matches found for …") as its last act, and the
+/// caller flips `busy` in the same JS turn, before the host renders either.
+fn wait_for_search_finished(harness: &mut EditorTestHarness) {
+    harness
+        .wait_until(|h| {
+            h.screen_to_string().lines().any(|line| {
+                (line.contains("Found ") && line.contains(" matches"))
+                    || line.contains("No matches found for")
+            })
+        })
+        .unwrap();
+}
+
 /// Trigger Replace All (Alt+Enter), accept the confirmation prompt, and wait
 /// for the "Replaced" status. Used by every test that exercises a successful
 /// replacement — the confirmation prompt was added to guard against the
 /// accidental-replace-you-can't-undo case described in bug #1.
 fn confirm_replace_all(harness: &mut EditorTestHarness) {
+    // Alt+Enter is dropped outright while the search is still streaming, so
+    // the replace has to wait for the search to land (see
+    // `wait_for_search_finished`).
+    wait_for_search_finished(harness);
     harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-    harness.wait_for_prompt().unwrap();
+    // If the replace was refused after all, say so here instead of waiting
+    // out the external timeout on a prompt that will never open.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            if screen.contains("Search still running") {
+                panic!(
+                    "Replace All was dropped: the search was still streaming. Screen:\n{screen}"
+                );
+            }
+            h.editor().is_prompting()
+        })
+        .unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
@@ -554,12 +597,19 @@ fn test_search_replace_current_file_unnamed_buffer() {
     enter_search_and_replace(&mut harness, "hello", "goodbye");
 
     // The three in-buffer matches must be found (this is the regression:
-    // it used to read "No matches found").
-    harness
-        .wait_until(|h| h.screen_to_string().contains("3 matches"))
-        .unwrap();
+    // it used to read "No matches found"). Gate on the search *finishing*
+    // rather than on the count appearing: a wait for "3 matches" can only
+    // ever resolve when the test passes, so the regression it guards would
+    // show up as an unexplained 180s timeout instead of this assertion.
+    wait_for_search_finished(&mut harness);
 
     let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("3 matches"),
+        "The unnamed buffer holds three \"hello\"s, so the finished search \
+         must report three matches. Got:\n{}",
+        screen
+    );
     assert!(
         !screen.contains("No matches"),
         "Unnamed-buffer search must find the in-memory matches, not report \


### PR DESCRIPTION
Follow-up to #3097. Three tests failed after it landed — one assertion failure and two 180s nextest timeouts — with three unrelated causes. One commit, six files.

The only tests touched beyond those three are the ones sharing the exact gate the first failure exposed.

## Review Diff: Stash — `test_stash_review_ignores_external_diff_and_format_settings` (FAIL)

The failure screen says it outright: review toolbar up, diff area blank, `Generating Review Diff Stream...` still on the status line. This test gates on the toolbar alone, which is the half-drawn frame #3097 fixed for the range review. `createBufferGroup` paints the toolbar near the *start* of `openReviewPanels`, while the stream's body is written by the `updateMagitDisplay` after it and the status is only replaced by the `updateReviewStatus` after that.

It now calls the `wait_for_review_ready` its neighbours in the file already share. The three other review openers still gating on the toolbar alone go with it — `audit_mode`'s, `crash_repro`'s, and `review_diff_line_staging`'s, whose staging assertions all read the diff area. Those four call sites are the whole of the "same pattern" scope here.

Its preamble had the second half of the same problem: `wait_for_prompt` after the palette command was satisfied by the palette itself, which is still up when its Enter is dispatched, so the Enter meant for the stash-ref picker could land on the palette. It now waits for the picker's own label.

## Search & Replace — `test_search_replace_current_file_unnamed_buffer` (TIMEOUT)

Timed out with no failed assertion. The test fires Alt+Enter as soon as the panel shows "3 matches", and that is not a gate on the search having finished: `buildMatchStatsEntries` prints `(N matches / M files)` straight from `panel.searchResults` as the streaming pump appends to it, while `panel.busy` is still true. `doReplaceAll` refuses to run while busy — it sets "Search still running — please wait, then try again." and **drops** the keystroke rather than queueing it — so the confirmation prompt the test waits for never opens, and an indefinite wait (CONTRIBUTING Testing §3) runs out the external clock.

`confirm_replace_all` now waits for the end of the search, visible on the status line: `performSearch` sets "Found N matches" as its last act and the caller clears `busy` in the same JS turn. If the replace is refused anyway, the wait panics with the screen instead of hanging.

The count check moves the same way. Waiting for `"3 matches"` could only ever resolve when the test passes, so the regression it guards ("No matches found" for an unnamed buffer) would have surfaced as another unexplained timeout. It now waits for the search to land and *asserts* the count.

## Compose scrollbar — `heading_marks_survive_exploring_the_document` (TIMEOUT)

It is the only test in its file that settles inside a loop: twelve PageDowns, each followed by `wait_for_async_quiescence(4)`. Quiescence is bounded but not cheap — several consecutive no-work ticks at 50ms apiece, with the compose plugin re-decorating every newly visible page — so it grows with the load on the runner: ~1.2s per call measured with eight sibling tests running (13 calls, 19s, against ~8s idle), and it gives up only after 30s when the pipeline never goes quiet.

The per-page settle buys nothing the final one doesn't: every page's `lines_changed` batch is queued by the scroll whether or not the test waits for it, and it is the settle after the last page that the mark-set comparison reads — so a whole-namespace republish, the bug this test exists for, is still caught. Each page now settles the frame instead. Deliberately *not* "wait for the screen to change": a PageDown at the end of the document is a no-op, and this sweep runs twelve pages over a document about thirteen deep, so that wait would sit one viewport row from being the hang it replaced.

**This mechanism is inferred, not observed.** nextest reported the timeout without the test's stderr, so the alternative — the fire-and-forget heading pre-scan silently skipping, leaving the `marker_rows >= 10` wait with nothing to wait for — is not ruled out. A recurrence tells them apart: repeated `wait_until still pending` screen dumps mean the pre-scan; `wait_for_async_quiescence: pipeline still busy` lines mean this.

## Verification

`cargo fmt --check` clean and the e2e test binary builds. An earlier revision of this branch, which contained these fixes plus a large palette-gating sweep, ran the full `fresh-editor::e2e_tests` under nextest green (3582 passed, 0 failed); the sweep has since been dropped and CI on this head is the check that matters.

## Not included

A survey turned up ~245 palette invocations across the suite that press Enter without waiting for the palette to list the command, and a handful of other settle-in-a-loop sites. None of them is one of the three failures above, so they are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC5Av1G7JhZyxqy3THRNdz