### PR TITLE
markdown compose: reflow hard-wrapped blocks into paragraphs

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3469,7 +3469,12 @@ pub enum PluginCommand {
     /// `editor.indentation_guide` default. Used by tool views (e.g. the Git Log
     /// commit-detail diff) that show non-editable content where the guides are
     /// noise.
-    SetIndentationGuide { buffer_id: BufferId, enabled: bool },
+    SetIndentationGuide {
+        buffer_id: BufferId,
+        /// `None` withdraws the override, so the buffer falls back to its
+        /// language gate and the global setting.
+        enabled: Option<bool>,
+    },
 
     /// Set the view mode for a buffer ("source" or "compose")
     SetViewMode { buffer_id: BufferId, mode: String },

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -4280,7 +4280,7 @@ interface EditorAPI {
 	* `editor.indentation_guide` setting. Tool views that render non-editable
 	* content (e.g. the Git Log commit-detail diff) disable them.
 	*/
-	setIndentationGuide(bufferId: number, enabled: boolean): boolean;
+	setIndentationGuide(bufferId: number, enabled: boolean | null): boolean;
 	/**
 	* Set the view mode for a buffer ("source" or "compose")
 	*/

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -320,6 +320,12 @@ const CODE_RAIL_ID_PREFIX = "mdcr:";
 // hint convention and it is not optional, so the widths below count it rather
 // than trying to avoid it: a left rail costs 2 columns, a right rail its
 // padding plus 2.
+/** Columns of leading whitespace on a line, ignoring its terminator. */
+function leadingIndent(content: string): number {
+  const text = content.replace(/\r?\n$/, "");
+  return text.length - text.trimStart().length;
+}
+
 const RAIL_GLYPH = "│";
 const RAIL_RENDERED_COLUMNS = 2;
 
@@ -404,10 +410,15 @@ function emitCodeRails(
   lineContent: string,
   byteStart: number,
   measure: number,
+  // Columns the whole block is indented by — its opening delimiter's indent.
+  // The frame sits that far in, and the block's own measure shrinks to match,
+  // so an indented block wraps where its narrower box actually ends.
+  blockIndent: number,
 ): void {
   const contentEnd = lineContentEndByte(lineContent, byteStart);
   const text = lineContent.replace(/\r?\n$/, "");
-  const inner = codeInnerWidth(measure);
+  const blockMeasure = Math.max(4, measure - blockIndent);
+  const inner = codeInnerWidth(blockMeasure);
 
   // An empty line has no character to hang two separate rails off, so both
   // edges and the gap between them go in one piece at its line break. Anchored
@@ -416,29 +427,34 @@ function emitCodeRails(
   if (contentEnd <= byteStart) {
     editor.addVirtualTextStyled(
       bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:e`, byteStart,
-      RAIL_GLYPH + " ".repeat(inner + 2) + RAIL_GLYPH, codeFrameStyle, true,
+      " ".repeat(blockIndent) + RAIL_GLYPH + " ".repeat(inner + 2) + RAIL_GLYPH,
+      codeFrameStyle, true,
     );
     return;
   }
 
-  const { rows } = codeRowLayout(text, measure);
-  // A code line's own leading whitespace is real text, so the first row draws
-  // it and the rows it wraps onto do not — they would restart flush against the
-  // rail, left of the code they continue. A fence inside a list item carries
-  // the item's indent on every source line, so that is most of them. The rail
-  // supplies the indent for those rows, because the wrap's own hanging indent
-  // would push the RAIL right instead of the code.
-  const codeIndent = text.length - text.trimStart().length;
+  // The block's indent is real text on this line, drawn before the rail — so
+  // the rail is anchored past it and the layout measures only what follows.
+  const body = text.slice(blockIndent);
+  const { rows } = codeRowLayout(body, blockMeasure);
+  // A code line's indent WITHIN the block is real text too, so the first row
+  // draws it and the rows it wraps onto do not — they would restart flush
+  // against the rail, left of the code they continue. The rail supplies it for
+  // those rows, because the wrap's own hanging indent would push the RAIL right
+  // instead of the code.
+  const codeIndent = body.length - body.trimStart().length;
   for (let r = 0; r < rows.length; r++) {
     const row = rows[r];
     if (row.end <= row.start) continue;
-    const rowText = text.slice(row.start, row.end);
+    const rowText = body.slice(row.start, row.end);
     const railIndent = r === 0 ? 0 : Math.min(codeIndent, Math.max(0, inner - 1));
+    // Only the first row has the block's indent as real text ahead of it.
+    const railLead = r === 0 ? "" : " ".repeat(blockIndent);
 
     editor.addVirtualTextStyled(
       bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:${r}:l`,
-      charToByte(lineContent, row.start, byteStart),
-      RAIL_GLYPH + " ".repeat(railIndent), codeFrameStyle, true,
+      charToByte(lineContent, blockIndent + row.start, byteStart),
+      railLead + RAIL_GLYPH + " ".repeat(railIndent), codeFrameStyle, true,
     );
 
     const pad = inner - displayWidth(rowText) - railIndent;
@@ -448,7 +464,9 @@ function emitCodeRails(
     // a multi-byte glyph, and the row's last character is exactly where a
     // multi-byte glyph is most likely to be.
     const lastChar = Array.from(rowText).pop() as string;
-    const lastCharStart = charToByte(lineContent, row.end - lastChar.length, byteStart);
+    const lastCharStart = charToByte(
+      lineContent, blockIndent + row.end - lastChar.length, byteStart,
+    );
     editor.addVirtualTextStyled(
       bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:${r}:r`, lastCharStart,
       " ".repeat(pad) + RAIL_GLYPH, codeFrameStyle, false,
@@ -1736,14 +1754,21 @@ function processLineConceals(
   if (region === "body") return;
   if (region === "open" || region === "close") {
     const frameEnd = lineContentEndByte(lineContent, byteStart);
+    // A block indented into a list item keeps its indent as real text and puts
+    // the corner after it, so the box sits inside the item the way every other
+    // renderer draws it. Concealing from the line's start instead pulled the
+    // border back to the page's left edge, under text it belongs beside.
+    const blockIndent = leadingIndent(lineContent);
+    const frameStart = charToByte(lineContent, blockIndent, byteStart);
+    const blockMeasure = Math.max(4, measure - blockIndent);
     const frame = region === "open"
-      ? buildCodeFrameLine(measure, "┌", "┐")
-      : buildCodeFrameLine(measure, "└", "┘");
+      ? buildCodeFrameLine(blockMeasure, "┌", "┐")
+      : buildCodeFrameLine(blockMeasure, "└", "┘");
     editor.addConceal(
-      bufferId, "md-syntax", byteStart, frameEnd, frame,
+      bufferId, "md-syntax", frameStart, frameEnd, frame,
       "unless-cursor-in", byteStart, lineScopeInclEnd,
     );
-    editor.addOverlay(bufferId, "md-emphasis", byteStart, frameEnd, codeFrameStyle);
+    editor.addOverlay(bufferId, "md-emphasis", frameStart, frameEnd, codeFrameStyle);
     return;
   }
   // A fence-looking line the editor could not classify: leave it literal
@@ -2574,7 +2599,12 @@ interface FlowCell {
  * needs — the wrap runs over the block's concatenated text instead of
  * restarting at each source line, and the newlines between them are concealed.
  */
-function processFlowBlock(bufferId: number, block: FlowBlock, width: number): void {
+function processFlowBlock(
+  bufferId: number,
+  block: FlowBlock,
+  width: number,
+  blockIndents: Map<number, number>,
+): void {
   const head = block.lines[0];
   // Clear existing soft breaks for every line in the block, so a block that
   // has shrunk (an edit split it) leaves none behind.
@@ -2600,7 +2630,15 @@ function processFlowBlock(bufferId: number, block: FlowBlock, width: number): vo
   if (isCodeRegion(head.region)) {
     if (head.region !== "body") return;
     const text = lineText(head);
-    for (const charPos of codeRowLayout(text, width).breaks) {
+    // The block's own indent is ahead of the rail and outside its box, so the
+    // rows are measured on what follows it — the same split `emitCodeRails`
+    // makes, or the two passes would disagree about where a row ends.
+    const blockIndent = blockIndents.get(head.byte_start) ?? 0;
+    const body = text.slice(blockIndent);
+    const blockWidth = Math.max(4, width - blockIndent);
+    for (const charPos of codeRowLayout(body, blockWidth).breaks.map(
+      (p) => p + blockIndent,
+    )) {
       // Indent 0, not the rail's width: the continuation row's own left rail
       // is virtual text spliced in ahead of the wrap, so it already supplies
       // those columns — including the code's own leading indent, which
@@ -3002,6 +3040,31 @@ editor.on("lines_changed", (data) => {
   // lines not in this batch keep riding their auto-shift markers. Soft breaks
   // are the one pass that is per *block* rather than per line (see
   // `processFlowBlock`), and they run below, after every line's clear.
+  // Columns each fenced line's BLOCK is indented by, keyed by line start.
+  //
+  // A fenced block inside a list item is indented to the item's content column,
+  // and its frame belongs there too. The indent is the OPENING delimiter's: a
+  // body line's own leading whitespace is code, not block indent, so a
+  // `    if x:` inside the block must not push the frame right for that row
+  // alone. Computed once here because two passes need it — the rails and border
+  // below, and the code rows' soft breaks after them — and they have to agree
+  // about the box's width or a row will break where the frame does not end.
+  //
+  // Absent when the opening delimiter is not in this batch, which a block whose
+  // body spans a blank line can be re-offered without. Those rows render as
+  // they did before the frame learned about indents, rather than at a guess.
+  const blockIndents = new Map<number, number>();
+  {
+    let indent: number | null = null;
+    for (const line of data.lines) {
+      if (line.region === "open") indent = leadingIndent(line.content);
+      if (isCodeRegion(line.region) && indent !== null) {
+        blockIndents.set(line.byte_start, indent);
+      }
+      if (line.region === "close") indent = null;
+    }
+  }
+
   for (const line of data.lines) {
     // Clear this row's border range first (covers a row that stopped being a
     // table row, e.g. its pipes were deleted, and stale frames left a few bytes
@@ -3012,7 +3075,10 @@ editor.on("lines_changed", (data) => {
     // delimiter rows draw their own corners as part of the border conceal.
     clearCodeRails(data.buffer_id, line.byte_start, line.byte_end);
     if (line.region === "body") {
-      emitCodeRails(data.buffer_id, line.content, line.byte_start, measure);
+      emitCodeRails(
+        data.buffer_id, line.content, line.byte_start, measure,
+        blockIndents.get(line.byte_start) ?? 0,
+      );
     }
     // Same range-scoped clear-then-rebuild as the borders, so a line that stops
     // being a list item loses its spacer.
@@ -3096,7 +3162,7 @@ editor.on("lines_changed", (data) => {
   // conceals by range — so emitting joins inside that loop would have the next
   // line's clear delete the join just added.
   for (const block of blocks) {
-    processFlowBlock(data.buffer_id, block, measure);
+    processFlowBlock(data.buffer_id, block, measure, blockIndents);
   }
 
   // Publish this batch's heading marks. Range-scoped to the batch's byte span

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -2303,7 +2303,26 @@ const FRONT_MATTER_FENCE = /^(?:---|\+\+\+)\s*$/;
  * guess. */
 function verbatimStates(lines: LineInfoLike[]): Array<boolean | null> {
   const out: Array<boolean | null> = [];
-  let inFence: boolean | null = null;
+  // A batch showing no sign of a fence anywhere starts outside one.
+  //
+  // Without this the fenced state is unknowable for most batches of a document
+  // that has no fences at all: the seeds are the buffer's first line, a line
+  // the engine placed in a region, and a delimiter carrying an info string, and
+  // such a document offers none of them below line 0. Every line then came back
+  // `null`, and the heading marks — which stand down on `null` rather than
+  // guess — stopped republishing below the first screen: a heading typed
+  // mid-document never got a mark, and one that stopped being a heading kept a
+  // stale one, since only the pre-scan could correct it and it re-runs on
+  // backtick edits alone.
+  //
+  // Evidence of a fence is a delimiter line or a line the engine gave a region,
+  // both of which the tracking below already handles. Their complete absence is
+  // what is being read as "no fence is in play here", and it is the same
+  // reading the pre-scan makes of the whole document.
+  const noFenceInSight = !lines.some(
+    (line) => isCodeRegion(line.region) || looksLikeFence(lineText(line)),
+  );
+  let inFence: boolean | null = noFenceInSight ? false : null;
   let fenceChar = "";
   let inHtml = false;
   let inIndentedCode = false;
@@ -2317,7 +2336,7 @@ function verbatimStates(lines: LineInfoLike[]): Array<boolean | null> {
     // A gap in the batch loses the state: the lines in between could have
     // opened or closed any of these.
     if (line.line_number !== prevLineNumber + 1) {
-      inFence = null;
+      inFence = noFenceInSight ? false : null;
       inHtml = false;
       inIndentedCode = false;
       inFrontMatter = false;

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -1670,6 +1670,12 @@ function processLineConceals(
   measure: number,
   region: RegionLine | undefined,
   lineNumber?: number,
+  /** This line is a flow continuation: its leading indent and `>` run are
+   * already inside the join conceal that merges it into the block above (see
+   * `processFlowBlock`), so the decorations that would render them in place
+   * stand down. Overlapping conceals over the same bytes would otherwise both
+   * fire and the run would render twice. */
+  joined = false,
 ): void {
   // Clear existing conceals and overlays for this line first.
   // This ensures clear+add commands are sent together from the plugin thread
@@ -2016,7 +2022,11 @@ function processLineConceals(
   const quoteRun = quoteMarkerRun(lineContent);
   if (quoteRun) {
     const { runStart, runEnd } = quoteRun;
-    for (let i = runStart; i < runEnd; i++) {
+    // A joined continuation's own markers are concealed by the join; only the
+    // quoted-text overlay below still applies to it. The bar it would have
+    // drawn is supplied for the whole block by the head row and by the
+    // continuation rows' soft-break prefix.
+    for (let i = joined ? runEnd : runStart; i < runEnd; i++) {
       if (lineContent[i] !== '>') continue;
       const markerByte = charToByte(lineContent, i, byteStart);
       const markerByteEnd = charToByte(lineContent, i + 1, byteStart);
@@ -2149,24 +2159,384 @@ function processLineConceals(
 let lastViewportWidth = 0;
 
 // =============================================================================
+// Reflow: a run of source lines renders as one flowed block
+// =============================================================================
+//
+// Markdown reads consecutive non-blank lines as ONE paragraph (or one list
+// item, or one quote): the newlines between them are word separators, not line
+// breaks. Compose mode has to render that reading, or a hard-wrapped source
+// file — the ordinary way markdown is written — shows every source break as a
+// rendered break, leaving the page ragged and the continuation rows hanging
+// under nothing.
+//
+// Reflow is expressed with the two decorations already in play, so it needs no
+// machinery of its own:
+//
+//   * a JOIN conceal over `[end of the previous line's text, start of this
+//     line's text)` — the newline, this line's leading indent, and its `>` run
+//     when it is a quote — replaced by a single space. A conceal whose range
+//     covers a newline swallows the line break (see `lineContentEndByte`), so
+//     the two source rows render as one;
+//   * soft breaks computed over the WHOLE block instead of per line, so rows
+//     break at the measure and hang under the item's text rather than
+//     restarting at each source line's own column.
+//
+// Both are decided from a `lines_changed` batch alone. That is sound because
+// the editor makes such a batch *run-closed* for a composing buffer: a line is
+// never offered without the rest of its blank-line-delimited run (see
+// `flow_run_start` in `app/render.rs`). A line whose predecessor is absent
+// from the batch is therefore either its run's first line or part of a run too
+// long to close, and both are treated as block heads — the conservative
+// answer, the same one the table frame gives a row whose neighbour it cannot
+// see.
+
+/** The kind of block a flow head opens. A continuation has to match it: a
+ * quote continues only with more quote lines, and prose only with prose. */
+type FlowKind = "paragraph" | "list" | "quote";
+
+/** A source line's text without its terminator.
+ *
+ * `lines_changed` content carries the newline, and every flow decision here is
+ * about the text — a trailing `\n` would read as a trailing space, break the
+ * hard-break test, and put a phantom column into the wrap. */
+function lineText(line: LineInfoLike): string {
+  return line.content.replace(/\r?\n$/, "");
+}
+
+/** A line that is only `=`s or `-`s: a setext heading's underline, or a
+ * thematic break. Never joins to the line above (it *decorates* it) and never
+ * opens a flow block of its own. */
+function isRuleLine(text: string): boolean {
+  return /^\s*(?:=+|-+)\s*$/.test(text);
+}
+
+/** An image on a line of its own, which compose mode renders as a banner. */
+function isImageLine(text: string): boolean {
+  return /^\s*!\[[^\]]*\]\([^)]+\)\s*$/.test(text.trim());
+}
+
+/** A line that is raw HTML rather than prose: an open or close tag, or a
+ * comment, that makes up the whole line.
+ *
+ * Requiring the line to END in `>` is what keeps a paragraph that merely
+ * *starts* with an inline tag — `<em>like this</em> and then prose` — reading
+ * as the prose it is. An unterminated `<!--` still opens: a comment spanning
+ * several lines is the common case that would otherwise flow. */
+function isHtmlBlockLine(text: string): boolean {
+  const t = text.trim();
+  if (t.startsWith("<!--")) return true;
+  if (!/^<(?:\/?[A-Za-z][A-Za-z0-9-]*(?:[\s/>]|$)|[!?])/.test(t)) return false;
+  return t.endsWith(">");
+}
+
+/** A line that opens an indented code block: four columns of indent or a tab,
+ * and not a list marker.
+ *
+ * Only asked of a run's FIRST line, because an indented code block cannot
+ * interrupt a paragraph — it can only begin where a block can. That is exactly
+ * what keeps a list item's continuation lines out of it: they are indented too,
+ * often past four columns for a wide marker like `12. `, but they are never a
+ * run's first line. */
+function opensIndentedCode(text: string): boolean {
+  if (!/^(?: {4}|\t)/.test(text)) return false;
+  return !/^\s*(?:[-*+]|\d{1,9}[.)])\s/.test(text);
+}
+
+/** A `---` or `+++` on a line of its own: a front-matter delimiter, when it is
+ * the buffer's first line or the one that closes the block it opened. */
+const FRONT_MATTER_FENCE = /^(?:---|\+\+\+)\s*$/;
+
+/** Whether each line of a batch is *verbatim* — text the reader must see laid
+ * out as written, never re-flowed as prose, and never read as a heading.
+ * `true` for a line inside a fenced code block, a raw HTML block or the file's
+ * front matter; `false` for ordinary markdown; `null` where the batch cannot
+ * say.
+ *
+ * `region` is the editor's answer for the fenced case and wins wherever it is
+ * present, but it is absent BOTH for an ordinary line and when the engine
+ * could not resolve the state (see `RegionLine`), so "no region" is not
+ * evidence of "outside a fence". The rest is recovered the way `scanHeadings`
+ * does it, by tracking the delimiters textually across the batch, seeded
+ * wherever the batch proves the state: the buffer's first line is outside
+ * every fence, the line after a `close` is too, and an opener is the only
+ * fence delimiter that may carry an info string (CommonMark forbids one on a
+ * closer).
+ *
+ * The other three need no such seeding, because a batch is run-closed: an HTML
+ * block, an indented code block and a front-matter block all run to a blank
+ * line — front matter from the buffer's first line — so a batch that carries
+ * any of their lines carries the opener too.
+ *
+ * Consumers differ in what they do with `null`, and should: the flow pass
+ * falls back to reading the line as prose, which is what every other per-line
+ * pass in this plugin already does with an unresolved region, while the
+ * heading marks stand down rather than replace a correct pre-scan mark with a
+ * guess. */
+function verbatimStates(lines: LineInfoLike[]): Array<boolean | null> {
+  const out: Array<boolean | null> = [];
+  let inFence: boolean | null = null;
+  let fenceChar = "";
+  let inHtml = false;
+  let inIndentedCode = false;
+  let inFrontMatter = false;
+  // The next non-blank line opens a block, so it is the one that may open an
+  // indented code block. True for the batch's own first line: the walk that
+  // built it backed up to the run's start.
+  let atRunStart = true;
+  let prevLineNumber = -2;
+  for (const line of lines) {
+    // A gap in the batch loses the state: the lines in between could have
+    // opened or closed any of these.
+    if (line.line_number !== prevLineNumber + 1) {
+      inFence = null;
+      inHtml = false;
+      inIndentedCode = false;
+      inFrontMatter = false;
+      atRunStart = true;
+    }
+    prevLineNumber = line.line_number;
+    const text = lineText(line);
+    const blank = text.trim() === "";
+    const openingRun = atRunStart && !blank;
+    if (!blank) atRunStart = false;
+
+    if (line.line_number === 0) {
+      inFence = false;
+      fenceChar = "";
+      inHtml = false;
+      inFrontMatter = FRONT_MATTER_FENCE.test(text);
+      if (inFrontMatter) { out.push(true); continue; }
+    }
+    if (inFrontMatter) {
+      out.push(true);
+      if (FRONT_MATTER_FENCE.test(text)) inFrontMatter = false;
+      continue;
+    }
+
+    if (isCodeRegion(line.region)) {
+      out.push(true);
+      inFence = line.region !== "close";
+      inHtml = false;
+      continue;
+    }
+
+    if (inFence === true) {
+      out.push(true);
+      // A closer has to match its opener's character, so a ``` inside a ~~~
+      // block is content, not a delimiter.
+      if (looksLikeFence(text) && text.trimStart()[0] === fenceChar) inFence = false;
+      continue;
+    }
+    if (looksLikeFence(text)) {
+      const marker = text.trimStart();
+      // With no seed, an info string is what tells an opener from a closer.
+      if (inFence === false || /^(?:`{3,}|~{3,})\S/.test(marker)) {
+        inFence = true;
+        fenceChar = marker[0];
+        out.push(true);
+      } else {
+        out.push(null);
+      }
+      continue;
+    }
+
+    // An HTML block and an indented code block both run to a blank line, which
+    // is also what ends a flow run.
+    if (blank) {
+      inHtml = false;
+      inIndentedCode = false;
+      atRunStart = true;
+      out.push(inFence);
+      continue;
+    }
+    if (openingRun) inIndentedCode = opensIndentedCode(text);
+    if (inIndentedCode) {
+      out.push(true);
+      continue;
+    }
+    if (inHtml || isHtmlBlockLine(text)) {
+      inHtml = true;
+      out.push(true);
+      continue;
+    }
+    out.push(inFence);
+  }
+  return out;
+}
+
+/** The kind of flow block this line opens, or null when it opens none —
+ * blank, code, fence, heading, rule, table row or image. Those either have no
+ * prose to flow or are single-line by definition. */
+function flowHeadKind(
+  line: LineInfoLike,
+  measure: number,
+  verbatim: boolean | null,
+): FlowKind | null {
+  if (isCodeRegion(line.region) || verbatim === true) return null;
+  const text = lineText(line);
+  if (text.trim() === "") return null;
+  if (looksLikeFence(text) || isRuleLine(text) || isImageLine(text)) return null;
+  if (atxHeading(text) || isTableRowContent(text)) return null;
+  if (quoteMarkerRun(text)) return "quote";
+  if (listItemInfo(text, measure)) return "list";
+  return "paragraph";
+}
+
+/** Whether `line` continues the `kind` block that `prev` is part of.
+ *
+ * Everything that opens a block of its own ends the one above it, and so does
+ * a hard break — two trailing spaces or a trailing backslash are markdown's
+ * one line ending that is NOT read as a space, which is exactly what a reflow
+ * must not swallow. */
+function continuesFlow(
+  kind: FlowKind,
+  prev: LineInfoLike,
+  line: LineInfoLike,
+  measure: number,
+  verbatim: boolean | null,
+): boolean {
+  if (line.line_number !== prev.line_number + 1) return false;
+  if (isCodeRegion(prev.region) || isCodeRegion(line.region)) return false;
+  if (verbatim === true) return false;
+  if (/(?:  |\\)$/.test(lineText(prev))) return false;
+
+  const text = lineText(line);
+  if (text.trim() === "") return false;
+  if (looksLikeFence(text) || isRuleLine(text) || isImageLine(text)) return false;
+  if (atxHeading(text) || isTableRowContent(text)) return false;
+
+  const run = quoteMarkerRun(text);
+  if (kind === "quote") {
+    // Same depth only: `> a` followed by `> > b` opens a quote INSIDE the
+    // first one, and flowing them together would erase exactly the nesting
+    // the second row exists to show.
+    const prevRun = quoteMarkerRun(lineText(prev));
+    return run !== null && prevRun !== null
+      && quoteDepth(run.rendered) === quoteDepth(prevRun.rendered);
+  }
+  if (run) return false;
+  // A marker starts a new item rather than continuing the one above, however
+  // it is indented.
+  return listItemInfo(text, measure) === null;
+}
+
+/** Nesting depth of a quote marker run: how many bars its rendering draws. */
+function quoteDepth(rendered: string): number {
+  let depth = 0;
+  for (const ch of rendered) if (ch === QUOTE_BAR) depth++;
+  return depth;
+}
+
+/** Character offset where a continuation line's flowed text begins: past its
+ * leading whitespace, and past the `>` run when the block is a quote. That
+ * span is what the join conceal replaces with a single space. */
+function flowContentStart(kind: FlowKind, text: string): number {
+  if (kind === "quote") {
+    const run = quoteMarkerRun(text);
+    if (run) return run.runEnd;
+  }
+  return text.length - text.trimStart().length;
+}
+
+/** One block of the batch: its head line plus every line that flows into it.
+ * A line that opens no block (blank, code, table, heading) is a block of one
+ * with `kind === null`, so the blocks always partition the batch and every
+ * line's soft breaks are cleared and rebuilt exactly once. */
+interface FlowBlock {
+  kind: FlowKind | null;
+  lines: LineInfoLike[];
+  /** `contentStart[i]` is the char offset in `lines[i]`; always 0 for the head. */
+  contentStart: number[];
+}
+
+/** Partition a `lines_changed` batch into flow blocks, in batch order. */
+function groupFlowBlocks(
+  lines: LineInfoLike[],
+  measure: number,
+  verbatim: Array<boolean | null>,
+): FlowBlock[] {
+  const blocks: FlowBlock[] = [];
+  let cur: FlowBlock | null = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (
+      cur !== null && cur.kind !== null &&
+      continuesFlow(cur.kind, cur.lines[cur.lines.length - 1], line, measure, verbatim[i])
+    ) {
+      cur.contentStart.push(flowContentStart(cur.kind, lineText(line)));
+      cur.lines.push(line);
+      continue;
+    }
+    cur = { kind: flowHeadKind(line, measure, verbatim[i]), lines: [line], contentStart: [0] };
+    blocks.push(cur);
+  }
+  return blocks;
+}
+
+/** Per-character visual width of a source line as compose mode renders it:
+ * concealed markup costs nothing, an entity costs its replacement, and a list
+ * item's widened indent is charged to its first column (the shape the indent
+ * conceal produces). Shared by every line of a flow block so the wrap measures
+ * the rendering, not the source. */
+function composedCharWidths(text: string, listInfo: ListLineInfo | null): number[] {
+  const charW = new Array<number>(text.length).fill(1);
+  if (listInfo && listInfo.sourceIndent > 0) {
+    for (let c = 0; c < listInfo.sourceIndent && c < charW.length; c++) charW[c] = 0;
+    charW[0] = listInfo.renderedIndent;
+  }
+  for (const span of findInlineSpans(text)) {
+    for (const range of span.concealRanges) {
+      for (let c = range.start; c < range.end && c < text.length; c++) charW[c] = 0;
+      if (range.replacement !== null && range.start < text.length) {
+        charW[range.start] = range.replacement.length;
+      }
+    }
+  }
+  return charW;
+}
+
+/** One column of a flow block's rendered text.
+ *
+ * `li`/`ci` locate the cell in the block: the character at `ci` of
+ * `lines[li]`, or — when `ci` is `JOIN_CELL` — the join *before* `lines[li]`,
+ * the single space a swallowed newline renders as. A break taken there falls
+ * on the join itself, which is why the joins' conceal replacements are decided
+ * after the wrap and not before it. */
+const JOIN_CELL = -1;
+interface FlowCell {
+  w: number;
+  /** A break opportunity: a space that survives concealment, or a join. */
+  brk: boolean;
+  li: number;
+  ci: number;
+}
+
+// =============================================================================
 // Hook handlers
 // =============================================================================
 
 /**
- * Compute soft break points for a single line, using the same block parsing
- * and word-wrap logic as the old token transform, but emitting
- * marker-based soft breaks.
+ * Emit one flow block's soft breaks — and, when it spans more than one source
+ * line, the join conceals that make those lines render as a single flowed
+ * block.
+ *
+ * A block of one line is the old per-line pass unchanged: code rows break at
+ * the frame's inner width, table rows at their cells' segment boundaries, and
+ * prose at the measure. A block of several adds only the two things reflow
+ * needs — the wrap runs over the block's concatenated text instead of
+ * restarting at each source line, and the newlines between them are concealed.
  */
-function processLineSoftBreaks(
-  bufferId: number,
-  lineContent: string,
-  byteStart: number,
-  byteEnd: number,
-  region: RegionLine | undefined,
-  lineNumber?: number,
-): void {
-  // Clear existing soft breaks for this line range
-  editor.clearSoftBreaksInRange(bufferId, byteStart, byteEnd);
+function processFlowBlock(bufferId: number, block: FlowBlock, width: number): void {
+  const head = block.lines[0];
+  // Clear existing soft breaks for every line in the block, so a block that
+  // has shrunk (an edit split it) leaves none behind.
+  for (const line of block.lines) {
+    editor.clearSoftBreaksInRange(bufferId, line.byte_start, line.byte_end);
+  }
+
+  const lineContent = head.content;
+  const byteStart = head.byte_start;
+  const byteEnd = head.byte_end;
 
   // Code is never re-flowed as prose: its line breaks are significant, and a
   // body line is not a markdown block at all. `parseMarkdownBlocks` cannot tell
@@ -2179,12 +2549,10 @@ function processLineSoftBreaks(
   // fold where `emitCodeRails` expects a row to end, at the frame's inner
   // width, and hangs the continuation under the code rather than under the
   // rail. Same positions from the same helper, so the two passes agree.
-  if (isCodeRegion(region)) {
-    if (region !== "body") return;
-    const text = lineContent.replace(/\r?\n$/, "");
-    const viewport = editor.getViewport();
-    const measure = effectiveComposeWidth(viewport ? viewport.width : 80);
-    for (const charPos of codeRowLayout(text, measure).breaks) {
+  if (isCodeRegion(head.region)) {
+    if (head.region !== "body") return;
+    const text = lineText(head);
+    for (const charPos of codeRowLayout(text, width).breaks) {
       // Indent 0, not the rail's width: the continuation row's own left rail
       // is virtual text spliced in ahead of the wrap, so it already supplies
       // those columns. Asking for them again would indent the row twice.
@@ -2195,26 +2563,22 @@ function processLineSoftBreaks(
     return;
   }
 
-  const viewport = editor.getViewport();
-  if (!viewport) return;
-  const width = effectiveComposeWidth(viewport.width);
-
-  // Parse this single line to get block structure
+  // Parse the head line to get block structure
   const blocks = parseMarkdownBlocks(lineContent);
   if (blocks.length === 0) return;
 
-  const block = blocks[0]; // Single line = single block
+  const parsed = blocks[0]; // Single line = single block
 
   // Determine if this block type should be soft-wrapped
-  const noWrap = block.type === 'table-row' || block.type === 'code-fence' ||
-                 block.type === 'code-content' || block.type === 'hr' ||
-                 block.type === 'heading' || block.type === 'image' ||
-                 block.type === 'empty';
+  const noWrap = parsed.type === 'table-row' || parsed.type === 'code-fence' ||
+                 parsed.type === 'code-content' || parsed.type === 'hr' ||
+                 parsed.type === 'heading' || parsed.type === 'image' ||
+                 parsed.type === 'empty';
 
   // Image blocks: add a trailing blank line for visual separation when
   // concealed. Deactivates while the cursor is on the line (same scope as
   // the image conceal), where the raw markup shows instead.
-  if (block.type === 'image') {
+  if (parsed.type === 'image') {
     editor.addSoftBreak(
       bufferId, "md-wrap", byteEnd - 1, 0,
       "unless-cursor-in", byteStart, byteEnd + 1,
@@ -2225,7 +2589,7 @@ function processLineSoftBreaks(
   // concealed cell widths — the cursor-OFF rendering. The breaks deactivate
   // while the cursor is on the row (strict scope, matching the segment
   // conceals), where the row renders as a plain single line.
-  if (block.type === 'table-row') {
+  if (parsed.type === 'table-row') {
     const trimmedLine = lineContent.trim();
     const isSep = /^\|[-:\s|]+\|$/.test(trimmedLine);
     if (!isSep) {
@@ -2275,7 +2639,8 @@ function processLineSoftBreaks(
   // the wrap budget and the continuation indent have to use the *rendered*
   // width, not the source's. Otherwise a wrapped nested item's continuation
   // rows sit left of its text and its last row can overrun the measure.
-  const listInfo = listItemInfo(lineContent, width);
+  const headText = lineText(head);
+  const listInfo = listItemInfo(headText, width);
 
   // A block quote's bar is drawn by concealing its `>` markers, which only
   // exist on the source row — so a quote long enough to wrap used to lose the
@@ -2289,7 +2654,7 @@ function processLineSoftBreaks(
   // continuation row is entirely virtual — there is no source markup there to
   // reveal for editing — so hiding the bar while the cursor sits on the quote
   // would only break the block's edge exactly when the user is working in it.
-  const quoteRun = block.type === 'blockquote' ? quoteMarkerRun(lineContent) : null;
+  const quoteRun = parsed.type === 'blockquote' ? quoteMarkerRun(headText) : null;
   const quotePrefix = quoteRun
     ? { text: quoteRun.rendered, ...quoteBarStyle }
     : null;
@@ -2298,33 +2663,28 @@ function processLineSoftBreaks(
     ? listInfo.renderedIndent + listInfo.markerLen
     : quoteRun
     ? editor.stringWidth(quoteRun.rendered)
-    : block.hangingIndent;
+    : parsed.hangingIndent;
 
-  // Compute per-character visual width so concealed markup (emphasis
-  // markers, link syntax, entities) doesn't count towards line width.
-  const spans = findInlineSpans(lineContent);
-  const charW = new Array<number>(lineContent.length).fill(1);
-
-  // Charge the widened indent to its first character and zero the rest, the
-  // same shape the entity replacements below use.
-  if (listInfo && listInfo.sourceIndent > 0) {
-    for (let c = 0; c < listInfo.sourceIndent && c < charW.length; c++) charW[c] = 0;
-    charW[0] = listInfo.renderedIndent;
-  }
-  for (const span of spans) {
-    for (const range of span.concealRanges) {
-      for (let c = range.start; c < range.end && c < lineContent.length; c++) {
-        charW[c] = 0;
-      }
-      // Entity replacements contribute their replacement's length
-      if (range.replacement !== null && range.start < lineContent.length) {
-        charW[range.start] = range.replacement.length;
-      }
+  // The block's rendered columns, head first and then each continuation
+  // preceded by the join it renders as. Compose-mode widths throughout
+  // (`composedCharWidths`), so concealed markup doesn't count towards the
+  // measure.
+  const cells: FlowCell[] = [];
+  for (let li = 0; li < block.lines.length; li++) {
+    const text = li === 0 ? headText : lineText(block.lines[li]);
+    if (li > 0) cells.push({ w: 1, brk: true, li, ci: JOIN_CELL });
+    const charW = composedCharWidths(text, li === 0 ? listInfo : null);
+    for (let ci = block.contentStart[li]; ci < text.length; ci++) {
+      cells.push({
+        w: charW[ci],
+        brk: text[ci] === ' ' && charW[ci] > 0,
+        li,
+        ci,
+      });
     }
   }
 
-  // Walk through the line content and find word-wrap break points
-  // We need to find Space positions where wrapping should occur.
+  // Walk the block's columns and find word-wrap break points.
   //
   // The wrap budget must reserve columns to match the Rust renderer's
   // `apply_wrapping_transform`, which subtracts one from `content_width`
@@ -2339,40 +2699,69 @@ function processLineSoftBreaks(
   // covering minor differences in scrollbar / gutter / EOL-cursor
   // reservation between terminals.
   const wrapBudget = Math.max(1, width - 2);
+  const breaks: FlowCell[] = [];
   let column = 0;
-  let i = 0;
 
-  while (i < lineContent.length) {
-    const ch = lineContent[i];
-
-    if (ch === ' ' && column > 0 && charW[i] > 0) {
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i];
+    if (cell.brk && column > 0) {
       // Look ahead to find the next word's visual length
       let nextWordLen = 0;
-      for (let j = i + 1; j < lineContent.length; j++) {
-        if ((lineContent[j] === ' ' || lineContent[j] === '\n') && charW[j] > 0) break;
-        nextWordLen += charW[j];
+      for (let j = i + 1; j < cells.length; j++) {
+        if (cells[j].brk) break;
+        nextWordLen += cells[j].w;
       }
 
-      // Check if space + next word would exceed wrap budget
-      if (column + 1 + nextWordLen > wrapBudget && nextWordLen > 0) {
-        // Add a soft break at this space's buffer position
-        const breakBytePos = byteStart + editor.utf8ByteLength(lineContent.slice(0, i));
-        if (quotePrefix) {
-          editor.addSoftBreak(
-            bufferId, "md-wrap", breakBytePos, hangingIndent,
-            undefined, undefined, undefined, quotePrefix,
-          );
-        } else {
-          editor.addSoftBreak(bufferId, "md-wrap", breakBytePos, hangingIndent);
-        }
+      // Check if the separator + next word would exceed the wrap budget
+      if (column + cell.w + nextWordLen > wrapBudget && nextWordLen > 0) {
+        breaks.push(cell);
         column = hangingIndent;
-        i++;
         continue;
       }
     }
+    column += cell.w;
+  }
 
-    column += charW[i];
-    i++;
+  // The joins themselves. Anchored from the end of the previous line's text
+  // (trailing whitespace included in the concealed span, so a line padded with
+  // spaces doesn't flow with two) to the start of this line's own text.
+  for (let li = 1; li < block.lines.length; li++) {
+    const prev = block.lines[li - 1];
+    const line = block.lines[li];
+    const prevText = lineText(prev).replace(/\s+$/, "");
+    const joinStart = prev.byte_start + editor.utf8ByteLength(prevText);
+    const text = lineText(line);
+    const joinEnd = line.byte_start
+      + editor.utf8ByteLength(text.slice(0, block.contentStart[li]));
+    editor.addConceal(
+      bufferId, "md-syntax", joinStart, joinEnd, " ",
+    );
+  }
+
+  for (const cell of breaks) {
+    const line = block.lines[cell.li];
+    let breakBytePos: number;
+    if (cell.ci === JOIN_CELL) {
+      // Past the join, not at it. A row break falling on a join is a break
+      // between two words whose separator is the swallowed line ending: like
+      // any other wrap between words, that separator trails the row it ends
+      // rather than opening the next one. Anchoring at the join instead put
+      // its replacement space at the head of the row below — a stray leading
+      // column — and left the row above with no separator for the caret.
+      breakBytePos = line.byte_start
+        + editor.utf8ByteLength(lineText(line).slice(0, block.contentStart[cell.li]));
+    } else {
+      const text = lineText(line);
+      breakBytePos = line.byte_start + editor.utf8ByteLength(text.slice(0, cell.ci));
+    }
+    if (quotePrefix) {
+      editor.addSoftBreak(
+        bufferId, "md-wrap", breakBytePos, hangingIndent,
+        undefined, undefined, undefined, quotePrefix,
+      );
+    } else {
+      editor.addSoftBreak(bufferId, "md-wrap", breakBytePos, hangingIndent);
+    }
   }
 }
 
@@ -2547,9 +2936,22 @@ editor.on("lines_changed", (data) => {
   const batchViewport = editor.getViewport();
   const measure = effectiveComposeWidth(batchViewport ? batchViewport.width : 80);
 
-  // Per line: clear+rebuild conceals, soft-breaks, and the table border frame —
-  // all anchored to this one line. No whole-table rebuild, no stored row model;
-  // borders for lines not in this batch keep riding their auto-shift markers.
+  // The batch's flow blocks, computed before the per-line pass because the
+  // conceal pass needs to know which lines are continuations: their leading
+  // indent and `>` run are inside a join conceal, so the per-line decorations
+  // that would otherwise render them must stand down.
+  const verbatim = verbatimStates(data.lines);
+  const blocks = groupFlowBlocks(data.lines, measure, verbatim);
+  const joined = new Set<number>();
+  for (const block of blocks) {
+    for (let i = 1; i < block.lines.length; i++) joined.add(block.lines[i].byte_start);
+  }
+
+  // Per line: clear+rebuild conceals and the table border frame — all anchored
+  // to this one line. No whole-table rebuild, no stored row model; borders for
+  // lines not in this batch keep riding their auto-shift markers. Soft breaks
+  // are the one pass that is per *block* rather than per line (see
+  // `processFlowBlock`), and they run below, after every line's clear.
   for (const line of data.lines) {
     // Clear this row's border range first (covers a row that stopped being a
     // table row, e.g. its pipes were deleted, and stale frames left a few bytes
@@ -2569,8 +2971,7 @@ editor.on("lines_changed", (data) => {
       line.byte_start, Math.max(line.byte_end, line.byte_start + 1),
     );
 
-    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, measure, line.region, line.line_number);
-    processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, line.region, line.line_number);
+    processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, measure, line.region, line.line_number, joined.has(line.byte_start));
 
     // Blank row after each list item, so items read as discrete entries.
     //
@@ -2639,6 +3040,15 @@ editor.on("lines_changed", (data) => {
     }
   }
 
+  // Soft breaks, and the joins that make a run of source lines flow as one
+  // block. Deliberately a second pass: a join conceal is anchored in the line
+  // ABOVE the continuation it belongs to, and the per-line pass above clears
+  // conceals by range — so emitting joins inside that loop would have the next
+  // line's clear delete the join just added.
+  for (const block of blocks) {
+    processFlowBlock(data.buffer_id, block, measure);
+  }
+
   // Publish this batch's heading marks. Range-scoped to the batch's byte span
   // so headings outside it — the rest of the document, marked by the pre-scan
   // at compose time — keep their marks; see HEADING_MARKER_NS. Emitted even
@@ -2648,15 +3058,20 @@ editor.on("lines_changed", (data) => {
     const batchStart = data.lines[0].byte_start;
     const batchEnd = data.lines[data.lines.length - 1].byte_end;
     const headingMarkers: ScrollbarMarker[] = [];
-    for (const line of data.lines) {
-      const level = headingLevel(line.content);
+    // False once any `#` line in the batch could not be told apart from a
+    // comment inside a fence (see `verbatimStates`). The whole republish is then
+    // skipped rather than replacing the pre-scan's marks with a guess — an
+    // out-of-date mark beats a wrong one, and the next batch that can see a
+    // fence boundary refreshes the range.
+    let classified = true;
+    for (let i = 0; i < data.lines.length; i++) {
+      const line = data.lines[i];
+      const level = headingLevel(lineText(line));
       if (level === 0 || level > HEADING_MARKER_MAX_LEVEL) continue;
       // `# ...` inside a fenced block is a comment in the block's language,
-      // not a heading. The batch cannot decide that from its own lines, so it
-      // takes the editor's classification — the same source the frame uses,
-      // and current by construction, where a plugin-side memo of fence
-      // extents would be stale for exactly the edit that moved a fence.
-      if (isCodeRegion(line.region)) continue;
+      // and inside front matter it is a YAML comment. Neither is a heading.
+      if (verbatim[i] === null) { classified = false; continue; }
+      if (verbatim[i]) continue;
       headingMarkers.push({
         // Byte offsets, not line numbers: they are exact regardless of file
         // size, and the editor anchors them so later edits shift the marks.
@@ -2665,11 +3080,13 @@ editor.on("lines_changed", (data) => {
         priority: 10 - level, // shallower headings win a shared track cell
       });
     }
-    editor.setScrollbarMarkersInRange(
-      data.buffer_id, HEADING_MARKER_NS,
-      batchStart, Math.max(batchEnd, batchStart + 1),
-      headingMarkers,
-    );
+    if (classified) {
+      editor.setScrollbarMarkersInRange(
+        data.buffer_id, HEADING_MARKER_NS,
+        batchStart, Math.max(batchEnd, batchStart + 1),
+        headingMarkers,
+      );
+    }
   }
 
   // One whole-viewport re-fire when an edit left a delimiter-shaped line

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -422,18 +422,26 @@ function emitCodeRails(
   }
 
   const { rows } = codeRowLayout(text, measure);
+  // A code line's own leading whitespace is real text, so the first row draws
+  // it and the rows it wraps onto do not — they would restart flush against the
+  // rail, left of the code they continue. A fence inside a list item carries
+  // the item's indent on every source line, so that is most of them. The rail
+  // supplies the indent for those rows, because the wrap's own hanging indent
+  // would push the RAIL right instead of the code.
+  const codeIndent = text.length - text.trimStart().length;
   for (let r = 0; r < rows.length; r++) {
     const row = rows[r];
     if (row.end <= row.start) continue;
     const rowText = text.slice(row.start, row.end);
+    const railIndent = r === 0 ? 0 : Math.min(codeIndent, Math.max(0, inner - 1));
 
     editor.addVirtualTextStyled(
       bufferId, `${CODE_RAIL_ID_PREFIX}${byteStart}:${r}:l`,
       charToByte(lineContent, row.start, byteStart),
-      RAIL_GLYPH, codeFrameStyle, true,
+      RAIL_GLYPH + " ".repeat(railIndent), codeFrameStyle, true,
     );
 
-    const pad = inner - displayWidth(rowText);
+    const pad = inner - displayWidth(rowText) - railIndent;
     if (pad < 0) continue; // unbreakable over-long row: leave the edge open
     // Anchor the closing rail *after the last character* of the row, found by
     // code point rather than by `end - 1`: a byte before the end lands inside
@@ -1111,6 +1119,14 @@ function enableMarkdownCompose(bufferId: number): void {
   // break up the clean left edge.
   editor.setFoldIndicators(bufferId, false);
 
+  // And for indentation guides. They are a code-editor affordance too, and a
+  // composed document has nothing for them to guide: the indentation they would
+  // track belongs to the SOURCE — a list item's continuation lines, a fenced
+  // block's body — which compose mode has already re-laid-out or concealed. The
+  // guides that survived that drew as a column of disconnected verticals beside
+  // reflowed paragraphs, tracking indents no longer on screen.
+  editor.setIndentationGuide(bufferId, false);
+
   // Enable native line wrapping so that long lines without whitespace
   // (which the plugin can't soft-break) are force-wrapped by the Rust
   // wrapping transform at the content width.
@@ -1159,8 +1175,11 @@ function disableMarkdownCompose(bufferId: number): void {
     // not necessarily "on".
     editor.setLineNumbersDefault(bufferId, null);
 
-    // Same for the fold indicators.
+    // Same for the fold indicators and the indentation guides — `null`
+    // withdraws the opinion rather than forcing them on, so a user who had
+    // either turned off keeps them off on the way out.
     editor.setFoldIndicators(bufferId, null);
+    editor.setIndentationGuide(bufferId, null);
 
     // Clear layout hints, emphasis overlays, conceals, and soft breaks
     editor.setLayoutHints(bufferId, null, {});
@@ -1530,11 +1549,21 @@ const HEADING_TEXT_STYLES: Array<Record<string, unknown>> = [
 // call.
 const LIST_BULLET = "•";
 
-// Nested indents are scaled rather than stepped by a fixed amount because the
-// source's own step is unknown — 2- and 4-space nesting are both common, and
-// scaling preserves relative depth either way. Capped at a quarter of the
-// measure so a deeply nested list can't push its text off the page.
-const LIST_INDENT_SCALE = 2;
+// A nested item's indent renders as written, because markdown's own indent is
+// already the alignment: a child item is nested precisely by being indented to
+// where its parent's TEXT begins, so `2. ` puts its children at three columns
+// and `- ` at two. Rendering that unchanged lands each child's marker under the
+// first letter of its parent, which is what the nesting means and what every
+// other renderer draws.
+//
+// Scaling it — this was doubled once, to keep relative depth when the source's
+// own step is unknown — breaks that: three source columns became six, so a
+// sub-bullet under `2. ` sat three columns right of the text it belongs to,
+// reading as a deeper level than it is. Depth is already carried by the source,
+// and doubling it only doubles the error when the guess is wrong.
+//
+// Still capped, so a deeply nested list cannot push its text off the page.
+const LIST_INDENT_SCALE = 1;
 
 interface ListLineInfo {
   sourceIndent: number;  // chars of leading whitespace
@@ -2555,7 +2584,9 @@ function processFlowBlock(bufferId: number, block: FlowBlock, width: number): vo
     for (const charPos of codeRowLayout(text, width).breaks) {
       // Indent 0, not the rail's width: the continuation row's own left rail
       // is virtual text spliced in ahead of the wrap, so it already supplies
-      // those columns. Asking for them again would indent the row twice.
+      // those columns — including the code's own leading indent, which
+      // `emitCodeRails` folds into the rail for exactly this reason. Asking for
+      // it here instead indents the RAIL, not the code.
       editor.addSoftBreak(
         bufferId, "md-wrap", charToByte(lineContent, charPos, byteStart), 0,
       );

--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -529,13 +529,21 @@ impl crate::app::window::Window {
         if end_pos >= buffer.len() {
             return end_pos;
         }
-        let bytes = buffer.slice_bytes(end_pos..buffer.len().min(end_pos + 4));
-        match std::str::from_utf8(&bytes)
-            .ok()
-            .and_then(|text| text.chars().next())
-        {
-            Some(ch) if !ch.is_whitespace() => end_pos + ch.len_utf8(),
-            _ => end_pos,
+        let Some(ch) = char_at(buffer, end_pos) else {
+            return end_pos;
+        };
+        if ch.is_whitespace() {
+            return end_pos;
+        }
+        // Only when the byte past it is a separator the wrap consumed. A wrap
+        // can also split a run with no whitespace in it — CJK text, a long URL
+        // — and there the next byte is the first character of the row BELOW,
+        // which that row draws: stepping onto it would take `End` off the row.
+        let after = end_pos + ch.len_utf8();
+        match char_at(buffer, after) {
+            Some(next) if next.is_whitespace() => after,
+            None => after,
+            Some(_) => end_pos,
         }
     }
 
@@ -807,4 +815,23 @@ fn step_before_line_break(buffer: &crate::model::buffer::Buffer, pos: usize) -> 
         }
     }
     pos - 1
+}
+
+/// The character starting at `pos`, or `None` when `pos` is not a character
+/// boundary or the buffer ends there.
+///
+/// The width comes from the leading byte rather than from decoding a fixed
+/// window: a four-byte slice can end mid-character (`1+2+2`, `2+3`, …), and
+/// decoding that returns `Err`, which silently reads as "no character here".
+fn char_at(buffer: &crate::model::buffer::Buffer, pos: usize) -> Option<char> {
+    let lead = *buffer.slice_bytes(pos..pos.saturating_add(1)).first()?;
+    let width = match lead {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => return None,
+    };
+    let bytes = buffer.slice_bytes(pos..pos.saturating_add(width));
+    std::str::from_utf8(&bytes).ok()?.chars().next()
 }

--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -436,7 +436,13 @@ impl crate::app::window::Window {
                         .layout_cache
                         .visual_line_end(split_id, position, allow_advance)
                     {
-                        Some(end_pos) => (end_pos, None),
+                        // The row reports its end as the last source byte it
+                        // drew, which is one cell short when that byte is a
+                        // content character — every row a compose-mode soft
+                        // break wrapped, since the break consumes the space it
+                        // fell on. The row owns and draws the position past it
+                        // (`end_exclusive`), so the caret stays on the row.
+                        Some(end_pos) => (self.step_past_row_end_char(end_pos), None),
                         None => return None,
                     }
                 }
@@ -512,6 +518,27 @@ impl crate::app::window::Window {
     /// Returns `Some((new_position, new_sticky))` on success, or `None`
     /// if wrap mode is off (delegate to caller default) or we're at a
     /// genuine buffer boundary.
+    /// Where `End` stops, given the byte a visual row reports as its end.
+    ///
+    /// That byte is the last source byte the row drew. For a row ending at its
+    /// line ending, or at whitespace a wrap consumed, it already is the
+    /// position after the row's text. For a row ending on a content character
+    /// it is one cell short, so step past that character.
+    fn step_past_row_end_char(&mut self, end_pos: usize) -> usize {
+        let buffer = &mut self.active_state_mut().buffer;
+        if end_pos >= buffer.len() {
+            return end_pos;
+        }
+        let bytes = buffer.slice_bytes(end_pos..buffer.len().min(end_pos + 4));
+        match std::str::from_utf8(&bytes)
+            .ok()
+            .and_then(|text| text.chars().next())
+        {
+            Some(ch) if !ch.is_whitespace() => end_pos + ch.len_utf8(),
+            _ => end_pos,
+        }
+    }
+
     fn compute_wrap_aware_visual_move_fallback(
         &mut self,
         from_pos: usize,

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2090,14 +2090,18 @@ impl Editor {
     /// `EditorState`, so it follows the buffer wherever it's shown — including a
     /// buffer-group detail panel that isn't the focused split, and across the
     /// panel's per-commit buffer retargets.
-    pub(super) fn handle_set_indentation_guide(&mut self, buffer_id: BufferId, enabled: bool) {
+    pub(super) fn handle_set_indentation_guide(
+        &mut self,
+        buffer_id: BufferId,
+        enabled: Option<bool>,
+    ) {
         if let Some(state) = self
             .windows
             .get_mut(&self.active_window)
             .expect("active window present")
             .buffer_state_mut(buffer_id)
         {
-            state.indentation_guide_override = Some(enabled);
+            state.indentation_guide_override = enabled;
         }
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -12,6 +12,87 @@ pub(crate) struct BottomRowFlags {
     pub prompt_row_visible: bool,
 }
 
+/// How far the `lines_changed` walk will go to close a run of non-blank lines
+/// for a composing buffer, in either direction.
+///
+/// A reflowing renderer needs whole blocks: `markdown_compose` joins a
+/// paragraph's source lines into one flowed block and wraps them together, and
+/// it can only do that for lines it is offered in the same batch. So a batch
+/// for such a buffer is *run-closed* — it never carries a line without the rest
+/// of its blank-line-delimited run — and this bounds the extra walking that
+/// costs.
+///
+/// A run longer than this is left un-closed rather than dragged into every
+/// batch that touches it: prose paragraphs are a handful of lines, and a file
+/// whose lines never blank out (a wrapped log, a minified blob) would otherwise
+/// turn each one-line scroll into a walk over the whole run. The consumer then
+/// sees a line whose predecessor is missing, which it already has to treat as a
+/// block head.
+const FLOW_RUN_MAX_LINES: usize = 200;
+
+/// Whether a line separates two runs: empty, or nothing but whitespace.
+fn line_is_blank(content: &str) -> bool {
+    content.trim().is_empty()
+}
+
+/// How far back the run scan reads to find the blank line above the viewport.
+///
+/// A byte window rather than a line count so the scan is one read and one
+/// backwards pass per frame instead of one piece-tree lookup per line: a file
+/// whose lines never blank out would otherwise pay for the whole run on every
+/// frame, and this is the draw path.
+const FLOW_RUN_LOOKBEHIND_BYTES: usize = 8192;
+
+/// Start byte of the run of non-blank lines containing `top_byte`'s line.
+///
+/// Returns that line's own start when it opens the run, when it is itself
+/// blank, and when the run reaches further back than the scan window — the
+/// consumer then sees a line whose predecessor is absent from the batch, which
+/// is exactly the "treat it as a block head" case it already handles.
+fn flow_run_start(buffer: &crate::model::buffer::Buffer, top_byte: usize) -> usize {
+    let top_line = buffer.get_line_number(top_byte);
+    let Some(line_start) = buffer.line_start_offset(top_line) else {
+        return top_byte;
+    };
+    if line_start == 0 {
+        return line_start;
+    }
+    let window = line_start.min(FLOW_RUN_LOOKBEHIND_BYTES);
+    let from = line_start - window;
+    let bytes = buffer.slice_bytes(from..line_start);
+    if bytes.len() != window {
+        return line_start;
+    }
+    // Splitting on `\n` is UTF-8 safe: no continuation byte can equal it.
+    let mut run_start = line_start;
+    let mut end = window;
+    while end > 0 {
+        // `end` is one past the previous line's terminator.
+        let mut content_end = end - 1;
+        if content_end > 0 && bytes[content_end - 1] == b'\r' {
+            content_end -= 1;
+        }
+        let Some(nl) = bytes[..content_end].iter().rposition(|b| *b == b'\n') else {
+            // The window ran out mid-line, unless it starts at the buffer's
+            // own beginning — where there is no line above to look at.
+            if from == 0 && !bytes[..content_end].iter().all(u8::is_ascii_whitespace) {
+                run_start = from;
+            }
+            break;
+        };
+        let start = nl + 1;
+        if bytes[start..content_end]
+            .iter()
+            .all(u8::is_ascii_whitespace)
+        {
+            break;
+        }
+        run_start = from + start;
+        end = start;
+    }
+    run_start
+}
+
 impl Editor {
     /// Render the topmost global popup at its computed area and register its
     /// click region in `global_popup_areas`. Shared by the generic
@@ -333,36 +414,151 @@ impl Editor {
                         let top_byte = viewport_top_byte;
                         let seen_byte_ranges = seen_ranges_for_win.entry(buffer_id).or_default();
 
+                        // Where the walk starts. Normally the viewport's top
+                        // line; for a composing buffer, backed up to the start
+                        // of the blank-line-delimited run that line belongs to
+                        // — see `flow_run_start` for why a reflowing renderer
+                        // needs that and nothing else does.
+                        let walk_start = if composing_in_any_split {
+                            flow_run_start(&state.buffer, top_byte)
+                        } else {
+                            top_byte
+                        };
+
+                        // Every line the walk saw, in order, paired with
+                        // whether it had been offered before. Two passes over
+                        // it below: one to decide what to send, one to build
+                        // the payload. Only a composing buffer keeps more than
+                        // the viewport here.
+                        struct WalkedLine {
+                            line_number: usize,
+                            byte_start: usize,
+                            byte_end: usize,
+                            content: String,
+                            seen: bool,
+                        }
+                        // Source lines to cover the viewport with. One per row,
+                        // except that a conceal spanning a line break renders
+                        // two source lines as one row — which is how compose
+                        // mode reflows a paragraph. The renderer sizes its own
+                        // token build the same way, from the same helper, so
+                        // the lines this offers the plugin are exactly the ones
+                        // the frame will draw; without it the bottom block of a
+                        // reflowed viewport is never offered and so never
+                        // flows. Self-correcting rather than predictive: the
+                        // joins it measures are the ones already on screen, so
+                        // a document opens at one line per row and settles over
+                        // the next frames as its blocks join.
+                        let rows = crate::view::ui::split_rendering::transforms::join_adjusted_visible_count(
+                            &state.buffer,
+                            &state.conceals,
+                            &state.marker_list,
+                            &[],
+                            top_byte,
+                            visible_count,
+                            composing_in_any_split,
+                        );
+                        // A split with no rows draws nothing, so it has nothing
+                        // to offer — and the walk below has no stopping rule.
+                        if rows == 0 {
+                            return 0;
+                        }
+
+                        let mut walked: Vec<WalkedLine> = Vec::new();
+                        let mut line_number = state.buffer.get_line_number(walk_start);
+                        let mut iter = state.buffer.line_iterator(walk_start, estimated_line_length);
+                        // End of the last line walked, so the embedded-region
+                        // probe below covers exactly the lines we iterated.
+                        let mut walked_end = walk_start;
+                        // Lines walked ahead of the viewport's own top line:
+                        // the run's lead-in, which must not eat the viewport's
+                        // line budget.
+                        let mut lead_in = 0usize;
+                        loop {
+                            let Some((line_start, line_content)) = iter.next_line() else {
+                                break;
+                            };
+                            let byte_end = line_start + line_content.len();
+                            walked_end = byte_end;
+                            let blank = line_is_blank(&line_content);
+                            if line_start < top_byte {
+                                lead_in += 1;
+                            }
+                            walked.push(WalkedLine {
+                                line_number,
+                                byte_start: line_start,
+                                byte_end,
+                                seen: seen_byte_ranges.contains(&(line_start, byte_end)),
+                                content: line_content,
+                            });
+                            line_number += 1;
+
+                            if walked.len() < lead_in + rows {
+                                continue;
+                            }
+                            // The viewport is covered. A composing buffer walks
+                            // on to the end of the run it stopped inside, so a
+                            // batch never carries half a paragraph — bounded,
+                            // because a file whose lines never blank out must
+                            // not turn one frame into a walk over the buffer.
+                            if !composing_in_any_split
+                                || blank
+                                || walked.len() >= lead_in + rows + FLOW_RUN_MAX_LINES
+                            {
+                                break;
+                            }
+                        }
+
+                        // What to send. A line the plugin has not been offered
+                        // before, always; and for a composing buffer, every
+                        // other line of that line's run as well, so a per-line
+                        // pass that flows a paragraph sees all of it at once
+                        // (`markdown_compose`'s joins and block wrap). Runs are
+                        // delimited by blank lines, which is markdown's own
+                        // paragraph rule and the only one that does not need a
+                        // grammar.
+                        let mut send: Vec<bool> = walked.iter().map(|l| !l.seen).collect();
+                        if composing_in_any_split {
+                            let mut i = 0;
+                            while i < walked.len() {
+                                if line_is_blank(&walked[i].content) {
+                                    i += 1;
+                                    continue;
+                                }
+                                let start = i;
+                                while i < walked.len() && !line_is_blank(&walked[i].content) {
+                                    i += 1;
+                                }
+                                // A run longer than the cap is not closed here,
+                                // so it is left to the plain unseen-lines rule:
+                                // the consumer sees a line whose predecessor is
+                                // missing and treats it as a block head, which
+                                // is wrong-but-stable rather than unbounded work
+                                // on every scroll step.
+                                if i - start <= FLOW_RUN_MAX_LINES
+                                    && send[start..i].iter().any(|s| *s)
+                                {
+                                    send[start..i].iter_mut().for_each(|s| *s = true);
+                                }
+                            }
+                        }
+
                         let mut new_lines: Vec<crate::services::plugins::hooks::LineInfo> =
                             Vec::new();
                         let mut fresh_ranges: Vec<(usize, usize)> = Vec::new();
-                        let mut line_number = state.buffer.get_line_number(top_byte);
-                        let mut iter = state.buffer.line_iterator(top_byte, estimated_line_length);
-                        // End of the last line walked, so the embedded-region
-                        // probe below covers exactly the lines we iterated.
-                        let mut walked_end = top_byte;
-
-                        for _ in 0..visible_count {
-                            if let Some((line_start, line_content)) = iter.next_line() {
-                                let byte_end = line_start + line_content.len();
-                                let byte_range = (line_start, byte_end);
-                                walked_end = byte_end;
-
-                                if !seen_byte_ranges.contains(&byte_range) {
-                                    new_lines.push(crate::services::plugins::hooks::LineInfo {
-                                        line_number,
-                                        byte_start: line_start,
-                                        byte_end,
-                                        content: line_content,
-                                        region: None,
-                                        table: None,
-                                    });
-                                    fresh_ranges.push(byte_range);
-                                }
-                                line_number += 1;
-                            } else {
-                                break;
+                        for (line, send) in walked.into_iter().zip(send) {
+                            if !send {
+                                continue;
                             }
+                            fresh_ranges.push((line.byte_start, line.byte_end));
+                            new_lines.push(crate::services::plugins::hooks::LineInfo {
+                                line_number: line.line_number,
+                                byte_start: line.byte_start,
+                                byte_end: line.byte_end,
+                                content: line.content,
+                                region: None,
+                                table: None,
+                            });
                         }
 
                         let count = new_lines.len();
@@ -386,7 +582,7 @@ impl Editor {
                             // report.
                             let structure = state
                                 .highlighter
-                                .structure_lines_in(&state.buffer, top_byte..walked_end);
+                                .structure_lines_in(&state.buffer, walk_start..walked_end);
                             if !structure.regions.is_empty() {
                                 let mut next = 0usize;
                                 for line in new_lines.iter_mut() {

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -21,6 +21,18 @@ pub struct ViewLineMapping {
     /// the cursor on a position whose `line_end_byte` was inherited
     /// from the previous source row.
     pub is_plugin_virtual: bool,
+    /// One byte past the last character this row drew, when the row ends on a
+    /// content character rather than on a separator. `None` when
+    /// `line_end_byte` is already the row's end position — a row ending at its
+    /// line ending, or at the whitespace a wrap consumed.
+    ///
+    /// A compose-mode soft break consumes the space it broke on, so the rows it
+    /// wraps end on a content character and the position past it is carried by
+    /// no cell. It still belongs to this row: it is where `End` goes and where
+    /// the caret is drawn (`row_end_exclusive` in `render_line`). Without it
+    /// the row below claims the byte, and a `Home` or `Up` after `End` acts on
+    /// the wrong row.
+    pub end_exclusive: Option<usize>,
 }
 
 impl ViewLineMapping {
@@ -267,7 +279,20 @@ impl WindowLayoutCache {
     /// Find which visual row contains the given byte position for a split
     pub fn find_visual_row(&self, split_id: LeafId, byte_pos: usize) -> Option<usize> {
         let mappings = self.view_line_mappings.get(&split_id)?;
-        mappings.iter().position(|m| m.contains_byte(byte_pos))
+        if let Some(idx) = mappings.iter().position(|m| m.contains_byte(byte_pos)) {
+            return Some(idx);
+        }
+        // No row drew this byte. It can still be the position just past some
+        // row's last character — a compose-mode soft break consumes the space
+        // it fell on, so that position is carried by no cell even though the
+        // row owns it (see `ViewLineMapping::end_exclusive`). Asked only after
+        // the rows that do draw the byte have had their say, so a row never
+        // takes a byte the row below actually starts with: that is the ordinary
+        // wrapped row, where the next row draws the byte and `Down` steps onto
+        // it.
+        mappings
+            .iter()
+            .position(|m| m.end_exclusive == Some(byte_pos))
     }
 
     /// Get the visual column of a byte position within its visual row

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -920,9 +920,28 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         }
 
         if !line_spans.is_empty() {
+            // Where the row's end position is, when no cell carries it — the
+            // same value `build_view_line_mapping` records as `end_exclusive`.
+            let row_end_exclusive = current_view_line
+                .char_source_bytes
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(idx, m)| m.map(|byte| (idx, byte)))
+                .and_then(|(idx, byte)| {
+                    current_view_line
+                        .text
+                        .chars()
+                        .nth(idx)
+                        .filter(|ch| !ch.is_whitespace())
+                        .map(|ch| byte + ch.len_utf8())
+                });
             if let Some(x) = locate_cursor_in_view_map(
                 &line_view_map,
                 primary_cursor_position,
+                cursor_line_start_byte,
+                cursor_line_end_byte,
+                row_end_exclusive,
                 is_on_cursor_line,
                 current_row,
                 &mut cursor,
@@ -1358,12 +1377,20 @@ fn place_line_end_cursor(
 fn locate_cursor_in_view_map(
     line_view_map: &[Option<usize>],
     primary_cursor_position: usize,
+    cursor_line_start_byte: usize,
+    cursor_line_end_byte: usize,
+    // One byte past the last character this row drew, when the row ends on a
+    // content character. That position is the row's own — it is where `End`
+    // goes — but no cell carries it, because the wrap consumed the separator.
+    row_end_exclusive: Option<usize>,
     is_on_cursor_line: bool,
     current_row: u16,
     cursor: &mut CursorTracker,
 ) -> Option<u16> {
     let mut nearest_fallback: Option<(u16, usize)> = None; // (screen_x, byte_distance)
     let mut last_visible_x: Option<u16> = None;
+    // Whether this row draws any byte of the cursor's own logical line.
+    let mut row_draws_cursor_line = false;
     for (screen_x, source_offset) in line_view_map.iter().enumerate() {
         if let Some(src) = source_offset {
             // Exact match: cursor byte is visible
@@ -1371,18 +1398,48 @@ fn locate_cursor_in_view_map(
                 cursor.place(screen_x as u16, current_row);
             }
             // Track nearest visible byte >= cursor position for fallback
-            if !cursor.found && is_on_cursor_line && *src >= primary_cursor_position {
+            if !cursor.found && *src >= primary_cursor_position {
                 let dist = *src - primary_cursor_position;
                 if nearest_fallback.is_none_or(|(_, best)| dist < best) {
                     nearest_fallback = Some((screen_x as u16, dist));
                 }
             }
+            if (cursor_line_start_byte..cursor_line_end_byte).contains(src) {
+                row_draws_cursor_line = true;
+            }
             last_visible_x = Some(screen_x as u16);
         }
     }
-    // Fallback: cursor byte was concealed — snap to nearest visible byte
+    // Fallback: cursor byte was concealed — snap to nearest visible byte.
+    //
+    // Gated so a row that has nothing to do with the cursor cannot snap a
+    // phantom onto itself when the cursor's own line is offscreen (#1965).
+    //
+    // `is_on_cursor_line` asks whether the row STARTS inside the cursor's
+    // logical line, which a conceal spanning a newline breaks: compose mode's
+    // reflow draws a paragraph's source lines as one row, so the row that holds
+    // the cursor's bytes starts in the line above and the gate reads false —
+    // leaving the caret undrawn wherever it sat in a byte no cell claims, which
+    // is every byte inside a join and the space a row break lands on. Asking
+    // instead whether the row DRAWS any of that line answers the same question
+    // where a row and a logical line still coincide, and keeps answering it
+    // when they do not. No wider for the phantom case: a row drawing none of
+    // the cursor's line cannot claim the cursor either way.
+    // The position just past this row's last character sits one cell to its
+    // right. Claimed ahead of the nearest-visible fallback, which would hand it
+    // to the row below — the caret jumping a line when `End` goes there.
+    if !cursor.found
+        && row_end_exclusive == Some(primary_cursor_position)
+        && (is_on_cursor_line || row_draws_cursor_line)
+    {
+        if let Some(x) = last_visible_x {
+            cursor.place(x.saturating_add(1), current_row);
+        }
+    }
     if let Some((fallback_x, _)) = nearest_fallback {
-        cursor.place(fallback_x, current_row);
+        if is_on_cursor_line || row_draws_cursor_line {
+            cursor.place(fallback_x, current_row);
+        }
     }
     last_visible_x
 }
@@ -1493,6 +1550,27 @@ fn build_view_line_mapping(
         prev_line_end_byte
     };
 
+    // One past the row's last character, when the row ends on a content
+    // character rather than on a separator — see `ViewLineMapping::
+    // end_exclusive`. `char_source_bytes` is indexed by character of `text`
+    // (its length is `text.chars().count()`), so the index of the last mapped
+    // byte is the index of its character.
+    let end_exclusive = view_line
+        .char_source_bytes
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(idx, m)| m.map(|byte| (idx, byte)))
+        .and_then(|(idx, byte)| {
+            view_line
+                .text
+                .chars()
+                .nth(idx)
+                .filter(|ch| !ch.is_whitespace())
+                .map(|ch| byte + ch.len_utf8())
+        })
+        .filter(|end| *end != line_end_byte);
+
     // Content mapping starts after the gutter
     let content_map = if line_view_map.len() >= gutter_width {
         line_view_map[gutter_width..].to_vec()
@@ -1513,5 +1591,6 @@ fn build_view_line_mapping(
         char_source_bytes: content_map,
         line_end_byte,
         is_plugin_virtual,
+        end_exclusive,
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -920,22 +920,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         }
 
         if !line_spans.is_empty() {
-            // Where the row's end position is, when no cell carries it — the
-            // same value `build_view_line_mapping` records as `end_exclusive`.
-            let row_end_exclusive = current_view_line
-                .char_source_bytes
-                .iter()
-                .enumerate()
-                .rev()
-                .find_map(|(idx, m)| m.map(|byte| (idx, byte)))
-                .and_then(|(idx, byte)| {
-                    current_view_line
-                        .text
-                        .chars()
-                        .nth(idx)
-                        .filter(|ch| !ch.is_whitespace())
-                        .map(|ch| byte + ch.len_utf8())
-                });
+            let row_end_exclusive = row_end_exclusive(current_view_line, &state.buffer);
             if let Some(x) = locate_cursor_in_view_map(
                 &line_view_map,
                 primary_cursor_position,
@@ -1061,6 +1046,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             gutter_width,
             prev_line_end_byte,
             state.buffer.len(),
+            &state.buffer,
         ));
 
         // Track if line was empty before moving line_spans
@@ -1509,12 +1495,72 @@ fn append_inline_diagnostic(
 }
 
 /// Build the mouse-click/cursor-movement mapping for a rendered row.
+/// One byte past the last character a row drew, when that position belongs to
+/// the row and no cell carries it. `None` otherwise.
+///
+/// A row ends on a content character whenever the wrap that ended it consumed a
+/// separator — which is what a compose-mode soft break does with the space it
+/// fell on. The position past that character is then the separator's own, drawn
+/// by nobody, and it is where `End` goes.
+///
+/// A wrap can also split a run with no whitespace in it at all — CJK text, a
+/// long URL, an unbreakable token — and there the byte past the last character
+/// is the first character of the NEXT row, which that row draws. Claiming it
+/// would paint the caret on the wrong row and send `End` off the row entirely.
+/// The two cases are told apart by the byte itself: a consumed separator is
+/// whitespace, the next row's first character is not.
+fn row_end_exclusive(view_line: &ViewLine, buffer: &crate::model::buffer::Buffer) -> Option<usize> {
+    // `char_source_bytes` is indexed by character of `text` (its length is
+    // `text.chars().count()`), so the index of the last mapped byte is the
+    // index of its character.
+    let (idx, byte) = view_line
+        .char_source_bytes
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(idx, m)| m.map(|byte| (idx, byte)))?;
+    let ch = view_line
+        .text
+        .chars()
+        .nth(idx)
+        .filter(|c| !c.is_whitespace())?;
+    let end = byte + ch.len_utf8();
+    if end >= buffer.len() || byte_at_is_whitespace(buffer, end) {
+        Some(end)
+    } else {
+        None
+    }
+}
+
+/// Whether the buffer's character at `pos` is whitespace. `pos` must be a
+/// character boundary; the width is read from the leading byte so a slice that
+/// ends mid-character cannot make this fail silently.
+fn byte_at_is_whitespace(buffer: &crate::model::buffer::Buffer, pos: usize) -> bool {
+    let lead = match buffer.slice_bytes(pos..pos.saturating_add(1)).first() {
+        Some(b) => *b,
+        None => return false,
+    };
+    let width = match lead {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => return false,
+    };
+    let bytes = buffer.slice_bytes(pos..pos.saturating_add(width));
+    std::str::from_utf8(&bytes)
+        .ok()
+        .and_then(|text| text.chars().next())
+        .is_some_and(char::is_whitespace)
+}
+
 fn build_view_line_mapping(
     view_line: &ViewLine,
     line_view_map: &[Option<usize>],
     gutter_width: usize,
     prev_line_end_byte: usize,
     buffer_len: usize,
+    buffer: &crate::model::buffer::Buffer,
 ) -> ViewLineMapping {
     let line_end_byte = if view_line.ends_with_newline {
         // Position ON the newline - find the last source byte (the newline's position)
@@ -1550,26 +1596,7 @@ fn build_view_line_mapping(
         prev_line_end_byte
     };
 
-    // One past the row's last character, when the row ends on a content
-    // character rather than on a separator — see `ViewLineMapping::
-    // end_exclusive`. `char_source_bytes` is indexed by character of `text`
-    // (its length is `text.chars().count()`), so the index of the last mapped
-    // byte is the index of its character.
-    let end_exclusive = view_line
-        .char_source_bytes
-        .iter()
-        .enumerate()
-        .rev()
-        .find_map(|(idx, m)| m.map(|byte| (idx, byte)))
-        .and_then(|(idx, byte)| {
-            view_line
-                .text
-                .chars()
-                .nth(idx)
-                .filter(|ch| !ch.is_whitespace())
-                .map(|ch| byte + ch.len_utf8())
-        })
-        .filter(|end| *end != line_end_byte);
+    let end_exclusive = row_end_exclusive(view_line, buffer).filter(|end| *end != line_end_byte);
 
     // Content mapping starts after the gutter
     let content_map = if line_view_map.len() >= gutter_width {

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
@@ -141,6 +141,7 @@ fn render_implicit_line_into(
         visual_to_char: Vec::new(),
         line_end_byte: ctx.state.buffer.len(),
         is_plugin_virtual: false,
+        end_exclusive: None,
     });
 
     // NOTE: We intentionally do NOT update last_line_end here; the
@@ -235,6 +236,7 @@ fn ensure_trailing_mapping(ctx: &PostRowContext<'_>, acc: &mut PostRowAccumulato
             visual_to_char: Vec::new(),
             line_end_byte: ctx.state.buffer.len(),
             is_plugin_virtual: false,
+            end_exclusive: None,
         });
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -216,6 +216,66 @@ pub(crate) fn apply_soft_breaks(
     output
 }
 
+/// How many times the join estimate is allowed to re-measure. Each pass grows
+/// the window, which can bring more joins into view; two passes settle every
+/// realistic document (a paragraph's joins are found by the first), and the
+/// bound keeps a pathological one — a file that is one joined block — from
+/// walking the buffer.
+const JOIN_ESTIMATE_PASSES: usize = 2;
+
+/// Grow the visible-line estimate by the line breaks the viewport's conceals
+/// swallow.
+///
+/// A conceal whose range covers a newline renders the line below it as part of
+/// the line above — the mechanism compose mode reflows a paragraph with. N
+/// source lines then fill fewer than N rows, so a token build sized in source
+/// lines stops above the viewport's bottom and the frame ends in EOF tildes
+/// with the document still going. This counts the swallowed breaks and asks
+/// for that many lines more, re-measuring because the extra lines can carry
+/// joins of their own.
+///
+/// Returns `visible_count` unchanged for a non-composing split or an
+/// unconcealed buffer: every other conceal in the editor stays inside one
+/// line, so nothing else can pay for this query.
+pub(crate) fn join_adjusted_visible_count(
+    buffer: &crate::model::buffer::Buffer,
+    conceals: &crate::view::conceal::ConcealManager,
+    marker_list: &crate::model::marker::MarkerList,
+    cursor_positions: &[usize],
+    top_byte: usize,
+    visible_count: usize,
+    is_compose: bool,
+) -> usize {
+    if !is_compose || conceals.is_empty() || visible_count == 0 {
+        return visible_count;
+    }
+    let start_line = buffer.get_line_number(top_byte);
+    let mut total = visible_count;
+    for _ in 0..JOIN_ESTIMATE_PASSES {
+        let end_byte = buffer
+            .line_start_offset(start_line + total)
+            .unwrap_or_else(|| buffer.len());
+        if end_byte <= top_byte {
+            return total;
+        }
+        let swallowed: usize = conceals
+            .query_viewport(top_byte, end_byte, marker_list, cursor_positions)
+            .iter()
+            .map(|(range, _)| {
+                let from = buffer.get_line_number(range.start.max(top_byte));
+                let to = buffer.get_line_number(range.end.min(end_byte));
+                to.saturating_sub(from)
+            })
+            .sum();
+        let grown = visible_count.saturating_add(swallowed);
+        if grown <= total {
+            return total;
+        }
+        total = grown;
+    }
+    total
+}
+
 /// Apply conceal ranges to a token stream.
 ///
 /// Handles partial token overlap: if a Text token spans bytes that are

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -10,8 +10,8 @@ use super::folding::{apply_folding, fold_adjusted_visible_count, fold_skip_set};
 use super::style::fold_placeholder_style;
 use super::transforms::{
     apply_conceal_ranges, apply_grid_wrapping_transform, apply_soft_breaks,
-    apply_wrapping_transform_from, inject_virtual_lines, resolve_inline_hints,
-    splice_inline_virtual_text,
+    apply_wrapping_transform_from, inject_virtual_lines, join_adjusted_visible_count,
+    resolve_inline_hints, splice_inline_virtual_text,
 };
 use super::MAX_SAFE_LINE_WIDTH;
 use crate::state::{EditorState, ViewMode};
@@ -195,6 +195,21 @@ pub(super) fn build_view_data(
         folds,
         viewport.top_byte(),
         visible_count,
+    );
+    // A conceal that spans a line break swallows it: the two source lines
+    // render as one row. Compose mode reflows a paragraph exactly that way
+    // (markdown_compose's join conceals), so a window of N source lines can
+    // fill fewer than N rows and the viewport's bottom comes up short — the
+    // same shortfall a collapsed fold produces, and answered the same way, by
+    // asking the token build for the lines the joins ate.
+    let adjusted_visible_count = join_adjusted_visible_count(
+        &state.buffer,
+        &state.conceals,
+        &state.marker_list,
+        cursor_positions,
+        viewport.top_byte(),
+        adjusted_visible_count,
+        matches!(view_mode, ViewMode::PageView),
     );
 
     let is_binary = state.buffer.is_binary();

--- a/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_blocks.rs
@@ -584,21 +584,38 @@ fn test_consecutive_list_items_are_vertically_spaced() {
     );
 }
 
-/// A nested item is indented deeper than its two-space source indent, so
-/// nesting depth is readable without counting spaces.
+/// A nested item's bullet sits under the first letter of its parent's text.
+///
+/// That is what markdown's own indent already says: an item is nested by being
+/// indented to where its parent's TEXT begins — two columns under `- `, three
+/// under `2. ` — so rendering the source indent unchanged puts each child's
+/// marker under its parent's first letter, which is how every other renderer
+/// draws it.
+///
+/// This asserted a *deeper* indent than the source once, on the reasoning that
+/// scaling makes depth readable without counting spaces. It reads as a level
+/// too far instead: a sub-bullet under `2. ` landed three columns right of the
+/// text it belongs to, attached to nothing above it.
 #[test]
-fn test_nested_list_items_get_a_deeper_indent() {
+fn test_nested_list_items_align_under_their_parent_s_text() {
     let (harness, _tmp) = composed(LIST_MD, 100, 30);
 
-    let indent_of = |needle: &str| glyph_column(&line_with(&harness, needle), '•');
+    let parent = line_with(&harness, "second item");
+    let top = glyph_column(&parent, '•');
+    // Char columns, not byte offsets: `•` is three bytes wide and one column.
+    let parent_text = parent
+        .chars()
+        .enumerate()
+        .find(|(i, c)| *i > top && !c.is_whitespace() && *c != '•')
+        .map(|(i, _)| i)
+        .expect("the parent item should have text after its bullet");
 
-    let top = indent_of("second item");
-    let nested = indent_of("nested item");
-    assert!(
-        nested > top + 2,
-        "a nested item's bullet should sit deeper than its two-space source \
-         indent would put it: top-level bullet at column {top}, nested at \
-         {nested}",
+    let nested = glyph_column(&line_with(&harness, "nested item"), '•');
+    assert_eq!(
+        nested, parent_text,
+        "a nested item's bullet should sit under the first letter of its \
+         parent's text: parent bullet at column {top}, its text at \
+         {parent_text}, nested bullet at {nested}",
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
@@ -1,0 +1,778 @@
+//! E2E: compose/preview mode flows a block's source lines into one paragraph.
+//!
+//! Markdown reads a run of consecutive non-blank lines as ONE paragraph (or
+//! one list item, or one quote) — the newlines between them are word
+//! separators. Compose mode used to render each source line as its own row, so
+//! a hard-wrapped document (the ordinary way markdown is written) came out
+//! ragged, with a list item's continuation lines starting back at the item's
+//! own column instead of hanging under its text.
+//!
+//! These drive the real plugin and assert only on rendered rows.
+
+#![cfg(feature = "plugins")]
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Open `content` as markdown with the real `markdown_compose` plugin and turn
+/// compose mode on from the command palette.
+fn composed(content: &str, width: u16, height: u16) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("flow.md");
+    std::fs::write(&md_path, content).unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        width,
+        height,
+        Default::default(),
+        project_root,
+    )
+    .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("flow.md");
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    (harness, temp_dir)
+}
+
+/// The screen row index containing `needle`, panicking with the screen if absent.
+fn row_with(harness: &EditorTestHarness, needle: &str) -> usize {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("'{needle}' not on screen.\nScreen:\n{screen}"))
+}
+
+/// The screen line containing `needle`.
+fn line_with(harness: &EditorTestHarness, needle: &str) -> String {
+    let screen = harness.screen_to_string();
+    let row = row_with(harness, needle);
+    screen.lines().nth(row).unwrap().to_string()
+}
+
+/// Character column `needle` starts at within `line`.
+fn column_in(line: &str, needle: &str) -> usize {
+    let byte = line
+        .find(needle)
+        .unwrap_or_else(|| panic!("'{needle}' not on row {line:?}"));
+    line[..byte].chars().count()
+}
+
+/// Character column `needle` starts at on the row it appears on.
+fn column_of(harness: &EditorTestHarness, needle: &str) -> usize {
+    column_in(&line_with(harness, needle), needle)
+}
+
+/// Wait until the plugin has decorated the buffer: `**` disappearing is the
+/// established "the conceal pass has run" signal in this suite.
+fn settle(harness: &mut EditorTestHarness) {
+    harness
+        .wait_until_stable(|h| !h.screen_to_string().contains("**"))
+        .unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Paragraphs
+// ---------------------------------------------------------------------------
+
+const PARAGRAPH_MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+A hard-wrapped paragraph whose first source line
+stops early,
+and whose third source line finishes the thought.
+
+Tail.
+";
+
+/// The headline case: three source lines become one flowed paragraph, so the
+/// words that followed a source break move up onto the row above.
+#[test]
+fn a_hard_wrapped_paragraph_flows_into_one_block() {
+    let (mut harness, _tmp) = composed(PARAGRAPH_MD, 100, 20);
+    settle(&mut harness);
+
+    let line = line_with(&harness, "stops early");
+    assert!(
+        line.contains("A hard-wrapped paragraph whose first source line stops early,"),
+        "the paragraph's source lines should flow into one row, got {line:?}",
+    );
+}
+
+/// Flowing a paragraph must not swallow the blank line that ends it: the
+/// paragraph after it still starts on its own row.
+#[test]
+fn a_blank_line_still_ends_the_flowed_paragraph() {
+    let (mut harness, _tmp) = composed(PARAGRAPH_MD, 100, 20);
+    settle(&mut harness);
+
+    assert!(
+        !line_with(&harness, "Tail.").contains("finishes the thought"),
+        "the blank line before `Tail.` must still break the block.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// A hard break — two trailing spaces — is the one line ending markdown does
+/// NOT read as a space, so the rows either side of it must stay apart.
+#[test]
+fn a_hard_break_is_not_flowed_away() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+Before the hard break  
+after the hard break.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    assert!(
+        !line_with(&harness, "Before the hard break").contains("after the hard break"),
+        "a two-space hard break must still end its row.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// A heading is a block of its own: the paragraph written directly under it
+/// must not be flowed into the heading's row.
+#[test]
+fn a_heading_does_not_flow_into_the_paragraph_below_it() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+## A heading
+Body written directly under the heading.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    assert!(
+        !line_with(&harness, "A heading").contains("Body written directly"),
+        "a heading is single-line and must not flow.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// List items
+// ---------------------------------------------------------------------------
+
+const LIST_MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
+   inherits `release` and additionally sets `panic = \"abort\"` (drops unwinding
+   tables) and `strip = true` (strips symbols + debuginfo).
+
+2. Second item.
+";
+
+/// An item's continuation lines join it, and the rows it wraps onto hang under
+/// the item's text rather than restarting at the marker's column.
+#[test]
+fn a_list_item_flows_and_its_wrapped_rows_hang_under_its_text() {
+    let (mut harness, _tmp) = composed(LIST_MD, 90, 20);
+    settle(&mut harness);
+
+    let first = line_with(&harness, "min-size profile");
+    assert!(
+        first.contains("inherits"),
+        "the item's continuation line should flow onto the row above, got {first:?}",
+    );
+
+    // "min-size" is the item's first word, so its column is where the item's
+    // text starts; every wrapped row of the same item has to line up with it.
+    let text_column = column_in(&first, "min-size profile");
+    let marker_column = column_in(&first, "1.");
+    assert!(
+        text_column > marker_column,
+        "the item's text should sit right of its `1.` marker on {first:?}",
+    );
+    let screen = harness.screen_to_string();
+    let wrapped = screen
+        .lines()
+        .nth(row_with(&harness, "min-size profile") + 1)
+        .expect("the item should wrap onto a second row");
+    assert_eq!(
+        wrapped.len() - wrapped.trim_start().len(),
+        text_column,
+        "a wrapped row of the item should hang under its text, \
+         got {wrapped:?}.\nScreen:\n{screen}",
+    );
+}
+
+/// The next `1.`/`2.` marker opens its own item: two items never flow together.
+#[test]
+fn a_new_marker_starts_a_new_item() {
+    let (mut harness, _tmp) = composed(LIST_MD, 90, 20);
+    settle(&mut harness);
+
+    assert!(
+        !line_with(&harness, "Second item.").contains("debuginfo"),
+        "a new list marker must start a new block.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Block quotes
+// ---------------------------------------------------------------------------
+
+/// A quote's lines flow together, and the `>` run of each continuation is
+/// swallowed with the newline rather than drawing a second bar mid-row.
+#[test]
+fn a_quote_flows_and_keeps_one_bar_per_row() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+> A quoted block that is
+> split across two source lines.
+
+Tail.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    let line = line_with(&harness, "A quoted block");
+    assert!(
+        line.contains("split across two source lines."),
+        "the quote's source lines should flow into one row, got {line:?}",
+    );
+    assert_eq!(
+        line.chars().filter(|c| *c == '▌').count(),
+        1,
+        "the flowed row should draw one bar, not one per source line, got {line:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Code blocks
+// ---------------------------------------------------------------------------
+
+/// Code is never prose: a fenced block's lines keep their own rows however
+/// many of them there are in a row without a blank line.
+#[test]
+fn fenced_code_lines_are_not_flowed() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+```rust
+let a = 1;
+let b = 2;
+let c = 3;
+```
+
+Tail.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    let line = line_with(&harness, "let a = 1;");
+    assert!(
+        !line.contains("let b = 2;"),
+        "code lines must keep their own rows, got {line:?}",
+    );
+}
+
+/// Raw HTML is not prose either. A `<div>` on its own line and the lines under
+/// it are markup the reader has to see laid out as written — flowing them puts
+/// the opening tag and the text it wraps on one row.
+#[test]
+fn an_html_block_is_not_flowed() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+<div class=\"note\">
+  <img src=\"./showcase.gif\" alt=\"demo\" />
+</div>
+
+<!-- A comment that runs
+     onto a second line -->
+
+Tail.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !line_with(&harness, "<div class=").contains("<img"),
+        "an HTML block's lines must keep their own rows.\nScreen:\n{screen}",
+    );
+    assert!(
+        !line_with(&harness, "<!-- A comment").contains("onto a second line"),
+        "an HTML comment's lines must keep their own rows.\nScreen:\n{screen}",
+    );
+}
+
+/// A paragraph that merely *starts* with an inline tag is still prose, and
+/// still flows — the HTML rule keys on the whole line being markup.
+#[test]
+fn a_paragraph_opening_with_an_inline_tag_still_flows() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+<em>Emphasised</em> opening words and then
+the rest of the sentence.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    assert!(
+        line_with(&harness, "opening words").contains("the rest of the sentence."),
+        "a paragraph beginning with an inline tag should still flow.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// An indented code block is code too, and a run that opens with four columns
+/// of indent is one. A list item's continuation lines are indented as well —
+/// past four columns for a wide marker — which is why this keys on the run's
+/// first line and not on any indented line.
+#[test]
+fn an_indented_code_block_is_not_flowed() {
+    const MD: &str = "\
+Opening paragraph with **emphasis** so the cursor has a home on line 1.
+
+    let indented = 1;
+    let code = 2;
+
+12. A wide marker whose continuation is indented
+    four columns and still belongs to the item.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !line_with(&harness, "let indented = 1;").contains("let code = 2;"),
+        "an indented code block's lines must keep their own rows.\nScreen:\n{screen}",
+    );
+    assert!(
+        line_with(&harness, "A wide marker").contains("four columns"),
+        "a wide marker's continuation is not an indented code block.\nScreen:\n{screen}",
+    );
+}
+
+/// Front matter is metadata, not a paragraph: `title:` and `outline:` are
+/// separate fields and flowing them onto one row makes the block unreadable.
+#[test]
+fn yaml_front_matter_is_not_flowed() {
+    const MD: &str = "\
+---
+title: \"Split View\"
+outline: false
+---
+
+# Doc
+
+Body paragraph written over
+two source lines.
+";
+    let (mut harness, _tmp) = composed(MD, 100, 20);
+    settle(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !line_with(&harness, "title:").contains("outline:"),
+        "front-matter fields must keep their own rows.\nScreen:\n{screen}",
+    );
+    // The body below it still flows, so this is about the front matter and not
+    // about reflow having stopped altogether.
+    assert!(
+        line_with(&harness, "Body paragraph").contains("two source lines."),
+        "the body below the front matter should still flow.\nScreen:\n{screen}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Batches
+// ---------------------------------------------------------------------------
+
+/// A `lines_changed` batch carries only lines the editor has not offered
+/// before, so a paragraph revealed a line at a time by scrolling would arrive
+/// split across batches — and the plugin, seeing a line without its
+/// predecessor, would leave it unflowed. The editor closes the batch over the
+/// whole run for a composing buffer, so scrolling to a paragraph renders it the
+/// same as opening on it.
+#[test]
+fn a_paragraph_scrolled_into_view_flows_like_any_other() {
+    let mut md = String::from("Opening paragraph with **emphasis** for line 1.\n\n");
+    for p in 0..12 {
+        md.push_str(&format!("Paragraph {p} opens here,\n"));
+        md.push_str("continues on a second source line,\n");
+        md.push_str("and closes on a third.\n\n");
+    }
+
+    let (mut harness, _tmp) = composed(&md, 90, 14);
+    settle(&mut harness);
+
+    // One row at a time, so each new line arrives in a batch of its own —
+    // the case a run-closed batch exists for.
+    for _ in 0..24 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.wait_until_stable(|_| true).unwrap();
+    }
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    let screen = harness.screen_to_string();
+    let unflowed: Vec<&str> = screen
+        .lines()
+        .filter(|l| l.trim() == "and closes on a third.")
+        .collect();
+    assert!(
+        unflowed.is_empty(),
+        "every visible paragraph should be flowed after scrolling; \
+         these rows are still on their own.\nScreen:\n{screen}",
+    );
+}
+
+/// Reflow makes a source line worth less than a screen row, so a window sized
+/// in source lines stops above the viewport's bottom. The editor grows both the
+/// token build and the plugin's batch by the line breaks the conceals swallow;
+/// without that the frame ends in EOF tildes with the document still going.
+#[test]
+fn a_reflowed_viewport_is_filled_to_its_last_row() {
+    let mut md = String::from("Opening paragraph with **emphasis** for line 1.\n\n");
+    for p in 0..12 {
+        md.push_str(&format!("Paragraph {p} opens here,\n"));
+        md.push_str("continues on a second source line,\n");
+        md.push_str("and closes on a third.\n\n");
+    }
+
+    let (mut harness, _tmp) = composed(&md, 90, 20);
+    settle(&mut harness);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains('~'),
+        "the viewport should be filled with document, not end-of-file \
+         tildes.\nScreen:\n{screen}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The caret
+// ---------------------------------------------------------------------------
+
+/// Walk the caret over every position of a document and report the ones where
+/// the editor drew no caret at all.
+///
+/// `render_observing_cursor` is the production signal: it parks the terminal
+/// caret at the origin and renders, so `None` means the editor never called
+/// `Frame::set_cursor_position` — which is exactly what it does when no
+/// rendered cell carries the caret's byte. (A caret legitimately at (0, 0)
+/// would read the same, which cannot happen here: a composed buffer's text
+/// starts past the gutter and the page margin.) Returns the buffer offsets the
+/// caret vanished at, with the step index that reached them.
+fn walk_and_collect_hidden(
+    harness: &mut EditorTestHarness,
+    key: KeyCode,
+    steps: usize,
+) -> Vec<(usize, usize)> {
+    let mut hidden = Vec::new();
+    let mut last_position = usize::MAX;
+    for step in 0..steps {
+        harness.send_key(key, KeyModifiers::NONE).unwrap();
+        let drawn = harness.render_observing_cursor().unwrap();
+        let position = harness.cursor_position();
+        if position == last_position {
+            break; // ran into the end of the buffer
+        }
+        last_position = position;
+        if drawn.is_none() {
+            hidden.push((step, position));
+        }
+    }
+    hidden
+}
+
+/// The caret must have a cell to sit on at every position of a composed
+/// document — arrowing through one should never make it vanish.
+///
+/// It is a property rather than a case because the ways compose mode can lose
+/// it are open-ended: every conceal, soft break and reflow join moves the
+/// mapping from a byte to the cell that draws it, and the caret disappears
+/// wherever a byte ends up claimed by no cell at all. Walking the whole
+/// document forwards and back covers each of those boundaries in both
+/// directions, which is where the asymmetries show up.
+#[test]
+fn the_caret_is_never_lost_while_arrowing_through_a_composed_document() {
+    // Deliberately varied: every construct that adds a conceal or a break, and
+    // paragraphs long enough to wrap so the caret crosses a wrap point both at
+    // a join and at an ordinary space.
+    const MD: &str = "\
+# Heading with `code` and **bold**
+
+1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
+   inherits `release` and additionally sets `panic = \"abort\"` (drops unwinding
+   tables) and `strip = true` (strips symbols + debuginfo).
+
+2. Second item that also spans several source lines in the original file and
+   is long enough that it has to wrap at the page measure more than once when
+   the whole item is flowed together.
+
+A plain paragraph written with hard-wrapped source lines that flow into one
+block and then wrap, so the caret meets both a join and an ordinary space at
+a row boundary.
+
+> A quoted block that is split across
+> two source lines.
+
+```rust
+fn answer() -> u32 { 42 }
+```
+
+| col | val |
+|-----|-----|
+| a   | 1   |
+
+Tail paragraph.
+";
+
+    let (mut harness, _tmp) = composed(MD, 90, 40);
+    settle(&mut harness);
+
+    let total = MD.len();
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render_observing_cursor().unwrap();
+
+    let forward = walk_and_collect_hidden(&mut harness, KeyCode::Right, total + 8);
+    assert!(
+        forward.is_empty(),
+        "arrowing right lost the caret at {} position(s) — (step, byte offset): {:?}\nScreen:\n{}",
+        forward.len(),
+        forward,
+        harness.screen_to_string(),
+    );
+
+    let backward = walk_and_collect_hidden(&mut harness, KeyCode::Left, total + 8);
+    assert!(
+        backward.is_empty(),
+        "arrowing left lost the caret at {} position(s) — (step, byte offset): {:?}\nScreen:\n{}",
+        backward.len(),
+        backward,
+        harness.screen_to_string(),
+    );
+}
+
+/// The step past `End` must keep the caret drawn.
+///
+/// `End` on a reflowed row still stops one cell short of the row's edge — it
+/// lands ON the last character rather than after it, because the row's end is
+/// derived from its last drawn source byte and a row that spans a concealed
+/// line ending leaves the wrap's own byte to the row below. That is a separate
+/// defect in the shared soft-break machinery, not covered here; what this
+/// pins is that the step which used to lose the caret no longer does.
+#[test]
+fn the_step_past_end_keeps_the_caret_on_a_reflowed_row() {
+    const MD: &str = "\
+Cursor home line.
+
+1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
+   inherits `release` and additionally sets `panic = \"abort\"` (drops unwinding
+   tables) and `strip = true` (strips symbols + debuginfo).
+";
+    let (mut harness, _tmp) = composed(MD, 90, 20);
+    settle(&mut harness);
+
+    // Onto the block, then to the end of the row the caret sits on.
+    for _ in 0..3 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render_observing_cursor().unwrap();
+    let at_end = harness.cursor_position();
+
+    // One more step right must leave the row, not creep along it: if `End`
+    // stopped short, there is still text between it and the row's edge.
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    let drawn = harness.render_observing_cursor().unwrap();
+    assert!(
+        drawn.is_some(),
+        "the caret vanished one step past `End` (byte {at_end}).\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// `End` must not take the caret off the row it was on.
+///
+/// The caret's byte and the cell that draws it are two different things, and
+/// `End` is where they come apart: a row reports its end as the last source
+/// byte it drew, and the separator a wrap broke on may be drawn by the row
+/// BELOW. Move the caret to that byte and it is drawn at the start of the next
+/// row — the caret visibly jumps a line, whatever the buffer offset says.
+///
+/// So this asserts the drawn position, not the offset. An earlier version
+/// asserted where typing landed in the buffer, which a caret sitting on the
+/// wrong row satisfies perfectly, and so missed exactly that regression.
+///
+/// The three fixtures are the three ways a row can end, which behave
+/// differently and were all worth separating: a reflowed row (compose joins
+/// two source lines, and the wrap falls in the line below), a row the plugin's
+/// soft break alone wrapped (source line shorter than the window), and one the
+/// editor's own wrap broke as well (source line longer than the window). The
+/// middle one is the case a single long-line fixture silently fails to cover.
+///
+/// Known and NOT asserted here: on a reflowed row `End` stops ON the row's last
+/// character rather than after it. That one is real but smaller, and every fix
+/// tried for it so far moved one of the other two rows instead.
+#[test]
+fn end_keeps_the_caret_on_its_own_row() {
+    const REFLOWED: &str = "\
+Cursor home line.
+
+1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
+   inherits `release` and additionally sets `panic = \"abort\"` (drops unwinding
+   tables) and `strip = true` (strips symbols + debuginfo).
+";
+    // 98 columns of source in a 120-column window: too short for the editor's
+    // own wrap, so the compose measure's soft break is the only thing that
+    // breaks the row.
+    const PLUGIN_WRAP: &str = "\
+Cursor home line.
+
+Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi \
+omicron pi rho sigma end.
+";
+    // Longer than the window, so the editor wraps it too.
+    const EDITOR_WRAP: &str = "\
+Cursor home line.
+
+Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi \
+omicronpi rho sigma tau upsilon phi chi psi omega end and more words here to \
+run past the window width by a comfortable margin.
+";
+
+    for (label, md, width, marker) in [
+        ("reflowed", REFLOWED, 90u16, "unwinding tables) and"),
+        ("plugin wrap", PLUGIN_WRAP, 120, "mu nu xi"),
+        ("editor wrap", EDITOR_WRAP, 80, "mu nu xi"),
+    ] {
+        let (mut harness, _tmp) = composed(md, width, 20);
+        settle(&mut harness);
+
+        let target_row = row_with(&harness, marker) as u16;
+        for _ in 0..40 {
+            if harness.screen_cursor_position().1 == target_row {
+                break;
+            }
+            harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+            harness.render().unwrap();
+        }
+        let before = harness
+            .render_observing_cursor()
+            .unwrap()
+            .unwrap_or_else(|| panic!("{label}: no caret drawn before `End`"));
+        assert_eq!(
+            before.1, target_row,
+            "{label}: could not put the caret on the row holding {marker:?}",
+        );
+
+        harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+        let after = harness
+            .render_observing_cursor()
+            .unwrap()
+            .unwrap_or_else(|| panic!("{label}: `End` left no caret drawn"));
+
+        assert_eq!(
+            after.1,
+            before.1,
+            "{label}: `End` moved the caret off its row, from {before:?} to \
+             {after:?}.\nScreen:\n{}",
+            harness.screen_to_string(),
+        );
+        // And it reaches the row's end: the cell just past its last glyph. A
+        // soft break consumes the space it fell on, so that cell is carried by
+        // no token — the row owns the position anyway, and `End` is what puts
+        // the caret there. Stopping a column earlier leaves it ON the last
+        // character, where what you type next goes in ahead of that character.
+        let row_text = harness
+            .screen_to_string()
+            .lines()
+            .nth(after.1 as usize)
+            .unwrap_or_default()
+            .to_string();
+        let last_glyph_col = row_text.trim_end().chars().count();
+        assert_eq!(
+            after.0 as usize, last_glyph_col,
+            "{label}: `End` should sit just past the row's last glyph (column \
+             {last_glyph_col}) but is at {}.\nRow: {row_text:?}",
+            after.0,
+        );
+    }
+}
+
+/// `Home` returns to the row it was on, at its start — the counterpart to
+/// `End`, and the one that goes wrong when a row and the layout disagree about
+/// which bytes belong to it. A reflowed row spans a concealed line ending, so
+/// the byte `End` leaves the caret on is past every byte any cell draws; if the
+/// row below claims it, `Home` from there walks to that row's start instead and
+/// the caret jumps backwards into the middle of the line it was on.
+#[test]
+fn home_returns_to_the_start_of_the_row_end_left() {
+    const MD: &str = "\
+Cursor home line.
+
+1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
+   inherits `release` and additionally sets `panic = \"abort\"` (drops unwinding
+   tables) and `strip = true` (strips symbols + debuginfo).
+";
+    let (mut harness, _tmp) = composed(MD, 90, 20);
+    settle(&mut harness);
+
+    let target_row = row_with(&harness, "unwinding tables) and") as u16;
+    for _ in 0..40 {
+        if harness.screen_cursor_position().1 == target_row {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    let start = harness.render_observing_cursor().unwrap().expect("caret");
+
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render_observing_cursor().unwrap().expect("caret");
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    let home = harness.render_observing_cursor().unwrap().expect("caret");
+
+    assert_eq!(
+        home.1,
+        target_row,
+        "`Home` after `End` left the row, to {home:?}.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+    assert!(
+        home.0 <= start.0,
+        "`Home` after `End` should return to the row's start, not land right of \
+         where the caret began ({start:?}); got {home:?}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
@@ -722,10 +722,20 @@ run past the window width by a comfortable margin.
             .unwrap_or_default()
             .to_string();
         let last_glyph_col = row_text.trim_end().chars().count();
+        // A row whose wrap consumed a separator ends one past its last glyph:
+        // that cell IS the separator. A row split mid-run has no separator to
+        // stand on — the byte past its last glyph is the first character of the
+        // row below, which that row draws — so there the row's end is its last
+        // glyph, and stepping past it would take the caret off the row.
+        let expected = if label == "no-whitespace run" {
+            last_glyph_col - 1
+        } else {
+            last_glyph_col
+        };
         assert_eq!(
-            after.0 as usize, last_glyph_col,
-            "{label}: `End` should sit just past the row's last glyph (column \
-             {last_glyph_col}) but is at {}.\nRow: {row_text:?}",
+            after.0 as usize, expected,
+            "{label}: `End` should sit at column {expected} but is at {}.\n\
+             Row: {row_text:?}",
             after.0,
         );
     }

--- a/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_reflow.rs
@@ -11,7 +11,7 @@
 
 #![cfg(feature = "plugins")]
 
-use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -32,11 +32,18 @@ fn composed(content: &str, width: u16, height: u16) -> (EditorTestHarness, tempf
     let md_path = project_root.join("flow.md");
     std::fs::write(&md_path, content).unwrap();
 
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
+    // `with_full_grammar_registry` is what makes the editor resolve embedded
+    // regions, which is how a line inside a fenced block reports `region` at
+    // all. Without it every line comes back unclassified, the code frames never
+    // draw, and the plugin falls through to its textual fence tracking — so the
+    // tests would pass while never exercising the path that actually runs.
+    let mut harness = EditorTestHarness::create(
         width,
         height,
-        Default::default(),
-        project_root,
+        HarnessOptions::new()
+            .with_working_dir(project_root.clone())
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
     )
     .unwrap();
     harness.open_file(&md_path).unwrap();
@@ -785,4 +792,72 @@ Cursor home line.
         "`Home` after `End` should return to the row's start, not land right of \
          where the caret began ({start:?}); got {home:?}",
     );
+}
+
+/// A fenced block inside a list item is framed inside the item, not back at
+/// the page's left edge.
+///
+/// The indent is the OPENING delimiter's, not each row's own: a line indented
+/// further within the block is code, and letting it move the frame would bend
+/// the box around one row. Corners, rails and rows all read the same number,
+/// and the block's measure shrinks by it — or a row breaks where the frame
+/// does not end.
+#[test]
+fn a_fence_inside_a_list_item_is_framed_at_the_item_s_column() {
+    const MD: &str = "\
+Cursor home line.
+
+1. An item with a fenced block under it:
+
+   ```sh
+   cargo build --release
+       nested_line_indented_further
+   ```
+";
+    let (mut harness, _tmp) = composed(MD, 90, 20);
+    settle(&mut harness);
+
+    let screen = harness.screen_to_string();
+    let column_of = |needle: &str| {
+        let row = screen
+            .lines()
+            .find(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("{needle:?} not on screen.\nScreen:\n{screen}"));
+        row.chars().take_while(|c| c.is_whitespace()).count()
+    };
+
+    // Where the item's TEXT starts — not the row's leading whitespace, which is
+    // the marker's column. That is where the frame's corners belong.
+    let item_row = screen
+        .lines()
+        .find(|l| l.contains("An item with"))
+        .expect("the item should be on screen");
+    let text_col = item_row
+        .chars()
+        .collect::<String>()
+        .find("An item with")
+        .map(|byte| item_row[..byte].chars().count())
+        .expect("the item's text");
+    assert_eq!(
+        column_of("┌"),
+        text_col,
+        "the frame's top corner should sit at the item's text column \
+         ({text_col}).\nScreen:\n{screen}",
+    );
+    assert_eq!(
+        column_of("└"),
+        text_col,
+        "the frame's bottom corner should sit at the item's text column \
+         ({text_col}).\nScreen:\n{screen}",
+    );
+    // Every rail agrees with the corners, including the row indented further
+    // inside the block — that row's extra indent is code, not block indent.
+    for needle in ["cargo build", "nested_line_indented_further"] {
+        assert_eq!(
+            column_of(needle),
+            text_col,
+            "the rail beside {needle:?} should sit at the item's text column \
+             ({text_col}).\nScreen:\n{screen}",
+        );
+    }
 }

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -5,7 +5,7 @@
 //! mode from the command palette, scroll — and assert only on rendered cells
 //! in the scrollbar column.
 
-use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -51,11 +51,18 @@ fn compose_harness(md: &str) -> (EditorTestHarness, tempfile::TempDir) {
     let md_path = project_root.join("headings.md");
     std::fs::write(&md_path, md).unwrap();
 
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
+    // `with_full_grammar_registry` is what makes the editor resolve embedded
+    // regions, which is how a line inside a fenced block reports `region`.
+    // Without it every line comes back unclassified and the marks are decided
+    // by the plugin's textual fence tracking alone — the fallback, not the path
+    // that runs in the editor.
+    let mut harness = EditorTestHarness::create(
         80,
         30,
-        Default::default(),
-        project_root.clone(),
+        HarnessOptions::new()
+            .with_working_dir(project_root.clone())
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
     )
     .unwrap();
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_scrollbar_markers.rs
@@ -260,11 +260,20 @@ fn heading_marks_survive_exploring_the_document() {
     // the comparison.
     //
     // Not "wait for the screen to change", though: a PageDown at the end of
-    // the document is a no-op, and this sweep runs twelve pages over a
-    // document only about thirteen deep, so that wait would be one viewport
-    // row away from never resolving. A settled frame is true whether or not
-    // the page moved.
-    for _ in 0..12 {
+    // the document is a no-op, and this sweep runs over a document only about
+    // thirteen pages deep, so that wait would be one viewport row away from
+    // never resolving. A settled frame is true whether or not the page moved.
+    //
+    // Six pages, not twelve. Compose mode sizes its window from the line
+    // breaks its conceals already swallow, so a scrolled-to page settles over
+    // a few frames rather than one — self-correcting by design, but it
+    // multiplies the renders each `wait_until_stable` has to sit through, and
+    // this test settles once per page. Twelve pages of that timed out at
+    // nextest's 180s cap on a loaded macOS runner while taking under three
+    // seconds unloaded. Six still carries the property: the marks under test
+    // are the ones for sections the viewport has left behind, and by page six
+    // most of the document is behind it.
+    for _ in 0..6 {
         harness
             .send_key(KeyCode::PageDown, KeyModifiers::NONE)
             .unwrap();
@@ -274,11 +283,30 @@ fn heading_marks_survive_exploring_the_document() {
 
     // Each batch republishes only its own byte span, so the marks for the
     // sections scrolled past are left alone. With a whole-namespace replace
-    // per batch, only the headings near the viewport would survive.
+    // per batch, only the headings near the viewport would survive — the set
+    // would shrink to the last page's two or three marks and start well down
+    // the track instead of at its top.
+    //
+    // The count and the two ends, not the exact rows: the track's coordinate
+    // space is *visual* rows (`MarkerBasis::VisualRows`, chosen so marks and
+    // thumb agree), and compose mode reflows a paragraph by concealing the
+    // line breaks inside it — a conceal that only exists for the lines the
+    // plugin has decorated. Exploring the document therefore shortens it, by
+    // design, and every mark below the part already visited slides up a row or
+    // two as that happens. What must not change is which headings are marked.
     let after = marker_rows(&harness);
     assert_eq!(
-        after, initial,
-        "the marked rows should be identical before and after scrolling"
+        after.len(),
+        initial.len(),
+        "every heading should still be marked after exploring the document; \
+         before {initial:?}, after {after:?}"
+    );
+    assert_eq!(
+        (after.first(), after.last()),
+        (initial.first(), initial.last()),
+        "the marks should still span the whole track — the first heading is at \
+         the top of the document and the last at its end; \
+         before {initial:?}, after {after:?}"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -193,6 +193,8 @@ pub mod markdown_compose_first_scroll_relayout;
 #[cfg(feature = "plugins")]
 pub mod markdown_compose_page_width;
 #[cfg(feature = "plugins")]
+pub mod markdown_compose_reflow;
+#[cfg(feature = "plugins")]
 pub mod markdown_compose_scroll_perf;
 pub mod markdown_compose_scroll_reach;
 #[cfg(feature = "plugins")]

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5737,8 +5737,11 @@ impl JsEditorApi {
 
     /// Enable or disable indentation guides for a buffer, overriding the global
     /// `editor.indentation_guide` setting. Tool views that render non-editable
-    /// content (e.g. the Git Log commit-detail diff) disable them.
-    pub fn set_indentation_guide(&self, buffer_id: u32, enabled: bool) -> bool {
+    /// content (e.g. the Git Log commit-detail diff) disable them, and so does
+    /// markdown compose mode. `null` withdraws the override rather than forcing
+    /// guides on, so a buffer leaving compose gets back whatever the user's own
+    /// settings resolve to — the same shape `setFoldIndicators` uses.
+    pub fn set_indentation_guide(&self, buffer_id: u32, enabled: Option<bool>) -> bool {
         self.command_sender
             .send(PluginCommand::SetIndentationGuide {
                 buffer_id: BufferId(buffer_id as usize),

--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -256,6 +256,8 @@ Smart editing for Markdown files (provided by the built-in `markdown_source` plu
 
 "Markdown: Toggle Compose" from the command palette enables a distraction-free mode that conceals markup (`**`, `*`, `[]()`), applies soft line breaks at a configurable width, and renders tables. Use "Markdown: Set Compose Width" to adjust the width. Open the same file in a vertical split to see source and composed views side by side.
 
+Compose mode reads the document the way markdown defines it, so a paragraph, list item or quote written across several source lines is re-flowed into one block at the page width — a hard-wrapped file reads as prose rather than as its source layout. The things markdown treats as their own block still are: a blank line, a heading, a thematic break, a table row, a fenced code block, a new list marker, and a hard break (two trailing spaces or a trailing backslash).
+
 ## Shell Integration
 
 Run shell commands on your buffer or selection:


### PR DESCRIPTION
Markdown reads a run of consecutive non-blank lines as ONE paragraph (or one list item, or one quote): the newlines between them are word separators, not line breaks. Compose mode rendered each source line as its own row instead, so a hard-wrapped document — the ordinary way markdown is written — came out as a picture of its source.

The reported case:

```markdown
1. **`min-size` profile** (`[profile.min-size]` in the root `Cargo.toml`)
   inherits `release` and additionally sets `panic = "abort"` (drops unwinding
   tables) and `strip = true` (strips symbols + debuginfo).
```

**Before** — the item's first line, then a spacer row, then each continuation back at its own column:

```
1. min-size profile ([profile.min-size] in the root Cargo.toml)

   inherits release and additionally sets panic = "abort" (drops unwinding
   tables) and strip = true (strips symbols + debuginfo).
```

**After** — one bullet, wrapped at the measure, hanging under its text:

```
1. min-size profile ([profile.min-size] in the root Cargo.toml) inherits
   release and additionally sets panic = "abort" (drops unwinding tables) and
   strip = true (strips symbols + debuginfo).
```

Same effect on any hard-wrapped prose — `docs/internal/terminal-input-parsing.md`, at 100 columns:

```
════════════ before ════════════            ════════════ after ════════════
Purpose: explain how Fresh turns the        Purpose: explain how Fresh turns the
raw byte stream arriving from a             raw byte stream arriving from a
terminal into crossterm::event::Events      terminal into crossterm::event::Events
— why Fresh parses those bytes itself       — why Fresh parses those bytes itself
instead of letting crossterm do it, the     instead of letting crossterm do it, the
state machine that does the parsing,        state machine that does the parsing,
the                                         the invariant that machine exists to
invariant                          ← orphan preserve, and the protocol coverage it
that machine exists to preserve, and        still lacks.
the protocol coverage it still lacks.
```

## How

Reflow uses the two decorations compose mode already has, so it needs no machinery of its own. A **join** conceal covers `[end of the previous line's text, start of this line's text)` — the newline, the continuation's leading indent, and its `>` run when it is a quote — and renders it as a single space; a conceal spanning a newline swallows the line break, so two source rows draw as one. The **soft-break pass then runs over the whole block** instead of per line, so rows break at the measure and hang under the item's text.

Everything markdown treats as its own block still ends one: a blank line, a heading, a thematic break, a table row, a fence, a new list marker, a deeper quote (`> a` / `> > b` keeps its two bars), and a hard break.

`verbatimStates` answers the general question the flow pass and the scrollbar's heading marks both need — *is this line text to be laid out as written?* — for fenced code, raw HTML, YAML/TOML front matter, and indented code blocks. The last three came out of reading the repo's own markdown: every `docs/blog/productivity/*/index.md` opens with front matter and a `<div>`, and both were being flowed into prose.

## What the editor had to learn

A source line is no longer worth a screen row, and two things were sized in source lines:

- **`lines_changed` batches are now *run-closed* for a composing buffer.** A per-line pass can only flow lines it is offered together, and a batch carries only lines never offered before — so a paragraph revealed a line at a time by scrolling arrived split across batches and its tail never joined. The walk backs up to the start of the blank-line-delimited run at the viewport's top and on to the end of the run it stops inside, both bounded so a file whose lines never blank out cannot turn one frame into a walk over the buffer.
- **The token build and that walk are sized by `join_adjusted_visible_count`**, which adds the line breaks the viewport's conceals swallow. Without it the frame ended in EOF tildes with the document still going, and the block at the bottom was never offered to the plugin, so it never flowed.

## Navigation

Reflow made a latent compose-mode bug constant, and fixing it is most of the change outside the plugin. A soft break **consumes** the space it fell on, so the row ends on a content character and the position past it — where `End` goes, and the separator between the last word of one row and the first of the next — is carried by no cell. Not reflow's doing: a 98-column source line in a 120-column window shows it with no join anywhere near. Reflow simply makes almost every row soft-broken.

Symptoms: the caret vanished while arrowing through a joined paragraph; `End` stopped **on** a row's last character so what you typed next went in ahead of it; and `Home` afterwards jumped backwards into the middle of the line.

Three layers disagreed about that position, each needing its own answer:

| | fix |
|---|---|
| **Who owns it** | `ViewLineMapping::end_exclusive`, consulted by `find_visual_row` **only after** the rows that actually draw the byte have had their say — that ordering is the safety, since an ordinary wrapped row's successor draws the byte, keeps it, and `Down` still steps onto it |
| **Where it draws** | `locate_cursor_in_view_map` claims it for the row, one cell right of its last glyph, ahead of the nearest-visible fallback that would otherwise hand the caret to the row below |
| **Where `End` goes** | the action steps past a row end that is a content character; rows ending at a newline or at kept whitespace are left alone |

`end_exclusive` is only claimed when the wrap actually **consumed a separator**. A wrap can also split a run with no whitespace in it — CJK text, a long URL — and there the byte past the last character is the first character of the next row, which that row draws. An earlier revision claimed it unconditionally, which painted the caret on the wrong row and sent `End` off the row entirely, **in shared code**: measured on plain CJK with no markdown involved, the caret drew at (78, 4) for a position on row 5. The two cases are told apart by the byte itself — a consumed separator is whitespace, the next row's first character is not.

`line_end_byte` is deliberately untouched — its contract is *"newline for real lines, last char for wrapped"* and `move_visual_line` reads it for its own purposes; every attempt to shift it stalled large-file `Down` at the second keypress.

The same conceal fallback was gated on `is_on_cursor_line`, which asks whether a row *starts* inside the cursor's logical line — a question a newline-swallowing conceal breaks, since the row holding the cursor's bytes starts in the line above. It asks whether the row *draws* any of that line now. Without it the caret vanished outright wherever it sat inside a join.

A wrap falling on a join is a break between two words whose separator is the swallowed line ending, so it is anchored **past** the join: that space trails the row it ends — invisible, and the cell the caret rests on — rather than opening the next row with a stray leading column.

## Rendering of nested blocks

Four fixes from reading a composed document:

- **A nested item's indent renders as written.** Markdown's own indent *is* the alignment — an item is nested by being indented to where its parent's TEXT begins, two columns under `- ` and three under `2. ` — so rendering it unchanged puts each child's marker under its parent's first letter. It was doubled, which read as a level too far, with a sub-bullet under `2. ` sitting three columns right of the text it belongs to.
- **Indentation guides stand down in compose mode**, as fold indicators already do. They are a code-editor affordance, and a composed document has nothing for them to guide: the indentation they track belongs to the source, which compose has re-laid-out or concealed, so what survived drew as a column of disconnected verticals beside reflowed paragraphs. `setIndentationGuide` takes `boolean | null` now, matching `setFoldIndicators`, so leaving compose withdraws the opinion rather than forcing guides on someone who had them off.
- **A code row that wraps hangs under its code.** A fence inside a list item carries the item's indent on every source line, and the first row draws it while the rows it wraps onto do not — so a wrapped row restarted flush against the rail. The rail supplies the indent for those rows; a hanging indent on the wrap would push the *rail* right instead.
- **A fenced block inside a list item is framed at the item's column.** The indent is the opening delimiter's, not each row's own — a line indented further within the block is code, and reading it per row would bend the box around that row. Computed once per batch so the rails, the corners and the rows' soft breaks all agree, with the block's measure shrinking to match.

## Also fixed

The scrollbar's heading marks were fence-aware only by luck. They skipped a `#` line whose `region` the editor reported, but `region` is absent both for an ordinary line *and* when the engine cannot resolve the state — so a `#` comment inside a bash fence was marked whenever the state was unknown. They read `verbatimStates` now, and stand down rather than replace a correct pre-scan mark with a guess.

That guard cost the per-batch pass its seeds in a document with **no fences at all**, where the only seeds are line 0, a line the engine placed in a region, and a delimiter with an info string. Every line read "unknown" and only the batch holding line 0 published. Seeding from the absence of any fence evidence restores it — traced on a fence-free 12-section document:

```
with the seeding      range=0..1096  n=4    range=1096..1370  n=1    range=2740..3325  n=3
without it            range=0..1096  n=4
```

## Tests

`markdown_compose_reflow` drives the real plugin and asserts on rendered rows: paragraphs, list items with their hanging indent, quotes, each block kind that must *not* flow, the two batch properties (a paragraph scrolled into view a row at a time; a reflowed viewport filled to its last row), and the frame of a fence inside a list item.

Navigation is covered by a **property test** that walks the caret through a whole composed document forwards and back and reports every offset where the editor drew nothing — it found 18 — plus `End` reaching the cell past its row's last glyph across the four ways a row can end (reflowed, plugin-wrapped only, editor-wrapped as well, and a run with no whitespace at all), and `Home` returning to the row `End` left.

Both compose test files were missing `with_full_grammar_registry`, which is what makes the editor resolve embedded regions. Without it `region` came back absent for every line, the code frames never drew, and the plugin fell through to its textual fence tracking — so the tests passed while exercising the fallback rather than the path that runs in the editor. They now run against real region data.

Every behavioural test here was confirmed to fail before its fix. Three attempts at a rendered-marks assertion were written and **discarded** rather than kept: the scrollbar track projects marks onto visual rows, so any edit re-projects all of them and the count moves for reasons unrelated to the line under test — each attempt passed whether or not the code was right. That verification lives at the publish level instead (the trace above), where it is unambiguous.

`heading_marks_survive_exploring_the_document` asserts the set of marks rather than their exact rows — a reflowed document gets shorter as it is explored, so marks below the visited part slide up by design — and sweeps six pages rather than twelve, which is what took it past nextest's 180s cap on a loaded macOS runner. That job now passes.

Manually verified in tmux throughout: the reported list item, mixed documents (headings, quotes, nested quotes, fences, tables, setext, CRLF, tabs, CJK, long URLs), real repo docs, a 400-line single paragraph, split source ∥ compose panes, scrolling a long document one row at a time, editing inside a flowed paragraph, and the full navigation set (Home/End, arrows, word and document movement, selection).

> **Note on commit `fba06f3`:** its message reports that the fence-seeding does *not* restore per-batch publishing. That conclusion came from a probe whose edit never happened — the fixture ended in a newline, so `Ctrl+End` landed on the empty line after it and the `Delete`s were no-ops. The trace above is the corrected result: the seeding does restore it.