### PR TITLE
fresh-ui: paint text by display width, measure Wrap::None without joining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ version = "0.4.10"
 dependencies = [
  "crossterm",
  "proptest",
+ "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/crates/fresh-editor/src/view/shell/fold.rs
+++ b/crates/fresh-editor/src/view/shell/fold.rs
@@ -25,6 +25,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 
+use fresh_ui::glyph::glyphs_in;
 use fresh_ui::{BorderStyle, Draw, LayoutSpec, Scrim, ThemeKey};
 
 use super::frame::HostTarget;
@@ -254,10 +255,17 @@ pub fn fold_band(
                 let clip = intersect(clip, rect);
                 for (i, line) in lines.iter().enumerate() {
                     let y = rect.y.saturating_add(i as u16);
-                    let mut x = rect.x;
-                    for ch in line.chars() {
-                        put(buf, x, y, ch, style, clip);
-                        x = x.saturating_add(1);
+                    // By display width, not by char — the library's policy
+                    // (`fresh_ui::glyph`): a wide glyph keeps both cells
+                    // layout measured for it, a mark rides in its base's
+                    // cell, and a glyph the clip would halve is a blank.
+                    for g in glyphs_in(
+                        line,
+                        i32::from(rect.x),
+                        i32::from(clip.x),
+                        i32::from(clip.x.saturating_add(clip.width)),
+                    ) {
+                        put_symbol(buf, g.x as u16, y, g.text, g.width, style, clip);
                     }
                 }
             }
@@ -423,12 +431,35 @@ fn contains(r: Rect, x: u16, y: u16) -> bool {
 }
 
 fn put(buf: &mut Buffer, x: u16, y: u16, ch: char, style: Style, clip: Rect) {
+    let mut b = [0u8; 4];
+    put_symbol(buf, x, y, ch.encode_utf8(&mut b), 1, style, clip);
+}
+
+/// Paint one grapheme cluster at `(x, y)`, and blank the `w - 1` cells after
+/// it that a wide glyph spills into.
+///
+/// `Cell::set_symbol` writes one cell and leaves the next alone, and ratatui
+/// then skips that next cell when it draws, because the wide glyph before it
+/// covers it — so whatever was in it stays *in the buffer*, and the moment
+/// something narrow is painted over the glyph, the stale cell is back on
+/// screen. Blanking it here is what `Buffer::set_stringn` does for the same
+/// reason.
+fn put_symbol(buf: &mut Buffer, x: u16, y: u16, sym: &str, w: u16, style: Style, clip: Rect) {
     if !contains(clip, x, y) || !contains(buf.area, x, y) {
         return;
     }
     let cell = &mut buf[(x, y)];
-    cell.set_char(ch);
+    cell.set_symbol(sym);
     cell.set_style(style);
+    for k in 1..w {
+        let cx = x.saturating_add(k);
+        if !contains(clip, cx, y) || !contains(buf.area, cx, y) {
+            break;
+        }
+        let cell = &mut buf[(cx, y)];
+        cell.set_symbol(" ");
+        cell.set_style(style);
+    }
 }
 
 fn fill(buf: &mut Buffer, r: Rect, ch: char, style: Style, clip: Rect) {
@@ -712,6 +743,85 @@ mod tests {
         let _ = fold(spec, &mut buf, &plain, &mut host_state);
 
         assert!(host_state.painted > 0);
+    }
+}
+
+#[cfg(test)]
+mod width_tests {
+    //! Display-width painting (plan §2.1, Stage 0.1): the fold advances by
+    //! what layout measured, and a wide glyph's continuation cell is blank.
+
+    use super::*;
+    use fresh_ui::{row, text, text_runs, Node, Run, Size, Sizing, Ui};
+
+    fn fold_into(root: Node<()>, w: u16) -> Buffer {
+        let mut ui: Ui<()> = Ui::new();
+        let spec = ui.frame(root, Size::new(w, 1)).clone();
+        // Pre-filled with a marker, so a cell the fold did not write is
+        // visible as one — a continuation cell that was merely skipped
+        // would still read `~`.
+        let mut buf = Buffer::filled(Rect::new(0, 0, w, 1), ratatui::buffer::Cell::new("~"));
+        struct NoHosts;
+        impl HostPainter for NoHosts {
+            fn paint_host(&mut self, _: HostTarget, _: Rect, _: &mut Buffer, _: &mut Caret) {
+                unreachable!("no hosts in these trees")
+            }
+        }
+        fn plain(_: &ThemeKey) -> Style {
+            Style::default()
+        }
+        fold(&spec, &mut buf, &plain, &mut NoHosts);
+        buf
+    }
+
+    fn symbols(buf: &Buffer) -> Vec<&str> {
+        (0..buf.area.width).map(|x| buf[(x, 0)].symbol()).collect()
+    }
+
+    /// `text("你好")` occupies exactly its four columns: the glyphs in the
+    /// first and third, blanks — written, not skipped — in the second and
+    /// fourth, and the sibling in the fifth.
+    #[test]
+    fn a_wide_glyph_takes_two_cells_and_blanks_its_continuation() {
+        let buf = fold_into(row().children([text("你好"), text("!")]), 6);
+        assert_eq!(symbols(&buf), ["你", " ", "好", " ", "!", "~"]);
+    }
+
+    /// The next run starts where the last one's glyphs end: a CJK identifier
+    /// then a keyword, and the keyword is at column four.
+    #[test]
+    fn the_next_run_starts_after_the_wide_glyphs() {
+        let buf = fold_into(
+            text_runs([
+                Run::themed("你好", "identifier"),
+                Run::themed("fn", "keyword"),
+            ]),
+            8,
+        );
+        assert_eq!(symbols(&buf), ["你", " ", "好", " ", "f", "n", "~", "~"]);
+    }
+
+    /// A combining mark is painted into its base's cell and takes no column
+    /// of its own; an emoji sequence is one two-cell symbol.
+    #[test]
+    fn marks_ride_in_their_base_cell_and_emoji_sequences_are_one_symbol() {
+        let buf = fold_into(row().children([text("e\u{301}x"), text("|")]), 4);
+        assert_eq!(symbols(&buf), ["e\u{301}", "x", "|", "~"]);
+
+        let family = "👨\u{200d}👩\u{200d}👧";
+        let buf = fold_into(row().children([text(family), text("|")]), 4);
+        assert_eq!(symbols(&buf), [family, " ", "|", "~"]);
+    }
+
+    /// A wide glyph the clip would halve is a blank in its visible column,
+    /// and its hidden column is never touched.
+    #[test]
+    fn a_wide_glyph_at_the_clip_edge_is_a_blank() {
+        let buf = fold_into(
+            row().children([text("你好").w(Sizing::Cells(3)), text("|")]),
+            5,
+        );
+        assert_eq!(symbols(&buf), ["你", " ", " ", "|", "~"]);
     }
 }
 

--- a/crates/fresh-ui/Cargo.toml
+++ b/crates/fresh-ui/Cargo.toml
@@ -15,11 +15,16 @@ name = "fresh_ui"
 path = "src/lib.rs"
 
 [dependencies]
+# Measurement and painting agree on display width through these two: the
+# width of a string is the sum of its grapheme clusters' widths, and
+# `render::glyph` walks clusters so every backend advances by what layout
+# measured.
 unicode-width = "0.2"
+unicode-segmentation = "1.12"
 
 [dev-dependencies]
-# Test and example support only. The library itself still depends on
-# `unicode-width` alone, and on no other crate in this workspace.
+# Test and example support only. The library itself depends on the two
+# unicode crates alone, and on no other crate in this workspace.
 proptest = "1.9"
 # The interactive example's terminal backend. A dev-dependency, so it is
 # compiled for examples and tests and never for the library.

--- a/crates/fresh-ui/examples/interactive.rs
+++ b/crates/fresh-ui/examples/interactive.rs
@@ -31,6 +31,7 @@ use crossterm::event::{
 use crossterm::style::{Color, Print, SetBackgroundColor, SetForegroundColor};
 use crossterm::{cursor, execute, queue, terminal};
 
+use fresh_ui::glyph::glyphs_in;
 use fresh_ui::Axis;
 use fresh_ui::{
     Draw, Input, KeyCode, KeyPress, Mods, MouseButton, Point, Rect, Scrim, Size, ThemeKey,
@@ -205,9 +206,12 @@ fn translate_mouse(m: event::MouseEvent, clicks: &mut Clicks) -> Option<Input> {
 // The backend: fold a display list into coloured cells
 // ---------------------------------------------------------------------------
 
-#[derive(Clone, Copy, PartialEq)]
+/// One cell. `sym` is the grapheme cluster painted into it — empty for the
+/// continuation cell after a wide glyph, which the terminal fills itself as
+/// it draws the glyph before it (see `fresh_ui::glyph`).
+#[derive(Clone, PartialEq)]
 struct Cell {
-    ch: char,
+    sym: String,
     fg: Color,
     bg: Color,
 }
@@ -215,7 +219,7 @@ struct Cell {
 impl Default for Cell {
     fn default() -> Self {
         Cell {
-            ch: ' ',
+            sym: " ".to_string(),
             fg: Color::Reset,
             bg: Color::Reset,
         }
@@ -262,7 +266,7 @@ impl Terminal {
         }
         let r = roles(dark);
         let ground = Cell {
-            ch: ' ',
+            sym: " ".to_string(),
             fg: c(r.text),
             bg: c(r.base),
         };
@@ -347,8 +351,11 @@ impl Terminal {
                 let clip = clip.intersect(r);
                 for (i, line) in lines.iter().enumerate() {
                     let y = r.y + i as i32;
-                    for (j, ch) in line.chars().enumerate() {
-                        self.put(r.x + j as i32, y, ch, fg, bg, clip);
+                    // By display width, not by char — the library's policy
+                    // (`fresh_ui::glyph`), so a wide glyph keeps the two
+                    // cells layout measured for it.
+                    for g in glyphs_in(line, r.x, clip.x, clip.right()) {
+                        self.put_symbol(g.x, y, g.text, g.width, (fg, bg), clip);
                     }
                 }
             }
@@ -387,10 +394,26 @@ impl Terminal {
     }
 
     fn put(&mut self, x: i32, y: i32, ch: char, fg: Color, bg: Color, clip: Rect) {
+        let mut b = [0u8; 4];
+        self.put_symbol(x, y, ch.encode_utf8(&mut b), 1, (fg, bg), clip);
+    }
+
+    /// Paint one cluster at `(x, y)`, and blank the `w - 1` cells after it
+    /// that the glyph spills into, so nothing stale shows through them.
+    fn put_symbol(&mut self, x: i32, y: i32, sym: &str, w: u16, ink: (Color, Color), clip: Rect) {
+        let (fg, bg) = ink;
         if let Some(cell) = self.cell_mut(x, y, clip) {
-            cell.ch = ch;
+            cell.sym.clear();
+            cell.sym.push_str(sym);
             cell.fg = fg;
             cell.bg = bg;
+        }
+        for k in 1..w as i32 {
+            if let Some(cell) = self.cell_mut(x + k, y, clip) {
+                cell.sym.clear();
+                cell.fg = fg;
+                cell.bg = bg;
+            }
         }
     }
 
@@ -458,7 +481,8 @@ impl Terminal {
         if let Some(cell) = self.cell_mut(x, y, frame) {
             cell.fg = c(roles.shadow);
             cell.bg = c(roles.shadow_bg);
-            cell.ch = ' ';
+            cell.sym.clear();
+            cell.sym.push(' ');
         }
     }
 
@@ -472,7 +496,13 @@ impl Terminal {
         for y in 0..self.h {
             queue!(self.out, cursor::MoveTo(0, y))?;
             for x in 0..self.w {
-                let cell = self.cells[y as usize * self.w as usize + x as usize];
+                let cell = &self.cells[y as usize * self.w as usize + x as usize];
+                // A continuation cell: the wide glyph before it already moved
+                // the terminal's cursor past it, so printing anything here
+                // would push the rest of the row along.
+                if cell.sym.is_empty() {
+                    continue;
+                }
                 if cell.fg != fg {
                     fg = cell.fg;
                     queue!(self.out, SetForegroundColor(fg))?;
@@ -481,7 +511,7 @@ impl Terminal {
                     bg = cell.bg;
                     queue!(self.out, SetBackgroundColor(bg))?;
                 }
-                queue!(self.out, Print(cell.ch))?;
+                queue!(self.out, Print(&cell.sym))?;
             }
         }
         if let Some(cur) = spec.cursor.filter(|c| c.visible) {

--- a/crates/fresh-ui/src/lib.rs
+++ b/crates/fresh-ui/src/lib.rs
@@ -60,6 +60,7 @@ pub use focus::{
 pub use hit::Dispatch;
 pub use key::{Key, KeyPath};
 pub use render::geom::{distribute, Constraints, Point, Rect, Size};
+pub use render::glyph;
 pub use render::object::{
     Band, FocusReg, Geom, Hit, HostLeaf, LayerGeom, LayoutCx, LayoutInfo, PlainHost, RenderId,
     RenderObject, ScrollInfo,

--- a/crates/fresh-ui/src/render/glyph.rs
+++ b/crates/fresh-ui/src/render/glyph.rs
@@ -1,0 +1,229 @@
+//! Display-width policy: which columns a row of text occupies.
+//!
+//! Layout measures text with `unicode-width`, so a run of `你好` reserves four
+//! cells. Every backend that paints a [`Draw::Lines`](crate::Draw) must then
+//! *advance* by the same widths, or a wide glyph is painted into one cell and
+//! everything after it lands two cells left of where layout put it — which is
+//! exactly what happened while each backend stepped one column per `char`.
+//! This module is the one statement of the policy, walked by every backend:
+//! the library's own reference backend, the interactive example, and the
+//! editor's ratatui fold.
+//!
+//! # The policy
+//!
+//! * **The unit is the extended grapheme cluster** (UAX #29), not the `char`.
+//!   A base letter and its combining marks are one cluster and paint into one
+//!   cell; an emoji ZWJ sequence (`👨‍👩‍👧`) is one cluster and paints into two
+//!   cells, not six. Per-`char` widths cannot express either: `unicode-width`
+//!   measures a *string* as the sum of its clusters, so painting by cluster is
+//!   what keeps paint in step with measure.
+//! * **A cluster's width is `unicode-width`'s width of the cluster**: one cell
+//!   for most text, two for East Asian wide and fullwidth glyphs and for emoji
+//!   presentation, zero for a cluster that is nothing but marks.
+//! * **A zero-width cluster consumes no column and is not painted.** A lone
+//!   combining mark, a zero-width joiner or space, a variation selector with no
+//!   base — there is no cell for it to go in. (Inside a cluster, a mark is part
+//!   of the glyph in its base's cell.)
+//! * **A wide cluster occupies its first column and blanks the rest.** The
+//!   cells after the first are *continuation* cells: they show nothing of their
+//!   own, and a backend whose cell model has a glyph per cell must write a
+//!   blank into them so that whatever was there before does not show through
+//!   (ratatui's `Cell::set_symbol` does not do this for the caller).
+//! * **A wide cluster that would straddle the clip edge is not painted.** Half
+//!   a glyph cannot be drawn. Its visible columns are painted as blanks in the
+//!   item's style, so nothing stale shows through the hole, and the walk still
+//!   advances by the cluster's full width so what follows is unaffected.
+//! * **Control characters paint as `unicode-width` measures them.** `\t` and
+//!   `\r` are one cell each to `unicode-width` 0.2, so they are one cell here;
+//!   a backend that cannot show them shows a blank. Rows never contain `\n`:
+//!   shaping splits on it before anything reaches a backend.
+//!
+//! # What this does not decide
+//!
+//! Where a *run* boundary splits a cluster — a base letter in one styled piece
+//! and its mark in the next — each piece is measured and painted on its own,
+//! so the mark becomes a zero-width cluster of its own and is dropped. The
+//! same is true of an emoji sequence cut by a style boundary. Both are
+//! defects of the description rather than of the painter, and no backend
+//! attempts to repair them.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+/// One painted cluster: where it starts, what it is, and how many columns it
+/// takes. `width` is never zero.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Glyph<'a> {
+    /// The column the cluster starts in.
+    pub x: i32,
+    /// The cluster's text — one or more `char`s, painted as one symbol into
+    /// the cell at `x`. A backend that stores a `char` per cell keeps the
+    /// first and loses the marks; that is its limitation, not the policy's.
+    pub text: &'a str,
+    /// Columns the cluster covers, from `x`. Cells `x + 1 .. x + width` are
+    /// continuation cells (see the module docs).
+    pub width: u16,
+}
+
+impl Glyph<'_> {
+    /// The column just past this cluster.
+    pub fn end(&self) -> i32 {
+        self.x + self.width as i32
+    }
+}
+
+/// The display width of `s`, in cells — what layout measures a run at, and
+/// what [`glyphs`] advances by in total.
+///
+/// `unicode-width` defines a string's width as the sum of its extended
+/// grapheme clusters' widths (and [`glyphs`] is tested against that), so this
+/// needs no segmentation of its own.
+pub fn width(s: &str) -> u16 {
+    UnicodeWidthStr::width(s).min(u16::MAX as usize) as u16
+}
+
+/// The clusters of `line` and the column each starts in, beginning at `x0`.
+///
+/// Zero-width clusters are dropped, per the policy above; every yielded glyph
+/// has `width >= 1`, and the glyphs are contiguous: each starts where the one
+/// before it ended.
+pub fn glyphs(line: &str, x0: i32) -> impl Iterator<Item = Glyph<'_>> {
+    let mut x = x0;
+    line.graphemes(true).filter_map(move |g| {
+        let w = width(g);
+        if w == 0 {
+            return None;
+        }
+        let at = x;
+        x += w as i32;
+        Some(Glyph {
+            x: at,
+            text: g,
+            width: w,
+        })
+    })
+}
+
+/// [`glyphs`], cut to the columns `lo..hi`.
+///
+/// A cluster wholly inside the range is yielded as it is. One wholly outside
+/// is dropped. A *wide* cluster that straddles either edge is yielded as one
+/// blank (`" "`, width 1) per column of it that is inside the range, so the
+/// caller paints the visible half of the hole rather than half a glyph — and
+/// every glyph this yields can be painted without a further clip test on its
+/// columns.
+pub fn glyphs_in(line: &str, x0: i32, lo: i32, hi: i32) -> impl Iterator<Item = Glyph<'_>> {
+    // A wide glyph straddling an edge becomes up to `width - 1` blanks, so the
+    // walk carries a small queue of what it has yet to hand out.
+    let mut pending: std::collections::VecDeque<Glyph<'_>> = std::collections::VecDeque::new();
+    let mut inner = glyphs(line, x0);
+    // Stops at the first cluster past the range: nothing after it is inside.
+    let mut done = false;
+    std::iter::from_fn(move || loop {
+        if let Some(g) = pending.pop_front() {
+            return Some(g);
+        }
+        if done {
+            return None;
+        }
+        let g = inner.next()?;
+        if g.x >= hi {
+            done = true;
+            return None;
+        }
+        if g.end() <= lo {
+            continue;
+        }
+        if g.x >= lo && g.end() <= hi {
+            return Some(g);
+        }
+        // Straddling. Only a wide glyph can, and only its visible columns are
+        // painted — as blanks.
+        for col in g.x.max(lo)..g.end().min(hi) {
+            pending.push_back(Glyph {
+                x: col,
+                text: " ",
+                width: 1,
+            });
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cols(line: &str) -> Vec<(i32, &str, u16)> {
+        glyphs(line, 0).map(|g| (g.x, g.text, g.width)).collect()
+    }
+
+    #[test]
+    fn ascii_is_one_column_per_char() {
+        assert_eq!(cols("fn"), vec![(0, "f", 1), (1, "n", 1)]);
+    }
+
+    #[test]
+    fn a_wide_glyph_takes_two_columns_and_the_next_starts_after_it() {
+        assert_eq!(cols("你好"), vec![(0, "你", 2), (2, "好", 2)]);
+        assert_eq!(cols("你a"), vec![(0, "你", 2), (2, "a", 1)]);
+    }
+
+    #[test]
+    fn a_combining_mark_rides_in_its_base_cell() {
+        // e + U+0301: one cluster, one cell, the mark inside it.
+        assert_eq!(cols("e\u{301}x"), vec![(0, "e\u{301}", 1), (1, "x", 1)]);
+    }
+
+    #[test]
+    fn a_lone_mark_consumes_no_column_and_is_not_painted() {
+        assert_eq!(cols("\u{301}x"), vec![(0, "x", 1)]);
+        assert_eq!(cols("\u{200d}"), vec![]);
+        assert_eq!(cols("a\u{200b}b"), vec![(0, "a", 1), (1, "b", 1)]);
+    }
+
+    #[test]
+    fn an_emoji_sequence_is_one_two_column_glyph() {
+        let fam = "👨\u{200d}👩\u{200d}👧";
+        assert_eq!(cols(fam), vec![(0, fam, 2)]);
+        // Emoji presentation via VS16 is two cells; the bare heart is one.
+        assert_eq!(cols("❤\u{fe0f}"), vec![(0, "❤\u{fe0f}", 2)]);
+        assert_eq!(cols("❤"), vec![(0, "❤", 1)]);
+    }
+
+    #[test]
+    fn the_walk_advances_by_exactly_the_measured_width() {
+        for s in [
+            "你好",
+            "fn 你好 fn",
+            "e\u{301}",
+            "👨\u{200d}👩\u{200d}👧!",
+            "🇯🇵",
+            "ｆｕｌｌ",
+            "\t",
+            "",
+        ] {
+            let end = glyphs(s, 3).last().map(|g| g.end()).unwrap_or(3);
+            assert_eq!(end - 3, width(s) as i32, "{s:?}");
+        }
+    }
+
+    #[test]
+    fn clipping_keeps_whole_glyphs_and_blanks_a_straddler() {
+        let v: Vec<_> = glyphs_in("你好", 0, 0, 4).collect();
+        assert_eq!(v.len(), 2);
+        // Only three columns: `好` straddles the edge and its visible column
+        // is a blank.
+        let v: Vec<_> = glyphs_in("你好", 0, 0, 3)
+            .map(|g| (g.x, g.text, g.width))
+            .collect();
+        assert_eq!(v, vec![(0, "你", 2), (2, " ", 1)]);
+        // Straddling the left edge likewise.
+        let v: Vec<_> = glyphs_in("你好", 0, 1, 4)
+            .map(|g| (g.x, g.text, g.width))
+            .collect();
+        assert_eq!(v, vec![(1, " ", 1), (2, "好", 2)]);
+        // Wholly outside: nothing.
+        assert_eq!(glyphs_in("你好", 0, 4, 8).count(), 0);
+        assert_eq!(glyphs_in("abc", 5, 0, 5).count(), 0);
+    }
+}

--- a/crates/fresh-ui/src/render/mod.rs
+++ b/crates/fresh-ui/src/render/mod.rs
@@ -1,6 +1,7 @@
 //! Geometry, layout and the display list.
 
 pub mod geom;
+pub mod glyph;
 pub mod layout;
 pub mod object;
 pub mod paint;

--- a/crates/fresh-ui/src/render/prim.rs
+++ b/crates/fresh-ui/src/render/prim.rs
@@ -905,7 +905,7 @@ const ELLIPSIS: &str = "…";
 /// a fragment mid-glyph. Fragments are walked whole and only the one straddling
 /// the boundary is split, so a styled run keeps its pieces' colours.
 fn elide_row(row: &[Frag], w: u16, mode: crate::desc::Elide) -> Vec<Frag> {
-    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+    use unicode_width::UnicodeWidthStr;
     let total: usize = row.iter().map(|f| UnicodeWidthStr::width(&*f.text)).sum();
     if mode == crate::desc::Elide::None || total <= w as usize {
         return row.to_vec();
@@ -923,24 +923,29 @@ fn elide_row(row: &[Frag], w: u16, mode: crate::desc::Elide) -> Vec<Frag> {
 
     // `take` walks a fragment in one direction and returns the piece that fits
     // in `left` cells, along with what it consumed.
+    //
+    // Walked by grapheme cluster, so a cut never separates a mark from its
+    // base or splits an emoji sequence — the units the painter advances by
+    // (`glyph`) are the units the cut is made in.
     let take = |f: &Frag, left: usize, from_end: bool| -> (String, usize) {
-        let mut chars: Vec<char> = f.text.chars().collect();
+        use unicode_segmentation::UnicodeSegmentation;
+        let mut parts: Vec<&str> = f.text.graphemes(true).collect();
         if from_end {
-            chars.reverse();
+            parts.reverse();
         }
-        let (mut used, mut out) = (0usize, String::new());
-        for c in chars {
-            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        let (mut used, mut kept) = (0usize, Vec::new());
+        for part in parts {
+            let cw = UnicodeWidthStr::width(part);
             if used + cw > left {
                 break;
             }
             used += cw;
-            out.push(c);
+            kept.push(part);
         }
         if from_end {
-            out = out.chars().rev().collect();
+            kept.reverse();
         }
-        (out, used)
+        (kept.concat(), used)
     };
 
     let mut kept: Vec<Frag> = Vec::new();
@@ -1008,6 +1013,17 @@ pub struct TextRender {
     /// Rather than depend on every path remembering to re-measure, the cache
     /// says whether it is still true, and paint re-shapes when it is not.
     pub(crate) stale: bool,
+    /// The pieces [`Self::shaped`] was shaped from, when it was shaped
+    /// unwrapped — `None` after a wrapped shaping, whose rows depend on a
+    /// width as well.
+    ///
+    /// An unwrapped shaping is a function of the pieces alone, so a measure
+    /// that finds the same pieces keeps it rather than joining and re-cutting
+    /// them. The editor rebuilds its tree every frame with fresh `Rc`s around
+    /// unchanged text, so this compares content when the pointers differ:
+    /// a walk over the bytes, against a shaping that allocates per row and
+    /// per fragment.
+    shaped_from: Option<Rc<[crate::desc::Run]>>,
 }
 
 impl TextRender {
@@ -1016,31 +1032,72 @@ impl TextRender {
             props,
             shaped: Shaping::default(),
             stale: false,
+            shaped_from: None,
+        }
+    }
+
+    /// Whether [`Self::shaped`] is the unwrapped shaping of the pieces held
+    /// now.
+    fn shaped_unwrapped_from_props(&self) -> bool {
+        match &self.shaped_from {
+            Some(from) => Rc::ptr_eq(from, &self.props.runs) || **from == *self.props.runs,
+            None => false,
         }
     }
 }
 
+/// The extent of `runs` laid out unwrapped: the widest line in cells, and how
+/// many lines there are.
+///
+/// Measured from the pieces, without joining them (plan §2.5). A `\n` inside a
+/// piece ends a line, and a line's width is the sum of the widths of the
+/// pieces of it — which is also how paint places them, one item per fragment,
+/// so a cluster a piece boundary happens to split measures and paints the
+/// same (see [`glyph`](crate::render::glyph) for what that does to it).
+pub fn unwrapped_extent(runs: &[crate::desc::Run]) -> (u16, usize) {
+    let mut widest = 0usize;
+    let mut cur = 0usize;
+    let mut lines = 1usize;
+    for r in runs {
+        let mut parts = r.text.split('\n');
+        cur += crate::render::glyph::width(parts.next().unwrap_or("")) as usize;
+        for part in parts {
+            widest = widest.max(cur);
+            cur = crate::render::glyph::width(part) as usize;
+            lines += 1;
+        }
+    }
+    (widest.max(cur).min(u16::MAX as usize) as u16, lines)
+}
+
 impl RenderObject for TextRender {
     fn layout(&mut self, c: Constraints, _cx: &mut dyn LayoutCx) -> Size {
-        use unicode_width::UnicodeWidthStr;
-        // Measured as one string, whatever it is made of: the pieces are one
-        // logical run, so styling never changes where the text breaks.
-        let whole = self.props.plain();
-        let natural = UnicodeWidthStr::width(whole.as_str()) as u16;
+        // Measured from the pieces, never by joining them into a string of
+        // their own (plan §2.5): the natural width is a sum of piece widths,
+        // and shaping — which does join, because a wrap point may fall inside
+        // a piece and the byte mapping indexes the joined string — happens
+        // once per distinct content rather than once per measure.
+        let (natural, _) = unwrapped_extent(&self.props.runs);
         if self.props.wrap != Wrap::None {
             let w = if c.min_w > 0 {
                 c.max_w
             } else {
                 c.max_w.min(natural.max(1))
             };
+            // The pieces are one logical run, so styling never changes where
+            // the text breaks: `shape_runs` wraps them as one string.
             self.shaped = shape_runs(&self.props.runs, w, self.props.wrap);
+            self.shaped_from = None;
             self.stale = false;
             c.constrain(Size::new(
                 w,
                 self.shaped.rows.len().min(u16::MAX as usize) as u16,
             ))
         } else {
-            self.shaped = shape_runs(&self.props.runs, 0, Wrap::None);
+            if !self.shaped_unwrapped_from_props() {
+                self.shaped = shape_runs(&self.props.runs, 0, Wrap::None);
+                self.shaped_from = Some(self.props.runs.clone());
+            }
             self.stale = false;
             c.constrain(Size::new(natural, self.shaped.rows.len().max(1) as u16))
         }
@@ -1098,11 +1155,13 @@ impl RenderObject for TextRender {
                 .collect();
             out.push(Draw::Lines(lines), g);
         } else {
-            use unicode_width::UnicodeWidthStr;
             for (i, row) in rows.iter().enumerate() {
                 let mut x = g.rect.x;
                 for frag in row {
-                    let w = UnicodeWidthStr::width(&*frag.text) as u16;
+                    // Display cells, as layout measured and as every backend
+                    // advances (`glyph`), so the next fragment starts where
+                    // this one's last cluster ends.
+                    let w = crate::render::glyph::width(&frag.text);
                     if w == 0 {
                         continue;
                     }
@@ -1708,6 +1767,176 @@ impl RenderObject for ReaderRender {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod measure_tests {
+    //! How a `TextRun` measures (plan §2.5): from its pieces, not from a
+    //! string joined out of them, and shaping the unwrapped case once per
+    //! distinct content rather than once per measure.
+
+    use std::rc::Rc;
+
+    use super::{unwrapped_extent, TextRender};
+    use crate::desc::{Elide, Run, TextProps, Wrap};
+    use crate::render::geom::{Constraints, Point, Size};
+    use crate::render::object::{LayoutCx, LayoutInfo, RenderId, RenderObject, ScrollInfo};
+
+    /// A leaf has no children and asks its context for nothing, so this is
+    /// the least a `LayoutCx` can be.
+    struct Leaf;
+
+    impl LayoutCx for Leaf {
+        fn children(&self) -> Vec<RenderId> {
+            Vec::new()
+        }
+        fn sizing(&self, _: RenderId) -> (crate::desc::Sizing, crate::desc::Sizing) {
+            unreachable!("a text run has no children")
+        }
+        fn measure(&mut self, _: RenderId, _: Constraints) -> Size {
+            unreachable!("a text run has no children")
+        }
+        fn place(&mut self, _: RenderId, _: Point) {
+            unreachable!("a text run has no children")
+        }
+        fn enclosing_window(&self, info: LayoutInfo) -> LayoutInfo {
+            info
+        }
+        fn scroll(&self) -> Point {
+            Point::new(0, 0)
+        }
+        fn set_offset(&mut self, _: Point) {}
+        fn set_scroll(&mut self, _: ScrollInfo) {}
+        fn rebuild(&mut self, _: LayoutInfo) {}
+        fn element(&self) -> crate::element::ElementId {
+            unreachable!("nothing here reads the element")
+        }
+    }
+
+    fn props(runs: Vec<Run>, wrap: Wrap) -> TextProps {
+        TextProps {
+            runs: Rc::from(runs),
+            wrap,
+            elide: Elide::None,
+            cursor: None,
+        }
+    }
+
+    fn loose() -> Constraints {
+        Constraints {
+            min_w: 0,
+            max_w: 80,
+            min_h: 0,
+            max_h: 20,
+        }
+    }
+
+    #[test]
+    fn the_unwrapped_extent_is_the_widest_line_by_display_width() {
+        assert_eq!(unwrapped_extent(&[Run::plain("fn")]), (2, 1));
+        assert_eq!(unwrapped_extent(&[Run::plain("你好")]), (4, 1));
+        // Pieces sum; a piece boundary is not a column.
+        assert_eq!(
+            unwrapped_extent(&[Run::themed("你好", "kw"), Run::plain("fn")]),
+            (6, 1)
+        );
+        // Lines end inside a piece, and across pieces the line continues.
+        assert_eq!(unwrapped_extent(&[Run::plain("ab\ncdef\nx")]), (4, 3));
+        assert_eq!(
+            unwrapped_extent(&[Run::plain("ab"), Run::plain("cd\ne")]),
+            (4, 2)
+        );
+        assert_eq!(unwrapped_extent(&[]), (0, 1));
+        assert_eq!(unwrapped_extent(&[Run::plain("")]), (0, 1));
+        // A combining mark is not a column; an emoji sequence is two.
+        assert_eq!(unwrapped_extent(&[Run::plain("e\u{301}")]), (1, 1));
+        assert_eq!(
+            unwrapped_extent(&[Run::plain("👨\u{200d}👩\u{200d}👧")]),
+            (2, 1)
+        );
+    }
+
+    /// The width and height an unwrapped run reports are the extent of its
+    /// pieces, and a multi-line run is as wide as its widest line — not the
+    /// sum of them, which is what measuring the joined string used to say.
+    #[test]
+    fn an_unwrapped_run_measures_its_widest_line() {
+        let mut t = TextRender::new(props(vec![Run::plain("你好\nab")], Wrap::None));
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(4, 2));
+    }
+
+    /// Equal content in a fresh `Rc` — what the editor hands a live object
+    /// every frame — keeps the shaping it has instead of joining and cutting
+    /// again. Changed content does not.
+    #[test]
+    fn an_unwrapped_measure_reshapes_only_when_the_pieces_change() {
+        let first: Rc<[Run]> = Rc::from(vec![Run::themed("你好", "kw"), Run::plain(" fn")]);
+        let mut t = TextRender::new(TextProps {
+            runs: first.clone(),
+            wrap: Wrap::None,
+            elide: Elide::None,
+            cursor: None,
+        });
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(7, 1));
+        assert!(t
+            .shaped_from
+            .as_ref()
+            .is_some_and(|f| Rc::ptr_eq(f, &first)));
+
+        // Same pieces, new allocation.
+        t.props.runs = Rc::from(vec![Run::themed("你好", "kw"), Run::plain(" fn")]);
+        t.stale = true;
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(7, 1));
+        assert!(
+            t.shaped_from
+                .as_ref()
+                .is_some_and(|f| Rc::ptr_eq(f, &first)),
+            "unchanged pieces were shaped again"
+        );
+        assert!(!t.stale);
+
+        // A different theme on the same text is a different shaping: the
+        // fragments carry the theme.
+        let third: Rc<[Run]> = Rc::from(vec![Run::themed("你好", "id"), Run::plain(" fn")]);
+        t.props.runs = third.clone();
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(7, 1));
+        assert!(t
+            .shaped_from
+            .as_ref()
+            .is_some_and(|f| Rc::ptr_eq(f, &third)));
+        assert_eq!(t.shaped.frags[0][0].theme, third[0].theme);
+
+        // Different text: reshaped, and the rows say so.
+        t.props.runs = Rc::from(vec![Run::plain("a\nb")]);
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(1, 2));
+        assert_eq!(t.shaped.rows.len(), 2);
+    }
+
+    /// A wrapped shaping depends on the width too, so it is never kept
+    /// across a measure — and switching an object from wrapped to unwrapped
+    /// with the same pieces must not reuse the wrapped rows.
+    #[test]
+    fn a_wrapped_shaping_is_not_kept_for_an_unwrapped_measure() {
+        let runs: Rc<[Run]> = Rc::from(vec![Run::plain("one two three")]);
+        let mut t = TextRender::new(TextProps {
+            runs: runs.clone(),
+            wrap: Wrap::Word,
+            elide: Elide::None,
+            cursor: None,
+        });
+        let narrow = Constraints {
+            min_w: 0,
+            max_w: 5,
+            min_h: 0,
+            max_h: 20,
+        };
+        assert_eq!(t.layout(narrow, &mut Leaf), Size::new(5, 3));
+        assert!(t.shaped_from.is_none());
+
+        t.props.wrap = Wrap::None;
+        assert_eq!(t.layout(loose(), &mut Leaf), Size::new(13, 1));
+        assert_eq!(t.shaped.rows.len(), 1);
     }
 }
 

--- a/crates/fresh-ui/src/render/spec.rs
+++ b/crates/fresh-ui/src/render/spec.rs
@@ -147,6 +147,12 @@ pub enum Draw {
     /// Covers everything painted before it.
     Scrim(Scrim),
     /// Text, one entry per visual row.
+    ///
+    /// A row's columns are what [`glyph::glyphs`](crate::render::glyph::glyphs)
+    /// says they are: a backend paints each cluster it yields at the column it
+    /// names and blanks the continuation cells of a wide one. Stepping one cell
+    /// per `char` puts everything after a wide glyph two cells left of where
+    /// layout measured it.
     Lines(Vec<Rc<str>>),
     Scrollbar {
         /// How far the window has travelled, in whatever the viewport counts.

--- a/crates/fresh-ui/tests/glyphs.rs
+++ b/crates/fresh-ui/tests/glyphs.rs
@@ -1,0 +1,132 @@
+//! Display-width conformance (plan §2.1, Stage 0.1).
+//!
+//! Layout measures text with `unicode-width`; the reference backend must
+//! paint each row into exactly the columns that measure reserved. These
+//! tests pin the policy `fresh_ui::glyph` states, end to end: a description
+//! goes in, a screen comes out, and the cells are where layout said.
+
+mod support;
+
+use fresh_ui::{row, text, text_runs, Draw, Run, Size, Sizing, Ui};
+use support::screen::{render, Screen};
+
+const FRAME: Size = Size { w: 12, h: 1 };
+
+fn paint(root: fresh_ui::Node<()>) -> (fresh_ui::LayoutSpec, Screen) {
+    let mut ui: Ui<()> = Ui::new();
+    let spec = ui.frame(root, FRAME).clone();
+    let screen = render(&spec);
+    (spec, screen)
+}
+
+/// The row as a list of cells, so an assertion reads like the screen: a wide
+/// glyph, then the empty cell it spills into.
+fn cells(s: &Screen, y: u16) -> Vec<&str> {
+    (0..s.w).map(|x| s.symbol(x, y)).collect()
+}
+
+/// `text("你好")` reserves four columns and paints all four: the glyphs in
+/// the first and third, their continuations in the second and fourth. The
+/// exit criterion of Stage 0.1.
+#[test]
+fn a_wide_glyph_occupies_the_two_columns_layout_measured() {
+    let (spec, s) = paint(row().children([text("你好"), text("!")]));
+    let rects: Vec<_> = spec
+        .items
+        .iter()
+        .filter(|i| matches!(i.draw, Draw::Lines(_)))
+        .map(|i| (i.rect.x, i.rect.w))
+        .collect();
+    assert_eq!(
+        rects,
+        vec![(0, 4), (4, 1)],
+        "layout reserves by display width"
+    );
+    assert_eq!(
+        cells(&s, 0),
+        ["你", "", "好", "", "!", " ", " ", " ", " ", " ", " ", " "]
+    );
+    assert!(s.is_continuation(1, 0) && s.is_continuation(3, 0));
+    assert_eq!(s.line(0).trim_end(), "你好!");
+}
+
+/// A styled run is several items, one per fragment, and each starts where the
+/// last one's glyphs end — so a CJK identifier followed by a keyword paints the
+/// keyword at column four, not at column two where a per-char walk would put
+/// it (and not two cells past its own hole, either).
+#[test]
+fn mixed_runs_paint_end_to_end_with_no_hole() {
+    let (spec, s) = paint(text_runs([
+        Run::themed("你好", "identifier"),
+        Run::themed("fn", "keyword"),
+    ]));
+    let rects: Vec<_> = spec
+        .items
+        .iter()
+        .filter(|i| matches!(i.draw, Draw::Lines(_)))
+        .map(|i| (i.rect.x, i.rect.w, i.theme.as_str().to_string()))
+        .collect();
+    assert_eq!(
+        rects,
+        vec![(0, 4, "identifier".into()), (4, 2, "keyword".into())]
+    );
+    assert_eq!(
+        cells(&s, 0),
+        ["你", "", "好", "", "f", "n", " ", " ", " ", " ", " ", " "]
+    );
+}
+
+/// A base letter and its combining mark are one cell, and the mark rides in
+/// it: what follows starts one column on, not two.
+#[test]
+fn a_combining_mark_consumes_no_column() {
+    let (spec, s) = paint(row().children([text("e\u{301}x"), text("|")]));
+    let rects: Vec<_> = spec
+        .items
+        .iter()
+        .filter(|i| matches!(i.draw, Draw::Lines(_)))
+        .map(|i| (i.rect.x, i.rect.w))
+        .collect();
+    assert_eq!(rects, vec![(0, 2), (2, 1)]);
+    assert_eq!(s.symbol(0, 0), "e\u{301}", "the mark is in its base's cell");
+    assert_eq!(s.symbol(1, 0), "x");
+    assert_eq!(s.symbol(2, 0), "|");
+}
+
+/// An emoji ZWJ sequence is one glyph two cells wide — not one cell per
+/// scalar, of which it has five.
+#[test]
+fn an_emoji_sequence_is_one_two_column_glyph() {
+    let family = "👨\u{200d}👩\u{200d}👧";
+    let (spec, s) = paint(row().children([text(family), text("!")]));
+    let rects: Vec<_> = spec
+        .items
+        .iter()
+        .filter(|i| matches!(i.draw, Draw::Lines(_)))
+        .map(|i| (i.rect.x, i.rect.w))
+        .collect();
+    assert_eq!(rects, vec![(0, 2), (2, 1)]);
+    assert_eq!(s.symbol(0, 0), family);
+    assert!(s.is_continuation(1, 0));
+    assert_eq!(s.symbol(2, 0), "!");
+}
+
+/// A wide glyph the clip cuts in half is not painted at all; the column of it
+/// that is visible is a blank, and nothing of it leaks past the clip.
+#[test]
+fn a_wide_glyph_straddling_the_clip_edge_paints_as_a_blank() {
+    // Three cells for four columns of text: `好` straddles the edge.
+    let (spec, s) = paint(row().children([text("你好").w(Sizing::Cells(3)), text("|")]));
+    let rects: Vec<_> = spec
+        .items
+        .iter()
+        .filter(|i| matches!(i.draw, Draw::Lines(_)))
+        .map(|i| (i.rect.x, i.rect.w))
+        .collect();
+    assert_eq!(rects, vec![(0, 3), (3, 1)]);
+    assert_eq!(
+        cells(&s, 0)[..5],
+        ["你", "", " ", "|", " "],
+        "half of 好 is a blank, and the neighbour is untouched"
+    );
+}

--- a/crates/fresh-ui/tests/support/screen.rs
+++ b/crates/fresh-ui/tests/support/screen.rs
@@ -6,15 +6,22 @@
 //! print. A real terminal backend does the same fold into cells with colours.
 
 use fresh_ui::desc::Scrim;
+use fresh_ui::glyph::glyphs_in;
 use fresh_ui::render::geom::Rect;
 use fresh_ui::render::spec::{Draw, Item, LayoutSpec};
 
-/// A character grid.
+/// A grid of cells, each holding the symbol painted into it.
+///
+/// A symbol is a grapheme cluster — one `char` for most text, a base and its
+/// marks for a composed one — and a wide cluster occupies its first cell and
+/// leaves the cells after it *empty* (`""`), which is how `line` comes out the
+/// right length in columns and how a test can tell a continuation cell from a
+/// blank one. See `fresh_ui::glyph` for the policy.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Screen {
     pub w: u16,
     pub h: u16,
-    cells: Vec<char>,
+    cells: Vec<String>,
 }
 
 impl Screen {
@@ -22,26 +29,71 @@ impl Screen {
         Screen {
             w,
             h,
-            cells: vec![' '; w as usize * h as usize],
+            cells: vec![" ".to_string(); w as usize * h as usize],
         }
     }
 
     fn put(&mut self, x: i32, y: i32, c: char, clip: Rect) {
+        let mut b = [0u8; 4];
+        self.put_symbol(x, y, c.encode_utf8(&mut b), 1, clip);
+    }
+
+    /// Paint `sym` at `(x, y)` and blank the `w - 1` continuation cells after
+    /// it. The caller has already clipped the columns (`glyph::glyphs_in`).
+    fn put_symbol(&mut self, x: i32, y: i32, sym: &str, w: u16, clip: Rect) {
         if x < 0 || y < 0 || x >= self.w as i32 || y >= self.h as i32 {
             return;
         }
         if !clip.contains(fresh_ui::render::geom::Point::new(x, y)) {
             return;
         }
-        self.cells[y as usize * self.w as usize + x as usize] = c;
+        let row = y as usize * self.w as usize;
+        let end = row + self.w as usize;
+        let i = row + x as usize;
+        // Painting over the continuation of a wide glyph cuts that glyph in
+        // half; what is left of it shows as a blank, as it would on a
+        // terminal that cannot draw half of `你`.
+        if self.cells[i].is_empty() {
+            let mut j = i;
+            while j > row && self.cells[j].is_empty() {
+                j -= 1;
+            }
+            self.cells[j] = " ".to_string();
+        }
+        self.cells[i] = sym.to_string();
+        for k in 1..w as usize {
+            if i + k < end {
+                self.cells[i + k].clear();
+            }
+        }
+        // And a narrower glyph over the head of a wide one orphans the wide
+        // one's continuation cells, which then belong to nothing.
+        let mut j = i + w as usize;
+        while j < end && self.cells[j].is_empty() {
+            self.cells[j] = " ".to_string();
+            j += 1;
+        }
     }
 
+    /// The symbol in a cell: `" "` when blank, `""` when the cell is the
+    /// continuation of a wide glyph to its left.
+    pub fn symbol(&self, x: u16, y: u16) -> &str {
+        &self.cells[y as usize * self.w as usize + x as usize]
+    }
+
+    /// The first `char` of the cell's symbol; a blank for a continuation
+    /// cell, which shows nothing of its own.
     pub fn at(&self, x: u16, y: u16) -> char {
-        self.cells[y as usize * self.w as usize + x as usize]
+        self.symbol(x, y).chars().next().unwrap_or(' ')
+    }
+
+    /// Whether the cell is the second (or later) column of a wide glyph.
+    pub fn is_continuation(&self, x: u16, y: u16) -> bool {
+        self.symbol(x, y).is_empty()
     }
 
     pub fn line(&self, y: u16) -> String {
-        (0..self.w).map(|x| self.at(x, y)).collect()
+        (0..self.w).map(|x| self.symbol(x, y)).collect()
     }
 
     /// Every row, trailing blanks trimmed, one per line.
@@ -108,8 +160,12 @@ fn draw(s: &mut Screen, item: &Item, frame: Rect, fill_char: &impl Fn(&str) -> O
             let clip = clip.intersect(r);
             for (i, line) in lines.iter().enumerate() {
                 let y = r.y + i as i32;
-                for (j, ch) in line.chars().enumerate() {
-                    s.put(r.x + j as i32, y, ch, clip);
+                // By display width, not by char: the library says which
+                // columns each cluster takes (`glyph`), and a backend that
+                // stepped one cell per char would paint `你好` into two cells
+                // of the four layout reserved.
+                for g in glyphs_in(line, r.x, clip.x, clip.right()) {
+                    s.put_symbol(g.x, y, g.text, g.width, clip);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Stage 0.1 and 0.2 of the retained-mode migration plan (§2.1, §2.5): wide characters occupy the columns layout gave them in every backend, and `TextRender::layout` under `Wrap::None` no longer joins the runs into a fresh `String` to measure them.

### The defect

Layout measured text with `unicode-width`, but every consumer of `Draw::Lines` painted one column per `char`. So `text("你好")` reserved four cells, painted two, and left a hole before its sibling; a styled CJK run followed by a keyword painted the keyword two cells right of where the run ended; and in the ratatui fold `Cell::set_char` left the continuation cell holding whatever was there before.

### The grapheme policy

Stated once, in `fresh_ui::glyph` (`crates/fresh-ui/src/render/glyph.rs`), and walked by all three backends through `glyph::glyphs_in`:

- The unit is the extended grapheme cluster, and its width is `unicode-width`'s width of the cluster. A base letter plus combining mark is one cell; an emoji ZWJ sequence is one two-cell glyph, not one cell per scalar.
- A zero-width cluster (lone mark, ZWJ, variation selector) consumes no column and is not painted.
- A wide cluster occupies its first column, and the backend blanks its continuation cells.
- A wide cluster that would straddle the clip edge is not painted; its visible column becomes a blank in the item's style, and the walk still advances by the full width.
- Not repaired: a run boundary that splits a cluster measures and paints per piece. That is a description defect, documented rather than patched.

`unicode-segmentation` joins `unicode-width` as the library's dependency. Per-`char` widths would not have been enough even with correct advancing: `unicode-width`'s string width diverges from the sum of char widths for emoji sequences and VS16, so grapheme segmentation is required to keep paint in step with measure.

### Changes

- `crates/fresh-ui/src/render/glyph.rs` (new): policy, `Glyph`, `width`, `glyphs`, `glyphs_in`, unit tests. Exported as `fresh_ui::glyph`.
- `crates/fresh-ui/src/render/prim.rs`: `Wrap::None` measures via new `unwrapped_extent` (widest line, summed piece widths) with no `plain()` call. The unwrapped shaping is kept across measures whose pieces are unchanged, comparing content when the `Rc`s differ. Per-fragment paint uses the shared width helper; elision cuts by cluster.
- `crates/fresh-ui/tests/support/screen.rs`: a cell holds a symbol string, continuation cells are empty, orphaned halves are blanked.
- `crates/fresh-ui/examples/interactive.rs`: same cell model; flush skips continuation cells.
- `crates/fresh-editor/src/view/shell/fold.rs`: `Draw::Lines` walks `glyphs_in`; new `put_symbol` blanks continuation cells the way `Buffer::set_stringn` does.
- `crates/fresh-ui/src/render/spec.rs`: `Draw::Lines` doc points at the walker.

### Behaviour change

A multi-line `Wrap::None` run now measures its widest line. Previously it measured the joined string, which counted every line plus one cell per `\n`. No golden changed.

### Notes against the plan doc

§2.5 understates the concatenation: besides `plain()`, `shape_runs` joins the runs again into `Shaping.whole`, which the byte mapping (`cell_of`/`byte_of`) indexes, so that join cannot be removed outright. This PR removes the measure-time join and caches the shaping instead.

## Tests

- `crates/fresh-ui/tests/glyphs.rs`: five reference-backend tests (`你好`, mixed runs, combining mark, emoji, clip straddle).
- `prim::measure_tests`: four tests on `unwrapped_extent`, widest-line measurement, and shaping reuse.
- `fold::width_tests`: four tests against a ratatui `Buffer`, asserting the continuation cell is written blank and the next run starts at the right column.
- Seven unit tests in `glyph.rs`.

Verified: `cargo test -p fresh-ui`, `cargo test -p fresh-editor --lib` (3775 passed), `cargo test -p fresh-editor --test ui_shell_frame_parity`, `cargo test -p fresh-editor --features web --test scene_parity`. `cargo clippy -p fresh-ui --all-targets` reports only warnings present on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqePM1E2REiCY5TCNxrfQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqePM1E2REiCY5TCNxrfQd)_