### PR TITLE
fresh-ui: what the editor migration needed from the library

### DIFF
--- a/crates/fresh-ui/src/ambient.rs
+++ b/crates/fresh-ui/src/ambient.rs
@@ -99,6 +99,19 @@ impl AmbientNode {
 pub struct ProvideProps {
     pub key: AmbientKey,
     pub value: Rc<dyn Any>,
+    /// Whether a newly-built value is the *same* value as the one already
+    /// provided. `None` means pointer identity, which is the only test
+    /// available for a `T` with no equality.
+    ///
+    /// **Why this exists.** A host that rebuilds its description every frame —
+    /// which the cost model invites, since a rebuild costs one allocation per
+    /// node — hands `provide` a *fresh* `Rc` each time. Under pointer identity
+    /// alone that is a change: every dependent is marked dirty every frame,
+    /// and any `Persisted` beneath it trips the "ambient read in `init()`
+    /// changed" assertion on the second frame, having never actually changed.
+    /// [`provide_eq`] supplies the comparison and both go away.
+    #[allow(clippy::type_complexity)]
+    pub same: Option<Rc<dyn Fn(&dyn Any, &dyn Any) -> bool>>,
 }
 
 impl fmt::Debug for ProvideProps {
@@ -112,7 +125,60 @@ pub fn provide<M, T: 'static>(ambient: &Ambient<T>, value: Rc<T>, child: Node<M>
     let mut n = Node::new(Desc::Provide(ProvideProps {
         key: ambient.key(),
         value: value as Rc<dyn Any>,
+        same: None,
     }));
     n.children.push(child);
     n
+}
+
+/// [`provide`], for a value that knows when it has actually changed.
+///
+/// Prefer this wherever `T: PartialEq`. Without it the provider compares by
+/// pointer, so a host that rebuilds its description each frame re-provides an
+/// equal-but-fresh `Rc` and every consumer below is marked dirty for a change
+/// that did not happen.
+pub fn provide_eq<M, T: PartialEq + 'static>(
+    ambient: &Ambient<T>,
+    value: Rc<T>,
+    child: Node<M>,
+) -> Node<M> {
+    let mut n = Node::new(Desc::Provide(ProvideProps {
+        key: ambient.key(),
+        value: value as Rc<dyn Any>,
+        same: Some(Rc::new(|a: &dyn Any, b: &dyn Any| {
+            match (a.downcast_ref::<T>(), b.downcast_ref::<T>()) {
+                (Some(a), Some(b)) => a == b,
+                // A type mismatch is not "unchanged"; let the caller through
+                // rather than silently swallowing it.
+                _ => false,
+            }
+        })),
+    }));
+    n.children.push(child);
+    n
+}
+
+/// A document boundary: one node that both **provides**
+/// [`PERSISTENCE_SCOPE`](crate::behavior::PERSISTENCE_SCOPE) and **keys** the
+/// subtree by the same id.
+///
+/// The two have to travel together, and not as a convention. A scope that
+/// changes value under a *surviving* provider element is an ambient change,
+/// and [`Persisted`](crate::behavior::Persisted) reads its scope in `init()`,
+/// which the library forbids changing for a live element — so keying only
+/// *inside* the provider trips that assertion rather than switching documents.
+/// Keying the provider makes a switch a replacement, and the scope is never
+/// observed to change.
+///
+/// Providing without keying is the other half of the same mistake: two
+/// documents then share one element, and the value that was supposed to be
+/// scoped is simply the same value.
+///
+/// ```ignore
+/// scope("doc-2", col().children(document_body(doc)))
+/// ```
+pub fn scope<M: 'static>(id: impl Into<String>, child: Node<M>) -> Node<M> {
+    let id = id.into();
+    let key = crate::key::Key::Str(id.clone().into());
+    provide_eq(&crate::behavior::PERSISTENCE_SCOPE, Rc::new(id), child).key(key)
 }

--- a/crates/fresh-ui/src/behavior/misc.rs
+++ b/crates/fresh-ui/src/behavior/misc.rs
@@ -202,13 +202,24 @@ pub trait Store {
     fn set(&self, key: &str, value: Rc<dyn std::any::Any>);
 }
 
-/// A value read from the host store at construction and written back at
-/// teardown.
+/// A value read from the host store at construction and written through on
+/// every change.
 ///
 /// Unmount still destroys the state object; the value is restored at the next
 /// construction. Keys are anchored to the enclosing `PersistenceScope` rather
 /// than to tree position, so moving a widget does not lose its value and two
 /// widgets at the same position under different documents do not share one.
+///
+/// **Why [`Persisted::set`] writes through rather than the value being saved
+/// at teardown.** Disposal is deferred to the end of a flush, on purpose —
+/// reconcile is transactional and must be unwindable — so a replacement
+/// subtree is *constructed before* the outgoing one is disposed. A value
+/// written only at teardown is therefore not yet in the store when anything
+/// mounted in the same flush reads it, and a widget that moves in a way
+/// reconciliation cannot match by key reads the default and then has the old
+/// instance's value written over the top of it. Writing on change removes the
+/// ordering question: the store is current whenever anyone looks. Teardown
+/// still writes, so a store that only sees a final flush is unaffected.
 ///
 /// Scope: **new incidental state only.** Existing serialized view state stays
 /// application state.
@@ -233,9 +244,21 @@ impl<T: Clone + 'static> Persisted<T> {
         self.value.borrow().clone()
     }
 
+    /// Set the value, and write it through to the host store.
+    ///
+    /// See the type's documentation: the write is here rather than only in
+    /// [`Behavior::teardown`] because disposal is deferred past the
+    /// construction of whatever replaces this element.
     pub fn set(&self, v: T) {
         *self.value.borrow_mut() = v;
+        if let Some(s) = self.store.borrow().as_ref() {
+            s.set(&self.key, Rc::new(v_clone(&self.value)));
+        }
     }
+}
+
+fn v_clone<T: Clone>(v: &RefCell<T>) -> T {
+    v.borrow().clone()
 }
 
 impl<T: Clone + 'static> Behavior for Persisted<T> {

--- a/crates/fresh-ui/src/behavior/misc.rs
+++ b/crates/fresh-ui/src/behavior/misc.rs
@@ -202,6 +202,63 @@ pub trait Store {
     fn set(&self, key: &str, value: Rc<dyn std::any::Any>);
 }
 
+/// The in-memory [`Store`]: a `HashMap` that lives as long as it is held.
+///
+/// Every host that adopts [`Persisted`] needs one of these before it needs
+/// anything cleverer, and the twelve lines are the same twelve lines each
+/// time — so they are here rather than in each host. A host that wants values
+/// to outlive the process puts its own implementation behind the trait; this
+/// one is the floor, not a placeholder.
+///
+/// [`forget_scope`](MemStore::forget_scope) is the piece a map alone does not
+/// give you. A scope's values are dead the moment the thing the scope names is
+/// gone — a closed document, a closed workspace — and nothing else can know
+/// that: the tree only ever sees a subtree it is not currently showing, which
+/// is precisely the case where the values must be *kept*. So the host says so,
+/// and until it does the map grows for the life of the process.
+#[derive(Default)]
+pub struct MemStore {
+    values: RefCell<std::collections::HashMap<String, Rc<dyn std::any::Any>>>,
+}
+
+impl MemStore {
+    pub fn new() -> Self {
+        MemStore::default()
+    }
+
+    /// Drop every value belonging to `scope`, and nothing else.
+    ///
+    /// A [`Persisted`] key is `"{scope}/{key}"`, so this is the prefix — with
+    /// the separator, which is what keeps `"window:1"` from taking
+    /// `"window:10"` with it.
+    pub fn forget_scope(&self, scope: &str) {
+        let prefix = format!("{scope}/");
+        self.values
+            .borrow_mut()
+            .retain(|k, _| !k.starts_with(&prefix));
+    }
+
+    /// How many values are held. For a host that wants to assert its own
+    /// cleanup ran, and for tests.
+    pub fn len(&self) -> usize {
+        self.values.borrow().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Store for MemStore {
+    fn get(&self, key: &str) -> Option<Rc<dyn std::any::Any>> {
+        self.values.borrow().get(key).cloned()
+    }
+
+    fn set(&self, key: &str, value: Rc<dyn std::any::Any>) {
+        self.values.borrow_mut().insert(key.into(), value);
+    }
+}
+
 /// A value read from the host store at construction and written through on
 /// every change.
 ///

--- a/crates/fresh-ui/src/behavior/mod.rs
+++ b/crates/fresh-ui/src/behavior/mod.rs
@@ -26,7 +26,7 @@ pub mod misc;
 pub mod tasks;
 
 pub use anchor::Anchor;
-pub use misc::{Cache, Controller, Persisted, Store, Ticker, PERSISTENCE_SCOPE};
+pub use misc::{Cache, Controller, MemStore, Persisted, Store, Ticker, PERSISTENCE_SCOPE};
 pub use tasks::{TaskHandle, Tasks};
 
 pub trait Behavior {

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -220,6 +220,34 @@ pub enum Elide {
     Head,
 }
 
+/// How a run breaks lines too long for the width it is given.
+///
+/// **Hanging is a text-layout rule, not a caller's post-process.** Only the
+/// thing that wraps knows where it broke, so only it can say what the next row
+/// starts with — a caller that wanted this had to wrap the text itself, which
+/// means deciding the width, which is the layout's answer and not the
+/// caller's. (The editor's popups did exactly that, and lost the indent the
+/// moment their content became nodes.)
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Wrap {
+    /// Lines break only where the text says `\n`.
+    #[default]
+    None,
+    /// Greedy word wrap; a word too long for a line of its own is broken.
+    Word,
+    /// Word wrap, with each continuation row starting at the line's own
+    /// leading whitespace — so a wrapped list item or parameter description
+    /// stays visually inside its own entry instead of merging into the next.
+    ///
+    /// The indent is dropped when it would leave the text almost no room:
+    /// below [`HANGING_MIN_TEXT`] columns for the text itself, a continuation
+    /// row starts at the left edge instead.
+    Hanging,
+}
+
+/// The columns a hanging indent must leave for the text, or it is not applied.
+pub const HANGING_MIN_TEXT: usize = 10;
+
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct TextProps {
     /// The run's content, in pieces. One piece for ordinary text; several when
@@ -230,9 +258,9 @@ pub struct TextProps {
     /// the difference between this and laying separate `TextRun`s side by side,
     /// which wrap and truncate independently.
     pub runs: Rc<[Run]>,
-    pub wrap: bool,
+    pub wrap: Wrap,
     /// Which end survives when the run is given less than it measured at.
-    /// Ignored when `wrap` is set: wrapped text has no overflow to mark.
+    /// Ignored when the run wraps: wrapped text has no overflow to mark.
     pub elide: Elide,
     /// Where the text cursor sits within this run, in columns. Set by whatever
     /// is being edited; the library places it and the backend shows it.
@@ -876,7 +904,7 @@ pub fn stack<M>() -> Node<M> {
 pub fn text<M>(s: impl AsRef<str>) -> Node<M> {
     Node::new(Desc::TextRun(TextProps {
         runs: Rc::from(vec![Run::plain(s)]),
-        wrap: false,
+        wrap: Wrap::None,
         elide: Elide::None,
         cursor: None,
     }))
@@ -896,7 +924,7 @@ pub fn text<M>(s: impl AsRef<str>) -> Node<M> {
 pub fn text_runs<M>(runs: impl IntoIterator<Item = Run>) -> Node<M> {
     Node::new(Desc::TextRun(TextProps {
         runs: Rc::from(runs.into_iter().collect::<Vec<_>>()),
-        wrap: false,
+        wrap: Wrap::None,
         elide: Elide::None,
         cursor: None,
     }))
@@ -1210,9 +1238,20 @@ impl<M> Node<M> {
         self
     }
 
-    pub fn wrap(mut self) -> Self {
+    /// Break lines too long for the width, at word boundaries.
+    pub fn wrap(self) -> Self {
+        self.wrapping(Wrap::Word)
+    }
+
+    /// Wrap, and start every continuation row at the line's own leading
+    /// indent — see [`Wrap::Hanging`].
+    pub fn wrap_hanging(self) -> Self {
+        self.wrapping(Wrap::Hanging)
+    }
+
+    pub fn wrapping(mut self, w: Wrap) -> Self {
         match &mut self.desc {
-            Desc::TextRun(p) => p.wrap = true,
+            Desc::TextRun(p) => p.wrap = w,
             _ => panic!("wrap() applies to TextRun nodes only"),
         }
         self

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -615,6 +615,23 @@ pub struct LayerProps<M> {
     /// carrying it, else a rectangle the host published for it, else the frame.
     /// So a region the tree does not contain yet can still be named.
     pub within: Option<crate::key::Key>,
+    /// Where the thing this layer hangs off actually is, relative to the
+    /// anchor rectangle the tree can name.
+    ///
+    /// **For an anchor inside a leaf.** A dropdown hangs off the `[value ▼]`
+    /// button inside a row a widget runtime laid out; a completion list hangs
+    /// off a row of a sub-render that has no node of its own. Neither has an
+    /// element to name, and both are known *relative* to something that does —
+    /// which is the same fact [`crate::Ui::set_host_anchor`] publishes, for a
+    /// caller that holds the offset rather than the absolute rectangle.
+    ///
+    /// The anchor rectangle is shifted by this before the placement runs, so
+    /// `Place`, `align_to_anchor` and `Fit` all see the real anchor: a
+    /// dropdown that flips above still clears the button it hangs off.
+    ///
+    /// It does not move [`Anchor::Screen`], which is placed against the
+    /// bounds and has no anchor rectangle to shift.
+    pub offset: (i16, i16),
 }
 
 impl<M> Default for LayerProps<M> {
@@ -625,6 +642,7 @@ impl<M> Default for LayerProps<M> {
             fit: Fit::default(),
             align: None,
             within: None,
+            offset: (0, 0),
             modality: Modality::default(),
             scrim: None,
             dismiss: Dismiss::default(),
@@ -645,6 +663,7 @@ impl<M> Clone for LayerProps<M> {
             dismiss: self.dismiss,
             on_dismiss: self.on_dismiss.clone(),
             within: self.within.clone(),
+            offset: self.offset,
         }
     }
 }
@@ -658,6 +677,7 @@ impl<M> LayerProps<M> {
             && self.fit == o.fit
             && self.align == o.align
             && self.within == o.within
+            && self.offset == o.offset
     }
 }
 
@@ -1472,6 +1492,13 @@ impl<M> Node<M> {
     /// See [`LayerProps::within`].
     pub fn within(mut self, key: crate::key::Key) -> Self {
         self.layer_props().within = Some(key);
+        self
+    }
+
+    /// Where this layer's real anchor is relative to the rectangle it named.
+    /// See [`LayerProps::offset`].
+    pub fn offset(mut self, dx: i16, dy: i16) -> Self {
+        self.layer_props().offset = (dx, dy);
         self
     }
 

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -196,6 +196,9 @@ pub struct BoxProps {
     /// [`border`](Node::border) turns it on, because a frame its own content
     /// can paint over is not a frame.
     pub clip: bool,
+    /// Break onto a new line when the next child would not fit, instead of
+    /// letting the row overflow. See [`Node::wrap_children`].
+    pub wrap: bool,
 }
 
 /// How a run gives up cells it was not given.
@@ -1201,6 +1204,29 @@ impl<M> Node<M> {
         let p = self.box_props();
         p.border = true;
         p.clip = true;
+        self
+    }
+
+    /// Break onto a new line when the next child would not fit.
+    ///
+    /// CSS calls this `flex-wrap: wrap`, and the shape is the same: children
+    /// are never split — a break happens at a child boundary — so a group that
+    /// must stay together is a nested non-wrapping box. A child wider than the
+    /// whole container gets a line to itself and overflows it, which is the
+    /// honest answer; the alternative is silently shrinking something that
+    /// said how wide it was.
+    ///
+    /// **`Flex` on the main axis is treated as `Auto` in a wrapping box.** A
+    /// flexible child absorbs the remainder of its line, so one of them makes
+    /// every line the full width and there is nothing left to wrap. The two
+    /// features answer opposite questions — "fill the row" and "let the row
+    /// become as many rows as it needs" — and a container honouring both would
+    /// silently do neither.
+    ///
+    /// No effect on a [`stack`](crate::stack), whose children all get the
+    /// whole rect.
+    pub fn wrap_children(mut self) -> Self {
+        self.box_props().wrap = true;
         self
     }
 

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -308,8 +308,105 @@ impl TextProps {
     }
 }
 
+/// How many cells each of a viewport's items occupies.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ItemRows {
+    /// Every item the same height, which is what a list of lines is and what
+    /// a list of equal cards is.
+    ///
+    /// **The fast case, and the reason the distinction is worth making**: a
+    /// window can name the items it holds by dividing, without looking at any
+    /// of them. That is what keeps a window onto a million rows cheap.
+    Uniform(u16),
+    /// One height per item, for a list whose rows differ in kind — a tree of
+    /// folder headers one row tall and session cards several.
+    ///
+    /// The caller states them because it is the caller that knows: they come
+    /// from what the items *are*, not from measuring them. Resolving the
+    /// window walks the heights from the offset, so this is linear in what is
+    /// on screen for the window and linear in the list for the extent — fine
+    /// for the tens or hundreds of items a list like that has, and not the
+    /// shape to reach for at a million.
+    Each(std::rc::Rc<[u16]>),
+}
+
+impl Default for ItemRows {
+    fn default() -> Self {
+        ItemRows::Uniform(1)
+    }
+}
+
+impl ItemRows {
+    /// How tall item `i` is. An index past the end is one cell, which is what
+    /// an item that is not there costs.
+    pub fn at(&self, i: usize) -> u16 {
+        match self {
+            ItemRows::Uniform(h) => (*h).max(1),
+            ItemRows::Each(hs) => hs.get(i).copied().unwrap_or(1).max(1),
+        }
+    }
+
+    /// How many items starting at `first` fit in `cells`, at least one — a
+    /// window shows something even when the item is taller than it is.
+    pub fn fit(&self, first: usize, count: usize, cells: u16) -> u32 {
+        match self {
+            ItemRows::Uniform(h) => {
+                let _ = first;
+                let _ = count;
+                (cells / (*h).max(1)).max(1) as u32
+            }
+            ItemRows::Each(_) => {
+                let mut used = 0u32;
+                let mut n = 0u32;
+                for i in first..count {
+                    let h = self.at(i) as u32;
+                    if used + h > cells as u32 && n > 0 {
+                        break;
+                    }
+                    used += h;
+                    n += 1;
+                }
+                n.max(1)
+            }
+        }
+    }
+
+    /// The whole list's extent in cells.
+    pub fn total(&self, count: usize) -> u32 {
+        match self {
+            ItemRows::Uniform(h) => (count as u32).saturating_mul((*h).max(1) as u32),
+            ItemRows::Each(hs) => hs.iter().take(count).map(|h| (*h).max(1) as u32).sum(),
+        }
+    }
+
+    /// The largest offset that still fills the window — scrolling past it
+    /// would leave blank rows under the last item.
+    pub fn max_offset(&self, count: usize, cells: u16) -> u32 {
+        match self {
+            ItemRows::Uniform(h) => {
+                let rows = (cells / (*h).max(1)).max(1) as u32;
+                (count as u32).saturating_sub(rows)
+            }
+            ItemRows::Each(_) => {
+                // Walk back from the end, taking items while they fit.
+                let mut used = 0u32;
+                let mut first = count;
+                while first > 0 {
+                    let h = self.at(first - 1) as u32;
+                    if used + h > cells as u32 {
+                        break;
+                    }
+                    used += h;
+                    first -= 1;
+                }
+                first as u32
+            }
+        }
+    }
+}
+
 /// What a viewport's scroll offset counts.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum ScrollMode {
     /// Cells of content. The viewport translates its children.
     #[default]
@@ -318,12 +415,10 @@ pub enum ScrollMode {
     /// offset is an index. This is what lets a window onto a million rows exist
     /// at all: a cell extent that large does not fit a coordinate.
     ///
-    /// `height` is how many cells one item occupies, and it is uniform because
-    /// that is what makes an index answerable without measuring: a window that
-    /// has to measure every row to know which ones it holds is not a window
-    /// onto a million rows. A card list — items that are little blocks rather
-    /// than lines — is the case it exists for.
-    Items { count: u32, height: u16 },
+    /// `rows` is how many cells each item occupies — see [`ItemRows`]. A card
+    /// list, whose items are little blocks rather than lines, is why it is not
+    /// always one.
+    Items { count: u32, rows: ItemRows },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -1150,21 +1245,26 @@ impl<M> Node<M> {
     /// tall. See [`Node::item_rows`] for taller ones.
     pub fn items(mut self, count: u32) -> Self {
         match &mut self.desc {
-            Desc::Viewport(p) => p.mode = ScrollMode::Items { count, height: 1 },
+            Desc::Viewport(p) => {
+                p.mode = ScrollMode::Items {
+                    count,
+                    rows: ItemRows::default(),
+                }
+            }
             _ => panic!("items() applies to Viewport nodes only"),
         }
         self
     }
 
-    /// How many cells one item occupies. Applies after [`Node::items`], which
-    /// sets the count; uniform, and at least one.
-    pub fn item_rows(mut self, height: u16) -> Self {
+    /// How many cells each item occupies. Applies after [`Node::items`], which
+    /// sets the count. See [`ItemRows`].
+    pub fn item_rows(mut self, rows: ItemRows) -> Self {
         match &mut self.desc {
-            Desc::Viewport(p) => match p.mode {
+            Desc::Viewport(p) => match &p.mode {
                 ScrollMode::Items { count, .. } => {
                     p.mode = ScrollMode::Items {
-                        count,
-                        height: height.max(1),
+                        count: *count,
+                        rows,
                     }
                 }
                 ScrollMode::Cells => panic!("item_rows() applies after items()"),

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -317,7 +317,13 @@ pub enum ScrollMode {
     /// Items. The child renders only the window, so nothing is translated; the
     /// offset is an index. This is what lets a window onto a million rows exist
     /// at all: a cell extent that large does not fit a coordinate.
-    Items(u32),
+    ///
+    /// `height` is how many cells one item occupies, and it is uniform because
+    /// that is what makes an index answerable without measuring: a window that
+    /// has to measure every row to know which ones it holds is not a window
+    /// onto a million rows. A card list — items that are little blocks rather
+    /// than lines — is the case it exists for.
+    Items { count: u32, height: u16 },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -1140,11 +1146,30 @@ impl<M> Node<M> {
         self
     }
 
-    /// Scroll by item index rather than by cell, over `count` items.
+    /// Scroll by item index rather than by cell, over `count` items one cell
+    /// tall. See [`Node::item_rows`] for taller ones.
     pub fn items(mut self, count: u32) -> Self {
         match &mut self.desc {
-            Desc::Viewport(p) => p.mode = ScrollMode::Items(count),
+            Desc::Viewport(p) => p.mode = ScrollMode::Items { count, height: 1 },
             _ => panic!("items() applies to Viewport nodes only"),
+        }
+        self
+    }
+
+    /// How many cells one item occupies. Applies after [`Node::items`], which
+    /// sets the count; uniform, and at least one.
+    pub fn item_rows(mut self, height: u16) -> Self {
+        match &mut self.desc {
+            Desc::Viewport(p) => match p.mode {
+                ScrollMode::Items { count, .. } => {
+                    p.mode = ScrollMode::Items {
+                        count,
+                        height: height.max(1),
+                    }
+                }
+                ScrollMode::Cells => panic!("item_rows() applies after items()"),
+            },
+            _ => panic!("item_rows() applies to Viewport nodes only"),
         }
         self
     }

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -457,13 +457,26 @@ pub enum Scrim {
     Opaque,
 }
 
-/// What dismisses a layer.
+/// What dismisses a layer, and whether closing it is the whole gesture.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Dismiss {
     pub outside_pointer: bool,
     pub escape: bool,
     pub any_key: bool,
     pub any_input: bool,
+    /// Whether the input that dismissed this layer goes on to whatever it was
+    /// aimed at. `false` — the default, and what every layer did before this
+    /// existed — spends it on the dismissal.
+    ///
+    /// A click outside a menu is spent closing the menu: that *is* the
+    /// gesture, and the menu was in the way of it. A tooltip is not in the
+    /// way of anything — clicking into the document while one is showing
+    /// should hide it *and* put the caret where the user clicked, or the
+    /// tooltip has charged them a click to get rid of it.
+    ///
+    /// The same rule the wheel follows: act, and claim only when the act was
+    /// the whole of it.
+    pub pass_through: bool,
 }
 
 impl Dismiss {
@@ -472,6 +485,7 @@ impl Dismiss {
         escape: false,
         any_key: false,
         any_input: false,
+        pass_through: false,
     };
     pub const OUTSIDE_POINTER: Dismiss = Dismiss {
         outside_pointer: true,
@@ -496,6 +510,16 @@ impl Dismiss {
             escape: self.escape | o.escape,
             any_key: self.any_key | o.any_key,
             any_input: self.any_input | o.any_input,
+            pass_through: self.pass_through | o.pass_through,
+        }
+    }
+
+    /// Let the input that dismissed this layer go on to what it was aimed at.
+    /// See [`Dismiss::pass_through`].
+    pub const fn passing_through(self) -> Dismiss {
+        Dismiss {
+            pass_through: true,
+            ..self
         }
     }
 }

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -409,6 +409,15 @@ pub enum Anchor {
     Node(Key),
     /// A position with no extent. A click happened *at* a coordinate, and a
     /// menu placed `Over` it starts there.
+    ///
+    /// **In the coordinate space the layer is placed in**, which is the frame
+    /// unless the layer names a region with [`crate::desc::LayerProps::within`]
+    /// — then it is that region's, origin included. The bounds are "the whole
+    /// coordinate space the placement works in, not just a right-hand limit",
+    /// and a point is the one anchor that used to ignore it: a caller with
+    /// panel-inner coordinates had to add the panel's origin by hand, which is
+    /// the geometry duplication naming a region exists to remove. A layer that
+    /// names no region is unaffected — the frame's origin is `(0, 0)`.
     Point(u16, u16),
     /// A single cell, which is what a caret or a hovered cell is.
     ///
@@ -419,6 +428,8 @@ pub enum Anchor {
     /// click position has no extent, a caret occupies one — and a completion
     /// popup that opens on top of the character it is completing is the bug
     /// that comes of having only the first.
+    ///
+    /// Region-relative like [`Anchor::Point`], for the same reason.
     Cell(u16, u16),
     Screen(Align),
 }

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -308,105 +308,8 @@ impl TextProps {
     }
 }
 
-/// How many cells each of a viewport's items occupies.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum ItemRows {
-    /// Every item the same height, which is what a list of lines is and what
-    /// a list of equal cards is.
-    ///
-    /// **The fast case, and the reason the distinction is worth making**: a
-    /// window can name the items it holds by dividing, without looking at any
-    /// of them. That is what keeps a window onto a million rows cheap.
-    Uniform(u16),
-    /// One height per item, for a list whose rows differ in kind — a tree of
-    /// folder headers one row tall and session cards several.
-    ///
-    /// The caller states them because it is the caller that knows: they come
-    /// from what the items *are*, not from measuring them. Resolving the
-    /// window walks the heights from the offset, so this is linear in what is
-    /// on screen for the window and linear in the list for the extent — fine
-    /// for the tens or hundreds of items a list like that has, and not the
-    /// shape to reach for at a million.
-    Each(std::rc::Rc<[u16]>),
-}
-
-impl Default for ItemRows {
-    fn default() -> Self {
-        ItemRows::Uniform(1)
-    }
-}
-
-impl ItemRows {
-    /// How tall item `i` is. An index past the end is one cell, which is what
-    /// an item that is not there costs.
-    pub fn at(&self, i: usize) -> u16 {
-        match self {
-            ItemRows::Uniform(h) => (*h).max(1),
-            ItemRows::Each(hs) => hs.get(i).copied().unwrap_or(1).max(1),
-        }
-    }
-
-    /// How many items starting at `first` fit in `cells`, at least one — a
-    /// window shows something even when the item is taller than it is.
-    pub fn fit(&self, first: usize, count: usize, cells: u16) -> u32 {
-        match self {
-            ItemRows::Uniform(h) => {
-                let _ = first;
-                let _ = count;
-                (cells / (*h).max(1)).max(1) as u32
-            }
-            ItemRows::Each(_) => {
-                let mut used = 0u32;
-                let mut n = 0u32;
-                for i in first..count {
-                    let h = self.at(i) as u32;
-                    if used + h > cells as u32 && n > 0 {
-                        break;
-                    }
-                    used += h;
-                    n += 1;
-                }
-                n.max(1)
-            }
-        }
-    }
-
-    /// The whole list's extent in cells.
-    pub fn total(&self, count: usize) -> u32 {
-        match self {
-            ItemRows::Uniform(h) => (count as u32).saturating_mul((*h).max(1) as u32),
-            ItemRows::Each(hs) => hs.iter().take(count).map(|h| (*h).max(1) as u32).sum(),
-        }
-    }
-
-    /// The largest offset that still fills the window — scrolling past it
-    /// would leave blank rows under the last item.
-    pub fn max_offset(&self, count: usize, cells: u16) -> u32 {
-        match self {
-            ItemRows::Uniform(h) => {
-                let rows = (cells / (*h).max(1)).max(1) as u32;
-                (count as u32).saturating_sub(rows)
-            }
-            ItemRows::Each(_) => {
-                // Walk back from the end, taking items while they fit.
-                let mut used = 0u32;
-                let mut first = count;
-                while first > 0 {
-                    let h = self.at(first - 1) as u32;
-                    if used + h > cells as u32 {
-                        break;
-                    }
-                    used += h;
-                    first -= 1;
-                }
-                first as u32
-            }
-        }
-    }
-}
-
 /// What a viewport's scroll offset counts.
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum ScrollMode {
     /// Cells of content. The viewport translates its children.
     #[default]
@@ -415,10 +318,12 @@ pub enum ScrollMode {
     /// offset is an index. This is what lets a window onto a million rows exist
     /// at all: a cell extent that large does not fit a coordinate.
     ///
-    /// `rows` is how many cells each item occupies — see [`ItemRows`]. A card
-    /// list, whose items are little blocks rather than lines, is why it is not
-    /// always one.
-    Items { count: u32, rows: ItemRows },
+    /// `height` is how many cells one item occupies, and it is uniform because
+    /// that is what makes an index answerable without measuring: a window that
+    /// has to measure every row to know which ones it holds is not a window
+    /// onto a million rows. A card list — items that are little blocks rather
+    /// than lines — is the case it exists for.
+    Items { count: u32, height: u16 },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -1245,26 +1150,21 @@ impl<M> Node<M> {
     /// tall. See [`Node::item_rows`] for taller ones.
     pub fn items(mut self, count: u32) -> Self {
         match &mut self.desc {
-            Desc::Viewport(p) => {
-                p.mode = ScrollMode::Items {
-                    count,
-                    rows: ItemRows::default(),
-                }
-            }
+            Desc::Viewport(p) => p.mode = ScrollMode::Items { count, height: 1 },
             _ => panic!("items() applies to Viewport nodes only"),
         }
         self
     }
 
-    /// How many cells each item occupies. Applies after [`Node::items`], which
-    /// sets the count. See [`ItemRows`].
-    pub fn item_rows(mut self, rows: ItemRows) -> Self {
+    /// How many cells one item occupies. Applies after [`Node::items`], which
+    /// sets the count; uniform, and at least one.
+    pub fn item_rows(mut self, height: u16) -> Self {
         match &mut self.desc {
-            Desc::Viewport(p) => match &p.mode {
+            Desc::Viewport(p) => match p.mode {
                 ScrollMode::Items { count, .. } => {
                     p.mode = ScrollMode::Items {
-                        count: *count,
-                        rows,
+                        count,
+                        height: height.max(1),
                     }
                 }
                 ScrollMode::Cells => panic!("item_rows() applies after items()"),

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -531,6 +531,24 @@ pub struct LayerProps<M> {
     /// Fired when a declared dismissal condition is met. The layer is described
     /// by the application, so closing it is the application's move.
     pub on_dismiss: Option<Handler<M>>,
+    /// The region this layer is placed *inside*. `None` is the frame, which is
+    /// where every layer went before this existed.
+    ///
+    /// A layer is measured, aligned and fitted against the whole frame, and for
+    /// a surface that floats over everything that is right. Some do not: a
+    /// popup that hangs off the status bar must not put its right border on the
+    /// editor's scrollbar, so the region it may occupy is the frame *less that
+    /// column*. Clamping to the frame lands it exactly there.
+    ///
+    /// It is not something the caller can correct afterwards — the tree places
+    /// the layer, and by the time the host can read the rectangle back the
+    /// placement has happened. Nor is shrinking the layer the same thing: that
+    /// changes how big the box is, when what is wanted is where it may go.
+    ///
+    /// Names a key, and resolves the way [`Anchor::Node`] does — an element
+    /// carrying it, else a rectangle the host published for it, else the frame.
+    /// So a region the tree does not contain yet can still be named.
+    pub within: Option<crate::key::Key>,
 }
 
 impl<M> Default for LayerProps<M> {
@@ -540,6 +558,7 @@ impl<M> Default for LayerProps<M> {
             place: Place::default(),
             fit: Fit::default(),
             align: None,
+            within: None,
             modality: Modality::default(),
             scrim: None,
             dismiss: Dismiss::default(),
@@ -559,6 +578,7 @@ impl<M> Clone for LayerProps<M> {
             scrim: self.scrim,
             dismiss: self.dismiss,
             on_dismiss: self.on_dismiss.clone(),
+            within: self.within.clone(),
         }
     }
 }
@@ -571,6 +591,7 @@ impl<M> LayerProps<M> {
             && self.place == o.place
             && self.fit == o.fit
             && self.align == o.align
+            && self.within == o.within
     }
 }
 
@@ -1344,6 +1365,13 @@ impl<M> Node<M> {
 
     pub fn fit(mut self, f: Fit) -> Self {
         self.layer_props().fit = f;
+        self
+    }
+
+    /// Confine this layer to the region carrying `key`, rather than the frame.
+    /// See [`LayerProps::within`].
+    pub fn within(mut self, key: crate::key::Key) -> Self {
+        self.layer_props().within = Some(key);
         self
     }
 

--- a/crates/fresh-ui/src/desc.rs
+++ b/crates/fresh-ui/src/desc.rs
@@ -301,6 +301,10 @@ pub struct ViewportProps {
     pub max_h: Option<u16>,
     /// Emit a scrollbar item when the content exceeds the window.
     pub scrollbar: bool,
+    /// Keep the bar's gutter reserved even when no bar is drawn.
+    pub stable_gutter: bool,
+    /// Appearance of the bar itself, named apart from the window's.
+    pub bar_theme: Option<Rc<str>>,
     pub mode: ScrollMode,
 }
 
@@ -957,6 +961,45 @@ impl<M> Node<M> {
         match &mut self.desc {
             Desc::Viewport(p) => p.scrollbar = true,
             _ => panic!("scrollbar() applies to Viewport nodes only"),
+        }
+        self
+    }
+
+    /// Keep the bar's column whether or not the bar is there.
+    ///
+    /// By default the gutter appears with the bar and goes with it, so a list
+    /// that grows past its window reflows its content by a cell. Two things
+    /// want the column reserved regardless: content that must not move when a
+    /// row is added, and a window whose gutter is part of the frame around it
+    /// — there the frame keeps drawing in the column when the bar does not,
+    /// and a gutter that came and went would leave the bar beside the frame
+    /// rather than on it. CSS spells the same thing `scrollbar-gutter:
+    /// stable`.
+    ///
+    /// Implies [`scrollbar`](Node::scrollbar): a gutter is the bar's column,
+    /// so asking for one asks for the bar.
+    pub fn scrollbar_gutter(mut self) -> Self {
+        match &mut self.desc {
+            Desc::Viewport(p) => {
+                p.scrollbar = true;
+                p.stable_gutter = true;
+            }
+            _ => panic!("scrollbar_gutter() applies to Viewport nodes only"),
+        }
+        self
+    }
+
+    /// Name the bar's appearance, apart from the window's.
+    ///
+    /// [`theme`](Node::theme) tags a node *and its descendants*, so a window
+    /// that named its bar that way would name its content too — and, because a
+    /// region that names its appearance is a region that paints, would fill
+    /// itself in the bar's colours behind everything in it. The bar is one
+    /// item among the window's; this names that item and nothing else.
+    pub fn scrollbar_theme(mut self, name: impl AsRef<str>) -> Self {
+        match &mut self.desc {
+            Desc::Viewport(p) => p.bar_theme = Some(Rc::from(name.as_ref())),
+            _ => panic!("scrollbar_theme() applies to Viewport nodes only"),
         }
         self
     }

--- a/crates/fresh-ui/src/element.rs
+++ b/crates/fresh-ui/src/element.rs
@@ -549,10 +549,18 @@ impl<M: 'static> Ui<M> {
         };
         let value = p.value.clone();
         let key = p.key;
+        let p_same = p.same.clone();
         let Some(node) = self.arena[id].provides.clone() else {
             return;
         };
-        if Rc::ptr_eq(&node.value.borrow(), &value) {
+        let unchanged = {
+            let held = node.value.borrow();
+            Rc::ptr_eq(&held, &value)
+                || p_same
+                    .as_ref()
+                    .is_some_and(|same| same(held.as_ref(), value.as_ref()))
+        };
+        if unchanged {
             return;
         }
         *node.value.borrow_mut() = value;

--- a/crates/fresh-ui/src/focus/mod.rs
+++ b/crates/fresh-ui/src/focus/mod.rs
@@ -623,6 +623,27 @@ impl<M: 'static> Ui<M> {
     }
 
     fn default_for_intent(&mut self, intent: Intent) -> bool {
+        // **A direction needs somewhere to move from.**
+        //
+        // Tab enters the interface from nowhere — that is what Tab is for, and
+        // `move_focus` picking a first node is the right answer for it. An
+        // arrow key is not that gesture. With nothing focused it belongs to
+        // whoever else is listening, and in a host that offers its keys to this
+        // tree before its own handlers, "whoever else" is the application.
+        //
+        // The editor found this the expensive way: adding one focusable to the
+        // frame — a suggestion list that is driven by the app and has no
+        // keyboard of its own — gave directional traversal somewhere to go, so
+        // `Right` in a command palette started moving focus instead of the
+        // text cursor. `Home` was unaffected, which is the tell: it has no
+        // default here.
+        let directional = matches!(
+            intent,
+            Intent::Up | Intent::Down | Intent::Left | Intent::Right
+        );
+        if directional && self.focus.is_none() {
+            return false;
+        }
         match intent {
             Intent::Next => self.move_focus(FocusDir::Next),
             Intent::Prev => self.move_focus(FocusDir::Prev),

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -624,15 +624,43 @@ impl<M: 'static> Ui<M> {
     }
 
     /// Map a pointer row on the scrollbar track to a scroll offset and apply it.
-    /// The top of the window follows the pointer across the track's travel.
+    ///
+    /// **The thumb's top lands on the row pointed at.** Its travel is the part
+    /// of the track it can reach — `track - len`, not the whole track — and
+    /// dividing by the track instead leaves the thumb short of the row by
+    /// `len` cells at the bottom and the last row of the track unable to reach
+    /// the end of the content. So the same `len` [`Draw::scrollbar_thumb`]
+    /// paints with is what this divides by; press and drag both come here, so
+    /// they agree by construction.
     fn scroll_to_pointer(&mut self, r: RenderId, y: i32) {
         let (rect, max) = {
             let Some(n) = self.render.get(r) else { return };
             (n.data.rect, n.data.scroll_max.y)
         };
-        let travel = (rect.h.max(1) as i32 - 1).max(1);
-        let rel = (y - rect.y).clamp(0, travel);
-        let off = (rel * max) / travel;
+        use crate::render::spec::Draw;
+        let track = rect.h.max(1);
+        let content = max.max(0) as u32 + track as u32;
+        let top_of = |off: i32| Draw::scrollbar_thumb(off.max(0) as u32, content, track).0 as i32;
+        let (_, len) = Draw::scrollbar_thumb(0, content, track);
+        let travel = (track as i32 - len as i32).max(0);
+        let off = if travel == 0 || max <= 0 {
+            0
+        } else {
+            let rel = (y - rect.y).clamp(0, travel);
+            // `scrollbar_thumb` *floors* offset -> row, so dividing back the
+            // same way lands the thumb a row above the one pointed at whenever
+            // the quotient has a fraction. Take the smallest offset that
+            // reaches the row instead, and keep the one below it as a
+            // candidate: with fewer scroll positions than track rows not every
+            // row is reachable, and there the nearer of the two wins.
+            let hi = ((rel * max + travel - 1) / travel).min(max);
+            let lo = (hi - 1).max(0);
+            if (top_of(lo) - rel).abs() < (top_of(hi) - rel).abs() {
+                lo
+            } else {
+                hi
+            }
+        };
         if let Some(n) = self.render.get_mut(r) {
             n.data.scroll.y = off.clamp(0, max);
         }

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -138,8 +138,11 @@ impl<M: 'static> Ui<M> {
                 // that same press, so consuming it would cost the user a
                 // click. Same rule a viewport applies to the wheel: act, and
                 // claim only when the act was the whole of it.
-                let dismissed = self.dismiss_for_pointer(pos, out);
-                let dismiss_claims = dismissed && button == MouseButton::Left;
+                // Whether anything was dismissed, and whether any of it was
+                // spent on the dismissal.
+                let (dismissed, spent) = self.dismiss_for_pointer(pos, out);
+                let _ = dismissed;
+                let dismiss_claims = spent && button == MouseButton::Left;
                 let paths = self.route(pos);
                 // Every stacked path's target, so a click is derived per path:
                 // a transparent overlay and what is behind it were both
@@ -776,10 +779,12 @@ impl<M: 'static> Ui<M> {
         }
     }
 
-    /// Reports whether any layer was dismissed.
-    fn dismiss_for_pointer(&mut self, pos: Point, out: &mut Vec<M>) -> bool {
+    /// Reports whether any layer was dismissed, and whether any of those spent
+    /// the press on it — see [`crate::desc::Dismiss::pass_through`].
+    fn dismiss_for_pointer(&mut self, pos: Point, out: &mut Vec<M>) -> (bool, bool) {
         let mut dismissed = false;
-        let path = self.hit_test(pos);
+        let mut spent = false;
+        let paths = self.hit_paths(pos);
         let layers: Vec<ElementId> = self
             .pending_layers
             .iter()
@@ -793,8 +798,11 @@ impl<M: 'static> Ui<M> {
                 continue;
             }
             // An ancestor test over the existing tree: inside the layer's
-            // subtree, or not.
-            if path.contains(&lid) {
+            // subtree, or not. Every stacked path, because a layer whose own
+            // chrome is transparent — a strip carrying its title — puts the
+            // press on a path that reaches *behind* it as well, and only one
+            // of the two says the press was inside.
+            if paths.iter().any(|p| p.contains(&lid)) {
                 continue;
             }
             if let Some(h) = self.dismiss_handler(lid) {
@@ -822,8 +830,12 @@ impl<M: 'static> Ui<M> {
             // A layer that declared the dismissal was dismissed, whether or
             // not it also had something to say about it.
             dismissed = true;
+            // One layer that spends the press is enough to spend it: a menu
+            // and a tooltip open at once, and the click closing the menu was
+            // aimed at the menu.
+            spent |= !geom.dismiss.pass_through;
         }
-        dismissed
+        (dismissed, spent)
     }
 
     pub(crate) fn dismiss_for_key(&mut self, k: KeyPress, out: &mut Vec<M>) -> bool {

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -11,6 +11,7 @@
 //! bubble : target -> root           // each node may claim
 //! ```
 
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use crate::desc::{resolve, Desc, ElemType};
@@ -284,9 +285,20 @@ impl<M: 'static> Ui<M> {
         out: &mut Vec<M>,
     ) -> (bool, bool) {
         let mut prevented = false;
+        // **One event, one call per listener.** Stacked paths share their
+        // upper reaches: a transparent region and whatever is behind it hang
+        // off the same ancestors, so walking each path in full would offer the
+        // event to those ancestors once per path. A capture-phase observer
+        // near the root — the kind an application uses to watch a channel
+        // without claiming it — would then fire two or three times for one
+        // click. What the extra paths are for is the elements *behind* the
+        // transparent one, and those are exactly the elements the earlier
+        // paths did not contain.
+        let mut seen: HashSet<(ElementId, bool)> = HashSet::new();
         for path in paths {
-            let (claimed, p) =
-                self.propagate(path, kind, pos, button, mods, wheel, None, clicks, out);
+            let (claimed, p) = self.propagate(
+                path, kind, pos, button, mods, wheel, None, clicks, out, &mut seen,
+            );
             prevented |= p;
             if claimed {
                 return (true, prevented);
@@ -472,6 +484,9 @@ impl<M: 'static> Ui<M> {
         key: Option<KeyPress>,
         clicks: u8,
         out: &mut Vec<M>,
+        // Elements this event has already been offered to, across the stacked
+        // paths of one dispatch. See `propagate_all`.
+        seen: &mut HashSet<(ElementId, bool)>,
     ) -> (bool, bool) {
         let Some(&target) = path.last() else {
             return (false, false);
@@ -487,6 +502,9 @@ impl<M: 'static> Ui<M> {
             for n in order {
                 let handlers = self.listeners(n, kind, capture);
                 if handlers.is_empty() {
+                    continue;
+                }
+                if !seen.insert((n, capture)) {
                     continue;
                 }
                 let rect = self.rect_of(n);

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -68,6 +68,17 @@ impl<M: std::fmt::Debug> std::fmt::Debug for Dispatch<M> {
     }
 }
 
+/// What one stacked path did with a wheel notch.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Chain {
+    /// A window moved.
+    Scrolled,
+    /// A floating surface stopped the search before anything moved.
+    Contained,
+    /// Nothing along this path could take it.
+    Nothing,
+}
+
 impl<M: 'static> Ui<M> {
     /// Route one host input into the tree, reporting the messages handlers
     /// produced and whether the event was claimed. Handlers run during this
@@ -215,11 +226,38 @@ impl<M: 'static> Ui<M> {
                 if !claimed && !prevented {
                     // Scroll chaining: the first viewport along the path whose
                     // offset can actually move takes it. One at its bound does
-                    // not claim, so the wheel continues outward.
-                    if let Some(p) = paths.first() {
+                    // not claim, so the wheel continues outward — and a wheel
+                    // that moved a window *is* claimed, or a host with its own
+                    // pipeline behind this tree scrolls something a second time
+                    // for the same notch. The editor found this the expensive
+                    // way: a wheel over a hover popup scrolled the popup here
+                    // and then scrolled the buffer underneath, which also
+                    // dismissed the popup it had just scrolled.
+                    // Every stacked path, in the order the routing produced
+                    // them — the same order `propagate_all` uses, and for the
+                    // same reason: a transparent region is *why* there is more
+                    // than one path, so a decorative strip lying over a
+                    // scrollable window must not be where the search stops.
+                    // Every stacked path, in the order the routing produced
+                    // them — the same order `propagate_all` uses, and for the
+                    // same reason: a transparent region is *why* there is more
+                    // than one path, so a decorative strip lying over a
+                    // scrollable window must not be where the search stops.
+                    //
+                    // Containment is decided after all of them, never during:
+                    // a strip's own path reaches the layer immediately, and
+                    // absorbing there would leave the window behind it — the
+                    // one the wheel was aimed at — never asked.
+                    let mut contained = false;
+                    for p in paths.iter() {
                         let p = p.clone();
-                        self.scroll_chain(&p, wheel);
+                        match self.scroll_chain(&p, wheel) {
+                            Chain::Scrolled => return true,
+                            Chain::Contained => contained = true,
+                            Chain::Nothing => {}
+                        }
                     }
+                    return contained;
                 }
                 claimed
             }
@@ -604,23 +642,34 @@ impl<M: 'static> Ui<M> {
     /// The viewport whose scrollbar gutter is under a point, if any. The gutter
     /// is the node's last column, which its content does not cover, so a hit
     /// there is unambiguous.
+    /// The scrollable window whose gutter is under this point, if any.
+    ///
+    /// Every stacked path, not just the topmost: a transparent region lying
+    /// over a window — a strip carrying a popup's title — is exactly the case
+    /// that produces a second path, and the gutter is on the second one. The
+    /// deepest match within a path wins, which is the innermost window.
     fn scrollbar_hit(&self, pos: Point) -> Option<RenderId> {
-        let mut found = None;
-        for e in self.hit_test(pos) {
-            let Some(r) = self.arena.get(e).and_then(|el| el.render) else {
-                continue;
-            };
-            let Some(n) = self.render.get(r) else {
-                continue;
-            };
-            if n.scrollbar && n.clips && n.data.scroll_max.y > 0 {
-                let rect = n.data.rect;
-                if pos.x == rect.right() - 1 && rect.y <= pos.y && pos.y < rect.bottom() {
-                    found = Some(r);
+        for path in self.hit_paths(pos) {
+            let mut found = None;
+            for e in path {
+                let Some(r) = self.arena.get(e).and_then(|el| el.render) else {
+                    continue;
+                };
+                let Some(n) = self.render.get(r) else {
+                    continue;
+                };
+                if n.scrollbar && n.clips && n.data.scroll_max.y > 0 {
+                    let rect = n.data.rect;
+                    if pos.x == rect.right() - 1 && rect.y <= pos.y && pos.y < rect.bottom() {
+                        found = Some(r);
+                    }
                 }
             }
+            if found.is_some() {
+                return found;
+            }
         }
-        found
+        None
     }
 
     /// Map a pointer row on the scrollbar track to a scroll offset and apply it.
@@ -667,17 +716,35 @@ impl<M: 'static> Ui<M> {
         self.mark_render_dirty(r);
     }
 
-    fn scroll_chain(&mut self, path: &[ElementId], wheel: Wheel) {
+    /// What one path did with the wheel.
+    ///
+    /// **The chain stops at a layer.** Walking outward past a floating surface
+    /// would hand the wheel to whatever it is floating over — so a popup
+    /// scrolled to its last line would start scrolling the document behind it,
+    /// which is not what the wheel was aimed at and, in an editor, dismisses
+    /// the popup that was being read. Every platform contains overscroll at an
+    /// overlay's edge; the web spells it `overscroll-behavior: contain`. A
+    /// layer that scrolled nothing still absorbs the notch — but only once
+    /// every path has been asked, which is the caller's job.
+    fn scroll_chain(&mut self, path: &[ElementId], wheel: Wheel) -> Chain {
         for &n in path.iter().rev() {
             let Some(r) = self.render_for(n) else {
                 continue;
             };
-            let (scroll, max, clips) = {
+            let (scroll, max, clips, floating) = {
                 let Some(node) = self.render.get(r) else {
                     continue;
                 };
-                (node.data.scroll, node.data.scroll_max, node.clips)
+                (
+                    node.data.scroll,
+                    node.data.scroll_max,
+                    node.clips,
+                    node.out_of_flow,
+                )
             };
+            if floating {
+                return Chain::Contained;
+            }
             if !clips {
                 continue;
             }
@@ -694,9 +761,10 @@ impl<M: 'static> Ui<M> {
                     }
                 }
                 self.mark_render_dirty(r);
-                return;
+                return Chain::Scrolled;
             }
         }
+        Chain::Nothing
     }
 
     /// The one part of a layer that cannot live on the render object: a

--- a/crates/fresh-ui/src/hit.rs
+++ b/crates/fresh-ui/src/hit.rs
@@ -838,6 +838,11 @@ impl<M: 'static> Ui<M> {
         (dismissed, spent)
     }
 
+    /// Reports whether any dismissed layer *spent* the key on its dismissal —
+    /// see [`crate::desc::Dismiss::pass_through`], which reads the same here as
+    /// it does for the pointer. Escape closing a menu is the menu's reply and
+    /// belongs to nothing else; a key that hides a tooltip should still be
+    /// typed, or the tooltip has charged the user a keystroke to get rid of it.
     pub(crate) fn dismiss_for_key(&mut self, k: KeyPress, out: &mut Vec<M>) -> bool {
         use crate::event::KeyCode;
         let layers: Vec<ElementId> = self
@@ -845,7 +850,7 @@ impl<M: 'static> Ui<M> {
             .iter()
             .filter_map(|(l, _)| self.element_of(*l))
             .collect();
-        let mut any = false;
+        let mut spent = false;
         for lid in layers {
             let Some(geom) = self.render_for(lid).and_then(|r| self.layer_geom(r)) else {
                 continue;
@@ -877,10 +882,13 @@ impl<M: 'static> Ui<M> {
                 if let Some(m) = h(&ev) {
                     out.push(m);
                 }
-                any = true;
             }
+            // Dismissed whether or not it also had something to say about it,
+            // and one layer that spends the key is enough to spend it — both
+            // the same rules `dismiss_for_pointer` states.
+            spent |= !geom.dismiss.pass_through;
         }
-        any
+        spent
     }
 }
 

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -45,6 +45,7 @@ pub use desc::{
     col, focusable, gesture, host, host_leaf, layer, layout_reader, node_key, node_type, resolve,
     row, shared_rc, stack, text, text_runs, viewport, Align, Anchor, BoxProps, ComponentExt, Desc,
     Dir, Dismiss, ElemType, Elide, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec,
+    ItemRows,
     LayerProps, LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Run, Scrim,
     ScrollMode, Sizing, TextProps, ViewportProps,
 };

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -38,7 +38,7 @@ pub mod schedule;
 pub mod services;
 pub mod widgets;
 
-pub use ambient::{provide, Ambient, AmbientKey, ProvideProps};
+pub use ambient::{provide, provide_eq, scope, Ambient, AmbientKey, ProvideProps};
 pub use behavior::Behavior;
 pub use component::{AnyComponent, Component};
 pub use desc::{

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -45,7 +45,6 @@ pub use desc::{
     col, focusable, gesture, host, host_leaf, layer, layout_reader, node_key, node_type, resolve,
     row, shared_rc, stack, text, text_runs, viewport, Align, Anchor, BoxProps, ComponentExt, Desc,
     Dir, Dismiss, ElemType, Elide, Fit, FocusProps, GestureProps, Handler, HostId, HostSpec,
-    ItemRows,
     LayerProps, LayoutReaderProps, Listener, Modality, Node, Pad, Place, PointerMode, Run, Scrim,
     ScrollMode, Sizing, TextProps, ViewportProps,
 };

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -822,11 +822,17 @@ impl<M: 'static> Ui<M> {
                     .map(|r| self.render[r].data.rect)
                     .or_else(|| self.host_anchors.get(k).copied())
                     .unwrap_or(self.render[parent].data.rect),
-                Anchor::Point(x, y) => Rect::new(*x as i32, *y as i32, 0, 0),
+                // In `bounds`' space, origin included — the frame when the
+                // layer named no region. A region "moves the origin as well as
+                // the limit" for a screen anchor already; a point was the one
+                // that did not, so a caller holding coordinates inside a panel
+                // had to add the panel's origin itself, and that addition is
+                // the second source of geometry naming a region removes.
+                Anchor::Point(x, y) => Rect::new(bounds.x + *x as i32, bounds.y + *y as i32, 0, 0),
                 // One cell, which is the whole difference: `Place::Below` a
                 // cell is the row after it, while below a point is the point's
                 // own row.
-                Anchor::Cell(x, y) => Rect::new(*x as i32, *y as i32, 1, 1),
+                Anchor::Cell(x, y) => Rect::new(bounds.x + *x as i32, bounds.y + *y as i32, 1, 1),
                 Anchor::Screen(_) => bounds,
             };
             let c = if props.place == Place::Fill {

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -835,6 +835,17 @@ impl<M: 'static> Ui<M> {
                 Anchor::Cell(x, y) => Rect::new(bounds.x + *x as i32, bounds.y + *y as i32, 1, 1),
                 Anchor::Screen(_) => bounds,
             };
+            // Where the layer's real anchor is, when it is inside a leaf the
+            // tree cannot name — a button inside a row a widget runtime laid
+            // out, a row of a sub-render with no node of its own. Applied to
+            // the anchor rather than to the result, so the placement, the
+            // cross-axis alignment and the fit all work against the real one:
+            // a dropdown that flips above clears the button it hangs off.
+            // `Anchor::Screen` has no anchor rectangle and is left alone.
+            let anchor = match props.anchor {
+                Anchor::Screen(_) => anchor,
+                _ => anchor.translate(props.offset.0 as i32, props.offset.1 as i32),
+            };
             let c = if props.place == Place::Fill {
                 Constraints::tight(anchor.size())
             } else if props.align == Some(Align::Stretch) {

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -797,6 +797,19 @@ impl<M: 'static> Ui<M> {
             let Some(props) = self.layer_geom(lr) else {
                 continue;
             };
+            // Where this layer may go. The frame unless it named a region —
+            // resolved the same way an `Anchor::Node` is, so a region the tree
+            // does not contain yet can still be named.
+            let bounds = props
+                .within
+                .as_ref()
+                .and_then(|k| {
+                    self.find_by_key(k)
+                        .and_then(|e| self.render_for(e))
+                        .map(|r| self.render[r].data.rect)
+                        .or_else(|| self.host_anchors.get(k).copied())
+                })
+                .unwrap_or(Rect::from_size(frame));
             let anchor = match &props.anchor {
                 Anchor::Parent => self.render[parent].data.rect,
                 // An element carrying the key first; then a rectangle the
@@ -814,7 +827,7 @@ impl<M: 'static> Ui<M> {
                 // cell is the row after it, while below a point is the point's
                 // own row.
                 Anchor::Cell(x, y) => Rect::new(*x as i32, *y as i32, 1, 1),
-                Anchor::Screen(_) => Rect::from_size(frame),
+                Anchor::Screen(_) => bounds,
             };
             let c = if props.place == Place::Fill {
                 Constraints::tight(anchor.size())
@@ -824,12 +837,12 @@ impl<M: 'static> Ui<M> {
                 // measuring the button.
                 let a = anchor.size();
                 match props.place {
-                    Place::Above | Place::Below => Constraints::new(a.w, a.w, 0, frame.h),
-                    Place::LeftOf | Place::RightOf => Constraints::new(0, frame.w, a.h, a.h),
-                    Place::Over | Place::Fill => Constraints::loose(frame),
+                    Place::Above | Place::Below => Constraints::new(a.w, a.w, 0, bounds.h),
+                    Place::LeftOf | Place::RightOf => Constraints::new(0, bounds.w, a.h, a.h),
+                    Place::Over | Place::Fill => Constraints::loose(bounds.size()),
                 }
             } else {
-                Constraints::loose(frame)
+                Constraints::loose(bounds.size())
             };
             self.render.get_mut(lr).expect("live").data.needs_layout = true;
             let size = self.measure(lr, c);
@@ -840,7 +853,7 @@ impl<M: 'static> Ui<M> {
                 props.align,
                 anchor,
                 size,
-                frame,
+                bounds,
             );
             self.arrange(lr, origin, Rect::from_size(frame));
         }
@@ -875,25 +888,28 @@ fn place(
     align: Option<Align>,
     anchor: Rect,
     size: Size,
-    frame: Size,
+    // Where the layer may go: the frame, or the region it named. Every edge
+    // below is this rectangle's, not the screen's.
+    bounds: Rect,
 ) -> Point {
-    let fw = frame.w as i32;
-    let fh = frame.h as i32;
+    let (left, top) = (bounds.x, bounds.y);
+    let right = bounds.right();
+    let bottom = bounds.bottom();
     let sw = size.w as i32;
     let sh = size.h as i32;
 
     if let Anchor::Screen(a) = anchor_kind {
         let x = match a {
-            Align::Stretch | Align::Start => 0,
-            Align::Center => (fw - sw) / 2,
-            Align::End => fw - sw,
+            Align::Stretch | Align::Start => left,
+            Align::Center => left + (bounds.w as i32 - sw) / 2,
+            Align::End => right - sw,
         };
         let y = match a {
-            Align::Stretch | Align::Start => 0,
-            Align::Center => (fh - sh) / 2,
-            Align::End => fh - sh,
+            Align::Stretch | Align::Start => top,
+            Align::Center => top + (bounds.h as i32 - sh) / 2,
+            Align::End => bottom - sh,
         };
-        return Point::new(x.max(0), y.max(0));
+        return Point::new(x.max(left), y.max(top));
     }
 
     let (mut x, mut y) = match p {
@@ -927,18 +943,18 @@ fn place(
 
     if fit.flip {
         match p {
-            Place::Below if y + sh > fh && anchor.y - sh >= 0 => y = anchor.y - sh,
-            Place::Above if y < 0 && anchor.bottom() + sh <= fh => y = anchor.bottom(),
-            Place::RightOf if x + sw > fw && anchor.x - sw >= 0 => x = anchor.x - sw,
-            Place::LeftOf if x < 0 && anchor.right() + sw <= fw => x = anchor.right(),
+            Place::Below if y + sh > bottom && anchor.y - sh >= top => y = anchor.y - sh,
+            Place::Above if y < top && anchor.bottom() + sh <= bottom => y = anchor.bottom(),
+            Place::RightOf if x + sw > right && anchor.x - sw >= left => x = anchor.x - sw,
+            Place::LeftOf if x < left && anchor.right() + sw <= right => x = anchor.right(),
             _ => {}
         }
     }
     if fit.shift || fit.clamp {
-        x = x.min(fw - sw).max(0);
+        x = x.min(right - sw).max(left);
     }
     if fit.clamp {
-        y = y.min(fh - sh).max(0);
+        y = y.min(bottom - sh).max(top);
     }
     Point::new(x, y)
 }

--- a/crates/fresh-ui/src/render/layout.rs
+++ b/crates/fresh-ui/src/render/layout.rs
@@ -543,10 +543,7 @@ impl<M: 'static> Ui<M> {
         // A constraint-dependent builder may have replaced part of its subtree.
         self.process_disposals();
 
-        self.pending_layers.clear();
-        self.arrange(root, Point::ZERO, Rect::from_size(frame));
-        self.resolve_layers(frame);
-        self.process_disposals();
+        self.replace_layers(frame);
 
         // Commands an owner queued through a handle, applied once geometry
         // exists and before anything reads it.
@@ -554,13 +551,26 @@ impl<M: 'static> Ui<M> {
             // The layers found by the first walk are stale the moment anything
             // moves: re-arranging without clearing them would resolve, paint
             // and dismiss every one of them twice.
-            self.pending_layers.clear();
-            self.arrange(root, Point::ZERO, Rect::from_size(frame));
-            self.resolve_layers(frame);
-            self.process_disposals();
+            self.replace_layers(frame);
         }
 
         self.refresh_geometry();
+    }
+
+    /// Arrange the tree and place every layer against the anchors as they
+    /// stand.
+    ///
+    /// Re-runnable by construction, and run more than once already: a scroll
+    /// command applied after the first walk moves content, which moves anything
+    /// anchored to it. The layer list is rebuilt rather than reused because
+    /// `arrange` appends to it — resolving the accumulated list would place,
+    /// paint and dismiss every layer twice.
+    pub(crate) fn replace_layers(&mut self, frame: Size) {
+        let Some(root) = self.render_root else { return };
+        self.pending_layers.clear();
+        self.arrange(root, Point::ZERO, Rect::from_size(frame));
+        self.resolve_layers(frame);
+        self.process_disposals();
     }
 
     /// Update the geometry of every element somebody holds a handle to. The
@@ -789,10 +799,15 @@ impl<M: 'static> Ui<M> {
             };
             let anchor = match &props.anchor {
                 Anchor::Parent => self.render[parent].data.rect,
+                // An element carrying the key first; then a rectangle the
+                // host published for it, for a thing that lives inside a host
+                // leaf and has no element of its own; then the parent, which is
+                // what a name nobody answers has always fallen back to.
                 Anchor::Node(k) => self
                     .find_by_key(k)
                     .and_then(|e| self.render_for(e))
                     .map(|r| self.render[r].data.rect)
+                    .or_else(|| self.host_anchors.get(k).copied())
                     .unwrap_or(self.render[parent].data.rect),
                 Anchor::Point(x, y) => Rect::new(*x as i32, *y as i32, 0, 0),
                 // One cell, which is the whole difference: `Place::Below` a

--- a/crates/fresh-ui/src/render/object.rs
+++ b/crates/fresh-ui/src/render/object.rs
@@ -150,6 +150,8 @@ pub struct LayerGeom {
     pub modality: Modality,
     pub scrim: Option<Scrim>,
     pub dismiss: Dismiss,
+    /// See [`crate::desc::LayerProps::within`].
+    pub within: Option<crate::key::Key>,
 }
 
 /// A node's focus registration, as the focus tree needs it.

--- a/crates/fresh-ui/src/render/object.rs
+++ b/crates/fresh-ui/src/render/object.rs
@@ -152,6 +152,8 @@ pub struct LayerGeom {
     pub dismiss: Dismiss,
     /// See [`crate::desc::LayerProps::within`].
     pub within: Option<crate::key::Key>,
+    /// See [`crate::desc::LayerProps::offset`].
+    pub offset: (i16, i16),
 }
 
 /// A node's focus registration, as the focus tree needs it.

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -1040,7 +1040,7 @@ impl RenderObject for ViewportRender {
         let scroll = cx.scroll();
 
         let mut own = own;
-        match self.props.mode {
+        match self.props.mode.clone() {
             ScrollMode::Cells => {
                 let w = own.w;
                 self.window = Rect::at(scroll, own);
@@ -1105,7 +1105,7 @@ impl RenderObject for ViewportRender {
                     translate: true,
                 });
             }
-            ScrollMode::Items { count: n, height } => {
+            ScrollMode::Items { count: n, rows } => {
                 // The child renders only the window, so nothing is translated
                 // and the offset is an index. A cell extent over a million rows
                 // would not fit a coordinate; an index does.
@@ -1122,26 +1122,27 @@ impl RenderObject for ViewportRender {
                     own.w = c.constrain(Size::new(natural, own.h)).w;
                 }
                 // Given a loose height, the viewport is as tall as its items —
-                // which is `count * height` cells, not `count` rows.
-                let want = (n.saturating_mul(height as u32)).min(u16::MAX as u32) as u16;
+                // which is their cells, not their count.
+                let want = rows.total(n as usize).min(u16::MAX as u32) as u16;
                 own = c.constrain(Size::new(own.w, want));
                 // The window is stated in *items*, because that is what the
                 // offset counts and what the builder inside it asks for. Cells
-                // enter only here, dividing.
-                let rows = (own.h / height) as u32;
+                // enter only here, resolving how many of them fit.
+                let first = scroll.y.max(0) as usize;
+                let visible = rows.fit(first, n as usize, own.h);
                 self.items = n;
                 // When the content overflows and a scrollbar is asked for, the
                 // last column is a gutter the scrollbar owns: content laid out
                 // over it would paint the bar away, since a node's own paint is
                 // under its children. A stable gutter reserves it either way.
                 let gutter =
-                    u16::from(self.props.scrollbar && (self.props.stable_gutter || n > rows));
+                    u16::from(self.props.scrollbar && (self.props.stable_gutter || n > visible));
                 let inner_w = own.w.saturating_sub(gutter);
-                self.window = Rect::new(0, scroll.y, inner_w, rows.min(u16::MAX as u32) as u16);
+                self.window = Rect::new(0, scroll.y, inner_w, visible.min(u16::MAX as u32) as u16);
                 cx.set_scroll(ScrollInfo {
                     window: self.window,
-                    content: Size::new(inner_w, rows.min(u16::MAX as u32) as u16),
-                    max: Point::new(0, n.saturating_sub(rows) as i32),
+                    content: Size::new(inner_w, visible.min(u16::MAX as u32) as u16),
+                    max: Point::new(0, rows.max_offset(n as usize, own.h) as i32),
                     translate: false,
                 });
                 let inner = Constraints::new(inner_w, inner_w, 0, own.h);
@@ -1163,9 +1164,9 @@ impl RenderObject for ViewportRender {
         if !self.props.scrollbar {
             return;
         }
-        let (offset, content) = match self.props.mode {
+        let (offset, content) = match &self.props.mode {
             ScrollMode::Cells => (self.window.y.max(0) as u32, self.content.h as u32),
-            ScrollMode::Items { count, .. } => (self.window.y.max(0) as u32, count),
+            ScrollMode::Items { count, .. } => (self.window.y.max(0) as u32, *count),
         };
         // The window is in the same unit the offset and the content are: cells
         // for `Cells`, items for `Items`. They differ once an item is more than

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -1105,7 +1105,7 @@ impl RenderObject for ViewportRender {
                     translate: true,
                 });
             }
-            ScrollMode::Items(n) => {
+            ScrollMode::Items { count: n, height } => {
                 // The child renders only the window, so nothing is translated
                 // and the offset is an index. A cell extent over a million rows
                 // would not fit a coordinate; an index does.
@@ -1121,8 +1121,14 @@ impl RenderObject for ViewportRender {
                     }
                     own.w = c.constrain(Size::new(natural, own.h)).w;
                 }
-                own = c.constrain(Size::new(own.w, (n.min(u16::MAX as u32)) as u16));
-                let rows = own.h as u32;
+                // Given a loose height, the viewport is as tall as its items —
+                // which is `count * height` cells, not `count` rows.
+                let want = (n.saturating_mul(height as u32)).min(u16::MAX as u32) as u16;
+                own = c.constrain(Size::new(own.w, want));
+                // The window is stated in *items*, because that is what the
+                // offset counts and what the builder inside it asks for. Cells
+                // enter only here, dividing.
+                let rows = (own.h / height) as u32;
                 self.items = n;
                 // When the content overflows and a scrollbar is asked for, the
                 // last column is a gutter the scrollbar owns: content laid out
@@ -1131,10 +1137,10 @@ impl RenderObject for ViewportRender {
                 let gutter =
                     u16::from(self.props.scrollbar && (self.props.stable_gutter || n > rows));
                 let inner_w = own.w.saturating_sub(gutter);
-                self.window = Rect::new(0, scroll.y, inner_w, own.h);
+                self.window = Rect::new(0, scroll.y, inner_w, rows.min(u16::MAX as u32) as u16);
                 cx.set_scroll(ScrollInfo {
                     window: self.window,
-                    content: Size::new(inner_w, own.h),
+                    content: Size::new(inner_w, rows.min(u16::MAX as u32) as u16),
                     max: Point::new(0, n.saturating_sub(rows) as i32),
                     translate: false,
                 });
@@ -1159,15 +1165,20 @@ impl RenderObject for ViewportRender {
         }
         let (offset, content) = match self.props.mode {
             ScrollMode::Cells => (self.window.y.max(0) as u32, self.content.h as u32),
-            ScrollMode::Items(n) => (self.window.y.max(0) as u32, n),
+            ScrollMode::Items { count, .. } => (self.window.y.max(0) as u32, count),
         };
-        if content <= g.rect.h as u32 {
+        // The window is in the same unit the offset and the content are: cells
+        // for `Cells`, items for `Items`. They differ once an item is more than
+        // one cell tall, and taking the rectangle's height for both is what
+        // made a card list's thumb read as a line list's.
+        let window = self.window.h;
+        if content <= window as u32 {
             return;
         }
         let bar = Draw::Scrollbar {
             offset,
             content,
-            window: g.rect.h,
+            window,
         };
         let rect = Rect::new(g.rect.right() - 1, g.rect.y, 1, g.rect.h);
         match &self.props.bar_theme {

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -1040,7 +1040,7 @@ impl RenderObject for ViewportRender {
         let scroll = cx.scroll();
 
         let mut own = own;
-        match self.props.mode.clone() {
+        match self.props.mode {
             ScrollMode::Cells => {
                 let w = own.w;
                 self.window = Rect::at(scroll, own);
@@ -1105,7 +1105,7 @@ impl RenderObject for ViewportRender {
                     translate: true,
                 });
             }
-            ScrollMode::Items { count: n, rows } => {
+            ScrollMode::Items { count: n, height } => {
                 // The child renders only the window, so nothing is translated
                 // and the offset is an index. A cell extent over a million rows
                 // would not fit a coordinate; an index does.
@@ -1122,27 +1122,26 @@ impl RenderObject for ViewportRender {
                     own.w = c.constrain(Size::new(natural, own.h)).w;
                 }
                 // Given a loose height, the viewport is as tall as its items —
-                // which is their cells, not their count.
-                let want = rows.total(n as usize).min(u16::MAX as u32) as u16;
+                // which is `count * height` cells, not `count` rows.
+                let want = (n.saturating_mul(height as u32)).min(u16::MAX as u32) as u16;
                 own = c.constrain(Size::new(own.w, want));
                 // The window is stated in *items*, because that is what the
                 // offset counts and what the builder inside it asks for. Cells
-                // enter only here, resolving how many of them fit.
-                let first = scroll.y.max(0) as usize;
-                let visible = rows.fit(first, n as usize, own.h);
+                // enter only here, dividing.
+                let rows = (own.h / height) as u32;
                 self.items = n;
                 // When the content overflows and a scrollbar is asked for, the
                 // last column is a gutter the scrollbar owns: content laid out
                 // over it would paint the bar away, since a node's own paint is
                 // under its children. A stable gutter reserves it either way.
                 let gutter =
-                    u16::from(self.props.scrollbar && (self.props.stable_gutter || n > visible));
+                    u16::from(self.props.scrollbar && (self.props.stable_gutter || n > rows));
                 let inner_w = own.w.saturating_sub(gutter);
-                self.window = Rect::new(0, scroll.y, inner_w, visible.min(u16::MAX as u32) as u16);
+                self.window = Rect::new(0, scroll.y, inner_w, rows.min(u16::MAX as u32) as u16);
                 cx.set_scroll(ScrollInfo {
                     window: self.window,
-                    content: Size::new(inner_w, visible.min(u16::MAX as u32) as u16),
-                    max: Point::new(0, rows.max_offset(n as usize, own.h) as i32),
+                    content: Size::new(inner_w, rows.min(u16::MAX as u32) as u16),
+                    max: Point::new(0, n.saturating_sub(rows) as i32),
                     translate: false,
                 });
                 let inner = Constraints::new(inner_w, inner_w, 0, own.h);
@@ -1164,9 +1163,9 @@ impl RenderObject for ViewportRender {
         if !self.props.scrollbar {
             return;
         }
-        let (offset, content) = match &self.props.mode {
+        let (offset, content) = match self.props.mode {
             ScrollMode::Cells => (self.window.y.max(0) as u32, self.content.h as u32),
-            ScrollMode::Items { count, .. } => (self.window.y.max(0) as u32, *count),
+            ScrollMode::Items { count, .. } => (self.window.y.max(0) as u32, count),
         };
         // The window is in the same unit the offset and the content are: cells
         // for `Cells`, items for `Items`. They differ once an item is more than

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -1264,6 +1264,7 @@ impl LayerRender {
                 scrim: p.scrim,
                 dismiss: p.dismiss,
                 within: p.within.clone(),
+                offset: p.offset,
             },
         }
     }

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -7,7 +7,9 @@
 
 use std::rc::Rc;
 
-use crate::desc::{Align, BoxProps, Dir, LayerProps, Sizing, TextProps, ViewportProps};
+use crate::desc::{
+    Align, BoxProps, Dir, LayerProps, Sizing, TextProps, ViewportProps, Wrap, HANGING_MIN_TEXT,
+};
 use crate::render::geom::{distribute, Constraints, Point, Rect, Size};
 use crate::render::object::{FocusReg, Geom, LayerGeom, LayoutCx, LayoutInfo, RenderObject};
 use crate::render::spec::{Draw, DrawList};
@@ -92,42 +94,141 @@ fn align_offset(align: Align, extent: u16, size: u16) -> i32 {
     }
 }
 
+/// One wrapped row: what it shows, and how it lines up with the source.
+///
+/// Wrapping is not a pure slicing of the input — it drops the space it broke
+/// at and, for [`Wrap::Hanging`], puts spaces of its own at the front. A
+/// caller that has to map rows back onto the pieces they came from needs both
+/// of those numbers, so the row carries them rather than leaving the caller to
+/// guess (it used to guess: "step past one space if there is one", which is
+/// right only when exactly one was dropped).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Row {
+    pub text: String,
+    /// Leading chars of `text` that wrapping *added*, with no source behind them.
+    pub indent: usize,
+    /// Source chars dropped before this row's first character — the whitespace
+    /// the break consumed.
+    pub skipped: usize,
+}
+
+/// The chunks a line breaks into: each carries the spaces that precede it, so
+/// a run of spaces inside the line survives a wrap and the line's own leading
+/// indent belongs to its first chunk.
+///
+/// `split(' ')` loses both. It yields an empty piece per space, and a wrapper
+/// that skips empties has silently normalised `"    sep  a string"` to
+/// `"sep a string"` — which is how the migrated popups lost the indent on
+/// their *first* row as well as their continuations.
+fn chunks(para: &str) -> Vec<&str> {
+    let mut out: Vec<&str> = Vec::new();
+    let mut start = 0usize;
+    let mut seen_word = false;
+    for (i, c) in para.char_indices() {
+        if c == ' ' {
+            if seen_word {
+                out.push(&para[start..i]);
+                start = i;
+                seen_word = false;
+            }
+        } else {
+            seen_word = true;
+        }
+    }
+    if start < para.len() || out.is_empty() {
+        out.push(&para[start..]);
+    }
+    out
+}
+
 /// Greedy word wrap, breaking a word too long for a line of its own.
 ///
 /// Measure and paint call this same function, so the height layout reserves is
 /// exactly the number of rows paint emits.
-pub fn wrap_text(text: &str, width: u16) -> Vec<String> {
+pub fn wrap_text(text: &str, width: u16, mode: Wrap) -> Vec<String> {
+    wrap_rows(text, width, mode)
+        .into_iter()
+        .map(|r| r.text)
+        .collect()
+}
+
+/// [`wrap_text`], keeping each row's alignment with the source.
+pub fn wrap_rows(text: &str, width: u16, mode: Wrap) -> Vec<Row> {
     use unicode_width::UnicodeWidthStr;
     if width == 0 {
         return Vec::new();
     }
+    let w = |s: &str| UnicodeWidthStr::width(s);
     let width = width as usize;
-    let mut out: Vec<String> = Vec::new();
+    let mut out: Vec<Row> = Vec::new();
     for para in text.split('\n') {
-        let mut line = String::new();
-        for word in para.split(' ') {
-            if line.is_empty() {
-                line.push_str(word);
-            } else if UnicodeWidthStr::width(line.as_str()) + 1 + UnicodeWidthStr::width(word)
-                <= width
-            {
-                line.push(' ');
-                line.push_str(word);
-            } else {
-                out.push(std::mem::take(&mut line));
-                line.push_str(word);
+        // What every row after the first starts with. Dropped when it would
+        // leave the text almost nothing — a deeply indented line in a narrow
+        // box is better flush left than one word per row.
+        let indent = match mode {
+            Wrap::Hanging => {
+                let n = para.chars().take_while(|c| *c == ' ').count();
+                match n + HANGING_MIN_TEXT <= width {
+                    true => n,
+                    false => 0,
+                }
             }
-            while UnicodeWidthStr::width(line.as_str()) > width {
-                let head: String = line.chars().take(width).collect();
-                let tail: String = line.chars().skip(width).collect();
-                out.push(head);
-                line = tail;
+            _ => 0,
+        };
+        let pad = " ".repeat(indent);
+        let mut row = Row {
+            text: String::new(),
+            indent: 0,
+            skipped: 0,
+        };
+        let mut first = true;
+        for chunk in chunks(para) {
+            // The line's own leading whitespace is source text and stays.
+            if first {
+                row.text.push_str(chunk);
+                first = false;
+            } else if w(&row.text) + w(chunk) <= width {
+                row.text.push_str(chunk);
+            } else {
+                // The break eats the spaces before the chunk, and the next row
+                // opens with the hanging indent instead.
+                let body = chunk.trim_start_matches(' ');
+                let eaten = chunk.chars().count() - body.chars().count();
+                out.push(std::mem::replace(
+                    &mut row,
+                    Row {
+                        text: pad.clone(),
+                        indent,
+                        skipped: eaten,
+                    },
+                ));
+                row.text.push_str(body);
+            }
+            // A chunk too long for a row of its own is cut, and the remainder
+            // opens the next row — still behind the indent.
+            while w(&row.text) > width {
+                let head: String = row.text.chars().take(width).collect();
+                let tail: String = row.text.chars().skip(width).collect();
+                out.push(Row {
+                    text: head,
+                    indent: row.indent,
+                    skipped: row.skipped,
+                });
+                row = Row {
+                    text: format!("{pad}{tail}"),
+                    indent,
+                    skipped: 0,
+                };
             }
         }
-        out.push(line);
+        out.push(row);
     }
     if out.is_empty() {
-        out.push(String::new());
+        out.push(Row {
+            text: String::new(),
+            indent: 0,
+            skipped: 0,
+        });
     }
     out
 }
@@ -147,27 +248,67 @@ pub struct Frag {
 /// is then cut back into fragments along the original piece boundaries. A wrap
 /// point inside a piece splits it; a row crossing three pieces is three
 /// fragments.
-pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: bool) -> Vec<Vec<Frag>> {
-    use unicode_width::UnicodeWidthStr;
-
+pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: Wrap) -> Vec<Vec<Frag>> {
     let whole: String = runs.iter().map(|r| &*r.text).collect();
-    let rows: Vec<String> = if wrap {
-        wrap_text(&whole, width)
-    } else {
-        whole.split('\n').map(|s| s.to_string()).collect()
+    let rows: Vec<Row> = match wrap {
+        Wrap::None => whole
+            .split('\n')
+            .map(|s| Row {
+                text: s.to_string(),
+                indent: 0,
+                skipped: 0,
+            })
+            .collect(),
+        mode => wrap_rows(&whole, width, mode),
     };
 
-    // Walk the pieces alongside the rows. Wrapping can drop a separator at a
-    // break, so rows are matched by content length rather than by byte offset
-    // into the original.
+    // Walk the pieces alongside the rows. A row is not a slice of the source —
+    // the break ate whitespace, and a hanging indent added some — so each row
+    // says how much of each, and this steps by those numbers rather than
+    // guessing at them.
     let mut piece = 0usize;
     let mut used = 0usize; // chars of the current piece already emitted
     let mut out: Vec<Vec<Frag>> = Vec::with_capacity(rows.len());
 
+    // Step over source characters the wrap consumed and nothing shows.
+    let skip = |n: usize, piece: &mut usize, used: &mut usize| {
+        let mut left = n;
+        while left > 0 && *piece < runs.len() {
+            let chars = runs[*piece].text.chars().count();
+            let here = chars.saturating_sub(*used).min(left);
+            *used += here;
+            left -= here;
+            if *used >= chars {
+                *piece += 1;
+                *used = 0;
+            }
+        }
+    };
+
     for row in &rows {
+        skip(row.skipped, &mut piece, &mut used);
         let mut frags: Vec<Frag> = Vec::new();
-        let mut want: usize = row.chars().count();
-        let mut at = 0usize; // chars of this row already taken
+        let mut at = row.indent; // chars of this row already taken
+        let mut want: usize = row.text.chars().count().saturating_sub(row.indent);
+
+        // The indent has no source behind it, so it takes the theme of the
+        // text it is indenting — the row it belongs to, not the one before.
+        if row.indent > 0 {
+            let mut theme = None;
+            let mut p = piece;
+            while p < runs.len() {
+                if runs[p].text.chars().count() > used || p > piece {
+                    theme = runs[p].theme.clone();
+                    break;
+                }
+                p += 1;
+            }
+            let pad: String = row.text.chars().take(row.indent).collect();
+            frags.push(Frag {
+                text: Rc::from(pad.as_str()),
+                theme,
+            });
+        }
 
         while want > 0 && piece < runs.len() {
             let piece_chars: Vec<char> = runs[piece].text.chars().collect();
@@ -180,7 +321,7 @@ pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: bool) -> Vec<Vec<F
             let take = left.min(want);
             // Take the text from the *row*, not the piece: the row is what
             // wrapping produced, and it is what must appear on screen.
-            let seg: String = row.chars().skip(at).take(take).collect();
+            let seg: String = row.text.chars().skip(at).take(take).collect();
             if !seg.is_empty() {
                 frags.push(Frag {
                     text: Rc::from(seg.as_str()),
@@ -196,22 +337,6 @@ pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: bool) -> Vec<Vec<F
             }
         }
 
-        // A separator consumed by the wrap: step past it so the next row starts
-        // at the right place in the piece list.
-        if want == 0 && piece < runs.len() {
-            let piece_chars = runs[piece].text.chars().count();
-            if used < piece_chars {
-                let next: Option<char> = runs[piece].text.chars().nth(used);
-                if next == Some(' ') {
-                    used += 1;
-                    if used >= piece_chars {
-                        piece += 1;
-                        used = 0;
-                    }
-                }
-            }
-        }
-
         if frags.is_empty() {
             frags.push(Frag {
                 text: Rc::from(""),
@@ -221,7 +346,6 @@ pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: bool) -> Vec<Vec<F
         out.push(frags);
     }
 
-    let _ = UnicodeWidthStr::width("");
     if out.is_empty() {
         out.push(vec![Frag {
             text: Rc::from(""),
@@ -609,16 +733,16 @@ impl RenderObject for TextRender {
         // logical run, so styling never changes where the text breaks.
         let whole = self.props.plain();
         let natural = UnicodeWidthStr::width(whole.as_str()) as u16;
-        if self.props.wrap {
+        if self.props.wrap != Wrap::None {
             let w = if c.min_w > 0 {
                 c.max_w
             } else {
                 c.max_w.min(natural.max(1))
             };
-            self.rows = wrap_runs(&self.props.runs, w, true);
+            self.rows = wrap_runs(&self.props.runs, w, self.props.wrap);
             c.constrain(Size::new(w, self.rows.len().min(u16::MAX as usize) as u16))
         } else {
-            self.rows = wrap_runs(&self.props.runs, 0, false);
+            self.rows = wrap_runs(&self.props.runs, 0, Wrap::None);
             c.constrain(Size::new(natural, self.rows.len().max(1) as u16))
         }
     }
@@ -628,17 +752,17 @@ impl RenderObject for TextRender {
         // mark, and `Elide::None` is the whole of today's behaviour, so both
         // pass straight through.
         let elided: Vec<Vec<Frag>>;
-        let rows: &[Vec<Frag>] = if self.props.wrap || self.props.elide == crate::desc::Elide::None
-        {
-            &self.rows
-        } else {
-            elided = self
-                .rows
-                .iter()
-                .map(|r| elide_row(r, g.rect.w, self.props.elide))
-                .collect();
-            &elided
-        };
+        let rows: &[Vec<Frag>] =
+            if self.props.wrap != Wrap::None || self.props.elide == crate::desc::Elide::None {
+                &self.rows
+            } else {
+                elided = self
+                    .rows
+                    .iter()
+                    .map(|r| elide_row(r, g.rect.w, self.props.elide))
+                    .collect();
+                &elided
+            };
 
         // An unstyled run is one item, exactly as before. A styled one emits an
         // item per fragment, each carrying its own theme — so the display list

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -974,6 +974,7 @@ impl LayerRender {
                 modality: p.modality,
                 scrim: p.scrim,
                 dismiss: p.dismiss,
+                within: p.within.clone(),
             },
         }
     }

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -506,8 +506,17 @@ fn stack_in(c: Constraints, cx: &mut dyn LayoutCx, align: Align, inset: Point) -
     let mut sizes = Vec::with_capacity(kids.len());
     for &k in &kids {
         let (sw, sh) = cx.sizing(k);
+        // **The floor wins over the sizing, here as in a row.** `min_w` says
+        // "never narrower than this, whatever the sizing resolves to", and a
+        // stack honouring the sizing but not the floor made that a promise
+        // that held in flow layout and quietly did not in a stack — or in a
+        // layer, which measures its child through this. A percentage below the
+        // floor is exactly where the two differ, so it is exactly where the
+        // omission hid.
+        let (fw, fh) = cx.floor(k);
         let wc = range(sw, c.max_w, w_definite, align);
         let hc = range(sh, c.max_h, h_definite, align);
+        let (wc, hc) = ((wc.0.max(fw), wc.1.max(fw)), (hc.0.max(fh), hc.1.max(fh)));
         let s = cx.measure(k, Constraints::new(wc.0, wc.1, hc.0, hc.1));
         sizes.push(s);
         size = Size::new(size.w.max(s.w), size.h.max(s.h));

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -782,8 +782,13 @@ impl RenderObject for ViewportRender {
                 own = c.constrain(Size::new(content.w.max(c.min_w), content.h));
                 // A vertical scrollbar takes a one-column gutter when the
                 // content is taller than the window; re-measure the content in
-                // the narrower area so it is not painted over the bar.
-                let gutter = u16::from(self.props.scrollbar && content.h > own.h);
+                // the narrower area so it is not painted over the bar. A
+                // stable gutter keeps the column whether the bar is drawn or
+                // not, so the content does not reflow when the list crosses
+                // the length that makes it overflow.
+                let gutter = u16::from(
+                    self.props.scrollbar && (self.props.stable_gutter || content.h > own.h),
+                );
                 if gutter > 0 {
                     let inner_w = own.w.saturating_sub(gutter);
                     let narrow = if c.min_w == c.max_w {
@@ -833,8 +838,9 @@ impl RenderObject for ViewportRender {
                 // When the content overflows and a scrollbar is asked for, the
                 // last column is a gutter the scrollbar owns: content laid out
                 // over it would paint the bar away, since a node's own paint is
-                // under its children.
-                let gutter = u16::from(self.props.scrollbar && n > rows);
+                // under its children. A stable gutter reserves it either way.
+                let gutter =
+                    u16::from(self.props.scrollbar && (self.props.stable_gutter || n > rows));
                 let inner_w = own.w.saturating_sub(gutter);
                 self.window = Rect::new(0, scroll.y, inner_w, own.h);
                 cx.set_scroll(ScrollInfo {
@@ -869,15 +875,16 @@ impl RenderObject for ViewportRender {
         if content <= g.rect.h as u32 {
             return;
         }
-        out.push_at(
-            Draw::Scrollbar {
-                offset,
-                content,
-                window: g.rect.h,
-            },
-            Rect::new(g.rect.right() - 1, g.rect.y, 1, g.rect.h),
-            g.clip,
-        );
+        let bar = Draw::Scrollbar {
+            offset,
+            content,
+            window: g.rect.h,
+        };
+        let rect = Rect::new(g.rect.right() - 1, g.rect.y, 1, g.rect.h);
+        match &self.props.bar_theme {
+            Some(t) => out.push_themed(bar, rect, g.clip, crate::ThemeKey(Some(t.clone()))),
+            None => out.push_at(bar, rect, g.clip),
+        }
     }
 
     fn relayout_boundary(&self) -> bool {

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -355,6 +355,147 @@ pub fn wrap_runs(runs: &[crate::desc::Run], width: u16, wrap: Wrap) -> Vec<Vec<F
     out
 }
 
+/// Lay children out along the main axis, breaking onto a new line whenever the
+/// next child would not fit.
+///
+/// CSS calls this `flex-wrap: wrap`, and the shape is the same: children are
+/// never split — a break happens at a child boundary — so a group that must
+/// stay together is a nested non-wrapping box. A child wider than the whole
+/// container gets a line to itself and overflows it, which is the honest
+/// answer: the alternative is silently shrinking something that said how wide
+/// it was.
+///
+/// **`Flex` on the main axis is treated as `Auto` here**, deliberately. A
+/// flexible child absorbs the remainder of its line, so one of them makes
+/// every line the full width and there is nothing left to wrap; the two
+/// features answer opposite questions ("fill the row" and "let the row become
+/// as many rows as it needs") and a container that tried to honour both would
+/// silently do neither. Cross-axis sizing is unaffected.
+fn wrap_in(
+    c: Constraints,
+    cx: &mut dyn LayoutCx,
+    dir: Dir,
+    align: Align,
+    gap: u16,
+    inset: Point,
+) -> Size {
+    let kids = cx.children();
+    let n = kids.len();
+    let avail = main_of(dir, c.max());
+    let cross_extent = cross_of(dir, c.max());
+
+    // Every child at its natural main extent. Nothing here depends on which
+    // line a child lands on, so this is one pass — the lines are decided from
+    // the answers.
+    let mut mains = vec![0u16; n];
+    let mut crosses = vec![0u16; n];
+    for i in 0..n {
+        let (sw, sh) = cx.sizing(kids[i]);
+        let (s_main, s_cross) = match dir {
+            Dir::Row => (sw, sh),
+            Dir::Col => (sh, sw),
+        };
+        let floor = main_floor(dir, cx.floor(kids[i]));
+        let main = match s_main {
+            Sizing::Cells(v) => (v.min(avail), v.min(avail)),
+            Sizing::Pct(p) => {
+                let v = pct(avail, p);
+                (v, v)
+            }
+            // See above: flexible means "as big as it needs" in a wrapping box.
+            Sizing::Auto | Sizing::Flex(_) => (0, avail),
+        };
+        let main = (main.0.max(floor), main.1.max(floor));
+        // The cross axis is never definite per-child here: a line's extent is
+        // not known until the line is full, so a child that wants to fill it
+        // is stretched afterwards rather than measured against a guess.
+        let cross = range(s_cross, cross_extent, false, Align::Start);
+        let s = cx.measure(kids[i], axes(dir, main, cross));
+        mains[i] = main_of(dir, s);
+        crosses[i] = cross_of(dir, s);
+    }
+
+    // Greedy fill. `used` is the line's main extent including the gaps already
+    // spent inside it, so the fit test is the same arithmetic as the placement.
+    let mut lines: Vec<(usize, usize)> = Vec::new(); // [start, end)
+    let mut start = 0usize;
+    let mut used = 0u16;
+    for i in 0..n {
+        let with_gap = match i == start {
+            true => mains[i],
+            false => mains[i].saturating_add(gap),
+        };
+        if i > start && used.saturating_add(with_gap) > avail {
+            lines.push((start, i));
+            start = i;
+            used = mains[i];
+        } else {
+            used = used.saturating_add(with_gap);
+        }
+    }
+    if start < n {
+        lines.push((start, n));
+    }
+
+    let line_cross: Vec<u16> = lines
+        .iter()
+        .map(|&(a, b)| crosses[a..b].iter().copied().max().unwrap_or(0))
+        .collect();
+    let content_main = lines
+        .iter()
+        .map(|&(a, b)| {
+            let sum = mains[a..b].iter().fold(0u16, |x, y| x.saturating_add(*y));
+            sum.saturating_add(gap.saturating_mul((b - a).saturating_sub(1) as u16))
+        })
+        .max()
+        .unwrap_or(0);
+    let content_cross = line_cross
+        .iter()
+        .fold(0u16, |x, y| x.saturating_add(*y))
+        .saturating_add(gap.saturating_mul(lines.len().saturating_sub(1) as u16));
+
+    // A child that asked to fill its line's cross extent is measured again now
+    // that the line is full — the same second pass the non-wrapping path makes
+    // when the cross extent was not known in advance, per line instead of per
+    // container.
+    if align == Align::Stretch {
+        for (li, &(a, b)) in lines.iter().enumerate() {
+            for i in a..b {
+                let (sw, sh) = cx.sizing(kids[i]);
+                let s_cross = match dir {
+                    Dir::Row => sh,
+                    Dir::Col => sw,
+                };
+                if s_cross == Sizing::Auto && crosses[i] != line_cross[li] {
+                    let s = cx.measure(
+                        kids[i],
+                        axes(dir, (mains[i], mains[i]), (line_cross[li], line_cross[li])),
+                    );
+                    mains[i] = main_of(dir, s);
+                    crosses[i] = cross_of(dir, s);
+                }
+            }
+        }
+    }
+
+    let mut cross_at = 0u16;
+    for (li, &(a, b)) in lines.iter().enumerate() {
+        let mut main_at = 0u16;
+        for i in a..b {
+            let at = point_of(
+                dir,
+                main_at as i32,
+                cross_at as i32 + align_offset(align, line_cross[li], crosses[i]),
+            );
+            cx.place(kids[i], Point::new(at.x + inset.x, at.y + inset.y));
+            main_at = main_at.saturating_add(mains[i]).saturating_add(gap);
+        }
+        cross_at = cross_at.saturating_add(line_cross[li]).saturating_add(gap);
+    }
+
+    c.constrain(size_of(dir, content_main, content_cross))
+}
+
 /// Lay children out one on top of another, each honouring its own size
 /// request. What a node with no layout of its own does.
 fn stack_in(c: Constraints, cx: &mut dyn LayoutCx, align: Align, inset: Point) -> Size {
@@ -420,6 +561,21 @@ impl RenderObject for BoxRender {
 
         if p.stack {
             let content = stack_in(inner, cx, p.align, Point::new(ins_x as i32, ins_y as i32));
+            return c.constrain(Size::new(
+                content.w.saturating_add(2 * ins_x),
+                content.h.saturating_add(2 * ins_y),
+            ));
+        }
+
+        if p.wrap {
+            let content = wrap_in(
+                inner,
+                cx,
+                p.dir,
+                p.align,
+                p.gap,
+                Point::new(ins_x as i32, ins_y as i32),
+            );
             return c.constrain(Size::new(
                 content.w.saturating_add(2 * ins_x),
                 content.h.saturating_add(2 * ins_y),

--- a/crates/fresh-ui/src/schedule.rs
+++ b/crates/fresh-ui/src/schedule.rs
@@ -454,6 +454,20 @@ pub struct Ui<M> {
     pub(crate) frame_size: Size,
     /// Relayout boundaries awaiting a measure pass.
     pub(crate) layout_dirty: Vec<crate::render::object::RenderId>,
+    /// Rectangles the host supplied for keys no element carries.
+    ///
+    /// An [`Anchor::Node`] names a thing; usually that thing is an element and
+    /// the tree knows where it is. Sometimes it is a point *inside* a host leaf
+    /// — a text caret, a terminal's cursor — and the tree hands that leaf a
+    /// rectangle and knows nothing about what is in it. The owner of the space
+    /// supplies the rectangle instead, and the anchor is still a name rather
+    /// than a number in a description.
+    ///
+    /// The web platform calls this an anchor element with a virtual reference;
+    /// the rule here is the same one: whoever owns the space answers where the
+    /// thing is. Cleared at the start of every frame, because a stale caret is
+    /// worse than none.
+    pub(crate) host_anchors: std::collections::HashMap<crate::key::Key, Rect>,
     /// Out-of-flow layers found by the last arrange walk, with their parents.
     pub(crate) pending_layers: Vec<(
         crate::render::object::RenderId,
@@ -519,6 +533,7 @@ impl<M: 'static> Ui<M> {
             frame_no: 0,
             frame_size: Size::ZERO,
             layout_dirty: Vec::new(),
+            host_anchors: std::collections::HashMap::new(),
             pending_layers: Vec::new(),
             spec: LayoutSpec::default(),
             hover: Vec::new(),
@@ -541,9 +556,40 @@ impl<M: 'static> Ui<M> {
     /// One frame: take a freshly built root description, reconcile it, lay it
     /// out for a terminal of `size`, and return the display list.
     pub fn frame(&mut self, root: Node<M>, size: Size) -> &LayoutSpec {
+        self.host_anchors.clear();
         self.run_flush(Some(root));
         self.flush_layout(size);
         self.settle(size);
+        self.flush_paint(size);
+        &self.spec
+    }
+
+    /// Tell the tree where something inside a host leaf is, so an
+    /// [`Anchor::Node`] naming it can resolve.
+    ///
+    /// The tree gives a host a rectangle and knows nothing about its interior,
+    /// so a layer anchored to a text caret names something only the host can
+    /// locate. This is how the host answers. See [`Ui::host_anchors`].
+    ///
+    /// An element carrying the key always wins: this fills a gap, it cannot
+    /// shadow a real node. Anchors are per-frame and [`Ui::frame`] clears them.
+    /// Call [`Ui::place_layers`] afterwards to put the layers where the new
+    /// anchors say.
+    pub fn set_host_anchor(&mut self, key: crate::key::Key, rect: Rect) {
+        self.host_anchors.insert(key, rect);
+    }
+
+    /// Place every layer again, against the anchors as they now stand, and
+    /// repaint.
+    ///
+    /// For a host whose own pipeline is interleaved with the tree's: it needs
+    /// the frame laid out before it can work out where its caret is, and the
+    /// caret before a layer hanging off it can be placed. Re-running the frame
+    /// would reconcile a description that has not changed and pump every
+    /// behaviour a second time; this re-walks the arrangement and repaints,
+    /// which is what actually has to happen.
+    pub fn place_layers(&mut self, size: Size) -> &LayoutSpec {
+        self.replace_layers(size);
         self.flush_paint(size);
         &self.spec
     }

--- a/crates/fresh-ui/src/widgets/button.rs
+++ b/crates/fresh-ui/src/widgets/button.rs
@@ -136,6 +136,7 @@ impl<M: 'static> Component<M> for Button<M> {
 pub struct Toggle<M> {
     label: Rc<str>,
     value: bool,
+    indeterminate: bool,
     on_change: Option<Rc<dyn Fn(bool) -> M>>,
 }
 
@@ -144,8 +145,26 @@ impl<M: 'static> Toggle<M> {
         Toggle {
             label: Rc::from(label.as_ref()),
             value,
+            indeterminate: false,
             on_change: None,
         }
+    }
+
+    /// Neither on nor off: `[-]`, and the value means nothing.
+    ///
+    /// The third state a checkbox has wherever a value can be *unset* — the
+    /// web platform spells it `input.indeterminate`, and a settings form needs
+    /// it wherever a field inherits from a layer below rather than being
+    /// chosen. A definite `[ ]` there reads as "the user turned this off",
+    /// which is a different fact and usually the wrong one.
+    ///
+    /// It is display only. Toggling still reports `!value`, so the owner
+    /// decides what leaving the unset state means — which is the owner's
+    /// question: "inherit" resolves to on for some fields and off for others,
+    /// and a widget that guessed would be wrong half the time.
+    pub fn indeterminate(mut self, yes: bool) -> Self {
+        self.indeterminate = yes;
+        self
     }
 
     pub fn on_change(mut self, f: impl Fn(bool) -> M + 'static) -> Self {
@@ -158,7 +177,11 @@ impl<M: 'static> Component<M> for Toggle<M> {
     type State = FocusMirror;
 
     fn build(&self, s: &FocusMirror, cx: &mut BuildCx<'_, M>) -> Node<M> {
-        let mark = if self.value { "[x] " } else { "[ ] " };
+        let mark = match (self.indeterminate, self.value) {
+            (true, _) => "[-] ",
+            (false, true) => "[x] ",
+            (false, false) => "[ ] ",
+        };
         let theme = if s.focused {
             "toggle.focused"
         } else if s.hovered {

--- a/crates/fresh-ui/src/widgets/list.rs
+++ b/crates/fresh-ui/src/widgets/list.rs
@@ -151,7 +151,7 @@ pub struct List<M> {
     bar_theme: Option<String>,
     #[allow(clippy::type_complexity)]
     row_theme: Option<Rc<dyn Fn(usize, RowState) -> String>>,
-    row_rows: crate::desc::ItemRows,
+    row_rows: u16,
 }
 
 impl<M: 'static> List<M> {
@@ -195,7 +195,7 @@ impl<M: 'static> List<M> {
             stable_gutter: false,
             bar_theme: None,
             row_theme: None,
-            row_rows: crate::desc::ItemRows::default(),
+            row_rows: 1,
         }
     }
 
@@ -283,18 +283,17 @@ impl<M: 'static> List<M> {
         self
     }
 
-    /// How many cells each row occupies. One by default, which is what a list
-    /// of lines is; a card list says more. See [`crate::desc::ItemRows`].
+    /// How many cells one row occupies. One by default, which is what a list
+    /// of lines is.
+    ///
+    /// **Uniform, and that is the point.** A card list — each item a little
+    /// block rather than a line — is still addressable by index: the window
+    /// knows which items it holds without measuring any of them, which is what
+    /// keeps a window onto a million of them possible. Rows that each decide
+    /// their own height are a different widget and would need a different
+    /// answer.
     pub fn row_rows(mut self, cells: u16) -> Self {
-        self.row_rows = crate::desc::ItemRows::Uniform(cells.max(1));
-        self
-    }
-
-    /// One height per row, for a list whose rows differ in kind — a tree of
-    /// folder headers one row tall and cards several. See
-    /// [`crate::desc::ItemRows::Each`].
-    pub fn row_rows_each(mut self, cells: impl Into<Rc<[u16]>>) -> Self {
-        self.row_rows = crate::desc::ItemRows::Each(cells.into());
+        self.row_rows = cells.max(1);
         self
     }
 }
@@ -398,7 +397,7 @@ impl<M: 'static> Component<M> for List<M> {
 
         // The window comes from the viewport, which owns it. This component
         // decides only which rows fill it.
-        let row_rows = self.row_rows.clone();
+        let row_rows = self.row_rows;
         let reader = layout_reader(move |info| {
             let win = info.scroll_window.unwrap_or_default();
             let visible = (win.h as usize).max(1);
@@ -423,7 +422,7 @@ impl<M: 'static> Component<M> for List<M> {
                     Some(f) => f(i, state),
                     None => state.theme().to_string(),
                 };
-                let content = row.key(k).theme(theme).h(Sizing::Cells(row_rows.at(i)));
+                let content = row.key(k).theme(theme).h(Sizing::Cells(row_rows));
                 let g = gesture(content).on_enter(hover(i)).on_leave(hover(i));
                 match &click {
                     Some(mk) => g.on(GestureKind::Click, mk(i)),
@@ -432,9 +431,7 @@ impl<M: 'static> Component<M> for List<M> {
             }))
         });
 
-        let mut body = viewport(reader)
-            .items(n as u32)
-            .item_rows(self.row_rows.clone());
+        let mut body = viewport(reader).items(n as u32).item_rows(row_rows);
         if let Some(a) = anchor.clone() {
             body = body.anchor_to(a);
         }

--- a/crates/fresh-ui/src/widgets/list.rs
+++ b/crates/fresh-ui/src/widgets/list.rs
@@ -151,6 +151,7 @@ pub struct List<M> {
     bar_theme: Option<String>,
     #[allow(clippy::type_complexity)]
     row_theme: Option<Rc<dyn Fn(usize, RowState) -> String>>,
+    row_rows: u16,
 }
 
 impl<M: 'static> List<M> {
@@ -194,6 +195,7 @@ impl<M: 'static> List<M> {
             stable_gutter: false,
             bar_theme: None,
             row_theme: None,
+            row_rows: 1,
         }
     }
 
@@ -278,6 +280,20 @@ impl<M: 'static> List<M> {
     /// [`Node::scrollbar_theme`](crate::Node::scrollbar_theme).
     pub fn scrollbar_theme(mut self, name: impl AsRef<str>) -> Self {
         self.bar_theme = Some(name.as_ref().to_string());
+        self
+    }
+
+    /// How many cells one row occupies. One by default, which is what a list
+    /// of lines is.
+    ///
+    /// **Uniform, and that is the point.** A card list — each item a little
+    /// block rather than a line — is still addressable by index: the window
+    /// knows which items it holds without measuring any of them, which is what
+    /// keeps a window onto a million of them possible. Rows that each decide
+    /// their own height are a different widget and would need a different
+    /// answer.
+    pub fn row_rows(mut self, cells: u16) -> Self {
+        self.row_rows = cells.max(1);
         self
     }
 }
@@ -381,6 +397,7 @@ impl<M: 'static> Component<M> for List<M> {
 
         // The window comes from the viewport, which owns it. This component
         // decides only which rows fill it.
+        let row_rows = self.row_rows;
         let reader = layout_reader(move |info| {
             let win = info.scroll_window.unwrap_or_default();
             let visible = (win.h as usize).max(1);
@@ -405,7 +422,7 @@ impl<M: 'static> Component<M> for List<M> {
                     Some(f) => f(i, state),
                     None => state.theme().to_string(),
                 };
-                let content = row.key(k).theme(theme).h(Sizing::Cells(1));
+                let content = row.key(k).theme(theme).h(Sizing::Cells(row_rows));
                 let g = gesture(content).on_enter(hover(i)).on_leave(hover(i));
                 match &click {
                     Some(mk) => g.on(GestureKind::Click, mk(i)),
@@ -414,7 +431,7 @@ impl<M: 'static> Component<M> for List<M> {
             }))
         });
 
-        let mut body = viewport(reader).items(n as u32);
+        let mut body = viewport(reader).items(n as u32).item_rows(row_rows);
         if let Some(a) = anchor.clone() {
             body = body.anchor_to(a);
         }

--- a/crates/fresh-ui/src/widgets/list.rs
+++ b/crates/fresh-ui/src/widgets/list.rs
@@ -151,7 +151,7 @@ pub struct List<M> {
     bar_theme: Option<String>,
     #[allow(clippy::type_complexity)]
     row_theme: Option<Rc<dyn Fn(usize, RowState) -> String>>,
-    row_rows: u16,
+    row_rows: crate::desc::ItemRows,
 }
 
 impl<M: 'static> List<M> {
@@ -195,7 +195,7 @@ impl<M: 'static> List<M> {
             stable_gutter: false,
             bar_theme: None,
             row_theme: None,
-            row_rows: 1,
+            row_rows: crate::desc::ItemRows::default(),
         }
     }
 
@@ -283,17 +283,18 @@ impl<M: 'static> List<M> {
         self
     }
 
-    /// How many cells one row occupies. One by default, which is what a list
-    /// of lines is.
-    ///
-    /// **Uniform, and that is the point.** A card list — each item a little
-    /// block rather than a line — is still addressable by index: the window
-    /// knows which items it holds without measuring any of them, which is what
-    /// keeps a window onto a million of them possible. Rows that each decide
-    /// their own height are a different widget and would need a different
-    /// answer.
+    /// How many cells each row occupies. One by default, which is what a list
+    /// of lines is; a card list says more. See [`crate::desc::ItemRows`].
     pub fn row_rows(mut self, cells: u16) -> Self {
-        self.row_rows = cells.max(1);
+        self.row_rows = crate::desc::ItemRows::Uniform(cells.max(1));
+        self
+    }
+
+    /// One height per row, for a list whose rows differ in kind — a tree of
+    /// folder headers one row tall and cards several. See
+    /// [`crate::desc::ItemRows::Each`].
+    pub fn row_rows_each(mut self, cells: impl Into<Rc<[u16]>>) -> Self {
+        self.row_rows = crate::desc::ItemRows::Each(cells.into());
         self
     }
 }
@@ -397,7 +398,7 @@ impl<M: 'static> Component<M> for List<M> {
 
         // The window comes from the viewport, which owns it. This component
         // decides only which rows fill it.
-        let row_rows = self.row_rows;
+        let row_rows = self.row_rows.clone();
         let reader = layout_reader(move |info| {
             let win = info.scroll_window.unwrap_or_default();
             let visible = (win.h as usize).max(1);
@@ -422,7 +423,7 @@ impl<M: 'static> Component<M> for List<M> {
                     Some(f) => f(i, state),
                     None => state.theme().to_string(),
                 };
-                let content = row.key(k).theme(theme).h(Sizing::Cells(row_rows));
+                let content = row.key(k).theme(theme).h(Sizing::Cells(row_rows.at(i)));
                 let g = gesture(content).on_enter(hover(i)).on_leave(hover(i));
                 match &click {
                     Some(mk) => g.on(GestureKind::Click, mk(i)),
@@ -431,7 +432,9 @@ impl<M: 'static> Component<M> for List<M> {
             }))
         });
 
-        let mut body = viewport(reader).items(n as u32).item_rows(row_rows);
+        let mut body = viewport(reader)
+            .items(n as u32)
+            .item_rows(self.row_rows.clone());
         if let Some(a) = anchor.clone() {
             body = body.anchor_to(a);
         }

--- a/crates/fresh-ui/src/widgets/list.rs
+++ b/crates/fresh-ui/src/widgets/list.rs
@@ -147,6 +147,8 @@ pub struct List<M> {
     focusable: bool,
     autofocus: bool,
     scrollbar: bool,
+    stable_gutter: bool,
+    bar_theme: Option<String>,
     #[allow(clippy::type_complexity)]
     row_theme: Option<Rc<dyn Fn(usize, RowState) -> String>>,
 }
@@ -189,6 +191,8 @@ impl<M: 'static> List<M> {
             focusable: true,
             autofocus: false,
             scrollbar: false,
+            stable_gutter: false,
+            bar_theme: None,
             row_theme: None,
         }
     }
@@ -223,6 +227,14 @@ impl<M: 'static> List<M> {
         self
     }
 
+    /// Whether the list joins the focus ring.
+    ///
+    /// A list that is driven from outside — its selection set by the caller
+    /// each frame, its keys handled by whatever *does* hold the keyboard —
+    /// should say no. Otherwise it is a stop on the way round, and Tab lands
+    /// on a widget that has nothing to do with the key it was pressed for.
+    /// The rows keep answering the mouse either way: this is about the
+    /// keyboard, not about being inert.
     pub fn focusable(mut self, yes: bool) -> Self {
         self.focusable = yes;
         self
@@ -251,6 +263,21 @@ impl<M: 'static> List<M> {
     /// Show how far through the list the window is.
     pub fn scrollbar(mut self) -> Self {
         self.scrollbar = true;
+        self
+    }
+
+    /// The same, with the bar's column reserved whether the bar is there or
+    /// not — see [`Node::scrollbar_gutter`](crate::Node::scrollbar_gutter).
+    pub fn scrollbar_gutter(mut self) -> Self {
+        self.scrollbar = true;
+        self.stable_gutter = true;
+        self
+    }
+
+    /// Name the bar's appearance — see
+    /// [`Node::scrollbar_theme`](crate::Node::scrollbar_theme).
+    pub fn scrollbar_theme(mut self, name: impl AsRef<str>) -> Self {
+        self.bar_theme = Some(name.as_ref().to_string());
         self
     }
 }
@@ -289,19 +316,27 @@ impl<M: 'static> Component<M> for List<M> {
         let row_theme = self.row_theme.clone();
         // Clicking a row selects it, the same selection the keyboard drives.
         // Built here so it rides along with each visible row the reader emits.
-        let click: Option<RowClick<M>> = if self.focusable {
+        //
+        // A list that is not focusable still has a mouse: declining the focus
+        // ring says the *keyboard* is somewhere else, not that the rows stop
+        // answering. The click asks for focus only where there is focus to
+        // ask for.
+        let click: Option<RowClick<M>> = {
             let up = up.clone();
             let anchor = anchor.clone();
             let on_select = self.on_select.clone();
             let on_activate = self.on_activate.clone();
             let activate_on = self.activate_on;
+            let takes_focus = self.focusable;
             Some(Rc::new(move |i: usize| {
                 let up = up.clone();
                 let anchor = anchor.clone();
                 let on_select = on_select.clone();
                 let on_activate = on_activate.clone();
                 let handler: crate::desc::Handler<M> = Rc::new(move |e: &Event| {
-                    e.request_focus(crate::event::SelectionOnFocus::Preserve);
+                    if takes_focus {
+                        e.request_focus(crate::event::SelectionOnFocus::Preserve);
+                    }
                     up.set(move |st: &mut ListState| st.selected = i);
                     let _ = &anchor;
                     // A click always moves the selection; whether it also
@@ -320,8 +355,6 @@ impl<M: 'static> Component<M> for List<M> {
                 });
                 handler
             }))
-        } else {
-            None
         };
 
         // The row under the pointer tints itself. Enter and Leave are mirrored
@@ -385,8 +418,13 @@ impl<M: 'static> Component<M> for List<M> {
         if let Some(a) = anchor.clone() {
             body = body.anchor_to(a);
         }
-        if self.scrollbar {
+        if self.stable_gutter {
+            body = body.scrollbar_gutter();
+        } else if self.scrollbar {
             body = body.scrollbar();
+        }
+        if let Some(t) = &self.bar_theme {
+            body = body.scrollbar_theme(t);
         }
 
         if !self.focusable {

--- a/crates/fresh-ui/tests/focus.rs
+++ b/crates/fresh-ui/tests/focus.rs
@@ -450,3 +450,41 @@ fn moving_focus_directly_is_available_without_a_key() {
     assert!(ui.move_focus(FocusDir::Next));
     assert_eq!(ui.focused(), Some(ui.at(&[0]).unwrap()));
 }
+
+/// **A direction needs somewhere to move from; Tab does not.**
+///
+/// `dispatch_key` resolves a key to an `Intent` and falls back to default
+/// traversal even when nothing is focused, so an arrow key used to move focus
+/// "from nowhere" onto the first focusable — and *claim* the key. In a host
+/// that offers its keys to this tree before its own handlers, that key was the
+/// application's: the editor's command palette lost a `Right` to it the moment
+/// its frame gained a focusable, moving focus instead of the text cursor.
+///
+/// Tab is the gesture that means "enter the interface", and still does.
+#[test]
+fn an_arrow_key_with_nothing_focused_is_not_traversal() {
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        col().children([focusable(text("one")), focusable(text("two"))]),
+        FRAME,
+    );
+    assert!(ui.focused().is_none(), "nothing is focused to begin with");
+
+    for code in [KeyCode::Right, KeyCode::Left, KeyCode::Up, KeyCode::Down] {
+        let got = ui.dispatch(Input::Key(KeyPress::new(code)));
+        assert!(
+            !got.claimed,
+            "{code:?} with nothing focused belongs to the application"
+        );
+        assert!(ui.focused().is_none(), "{code:?} moved focus from nowhere");
+    }
+
+    // Tab does enter, and from then on the directions work as they always did.
+    assert!(ui.dispatch(Input::Key(KeyPress::new(KeyCode::Tab))).claimed);
+    assert!(ui.focused().is_some(), "Tab enters the interface");
+    assert!(
+        ui.dispatch(Input::Key(KeyPress::new(KeyCode::Down)))
+            .claimed,
+        "with a starting point, a direction traverses"
+    );
+}

--- a/crates/fresh-ui/tests/golden/context_modal.txt
+++ b/crates/fresh-ui/tests/golden/context_modal.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === moved to Delete
@@ -27,7 +27,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === the confirmation modal, with a scrim
@@ -75,6 +75,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/deleting.txt
+++ b/crates/fresh-ui/tests/golden/deleting.txt
@@ -27,6 +27,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 4 tasks · light · synced 0 · deleted #3
 

--- a/crates/fresh-ui/tests/golden/divider.txt
+++ b/crates/fresh-ui/tests/golden/divider.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === dragged right — the pointer left the divider's own column
@@ -27,7 +27,7 @@ Filter              │new task…                      Add
                     │
                     │
                     │
-                    │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === and back left, over an unrelated widget
@@ -43,7 +43,7 @@ Filter  │new task…                                  Add
         │
         │
         │
-        │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === released: moving no longer resizes
@@ -59,6 +59,6 @@ Filter  │new task…                                  Add
         │
         │
         │
-        │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/filtering.txt
+++ b/crates/fresh-ui/tests/golden/filtering.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === clicked Done
@@ -27,7 +27,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === back to All
@@ -43,6 +43,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/menu.txt
+++ b/crates/fresh-ui/tests/golden/menu.txt
@@ -11,7 +11,7 @@
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === a click outside dismisses it
@@ -27,6 +27,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/million.txt
+++ b/crates/fresh-ui/tests/golden/million.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === three notches down
@@ -27,7 +27,7 @@ Filter      │new task…                              Add
             │»[ ] task 10                           #11│
             │»[ ] task 11                           #12│
             │»[x] task 12                           #13│
-            │»[ ] task 13                           #14│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === half a million rows down
@@ -43,7 +43,7 @@ Filter      │new task…                              Add
             │»[ ] task 499010                   #499011│
             │»[x] task 499011                   #499012│
             │»[ ] task 499012                   #499013│
-            │»[ ] task 499013                   #499014│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === and back to the top
@@ -59,6 +59,6 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/million.txt
+++ b/crates/fresh-ui/tests/golden/million.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === three notches down
@@ -27,7 +27,7 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === half a million rows down
@@ -43,7 +43,7 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 
 === and back to the top
@@ -59,6 +59,6 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
-            │»[ ] task 10                           #11│
+ alpha · visit 1
 1000000 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/million.txt
+++ b/crates/fresh-ui/tests/golden/million.txt
@@ -11,39 +11,39 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
- alpha · visit 1
+            │»[ ] task 10                           #11│
 1000000 tasks · light · synced 0 · ready
 
 === three notches down
  File  Go ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
-( ) Open    │»[ ] task 1                             #2│
-( ) Done    │»[ ] task 2                             #3│
-┌──────────┐│»[x] task 3                             #4│
-│clip-test ││»[ ] task 4                             #5│
-└──────────┘│»[ ] task 5                             #6│
-            │»[x] task 6                             #7│
-            │»[ ] task 7                             #8│
-            │»[ ] task 8                             #9│
+( ) Open    │»[ ] task 4                             #5│
+( ) Done    │»[ ] task 5                             #6│
+┌──────────┐│»[x] task 6                             #7│
+│clip-test ││»[ ] task 7                             #8│
+└──────────┘│»[ ] task 8                             #9│
             │»[x] task 9                            #10│
- alpha · visit 1
+            │»[ ] task 10                           #11│
+            │»[ ] task 11                           #12│
+            │»[x] task 12                           #13│
+            │»[ ] task 13                           #14│
 1000000 tasks · light · synced 0 · ready
 
 === half a million rows down
  File  Go ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 Filter      │new task…                              Add
 (o) All░░░░░│ ribbon: click the text, it falls through ·
-( ) Open    │»[ ] task 1                             #2│
-( ) Done    │»[ ] task 2                             #3│
-┌──────────┐│»[x] task 3                             #4│
-│clip-test ││»[ ] task 4                             #5│
-└──────────┘│»[ ] task 5                             #6│
-            │»[x] task 6                             #7│
-            │»[ ] task 7                             #8│
-            │»[ ] task 8                             #9│
-            │»[x] task 9                            #10│
- alpha · visit 1
+( ) Open    │»[ ] task 499004                   #499005│
+( ) Done    │»[x] task 499005                   #499006│
+┌──────────┐│»[ ] task 499006                   #499007│
+│clip-test ││»[ ] task 499007                   #499008█
+└──────────┘│»[x] task 499008                   #499009│
+            │»[ ] task 499009                   #499010│
+            │»[ ] task 499010                   #499011│
+            │»[x] task 499011                   #499012│
+            │»[ ] task 499012                   #499013│
+            │»[ ] task 499013                   #499014│
 1000000 tasks · light · synced 0 · ready
 
 === and back to the top
@@ -59,6 +59,6 @@ Filter      │new task…                              Add
             │»[ ] task 7                             #8│
             │»[ ] task 8                             #9│
             │»[x] task 9                            #10│
- alpha · visit 1
+            │»[ ] task 10                           #11│
 1000000 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/opening.txt
+++ b/crates/fresh-ui/tests/golden/opening.txt
@@ -11,6 +11,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/palette.txt
+++ b/crates/fresh-ui/tests/golden/palette.txt
@@ -11,7 +11,7 @@ Filter      │new task…                              Add
             │   │Sync                  │
             │   └──────────────────────┘
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === filtered to matches containing p
@@ -27,7 +27,7 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === filtered to matches containing t
@@ -43,7 +43,7 @@ Filter      │new task…                              Add
             │   └──────────────────────┘
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === ran Toggle theme: the accent and the status change
@@ -59,6 +59,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · dark · synced 0 · theme dark
 

--- a/crates/fresh-ui/tests/golden/resize.txt
+++ b/crates/fresh-ui/tests/golden/resize.txt
@@ -11,17 +11,17 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === at 30x8
  File  Go ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
 Filter      │new task…    Add
 (o) All░░░░░│ ribbon: click th
-( ) Open    │»[x] build the re
-( ) Done    │»[ ] lay it out
-┌──────────┐│»[ ] route the po
-└──────────┘│»[ ] wire up focu
+( ) Open    │»[x] build the r█
+( ) Done    │»[ ] lay it out #
+            │»[ ] route the p│
+ alpha · visit 1
 5 tasks · light · synced 0 · r
 
 === at 90x6
@@ -29,7 +29,7 @@ Filter      │new task…    Add
 Filter      │new task…                                                                Add
 (o) All░░░░░│ ribbon: click the text, it falls through · last press: — ░░░ [clear filter]
 ( ) Open    │»[x] build the reconciler                                                 #2│
-( ) Done    │»[ ] lay it out                                                           #3│
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === back to 56x14
@@ -45,6 +45,6 @@ Filter      │new task…                              Add
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 

--- a/crates/fresh-ui/tests/golden/typing.txt
+++ b/crates/fresh-ui/tests/golden/typing.txt
@@ -11,7 +11,7 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === typed
@@ -27,7 +27,7 @@ Filter      │ship it▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪�
             │
             │
             │
-            │
+ alpha · visit 1
 5 tasks · light · synced 0 · ready
 
 === submitted
@@ -43,7 +43,7 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
             │
             │
             │
-            │
+ alpha · visit 1
 6 tasks · light · synced 0 · added #6
 
 === the field is empty, so backspace does nothing
@@ -59,6 +59,6 @@ Filter      │new task…▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
             │
             │
             │
-            │
+ alpha · visit 1
 6 tasks · light · synced 0 · added #6
 

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -1157,3 +1157,43 @@ fn an_empty_wrapping_box_has_no_lines() {
     let ui = wrapped(10, 0, &[]);
     assert_eq!(wrapper(&ui).h, 0);
 }
+
+/// **`min_w` means the same thing in a stack as in a row.** "Never narrower
+/// than this, whatever the sizing resolves to" — and a percentage that
+/// resolves below the floor is exactly where the two could differ, so it is
+/// exactly where an omission would hide.
+///
+/// A layer measures its child through the same path, which is how this was
+/// found: a dialog sized `Pct(10)` with a 20-cell floor came out ten wide.
+#[test]
+fn a_stack_honours_its_childs_size_floor() {
+    let mut ui = ui();
+    ui.frame(
+        fresh_ui::stack().child(text("x").w(Sizing::Pct(10)).min_w(20).h(Sizing::Cells(1))),
+        Size::new(100, 24),
+    );
+    assert_eq!(ui.rect(ui.at(&[0]).unwrap()).w, 20, "the floor wins");
+}
+
+/// And the floor does not *become* the size: a percentage above it resolves
+/// normally.
+#[test]
+fn a_stacks_floor_does_not_override_a_larger_size() {
+    let mut ui = ui();
+    ui.frame(
+        fresh_ui::stack().child(text("x").w(Sizing::Pct(50)).min_w(20).h(Sizing::Cells(1))),
+        Size::new(100, 24),
+    );
+    assert_eq!(ui.rect(ui.at(&[0]).unwrap()).w, 50);
+}
+
+/// The same on the cross axis, so `min_h` is not a second omission waiting.
+#[test]
+fn a_stack_honours_a_height_floor_too() {
+    let mut ui = ui();
+    ui.frame(
+        fresh_ui::stack().child(text("x").h(Sizing::Pct(10)).min_h(6).w(Sizing::Cells(4))),
+        Size::new(100, 20),
+    );
+    assert_eq!(ui.rect(ui.at(&[0]).unwrap()).h, 6);
+}

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -904,3 +904,66 @@ fn an_element_outranks_a_published_anchor_for_the_same_key() {
         "the real node still answers for its own key"
     );
 }
+
+/// **A layer can be confined to a region rather than to the frame.**
+///
+/// A surface that floats over everything belongs to the frame. Some do not: a
+/// popup hanging off a status bar must not put its right border on the
+/// editor's scrollbar, and clamping to the frame lands it exactly there.
+/// Shrinking the layer is not the same statement — that changes how big the
+/// box is, when what is wanted is where it may go.
+#[test]
+fn a_layer_confined_to_a_region_clamps_to_that_region() {
+    let area = Key::Str("area".into());
+    let popup = Key::Str("popup".into());
+    // The layer wants to sit at x=70 and is 20 wide, so it overhangs both the
+    // frame (80) and the region (79) and has to be pulled back.
+    let tree = |within: Option<Key>| -> Node<()> {
+        let mut l = fresh_ui::layer()
+            .key(popup.clone())
+            .anchor(fresh_ui::Anchor::Point(70, 5))
+            .place(fresh_ui::Place::Over)
+            .fit(fresh_ui::Fit::CLAMP);
+        if let Some(k) = within {
+            l = l.within(k);
+        }
+        col().child(l.child(col().w(Sizing::Cells(20)).h(Sizing::Cells(2)).theme("p")))
+    };
+    let x_of = |ui: &Ui<()>| ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap().x;
+
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(tree(None), FRAME);
+    assert_eq!(x_of(&ui), 60, "clamped to the frame's right edge");
+
+    // The same layer, told it may only occupy the frame less its last column.
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(tree(Some(area.clone())), FRAME);
+    ui.set_host_anchor(area.clone(), Rect::new(0, 0, FRAME.w - 1, FRAME.h));
+    ui.place_layers(FRAME);
+    assert_eq!(x_of(&ui), 59, "the reserved column is left alone");
+}
+
+/// A region also moves where a screen-anchored layer centres, and where it can
+/// start: the bounds are the whole coordinate space the placement works in, not
+/// just a right-hand limit.
+#[test]
+fn a_region_moves_the_origin_as_well_as_the_limit() {
+    let area = Key::Str("area".into());
+    let popup = Key::Str("popup".into());
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        col().child(
+            fresh_ui::layer()
+                .key(popup.clone())
+                .anchor(fresh_ui::Anchor::Screen(Align::Center))
+                .within(area.clone())
+                .child(col().w(Sizing::Cells(10)).h(Sizing::Cells(2)).theme("p")),
+        ),
+        FRAME,
+    );
+    // A region 40 wide starting at x=20: the centre is 20 + (40-10)/2 = 35.
+    ui.set_host_anchor(area.clone(), Rect::new(20, 4, 40, 10));
+    ui.place_layers(FRAME);
+    let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+    assert_eq!((r.x, r.y), (35, 4 + (10 - 2) / 2));
+}

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -828,3 +828,79 @@ fn a_layer_aligns_on_the_axis_its_placement_leaves_free() {
     // Stretch is the case `stretch_to_anchor` already spelled, unchanged.
     assert_eq!(at(Some(Align::Stretch)), (0, 30));
 }
+
+/// **A host can say where something inside it is, and an anchor can name it.**
+///
+/// The tree hands a host leaf a rectangle and knows nothing about its interior,
+/// so a layer anchored to a text caret names a thing the tree cannot locate.
+/// The alternative is a screen coordinate in the description, which is the
+/// caller doing the layout engine's job and carrying a number that goes stale.
+/// So the owner of the space answers where the thing is, and the description
+/// still names it.
+#[test]
+fn a_layer_can_anchor_to_a_rectangle_the_host_published() {
+    let caret = Key::Str("caret".into());
+    let popup = Key::Str("popup".into());
+    let tree = || -> Node<()> {
+        col().child(fresh_ui::host(1u64).flex(1)).child(
+            fresh_ui::layer()
+                .key(popup.clone())
+                .anchor(fresh_ui::Anchor::Node(caret.clone()))
+                .place(fresh_ui::Place::Below)
+                .child(col().w(Sizing::Cells(10)).h(Sizing::Cells(3)).theme("p")),
+        )
+    };
+    let rect_of = |ui: &Ui<()>| ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+
+    // No element and no published rectangle: the anchor falls back, as a name
+    // nobody answers always has.
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(tree(), FRAME);
+    let fallback = rect_of(&ui);
+
+    // The host says where its caret is; the layer lands on the row below it.
+    ui.set_host_anchor(caret.clone(), Rect::new(30, 8, 1, 1));
+    ui.place_layers(FRAME);
+    let placed = rect_of(&ui);
+    assert_eq!((placed.x, placed.y), (30, 9), "below the published cell");
+    assert_ne!(placed, fallback, "publishing an anchor moved the layer");
+
+    // It moves with the caret, without the description changing.
+    ui.set_host_anchor(caret.clone(), Rect::new(12, 3, 1, 1));
+    ui.place_layers(FRAME);
+    assert_eq!((rect_of(&ui).x, rect_of(&ui).y), (12, 4));
+
+    // Anchors are per-frame: a new frame with nothing published falls back
+    // again rather than reusing a caret that has since moved.
+    ui.frame(tree(), FRAME);
+    assert_eq!(rect_of(&ui), fallback, "a stale caret is worse than none");
+}
+
+/// An element carrying the key wins: a published rectangle fills a gap, it
+/// cannot shadow a real node.
+#[test]
+fn an_element_outranks_a_published_anchor_for_the_same_key() {
+    let k = Key::Str("thing".into());
+    let popup = Key::Str("popup".into());
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        col()
+            .child(col().key(k.clone()).w(Sizing::Cells(4)).h(Sizing::Cells(2)))
+            .child(
+                fresh_ui::layer()
+                    .key(popup.clone())
+                    .anchor(fresh_ui::Anchor::Node(k.clone()))
+                    .place(fresh_ui::Place::Below)
+                    .child(col().w(Sizing::Cells(6)).h(Sizing::Cells(1)).theme("p")),
+            ),
+        FRAME,
+    );
+    let with_element = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+    ui.set_host_anchor(k.clone(), Rect::new(50, 20, 1, 1));
+    ui.place_layers(FRAME);
+    assert_eq!(
+        ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap(),
+        with_element,
+        "the real node still answers for its own key"
+    );
+}

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -968,6 +968,56 @@ fn a_region_moves_the_origin_as_well_as_the_limit() {
     assert_eq!((r.x, r.y), (35, 4 + (10 - 2) / 2));
 }
 
+/// And it moves where a *point* starts, which is what lets a caller state a
+/// coordinate in the space it already holds one in.
+///
+/// A plugin panel's dropdown anchors at a row and column inside the panel. The
+/// panel's own origin is the shell's business, not the description's, so the
+/// description names the region and the point — and before this, the point was
+/// read as a frame coordinate and the pop-over opened in the top-left corner
+/// whenever the panel was not already there.
+#[test]
+fn a_region_moves_where_a_point_anchor_starts() {
+    let area = Key::Str("area".into());
+    let popup = Key::Str("popup".into());
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        col().child(
+            fresh_ui::layer()
+                .key(popup.clone())
+                .anchor(fresh_ui::Anchor::Point(3, 2))
+                .place(fresh_ui::Place::Over)
+                .within(area.clone())
+                .child(col().w(Sizing::Cells(10)).h(Sizing::Cells(2)).theme("p")),
+        ),
+        FRAME,
+    );
+    ui.set_host_anchor(area.clone(), Rect::new(20, 4, 40, 10));
+    ui.place_layers(FRAME);
+    let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+    assert_eq!((r.x, r.y), (23, 6), "the region's origin plus the point");
+}
+
+/// A layer that names no region is unaffected: the frame's origin is `(0, 0)`,
+/// so a screen coordinate stays a screen coordinate.
+#[test]
+fn a_point_with_no_region_is_still_a_frame_coordinate() {
+    let popup = Key::Str("popup".into());
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(
+        col().child(
+            fresh_ui::layer()
+                .key(popup.clone())
+                .anchor(fresh_ui::Anchor::Point(12, 7))
+                .place(fresh_ui::Place::Over)
+                .child(col().w(Sizing::Cells(4)).h(Sizing::Cells(1)).theme("p")),
+        ),
+        FRAME,
+    );
+    let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+    assert_eq!((r.x, r.y), (12, 7));
+}
+
 // ---------------------------------------------------------------------------
 // Wrapping boxes
 // ---------------------------------------------------------------------------

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -1018,6 +1018,77 @@ fn a_point_with_no_region_is_still_a_frame_coordinate() {
     assert_eq!((r.x, r.y), (12, 7));
 }
 
+/// A layer whose real anchor is inside a leaf places against *that*, not
+/// against the rectangle it could name.
+///
+/// The dropdown case: the trigger row is a node, the `[value ▼]` button inside
+/// it is not — a widget runtime laid the row's text out and the tree only
+/// knows where the row is. The offset says where the button is within it, and
+/// the pop-over opens under the button rather than under the row's left edge.
+#[test]
+fn an_offset_moves_the_anchor_the_layer_places_against() {
+    let trigger = Key::Str("trigger".into());
+    let popup = Key::Str("popup".into());
+    let tree = |dx: i16| -> Node<()> {
+        col().h(Sizing::Cells(1)).child(
+            row()
+                .key(trigger.clone())
+                .h(Sizing::Cells(1))
+                .w(Sizing::Cells(30))
+                .child(
+                    fresh_ui::layer()
+                        .key(popup.clone())
+                        .anchor(fresh_ui::Anchor::Parent)
+                        .place(fresh_ui::Place::Below)
+                        .offset(dx, 0)
+                        .child(col().w(Sizing::Cells(8)).h(Sizing::Cells(3)).theme("p")),
+                ),
+        )
+    };
+    let at = |dx: i16| {
+        let mut ui: Ui<()> = Ui::new();
+        ui.frame(tree(dx), FRAME);
+        let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+        (r.x, r.y)
+    };
+    assert_eq!(at(0), (0, 1), "the row's left edge, the row after it");
+    assert_eq!(at(11), (11, 1), "the button's column, the row after it");
+}
+
+/// And the fit sees the moved anchor: a flip clears the button, not the row.
+#[test]
+fn an_offset_anchor_is_what_a_flip_clears() {
+    let trigger = Key::Str("trigger".into());
+    let popup = Key::Str("popup".into());
+    let mut ui: Ui<()> = Ui::new();
+    // The trigger is on the last row of the frame, so a pop-over three rows
+    // tall cannot open below it and flips above.
+    ui.frame(
+        col().child(row().flex(1)).child(
+            row()
+                .key(trigger.clone())
+                .h(Sizing::Cells(1))
+                .w(Sizing::Cells(30))
+                .child(
+                    fresh_ui::layer()
+                        .key(popup.clone())
+                        .anchor(fresh_ui::Anchor::Parent)
+                        .place(fresh_ui::Place::Below)
+                        .fit(fresh_ui::Fit::FLIP.or(fresh_ui::Fit::CLAMP))
+                        .offset(4, 0)
+                        .child(col().w(Sizing::Cells(8)).h(Sizing::Cells(3)).theme("p")),
+                ),
+        ),
+        FRAME,
+    );
+    let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
+    assert_eq!(
+        (r.x, r.y, r.h),
+        (4, FRAME.h as i32 - 1 - 3, 3),
+        "above the trigger's row, still under the button's column"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Wrapping boxes
 // ---------------------------------------------------------------------------

--- a/crates/fresh-ui/tests/layout.rs
+++ b/crates/fresh-ui/tests/layout.rs
@@ -967,3 +967,193 @@ fn a_region_moves_the_origin_as_well_as_the_limit() {
     let r = ui.find_by_key(&popup).map(|id| ui.rect_of(id)).unwrap();
     assert_eq!((r.x, r.y), (35, 4 + (10 - 2) / 2));
 }
+
+// ---------------------------------------------------------------------------
+// Wrapping boxes
+// ---------------------------------------------------------------------------
+
+/// `n` fixed-width children in a wrapping row of the given width.
+///
+/// Nested in a column so the row's own height is free: as the root it would be
+/// constrained to the frame, and the height is half of what these tests are
+/// about.
+fn wrapped(width: u16, gap: u16, widths: &[u16]) -> Ui<()> {
+    let mut ui = ui();
+    ui.frame(
+        col().child(
+            row()
+                .wrap_children()
+                .gap(gap)
+                .children(
+                    widths
+                        .iter()
+                        .map(|w| text("x").w(Sizing::Cells(*w)).h(Sizing::Cells(1)))
+                        .collect::<Vec<_>>(),
+                )
+                .w(Sizing::Cells(width)),
+        ),
+        Size::new(width, 24),
+    );
+    ui
+}
+
+/// The wrapping row's own rectangle.
+fn wrapper(ui: &Ui<()>) -> Rect {
+    ui.rect(ui.at(&[0]).unwrap())
+}
+
+fn rects(ui: &Ui<()>, n: usize) -> Vec<Rect> {
+    (0..n).map(|i| ui.rect(ui.at(&[0, i]).unwrap())).collect()
+}
+
+/// Children that fit are laid out exactly as a plain row lays them out — a
+/// wrapping box that never wraps is not a different box.
+#[test]
+fn a_wrapping_row_that_fits_is_an_ordinary_row() {
+    let ui = wrapped(30, 0, &[10, 10, 10]);
+    assert_eq!(
+        rects(&ui, 3),
+        vec![
+            Rect::new(0, 0, 10, 1),
+            Rect::new(10, 0, 10, 1),
+            Rect::new(20, 0, 10, 1)
+        ]
+    );
+}
+
+/// **The whole point.** The fourth child does not fit, so it starts a second
+/// line and the container is two rows tall instead of one row wide and
+/// overflowing.
+#[test]
+fn a_child_that_does_not_fit_starts_a_new_line() {
+    let ui = wrapped(30, 0, &[10, 10, 10, 10]);
+    assert_eq!(
+        rects(&ui, 4),
+        vec![
+            Rect::new(0, 0, 10, 1),
+            Rect::new(10, 0, 10, 1),
+            Rect::new(20, 0, 10, 1),
+            Rect::new(0, 1, 10, 1),
+        ]
+    );
+    assert_eq!(wrapper(&ui).h, 2, "the row grew a line");
+}
+
+/// The gap is spent inside a line and between lines, and the fit test counts
+/// it — two 10-wide children with a gap of 2 fit in 22, not in 21.
+#[test]
+fn the_gap_counts_toward_the_fit_and_between_the_lines() {
+    let tight = wrapped(21, 2, &[10, 10]);
+    assert_eq!(
+        rects(&tight, 2),
+        vec![Rect::new(0, 0, 10, 1), Rect::new(0, 3, 10, 1)],
+        "21 is one cell short, so the second child wraps — and the line gap is          the same two cells, so the second line starts at 1 + 2"
+    );
+
+    let roomy = wrapped(22, 2, &[10, 10]);
+    assert_eq!(
+        rects(&roomy, 2),
+        vec![Rect::new(0, 0, 10, 1), Rect::new(12, 0, 10, 1)],
+        "22 is exactly enough"
+    );
+}
+
+/// A child wider than the container gets a line to itself and overflows it.
+/// The alternative — shrinking it — would silently contradict what it said
+/// about its own width.
+#[test]
+fn a_child_too_wide_for_the_container_gets_its_own_line() {
+    let ui = wrapped(10, 0, &[4, 20, 4]);
+    let r = rects(&ui, 3);
+    assert_eq!(r[0], Rect::new(0, 0, 4, 1));
+    assert_eq!(r[1].y, 1, "the wide one starts a line");
+    assert_eq!(r[2], Rect::new(0, 2, 4, 1), "and the next starts another");
+}
+
+/// **`Flex` is `Auto` here, and this is the test that says so.** A flexible
+/// child would otherwise absorb the rest of its line, so nothing after it
+/// could ever share one — wrapping and filling are opposite requests.
+#[test]
+fn a_flexible_child_does_not_swallow_its_line() {
+    let mut ui = ui();
+    ui.frame(
+        col().child(
+            row()
+                .wrap_children()
+                .children([
+                    text("aaaa").flex(1).h(Sizing::Cells(1)),
+                    text("bbbb").w(Sizing::Cells(4)).h(Sizing::Cells(1)),
+                ])
+                .w(Sizing::Cells(20)),
+        ),
+        Size::new(20, 24),
+    );
+    let r = rects(&ui, 2);
+    assert_eq!(r[0].w, 4, "sized to its content, not to the line");
+    assert_eq!(r[1].y, 0, "so the two share a line");
+    assert_eq!(r[1].x, 4);
+}
+
+/// Within a line, a child that asked to fill the cross axis fills *that
+/// line's* height — not the container's, which would put a short child on one
+/// line at the height of a tall child on another.
+#[test]
+fn a_stretching_child_fills_its_own_line_and_not_the_container() {
+    let mut ui = ui();
+    ui.frame(
+        col().child(
+            row()
+                .wrap_children()
+                .align(Align::Stretch)
+                .children([
+                    text("a\nb\nc").w(Sizing::Cells(6)),
+                    text("d").w(Sizing::Cells(6)),
+                    text("e").w(Sizing::Cells(6)),
+                ])
+                .w(Sizing::Cells(12)),
+        ),
+        Size::new(12, 24),
+    );
+    let r = rects(&ui, 3);
+    assert_eq!(r[0].h, 3, "three lines of text");
+    assert_eq!(r[1].h, 3, "stretched to its line, which the tall one set");
+    assert_eq!(r[2].y, 3, "the third child is on the second line");
+    assert_eq!(r[2].h, 1, "whose height is its own content's");
+}
+
+/// It is a property of the box, not of rows: a wrapping column breaks into
+/// columns when it runs out of rows.
+#[test]
+fn a_wrapping_column_breaks_into_columns() {
+    let mut ui = ui();
+    ui.frame(
+        row().child(
+            col()
+                .wrap_children()
+                .children(
+                    (0..4)
+                        .map(|_| text("x").h(Sizing::Cells(2)).w(Sizing::Cells(3)))
+                        .collect::<Vec<_>>(),
+                )
+                .h(Sizing::Cells(4)),
+        ),
+        Size::new(40, 4),
+    );
+    assert_eq!(
+        rects(&ui, 4),
+        vec![
+            Rect::new(0, 0, 3, 2),
+            Rect::new(0, 2, 3, 2),
+            Rect::new(3, 0, 3, 2),
+            Rect::new(3, 2, 3, 2),
+        ]
+    );
+}
+
+/// A wrapping box with no children has no lines and no size, rather than one
+/// empty line's worth of height.
+#[test]
+fn an_empty_wrapping_box_has_no_lines() {
+    let ui = wrapped(10, 0, &[]);
+    assert_eq!(wrapper(&ui).h, 0);
+}

--- a/crates/fresh-ui/tests/paint.rs
+++ b/crates/fresh-ui/tests/paint.rs
@@ -368,6 +368,82 @@ fn styling_does_not_change_where_text_breaks() {
     assert_eq!(plain, styled);
 }
 
+/// **A wrapped list entry stays inside its own entry.**
+///
+/// `Wrap::Hanging` starts every continuation row at the line's own leading
+/// whitespace. Only the thing that wraps knows where it broke, so only it can
+/// say what the next row starts with — a caller wanting this had to wrap the
+/// text itself, which means deciding the width, which is layout's answer.
+#[test]
+fn a_hanging_wrap_indents_every_row_after_the_first() {
+    let rows = |node: Node<()>| -> Vec<String> {
+        let mut ui: Ui<()> = Ui::new();
+        painted_rows(ui.frame(node, Size::new(20, 6)))
+    };
+    let entry = "    sep  a string put between the values";
+
+    assert_eq!(
+        rows(text(entry).wrap_hanging().w(Sizing::Cells(20))),
+        vec![
+            "    sep  a string".to_string(),
+            "    put between the".to_string(),
+            "    values".to_string(),
+        ],
+        "the four leading spaces carry to every continuation row"
+    );
+    // Plain wrapping is unchanged: the continuation rows start at the edge.
+    assert_eq!(
+        rows(text(entry).wrap().w(Sizing::Cells(20))),
+        vec![
+            "    sep  a string".to_string(),
+            "put between the".to_string(),
+            "values".to_string(),
+        ],
+    );
+}
+
+/// **Wrapping is not allowed to normalise the text it wraps.**
+///
+/// `split(' ')` yields an empty piece per space, and skipping empties quietly
+/// turned `"    sep  a string"` into `"sep a string"` — so a wrapped popup lost
+/// the indent on its *first* row and the double space that separated a
+/// parameter name from its description. The break still eats the space it
+/// broke at; everything else survives.
+#[test]
+fn wrapping_keeps_the_spaces_the_text_came_with() {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(
+        text("    sep  a string here").wrap().w(Sizing::Cells(20)),
+        Size::new(20, 4),
+    );
+    assert_eq!(
+        painted_rows(spec),
+        vec!["    sep  a string".to_string(), "here".to_string()],
+        "the leading four and the inner two are the text's, not the wrapper's"
+    );
+}
+
+/// The indent is dropped when it would leave the text almost nothing — a
+/// deeply indented line in a narrow box reads better flush left than one word
+/// per row.
+#[test]
+fn a_hanging_indent_yields_when_it_would_starve_the_text() {
+    let mut ui: Ui<()> = Ui::new();
+    // 8 spaces of indent in 12 columns leaves 4 for the text, under the
+    // `HANGING_MIN_TEXT` floor of 10.
+    let spec = ui.frame(
+        text("        alpha beta gamma")
+            .wrap_hanging()
+            .w(Sizing::Cells(12)),
+        Size::new(12, 6),
+    );
+    let rows = painted_rows(spec);
+    assert!(
+        rows.iter().skip(1).all(|r| !r.starts_with(' ')),
+        "no room for the indent, so it is not applied: {rows:?}"
+    );
+}
+
 // -- the in-flow / out-of-flow split -----------------------------------------
 
 /// **What `layers_from` is for.** A backend that draws content of its own

--- a/crates/fresh-ui/tests/persistence.rs
+++ b/crates/fresh-ui/tests/persistence.rs
@@ -1,0 +1,325 @@
+//! Scoped persistence: what a document switch does to element state.
+//!
+//! `Persisted` is the library's answer to a question every multi-document host
+//! asks — *this subtree is going away and coming back; what survives?* Its own
+//! documentation states the contract: a value is read at construction and
+//! written back at teardown, and "keys are anchored to the enclosing
+//! `PersistenceScope` rather than to tree position, so moving a widget does not
+//! lose its value and two widgets at the same position under different
+//! documents do not share one."
+//!
+//! Every claim in that sentence is load-bearing for a host that keys a document
+//! subtree and swaps it, and none of them was covered. These tests are the
+//! cover. They are deliberately written against the *host's* usage shape —
+//! a keyed subtree per document, a scope ambient at its root, identical keys
+//! inside — rather than against the behavior in isolation, because the failure
+//! modes are all about ordering and identity between two subtrees rather than
+//! about one value round-tripping.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use fresh_ui::ambient::{provide, scope};
+use fresh_ui::behavior::{Persisted, Store, PERSISTENCE_SCOPE};
+use fresh_ui::key::Key;
+use fresh_ui::{col, text, BuildCx, Component, ComponentExt, InitCx, Node, Size, Ui};
+
+// ---------------------------------------------------------------------------
+// A host store, and a log of what the library asked it to do
+// ---------------------------------------------------------------------------
+
+/// The host's side of persistence, plus a transcript.
+///
+/// The transcript is most of the point: two of the four things under test are
+/// about *ordering* between one subtree's teardown and the next one's
+/// construction, and a store that only remembers its final contents cannot
+/// tell a correct order from a lucky one.
+#[derive(Default)]
+struct Spy {
+    values: RefCell<HashMap<String, Rc<dyn std::any::Any>>>,
+    log: RefCell<Vec<String>>,
+}
+
+impl Spy {
+    fn log(&self) -> Vec<String> {
+        self.log.borrow().clone()
+    }
+}
+
+impl Store for Spy {
+    fn get(&self, key: &str) -> Option<Rc<dyn std::any::Any>> {
+        let v = self.values.borrow().get(key).cloned();
+        self.log
+            .borrow_mut()
+            .push(format!("get {key} -> {}", v.is_some()));
+        v
+    }
+
+    fn set(&self, key: &str, value: Rc<dyn std::any::Any>) {
+        self.log.borrow_mut().push(format!("set {key}"));
+        self.values.borrow_mut().insert(key.into(), value);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A leaf that keeps one scoped value
+// ---------------------------------------------------------------------------
+
+/// A component holding one persisted `String`, under whatever scope encloses
+/// it. Its own key is the same in every document, on purpose: that collision
+/// is what the scope has to survive.
+struct Note {
+    /// What this instance writes into its value once mounted. `None` leaves
+    /// whatever was restored, which is how the tests read a value back.
+    write: Option<&'static str>,
+}
+
+/// `Option`, because `Component::State` must be `Default` and a live
+/// behavior handle has no default — the same shape `tests/behavior.rs` uses.
+#[derive(Default)]
+struct NoteState {
+    value: Option<Rc<Persisted<String>>>,
+}
+
+impl Component<()> for Note {
+    type State = NoteState;
+
+    fn init(&self, cx: &mut InitCx<'_, ()>) -> NoteState {
+        // The scope is read by the caller — "the framework does not guess it"
+        // — so a component that forgets this line silently shares one value
+        // across every document. See the last test.
+        let scope = cx
+            .read(&PERSISTENCE_SCOPE)
+            .map(|s| (*s).clone())
+            .unwrap_or_else(|| "<none>".into());
+        let value = cx.register(Persisted::new(&scope, "note", String::new()));
+        if let Some(w) = self.write {
+            value.set(w.into());
+        }
+        NoteState { value: Some(value) }
+    }
+
+    fn build(&self, s: &NoteState, _cx: &mut BuildCx<'_, ()>) -> Node<()> {
+        text(s.value.as_ref().map(|v| v.get()).unwrap_or_default())
+    }
+}
+
+/// One document: `scope()` provides the persistence scope and keys the
+/// subtree by the same id, which is the pairing this whole file is about.
+fn document(id: &str, write: Option<&'static str>) -> Node<()> {
+    scope(
+        id,
+        col().child(Note { write }.node().key(Key::Str("note".into()))),
+    )
+}
+
+fn shown(ui: &Ui<()>) -> String {
+    ui.spec()
+        .in_flow()
+        .iter()
+        .filter_map(|i| match &i.draw {
+            fresh_ui::render::spec::Draw::Lines(l) => Some(l.join("")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn ui_with(store: &Rc<Spy>) -> Ui<()> {
+    let mut ui: Ui<()> = Ui::new();
+    ui.set_store(store.clone() as Rc<dyn Store>);
+    ui
+}
+
+// ---------------------------------------------------------------------------
+
+/// **A key change discards a subtree, and discarding it writes the value back.**
+///
+/// The whole scheme rests on this: a host that swaps documents by changing one
+/// key gets teardown for free. If `teardown` only ran when the `Ui` dropped,
+/// every switch would lose the value and the loss would look exactly like
+/// "persistence is not wired up yet".
+#[test]
+fn switching_documents_writes_the_outgoing_value_back() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("alpha's note")), Size::new(40, 4));
+    assert_eq!(shown(&ui), "alpha's note");
+
+    // The switch: a different key at the same position.
+    ui.frame(document("beta", Some("beta's note")), Size::new(40, 4));
+    assert_eq!(shown(&ui), "beta's note");
+
+    assert!(
+        spy.log().contains(&"set alpha/note".to_string()),
+        "alpha's note must be written back when its subtree goes away, log: {:?}",
+        spy.log()
+    );
+}
+
+/// **A value is in the store as soon as it is set, not when its element dies.**
+///
+/// This is the ordering hazard, and the reason `Persisted::set` writes
+/// through. Disposal is deferred to the end of a flush — reconcile is
+/// transactional and must be unwindable — so the *replacement* subtree is
+/// constructed before the outgoing one is disposed. Under a teardown-only
+/// write the log read `get alpha`, `get beta`, `set alpha`: anything mounted
+/// in the same flush saw the store before the outgoing value reached it, and a
+/// widget whose move reconciliation could not match by key read the default
+/// and then had the old instance's value written over the top of it.
+///
+/// Writing on change removes the question entirely: the store is current
+/// whenever anyone looks, whatever order disposal runs in.
+#[test]
+fn a_value_reaches_the_store_when_it_is_set() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("written")), Size::new(40, 4));
+    assert!(
+        spy.log().contains(&"set alpha/note".to_string()),
+        "the value must be in the store while its element is still alive, log: {:?}",
+        spy.log()
+    );
+
+    // And it is there before anything the next flush constructs asks for it.
+    ui.frame(document("beta", Some("other")), Size::new(40, 4));
+    let log = spy.log();
+    let set_alpha = log.iter().position(|l| l == "set alpha/note").unwrap();
+    let get_beta = log
+        .iter()
+        .position(|l| l.starts_with("get beta/note"))
+        .unwrap();
+    assert!(
+        set_alpha < get_beta,
+        "alpha's value is stored before beta is built, log: {log:?}"
+    );
+}
+
+/// **A document's value comes back when the document does.**
+///
+/// The round trip, through a discard — which is the case a host actually hits,
+/// and the one that distinguishes "persisted" from "the element happened to
+/// survive".
+#[test]
+fn a_documents_value_survives_being_switched_away_from() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("kept")), Size::new(40, 4));
+    ui.frame(document("beta", Some("beta's own")), Size::new(40, 4));
+    // Back to alpha, writing nothing: what shows is what was restored.
+    ui.frame(document("alpha", None), Size::new(40, 4));
+
+    assert_eq!(
+        shown(&ui),
+        "kept",
+        "alpha's note should be restored from the store, log: {:?}",
+        spy.log()
+    );
+}
+
+/// **Two documents at the same position, with the same key, do not share.**
+///
+/// This is the sentence in `Persisted`'s own documentation, and it is the one
+/// a multi-document host stakes everything on. The two notes here are the same
+/// component, at the same position, under the same key — the collision is
+/// deliberate, because per-document ids that restart at 1 produce exactly it.
+#[test]
+fn two_documents_do_not_share_one_value() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("alpha")), Size::new(40, 4));
+    ui.frame(document("beta", Some("beta")), Size::new(40, 4));
+    ui.frame(document("alpha", None), Size::new(40, 4));
+    assert_eq!(shown(&ui), "alpha");
+    ui.frame(document("beta", None), Size::new(40, 4));
+    assert_eq!(shown(&ui), "beta");
+
+    let values = spy.values.borrow();
+    assert!(
+        values.contains_key("alpha/note") && values.contains_key("beta/note"),
+        "each document keeps its own entry, got {:?}",
+        values.keys().collect::<Vec<_>>()
+    );
+}
+
+/// **Only the visible document is mounted.**
+///
+/// The efficiency claim a host relies on when it decides *not* to keep every
+/// document's subtree alive: switching does not leave the outgoing document
+/// costing anything. If both stayed mounted, the display list would carry both
+/// notes.
+#[test]
+fn the_document_that_is_not_shown_costs_nothing() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("alpha")), Size::new(40, 4));
+    ui.frame(document("beta", Some("beta")), Size::new(40, 4));
+
+    let out = shown(&ui);
+    assert!(
+        out.contains("beta") && !out.contains("alpha"),
+        "only the mounted document contributes to the display list, got {out:?}"
+    );
+}
+
+/// **Rebuilding the same document, frame after frame, is not a scope change.**
+///
+/// The case a host that rebuilds its whole description every frame is in all
+/// the time — which the cost model invites, since a rebuild costs one
+/// allocation per node. Each frame hands `provide` a *fresh* `Rc` holding an
+/// equal value. Under pointer identity that is a change: every dependent is
+/// marked dirty every frame, and a `Persisted` beneath it trips the "ambient
+/// read in `init()` changed" assertion on the second frame having never
+/// actually changed. `scope()` provides through `provide_eq`, so an equal
+/// value re-provided is not a change.
+#[test]
+fn rebuilding_the_same_document_is_not_a_scope_change() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+
+    ui.frame(document("alpha", Some("written")), Size::new(40, 4));
+    ui.frame(document("alpha", None), Size::new(40, 4));
+    ui.frame(document("alpha", None), Size::new(40, 4));
+
+    assert_eq!(shown(&ui), "written");
+    let gets = spy
+        .log()
+        .iter()
+        .filter(|l| l.starts_with("get alpha/note"))
+        .count();
+    assert_eq!(
+        gets,
+        1,
+        "one construction across three frames of the same document, log: {:?}",
+        spy.log()
+    );
+}
+
+/// **The trap `scope()` exists to close.**
+///
+/// Plain `provide` compares by pointer, so a fresh `Rc` of an equal value is a
+/// change; `Persisted` reads its scope in `init()`, which the library forbids
+/// changing for a live element. The two meet on the second frame. This is not
+/// a bug in either — it is the pairing being separable — and it is why the
+/// boundary is one node.
+#[test]
+#[should_panic(expected = "only read it in init()")]
+fn provide_by_pointer_identity_and_a_constructor_read_do_not_mix() {
+    let spy = Rc::new(Spy::default());
+    let mut ui = ui_with(&spy);
+    let doc = |id: &str| {
+        provide(
+            &PERSISTENCE_SCOPE,
+            Rc::new(id.to_string()),
+            col().child(Note { write: None }.node().key(Key::Str("note".into()))),
+        )
+    };
+    ui.frame(doc("alpha"), Size::new(40, 4));
+    ui.frame(doc("alpha"), Size::new(40, 4));
+}

--- a/crates/fresh-ui/tests/persistence.rs
+++ b/crates/fresh-ui/tests/persistence.rs
@@ -323,3 +323,74 @@ fn provide_by_pointer_identity_and_a_constructor_read_do_not_mix() {
     ui.frame(doc("alpha"), Size::new(40, 4));
     ui.frame(doc("alpha"), Size::new(40, 4));
 }
+
+// ---------------------------------------------------------------------------
+// `MemStore`: the floor every host stands on, and the one operation a map lacks
+// ---------------------------------------------------------------------------
+
+/// A host that installs the shipped store gets the round trip, with no store
+/// of its own to write. This is the same switch as
+/// `a_documents_value_survives_being_switched_away_from`, driven through
+/// `MemStore` instead of the spy — because the spy is a test double and the
+/// thing hosts will actually use is this.
+#[test]
+fn the_shipped_store_carries_a_value_across_a_switch() {
+    use fresh_ui::behavior::MemStore;
+    let store = Rc::new(MemStore::new());
+    let mut ui: Ui<()> = Ui::new();
+    ui.set_store(store.clone() as Rc<dyn Store>);
+
+    ui.frame(document("alpha", Some("kept")), Size::new(40, 4));
+    ui.frame(document("beta", None), Size::new(40, 4));
+    assert_eq!(shown(&ui), "", "beta has its own value, not alpha's");
+    ui.frame(document("alpha", None), Size::new(40, 4));
+    assert_eq!(shown(&ui), "kept", "alpha's value came back");
+}
+
+/// **The operation a plain map does not have.** A scope's values are dead when
+/// the thing it names is gone, and the tree cannot know that — an unmounted
+/// subtree is exactly the case where the values must be *kept*. So the host
+/// says so, and `forget_scope` is how.
+///
+/// The separator is the part worth pinning: prefix-matching on the bare scope
+/// name would take `window:10` down with `window:1`.
+#[test]
+fn forgetting_a_scope_takes_that_scope_and_no_neighbour() {
+    use fresh_ui::behavior::MemStore;
+    let store = MemStore::new();
+    store.set("window:1/scroll", Rc::new(7u32));
+    store.set("window:1/filter", Rc::new(String::from("x")));
+    store.set("window:10/scroll", Rc::new(9u32));
+    store.set("window:2/scroll", Rc::new(3u32));
+    assert_eq!(store.len(), 4);
+
+    store.forget_scope("window:1");
+
+    assert_eq!(store.len(), 2, "both of window:1's values went");
+    assert!(store.get("window:1/scroll").is_none());
+    assert!(store.get("window:1/filter").is_none());
+    assert!(
+        store.get("window:10/scroll").is_some(),
+        "window:10 is not inside window:1"
+    );
+    assert!(store.get("window:2/scroll").is_some());
+}
+
+/// A forgotten scope is a *new* document when it comes back: the next mount
+/// reads the default, not the value the last one left. Which is the whole
+/// point — a closed workspace's scroll offset must not be waiting for the next
+/// workspace that happens to reuse its id.
+#[test]
+fn a_forgotten_scope_comes_back_empty() {
+    use fresh_ui::behavior::MemStore;
+    let store = Rc::new(MemStore::new());
+    let mut ui: Ui<()> = Ui::new();
+    ui.set_store(store.clone() as Rc<dyn Store>);
+
+    ui.frame(document("alpha", Some("kept")), Size::new(40, 4));
+    ui.frame(document("beta", None), Size::new(40, 4));
+    store.forget_scope("alpha");
+    ui.frame(document("alpha", None), Size::new(40, 4));
+
+    assert_eq!(shown(&ui), "", "the value was forgotten, not restored");
+}

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -808,3 +808,61 @@ fn pressing_a_track_row_puts_the_thumb_on_that_row() {
         );
     }
 }
+
+/// **Closing a layer is not always the whole gesture.**
+///
+/// A click outside a menu is spent closing it — the menu was in the way. A
+/// tooltip is in the way of nothing: clicking into the document while one is
+/// showing should hide it *and* put the caret where the click landed, or the
+/// tooltip has charged the user a click to get rid of it.
+#[test]
+fn a_pass_through_dismissal_leaves_the_press_for_what_it_was_aimed_at() {
+    let log: Log = Rc::new(RefCell::new(Vec::new()));
+    let build = |pass: bool, log: &Log| -> Node<()> {
+        let l = log.clone();
+        let d = match pass {
+            true => fresh_ui::Dismiss::OUTSIDE_POINTER.passing_through(),
+            false => fresh_ui::Dismiss::OUTSIDE_POINTER,
+        };
+        let ll = log.clone();
+        stack().children([
+            // What the press was aimed at, behind the layer.
+            gesture(col().theme("doc")).on(
+                GestureKind::Press,
+                Rc::new(move |_: &Event| note(&ll, "document".into())),
+            ),
+            fresh_ui::layer()
+                .anchor(fresh_ui::Anchor::Point(0, 0))
+                .place(fresh_ui::Place::Over)
+                .dismiss(d)
+                .on_dismiss_handler(Rc::new(move |_: &Event| note(&l, "dismissed".into())))
+                .child(col().w(Sizing::Cells(4)).h(Sizing::Cells(2)).theme("pop")),
+        ])
+    };
+
+    // The claim is what the *host* is told — a host with its own pipeline
+    // behind this tree reads it to decide whether the press is still going.
+    // The tree's own handlers run either way, which is why the document's
+    // press is logged in both.
+    let press = |ui: &mut Ui<()>| {
+        ui.dispatch(Input::press(
+            Point::new(10, 6),
+            MouseButton::Left,
+            Mods::NONE,
+        ))
+        .claimed
+    };
+
+    // Spending the press: the host is told it is gone.
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(build(false, &log), FRAME);
+    assert!(press(&mut ui), "closing the layer was the whole gesture");
+    assert_eq!(*log.borrow(), vec!["dismissed", "document"]);
+
+    // Passing it through: dismissed, and the host still has the press.
+    log.borrow_mut().clear();
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(build(true, &log), FRAME);
+    assert!(!press(&mut ui), "the press is still going somewhere");
+    assert_eq!(*log.borrow(), vec!["dismissed", "document"]);
+}

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -866,3 +866,44 @@ fn a_pass_through_dismissal_leaves_the_press_for_what_it_was_aimed_at() {
     assert!(!press(&mut ui), "the press is still going somewhere");
     assert_eq!(*log.borrow(), vec!["dismissed", "document"]);
 }
+
+/// **And the same rule for the key that dismissed it.**
+///
+/// `pass_through` said "the input that dismissed this layer goes on to whatever
+/// it was aimed at", and the pointer honoured it while the keyboard did not:
+/// any dismissal at all reported the key as claimed. So a tooltip that hides on
+/// the next keystroke ate that keystroke — the tooltip charging the user a key
+/// to get rid of it, which is exactly the case the flag exists for.
+#[test]
+fn a_pass_through_dismissal_leaves_the_key_for_what_it_was_aimed_at() {
+    let build = |pass: bool| -> Node<()> {
+        let d = match pass {
+            true => fresh_ui::Dismiss::ANY_KEY.passing_through(),
+            false => fresh_ui::Dismiss::ANY_KEY,
+        };
+        stack().children([
+            col().theme("doc"),
+            fresh_ui::layer()
+                .anchor(fresh_ui::Anchor::Point(0, 0))
+                .place(fresh_ui::Place::Over)
+                .dismiss(d)
+                .on_dismiss_handler(Rc::new(|_: &Event| None))
+                .child(col().w(Sizing::Cells(4)).h(Sizing::Cells(2)).theme("pop")),
+        ])
+    };
+    let typed = |ui: &mut Ui<()>| {
+        ui.dispatch(Input::Key(fresh_ui::KeyPress::with(
+            fresh_ui::KeyCode::Char('j'),
+            Mods::NONE,
+        )))
+        .claimed
+    };
+
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(build(false), FRAME);
+    assert!(typed(&mut ui), "closing the layer was the whole keystroke");
+
+    let mut ui: Ui<()> = Ui::new();
+    ui.frame(build(true), FRAME);
+    assert!(!typed(&mut ui), "the key is still going somewhere");
+}

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -173,6 +173,48 @@ fn a_transparent_region_runs_its_handlers_then_lets_the_hit_continue() {
     );
 }
 
+/// **An observer above a transparent region hears the event once.**
+///
+/// Stacked paths share their upper reaches. Walking each in full offered the
+/// event to those shared ancestors once per path, so a capture-phase observer
+/// near the root — the way an application watches a channel without claiming
+/// it — fired two, three, however many times the point happened to stack. The
+/// extra paths exist for the elements *behind* the transparent one; the ones
+/// above it are the same elements either way.
+#[test]
+fn an_observer_above_a_transparent_region_hears_one_event_once() {
+    let log: Log = Rc::default();
+    let mut ui: Ui<()> = Ui::new();
+    let l = log.clone();
+    ui.frame(
+        gesture(
+            stack().children([
+                traced("behind", &log, text("xxxxxxxx"))
+                    .w(Sizing::Cells(8))
+                    .h(Sizing::Cells(1)),
+                gesture(Node::nil())
+                    .pointer_mode(PointerMode::Transparent)
+                    .w(Sizing::Cells(8))
+                    .h(Sizing::Cells(1)),
+            ]),
+        )
+        .on_capture(
+            GestureKind::Click,
+            Rc::new(move |_: &Event| note(&l, "observer".into())),
+        ),
+        FRAME,
+    );
+    click(&mut ui, 2, 0);
+    assert_eq!(
+        log.borrow().iter().filter(|s| *s == "observer").count(),
+        1,
+        "one click, one call: {:?}",
+        log.borrow()
+    );
+    // And what the extra path is for still happens.
+    assert!(log.borrow().iter().any(|s| s.starts_with("behind")));
+}
+
 #[test]
 fn capture_survives_the_pointer_leaving_the_rectangle() {
     let moves: Rc<RefCell<Vec<Point>>> = Rc::default();

--- a/crates/fresh-ui/tests/pointer.rs
+++ b/crates/fresh-ui/tests/pointer.rs
@@ -750,3 +750,61 @@ fn a_bound_keeps_a_press_from_reaching_what_was_clipped_away() {
         "the name's cells are not the slot's"
     );
 }
+
+/// **The thumb's top lands on the row pressed.**
+///
+/// Its travel is the part of the track it can reach — `track - len`, not the
+/// whole track — and dividing by the track instead leaves the thumb short of
+/// the row by up to `len` cells and the last row of the track unable to reach
+/// the end of the content. A one-cell thumb hides the bug (`track - 1` and
+/// `track - len` agree there), so this uses a window big enough for a thumb
+/// several rows tall.
+#[test]
+fn pressing_a_track_row_puts_the_thumb_on_that_row() {
+    let mut ui: Ui<()> = Ui::new();
+    // Twice the window's height of content: the thumb is half the track.
+    let rows: Vec<Node<()>> = (0..(FRAME.h as usize * 2))
+        .map(|i| text(format!("row {i}")))
+        .collect();
+    ui.frame(viewport(col().children(rows)).scrollbar(), FRAME);
+
+    let thumb = |ui: &Ui<()>| -> (u16, u16) {
+        let bar = ui
+            .spec()
+            .items
+            .iter()
+            .find_map(|i| match i.draw {
+                fresh_ui::Draw::Scrollbar {
+                    offset, content, ..
+                } => Some((offset, content, i.rect.h)),
+                _ => None,
+            })
+            .expect("an overflowing viewport shows a bar");
+        fresh_ui::Draw::scrollbar_thumb(bar.0, bar.1, bar.2)
+    };
+
+    let (_, len) = thumb(&ui);
+    assert!(
+        len > 1,
+        "the thumb must be taller than one cell to be a test"
+    );
+    let gutter = FRAME.w as i32 - 1;
+    for target in 0..=(FRAME.h - len) {
+        ui.dispatch(Input::press(
+            Point::new(gutter, target as i32),
+            MouseButton::Left,
+            Mods::NONE,
+        ));
+        ui.dispatch(Input::release(
+            Point::new(gutter, target as i32),
+            MouseButton::Left,
+            Mods::NONE,
+        ));
+        ui.tick();
+        assert_eq!(
+            thumb(&ui).0,
+            target,
+            "pressing track row {target} must put the thumb there"
+        );
+    }
+}

--- a/crates/fresh-ui/tests/support/demo/mod.rs
+++ b/crates/fresh-ui/tests/support/demo/mod.rs
@@ -52,6 +52,10 @@ impl Demo {
     pub fn with_app(app: App, size: Size) -> Self {
         let mut ui = Ui::new();
         ui.set_shortcuts(shortcuts());
+        // The host's half of `Persisted`: without a store the values are
+        // per-element defaults and a document switch loses them, which is
+        // exactly the failure the demo is here to not have.
+        ui.set_store(std::rc::Rc::new(MemStore::default()));
         let mut demo = Demo {
             app,
             ui,
@@ -125,5 +129,22 @@ impl Demo {
             "list.row.hover" | "button.hover" | "toggle.hover" | "number.hover" => None,
             _ => None,
         })
+    }
+}
+
+/// A process-lifetime store, which is all a demo needs. A real host would put
+/// this behind whatever it already persists workspace state with.
+#[derive(Default)]
+pub struct MemStore {
+    values: std::cell::RefCell<std::collections::HashMap<String, std::rc::Rc<dyn std::any::Any>>>,
+}
+
+impl fresh_ui::behavior::Store for MemStore {
+    fn get(&self, key: &str) -> Option<std::rc::Rc<dyn std::any::Any>> {
+        self.values.borrow().get(key).cloned()
+    }
+
+    fn set(&self, key: &str, value: std::rc::Rc<dyn std::any::Any>) {
+        self.values.borrow_mut().insert(key.into(), value);
     }
 }

--- a/crates/fresh-ui/tests/support/demo/mod.rs
+++ b/crates/fresh-ui/tests/support/demo/mod.rs
@@ -55,7 +55,7 @@ impl Demo {
         // The host's half of `Persisted`: without a store the values are
         // per-element defaults and a document switch loses them, which is
         // exactly the failure the demo is here to not have.
-        ui.set_store(std::rc::Rc::new(MemStore::default()));
+        ui.set_store(std::rc::Rc::new(fresh_ui::behavior::MemStore::new()));
         let mut demo = Demo {
             app,
             ui,
@@ -129,22 +129,5 @@ impl Demo {
             "list.row.hover" | "button.hover" | "toggle.hover" | "number.hover" => None,
             _ => None,
         })
-    }
-}
-
-/// A process-lifetime store, which is all a demo needs. A real host would put
-/// this behind whatever it already persists workspace state with.
-#[derive(Default)]
-pub struct MemStore {
-    values: std::cell::RefCell<std::collections::HashMap<String, std::rc::Rc<dyn std::any::Any>>>,
-}
-
-impl fresh_ui::behavior::Store for MemStore {
-    fn get(&self, key: &str) -> Option<std::rc::Rc<dyn std::any::Any>> {
-        self.values.borrow().get(key).cloned()
-    }
-
-    fn set(&self, key: &str, value: std::rc::Rc<dyn std::any::Any>) {
-        self.values.borrow_mut().insert(key.into(), value);
     }
 }

--- a/crates/fresh-ui/tests/support/demo/model.rs
+++ b/crates/fresh-ui/tests/support/demo/model.rs
@@ -94,7 +94,18 @@ impl Visible {
     }
 }
 
+/// The two documents the demo switches between.
+///
+/// The demo has one task list, deliberately: what changes with the project is
+/// not the model but the *scope* the view is built under, which is the whole
+/// point. `Ctrl-P` switches, and the scratch note beside the status bar is
+/// per-project incidental state — owned by the element, restored by
+/// `Persisted`, and never touched by this model.
+pub const PROJECTS: [&str; 2] = ["alpha", "beta"];
+
 pub struct App {
+    /// Index into [`PROJECTS`]. The view keys and scopes on it.
+    pub project: usize,
     pub tasks: Rc<Vec<Task>>,
     pub filter: Filter,
     pub selected: usize,
@@ -209,6 +220,7 @@ impl App {
     pub fn with_tasks(tasks: Vec<Task>) -> Self {
         let next_id = tasks.iter().map(|t| t.id).max().unwrap_or(0) + 1;
         App {
+            project: 0,
             tasks: Rc::new(tasks),
             filter: Filter::All,
             selected: 0,
@@ -280,6 +292,9 @@ impl App {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Msg {
+    /// Switch documents. Nothing else in the model changes — the view's scope
+    /// does, and the element state under it goes with it.
+    NextProject,
     Draft(String),
     Add,
     Toggle(usize),
@@ -317,6 +332,10 @@ pub enum Msg {
 /// The whole of the application's behaviour, in one place.
 pub fn update(app: &mut App, msg: Msg) {
     match msg {
+        Msg::NextProject => {
+            app.project = (app.project + 1) % PROJECTS.len();
+            app.status = format!("project: {}", PROJECTS[app.project]);
+        }
         Msg::Clicked(i, n) => app.last_click = Some((i, n)),
         Msg::RibbonClear => {
             app.filter = Filter::All;

--- a/crates/fresh-ui/tests/support/demo/view.rs
+++ b/crates/fresh-ui/tests/support/demo/view.rs
@@ -19,7 +19,7 @@ use fresh_ui::schedule::BuildCx;
 use fresh_ui::widgets::{divider, Button, Dropdown, List, RadioGroup, TextField};
 use fresh_ui::{Component, ComponentExt};
 
-use super::model::{App, Filter, Menu, Msg, Task, Theme, COMMANDS};
+use super::model::{App, Filter, Menu, Msg, Task, Theme, COMMANDS, PROJECTS};
 
 /// The theme reaches the status bar and the rows without appearing in a single
 /// intermediate signature.
@@ -37,6 +37,63 @@ pub fn view(app: &App) -> Node<Msg> {
         // wherever focus happens to be — that is what makes them global.
         .action(Intent::Custom("menu.file"), |_| Msg::Menu(Some(Menu::File)))
         .action(Intent::Custom("menu.go"), |_| Msg::Menu(Some(Menu::Go)))
+        .action(Intent::Custom("project.next"), |_| Msg::NextProject)
+}
+
+/// A scratch note, per project, owned by the element and not by the model.
+///
+/// **The point of the whole arrangement.** Its value is `Persisted` under the
+/// enclosing scope, so switching projects discards this element — the subtree
+/// above it is keyed by project — and switching back restores what this
+/// project had. Nothing in `App` knows the note exists.
+///
+/// A per-project visit counter, and the reason it counts rather than saying
+/// something fixed.
+///
+/// A note seeded per project reads the same whether it was *restored* or
+/// merely re-seeded, so it proves nothing. A count cannot be faked: this
+/// element is constructed once per visit — the subtree above it is keyed by
+/// project, so switching away destroys it — and the number it shows is
+/// therefore the number of times this project has been visited, which is only
+/// possible if the previous visit's value came back.
+///
+/// Alt-P a few times and watch the two counts advance independently. Without
+/// the scope, or without a `Store` installed on the `Ui`, both would sit at 1
+/// forever.
+struct Scratch;
+
+#[derive(Default)]
+struct ScratchState {
+    visits: Option<Rc<fresh_ui::behavior::Persisted<u32>>>,
+    scope: String,
+}
+
+impl Component<Msg> for Scratch {
+    type State = ScratchState;
+
+    fn init(&self, cx: &mut fresh_ui::InitCx<'_, Msg>) -> ScratchState {
+        // Read in `init`, which is where `Persisted` needs it — and is safe
+        // precisely because `scope()` keys the subtree, so this element never
+        // outlives the scope it read.
+        let scope = cx
+            .read(&fresh_ui::behavior::PERSISTENCE_SCOPE)
+            .map(|s| (*s).clone())
+            .unwrap_or_else(|| "<unscoped>".into());
+        let visits = cx.register(fresh_ui::behavior::Persisted::new(&scope, "visits", 0u32));
+        // One construction is one visit. `set` writes through, so the store is
+        // current immediately rather than at teardown — which matters because
+        // disposal is deferred past the *next* document's construction.
+        visits.set(visits.get() + 1);
+        ScratchState {
+            visits: Some(visits),
+            scope,
+        }
+    }
+
+    fn build(&self, s: &ScratchState, _cx: &mut BuildCx<'_, Msg>) -> Node<Msg> {
+        let n = s.visits.as_ref().map(|v| v.get()).unwrap_or(0);
+        text(format!(" {} · visit {n}", s.scope)).theme("statusbar")
+    }
 }
 
 fn app_body(app: &App) -> Node<Msg> {
@@ -47,12 +104,27 @@ fn app_body(app: &App) -> Node<Msg> {
             .theme("app")
             .children([
                 menu_bar(app),
-                row().flex(1).children([
-                    sidebar(app).w(Sizing::Cells(app.sidebar)),
-                    grip(),
-                    body(app).flex(1),
-                    preview(app),
-                ]),
+                // **The document boundary.** `scope` keys this subtree by the
+                // project *and* provides the persistence scope, which have to
+                // travel together: a scope that changed value under a
+                // surviving element would be an ambient change, and
+                // `Persisted` reads its scope in `init()`. Switching projects
+                // therefore replaces everything below — and the scratch note
+                // comes back, because its value is anchored to the scope
+                // rather than to a position in the tree.
+                fresh_ui::ambient::scope(
+                    PROJECTS[app.project],
+                    col().flex(1).children([
+                        row().flex(1).children([
+                            sidebar(app).w(Sizing::Cells(app.sidebar)),
+                            grip(),
+                            body(app).flex(1),
+                            preview(app),
+                        ]),
+                        Scratch.node().h(Sizing::Cells(1)),
+                    ]),
+                )
+                .flex(1),
                 StatusBar {
                     count: app.tasks.len(),
                     status: app.status.clone(),
@@ -476,6 +548,12 @@ pub fn shortcuts() -> Vec<fresh_ui::focus::Shortcut> {
     s.push(fresh_ui::focus::Shortcut::new(
         KeyPress::with(KeyCode::Char('g'), Mods::ALT),
         Intent::Custom("menu.go"),
+    ));
+    // Alt-P switches documents. Everything below the scope is replaced, and
+    // the scratch note comes back with the project it belongs to.
+    s.push(fresh_ui::focus::Shortcut::new(
+        KeyPress::with(KeyCode::Char('p'), Mods::ALT),
+        Intent::Custom("project.next"),
     ));
     s
 }

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -775,6 +775,80 @@ fn a_bar_carries_its_own_theme_and_the_rows_keep_theirs() {
     );
 }
 
+/// **A card list is a list whose items are blocks.**
+///
+/// Each item takes a fixed band of rows, and everything else about the list —
+/// the window, the index the offset counts, the selection, the click — is
+/// unchanged, because an item is still an item. What would break it is rows
+/// that each decide their own height: then the window could not say which
+/// items it holds without measuring all of them.
+#[test]
+fn a_card_lists_items_take_a_band_of_rows_each() {
+    let card = |i: usize| -> Node<Msg> {
+        fresh_ui::col()
+            .child(fresh_ui::text(format!("title {i}")))
+            .child(fresh_ui::text(format!("body {i}")))
+            .child(fresh_ui::text("────"))
+    };
+    let mut ui: Ui<Msg> = Ui::new();
+    // Nine rows of window, three rows per card: three cards fit.
+    ui.frame(
+        List::windowed(20, fresh_ui::Key::from, card)
+            .row_rows(3)
+            .scrollbar()
+            .node(),
+        Size::new(20, 9),
+    );
+    let band = |i: usize| {
+        let id = ui
+            .find_by_key(&fresh_ui::Key::from(i))
+            .unwrap_or_else(|| panic!("card {i}"));
+        let r = ui.rect_of(id);
+        (r.y, r.h)
+    };
+    assert_eq!(band(0), (0, 3), "the first card's band");
+    assert_eq!(band(1), (3, 3), "and they stack by their own height");
+    assert_eq!(band(2), (6, 3));
+    // The window is three cards tall; a fourth is built for overscan and lands
+    // below it, which is the whole of "the window knows what it holds".
+    assert_eq!(band(3).0, 9, "past the window's last row");
+}
+
+/// And the bar reads in items, not in cells. Nine cells of window over cards
+/// three rows tall is a window of *three* items — a thumb sized from the nine
+/// would claim the list is three times as visible as it is.
+#[test]
+fn a_card_lists_bar_measures_the_window_in_items() {
+    let card = |i: usize| -> Node<Msg> {
+        fresh_ui::col()
+            .child(fresh_ui::text(format!("title {i}")))
+            .child(fresh_ui::text(format!("body {i}")))
+            .child(fresh_ui::text("────"))
+    };
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        List::windowed(20, fresh_ui::Key::from, card)
+            .row_rows(3)
+            .scrollbar()
+            .node(),
+        Size::new(20, 9),
+    );
+    let bar = ui
+        .spec()
+        .items
+        .iter()
+        .find_map(|i| match i.draw {
+            Draw::Scrollbar {
+                offset,
+                content,
+                window,
+            } => Some((offset, content, window)),
+            _ => None,
+        })
+        .expect("an overflowing card list shows a bar");
+    assert_eq!(bar, (0, 20, 3), "twenty items, three of them visible");
+}
+
 /// **Declining the focus ring is about the keyboard, not about being inert.**
 ///
 /// A list driven from outside — its selection set by the caller each frame —

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -849,6 +849,54 @@ fn a_card_lists_bar_measures_the_window_in_items() {
     assert_eq!(bar, (0, 20, 3), "twenty items, three of them visible");
 }
 
+/// **A list whose rows differ in kind.** A tree of folder headers one row tall
+/// and cards several is still a list addressed by index — the offset counts
+/// items, the selection is an item, a click names one — and the only thing it
+/// cannot do is divide to find its window.
+#[test]
+fn a_list_can_give_each_row_its_own_height() {
+    // header, card, header, card, … — 1, 4, 1, 4, …
+    let heights: Vec<u16> = (0..10).map(|i| if i % 2 == 0 { 1 } else { 4 }).collect();
+    let hs = heights.clone();
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        List::windowed(10, fresh_ui::Key::from, move |i| {
+            fresh_ui::col()
+                .children((0..hs[i]).map(|r| fresh_ui::text(format!("{i}.{r}"))))
+        })
+        .row_rows_each(heights.clone())
+        .scrollbar()
+        .node(),
+        Size::new(20, 10),
+    );
+    let band = |i: usize| {
+        let id = ui.find_by_key(&fresh_ui::Key::from(i)).expect("row");
+        let r = ui.rect_of(id);
+        (r.y, r.h)
+    };
+    assert_eq!(band(0), (0, 1), "a header");
+    assert_eq!(band(1), (1, 4), "a card under it");
+    assert_eq!(band(2), (5, 1));
+    assert_eq!(band(3), (6, 4));
+
+    // Ten rows of window hold header/card/header/card = four items, and the
+    // bar says so: dividing by any single height would not have.
+    let bar = ui
+        .spec()
+        .items
+        .iter()
+        .find_map(|i| match i.draw {
+            Draw::Scrollbar {
+                offset,
+                content,
+                window,
+            } => Some((offset, content, window)),
+            _ => None,
+        })
+        .expect("a bar");
+    assert_eq!(bar, (0, 10, 4));
+}
+
 /// **Declining the focus ring is about the keyboard, not about being inert.**
 ///
 /// A list driven from outside — its selection set by the caller each frame —

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -849,54 +849,6 @@ fn a_card_lists_bar_measures_the_window_in_items() {
     assert_eq!(bar, (0, 20, 3), "twenty items, three of them visible");
 }
 
-/// **A list whose rows differ in kind.** A tree of folder headers one row tall
-/// and cards several is still a list addressed by index — the offset counts
-/// items, the selection is an item, a click names one — and the only thing it
-/// cannot do is divide to find its window.
-#[test]
-fn a_list_can_give_each_row_its_own_height() {
-    // header, card, header, card, … — 1, 4, 1, 4, …
-    let heights: Vec<u16> = (0..10).map(|i| if i % 2 == 0 { 1 } else { 4 }).collect();
-    let hs = heights.clone();
-    let mut ui: Ui<Msg> = Ui::new();
-    ui.frame(
-        List::windowed(10, fresh_ui::Key::from, move |i| {
-            fresh_ui::col()
-                .children((0..hs[i]).map(|r| fresh_ui::text(format!("{i}.{r}"))))
-        })
-        .row_rows_each(heights.clone())
-        .scrollbar()
-        .node(),
-        Size::new(20, 10),
-    );
-    let band = |i: usize| {
-        let id = ui.find_by_key(&fresh_ui::Key::from(i)).expect("row");
-        let r = ui.rect_of(id);
-        (r.y, r.h)
-    };
-    assert_eq!(band(0), (0, 1), "a header");
-    assert_eq!(band(1), (1, 4), "a card under it");
-    assert_eq!(band(2), (5, 1));
-    assert_eq!(band(3), (6, 4));
-
-    // Ten rows of window hold header/card/header/card = four items, and the
-    // bar says so: dividing by any single height would not have.
-    let bar = ui
-        .spec()
-        .items
-        .iter()
-        .find_map(|i| match i.draw {
-            Draw::Scrollbar {
-                offset,
-                content,
-                window,
-            } => Some((offset, content, window)),
-            _ => None,
-        })
-        .expect("a bar");
-    assert_eq!(bar, (0, 10, 4));
-}
-
 /// **Declining the focus ring is about the keyboard, not about being inert.**
 ///
 /// A list driven from outside — its selection set by the caller each frame —

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -122,6 +122,43 @@ fn a_toggle_reports_the_value_it_would_move_to() {
     assert_eq!(click(&mut ui, 1, 0), vec![Msg::Toggled(false)]);
 }
 
+/// **The third state a checkbox has wherever a value can be unset.** A
+/// definite `[ ]` there reads as "the user turned this off", which is a
+/// different fact and usually the wrong one.
+#[test]
+fn an_indeterminate_toggle_shows_neither_on_nor_off() {
+    let mut ui: Ui<Msg> = Ui::new();
+    for value in [false, true] {
+        ui.frame(
+            Toggle::new("wrap", value)
+                .indeterminate(true)
+                .on_change(Msg::Toggled)
+                .node(),
+            FRAME,
+        );
+        assert!(
+            texts(&ui).iter().any(|t| t.contains("[-]")),
+            "the mark does not depend on the value it is hiding (value={value})"
+        );
+    }
+}
+
+/// It is display only, and the toggle still reports `!value`. What leaving
+/// the unset state *means* is the owner's question — "inherit" resolves to on
+/// for some fields and off for others — so the widget does not guess.
+#[test]
+fn an_indeterminate_toggle_still_reports_the_flip() {
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        Toggle::new("wrap", false)
+            .indeterminate(true)
+            .on_change(Msg::Toggled)
+            .node(),
+        FRAME,
+    );
+    assert_eq!(click(&mut ui, 1, 0), vec![Msg::Toggled(true)]);
+}
+
 // -- TextField ---------------------------------------------------------------
 
 #[test]

--- a/crates/fresh-ui/tests/widgets.rs
+++ b/crates/fresh-ui/tests/widgets.rs
@@ -640,3 +640,125 @@ fn a_run_longer_than_its_item_is_clipped_to_it() {
         "four columns were given, four were painted"
     );
 }
+
+/// **A stable gutter is there whether the bar is or not.**
+///
+/// Without it the column appears with the bar and goes with it, so a list that
+/// grows past its window reflows its content by a cell — and a window whose
+/// gutter is part of the frame around it gets the bar drawn *beside* that
+/// frame instead of on it, because the column the bar wants is one the frame
+/// already owns.
+#[test]
+fn a_stable_gutter_reserves_its_column_with_no_bar_to_put_in_it() {
+    let list = |n: usize| -> Node<Msg> {
+        List::windowed(n, fresh_ui::Key::from, |i| {
+            fresh_ui::col()
+                .theme("list.row")
+                .child(fresh_ui::text(format!("row {i}")))
+        })
+        .scrollbar_gutter()
+        .node()
+    };
+    let frame = Size::new(20, 5);
+
+    // Short enough to fit: no bar is drawn.
+    let mut short: Ui<Msg> = Ui::new();
+    short.frame(list(3), frame);
+    assert!(
+        !short
+            .spec()
+            .items
+            .iter()
+            .any(|i| matches!(i.draw, Draw::Scrollbar { .. })),
+        "a list that fits draws no bar"
+    );
+
+    // Long enough to overflow: a bar appears in the last column.
+    let mut long: Ui<Msg> = Ui::new();
+    long.frame(list(500), frame);
+    let bar = long
+        .spec()
+        .items
+        .iter()
+        .find(|i| matches!(i.draw, Draw::Scrollbar { .. }))
+        .expect("an overflowing list shows a bar");
+    assert_eq!(bar.rect.x, frame.w as i32 - 1);
+
+    // And the rows are the same width either way: the gutter did not move.
+    let row_width = |ui: &Ui<Msg>| {
+        ui.spec()
+            .items
+            .iter()
+            .filter(|i| matches!(i.draw, Draw::Fill))
+            .map(|i| i.rect.w)
+            .max()
+            .expect("rows paint their ground")
+    };
+    assert_eq!(
+        row_width(&short),
+        row_width(&long),
+        "content must not reflow when the bar appears"
+    );
+    assert_eq!(row_width(&short), frame.w - 1, "the gutter is not content");
+}
+
+/// **The bar's appearance is named apart from the window's.**
+///
+/// `theme` tags a node *and its descendants*, and a region that names its
+/// appearance is a region that paints — so a window that named its bar that
+/// way would also fill itself in the bar's colours behind every row.
+#[test]
+fn a_bar_carries_its_own_theme_and_the_rows_keep_theirs() {
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        List::windowed(500, fresh_ui::Key::from, |i| {
+            fresh_ui::col()
+                .theme("list.row")
+                .child(fresh_ui::text(format!("row {i}")))
+        })
+        .scrollbar()
+        .scrollbar_theme("bar.thumb/bar.track")
+        .node(),
+        Size::new(20, 5),
+    );
+    let bar = ui
+        .spec()
+        .items
+        .iter()
+        .find(|i| matches!(i.draw, Draw::Scrollbar { .. }))
+        .expect("an overflowing list shows a bar");
+    assert_eq!(bar.theme.as_str(), "bar.thumb/bar.track");
+    assert!(
+        ui.spec()
+            .items
+            .iter()
+            .filter(|i| !matches!(i.draw, Draw::Scrollbar { .. }))
+            .all(|i| !i.theme.as_str().starts_with("bar.")),
+        "the bar's name reaches nothing but the bar"
+    );
+}
+
+/// **Declining the focus ring is about the keyboard, not about being inert.**
+///
+/// A list driven from outside — its selection set by the caller each frame —
+/// should not be a stop on the way round, or Tab lands on a widget that has
+/// nothing to do with the key. Its rows still answer the mouse.
+#[test]
+fn a_list_that_declines_focus_still_answers_a_click() {
+    let mut ui: Ui<Msg> = Ui::new();
+    ui.frame(
+        List::windowed(10, fresh_ui::Key::from, |i| {
+            fresh_ui::col().child(fresh_ui::text(format!("row {i}")))
+        })
+        .focusable(false)
+        .on_select(Msg::Selected)
+        .node(),
+        FRAME,
+    );
+    assert_eq!(click(&mut ui, 2, 3), vec![Msg::Selected(3)]);
+
+    // Tab does not stop here: with nothing focusable in the frame, the key is
+    // left for whoever else is listening.
+    let tab = ui.dispatch(Input::Key(KeyPress::new(KeyCode::Tab)));
+    assert!(tab.claimed == false && tab.msgs.is_empty());
+}


### PR DESCRIPTION
The base PR under the editor's fresh-ui migration (#3028). **Every** change that migration needs in `crates/fresh-ui` lives here — the migration branch carries no library diff, so #3028 reviews as pure editor code and this one reviews as pure library.

Each item was found the same way: by trying to express a real editor surface in the library and failing. None is a workaround parked at a call site, and none changes an existing caller's behaviour except where that behaviour was the bug.

---

## Scoped persistence

The library's answer to *"this subtree is going away and coming back — what survives?"* existed as types and did not work. `Persisted` / `Store` / `PERSISTENCE_SCOPE` were declared and exported with a complete-looking read/write path, but had **zero tests and zero uses** anywhere in the crate, and the demo they would be proven in is single-document.

**`Persisted::set` writes through.** Disposal is deferred to the end of a flush — reconcile is transactional and must be unwindable — so a replacement subtree is *constructed before* the outgoing one is disposed. A value written only at teardown is therefore not in the store when anything mounted in the same flush reads it. The observed log on a document switch was:

```
get alpha/note -> false
get beta/note  -> false
set alpha/note              <- after beta had already read
```

The visible failure is a widget whose move reconciliation cannot match by key: it reads the default, and then the old instance's value is written over the top of it, so the display and the store disagree. Writing on change removes the ordering question. Teardown still writes, so a store that only wants a final flush is unaffected.

**`provide_eq`, for an ambient that knows when it has actually changed.** Providers compared by `Rc::ptr_eq` alone. A host that rebuilds its description every frame — which the cost model invites, since a rebuild costs one allocation per node — hands `provide` an equal-but-fresh `Rc` each frame, and every dependent below is marked dirty for a change that did not happen. Worse, any `Persisted` beneath it trips the `"ambient read in init() changed"` assertion on the **second frame**, having never changed. `ProvideProps::same` carries an optional comparison; `provide_eq` supplies it for `T: PartialEq`. `provide` is unchanged.

**`scope(id, child)`** — one node that both keys the subtree and provides `PERSISTENCE_SCOPE`. They have to travel together, and separating them fails in two different ways: keying only *inside* the provider trips the init-read assertion instead of switching documents, because the provider element survives and its value changes; providing without keying silently gives two documents one element and one value.

**`MemStore`, and the one operation a map does not have.** Every host that adopts `Persisted` needs a `HashMap` behind a `RefCell` before it needs anything cleverer, and the crate had written those twelve lines twice already — once in the demo, once as the tests' spy. `forget_scope` is the part that is not boilerplate: a scope's values are dead the moment the thing it names is gone, and **the tree cannot know that** — what the tree sees is a subtree it is not currently showing, which is precisely the case where the values must be kept. Only the host can tell the two apart. Until it says so, the map grows for the life of the process. The separator is pinned by a test, because prefix-matching the bare scope name takes `window:10` down with `window:1`.

`tests/persistence.rs` covers: the round trip through a discard; that two documents at the same position under the same key do not share; that the inactive document contributes nothing to the display list; that a value is in the store when it is set; that rebuilding the same document is not a scope change; the round trip driven through the shipped store rather than the spy; that forgetting one scope takes that scope and no neighbour; that a forgotten scope comes back empty; and — `#[should_panic]` — the trap `scope()` closes.

The demo gains a document dimension. Alt-P switches project, and the scratch row is a **visit counter** rather than a fixed note, deliberately: a note reads the same whether it was restored or merely re-seeded, and a count cannot be faked. Driven interactively through the `interactive` example:

```
start     ->  alpha · visit 1
Alt-P     ->  beta  · visit 1
Alt-P     ->  alpha · visit 2
Alt-P     ->  beta  · visit 2
Alt-P     ->  alpha · visit 3
```

The two advance independently, which is only possible if each visit's value came back and the two documents are not sharing one. Without a `Store`, or without the scope, every line would read `visit 1`.

## Events reach a listener once, and reach everything behind

Four bugs, one mistake in four places: an answer derived from a hit that looks at only part of it.

**`propagate_all` visited shared ancestors once per path.** `hit_paths` returns one path per stacked transparent level, and stacked paths share their upper reaches — so a capture-phase observer near the root, the way an application watches a channel without claiming it, fired two or three times for one click. The extra paths exist for the elements *behind* the transparent one, and those are precisely the elements the earlier paths did not contain. Listeners are now visited once per event per phase.

**Everything else took only the first path.** `scroll_chain` took `paths.first()`, `scrollbar_hit` took `hit_test` (the first path again), and `dismiss_for_pointer` decided "inside the layer" from the topmost path. A transparent region is *why* there is more than one path — a strip lying over a window is exactly that shape — so the window behind it was never asked.

**A wheel that scrolled something is claimed.** `dispatch` ran the scroll chain and returned the propagation's `claimed`, which is false — so a host with its own pipeline behind this tree scrolled a second time for the same notch.

**Overscroll is contained at a layer.** A popup scrolled to its last line handed the next notch to whatever it floats over; the web spells the fix `overscroll-behavior: contain`. The decision is made after all paths have been asked, never during one — absorbing mid-walk is the first-path bug again, one level up.

`million.txt` moves because the recording had frozen one of these: that demo has a ribbon that falls through lying over its list, and the wheel never scrolled it.

## Layers: where they may go, and how they leave

**A host can say where something inside it is.** An `Anchor::Node` names a thing, and that thing had to be an element. A popup anchored to the text caret names something *inside a host leaf*: the tree hands the leaf a rectangle and knows nothing about its interior. The alternative was a screen coordinate in the description — the caller doing the layout engine's job, carrying a number stale the moment anything moves. `Anchor::Node` now resolves element first, then a host-published rectangle, then the parent as before; anchors are per-frame and `frame` clears them, because a stale caret is worse than none. `place_layers` is the other half, for hosts whose pipeline is interleaved with the tree's: re-running `frame` would reconcile an unchanged description and pump every behaviour twice, so the arrangement walk and repaint were factored out as `replace_layers` and called from both places.

**A layer can be confined to a region, not just to the frame.** A popup hanging off the status bar must not put its right border on the editor's vertical scrollbar, and `Fit::CLAMP` against the frame lands it exactly there. Shrinking the layer is a different statement — it changes how big the box is when what is wanted is where it may go — and the host cannot correct the placement afterwards, because the tree does the placing. `bounds` replaces `frame` throughout `place`, defaulting to the frame, so every existing layer is unchanged.

**A transient layer declares its own dismissal.** `Dismiss` claims the press it dismisses on, which is right for a menu and wrong for a tooltip: clicking into the buffer while one is up should hide it *and* put the caret where the click landed. `Dismiss::pass_through` is the rule the wheel already follows in the same file, applied to the pointer — act, and claim only when the act was the whole of it. It did not hold for keys (`dismiss_for_key` reported any dismissal as claimed); that is fixed here with the test the pointer's half already had.

**`popup::border_strip` stops after its row.** It ended in a `flex(1)` filler that made the strip greedy — invisible while the popups' layer is given an explicit height, but a measured popup would become the whole frame.

## Layout: a box can break onto a new line

`BoxProps` could say direction, gap, padding, border, alignment and clipping, and could not say what a row does when it runs out of room. The answer was "overflow", with no way to ask for the other one.

Found where the plugin panels meet the library: `WidgetSpec::Row` has carried a `wrap` flag since it was written — *"children that don't fit on one line reflow onto additional lines instead of being truncated; children are never split — wrap happens at child boundaries"* — and mapping those nineteen variants onto `widgets::*` is the migration's next wave. Every other variant has a counterpart; this one had none, and the workaround's shape would have been a caller measuring its own children to decide the breaks, which is layout's answer computed outside layout.

`wrap_children()` is `flex-wrap: wrap` with CSS's own atomicity rule. **`Flex` on the main axis is `Auto` in a wrapping box**, and a test says so rather than the doc alone: a flexible child absorbs the remainder of its line, so one of them makes every line full-width and nothing after it can ever share a line — "fill the row" and "let the row become as many rows as it needs" are opposite requests. The cross axis is per *line*, not per container, so a stretching child fills its own line's height; the other way round is the bug that makes a wrapped toolbar look like a table.

## Wrapping text keeps the indent, and the spaces

`.wrap()` had no rule for continuation rows, so a wrapped signature-help parameter merged into the next entry. A caller wanting a hanging indent would have to wrap the text itself, which means deciding the width — layout's answer, not the caller's. So it is a library capability: `Wrap::{None, Word, Hanging}`, with the guard that the indent yields when it would leave the text under ten columns.

A second bug fell out of writing the test: wrapping split on `' '` and skipped the empty pieces a run of spaces yields, so `"    sep  a string"` came out `"sep a string"` — losing the indent on the *first* row and the double space that separates a parameter name from its description. Wrapping now breaks a line into chunks that carry the spaces before them, so the only whitespace lost is the one the break consumed. `wrap_rows` exists beside `wrap_text` because `wrap_runs` mapped rows back onto styled pieces by assuming a row is a slice of the source — right only when exactly one space was dropped, wrong outright once the indent adds characters with no source at all. A row now reports its injected indent and the source it skipped.

## Focus, scrollbars, lists, and a checkbox's third state

**A direction needs somewhere to move from.** `default_for_intent` ran focus traversal with nothing focused: `move_focus` handed `None` to the policy, which picked a first node and claimed the key. Tab entering the interface from nowhere is what Tab is for; an arrow key is not that gesture. Found the expensive way — adding one focusable to the editor's frame gave directional traversal somewhere to go, and `Right` in the command palette began moving focus instead of the text cursor. Not a bug the migration introduced, a latent one it was the first to trip.

**A stable gutter.** `scrollbar()` reserves the bar's column only while the content overflows, so a list that grows past its window reflows its content by a cell, and a window whose gutter is part of the frame around it gets the bar drawn *beside* that frame. `scrollbar_gutter()` keeps the column either way — CSS spells it `scrollbar-gutter: stable`.

**A bar with its own name.** `theme()` tags a node *and its descendants*, so a window naming its bar that way fills itself in the bar's colours behind every row. `scrollbar_theme()` names the one item.

**The thumb lands where you point.** `scroll_to_pointer` divided the pointer's row by the whole track, but the thumb's travel is `track - len`; the round trip through `Draw::scrollbar_thumb`'s flooring left the thumb up to `len` rows above the row clicked, and the track's last row could never reach the end of the content. A one-cell thumb hides it — `track - 1` and `track - len` agree there — which is why nothing caught it.

**Declining focus is about the keyboard.** `List::focusable(false)` also took the rows' click handlers, so a list driven from outside had to join the focus ring to keep its mouse — and then Tab landed on a widget with nothing to do with the key. Rows answer clicks either way now; only the focus request is gated.

**`Toggle::indeterminate`.** A value that can be *unset* needs three states, and `Toggle` had two. The web platform spells it `input.indeterminate`; a settings form needs it wherever a field inherits from a layer below rather than being chosen, because a definite `[ ]` there reads as "the user turned this off". Display only, deliberately: the toggle still reports `!value`, because what leaving the unset state means is the owner's question — "inherit" resolves to on for some fields and off for others — and a widget that guessed would be wrong half the time.

---

## Shape of the diff

The library changes are in `desc.rs`, `hit.rs`, `render/{layout,object,prim}.rs`, `ambient.rs`, `behavior/{misc,mod}.rs`, `element.rs`, `focus/mod.rs`, `schedule.rs`, `widgets/{button,list}.rs`; proof is in `tests/{persistence,pointer,layout,paint,widgets,focus}.rs` and the interactive demo. Goldens are re-recorded only where a fixed bug was frozen into a recording — each one's commit says which row moved and why.

Full test suites run in CI on this branch rather than locally.