### PR TITLE
One geometry pass per frame: pane rects off the shell tree (Stage 2)

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -380,11 +380,22 @@ impl Editor {
             .shell_ui
             .take()
             .expect("the shell tree is taken and returned within one frame");
+        crate::view::shell::geometry::stats::note_shell_layout();
         ui.frame(
             crate::view::shell::frame::frame_tree(shell.clone()),
             fresh_ui::Size::new(size.width, size.height),
         );
         let regions = crate::view::shell::frame::regions_of(&ui, size);
+        // **The frame's one geometry pass, for the panes.** Every pane's box
+        // and content slot, off the tree just laid out. The plugin hooks below,
+        // the body painter's pass and the pane `Host`s all read this; nothing
+        // on the render path lays the grid out again to ask where a pane is.
+        // See `view::shell::geometry`.
+        let pane_rects = crate::view::shell::geometry::PaneRects::read(
+            &ui,
+            self.window_panes().into_iter().map(|(leaf, _)| leaf),
+            size,
+        );
         self.shell_ui = Some(ui);
         let region = |r: crate::view::shell::frame::HostRegion| -> ratatui::layout::Rect {
             regions
@@ -459,14 +470,17 @@ impl Editor {
         if plugins_active.unwrap_or(false) {
             let _s = tracing::info_span!("render_plugin_hooks").entered();
             let hooks_start = std::time::Instant::now();
-            // Get visible buffers and their areas
-            let visible_buffers = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .get_visible_buffers(editor_content_area);
+            // Get visible buffers and their areas — the boxes the tree placed
+            // them in.
+            let visible_buffers = pane_rects.visible(
+                &self
+                    .windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.buffers.splits())
+                    .map(|(mgr, _)| mgr)
+                    .expect("active window must have a populated split layout")
+                    .visible_leaves(),
+            );
 
             let mut total_new_lines = 0usize;
             for (split_id, buffer_id, split_area) in visible_buffers {
@@ -894,7 +908,8 @@ impl Editor {
             .as_ref()
             .map(|s| s.chrome.clone())
             .unwrap_or_default();
-        let mut body = crate::app::shell_host::BodyPainter::new(self, body_state, pane_chrome);
+        let mut body =
+            crate::app::shell_host::BodyPainter::new(self, body_state, pane_chrome, pane_rects);
         let mut provenance = FoldProvenance { runs: Vec::new() };
         let pending_hardware_cursor = crate::view::shell::fold::fold_band(
             ui.spec(),
@@ -6954,25 +6969,27 @@ impl Editor {
             .shell_ui
             .take()
             .expect("the shell tree is taken and returned within one call");
+        crate::view::shell::geometry::stats::note_shell_layout();
         ui.layout_only(
             crate::view::shell::frame::frame_tree(shell),
             fresh_ui::Size::new(size.width, size.height),
         );
-        let regions = crate::view::shell::frame::regions_of(&ui, size);
+        // The panes, off this same layout — the shape every frame reads them
+        // in (`render` does the same after its `frame`). What stood here read
+        // the body's region and handed it to a pass that laid the grid out a
+        // third time to find the panes inside it.
+        let pane_rects = crate::view::shell::geometry::PaneRects::read(
+            &ui,
+            self.window_panes().into_iter().map(|(leaf, _)| leaf),
+            size,
+        );
         self.shell_ui = Some(ui);
-        let editor_content_area = regions
-            .iter()
-            .find(|(r, _)| *r == crate::view::shell::frame::HostRegion::Body)
-            .map(|(_, rect)| *rect)
-            .unwrap_or_default();
 
         // Compute layout for all visible splits and update cached view_line_mappings.
         // Take one &mut borrow on the active window's splits; destructure into
         // (&SplitManager, &mut HashMap<...>) so both arguments come from the
         // same `&mut self.windows` borrow.
         let active_window_id = self.active_window;
-        // The same resolution the frame's description and the paint both use.
-        let pane_chrome = self.pane_chrome();
         let __win_l = self
             .windows
             .get_mut(&active_window_id)
@@ -6982,7 +6999,7 @@ impl Editor {
             .buffers
             .with_all_mut(|buffers, mgr, vs_map| {
                 SplitRenderer::compute_content_layout(
-                    editor_content_area,
+                    &pane_rects,
                     &*mgr,
                     buffers,
                     vs_map,
@@ -6994,7 +7011,6 @@ impl Editor {
                     self.config.editor.use_terminal_bg,
                     self.session_mode || !self.software_cursor_only,
                     self.software_cursor_only,
-                    &pane_chrome,
                     self.config.editor.diagnostics_inline_text,
                     self.config.editor.show_tilde,
                     crate::view::bracket_highlight_overlay::BracketHighlightSettings::from_config(

--- a/crates/fresh-editor/src/app/shell_host.rs
+++ b/crates/fresh-editor/src/app/shell_host.rs
@@ -31,6 +31,7 @@ use ratatui::style::Style;
 
 use crate::app::Editor;
 use crate::model::event::LeafId;
+use crate::view::shell::geometry::PaneRects;
 use crate::view::shell::splits::PaneChrome;
 use crate::view::ui::split_rendering::{
     paint_leaf, paint_separators, prepare_content, record_scrollbar_theme_runs, ContentPass,
@@ -154,6 +155,15 @@ pub struct BodyPainter<'a> {
     /// [`crate::view::ui::split_rendering::orchestration::paint_leaf`] to skip
     /// the text pass. See `FrameFacts::described_panes`.
     described_panes: HashSet<LeafId>,
+    /// Where the frame put every pane, read off the tree `render` just laid
+    /// out — the same tree whose display list this painter is folded over.
+    ///
+    /// The body's pass used to ask `SplitManager::get_visible_buffers` for
+    /// this, which laid the grid out a second time in a scratch `Ui<()>`; a
+    /// pane's box came from that grid and its `Host` rect from the tree, and
+    /// only a parity test said the two agreed. Now there is one answer, and
+    /// [`Self::pane`] asserts the fold's rect is it.
+    rects: PaneRects,
 }
 
 impl<'a> BodyPainter<'a> {
@@ -161,6 +171,7 @@ impl<'a> BodyPainter<'a> {
         editor: &'a mut Editor,
         state: BodyState,
         pane_chrome: std::collections::HashMap<LeafId, PaneChrome>,
+        rects: PaneRects,
     ) -> Self {
         let scrollback = editor
             .windows
@@ -187,6 +198,7 @@ impl<'a> BodyPainter<'a> {
             pane_chrome,
             scrollback,
             described_panes,
+            rects,
         }
     }
 
@@ -223,6 +235,9 @@ impl<'a> BodyPainter<'a> {
     fn body(&mut self, area: Rect, buf: &mut Buffer) {
         let state = self.state;
         self.screen_width = buf.area.width;
+        // The pass keeps its own copy: a `ContentPass` is what the preview
+        // path builds for a grid with no painter, so it owns its rects.
+        let rects = self.rects.clone();
         self.pass = with_grid(
             self.editor,
             state,
@@ -231,13 +246,15 @@ impl<'a> BodyPainter<'a> {
             &self.scrollback,
             &self.described_panes,
             |facts, stores, mgr, window_chrome| {
-                let base_visible = mgr.get_visible_buffers(area);
+                // The panes at the boxes the tree placed them in — not a
+                // second layout of the grid into `area`.
+                let base_visible = rects.visible(&mgr.visible_leaves());
                 let pass = prepare_content(
+                    rects,
                     &base_visible,
                     mgr,
                     stores.split_view_states.as_deref_mut(),
                     facts.grouped_subtrees,
-                    facts.pane_chrome,
                     window_chrome,
                 );
                 paint_separators(buf, area, mgr, &base_visible, facts, stores);
@@ -266,6 +283,13 @@ impl<'a> BodyPainter<'a> {
         let Some(mut pane) = pass.visible.iter().copied().find(|(_, id, ..)| *id == leaf) else {
             return;
         };
+        // The fold's rect is the pane's node's, and the pass's rect was read
+        // off the same node before the fold: one layout, one answer.
+        debug_assert_eq!(
+            self.rects.pane(leaf),
+            Some(rect),
+            "pane {leaf:?}: the fold's rect is not the one the tree placed it at"
+        );
         pane.3 = rect;
         let state = self.state;
         let out = &mut self.out;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -3069,6 +3069,7 @@ mod tests {
         let chrome = Rect::new(30, 0, 50, 24);
         let shell = editor.shell_frame((Some(dock), chrome));
         let mut ui = editor.shell_ui.take().expect("the shell tree");
+        crate::view::shell::geometry::stats::note_shell_layout();
         ui.frame(
             crate::view::shell::frame::frame_tree(shell),
             fresh_ui::Size::new(80, 24),

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2897,13 +2897,7 @@ impl Window {
         let Some((mgr, vs_map)) = self.buffers.splits() else {
             return HashMap::new();
         };
-        mgr.visible_leaves()
-            .into_iter()
-            .filter_map(|(leaf, _)| {
-                let group = vs_map.get(&leaf)?.active_group_tab?;
-                Some((leaf, self.grouped_subtrees.get(&group)?.clone()))
-            })
-            .collect()
+        mgr.pane_groups(vs_map, &self.grouped_subtrees)
     }
 
     /// Which chrome each of this window's visible panes has, by leaf.

--- a/crates/fresh-editor/src/view/shell/geometry.rs
+++ b/crates/fresh-editor/src/view/shell/geometry.rs
@@ -1,0 +1,369 @@
+//! Where the frame put each pane — read once, off the `Ui` that laid the
+//! frame out.
+//!
+//! **One source of pane geometry per frame.** The render path used to lay
+//! the pane grid out more than once and three different ways: `Editor::render`
+//! laid out the shell tree, `SplitManager::get_leaves_with_rects` laid the
+//! *same* grid out again in a scratch `Ui<()>` to answer where the panes are,
+//! and the macro-replay path did a third — a `layout_only` of the shell, then
+//! `compute_content_layout`, which ran the scratch grid inside it. The scratch
+//! grid was a second implementation of the pane layout; where it disagreed
+//! with the tree by a cell, the painter's clip papered over it.
+//!
+//! [`PaneRects`] is the one answer. It is read off the shell's `Ui` right
+//! after the frame's layout — [`Ui::frame`](fresh_ui::Ui::frame) on the render
+//! path, [`Ui::layout_only`](fresh_ui::Ui::layout_only) on the replay path —
+//! and handed to everything that used to ask the scratch grid: the plugin
+//! `lines_changed` hooks, the body painter, and the layout-only pass. The keys
+//! it reads are the ones the description applies: [`leaf_key`] for the box a
+//! pane fills and [`content_key`] for the content slot inside it, past the
+//! strip and beside the scrollbar.
+//!
+//! **Never last frame's rect.** Every chrome toggle — the dock, the explorer,
+//! the menu bar, a separator drag — changes pane widths between frames, and a
+//! pane laid out at the old width is a visibly wrong frame, not a short one.
+//! The rects here are this frame's, from this frame's layout.
+//!
+//! The session preview is the one caller with no tree to read: it paints
+//! *another window's* grid offscreen, where this window's tree has no nodes.
+//! [`PaneRects::offscreen`] lays that grid out once, from the same description
+//! the frame uses (`splits::overlay`), and reads it the same way — one layout
+//! of one description, rather than a scratch grid plus a per-pane interior.
+
+use std::collections::HashMap;
+
+use ratatui::layout::Rect;
+
+use crate::model::event::{BufferId, LeafId};
+use crate::view::split::SplitNode;
+
+use super::msg::UiMsg;
+use super::splits::{content_key, leaf_key, overlay, Splits};
+
+/// The two rectangles a pane is: the box it fills, and its content slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PaneRect {
+    /// The pane's box (`leaf_key`): what its `Host` is painted into, strip and
+    /// scrollbars included.
+    pub pane: Rect,
+    /// The content slot (`content_key`): past the strip, beside the vertical
+    /// bar, above the horizontal one. What the buffer is laid out in.
+    pub content: Rect,
+}
+
+/// Where the frame put every pane it placed, by the pane.
+///
+/// Outer panes and the panels inside an active buffer group alike — a group's
+/// leaves are panes of the same grid, mounted in their outer pane's content
+/// slot, and the tree keys them the same way.
+#[derive(Clone, Debug, Default)]
+pub struct PaneRects {
+    by_pane: HashMap<LeafId, PaneRect>,
+}
+
+impl PaneRects {
+    /// Read off `ui` — the tree that laid this frame out — for each of `panes`
+    /// the tree placed. `size` is the frame's area; the rectangles come back
+    /// in screen coordinates.
+    ///
+    /// A pane with no node — one hidden behind a maximized sibling — is simply
+    /// absent. A zero-size pane is *not*: the scratch grid answered a zero
+    /// rectangle for it and the painter painted nothing in it, and this keeps
+    /// that shape rather than dropping the pane from the frame's list.
+    pub fn read(
+        ui: &fresh_ui::Ui<UiMsg>,
+        panes: impl IntoIterator<Item = LeafId>,
+        size: Rect,
+    ) -> Self {
+        let at = |key: fresh_ui::Key| -> Option<Rect> {
+            let e = ui.find_by_key(&key)?;
+            Some(super::screen_rect(ui.rect_of(e), size))
+        };
+        let by_pane = panes
+            .into_iter()
+            .filter_map(|id| {
+                let pane = at(leaf_key(id))?;
+                // The interior always keys its content slot; a pane with a
+                // box and no content node would be a description bug, and
+                // a zero rect there is what the painter does with it.
+                let content = at(content_key(id)).unwrap_or_default();
+                Some((id, PaneRect { pane, content }))
+            })
+            .collect();
+        Self { by_pane }
+    }
+
+    /// The same grid laid out offscreen at `area`, for a window the frame has
+    /// no nodes for.
+    ///
+    /// The session preview paints another window's panes into a rectangle of
+    /// this one's frame. That grid is described by the same `overlay` the
+    /// frame mounts, laid out once here at the preview's box, so the preview's
+    /// panes come off one layout of one description — the rule the render
+    /// path follows, applied to the one grid the render path's tree cannot
+    /// hold.
+    pub fn offscreen(s: &Splits, area: Rect) -> Self {
+        stats::note_offscreen_grid();
+        let mut ui: fresh_ui::Ui<UiMsg> = fresh_ui::Ui::new();
+        ui.frame(overlay(s), fresh_ui::Size::new(area.width, area.height));
+        Self::read(&ui, panes_of(s), area)
+    }
+
+    /// The box `pane` fills, if the tree placed it.
+    pub fn pane(&self, pane: LeafId) -> Option<Rect> {
+        self.by_pane.get(&pane).map(|r| r.pane)
+    }
+
+    /// `pane`'s content slot, if the tree placed it.
+    pub fn content(&self, pane: LeafId) -> Option<Rect> {
+        self.by_pane.get(&pane).map(|r| r.content)
+    }
+
+    /// `leaves`, each with the box it fills — the shape
+    /// `SplitManager::get_visible_buffers` answered in, so the callers that
+    /// took that list take this one.
+    ///
+    /// A leaf the tree did not place gets a zero rectangle, as the scratch
+    /// grid gave one it could not find; the set of leaves is the caller's,
+    /// and `SplitManager::visible_leaves` already leaves out what a maximized
+    /// pane hides.
+    pub fn visible(&self, leaves: &[(LeafId, BufferId)]) -> Vec<(LeafId, BufferId, Rect)> {
+        leaves
+            .iter()
+            .map(|(leaf, buffer)| (*leaf, *buffer, self.pane(*leaf).unwrap_or_default()))
+            .collect()
+    }
+}
+
+/// Every pane `s` describes: the grid's leaves — only the maximized one, when
+/// one is — and the panels of each pane's active group.
+///
+/// The same rule as `SplitManager::visible_leaves` plus `Window::pane_groups`,
+/// stated over the description because that is what the offscreen layout has.
+fn panes_of(s: &Splits) -> Vec<LeafId> {
+    let mut out: Vec<LeafId> = match s.maximized.and_then(|id| s.root.find(id.0)) {
+        Some(SplitNode::Leaf { split_id, .. }) => vec![*split_id],
+        _ => s
+            .root
+            .visible_leaves()
+            .into_iter()
+            .map(|(l, _)| l)
+            .collect(),
+    };
+    for g in s.groups.values() {
+        out.extend(g.visible_leaves().into_iter().map(|(l, _)| l));
+    }
+    out
+}
+
+/// How many times the pane grid was laid out, per frame.
+///
+/// The instrument Stage 2 of the retained-mode plan asks for: a count of
+/// shell layout passes and of scratch-grid layouts, so a test can pin "one
+/// shell layout, no scratch grid" per frame and per replayed action, and so
+/// the next path to lay the grid out a second time fails a test rather than
+/// hiding behind the clip.
+///
+/// Thread-local, because the editor renders on one thread and tests run one
+/// editor per thread. Counted only with debug assertions on; the release
+/// build pays nothing.
+pub mod stats {
+    #[cfg(debug_assertions)]
+    use std::cell::Cell;
+
+    #[cfg(debug_assertions)]
+    thread_local! {
+        static SHELL_LAYOUTS: Cell<u32> = const { Cell::new(0) };
+        static SCRATCH_GRIDS: Cell<u32> = const { Cell::new(0) };
+        static OFFSCREEN_GRIDS: Cell<u32> = const { Cell::new(0) };
+    }
+
+    /// The counts since the last [`take`].
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct LayoutCounts {
+        /// Layouts of the shell tree: `Ui::frame` on the render path,
+        /// `Ui::layout_only` on the replay path. One per frame is the rule.
+        pub shell: u32,
+        /// Scratch layouts of the pane grid in a `Ui<()>` —
+        /// `SplitNode::get_leaves_with_rects`. Zero on the render path is
+        /// the rule; its remaining callers are model queries and tests.
+        pub scratch_grids: u32,
+        /// Offscreen layouts of another window's grid, for the session
+        /// preview ([`super::PaneRects::offscreen`]). One per embedded
+        /// window painted.
+        pub offscreen_grids: u32,
+    }
+
+    #[inline]
+    pub fn note_shell_layout() {
+        #[cfg(debug_assertions)]
+        SHELL_LAYOUTS.with(|c| c.set(c.get().saturating_add(1)));
+    }
+
+    #[inline]
+    pub fn note_scratch_grid() {
+        #[cfg(debug_assertions)]
+        SCRATCH_GRIDS.with(|c| c.set(c.get().saturating_add(1)));
+    }
+
+    #[inline]
+    pub fn note_offscreen_grid() {
+        #[cfg(debug_assertions)]
+        OFFSCREEN_GRIDS.with(|c| c.set(c.get().saturating_add(1)));
+    }
+
+    /// The counts since the last call, which resets them.
+    #[cfg(debug_assertions)]
+    pub fn take() -> LayoutCounts {
+        LayoutCounts {
+            shell: SHELL_LAYOUTS.with(|c| c.replace(0)),
+            scratch_grids: SCRATCH_GRIDS.with(|c| c.replace(0)),
+            offscreen_grids: OFFSCREEN_GRIDS.with(|c| c.replace(0)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::event::SplitDirection;
+    use crate::view::shell::splits::PaneChrome;
+    use fresh_core::SplitId;
+
+    fn leaf(n: usize) -> SplitNode {
+        SplitNode::leaf(BufferId(n), SplitId(n))
+    }
+
+    fn split(dir: SplitDirection, a: SplitNode, b: SplitNode, ratio: f32, id: usize) -> SplitNode {
+        SplitNode::split(dir, a, b, ratio, SplitId(id))
+    }
+
+    fn id(n: usize) -> LeafId {
+        LeafId(SplitId(n))
+    }
+
+    fn chrome(tabs: bool, vscroll: bool, hscroll: bool) -> PaneChrome {
+        PaneChrome {
+            tabs,
+            vscroll,
+            hscroll,
+        }
+    }
+
+    /// The tree's answer is the scratch grid's answer, pane for pane, for the
+    /// box and for the content slot — which is what lets the scratch grid go.
+    #[test]
+    fn the_tree_places_panes_where_the_scratch_grid_did() {
+        let root = split(
+            SplitDirection::Vertical,
+            leaf(0),
+            split(SplitDirection::Horizontal, leaf(1), leaf(2), 0.3, 11),
+            0.6,
+            10,
+        );
+        let s = Splits {
+            root: root.clone(),
+            maximized: None,
+            chrome: [
+                (id(0), chrome(true, true, true)),
+                (id(1), chrome(true, false, false)),
+                (id(2), chrome(false, true, false)),
+            ]
+            .into_iter()
+            .collect(),
+            controls: Default::default(),
+            groups: Default::default(),
+            interiors: Default::default(),
+        };
+        let area = Rect::new(3, 2, 100, 40);
+        let _ = stats::take();
+        let rects = PaneRects::offscreen(&s, area);
+
+        let want = root.get_leaves_with_rects(area);
+        assert_eq!(want.len(), 3);
+        // The instrument sees both: the one offscreen layout, and the oracle's
+        // scratch grid.
+        assert_eq!(
+            stats::take(),
+            stats::LayoutCounts {
+                shell: 0,
+                scratch_grids: 1,
+                offscreen_grids: 1,
+            }
+        );
+        for (leaf, _, r) in want {
+            assert_eq!(rects.pane(leaf), Some(r), "{leaf:?}'s box");
+            let c = s.chrome[&leaf];
+            let content = crate::view::ui::split_rendering::layout::split_layout(leaf, r, c);
+            assert_eq!(
+                rects.content(leaf),
+                Some(content.content_rect),
+                "{leaf:?}'s content slot"
+            );
+        }
+    }
+
+    /// A maximized pane is the only one placed; the others are absent, not
+    /// zero — and `visible` gives a leaf the tree did not place a zero rect,
+    /// as the scratch grid did.
+    #[test]
+    fn a_maximized_pane_is_the_only_one_placed() {
+        let s = Splits {
+            root: split(SplitDirection::Vertical, leaf(0), leaf(1), 0.5, 10),
+            maximized: Some(id(1)),
+            chrome: Default::default(),
+            controls: Default::default(),
+            groups: Default::default(),
+            interiors: Default::default(),
+        };
+        let area = Rect::new(0, 0, 80, 24);
+        let rects = PaneRects::offscreen(&s, area);
+        assert_eq!(rects.pane(id(1)), Some(area));
+        assert_eq!(rects.pane(id(0)), None);
+        assert_eq!(
+            rects.visible(&[(id(0), BufferId(0))]),
+            vec![(id(0), BufferId(0), Rect::default())]
+        );
+    }
+
+    /// A group's panels are panes of the same grid: placed inside the outer
+    /// pane's content slot, and readable by their own keys.
+    #[test]
+    fn a_groups_panels_are_placed_inside_the_outer_panes_content() {
+        let group = SplitNode::Grouped {
+            split_id: id(50),
+            name: "g".into(),
+            layout: Box::new(split(SplitDirection::Vertical, leaf(20), leaf(21), 0.5, 30)),
+            active_inner_leaf: id(20),
+        };
+        let s = Splits {
+            root: leaf(0),
+            maximized: None,
+            chrome: [
+                (id(0), chrome(true, true, false)),
+                (id(20), chrome(false, true, false)),
+                (id(21), chrome(false, false, false)),
+            ]
+            .into_iter()
+            .collect(),
+            controls: Default::default(),
+            groups: [(id(0), group.clone())].into_iter().collect(),
+            interiors: Default::default(),
+        };
+        let area = Rect::new(0, 0, 80, 24);
+        let rects = PaneRects::offscreen(&s, area);
+        let outer = rects.content(id(0)).expect("the outer content slot");
+        assert_eq!(outer, Rect::new(0, 1, 79, 23));
+        let want = group.get_leaves_with_rects(outer);
+        assert_eq!(want.len(), 2);
+        for (leaf, _, r) in want {
+            assert_eq!(rects.pane(leaf), Some(r), "{leaf:?} inside the outer pane");
+        }
+        // A panel with a scrollbar column gives it up from its own box.
+        let inner = rects.pane(id(20)).unwrap();
+        assert_eq!(
+            rects.content(id(20)),
+            Some(Rect::new(inner.x, inner.y, inner.width - 1, inner.height))
+        );
+    }
+}

--- a/crates/fresh-editor/src/view/shell/mod.rs
+++ b/crates/fresh-editor/src/view/shell/mod.rs
@@ -30,6 +30,7 @@ pub mod file_browser;
 pub mod file_explorer;
 pub mod fold;
 pub mod frame;
+pub mod geometry;
 pub mod grip;
 pub mod input;
 pub mod keybinding;

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1924,33 +1924,30 @@ impl SplitManager {
             .collect()
     }
 
-    /// Get all split IDs that display a specific buffer
+    /// Get all split IDs that display a specific buffer.
+    ///
+    /// A question about the leaf set, answered from the leaf set. It used to
+    /// lay the grid out in a 1×1 probe to get the same list — which put a
+    /// scratch layout on the render path once per pane per frame, through
+    /// `update_menu_context`'s "same buffer in another split" check.
     pub fn splits_for_buffer(&self, target_buffer_id: BufferId) -> Vec<LeafId> {
         self.root
-            .get_leaves_with_rects(Rect {
-                x: 0,
-                y: 0,
-                width: 1,
-                height: 1,
-            })
+            .visible_leaves()
             .into_iter()
-            .filter(|(_, buffer_id, _)| *buffer_id == target_buffer_id)
-            .map(|(split_id, _, _)| split_id)
+            .filter(|(_, buffer_id)| *buffer_id == target_buffer_id)
+            .map(|(split_id, _)| split_id)
             .collect()
     }
 
-    /// Get the buffer ID for a specific leaf split
+    /// Get the buffer ID for a specific leaf split. See
+    /// [`Self::splits_for_buffer`] for why this walks the tree rather than
+    /// laying it out.
     pub fn buffer_for_split(&self, target_split_id: LeafId) -> Option<BufferId> {
         self.root
-            .get_leaves_with_rects(Rect {
-                x: 0,
-                y: 0,
-                width: 1,
-                height: 1,
-            })
+            .visible_leaves()
             .into_iter()
-            .find(|(split_id, _, _)| *split_id == target_split_id)
-            .map(|(_, buffer_id, _)| buffer_id)
+            .find(|(split_id, _)| *split_id == target_split_id)
+            .map(|(_, buffer_id)| buffer_id)
     }
 
     /// Maximize the active split (hide all other splits temporarily)

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -947,9 +947,20 @@ impl SplitNode {
     ///
     /// Laying out a fresh tree per call is what makes this affordable: a
     /// three-pane grid costs ~38µs cold in a debug build (measured in
-    /// `shell::splits`), against callers that run once a frame or on resize.
+    /// `shell::splits`), against callers that run on a window action or on
+    /// resize.
+    ///
+    /// **Not on the render path.** A frame reads its panes off the shell
+    /// tree it laid out — `view::shell::geometry::PaneRects` — because a
+    /// second layout of the same grid is a second answer, and where the two
+    /// differed by a cell the painter's clip hid it. What is left to this is
+    /// the model's own questions (which leaves show a buffer, a probe for the
+    /// leaf set) and the tests that use it as the oracle the tree is checked
+    /// against. `geometry::stats` counts every call so a frame that reaches
+    /// it again fails a test.
     pub fn get_leaves_with_rects(&self, rect: Rect) -> Vec<(LeafId, BufferId, Rect)> {
         use crate::view::shell::splits::{grid, leaf_key};
+        crate::view::shell::geometry::stats::note_scratch_grid();
         let mut ui: fresh_ui::Ui<()> = fresh_ui::Ui::new();
         ui.frame(
             grid::<()>(self, None),
@@ -1890,6 +1901,27 @@ impl SplitManager {
             let prev_pos = if pos == 0 { leaf_ids.len() } else { pos } - 1;
             self.active_split = leaf_ids[prev_pos];
         }
+    }
+
+    /// The buffer group each visible pane is showing, by the pane showing
+    /// it — the shape `view::shell::splits::Splits::groups` takes.
+    ///
+    /// A group's layout lives in `grouped_subtrees`, keyed by the *group's*
+    /// leaf, and a pane names the group it shows through its view state's
+    /// `active_group_tab`. This is the one join of the two; the frame's
+    /// description and the session preview's offscreen layout both take it.
+    pub fn pane_groups(
+        &self,
+        view_states: &HashMap<LeafId, SplitViewState>,
+        grouped_subtrees: &HashMap<LeafId, SplitNode>,
+    ) -> HashMap<LeafId, SplitNode> {
+        self.visible_leaves()
+            .into_iter()
+            .filter_map(|(leaf, _)| {
+                let group = view_states.get(&leaf)?.active_group_tab?;
+                Some((leaf, grouped_subtrees.get(&group)?.clone()))
+            })
+            .collect()
     }
 
     /// Get all split IDs that display a specific buffer

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -216,7 +216,7 @@ impl SplitRenderer {
 
     #[allow(clippy::too_many_arguments)]
     pub fn compute_content_layout(
-        area: Rect,
+        rects: &crate::view::shell::geometry::PaneRects,
         split_manager: &SplitManager,
         buffers: &mut HashMap<BufferId, EditorState>,
         split_view_states: &mut HashMap<LeafId, crate::view::split::SplitViewState>,
@@ -228,13 +228,12 @@ impl SplitRenderer {
         use_terminal_bg: bool,
         session_mode: bool,
         software_cursor_only: bool,
-        pane_chrome: &HashMap<LeafId, crate::view::shell::splits::PaneChrome>,
         diagnostics_inline_text: bool,
         show_tilde: bool,
         bracket_highlight: BracketHighlightSettings,
     ) -> HashMap<LeafId, Vec<ViewLineMapping>> {
         orchestration::compute_content_layout(
-            area,
+            rects,
             split_manager,
             buffers,
             split_view_states,
@@ -246,7 +245,6 @@ impl SplitRenderer {
             use_terminal_bg,
             session_mode,
             software_cursor_only,
-            pane_chrome,
             diagnostics_inline_text,
             show_tilde,
             bracket_highlight,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -37,6 +37,7 @@ use crate::model::event::{BufferId, EventLog, LeafId};
 use crate::state::EditorState;
 use crate::view::bracket_highlight_overlay::BracketHighlightSettings;
 use crate::view::folding::FoldManager;
+use crate::view::shell::geometry::PaneRects;
 use crate::view::shell::splits::{PaneChrome, PaneKind};
 use crate::view::split::SplitManager;
 use crate::view::ui::tabs::TabsRenderer;
@@ -85,6 +86,10 @@ pub(crate) struct ContentPass {
     pub window_chrome: PaneChrome,
     pub active_split_id: LeafId,
     pub has_multiple_splits: bool,
+    /// Where the frame put every pane, off the one layout that placed them.
+    /// The rects in `visible` came from here, and [`paint_leaf`] checks the
+    /// content rect it carves against it.
+    pub rects: PaneRects,
 }
 
 /// What every pane in a frame reads and none of them writes.
@@ -274,13 +279,36 @@ pub(crate) fn render_content(
         hscroll: style.cfg.show_horizontal_scrollbar,
     };
 
-    let base_visible = split_manager.get_visible_buffers(area);
+    // The preview's grid, laid out once from the same description the frame
+    // mounts — `splits::overlay` — at the preview's box. This is the one grid
+    // the frame's own tree has no nodes for, so it is the one place the
+    // render path lays a grid out beside the frame; what it no longer does
+    // is lay it out in a scratch `Ui<()>` and carve each pane's interior a
+    // second time from the result.
+    let rects = PaneRects::offscreen(
+        &crate::view::shell::splits::Splits {
+            root: split_manager.root().clone(),
+            maximized: split_manager.maximized_split().map(LeafId),
+            chrome: pane_chrome.clone(),
+            // The strip's buttons take their width from the tabs slot, never
+            // from the content, and the preview paints none.
+            controls: Default::default(),
+            groups: stores
+                .split_view_states
+                .as_deref()
+                .map(|vs| split_manager.pane_groups(vs, grouped_subtrees))
+                .unwrap_or_default(),
+            interiors: Default::default(),
+        },
+        area,
+    );
+    let base_visible = rects.visible(&split_manager.visible_leaves());
     let pass = prepare_content(
+        rects,
         &base_visible,
         split_manager,
         stores.split_view_states.as_deref_mut(),
         grouped_subtrees,
-        pane_chrome,
         window_chrome,
     );
 
@@ -348,25 +376,25 @@ pub(crate) fn paint_separators(
 }
 
 /// Resolve what every pane in this frame shares. See [`ContentPass`].
+///
+/// `rects` is where the frame put every pane, and `base_visible` is the
+/// split manager's visible leaves at the boxes `rects` gives them — the
+/// caller reads both off the same layout, which is the whole point.
 pub(crate) fn prepare_content(
+    rects: PaneRects,
     base_visible: &[(LeafId, BufferId, Rect)],
     split_manager: &SplitManager,
     split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
     grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
-    pane_chrome: &HashMap<LeafId, PaneChrome>,
     window_chrome: PaneChrome,
 ) -> ContentPass {
     ContentPass {
         // Expand any active buffer-group tabs into their inner panels.
-        visible: expand_visible_buffers(
-            base_visible,
-            split_view_states,
-            grouped_subtrees,
-            pane_chrome,
-        ),
+        visible: expand_visible_buffers(base_visible, split_view_states, grouped_subtrees, &rects),
         window_chrome,
         active_split_id: split_manager.active_split(),
         has_multiple_splits: base_visible.len() > 1,
+        rects,
     }
 }
 
@@ -514,6 +542,16 @@ pub(crate) fn paint_leaf(
     // `pane_interior` with those two flags off lays out. It used to be
     // four rectangles written by hand right here.
     let layout = split_layout(split_id, split_area, chrome);
+    // The content rect this carves is the one the tree's `content_key` node
+    // has: `pane_interior` is one statement laid out twice, at the pane's box
+    // here and inside the frame there. The clip below is a release safety
+    // net, not the contract — where the two ever differ, this says so.
+    if let Some(described) = pass.rects.content(split_id) {
+        debug_assert_eq!(
+            layout.content_rect, described,
+            "pane {split_id:?}: the content rect handed to the painter is not the tree's"
+        );
+    }
     let (split_buffers, tab_scroll_offset) = if is_inner_group_leaf {
         (Vec::new(), 0)
     } else {
@@ -908,11 +946,16 @@ pub(crate) fn paint_leaf(
 /// one [`RenderKind::InnerLeaf`] entry per panel. Inner-panel viewports are
 /// resized to their rendered rects so `editor.getViewport()` reports the panel
 /// size (not the terminal size) and resize timing stays correct.
+///
+/// A panel's rect is the tree's: the group's grid is mounted in the outer
+/// pane's content slot and each panel is keyed there like any pane, so
+/// `rects` answers for it. This used to carve the outer pane's content rect
+/// and lay the group out again in a scratch grid inside it.
 fn expand_visible_buffers(
     base_visible: &[(LeafId, BufferId, Rect)],
     mut split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
     grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
-    pane_chrome: &HashMap<LeafId, PaneChrome>,
+    rects: &PaneRects,
 ) -> Vec<VisibleBuffer> {
     let mut visible_buffers: Vec<VisibleBuffer> = Vec::new();
     for (main_split_id, main_buffer_id, split_area) in base_visible {
@@ -933,14 +976,8 @@ fn expand_visible_buffers(
             continue;
         };
 
-        // Compute the content rect for this main split (after its tab bar),
-        // then lay the group's leaves out within it.
-        let main_layout = split_layout(
-            *main_split_id,
-            *split_area,
-            pane_chrome.get(main_split_id).copied().unwrap_or_default(),
-        );
-        let inner_leaves = grouped.get_leaves_with_rects(main_layout.content_rect);
+        // The group's panels, at the boxes the tree placed them in.
+        let inner_leaves = rects.visible(&grouped.visible_leaves());
         visible_buffers.push((
             *main_split_id,
             *main_split_id,
@@ -1334,9 +1371,15 @@ pub(crate) fn record_scrollbar_theme_runs(
 /// Layout-only path: computes view_line_mappings for all visible splits
 /// without drawing anything. Used by macro replay to keep the cached layout
 /// fresh between actions without paying the cost of full rendering.
+///
+/// `rects` is where the shell's geometry pass put the panes — read off the
+/// same `Ui` the frame lays out, by the caller, after `layout_only`. This
+/// used to lay the grid out again in a scratch `Ui<()>` and carve each
+/// pane's interior from the result; the content rect it hands the viewport
+/// is the tree's now.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_content_layout(
-    area: Rect,
+    rects: &PaneRects,
     split_manager: &SplitManager,
     buffers: &mut HashMap<BufferId, EditorState>,
     split_view_states: &mut HashMap<LeafId, crate::view::split::SplitViewState>,
@@ -1348,23 +1391,19 @@ pub(crate) fn compute_content_layout(
     use_terminal_bg: bool,
     session_mode: bool,
     software_cursor_only: bool,
-    pane_chrome: &HashMap<LeafId, PaneChrome>,
     diagnostics_inline_text: bool,
     show_tilde: bool,
     bracket_highlight: BracketHighlightSettings,
 ) -> HashMap<LeafId, Vec<ViewLineMapping>> {
-    let visible_buffers = split_manager.get_visible_buffers(area);
     let active_split_id = split_manager.active_split();
     let mut view_line_mappings: HashMap<LeafId, Vec<ViewLineMapping>> = HashMap::new();
 
-    for (split_id, buffer_id, split_area) in visible_buffers {
+    for (split_id, buffer_id) in split_manager.visible_leaves() {
         let is_active = split_id == active_split_id;
 
-        let layout = split_layout(
-            split_id,
-            split_area,
-            pane_chrome.get(&split_id).copied().unwrap_or_default(),
-        );
+        // A leaf the tree did not place gets a zero rect, as the scratch
+        // grid gave one it could not find.
+        let content_rect = rects.content(split_id).unwrap_or_default();
 
         let state = match buffers.get_mut(&buffer_id) {
             Some(s) => s,
@@ -1382,10 +1421,7 @@ pub(crate) fn compute_content_layout(
             .get(&split_id)
             .map(|vs| vs.viewport.clone())
             .unwrap_or_else(|| {
-                crate::view::viewport::Viewport::new(
-                    layout.content_rect.width,
-                    layout.content_rect.height,
-                )
+                crate::view::viewport::Viewport::new(content_rect.width, content_rect.height)
             });
         let mut viewport = viewport_clone;
 
@@ -1416,7 +1452,7 @@ pub(crate) fn compute_content_layout(
             &mut viewport,
             &mut state.buffer,
             &split_cursors,
-            layout.content_rect,
+            content_rect,
             &hidden_ranges,
             split_compose_width,
             split_show_line_numbers,
@@ -1443,7 +1479,7 @@ pub(crate) fn compute_content_layout(
             &split_cursors,
             &mut viewport,
             folds,
-            layout.content_rect,
+            content_rect,
             is_active,
             theme,
             lsp_waiting,

--- a/crates/fresh-editor/tests/geometry_pass.rs
+++ b/crates/fresh-editor/tests/geometry_pass.rs
@@ -1,0 +1,106 @@
+//! One geometry pass per frame.
+//!
+//! Stage 2 of the retained-mode migration (Blocker A.3): pane content rects
+//! come off the same `Ui` that describes the frame, and there is exactly one
+//! source of pane geometry per frame. Before it, the render path laid the
+//! pane grid out three ways — the shell tree, a scratch `Ui<()>` in
+//! `SplitManager::get_leaves_with_rects`, and (on macro replay) a
+//! `layout_only` of the shell followed by the scratch grid again.
+//!
+//! `view::shell::geometry::stats` counts the passes; these tests pin the
+//! counts a frame and a replayed action are allowed: **one shell layout, no
+//! scratch grid**, over the shapes the grid takes — one pane, nested splits,
+//! a maximized pane, the explorer open and shut. The counters exist only
+//! with debug assertions on, which is what `cargo test` builds with.
+#![cfg(debug_assertions)]
+
+mod common;
+
+use common::harness::EditorTestHarness;
+use fresh::input::keybindings::Action;
+use fresh::view::shell::geometry::stats::{self, LayoutCounts};
+
+/// One frame's layout counts.
+fn frame(h: &mut EditorTestHarness) -> LayoutCounts {
+    let _ = stats::take();
+    h.render().expect("render");
+    stats::take()
+}
+
+/// One replayed action's geometry pass, as `play_macro` runs it between
+/// actions.
+fn replay(h: &mut EditorTestHarness) -> LayoutCounts {
+    let _ = stats::take();
+    h.editor_mut().recompute_layout(80, 24);
+    stats::take()
+}
+
+const ONE_PASS: LayoutCounts = LayoutCounts {
+    shell: 1,
+    scratch_grids: 0,
+    offscreen_grids: 0,
+};
+
+#[test]
+fn a_frame_lays_the_grid_out_once() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    assert_eq!(frame(&mut h), ONE_PASS, "a single pane");
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    assert_eq!(frame(&mut h), ONE_PASS, "two panes side by side");
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitHorizontal);
+    assert_eq!(frame(&mut h), ONE_PASS, "a nested split");
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::ToggleMaximizeSplit);
+    assert_eq!(frame(&mut h), ONE_PASS, "a maximized pane");
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::ToggleMaximizeSplit);
+    assert_eq!(frame(&mut h), ONE_PASS, "restored");
+}
+
+/// A chrome toggle changes every pane's width between frames; the frame after
+/// it still lays the grid out once, and the panes come off that layout — not
+/// last frame's.
+#[test]
+fn a_chrome_toggle_costs_no_second_layout() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    assert_eq!(frame(&mut h), ONE_PASS);
+
+    h.editor_mut().toggle_file_explorer();
+    assert_eq!(frame(&mut h), ONE_PASS, "explorer open");
+    h.editor_mut().toggle_file_explorer();
+    assert_eq!(frame(&mut h), ONE_PASS, "explorer shut");
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::ToggleTabBar);
+    assert_eq!(frame(&mut h), ONE_PASS, "no tab strip");
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::ToggleTabBar);
+    assert_eq!(frame(&mut h), ONE_PASS, "tab strip back");
+}
+
+/// Macro replay's geometry pass is the frame's, minus the frame: one
+/// `layout_only`, and the panes read off it. It used to be a layout of the
+/// shell *plus* the scratch grid inside `compute_content_layout`.
+#[test]
+fn a_replayed_action_lays_the_grid_out_once() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    h.render().expect("render");
+    assert_eq!(replay(&mut h), ONE_PASS, "a single pane");
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitHorizontal);
+    h.render().expect("render");
+    assert_eq!(replay(&mut h), ONE_PASS, "nested splits");
+
+    h.editor_mut().toggle_file_explorer();
+    assert_eq!(replay(&mut h), ONE_PASS, "explorer open, no frame between");
+}


### PR DESCRIPTION
## Summary

Stage 2 of the retained-mode TUI migration (Blocker A.3, plan §2b step 3 / §4 Stage 2): **pane content rects come off the same `Ui` that describes the frame, and there is exactly one source of pane geometry per frame.**

Before, the render path laid the pane grid out three ways:

1. `Editor::render` laid out the shell tree (`Ui::frame`).
2. `SplitManager::get_leaves_with_rects` laid the *same* grid out again in a scratch `Ui<()>` to answer where the panes are; the body painter, the plugin `lines_changed` hooks and `compute_content_layout` all asked it.
3. Macro replay did a `layout_only` of the shell, then ran `compute_content_layout`, which ran the scratch grid inside it.

The scratch grid was a second implementation of the pane layout. Where it disagreed with the tree by a cell, the painter's clip hid it.

## What moved

- **`view::shell::geometry::PaneRects`** (new): every pane's box (`leaf_key`) and content slot (`content_key`), read once off the shell `Ui` right after its layout, for outer panes and the panels inside an active buffer group alike. Never last frame's rect (rejected in §2b A.3: a chrome toggle changes pane widths between frames).
- **`Editor::render`** reads `PaneRects` after `ui.frame(...)` and hands it to the plugin hooks (in place of `get_visible_buffers`) and to `BodyPainter::new`.
- **`BodyPainter::body`** builds the frame's pass from those rects instead of `mgr.get_visible_buffers(area)`; `expand_visible_buffers` places a group's panels from the tree instead of carving the outer pane's content rect and laying the group out again; `viewport.resize` is driven by the tree's rect.
- **`compute_content_layout`** takes `&PaneRects` instead of the body area and a chrome map; the content rect it hands each viewport is `content_key`'s.
- **`recompute_layout`** (macro replay) reads `PaneRects` after `layout_only`, the same shape `render` uses, so replay and render share one code path for "where is pane X". The pre-frame `layout_only` + `frame` on a real frame is still two library layouts of one description, as the plan accepts for now; the scratch grid is gone.
- **Session preview** (`render_content`) paints another window's grid, which the frame's tree has no nodes for. `PaneRects::offscreen` lays that grid out once from the same `splits::overlay` description and reads it the same way — one layout of one description, in place of the scratch grid plus a per-pane interior carve.
- **`SplitManager::splits_for_buffer` / `buffer_for_split`** answered a leaf-set question by laying the grid out in a 1×1 probe; `update_menu_context` asked the second once per pane at the top of every frame. Both now read `visible_leaves()`.
- **`SplitManager::pane_groups`** states the pane→group join once; `Window::pane_groups` delegates to it and the preview uses it.

**Exit criterion:** `get_leaves_with_rects` has no caller in `render.rs` or `split_rendering/orchestration`. It stays for `window_actions.rs` and the tests that use it as the oracle the tree is checked against.

## Instrumentation

- `geometry::stats` counts shell layouts, scratch grids and offscreen grids per frame (debug assertions only; no cost in release).
- `tests/geometry_pass.rs` pins **one shell layout, zero scratch grids** per frame and per replayed action across a single pane, nested splits, a maximized pane, and explorer / tab-bar toggles.
- `debug_assert!`s: the fold's rect for a pane equals the one the tree placed it at (`BodyPainter::pane`), and the content rect the painter carves equals `content_key`'s (`paint_leaf`). The e2e corpus runs with debug assertions on, so any pane where the interior carve and the tree disagree fails a test instead of being clipped.
- Unit tests in `geometry.rs` pin the tree against the scratch grid (box and content slot), the maximized case, and a group's panels inside the outer pane's content slot.

## Layout-pass counts (per frame, N top-level panes)

| | shell layouts | scratch grids |
|---|---|---|
| render, before | 1 | 1 + N (grid, plus one 1×1 probe per pane from the menu context) + one per active group |
| render, after | 1 | 0 |
| replay action, before | 1 (`layout_only`) | 1 |
| replay action, after | 1 (`layout_only`) | 0 |

## Seam for Stage 1

`PaneRects::content(leaf)` is the rect a `reconcile_pane(leaf, rect)` step should take. `compute_buffer_layout`'s signature and `render_buffer.rs` are untouched.

## Not in scope

`ChromeLayout`, `find_by_key`, the `Splits` clone, the per-pane `split_layout` interior carve (asserted equal to the tree, not replaced), and `fresh-ui` paint code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSxjKGEexLUTRWxPbLmeef

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSxjKGEexLUTRWxPbLmeef)_