### PR TITLE
Retained-mode Stage 1: scroll and margins out of paint

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -424,6 +424,36 @@ impl Editor {
         use crate::view::shell::frame::HostRegion;
         let status_bar_area = region(HostRegion::StatusBar);
         let editor_content_area = region(HostRegion::Body);
+
+        // The chrome each pane has, resolved with the shell's description of
+        // the same grid — read by the reconcile below and by the body's
+        // painter further down, so both lay the panes out the same way.
+        let pane_chrome = shell
+            .splits
+            .as_ref()
+            .map(|s| s.chrome.clone())
+            .unwrap_or_default();
+
+        // **Every text pane is reconciled here, before anything reads it.**
+        // The viewport's size, the byte and row placement of the cursor, the
+        // buffer's margins and its wrap index used to be brought up to date
+        // *inside* the paint, pane by pane, which is what made the formatter
+        // write the model and build its rows up to three times. Now the tree
+        // is laid out and `pane_rects` says where every pane is, so each pane
+        // is settled once at the content rect it will be painted at — the
+        // `lines_changed` hooks below offer the lines the frame will draw,
+        // and the fold's text pass is a read. The `BodyState` here is the
+        // painter's hover and caret state, which the reconcile does not read.
+        let prepared_grid = {
+            let _s = tracing::info_span!("reconcile_panes").entered();
+            crate::app::shell_host::reconcile_body(
+                self,
+                crate::app::shell_host::BodyState::default(),
+                &pane_rects,
+                size.width,
+                &pane_chrome,
+            )
+        };
         // Where the sidebar wants the hardware caret (its selected row) when it
         // owns the keyboard.
         //
@@ -903,13 +933,13 @@ impl Editor {
         // editor for the painter to find. One producer, one consumer, one
         // frame — a field for that is a value that could not be threaded, and
         // it is the same map the description above already carries.
-        let pane_chrome = shell
-            .splits
-            .as_ref()
-            .map(|s| s.chrome.clone())
-            .unwrap_or_default();
-        let mut body =
-            crate::app::shell_host::BodyPainter::new(self, body_state, pane_chrome, pane_rects);
+        let mut body = crate::app::shell_host::BodyPainter::new(
+            self,
+            body_state,
+            pane_chrome,
+            pane_rects,
+            prepared_grid,
+        );
         let mut provenance = FoldProvenance { runs: Vec::new() };
         let pending_hardware_cursor = crate::view::shell::fold::fold_band(
             ui.spec(),

--- a/crates/fresh-editor/src/app/shell_host.rs
+++ b/crates/fresh-editor/src/app/shell_host.rs
@@ -30,12 +30,12 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 
 use crate::app::Editor;
-use crate::model::event::LeafId;
+use crate::model::event::{BufferId, LeafId};
 use crate::view::shell::geometry::PaneRects;
 use crate::view::shell::splits::PaneChrome;
 use crate::view::ui::split_rendering::{
-    paint_leaf, paint_separators, prepare_content, record_scrollbar_theme_runs, ContentPass,
-    FrameFacts, Stores,
+    paint_leaf, paint_separators, prepare_content, reconcile_panes, record_scrollbar_theme_runs,
+    ContentPass, FrameFacts, Stores,
 };
 use crate::view::ui::{EditorRenderConfig, RenderStyle};
 
@@ -164,6 +164,19 @@ pub struct BodyPainter<'a> {
     /// only a parity test said the two agreed. Now there is one answer, and
     /// [`Self::pane`] asserts the fold's rect is it.
     rects: PaneRects,
+    /// The grid as [`reconcile_body`] prepared it for this frame, taken by
+    /// [`Self::body`] so the panes are prepared once per frame — preparing
+    /// them again would resize a buffer group's inner panels back to their
+    /// panel rects after the reconcile sized them to their content rects,
+    /// and the text pass would wrap at a width nobody placed for.
+    prepared: Option<PreparedGrid>,
+}
+
+/// What [`reconcile_body`] prepared: the frame's panes, in paint order, and
+/// the split manager's leaves the separators are drawn between.
+pub struct PreparedGrid {
+    base_visible: Vec<(LeafId, BufferId, Rect)>,
+    pass: ContentPass,
 }
 
 impl<'a> BodyPainter<'a> {
@@ -172,23 +185,9 @@ impl<'a> BodyPainter<'a> {
         state: BodyState,
         pane_chrome: std::collections::HashMap<LeafId, PaneChrome>,
         rects: PaneRects,
+        prepared: Option<PreparedGrid>,
     ) -> Self {
-        let scrollback = editor
-            .windows
-            .get(&editor.active_window)
-            .and_then(|win| {
-                win.buffers.splits().map(|(_, vs_map)| {
-                    vs_map
-                        .iter()
-                        .filter(|(leaf, svs)| {
-                            win.split_terminal_scrollback(**leaf, svs.active_buffer)
-                        })
-                        .map(|(leaf, _)| *leaf)
-                        .collect()
-                })
-            })
-            .unwrap_or_default();
-        let described_panes = editor.described_panes();
+        let (scrollback, described_panes) = frame_pane_sets(editor);
         Self {
             editor,
             state,
@@ -199,6 +198,7 @@ impl<'a> BodyPainter<'a> {
             scrollback,
             described_panes,
             rects,
+            prepared,
         }
     }
 
@@ -238,6 +238,9 @@ impl<'a> BodyPainter<'a> {
         // The pass keeps its own copy: a `ContentPass` is what the preview
         // path builds for a grid with no painter, so it owns its rects.
         let rects = self.rects.clone();
+        // The reconcile prepared the grid for this frame; prepare it again
+        // only when nothing did (a caller that folds without reconciling).
+        let prepared = self.prepared.take();
         self.pass = with_grid(
             self.editor,
             state,
@@ -246,17 +249,20 @@ impl<'a> BodyPainter<'a> {
             &self.scrollback,
             &self.described_panes,
             |facts, stores, mgr, window_chrome| {
-                // The panes at the boxes the tree placed them in — not a
-                // second layout of the grid into `area`.
-                let base_visible = rects.visible(&mgr.visible_leaves());
-                let pass = prepare_content(
-                    rects,
-                    &base_visible,
-                    mgr,
-                    stores.split_view_states.as_deref_mut(),
-                    facts.grouped_subtrees,
-                    window_chrome,
-                );
+                let PreparedGrid { base_visible, pass } = prepared.unwrap_or_else(|| {
+                    // The panes at the boxes the tree placed them in — not a
+                    // second layout of the grid into `area`.
+                    let base_visible = rects.visible(&mgr.visible_leaves());
+                    let pass = prepare_content(
+                        rects,
+                        &base_visible,
+                        mgr,
+                        stores.split_view_states.as_deref_mut(),
+                        facts.grouped_subtrees,
+                        window_chrome,
+                    );
+                    PreparedGrid { base_visible, pass }
+                });
                 paint_separators(buf, area, mgr, &base_visible, facts, stores);
                 pass
             },
@@ -305,6 +311,69 @@ impl<'a> BodyPainter<'a> {
             },
         );
     }
+}
+
+/// The two per-frame sets every pane's paint reads: the splits showing a
+/// terminal in read-only scrollback, and the panes the tree describes instead
+/// of painting. Gathered once per frame — a `paint_host` call is per pane.
+fn frame_pane_sets(editor: &Editor) -> (HashSet<LeafId>, HashSet<LeafId>) {
+    let scrollback = editor
+        .windows
+        .get(&editor.active_window)
+        .and_then(|win| {
+            win.buffers.splits().map(|(_, vs_map)| {
+                vs_map
+                    .iter()
+                    .filter(|(leaf, svs)| win.split_terminal_scrollback(**leaf, svs.active_buffer))
+                    .map(|(leaf, _)| *leaf)
+                    .collect()
+            })
+        })
+        .unwrap_or_default();
+    (scrollback, editor.described_panes())
+}
+
+/// Reconcile every text pane of the frame about to be painted — see
+/// `orchestration::reconcile`.
+///
+/// **Before the frame's paint, at the frame's rectangles.** `rects` is where
+/// the tree just laid out put every pane, and each pane is settled at the
+/// content rect the painter will format it into. `render` calls this once
+/// the tree is laid out and before the `lines_changed` hooks, so everything
+/// after it in the frame reads a settled viewport.
+///
+/// Returns the prepared grid for [`BodyPainter::new`], so the fold paints
+/// the panes this reconciled rather than preparing them a second time.
+pub fn reconcile_body(
+    editor: &mut Editor,
+    state: BodyState,
+    rects: &PaneRects,
+    screen_width: u16,
+    pane_chrome: &std::collections::HashMap<LeafId, PaneChrome>,
+) -> Option<PreparedGrid> {
+    let (scrollback, described_panes) = frame_pane_sets(editor);
+    let rects = rects.clone();
+    with_grid(
+        editor,
+        state,
+        screen_width,
+        pane_chrome,
+        &scrollback,
+        &described_panes,
+        |facts, stores, mgr, window_chrome| {
+            let base_visible = rects.visible(&mgr.visible_leaves());
+            let pass = prepare_content(
+                rects,
+                &base_visible,
+                mgr,
+                stores.split_view_states.as_deref_mut(),
+                facts.grouped_subtrees,
+                window_chrome,
+            );
+            reconcile_panes(&pass, facts, stores);
+            PreparedGrid { base_visible, pass }
+        },
+    )
 }
 
 /// Assemble the grid's borrows off the editor and hand them to `f`.

--- a/crates/fresh-editor/src/test_api.rs
+++ b/crates/fresh-editor/src/test_api.rs
@@ -29,6 +29,11 @@
 // one-directional contract documented in §2.1 of the design doc.
 pub use crate::input::keybindings::Action;
 
+// The text pipeline's frame-cost counters (`view::ui::split_rendering::instrument`):
+// how many panes a frame placed, formatted and built rows for. The e2e harness
+// asserts the three agree around every frame.
+pub use crate::view::ui::split_rendering::instrument::{snapshot as frame_counters, FrameCounters};
+
 /// A test-side projection of `crate::model::cursor::Cursor`.
 ///
 /// Carries only the fields that semantic tests typically assert on

--- a/crates/fresh-editor/src/view/margin.rs
+++ b/crates/fresh-editor/src/view/margin.rs
@@ -630,14 +630,28 @@ impl MarginManager {
     /// Update the left margin width based on buffer size.
     /// Only adjusts width when `show_line_numbers` is true.
     pub fn update_width_for_buffer(&mut self, buffer_total_lines: usize, show_line_numbers: bool) {
-        if show_line_numbers {
-            let digits = if buffer_total_lines == 0 {
-                1
-            } else {
-                ((buffer_total_lines as f64).log10().floor() as usize) + 1
-            };
-            self.left_config.width = digits.max(MIN_LINE_NUMBER_DIGITS);
-        }
+        update_left_width_for_buffer(&mut self.left_config, buffer_total_lines, show_line_numbers);
+    }
+
+    /// What [`Self::configure_for_line_numbers`] followed by
+    /// [`Self::update_width_for_buffer`] would leave `left_config` as —
+    /// computed without writing it.
+    ///
+    /// The margin state is per *buffer* while line-number visibility is per
+    /// *split*, so two panes showing one buffer can want two gutters in the
+    /// same frame. The render path resolves each pane's gutter from this and
+    /// reads only the value; the pre-frame reconcile writes it back so the
+    /// readers between frames (mouse mapping, `left_total_width`) see the
+    /// last pane's, as they always did.
+    pub fn resolved_left_config(
+        &self,
+        show_line_numbers: bool,
+        buffer_total_lines: usize,
+    ) -> MarginConfig {
+        let mut cfg = self.left_config.clone();
+        configure_left_for_line_numbers(&mut cfg, show_line_numbers);
+        update_left_width_for_buffer(&mut cfg, buffer_total_lines, show_line_numbers);
+        cfg
     }
 
     /// Get the total width of the left margin (including separator)
@@ -655,26 +669,11 @@ impl MarginManager {
     ///
     /// This adjusts `left_config.enabled` and `left_config.width` so that
     /// `left_total_width()` returns the correct gutter size for the given
-    /// `show_line_numbers` setting. Called at render time with the per-split
-    /// line number state.
+    /// `show_line_numbers` setting. Called with the per-split line number
+    /// state — by the pre-frame reconcile on the render path, and by the
+    /// appliers that flip the setting between frames.
     pub fn configure_for_line_numbers(&mut self, show_line_numbers: bool) {
-        if !show_line_numbers {
-            // Hide the line-number digits and the separator, but keep the gutter
-            // enabled with a zero-width number column so the 1-char indicator
-            // slot survives. This lets diagnostic / git / fold indicators still
-            // render in compose mode (issue #2146) without showing line numbers
-            // or the `│` separator. The render layer draws this slot in the
-            // compose desk margin so it doesn't shrink the text width.
-            self.left_config.width = 0;
-            self.left_config.enabled = true;
-            self.left_config.show_separator = false;
-        } else {
-            self.left_config.enabled = true;
-            self.left_config.show_separator = true;
-            if self.left_config.width == 0 {
-                self.left_config.width = MIN_LINE_NUMBER_DIGITS;
-            }
-        }
+        configure_left_for_line_numbers(&mut self.left_config, show_line_numbers);
     }
 
     /// Get the number of annotations in a position
@@ -683,6 +682,43 @@ impl MarginManager {
             MarginPosition::Left => self.left_annotations.values().map(|v| v.len()).sum(),
             MarginPosition::Right => self.right_annotations.values().map(|v| v.len()).sum(),
         }
+    }
+}
+
+/// Body of [`MarginManager::configure_for_line_numbers`], on a config value.
+fn configure_left_for_line_numbers(cfg: &mut MarginConfig, show_line_numbers: bool) {
+    if !show_line_numbers {
+        // Hide the line-number digits and the separator, but keep the gutter
+        // enabled with a zero-width number column so the 1-char indicator
+        // slot survives. This lets diagnostic / git / fold indicators still
+        // render in compose mode (issue #2146) without showing line numbers
+        // or the `│` separator. The render layer draws this slot in the
+        // compose desk margin so it doesn't shrink the text width.
+        cfg.width = 0;
+        cfg.enabled = true;
+        cfg.show_separator = false;
+    } else {
+        cfg.enabled = true;
+        cfg.show_separator = true;
+        if cfg.width == 0 {
+            cfg.width = MIN_LINE_NUMBER_DIGITS;
+        }
+    }
+}
+
+/// Body of [`MarginManager::update_width_for_buffer`], on a config value.
+fn update_left_width_for_buffer(
+    cfg: &mut MarginConfig,
+    buffer_total_lines: usize,
+    show_line_numbers: bool,
+) {
+    if show_line_numbers {
+        let digits = if buffer_total_lines == 0 {
+            1
+        } else {
+            ((buffer_total_lines as f64).log10().floor() as usize) + 1
+        };
+        cfg.width = digits.max(MIN_LINE_NUMBER_DIGITS);
     }
 }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
@@ -24,6 +24,8 @@ use std::collections::{BTreeMap, HashSet};
 /// `render_left_margin` and the orchestration code that prepares its input.
 pub(super) struct LeftMarginContext<'a> {
     pub state: &'a EditorState,
+    /// The pane's resolved left margin; see `LineRenderInput::margin`.
+    pub margin: &'a crate::view::margin::MarginConfig,
     pub theme: &'a Theme,
     pub is_continuation: bool,
     /// Line-start byte offset for fold/diagnostic/indicator lookups (None for continuations).
@@ -55,7 +57,7 @@ pub(super) fn render_left_margin(
     line_spans: &mut Vec<Span<'static>>,
     line_view_map: &mut Vec<Option<usize>>,
 ) {
-    if !ctx.state.margins.left_config.enabled {
+    if !ctx.margin.enabled {
         return;
     }
 
@@ -128,7 +130,7 @@ pub(super) fn render_left_margin(
     let use_cursor_line_bg = is_cursor_line && ctx.highlight_current_line && ctx.is_active;
 
     if ctx.is_continuation {
-        let blank = " ".repeat(ctx.state.margins.left_config.width);
+        let blank = " ".repeat(ctx.margin.width);
         let mut style = Style::default().fg(ctx.theme.line_number_fg);
         if use_cursor_line_bg {
             style = style.bg(ctx.theme.current_line_bg);
@@ -138,7 +140,7 @@ pub(super) fn render_left_margin(
         let rendered_text = format!(
             "{:>width$}",
             ctx.gutter_num,
-            width = ctx.state.margins.left_config.width
+            width = ctx.margin.width
         );
         let mut margin_style = if is_cursor_line {
             Style::default().fg(ctx.theme.editor_fg)
@@ -158,7 +160,7 @@ pub(super) fn render_left_margin(
         let rendered_text = format!(
             "{:>width$}",
             display_num,
-            width = ctx.state.margins.left_config.width
+            width = ctx.margin.width
         );
         let mut margin_style = if is_cursor_line {
             Style::default().fg(ctx.theme.editor_fg)
@@ -176,7 +178,7 @@ pub(super) fn render_left_margin(
             ctx.estimated_lines,
             ctx.show_line_numbers,
         );
-        let (rendered_text, style_opt) = margin_content.render(ctx.state.margins.left_config.width);
+        let (rendered_text, style_opt) = margin_content.render(ctx.margin.width);
 
         let mut margin_style =
             style_opt.unwrap_or_else(|| Style::default().fg(ctx.theme.line_number_fg));
@@ -187,7 +189,7 @@ pub(super) fn render_left_margin(
         push_span_with_map(line_spans, line_view_map, rendered_text, margin_style, None);
     }
 
-    if ctx.state.margins.left_config.show_separator {
+    if ctx.margin.show_separator {
         let mut separator_style = Style::default().fg(ctx.theme.line_number_fg);
         if use_cursor_line_bg {
             separator_style = separator_style.bg(ctx.theme.current_line_bg);
@@ -195,7 +197,7 @@ pub(super) fn render_left_margin(
         push_span_with_map(
             line_spans,
             line_view_map,
-            ctx.state.margins.left_config.separator.clone(),
+            ctx.margin.separator.clone(),
             separator_style,
             None,
         );

--- a/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
@@ -137,11 +137,7 @@ pub(super) fn render_left_margin(
         }
         push_span_with_map(line_spans, line_view_map, blank, style, None);
     } else if ctx.byte_offset_mode && ctx.show_line_numbers {
-        let rendered_text = format!(
-            "{:>width$}",
-            ctx.gutter_num,
-            width = ctx.margin.width
-        );
+        let rendered_text = format!("{:>width$}", ctx.gutter_num, width = ctx.margin.width);
         let mut margin_style = if is_cursor_line {
             Style::default().fg(ctx.theme.editor_fg)
         } else {
@@ -157,11 +153,7 @@ pub(super) fn render_left_margin(
         } else {
             ctx.gutter_num.abs_diff(ctx.cursor_line_number)
         };
-        let rendered_text = format!(
-            "{:>width$}",
-            display_num,
-            width = ctx.margin.width
-        );
+        let rendered_text = format!("{:>width$}", display_num, width = ctx.margin.width);
         let mut margin_style = if is_cursor_line {
             Style::default().fg(ctx.theme.editor_fg)
         } else {

--- a/crates/fresh-editor/src/view/ui/split_rendering/instrument.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/instrument.rs
@@ -1,0 +1,77 @@
+//! Frame-cost instruments for the text pipeline.
+//!
+//! Three counters, kept per thread so that tests running in parallel each
+//! see only their own frames:
+//!
+//! - `pane_placements`: [`super::orchestration::reconcile::place_pane`] ran —
+//!   a pane's viewport, margins and wrap index were settled for a frame;
+//! - `buffer_layouts`: `compute_buffer_layout` ran — a pane was formatted;
+//! - `view_data_builds`: `build_view_data` ran — a pane's rows were built.
+//!
+//! The invariant the retained-mode migration rests on is that these three
+//! advance in lockstep: **a visible text pane is placed once, formatted
+//! once, and has its rows built once per frame.** The test harness asserts
+//! it around every `Editor::render`; `tests/e2e/frame_once_per_pane.rs`
+//! asserts the count against the number of panes on screen.
+//!
+//! Always compiled — three relaxed increments per pane per frame cost
+//! nothing measurable — and read only through `test_api::frame_counters`.
+
+use std::cell::Cell;
+
+/// A snapshot of the counters. Differences between two snapshots taken
+/// around a frame are that frame's cost.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FrameCounters {
+    pub pane_placements: u64,
+    pub buffer_layouts: u64,
+    pub view_data_builds: u64,
+}
+
+impl FrameCounters {
+    /// What happened between `earlier` and `self`.
+    pub fn since(self, earlier: FrameCounters) -> FrameCounters {
+        FrameCounters {
+            pane_placements: self.pane_placements - earlier.pane_placements,
+            buffer_layouts: self.buffer_layouts - earlier.buffer_layouts,
+            view_data_builds: self.view_data_builds - earlier.view_data_builds,
+        }
+    }
+}
+
+thread_local! {
+    static COUNTERS: Cell<FrameCounters> = const { Cell::new(FrameCounters {
+        pane_placements: 0,
+        buffer_layouts: 0,
+        view_data_builds: 0,
+    }) };
+}
+
+/// The counters as they stand on this thread.
+pub fn snapshot() -> FrameCounters {
+    COUNTERS.with(|c| c.get())
+}
+
+pub(crate) fn count_pane_placement() {
+    COUNTERS.with(|c| {
+        let mut v = c.get();
+        v.pane_placements += 1;
+        c.set(v);
+    });
+}
+
+pub(crate) fn count_buffer_layout() {
+    COUNTERS.with(|c| {
+        let mut v = c.get();
+        v.buffer_layouts += 1;
+        c.set(v);
+    });
+}
+
+pub(crate) fn count_view_data_build() {
+    COUNTERS.with(|c| {
+        let mut v = c.get();
+        v.view_data_builds += 1;
+        c.set(v);
+    });
+}

--- a/crates/fresh-editor/src/view/ui/split_rendering/instrument.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/instrument.rs
@@ -6,13 +6,18 @@
 //! - `pane_placements`: [`super::orchestration::reconcile::place_pane`] ran —
 //!   a pane's viewport, margins and wrap index were settled for a frame;
 //! - `buffer_layouts`: `compute_buffer_layout` ran — a pane was formatted;
-//! - `view_data_builds`: `build_view_data` ran — a pane's rows were built.
+//! - `view_data_builds`: `build_view_data` ran — a pane's rows were built;
+//! - `composite_builds`: a side of a composite (side-by-side diff) pane
+//!   built its rows. The composite pipeline formats each side itself
+//!   (`render_composite_buffer`), once per side per frame, outside
+//!   `compute_buffer_layout`.
 //!
-//! The invariant the retained-mode migration rests on is that these three
-//! advance in lockstep: **a visible text pane is placed once, formatted
-//! once, and has its rows built once per frame.** The test harness asserts
-//! it around every `Editor::render`; `tests/e2e/frame_once_per_pane.rs`
-//! asserts the count against the number of panes on screen.
+//! The invariant the retained-mode migration rests on is that these advance
+//! in lockstep: **a visible text pane is placed once, formatted once, and has
+//! its rows built once per frame** — `placements == layouts` and
+//! `builds == layouts + composite_builds`. The test harness asserts it around
+//! every `Editor::render`; `tests/e2e/frame_once_per_pane.rs` asserts the
+//! count against the number of panes on screen.
 //!
 //! Always compiled — three relaxed increments per pane per frame cost
 //! nothing measurable — and read only through `test_api::frame_counters`.
@@ -26,6 +31,7 @@ pub struct FrameCounters {
     pub pane_placements: u64,
     pub buffer_layouts: u64,
     pub view_data_builds: u64,
+    pub composite_builds: u64,
 }
 
 impl FrameCounters {
@@ -35,6 +41,7 @@ impl FrameCounters {
             pane_placements: self.pane_placements - earlier.pane_placements,
             buffer_layouts: self.buffer_layouts - earlier.buffer_layouts,
             view_data_builds: self.view_data_builds - earlier.view_data_builds,
+            composite_builds: self.composite_builds - earlier.composite_builds,
         }
     }
 }
@@ -44,6 +51,7 @@ thread_local! {
         pane_placements: 0,
         buffer_layouts: 0,
         view_data_builds: 0,
+        composite_builds: 0,
     }) };
 }
 
@@ -72,6 +80,14 @@ pub(crate) fn count_view_data_build() {
     COUNTERS.with(|c| {
         let mut v = c.get();
         v.view_data_builds += 1;
+        c.set(v);
+    });
+}
+
+pub(crate) fn count_composite_build() {
+    COUNTERS.with(|c| {
+        let mut v = c.get();
+        v.composite_builds += 1;
         c.set(v);
     });
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -527,6 +527,7 @@ mod tests {
         let mut dummy_theme_map = Vec::new();
         let output = render_view_lines(LineRenderInput {
             state: &state,
+            margin: &state.margins.left_config,
             theme: &theme,
             view_lines: &view_data.lines,
             view_anchor,
@@ -639,6 +640,7 @@ mod tests {
         let mut dummy_theme_map = Vec::new();
         render_view_lines(LineRenderInput {
             state: &state,
+            margin: &state.margins.left_config,
             theme: &theme,
             view_lines: &view_data.lines,
             view_anchor,
@@ -3301,6 +3303,7 @@ mod tests {
 
         render_view_lines(LineRenderInput {
             state: &state,
+            margin: &state.margins.left_config,
             theme: &theme,
             view_lines: &view_data.lines,
             view_anchor,

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -17,6 +17,7 @@ mod char_style;
 mod folding;
 pub(crate) use folding::fold_skip_set;
 mod gutter;
+pub mod instrument;
 pub(crate) mod layout;
 mod orchestration;
 
@@ -26,8 +27,8 @@ mod orchestration;
 // rectangle is the one layout gave it.
 pub(crate) use orchestration::render_buffer::wrap_index_geometry_for;
 pub(crate) use orchestration::{
-    paint_leaf, paint_separators, prepare_content, record_scrollbar_theme_runs, ContentPass,
-    FrameFacts, PaneAreas, Stores,
+    paint_leaf, paint_separators, prepare_content, reconcile_panes, record_scrollbar_theme_runs,
+    ContentPass, FrameFacts, PaneAreas, Stores,
 };
 mod post_pass;
 pub(crate) mod scrollbar;
@@ -292,7 +293,21 @@ impl SplitRenderer {
         // - pending_hardware_cursor: the preview must not move the
         //   terminal's hardware cursor away from the prompt input.
         let mut sink: Option<(u16, u16)> = None;
-        orchestration::render_buffer_in_split(
+        // The leaf is outside the split tree, so the frame's pre-paint
+        // reconcile never saw it: place it here, immediately before its
+        // text pass. Only the formatter's half — this pane never ran the
+        // byte-oriented sync, and does not now.
+        orchestration::reconcile::place_pane(
+            state,
+            viewport,
+            cursors,
+            folds,
+            &view_mode,
+            compose_width,
+            show_line_numbers,
+            area,
+        );
+        let text = orchestration::render_buffer_in_split(
             buf,
             state,
             cursors,
@@ -318,7 +333,11 @@ impl SplitRenderer {
             cell_theme_map,
             screen_width,
             &mut sink,
-        )
+        );
+        // No horizontal scrollbar here; store the column the rows were
+        // drawn with.
+        orchestration::reconcile::settle_pane(state, viewport, text.left_column, false);
+        text.view_line_mappings
     }
 
     /// Public wrapper for building base tokens - used by render.rs for the

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -13,6 +13,7 @@
 pub(super) mod contexts;
 pub(super) mod overlay_sweep;
 pub(super) mod overlays;
+pub(crate) mod reconcile;
 pub(super) mod render_buffer;
 pub(super) mod render_composite;
 pub(super) mod render_line;
@@ -21,12 +22,11 @@ pub(super) mod tail_fill;
 
 use super::base_tokens::build_base_tokens;
 use super::layout::{
-    render_separator, resolve_view_preferences, split_buffers_for_tabs, split_layout,
-    sync_viewport_to_content, SplitLayout,
+    render_separator, resolve_view_preferences, split_buffers_for_tabs, split_layout, SplitLayout,
 };
 use super::scrollbar::{
-    compute_max_line_length, project_scrollbar_markers, render_composite_scrollbar,
-    render_horizontal_scrollbar, render_scrollbar, scrollbar_line_counts,
+    project_scrollbar_markers, render_composite_scrollbar, render_horizontal_scrollbar,
+    render_scrollbar, scrollbar_line_counts,
 };
 use super::EditorRenderConfig;
 use crate::app::types::ViewLineMapping;
@@ -36,10 +36,9 @@ use crate::model::buffer::Buffer;
 use crate::model::event::{BufferId, EventLog, LeafId};
 use crate::state::EditorState;
 use crate::view::bracket_highlight_overlay::BracketHighlightSettings;
-use crate::view::folding::FoldManager;
 use crate::view::shell::geometry::PaneRects;
 use crate::view::shell::splits::{PaneChrome, PaneKind};
-use crate::view::split::SplitManager;
+use crate::view::split::{SplitManager, SplitViewState};
 use crate::view::ui::tabs::TabsRenderer;
 use crate::view::ui::RenderStyle;
 use ratatui::layout::Rect;
@@ -50,6 +49,7 @@ use render_buffer::compute_buffer_layout;
 // Re-exported one level up (split_rendering::SplitRenderer) so the
 // `render_phantom_leaf` façade can forward into the per-leaf
 // pipeline. Stays crate-private; callers use the façade.
+use reconcile::{reconcile_pane, settle_pane, ReconcileInputs};
 pub(super) use render_buffer::render_buffer_in_split;
 use render_composite::render_composite_buffer;
 use std::collections::HashMap;
@@ -312,6 +312,12 @@ pub(crate) fn render_content(
         window_chrome,
     );
 
+    // The preview's panes are nobody else's to reconcile: this window's tree
+    // does not describe them, so the frame's pre-paint reconcile never saw
+    // them. Same step, same order, at the same rectangles — just before the
+    // paint rather than before the frame.
+    reconcile_panes(&pass, &facts, &mut stores);
+
     let mut out = PaneAreas::default();
     for pane in pass.visible.iter().copied() {
         paint_leaf(
@@ -430,8 +436,8 @@ pub(crate) fn paint_leaf(
         buffer_metadata,
         preview_buffer,
         grouped_subtrees,
-        pane_chrome,
-        scrollback_view_splits,
+        pane_chrome: _,
+        scrollback_view_splits: _,
         described_panes,
         lsp_waiting,
         hide_cursor,
@@ -453,7 +459,6 @@ pub(crate) fn paint_leaf(
         hide_current_line_on_selection,
         ..
     } = style.cfg;
-    let window_chrome = pass.window_chrome;
     let active_split_id = pass.active_split_id;
     let has_multiple_splits = pass.has_multiple_splits;
     let buffers = &mut *s.buffers;
@@ -509,29 +514,7 @@ pub(crate) fn paint_leaf(
             .is_some_and(|vs| vs.hide_tilde)
         && !active_buf_is_terminal;
 
-    // What this pane is, in the parts that decide its chrome — the
-    // scrollbars a `Fixed` panel never had, and the column a terminal
-    // gives up while it streams its live PTY grid (per split, so one
-    // terminal in two panes can differ — fresh#2595). The rule that
-    // narrows the window's offer by these is `PaneChrome::resolve`, and
-    // the shell's description resolves the same one for the same pane.
-    let chrome = if is_inner_group_leaf {
-        PaneChrome::resolve(
-            window_chrome,
-            PaneKind {
-                inner_group_leaf: true,
-                suppress_chrome: split_view_states
-                    .as_deref()
-                    .and_then(|svs| svs.get(&split_id))
-                    .is_some_and(|vs| vs.suppress_chrome),
-                scrollable: buffers.get(&buffer_id).is_none_or(|s| s.scrollable),
-                terminal_live_grid: active_buf_is_terminal
-                    && !scrollback_view_splits.contains(&split_id),
-            },
-        )
-    } else {
-        pane_chrome.get(&split_id).copied().unwrap_or_default()
-    };
+    let chrome = resolve_pane_chrome(pane, f, pass, buffers, split_view_states.as_deref());
     let split_tab_bar_visible = chrome.tabs;
     // A pane whose content is pinned to its size: it earns no scrollbar,
     // and its viewport does not scroll to follow the cursor either — the
@@ -662,69 +645,19 @@ pub(crate) fn paint_leaf(
     let event_log_opt = event_logs.get_mut(&buffer_id);
 
     if let Some(state) = state_opt {
-        // Get viewport from SplitViewState (authoritative source)
-        // We need to get it mutably for sync operations
-        // Use as_deref() to get Option<&HashMap> for read-only operations
-        let view_state_opt = split_view_states
-            .as_deref()
-            .and_then(|vs| vs.get(&split_id));
-        let viewport_clone = view_state_opt
-            .map(|vs| vs.viewport.clone())
-            .unwrap_or_else(|| {
-                crate::view::viewport::Viewport::new(
-                    layout.content_rect.width,
-                    layout.content_rect.height,
-                )
-            });
-        let mut viewport = viewport_clone;
-
-        // Get cursors from the split's view state
-        let split_cursors = split_view_states
-            .as_deref()
-            .and_then(|vs| vs.get(&split_id))
-            .map(|vs| vs.cursors.clone())
-            .unwrap_or_default();
-        // Resolve hidden fold byte ranges so ensure_visible can skip
-        // folded lines when counting distance to the cursor.
-        let hidden_ranges: Vec<(usize, usize)> = split_view_states
-            .as_deref()
-            .and_then(|vs| vs.get(&split_id))
-            .map(|vs| {
-                vs.folds
-                    .resolved_ranges(&state.buffer, &state.marker_list)
-                    .into_iter()
-                    .map(|r| (r.start_byte, r.end_byte))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        {
-            let _span = tracing::trace_span!("sync_viewport_to_content").entered();
-            let (split_compose_width, split_show_line_numbers) = split_view_states
-                .as_deref()
-                .and_then(|vs| vs.get(&split_id))
-                .map(|vs| (vs.compose_width, vs.show_line_numbers))
-                .unwrap_or((None, true));
-            sync_viewport_to_content(
-                &mut viewport,
-                &mut state.buffer,
-                &split_cursors,
-                layout.content_rect,
-                &hidden_ranges,
-                split_compose_width,
-                split_show_line_numbers,
-                is_non_scrollable,
-                state.buffer_settings.virtual_space,
-            );
-        }
         let view_prefs = resolve_view_preferences(state, split_view_states.as_deref(), split_id);
 
         // When cursors are hidden, also suppress current-line highlighting
         // and selection rendering so the buffer appears fully non-interactive.
         let has_selection = hide_current_line_on_selection
-            && split_cursors
-                .iter()
-                .any(|(_, c)| c.selection_range().is_some());
+            && split_view_states
+                .as_deref()
+                .and_then(|vs| vs.get(&split_id))
+                .is_some_and(|vs| {
+                    vs.cursors
+                        .iter()
+                        .any(|(_, c)| c.selection_range().is_some())
+                });
         let effective_highlight_current_line =
             view_prefs.highlight_current_line && state.show_cursors && !has_selection;
 
@@ -769,45 +702,55 @@ pub(crate) fn paint_leaf(
                 is_virtual_buffer,
             });
 
-        // Per-(split, buffer) pin, read before the mutable folds borrow.
+        // Per-(split, buffer) pin, read before the mutable view-state borrow.
         let fold_indicators_visible = split_view_states
             .as_deref()
             .and_then(|vs| vs.get(&split_id))
             .map(|vs| vs.fold_indicators_visible())
             .unwrap_or(true);
-        let mut empty_folds = FoldManager::new();
-        let folds = split_view_states
-            .as_deref_mut()
-            .and_then(|vs| vs.get_mut(&split_id))
-            .map(|vs| &mut vs.folds)
-            .unwrap_or(&mut empty_folds);
+
+        // The pane's view state — the authoritative viewport, cursors and
+        // folds, reconciled for this frame before any pane was painted
+        // (`reconcile_panes`). Read here; the one thing the text pass
+        // decides from its rows is stored by `settle_pane` below.
+        //
+        // A caller with no view states (none today; kept for the façade's
+        // contract) gets a fresh one, placed here because nothing else did.
+        let mut fallback_view: Option<SplitViewState> = None;
+        let vs: &mut SplitViewState = match split_view_states.and_then(|m| m.get_mut(&split_id)) {
+            Some(vs) => vs,
+            None => {
+                let fresh = fallback_view.insert(SplitViewState::with_buffer(
+                    layout.content_rect.width,
+                    layout.content_rect.height,
+                    buffer_id,
+                ));
+                reconcile_pane(
+                    state,
+                    fresh.active_state_mut(),
+                    ReconcileInputs {
+                        content_rect: layout.content_rect,
+                        pin_to_top: is_non_scrollable,
+                        show_horizontal_scrollbar,
+                    },
+                );
+                fresh
+            }
+        };
+        let bvs = vs.active_state_mut();
         // Resolved here, while the split's folds are in hand: the scrollbar
         // reads the same row space the render does, and that space now
         // excludes collapsed lines.
-        let scrollbar_fold_ranges = state.fold_ranges(folds);
+        let scrollbar_fold_ranges = state.fold_ranges(&bvs.folds);
 
         let _render_buf_span = tracing::trace_span!("render_buffer_in_split").entered();
 
-        // Use a previously discovered bound so an extra wheel step cannot
-        // paint a blank frame before the post-render scan refreshes it.
-        if show_horizontal_scrollbar
-            && !viewport.line_wrap_enabled
-            && viewport.max_line_length_seen > 0
-        {
-            let visible_width = viewport.width as usize;
-            let max_scroll = viewport
-                .max_line_length_seen
-                .max(visible_width)
-                .saturating_sub(visible_width);
-            viewport.left_column = viewport.left_column.min(max_scroll);
-        }
-
-        let split_view_mappings = render_buffer_in_split(
+        let text = render_buffer_in_split(
             buf,
             state,
-            &split_cursors,
-            &mut viewport,
-            folds,
+            &bvs.cursors,
+            &bvs.viewport,
+            &bvs.folds,
             event_log_opt,
             layout.content_rect,
             is_active,
@@ -833,7 +776,7 @@ pub(crate) fn paint_leaf(
         drop(_render_buf_span);
 
         // Store view line mappings for mouse click handling
-        view_line_mappings.insert(split_id, split_view_mappings);
+        view_line_mappings.insert(split_id, text.view_line_mappings);
 
         // For small files, count actual lines for accurate scrollbar
         // For large files, we'll use a constant thumb size
@@ -842,7 +785,7 @@ pub(crate) fn paint_leaf(
             let _span = tracing::trace_span!("scrollbar_line_counts").entered();
             scrollbar_line_counts(
                 state,
-                &viewport,
+                &bvs.viewport,
                 large_file_threshold_bytes,
                 buffer_len,
                 scrollbar_fold_ranges,
@@ -862,7 +805,7 @@ pub(crate) fn paint_leaf(
             render_scrollbar(
                 buf,
                 state,
-                &viewport,
+                &bvs.viewport,
                 layout.scrollbar_rect,
                 is_active,
                 theme,
@@ -875,25 +818,21 @@ pub(crate) fn paint_leaf(
             (0, 0)
         };
 
-        // Compute the actual max line length for horizontal scrollbar
-        let max_content_width = if show_horizontal_scrollbar && !viewport.line_wrap_enabled {
-            let mcw = compute_max_line_length(state, &mut viewport);
-            // Clamp left_column so content can't scroll past the end of the longest line
-            let visible_width = viewport.width as usize;
-            let max_scroll = mcw.saturating_sub(visible_width);
-            if viewport.left_column > max_scroll {
-                viewport.left_column = max_scroll;
-            }
-            mcw
-        } else {
-            0
-        };
+        // Store the column the rows were drawn with, and refresh the
+        // horizontal scrollbar's bound from the lines that were on screen.
+        // This is the pane's only write to its view state during the paint.
+        let max_content_width = settle_pane(
+            state,
+            &mut bvs.viewport,
+            text.left_column,
+            show_horizontal_scrollbar,
+        );
 
         // Render horizontal scrollbar for this split
         let (hthumb_start, hthumb_end) = if chrome.hscroll {
             render_horizontal_scrollbar(
                 buf,
-                &viewport,
+                &bvs.viewport,
                 layout.horizontal_scrollbar_rect,
                 is_active,
                 theme,
@@ -902,22 +841,6 @@ pub(crate) fn paint_leaf(
         } else {
             (0, 0)
         };
-
-        // Write back updated viewport to SplitViewState
-        // This is crucial for cursor visibility tracking (ensure_visible_in_layout updates)
-        // NOTE: We do NOT clear skip_ensure_visible here - it should persist across
-        // renders until something actually needs cursor visibility check
-        if let Some(view_states) = split_view_states.as_deref_mut() {
-            if let Some(view_state) = view_states.get_mut(&split_id) {
-                tracing::trace!(
-                    "Writing back viewport: top_byte={}, top_view_line_offset={}, skip_ensure_visible={}",
-                    viewport.top_byte(),
-                    viewport.top_view_line_offset(),
-                    viewport.should_skip_ensure_visible()
-                );
-                view_state.viewport = viewport.clone();
-            }
-        }
 
         // Store the areas for mouse handling
         split_areas.push((split_id, buffer_id, thumb_start, thumb_end));
@@ -938,6 +861,117 @@ pub(crate) fn paint_leaf(
                 hthumb_end,
             ));
         }
+    }
+}
+
+/// The chrome one pane has this frame: the scrollbars a `Fixed` panel never
+/// had, and the column a terminal gives up while it streams its live PTY
+/// grid (per split, so one terminal in two panes can differ — fresh#2595).
+/// The rule that narrows the window's offer by these is
+/// `PaneChrome::resolve`, and the shell's description resolves the same one
+/// for the same pane. Shared by the paint and the reconcile before it, so
+/// both lay the pane out at one content rect.
+fn resolve_pane_chrome(
+    pane: VisibleBuffer,
+    f: &FrameFacts<'_>,
+    pass: &ContentPass,
+    buffers: &HashMap<BufferId, EditorState>,
+    split_view_states: Option<&HashMap<LeafId, SplitViewState>>,
+) -> PaneChrome {
+    let (_, split_id, buffer_id, _, kind) = pane;
+    if kind != RenderKind::InnerLeaf {
+        return f.pane_chrome.get(&split_id).copied().unwrap_or_default();
+    }
+    let active_buf_is_terminal = f
+        .buffer_metadata
+        .get(&buffer_id)
+        .and_then(|m| m.virtual_mode())
+        .is_some_and(|m| m == "terminal");
+    PaneChrome::resolve(
+        pass.window_chrome,
+        PaneKind {
+            inner_group_leaf: true,
+            suppress_chrome: split_view_states
+                .and_then(|svs| svs.get(&split_id))
+                .is_some_and(|vs| vs.suppress_chrome),
+            scrollable: buffers.get(&buffer_id).is_none_or(|s| s.scrollable),
+            terminal_live_grid: active_buf_is_terminal
+                && !f.scrollback_view_splits.contains(&split_id),
+        },
+    )
+}
+
+/// Whether [`paint_leaf`] runs the text pass for this pane — as opposed to
+/// painting only its tab strip (a group's outer pane), leaving it to the
+/// tree (a described panel), painting the empty-workspace hint, or handing
+/// it to the composite pipeline. The same four gates, in the same order.
+fn pane_has_text_pass(
+    pane: VisibleBuffer,
+    f: &FrameFacts<'_>,
+    buffers: &HashMap<BufferId, EditorState>,
+) -> bool {
+    let (_, split_id, buffer_id, _, kind) = pane;
+    if kind == RenderKind::GroupTabBarOnly {
+        return false;
+    }
+    if f.described_panes.contains(&split_id) {
+        return false;
+    }
+    if f.buffer_metadata
+        .get(&buffer_id)
+        .is_some_and(|m| m.synthetic_placeholder)
+    {
+        return false;
+    }
+    buffers
+        .get(&buffer_id)
+        .is_some_and(|s| !s.is_composite_buffer)
+}
+
+/// Reconcile every pane of the frame that has a text pass, in paint order,
+/// at the content rect [`paint_leaf`] will format it into.
+///
+/// **Before the frame, not during it.** The shell calls this once the tree
+/// is laid out and before the `lines_changed` hooks and the fold; the
+/// preview and replay paths call it just ahead of their own pass. Each
+/// pane's viewport, margins and wrap index are then settled, and the text
+/// pass is a read.
+pub(crate) fn reconcile_panes(pass: &ContentPass, f: &FrameFacts<'_>, s: &mut Stores<'_>) {
+    let _span = tracing::trace_span!("reconcile_panes").entered();
+    let show_horizontal_scrollbar = f.style.cfg.show_horizontal_scrollbar;
+    for pane in pass.visible.iter().copied() {
+        let (_, split_id, buffer_id, split_area, _) = pane;
+        if !pane_has_text_pass(pane, f, s.buffers) {
+            continue;
+        }
+        // The content rect the tree placed the pane's text at; the painter
+        // carves the same one from the pane's box and asserts they agree.
+        let content_rect = pass.rects.content(split_id).unwrap_or_else(|| {
+            let chrome =
+                resolve_pane_chrome(pane, f, pass, s.buffers, s.split_view_states.as_deref());
+            split_layout(split_id, split_area, chrome).content_rect
+        });
+        let Some(state) = s.buffers.get_mut(&buffer_id) else {
+            continue;
+        };
+        let Some(vs) = s
+            .split_view_states
+            .as_deref_mut()
+            .and_then(|m| m.get_mut(&split_id))
+        else {
+            continue;
+        };
+        reconcile_pane(
+            state,
+            vs.active_state_mut(),
+            ReconcileInputs {
+                content_rect,
+                // A pane whose content is pinned to its size does not scroll
+                // to follow the cursor.
+                pin_to_top: !state.scrollable,
+                show_horizontal_scrollbar,
+            },
+        );
     }
 }
 
@@ -1416,49 +1450,6 @@ pub(crate) fn compute_content_layout(
             continue;
         }
 
-        // Get viewport from SplitViewState (authoritative source)
-        let viewport_clone = split_view_states
-            .get(&split_id)
-            .map(|vs| vs.viewport.clone())
-            .unwrap_or_else(|| {
-                crate::view::viewport::Viewport::new(content_rect.width, content_rect.height)
-            });
-        let mut viewport = viewport_clone;
-
-        // Get cursors from the split's view state
-        let split_cursors = split_view_states
-            .get(&split_id)
-            .map(|vs| vs.cursors.clone())
-            .unwrap_or_default();
-        // Resolve hidden fold byte ranges so ensure_visible can skip
-        // folded lines when counting distance to the cursor.
-        let hidden_ranges: Vec<(usize, usize)> = split_view_states
-            .get(&split_id)
-            .map(|vs| {
-                vs.folds
-                    .resolved_ranges(&state.buffer, &state.marker_list)
-                    .into_iter()
-                    .map(|r| (r.start_byte, r.end_byte))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let (split_compose_width, split_show_line_numbers) = split_view_states
-            .get(&split_id)
-            .map(|vs| (vs.compose_width, vs.show_line_numbers))
-            .unwrap_or((None, true));
-        let pin_to_top = !state.scrollable;
-        sync_viewport_to_content(
-            &mut viewport,
-            &mut state.buffer,
-            &split_cursors,
-            content_rect,
-            &hidden_ranges,
-            split_compose_width,
-            split_show_line_numbers,
-            pin_to_top,
-            state.buffer_settings.virtual_space,
-        );
         let view_prefs = resolve_view_preferences(state, Some(&*split_view_states), split_id);
 
         let effective_highlight_current_line =
@@ -1468,17 +1459,38 @@ pub(crate) fn compute_content_layout(
             .get(&split_id)
             .map(|vs| vs.fold_indicators_visible())
             .unwrap_or(true);
-        let mut empty_folds = FoldManager::new();
-        let folds = split_view_states
-            .get_mut(&split_id)
-            .map(|vs| &mut vs.folds)
-            .unwrap_or(&mut empty_folds);
+
+        // The split's view state — the authoritative viewport, cursors and
+        // folds. A split without one (none today) gets a fresh state that is
+        // laid out and dropped, as it always was.
+        let mut fallback_view: Option<SplitViewState> = None;
+        let vs: &mut SplitViewState = match split_view_states.get_mut(&split_id) {
+            Some(vs) => vs,
+            None => fallback_view.insert(SplitViewState::with_buffer(
+                content_rect.width,
+                content_rect.height,
+                buffer_id,
+            )),
+        };
+        let pin_to_top = !state.scrollable;
+        // The replay never paints, so it never scans for the longest line;
+        // the horizontal-scrollbar clamps stay off here as they were.
+        reconcile_pane(
+            state,
+            vs.active_state_mut(),
+            ReconcileInputs {
+                content_rect: content_rect,
+                pin_to_top,
+                show_horizontal_scrollbar: false,
+            },
+        );
+        let bvs = vs.active_state_mut();
 
         let layout_output = compute_buffer_layout(
             state,
-            &split_cursors,
-            &mut viewport,
-            folds,
+            &bvs.cursors,
+            &bvs.viewport,
+            &bvs.folds,
             content_rect,
             is_active,
             theme,
@@ -1503,12 +1515,9 @@ pub(crate) fn compute_content_layout(
             None, // No cell theme map for layout-only computation
         );
 
+        // Store the column the rows were laid out with.
+        settle_pane(state, &mut bvs.viewport, layout_output.left_column, false);
         view_line_mappings.insert(split_id, layout_output.view_line_mappings);
-
-        // Write back updated viewport to SplitViewState
-        if let Some(view_state) = split_view_states.get_mut(&split_id) {
-            view_state.viewport = viewport;
-        }
     }
 
     view_line_mappings

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/reconcile.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/reconcile.rs
@@ -1,0 +1,355 @@
+//! Pre-frame reconciliation of a text pane.
+//!
+//! Everything the formatter ([`super::render_buffer::compute_buffer_layout`])
+//! used to *write* while a frame was being painted lives here, and runs
+//! before the frame's description is painted — once per visible pane, in
+//! paint order, with the rectangle the pane will be painted at:
+//!
+//! 1. the viewport's size and the per-split mirrors (`compose_width`,
+//!    `show_line_numbers`), then the byte-oriented `ensure_visible`
+//!    ([`sync_viewport_to_content`]);
+//! 2. the horizontal-scrollbar clamp against the last known longest line;
+//! 3. the buffer's shared margin state, written from this pane's resolved
+//!    gutter ([`resolve_gutter_layout`]);
+//! 4. the wrap index for the pane's geometry (`ensure_built`) and the
+//!    row-space vertical placement (`ensure_visible_in_rows`), which sets
+//!    `row_pass_owns_placement` for the byte pass of the next frame;
+//! 5. the same-buffer scroll-sync's scroll-to-end, in row space.
+//!
+//! With these out of the way the formatter is a read of `(state, viewport,
+//! rect)` and builds its rows exactly once. The two placement decisions that
+//! genuinely need the built rows — the cursor's visual column for horizontal
+//! scroll, and the longest visible line for the horizontal scrollbar's bound —
+//! are computed by the formatter *as values* and stored by [`settle_pane`]
+//! after the pane has painted, which is when the writing form used to store
+//! them.
+//!
+//! **Order is behaviour.** The steps above run in the order the paint path
+//! ran them, so every flag that one step sets and a later one reads
+//! (`row_pass_owns_placement`, the resize-sync and ensure-visible skips) is
+//! read at the same point in the frame it was before.
+
+use super::super::layout::sync_viewport_to_content;
+use super::super::scrollbar::{
+    compute_max_line_length, MAX_WRAP_SCROLLBAR_BYTES, MAX_WRAP_SCROLLBAR_LINES,
+};
+use super::render_buffer::{resolve_gutter_layout, wrap_index_geometry_for};
+use crate::model::cursor::Cursors;
+use crate::state::{EditorState, ViewMode};
+use crate::view::folding::FoldManager;
+use crate::view::split::BufferViewState;
+use crate::view::viewport::{CursorLineExpansion, Viewport};
+use ratatui::layout::Rect;
+
+/// What a pane's reconcile needs beyond the view state.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ReconcileInputs {
+    /// The rectangle the pane's text is formatted into — the pane's content
+    /// rect, after its tab strip and scrollbars.
+    pub content_rect: Rect,
+    /// A pinned (non-scrollable) panel owns its own content window, so its
+    /// buffer viewport stays anchored at the top.
+    pub pin_to_top: bool,
+    /// Whether the horizontal scrollbar is shown, which is what gates the
+    /// `left_column` clamps against the longest line seen.
+    pub show_horizontal_scrollbar: bool,
+}
+
+/// Reconcile one pane's view state for the frame about to be painted.
+///
+/// `view` is the split's state for the buffer it shows; `state` is that
+/// buffer. Runs the byte pass, the scrollbar clamp, and then [`place_pane`].
+pub(crate) fn reconcile_pane(
+    state: &mut EditorState,
+    view: &mut BufferViewState,
+    inputs: ReconcileInputs,
+) {
+    let _span = tracing::trace_span!("reconcile_pane").entered();
+    let BufferViewState {
+        viewport,
+        cursors,
+        folds,
+        view_mode,
+        compose_width,
+        show_line_numbers,
+        ..
+    } = view;
+
+    // Resolve hidden fold byte ranges so ensure_visible can skip folded
+    // lines when counting distance to the cursor.
+    let hidden_ranges: Vec<(usize, usize)> = folds
+        .resolved_ranges(&state.buffer, &state.marker_list)
+        .into_iter()
+        .map(|r| (r.start_byte, r.end_byte))
+        .collect();
+
+    {
+        let _span = tracing::trace_span!("sync_viewport_to_content").entered();
+        sync_viewport_to_content(
+            viewport,
+            &mut state.buffer,
+            cursors,
+            inputs.content_rect,
+            &hidden_ranges,
+            *compose_width,
+            *show_line_numbers,
+            inputs.pin_to_top,
+            state.buffer_settings.virtual_space,
+        );
+    }
+
+    // Use a previously discovered bound so an extra wheel step cannot
+    // paint a blank frame before the post-paint scan refreshes it.
+    if inputs.show_horizontal_scrollbar
+        && !viewport.line_wrap_enabled
+        && viewport.max_line_length_seen > 0
+    {
+        let visible_width = viewport.width as usize;
+        let max_scroll = viewport
+            .max_line_length_seen
+            .max(visible_width)
+            .saturating_sub(visible_width);
+        viewport.left_column = viewport.left_column.min(max_scroll);
+    }
+
+    place_pane(
+        state,
+        viewport,
+        cursors,
+        folds,
+        view_mode,
+        *compose_width,
+        *show_line_numbers,
+        inputs.content_rect,
+    );
+}
+
+/// The formatter's half of the reconcile: margins, the wrap index, row-space
+/// placement, and the scroll-to-end sync. Everything `compute_buffer_layout`
+/// wrote before it built its rows, in the order it wrote it.
+///
+/// Callers that never ran the byte pass (the overlay preview's phantom leaf)
+/// call this directly; everything else comes through [`reconcile_pane`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn place_pane(
+    state: &mut EditorState,
+    viewport: &mut Viewport,
+    cursors: &Cursors,
+    folds: &FoldManager,
+    view_mode: &ViewMode,
+    compose_width: Option<u16>,
+    show_line_numbers: bool,
+    area: Rect,
+) {
+    let _span = tracing::trace_span!("place_pane").entered();
+    super::super::instrument::count_pane_placement();
+    let line_wrap = viewport.line_wrap_enabled;
+
+    // The buffer's shared margin state is what the readers between frames
+    // (mouse mapping, `left_total_width`) consult. It holds the last
+    // reconciled pane's gutter, as it used to hold the last painted pane's;
+    // the frame itself reads each pane's own resolved gutter.
+    let gutter = resolve_gutter_layout(
+        &state.margins,
+        show_line_numbers,
+        view_mode,
+        area,
+        compose_width,
+        gutter_estimated_lines(state),
+    );
+    state.margins.left_config = gutter.margin;
+
+    // This split's cursor byte positions, for cursor-dependent conceal /
+    // soft-break activation (evaluated per frame, per split — cursor
+    // movement changes what's active without any marker churn).
+    let cursor_positions = cursors.positions();
+
+    // Decide the scroll before anything is built. In row space the wrap index
+    // answers "which row is the cursor on" directly, so the common case — a
+    // cursor that has drifted into the scroll margin — is settled with no rows
+    // built at all.
+    //
+    // Build the index if it is stale, then place. With repair keeping the
+    // version current across text edits, a stale index here means a
+    // decoration batch arrived — compose's `lines_changed` round-trip — and
+    // re-placing against the fresh rows is exactly the re-place-on-arrival
+    // trigger the model requires (`test_arrival_without_replacement_loses_
+    // the_cursor`): nothing else re-runs placement. Bounded by the
+    // scrollbar's size ceilings so a huge file never builds an index just to
+    // place the viewport. Folds are in the geometry key, so index rows *are*
+    // drawn rows.
+    let fold_ranges = state.fold_ranges(folds);
+    let geometry = wrap_index_geometry_for(
+        viewport,
+        &state.buffer,
+        line_wrap,
+        view_mode,
+        crate::view::wrap_index::fold_signature(&fold_ranges),
+    );
+    let inputs = state.pipeline_inputs();
+    let cursor_byte = cursors.primary().position;
+    let buffer_len = state.buffer.len();
+    // Large-file mode has no line data at all — the gutter is byte-based and
+    // `line_count` is byte arithmetic, so an index built here would be one
+    // meaningless line and placement against it pins the viewport at the
+    // top. The byte pass owns those buffers outright. `line_count()` (an
+    // Option, no scan) replaces the earlier `get_line_number(len-1)`, which
+    // forced exactly the scan large-file mode exists to avoid.
+    let indexable = !state.buffer.is_large_file();
+    let within_bounds = indexable
+        && buffer_len <= MAX_WRAP_SCROLLBAR_BYTES
+        && state
+            .buffer
+            .line_count()
+            .is_some_and(|lc| lc <= MAX_WRAP_SCROLLBAR_LINES);
+    let has_index = if within_bounds || (indexable && state.wrap_indices.get(&geometry).is_some()) {
+        let line_ending = state.buffer.line_ending();
+        // Decorations — virtual-line anchors included — are resolved into
+        // one owned snapshot before `entry` takes `&mut state`.
+        let decorations = state.index_decorations(geometry.view_mode, fold_ranges.clone(), &[]);
+        let index = state.wrap_indices.entry(geometry);
+        index.ensure_built(
+            &mut state.buffer,
+            geometry,
+            inputs,
+            line_ending,
+            &decorations,
+        );
+
+        // Cursor-line expansion: the frame draws the cursor's line
+        // cursor-aware, so placement must target the row the cursor is
+        // *drawn* on and clamp against the rows that will actually exist.
+        // Activation scopes are line-local, so this one line is the only
+        // possible divergence; everything else stays canonical. Mirrors the
+        // model's `EditorModel.ensure_cursor_visible`.
+        let cursor_line = state.buffer.get_line_number(cursor_byte);
+        let cl_start = state.buffer.line_start_offset(cursor_line).unwrap_or(0);
+        let cl_end = state
+            .buffer
+            .line_start_offset(cursor_line + 1)
+            .unwrap_or_else(|| state.buffer.len());
+        let divergent = state
+            .conceals
+            .earliest_cursor_divergence(cl_start, cl_end, &state.marker_list, &cursor_positions)
+            .is_some()
+            || state
+                .soft_breaks
+                .earliest_cursor_divergence(cl_start, cl_end, &state.marker_list, &cursor_positions)
+                .is_some();
+        let expansion = if divergent {
+            let canonical = state
+                .wrap_indices
+                .get(&geometry)
+                .and_then(|i| i.line_wrap(cursor_line))
+                .filter(|lw| !lw.hidden)
+                .map(|lw| lw.wrap_rows());
+            let first_row = state
+                .wrap_indices
+                .get(&geometry)
+                .map(|i| i.row_of_byte(&state.buffer, cl_start));
+            match (canonical, first_row) {
+                (Some(canonical_rows), Some(first_row)) => {
+                    let aware = state.index_decorations(
+                        geometry.view_mode,
+                        state.fold_ranges(folds),
+                        &cursor_positions,
+                    );
+                    let starts = crate::view::wrap_index::line_drawn_row_starts(
+                        &mut state.buffer,
+                        cursor_line,
+                        geometry.rule,
+                        line_ending,
+                        &aware,
+                    );
+                    let rel = cursor_byte.saturating_sub(cl_start) as u32;
+                    let within = starts.partition_point(|s| *s <= rel).saturating_sub(1);
+                    Some(CursorLineExpansion {
+                        line_start: cl_start,
+                        first_row,
+                        canonical_rows: canonical_rows as usize,
+                        drawn_rows: starts.len().max(1),
+                        cursor_row_drawn: first_row + within as u32,
+                    })
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        if let Some(index) = state.wrap_indices.get(&geometry) {
+            viewport.ensure_visible_in_rows(index, &state.buffer, cursor_byte, expansion.as_ref());
+            viewport.row_pass_owns_placement = true;
+            true
+        } else {
+            false
+        }
+    } else {
+        // Beyond the size ceilings with no index built: the byte-oriented
+        // pass is the only vertical authority there is.
+        viewport.row_pass_owns_placement = false;
+        false
+    };
+
+    // Same-buffer scroll sync: the sync flagged this viewport to show the end
+    // of the document. Decided in row space now, where the formatter used to
+    // build the rows to count them and then build them again from the
+    // answer.
+    if viewport.sync_scroll_to_end {
+        viewport.sync_scroll_to_end = false;
+        if has_index {
+            if let Some(index) = state.wrap_indices.get(&geometry) {
+                viewport.scroll_to_end_in_rows(index, &state.buffer);
+            }
+        } else {
+            viewport.scroll_to_end_unindexed(&mut state.buffer);
+        }
+    }
+}
+
+/// Store what the pane's paint decided from its built rows, and refresh the
+/// horizontal scrollbar's bound from the lines that were on screen.
+///
+/// `left_column` is the column the frame was drawn with
+/// (`Viewport::layout_column_scroll`); it is stored now, after the paint,
+/// exactly when the writing form used to store it. The resize-sync skip is
+/// consumed here for the same reason: the layout pass was what consumed it.
+///
+/// The longest-line scan and its clamp come last because that is where they
+/// were: the frame paints with the column the cursor asked for, and the
+/// scan's (byte-measured) bound corrects it only for the readers between
+/// frames and the next frame's own clamp.
+pub(crate) fn settle_pane(
+    state: &mut EditorState,
+    viewport: &mut Viewport,
+    left_column: usize,
+    show_horizontal_scrollbar: bool,
+) -> usize {
+    viewport.left_column = left_column;
+    let _ = viewport.should_skip_resize_sync();
+
+    if show_horizontal_scrollbar && !viewport.line_wrap_enabled {
+        let mcw = compute_max_line_length(state, viewport);
+        // Clamp left_column so content can't scroll past the end of the
+        // longest line.
+        let visible_width = viewport.width as usize;
+        let max_scroll = mcw.saturating_sub(visible_width);
+        if viewport.left_column > max_scroll {
+            viewport.left_column = max_scroll;
+        }
+        mcw
+    } else {
+        0
+    }
+}
+
+/// The line count the gutter is sized for: the buffer's line count, or its
+/// byte length when the gutter shows byte offsets (large-file mode).
+pub(crate) fn gutter_estimated_lines(state: &EditorState) -> usize {
+    match state.buffer.line_count() {
+        Some(lines) => lines,
+        // In byte offset mode the gutter shows byte offsets, so size it for
+        // the largest byte offset (the file size).
+        None => state.buffer.len().max(1),
+    }
+}

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -51,6 +51,69 @@ pub(crate) struct BufferLayoutOutput {
     pub selection: SelectionContext,
 }
 
+/// The gutter one pane draws this frame.
+///
+/// Resolved from the pane's own line-number setting and view mode without
+/// writing the buffer's shared `MarginManager`: the margin state is per
+/// buffer, the setting is per split, and two panes on one buffer can want two
+/// gutters in one frame.
+pub(crate) struct GutterLayout {
+    /// The left margin as the row renderer should draw it.
+    pub margin: crate::view::margin::MarginConfig,
+    /// `margin.total_width()`, after the compose-mode reclaim below.
+    pub width: usize,
+    /// The compose layout, with the desk margin narrowed by the gutter when
+    /// there is room for it.
+    pub compose: ComposeLayout,
+}
+
+/// Resolve [`GutterLayout`] for a pane. Pure: the same inputs give the same
+/// gutter whether this runs in the pre-frame reconcile or in the formatter.
+pub(crate) fn resolve_gutter_layout(
+    margins: &crate::view::margin::MarginManager,
+    show_line_numbers: bool,
+    view_mode: &ViewMode,
+    area: Rect,
+    compose_width: Option<u16>,
+    estimated_lines: usize,
+) -> GutterLayout {
+    let mut margin = margins.resolved_left_config(show_line_numbers, estimated_lines);
+    // The diagnostic/indicator gutter is kept when line numbers are off only in
+    // compose mode, where the render below reclaims its width from the desk
+    // margin (issue #2146). In normal editor mode, line-numbers-off means no
+    // gutter at all — otherwise the 1-col indicator slot would eat into the
+    // text width and shift content right.
+    if !show_line_numbers && !matches!(view_mode, ViewMode::PageView) {
+        margin.enabled = false;
+        margin.width = 0;
+    }
+    let mut width = margin.total_width();
+
+    let mut compose = calculate_compose_layout(area, view_mode, compose_width);
+    // In compose mode the gutter (diagnostic / indicator slot) is drawn in the
+    // reclaimed desk margin so it does not shrink the centered text width
+    // (issue #2146). Only do this when there is enough desk margin to give up;
+    // if the paper already fills the area, drop the gutter instead of eating
+    // into the text so table/wrap layout stays intact.
+    if matches!(view_mode, ViewMode::PageView) && width > 0 {
+        let g = width as u16;
+        if compose.left_pad >= g {
+            compose.left_pad -= g;
+            let ra = compose.render_area;
+            compose.render_area = Rect::new(ra.x - g, ra.y, ra.width + g, ra.height);
+        } else {
+            margin.enabled = false;
+            margin.width = 0;
+            width = 0;
+        }
+    }
+    GutterLayout {
+        margin,
+        width,
+        compose,
+    }
+}
+
 /// Resolve the cursor position for the common "past end of buffer" edge
 /// case. Returns the input `current_cursor` unchanged if it is already
 /// `Some(_)` or the primary cursor isn't at buffer end.
@@ -121,9 +184,6 @@ pub(crate) fn compute_buffer_layout(
 ) -> BufferLayoutOutput {
     let _span = tracing::trace_span!("compute_buffer_layout").entered();
 
-    // Configure shared margin layout for this split's line number setting.
-    state.margins.configure_for_line_numbers(show_line_numbers);
-
     // Compute effective editor background: terminal default or theme-defined
     let effective_editor_bg = if use_terminal_bg {
         Color::Reset
@@ -149,38 +209,23 @@ pub(crate) fn compute_buffer_layout(
     } else {
         state.buffer.line_count().unwrap_or(1)
     };
-    state
-        .margins
-        .update_width_for_buffer(estimated_lines, show_line_numbers);
-    // The diagnostic/indicator gutter is kept when line numbers are off only in
-    // compose mode, where the render below reclaims its width from the desk
-    // margin (issue #2146). In normal editor mode, line-numbers-off means no
-    // gutter at all — otherwise the 1-col indicator slot would eat into the
-    // text width and shift content right.
-    if !show_line_numbers && !matches!(view_mode, ViewMode::PageView) {
-        state.margins.left_config.enabled = false;
-        state.margins.left_config.width = 0;
-    }
-    let mut gutter_width = state.margins.left_total_width();
-
-    let mut compose_layout = calculate_compose_layout(area, &view_mode, compose_width);
-    // In compose mode the gutter (diagnostic / indicator slot) is drawn in the
-    // reclaimed desk margin so it does not shrink the centered text width
-    // (issue #2146). Only do this when there is enough desk margin to give up;
-    // if the paper already fills the area, drop the gutter instead of eating
-    // into the text so table/wrap layout stays intact.
-    if matches!(view_mode, ViewMode::PageView) && gutter_width > 0 {
-        let g = gutter_width as u16;
-        if compose_layout.left_pad >= g {
-            compose_layout.left_pad -= g;
-            let ra = compose_layout.render_area;
-            compose_layout.render_area = Rect::new(ra.x - g, ra.y, ra.width + g, ra.height);
-        } else {
-            state.margins.left_config.enabled = false;
-            state.margins.left_config.width = 0;
-            gutter_width = 0;
-        }
-    }
+    let gutter = resolve_gutter_layout(
+        &state.margins,
+        show_line_numbers,
+        &view_mode,
+        area,
+        compose_width,
+        estimated_lines,
+    );
+    // The buffer's shared margin state is what the readers between frames
+    // (mouse mapping, `left_total_width`) consult; it holds the last pane's
+    // gutter, as it always has.
+    state.margins.left_config = gutter.margin.clone();
+    let GutterLayout {
+        margin,
+        width: gutter_width,
+        compose: compose_layout,
+    } = gutter;
     let render_area = compose_layout.render_area;
 
     // This split's cursor byte positions, for cursor-dependent conceal /
@@ -356,9 +401,9 @@ pub(crate) fn compute_buffer_layout(
         false
     };
 
-    // If the sync adjustment changed top_byte, rebuild view_data before
-    // ensure_visible_in_layout runs (so it sees the correct view lines).
-    let (view_data, may_rebuild) = if sync_scrolled {
+    // If the sync adjustment changed top_byte, rebuild view_data so the
+    // horizontal pass below sees the rows the frame will actually draw.
+    let view_data = if sync_scrolled {
         viewport.set_top_view_line_offset(0);
         let rebuilt = build_view_data(
             state,
@@ -377,68 +422,23 @@ pub(crate) fn compute_buffer_layout(
             None,
         );
         viewport.scroll_to_end_of_view(&rebuilt.lines);
-        (rebuilt, false)
+        rebuilt
     } else {
-        (view_data, true)
+        view_data
     };
 
-    // Ensure cursor is visible using Layout-aware check (handles virtual lines)
+    // Horizontal placement from the rows that were built. Vertical placement
+    // is settled in row space above (`ensure_visible_in_rows`), so this pass
+    // never moves `top_byte` and the rows never need rebuilding after it — the
+    // third build this function used to carry (a "scrolled, so rebuild" retry
+    // guarded by `may_rebuild`) could no longer run and is gone.
     let primary = *cursors.primary();
-    let top_byte_before_scroll = viewport.top_byte();
-    let scrolled = viewport.ensure_visible_in_layout_with_render_width(
+    viewport.ensure_visible_in_layout_with_render_width(
         &view_data.lines,
         &primary,
         render_area.width as usize,
         gutter_width,
     );
-
-    // If we scrolled AND `top_byte` changed, rebuild view_data from the new
-    // top_byte (the old view_data no longer matches what's visible).  We
-    // also reset `top_view_line_offset` to 0 and re-run the layout-aware
-    // check so that the offset is correct for the rebuilt view_data — the
-    // absolute indices from the old view_data don't map directly to the
-    // new one.
-    //
-    // When `top_byte` did NOT change (e.g. `snap_to_logical_line_start`
-    // kept `top_byte` at the current logical line's start and only
-    // shifted `top_view_line_offset` to a wrap-segment offset), the
-    // existing view_data already matches and
-    // `top_view_line_offset` is authoritative — resetting it here would
-    // erase the scroll that `ensure_visible_in_layout` just applied
-    // (issue #1574, Up-arrow jumpy variant: cy 5→7 at step 13 of the
-    // width-sweep).
-    let view_data = if scrolled && viewport.top_byte() != top_byte_before_scroll {
-        if may_rebuild {
-            viewport.set_top_view_line_offset(0);
-            let rebuilt = build_view_data(
-                state,
-                viewport,
-                estimated_line_length,
-                visible_count,
-                line_wrap,
-                render_area.width as usize,
-                gutter_width,
-                &view_mode,
-                folds,
-                theme,
-                &cursor_positions,
-                // Same: the viewport moved, so the old anchor no longer applies.
-                None,
-            );
-            // The rebuild is unanchored, so the layout pass owns the offsets again.
-            let _ = viewport.ensure_visible_in_layout_with_render_width(
-                &rebuilt.lines,
-                &primary,
-                render_area.width as usize,
-                gutter_width,
-            );
-            rebuilt
-        } else {
-            view_data
-        }
-    } else {
-        view_data
-    };
 
     let view_anchor = calculate_view_anchor(&view_data.lines, viewport.top_byte());
 
@@ -557,6 +557,7 @@ pub(crate) fn compute_buffer_layout(
 
     let render_output = render_view_lines(LineRenderInput {
         state,
+        margin: &margin,
         theme,
         view_lines: view_lines_to_render,
         view_anchor: adjusted_view_anchor,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -1,7 +1,10 @@
 //! Per-buffer render orchestration.
 //!
 //! Three functions compose here:
-//! - [`compute_buffer_layout`] — pure layout phase (no drawing).
+//! - [`compute_buffer_layout`] — pure layout phase (no drawing). A read of
+//!   the pane's state, viewport and rect; the writes that used to precede
+//!   the build (placement, margins, the wrap index) run before the frame,
+//!   in [`super::reconcile`].
 //! - [`draw_buffer_in_split`] — drawing phase from a `BufferLayoutOutput`.
 //! - [`render_buffer_in_split`] — the two phases combined, the API used by
 //!   the top-level `render_content`.
@@ -45,6 +48,9 @@ pub(crate) struct BufferLayoutOutput {
     pub compose_layout: ComposeLayout,
     pub effective_editor_bg: Color,
     pub view_mode: ViewMode,
+    /// The horizontal scroll the rows were laid out with — the viewport's
+    /// column after this frame's cursor-column check, which the pane's paint
+    /// stores back once it has drawn.
     pub left_column: usize,
     pub gutter_width: usize,
     pub buffer_ends_with_newline: bool,
@@ -153,12 +159,20 @@ pub(crate) fn resolve_cursor_fallback(
 /// Pure layout computation for a buffer in a split pane.
 /// No frame/drawing involved — produces a `BufferLayoutOutput` that the
 /// drawing phase can consume.
+///
+/// **A read of `(state, viewport, rect)`.** The viewport has been placed and
+/// the buffer's margins and wrap index brought up to date by
+/// [`super::reconcile`] before this runs; nothing here writes the viewport,
+/// the folds or the margins, and the rows are built exactly once. `state` is
+/// still `&mut` for the reads that fill caches as they go — the buffer's
+/// lazy chunk loads under `line_iterator`, the highlighter, the overlay and
+/// marker resolution in `decoration_context` — none of which is placement.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_buffer_layout(
     state: &mut EditorState,
     cursors: &Cursors,
-    viewport: &mut Viewport,
-    folds: &mut FoldManager,
+    viewport: &Viewport,
+    folds: &FoldManager,
     area: Rect,
     is_active: bool,
     theme: &Theme,
@@ -183,6 +197,7 @@ pub(crate) fn compute_buffer_layout(
     cell_theme_map: Option<(&mut Vec<CellThemeInfo>, u16)>,
 ) -> BufferLayoutOutput {
     let _span = tracing::trace_span!("compute_buffer_layout").entered();
+    crate::view::ui::split_rendering::instrument::count_buffer_layout();
 
     // Compute effective editor background: terminal default or theme-defined
     let effective_editor_bg = if use_terminal_bg {
@@ -217,10 +232,6 @@ pub(crate) fn compute_buffer_layout(
         compose_width,
         estimated_lines,
     );
-    // The buffer's shared margin state is what the readers between frames
-    // (mouse mapping, `left_total_width`) consult; it holds the last pane's
-    // gutter, as it always has.
-    state.margins.left_config = gutter.margin.clone();
     let GutterLayout {
         margin,
         width: gutter_width,
@@ -233,25 +244,14 @@ pub(crate) fn compute_buffer_layout(
     // movement changes what's active without any marker churn).
     let cursor_positions = cursors.positions();
 
-    // Decide the scroll *before* building. The layout-based pass below can only
-    // run on materialised rows, so it makes the frame build rows to discover it
-    // needs to scroll and then rebuild because it did. In row space the wrap
-    // index answers "which row is the cursor on" directly, so the common case —
-    // a cursor that has drifted into the scroll margin — is settled with no rows
-    // built at all, and the layout pass then finds nothing left to do.
-    //
-    // Build the index if it is stale, then place. With repair keeping the
-    // version current across text edits, a stale index here means a
-    // decoration batch arrived — compose's `lines_changed` round-trip — and
-    // re-placing against the fresh rows is exactly the re-place-on-arrival
-    // trigger the model requires (`test_arrival_without_replacement_loses_
-    // the_cursor`): nothing else re-runs placement, because the post-render
-    // fixup pass is gone. Bounded by the scrollbar's size ceilings so a huge
-    // file never builds an index just to place the viewport. (The fold
-    // carve-out that used to sit here is gone: folds are in the geometry key
-    // now, so index rows *are* drawn rows.)
-    let mut build_anchor: Option<BuildAnchor> = None;
-    {
+    // Where the build starts. The viewport was placed before this frame by
+    // `reconcile::place_pane`, which built the wrap index for this geometry
+    // (when the buffer is within the index's size ceilings) and decided the
+    // scroll in row space; here the same index — read, never built — says
+    // which row the viewport's top is and where the wrap can be resumed.
+    // Without an index the build starts at the logical line, as it always
+    // did for buffers beyond the ceilings.
+    let build_anchor: Option<BuildAnchor> = {
         let fold_ranges = state.fold_ranges(folds);
         let geometry = wrap_index_geometry_for(
             viewport,
@@ -260,119 +260,24 @@ pub(crate) fn compute_buffer_layout(
             &view_mode,
             crate::view::wrap_index::fold_signature(&fold_ranges),
         );
-        let inputs = state.pipeline_inputs();
-        let cursor_byte = cursors.primary().position;
-        let buffer_len = state.buffer.len();
-        // Large-file mode has no line data at all — the gutter is byte-based
-        // and `line_count` is byte arithmetic, so an index built here would be
-        // one meaningless line and placement against it pins the viewport at
-        // the top. The byte pass owns those buffers outright. `line_count()`
-        // (an Option, no scan) replaces the earlier `get_line_number(len-1)`,
-        // which forced exactly the scan large-file mode exists to avoid.
-        let indexable = !state.buffer.is_large_file();
-        let within_bounds = indexable
-            && buffer_len <= crate::view::ui::split_rendering::scrollbar::MAX_WRAP_SCROLLBAR_BYTES
-            && state.buffer.line_count().is_some_and(|lc| {
-                lc <= crate::view::ui::split_rendering::scrollbar::MAX_WRAP_SCROLLBAR_LINES
-            });
-        if within_bounds || (indexable && state.wrap_indices.get(&geometry).is_some()) {
-            let line_ending = state.buffer.line_ending();
-            // Decorations — virtual-line anchors included — are resolved into
-            // one owned snapshot before `entry` takes `&mut state`.
-            let decorations = state.index_decorations(geometry.view_mode, fold_ranges.clone(), &[]);
-            let index = state.wrap_indices.entry(geometry);
-            index.ensure_built(
-                &mut state.buffer,
-                geometry,
-                inputs,
-                line_ending,
-                &decorations,
-            );
-
-            // Cursor-line expansion: the frame draws the cursor's line
-            // cursor-aware, so placement must target the row the cursor is
-            // *drawn* on and clamp against the rows that will actually exist.
-            // Activation scopes are line-local, so this one line is the only
-            // possible divergence; everything else stays canonical. Mirrors
-            // the model's `EditorModel.ensure_cursor_visible`.
-            let cursor_line = state.buffer.get_line_number(cursor_byte);
-            let cl_start = state.buffer.line_start_offset(cursor_line).unwrap_or(0);
-            let cl_end = state
-                .buffer
-                .line_start_offset(cursor_line + 1)
-                .unwrap_or_else(|| state.buffer.len());
-            let divergent = state
-                .conceals
-                .earliest_cursor_divergence(cl_start, cl_end, &state.marker_list, &cursor_positions)
-                .is_some()
-                || state
-                    .soft_breaks
-                    .earliest_cursor_divergence(
-                        cl_start,
-                        cl_end,
-                        &state.marker_list,
-                        &cursor_positions,
-                    )
-                    .is_some();
-            let expansion = if divergent {
-                let canonical = state
-                    .wrap_indices
-                    .get(&geometry)
-                    .and_then(|i| i.line_wrap(cursor_line))
-                    .filter(|lw| !lw.hidden)
-                    .map(|lw| lw.wrap_rows());
-                let first_row = state
-                    .wrap_indices
-                    .get(&geometry)
-                    .map(|i| i.row_of_byte(&state.buffer, cl_start));
-                match (canonical, first_row) {
-                    (Some(canonical_rows), Some(first_row)) => {
-                        let aware = state.index_decorations(
-                            geometry.view_mode,
-                            state.fold_ranges(folds),
-                            &cursor_positions,
-                        );
-                        let starts = crate::view::wrap_index::line_drawn_row_starts(
-                            &mut state.buffer,
-                            cursor_line,
-                            geometry.rule,
-                            line_ending,
-                            &aware,
-                        );
-                        let rel = cursor_byte.saturating_sub(cl_start) as u32;
-                        let within = starts.partition_point(|s| *s <= rel).saturating_sub(1);
-                        Some(crate::view::viewport::CursorLineExpansion {
-                            line_start: cl_start,
-                            first_row,
-                            canonical_rows: canonical_rows as usize,
-                            drawn_rows: starts.len().max(1),
-                            cursor_row_drawn: first_row + within as u32,
-                        })
-                    }
-                    _ => None,
-                }
-            } else {
-                None
-            };
-
-            if let Some(index) = state.wrap_indices.get(&geometry) {
-                viewport.ensure_visible_in_rows(
-                    index,
-                    &state.buffer,
-                    cursor_byte,
-                    expansion.as_ref(),
-                );
-                viewport.row_pass_owns_placement = true;
-                // Resolve the anchor *after* the scroll decision, so the build
-                // starts where the frame will actually draw.
-                build_anchor = resolve_build_anchor(index, state, viewport, &cursor_positions);
-            }
-        } else {
-            // Beyond the size ceilings with no index built: the byte-oriented
-            // pass is the only vertical authority there is.
-            viewport.row_pass_owns_placement = false;
-        }
-    }
+        // The reconcile builds the index for every indexable buffer within
+        // the ceilings; a pane formatted without one is a pane reconciled
+        // against a different geometry, or not at all.
+        debug_assert!(
+            state.wrap_indices.get(&geometry).is_some()
+                || state.buffer.is_large_file()
+                || state.buffer.len()
+                    > crate::view::ui::split_rendering::scrollbar::MAX_WRAP_SCROLLBAR_BYTES
+                || state.buffer.line_count().is_none_or(|lc| {
+                    lc > crate::view::ui::split_rendering::scrollbar::MAX_WRAP_SCROLLBAR_LINES
+                }),
+            "compute_buffer_layout ran without a reconciled wrap index for its geometry"
+        );
+        state
+            .wrap_indices
+            .get(&geometry)
+            .and_then(|index| resolve_build_anchor(index, state, viewport, &cursor_positions))
+    };
 
     let view_data = {
         let _span = tracing::trace_span!("build_view_data").entered();
@@ -392,48 +297,13 @@ pub(crate) fn compute_buffer_layout(
         )
     };
 
-    // Same-buffer scroll sync: if the sync code flagged this viewport to
-    // scroll to the end, apply it now using the view lines we just built.
-    let sync_scrolled = if viewport.sync_scroll_to_end {
-        viewport.sync_scroll_to_end = false;
-        viewport.scroll_to_end_of_view(&view_data.lines)
-    } else {
-        false
-    };
-
-    // If the sync adjustment changed top_byte, rebuild view_data so the
-    // horizontal pass below sees the rows the frame will actually draw.
-    let view_data = if sync_scrolled {
-        viewport.set_top_view_line_offset(0);
-        let rebuilt = build_view_data(
-            state,
-            viewport,
-            estimated_line_length,
-            visible_count,
-            line_wrap,
-            render_area.width as usize,
-            gutter_width,
-            &view_mode,
-            folds,
-            theme,
-            &cursor_positions,
-            // A sync scroll moved the viewport; the anchor described where it
-            // used to be.
-            None,
-        );
-        viewport.scroll_to_end_of_view(&rebuilt.lines);
-        rebuilt
-    } else {
-        view_data
-    };
-
     // Horizontal placement from the rows that were built. Vertical placement
-    // is settled in row space above (`ensure_visible_in_rows`), so this pass
-    // never moves `top_byte` and the rows never need rebuilding after it — the
-    // third build this function used to carry (a "scrolled, so rebuild" retry
-    // guarded by `may_rebuild`) could no longer run and is gone.
+    // was settled in row space by the reconcile, so this never moves
+    // `top_byte` and the rows never need rebuilding after it. The column is a
+    // value here — the frame is drawn with it, and the pane's paint stores
+    // it afterwards (`reconcile::settle_pane`).
     let primary = *cursors.primary();
-    viewport.ensure_visible_in_layout_with_render_width(
+    let left_column = viewport.layout_column_scroll(
         &view_data.lines,
         &primary,
         render_area.width as usize,
@@ -507,7 +377,7 @@ pub(crate) fn compute_buffer_layout(
                 viewport_start,
                 estimated_line_length,
                 adjusted_visible_count,
-                viewport.left_column,
+                left_column,
                 render_area.width as usize,
             );
             (viewport_start, viewport_end)
@@ -570,7 +440,7 @@ pub(crate) fn compute_buffer_layout(
         is_active,
         line_wrap,
         estimated_lines,
-        left_column: viewport.left_column,
+        left_column,
         relative_line_numbers,
         session_mode,
         software_cursor_only,
@@ -602,7 +472,7 @@ pub(crate) fn compute_buffer_layout(
         compose_layout,
         effective_editor_bg,
         view_mode,
-        left_column: viewport.left_column,
+        left_column,
         gutter_width,
         buffer_ends_with_newline,
         selection,
@@ -801,16 +671,27 @@ pub(crate) fn draw_buffer_in_split(
     }
 }
 
+/// What a pane's text pass hands back to the paint that ran it.
+pub(crate) struct PaneTextResult {
+    /// The per-row mappings for mouse click handling.
+    pub view_line_mappings: Vec<ViewLineMapping>,
+    /// The horizontal scroll the rows were drawn with, for
+    /// [`super::reconcile::settle_pane`] to store.
+    pub left_column: usize,
+}
+
 /// Render a single buffer in a split pane (convenience wrapper).
 /// Calls [`compute_buffer_layout`] then [`draw_buffer_in_split`].
-/// Returns the view line mappings for mouse click handling.
+///
+/// The pane must have been reconciled for this frame
+/// (`super::reconcile`); this writes nothing to the view state.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_buffer_in_split(
     buf: &mut ratatui::buffer::Buffer,
     state: &mut EditorState,
     cursors: &Cursors,
-    viewport: &mut Viewport,
-    folds: &mut FoldManager,
+    viewport: &Viewport,
+    folds: &FoldManager,
     event_log: Option<&mut EventLog>,
     area: Rect,
     is_active: bool,
@@ -831,7 +712,7 @@ pub(crate) fn render_buffer_in_split(
     cell_theme_map: &mut Vec<CellThemeInfo>,
     screen_width: u16,
     pending_hardware_cursor: &mut Option<(u16, u16)>,
-) -> Vec<ViewLineMapping> {
+) -> PaneTextResult {
     // The style group provides theme + the appearance flags; unpack into the
     // locals the body already uses by name. The cfg fields this painter
     // doesn't read are ignored.
@@ -884,6 +765,7 @@ pub(crate) fn render_buffer_in_split(
     );
 
     let view_line_mappings = layout_output.view_line_mappings.clone();
+    let left_column = layout_output.left_column;
 
     draw_buffer_in_split(
         buf,
@@ -904,7 +786,10 @@ pub(crate) fn render_buffer_in_split(
         pending_hardware_cursor,
     );
 
-    view_line_mappings
+    PaneTextResult {
+        view_line_mappings,
+        left_column,
+    }
 }
 
 /// Where the build should start for this viewport, if the index can say.

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -245,6 +245,9 @@ fn build_pane_render_data(
         let content_width = pane_width.saturating_sub(gutter_width);
         let lines_needed = last_line - first_line + 10;
         let empty_folds = FoldManager::new();
+        // A composite side is formatted here, not by `compute_buffer_layout`;
+        // counted so the once-per-pane invariant can tell the two apart.
+        super::super::instrument::count_composite_build();
         let view_data = build_view_data(
             source_state,
             &viewport,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -50,6 +50,10 @@ pub(crate) struct LastLineEnd {
 
 pub(crate) struct LineRenderInput<'a> {
     pub state: &'a EditorState,
+    /// The left margin this pane draws, resolved for *this* pane's line-number
+    /// setting (`MarginManager::resolved_left_config`) — not read off
+    /// `state.margins`, which is per buffer and may hold another split's.
+    pub margin: &'a crate::view::margin::MarginConfig,
     pub theme: &'a Theme,
     /// Display lines from the view pipeline (each line has its own mappings, styles, etc.)
     pub view_lines: &'a [ViewLine],
@@ -472,6 +476,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
     let LineRenderInput {
         state,
+        margin,
         theme,
         view_lines,
         view_anchor,
@@ -732,6 +737,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         render_left_margin(
             &LeftMarginContext {
                 state,
+                margin,
                 theme,
                 is_continuation,
                 line_start_byte,
@@ -1124,6 +1130,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         last_line_end.as_ref(),
         &PostRowContext {
             state,
+            margin,
             theme,
             render_area,
             gutter_width,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
@@ -37,6 +37,8 @@ pub(super) struct PostRowAccumulator<'a> {
 /// Read-only inputs threaded from `render_view_lines`.
 pub(super) struct PostRowContext<'a> {
     pub state: &'a EditorState,
+    /// The pane's resolved left margin; see `LineRenderInput::margin`.
+    pub margin: &'a crate::view::margin::MarginConfig,
     pub theme: &'a Theme,
     pub render_area: Rect,
     pub gutter_width: usize,
@@ -104,7 +106,7 @@ fn render_implicit_line_into(
             None
         };
 
-    if ctx.state.margins.left_config.enabled {
+    if ctx.margin.enabled {
         push_left_margin(
             &mut implicit_line_spans,
             ctx,
@@ -116,8 +118,8 @@ fn render_implicit_line_into(
 
     // Fill remaining width with current_line_bg for cursor line.
     if let Some(bg) = implicit_cursor_bg {
-        let gutter_w = if ctx.state.margins.left_config.enabled {
-            ctx.state.margins.left_total_width()
+        let gutter_w = if ctx.margin.enabled {
+            ctx.margin.total_width()
         } else {
             0
         };
@@ -187,7 +189,7 @@ fn push_left_margin(
         format!(
             "{:>width$}",
             implicit_gutter_num,
-            width = ctx.state.margins.left_config.width
+            width = ctx.margin.width
         )
     } else {
         let estimated_lines =
@@ -200,7 +202,7 @@ fn push_left_margin(
             estimated_lines,
             ctx.show_line_numbers,
         );
-        margin_content.render(ctx.state.margins.left_config.width).0
+        margin_content.render(ctx.margin.width).0
     };
     let mut margin_style = Style::default().fg(ctx.theme.line_number_fg);
     if let Some(bg) = implicit_cursor_bg {
@@ -208,13 +210,13 @@ fn push_left_margin(
     }
     spans.push(Span::styled(rendered_text, margin_style));
 
-    if ctx.state.margins.left_config.show_separator {
+    if ctx.margin.show_separator {
         let mut sep_style = Style::default().fg(ctx.theme.line_number_fg);
         if let Some(bg) = implicit_cursor_bg {
             sep_style = sep_style.bg(bg);
         }
         spans.push(Span::styled(
-            ctx.state.margins.left_config.separator.to_string(),
+            ctx.margin.separator.to_string(),
             sep_style,
         ));
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/trailing.rs
@@ -186,11 +186,7 @@ fn push_left_margin(
 
     // Line number (or byte offset in byte_offset_mode).
     let rendered_text = if ctx.byte_offset_mode && ctx.show_line_numbers {
-        format!(
-            "{:>width$}",
-            implicit_gutter_num,
-            width = ctx.margin.width
-        )
+        format!("{:>width$}", implicit_gutter_num, width = ctx.margin.width)
     } else {
         let estimated_lines =
             ctx.state.buffer.line_count().unwrap_or(
@@ -215,10 +211,7 @@ fn push_left_margin(
         if let Some(bg) = implicit_cursor_bg {
             sep_style = sep_style.bg(bg);
         }
-        spans.push(Span::styled(
-            ctx.margin.separator.to_string(),
-            sep_style,
-        ));
+        spans.push(Span::styled(ctx.margin.separator.to_string(), sep_style));
     }
 }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -189,6 +189,7 @@ pub(super) fn build_view_data(
     cursor_positions: &[usize],
     anchor: Option<BuildAnchor>,
 ) -> ViewData {
+    super::instrument::count_view_data_build();
     let adjusted_visible_count = fold_adjusted_visible_count(
         &state.buffer,
         &state.marker_list,

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -42,8 +42,8 @@ pub struct Viewport {
     pub scroll_offset: usize,
 
     /// True while the row-space pass places this viewport vertically — set
-    /// each frame by the render path when a wrap index exists for the split's
-    /// geometry. While set, the byte-oriented `ensure_visible` yields its
+    /// each frame by the pre-frame reconcile (`orchestration::reconcile`)
+    /// when a wrap index exists for the split's geometry. While set, the byte-oriented `ensure_visible` yields its
     /// vertical half entirely: two passes deciding vertical placement is
     /// fresh#1574, and the byte pass's wrap counting is the one that
     /// disagrees with what is drawn. It stays for two jobs only — horizontal
@@ -124,10 +124,11 @@ pub struct Viewport {
     /// Updated incrementally as visible lines are rendered, avoiding full-file scans.
     pub max_line_length_seen: usize,
 
-    /// When true, the next render pass should scroll to show the last line at
-    /// the bottom of the viewport.  Set by same-buffer scroll sync when the
-    /// active split is at the end of the document.  Consumed (cleared) during
-    /// rendering after the adjustment is applied.
+    /// When true, the next frame should scroll to show the last line at the
+    /// bottom of the viewport.  Set by same-buffer scroll sync when the
+    /// active split is at the end of the document.  Consumed (cleared) by the
+    /// pre-frame reconcile, which applies it in row space
+    /// ([`Self::scroll_to_end_in_rows`]).
     pub sync_scroll_to_end: bool,
 
     /// Small per-viewport row-count cache used by the scroll hot paths
@@ -1251,10 +1252,13 @@ impl Viewport {
     /// rows are built.
     ///
     /// The layout-based [`Self::ensure_visible_in_layout`] can only run *after*
-    /// `build_view_data`, so the frame has to build rows to discover it needs to
-    /// scroll and then rebuild because it did — the up-to-three builds per frame
-    /// in `compute_buffer_layout`. Deciding in row space needs no rows at all:
-    /// the wrap index answers "which row is the cursor on" with a binary search.
+    /// `build_view_data`, so a frame that placed there had to build rows to
+    /// discover it needed to scroll and then rebuild because it did — the
+    /// up-to-three builds per frame `compute_buffer_layout` used to carry.
+    /// Deciding in row space needs no rows at all: the wrap index answers
+    /// "which row is the cursor on" with a binary search. This runs from the
+    /// pre-frame reconcile (`orchestration::reconcile::place_pane`), before
+    /// anything is built.
     ///
     /// Returns whether this pass **owns vertical placement** for the frame —
     /// not whether it moved anything. The caller forwards it to
@@ -1400,40 +1404,55 @@ impl Viewport {
         render_width: usize,
         gutter_width: usize,
     ) -> bool {
-        // Check if we should skip sync due to session restore
-        // This prevents the restored scroll position from being overwritten
-        if self.should_skip_resize_sync() {
-            return false;
-        }
+        self.left_column =
+            self.layout_column_scroll(view_lines, cursor, render_width, gutter_width);
+        // The pure form above reads the resize-sync flag; this, the writing
+        // form, consumes it as the layout pass always has.
+        let _ = self.should_skip_resize_sync();
+        false
+    }
 
-        // Check if we should skip ensure_visible due to scroll action
-        // This prevents scroll actions (Ctrl+Up/Down) from being immediately undone
-        if self.should_skip_ensure_visible() {
-            tracing::trace!("ensure_visible_in_layout: SKIPPING due to skip_ensure_visible flag");
-            return false;
+    /// The horizontal scroll this frame's rows call for — the pure form of
+    /// [`Self::ensure_visible_in_layout`].
+    ///
+    /// Returns the `left_column` the frame should draw with, from the rows
+    /// that were built: the cursor's visual column needs the row's own
+    /// char→column map (tabs, wide characters, spliced inlay hints), so this
+    /// is the one placement decision that cannot move ahead of the build.
+    /// Nothing is written; the pane's paint stores the value afterwards, with
+    /// [`Self::should_skip_resize_sync`] consumed then, so the frame paints
+    /// what the writing form used to paint.
+    pub(crate) fn layout_column_scroll(
+        &self,
+        view_lines: &[ViewLine],
+        cursor: &Cursor,
+        render_width: usize,
+        gutter_width: usize,
+    ) -> usize {
+        // A restored session keeps its scroll position for one frame, and a
+        // scroll action keeps its own (Ctrl+Up/Down); neither is undone here.
+        if self.skip_resize_sync || self.skip_ensure_visible {
+            tracing::trace!("layout_column_scroll: SKIPPING (skip flag set)");
+            return self.left_column;
         }
-        tracing::trace!(
-            "ensure_visible_in_layout: NOT skipping, skip_ensure_visible={}",
-            self.skip_ensure_visible
-        );
 
         let viewport_height = self.visible_line_count();
         if view_lines.is_empty() || viewport_height == 0 {
             tracing::trace!(
-                "ensure_visible_in_layout: early-out, view_lines.len={} viewport_height={} cursor_pos={} top_byte={}",
+                "layout_column_scroll: early-out, view_lines.len={} viewport_height={} cursor_pos={} top_byte={}",
                 view_lines.len(),
                 viewport_height,
                 cursor.position,
                 self.top_byte(),
             );
-            return false;
+            return self.left_column;
         }
 
         // Find the cursor's absolute view line position (in the full view_lines array)
         let cursor_view_line = self.find_view_line_for_byte(view_lines, cursor.position);
 
         tracing::trace!(
-            "ensure_visible_in_layout: enter cursor_pos={} cursor_view_line={} top_view_line_offset={} top_byte={} viewport_height={} view_lines.len={} line_wrap_enabled={}",
+            "layout_column_scroll: cursor_pos={} cursor_view_line={} top_view_line_offset={} top_byte={} viewport_height={} view_lines.len={} line_wrap_enabled={}",
             cursor.position,
             cursor_view_line,
             self.top_view_line_offset(),
@@ -1447,30 +1466,30 @@ impl Viewport {
         // `ensure_visible_in_rows`, which runs before anything is built and
         // decides in absolute rows; this pass sees only the window it was
         // handed and cannot reach past it, which is what made the two disagree.
-        self.scroll_cursor_column_into_view(
+        self.column_scroll_for_cursor_row(
             view_lines,
             cursor,
             cursor_view_line,
             render_width,
             gutter_width,
-        );
-        false
+        )
     }
 
-    /// Adjust horizontal scroll so the cursor's column stays on screen.
+    /// The horizontal scroll that keeps the cursor's column on screen.
     ///
-    /// Does nothing when the cursor is on a line not present in `view_lines`
-    /// (e.g. a newly inserted line) — `ensure_visible` already handled that.
-    fn scroll_cursor_column_into_view(
-        &mut self,
+    /// Returns the current `left_column` unchanged when the cursor is on a
+    /// line not present in `view_lines` (e.g. a newly inserted line) —
+    /// `ensure_visible` already handled that.
+    fn column_scroll_for_cursor_row(
+        &self,
         view_lines: &[ViewLine],
         cursor: &Cursor,
         cursor_view_line: usize,
         render_width: usize,
         gutter_width: usize,
-    ) {
+    ) -> usize {
         if cursor_view_line >= view_lines.len() {
-            return;
+            return self.left_column;
         }
 
         let line = &view_lines[cursor_view_line];
@@ -1494,7 +1513,7 @@ impl Viewport {
 
         // Only handle horizontal scroll if the cursor is actually within this line.
         if cursor.position >= line_end_byte {
-            return;
+            return self.left_column;
         }
 
         // Visual column of the cursor, taken from the canonical
@@ -1517,27 +1536,27 @@ impl Viewport {
         let line_visual_width = line
             .visual_width()
             .saturating_sub(usize::from(line.ends_with_newline));
-        self.ensure_column_visible_simple(
+        self.column_visible_simple(
             cursor_visual_col,
             line_visual_width,
             render_width,
             gutter_width,
-        );
+        )
     }
 
-    /// Renderer/layout-only column visibility check using laid-out line geometry.
-    fn ensure_column_visible_simple(
-        &mut self,
+    /// Renderer/layout-only column visibility check using laid-out line
+    /// geometry. Returns the `left_column` that shows `column`.
+    fn column_visible_simple(
+        &self,
         column: usize,
         line_length: usize,
         render_width: usize,
         gutter_width: usize,
-    ) {
+    ) -> usize {
         // Skip if line wrapping is enabled (all columns visible via wrapping)
         // or if this view never scrolls sideways (a widget panel).
         if self.line_wrap_enabled || !self.horizontal_scroll_enabled {
-            self.left_column = 0;
-            return;
+            return 0;
         }
 
         // `render_width` is the geometry used to build and draw these lines.
@@ -1546,29 +1565,31 @@ impl Viewport {
         let visible_width = render_width.saturating_sub(gutter_width);
 
         if visible_width == 0 {
-            return;
+            return self.left_column;
         }
 
         let effective_offset = self.horizontal_scroll_offset.min(visible_width / 2);
         let ideal_left = self.left_column + effective_offset;
         let ideal_right = self.left_column + visible_width.saturating_sub(effective_offset);
 
+        let mut left_column = self.left_column;
         if column < ideal_left {
-            self.left_column = column.saturating_sub(effective_offset);
+            left_column = column.saturating_sub(effective_offset);
         } else if column >= ideal_right {
             let target_position = visible_width
                 .saturating_sub(effective_offset)
                 .saturating_sub(1);
-            self.left_column = column.saturating_sub(target_position);
+            left_column = column.saturating_sub(target_position);
         }
 
         // Limit scroll to line length
         if line_length > 0 {
             let max_left_column = line_length.saturating_sub(visible_width.saturating_sub(1));
-            if self.left_column > max_left_column {
-                self.left_column = max_left_column;
+            if left_column > max_left_column {
+                left_column = max_left_column;
             }
         }
+        left_column
     }
 
     /// Set top_byte with automatic scroll limit enforcement
@@ -1780,25 +1801,41 @@ impl Viewport {
         self.set_top_byte_with_limit(buffer, &[], &[], target_position);
     }
 
-    /// Scroll so the last view line sits at the bottom of the viewport.
-    ///
-    /// Works in view-line space (soft-break-aware) — the same coordinate system
-    /// used by `ensure_visible_in_layout`.  Returns `true` if the viewport was
-    /// actually adjusted.
-    pub fn scroll_to_end_of_view(&mut self, view_lines: &[ViewLine]) -> bool {
+    /// Scroll so the document's last row sits at the bottom of the viewport,
+    /// decided in absolute rows from the wrap index — the row-space form of
+    /// [`Self::scroll_to_end_of_view`], which needed the rows built to count
+    /// them. Same clamp as [`Self::scroll_visual_rows`]: the last full page.
+    /// Returns `true` if the viewport moved.
+    pub fn scroll_to_end_in_rows(
+        &mut self,
+        index: &crate::view::wrap_index::WrapIndex,
+        buffer: &Buffer,
+    ) -> bool {
         let viewport_height = self.visible_line_count();
-        if view_lines.is_empty() || viewport_height == 0 {
+        if viewport_height == 0 {
             return false;
         }
-        let max_top = view_lines.len().saturating_sub(viewport_height);
-        if self.top_view_line_offset() == max_top {
+        let top_line = buffer.get_line_number(self.top_byte());
+        let top_row = index.line_first_row(top_line) as usize + self.top_view_line_offset();
+        let max_top = (index.total_rows() as usize).saturating_sub(viewport_height);
+        if top_row == max_top {
             return false;
         }
-        self.set_top_view_line_offset(max_top);
-        if let Some(new_top_byte) = self.get_source_byte_for_view_line(view_lines, max_top) {
-            self.set_top_byte(new_top_byte);
-        }
+        let addr = index.byte_of_row(buffer, max_top as u32);
+        self.set_top_byte(buffer.line_start_offset(addr.line).unwrap_or(0));
+        self.set_top_view_line_offset(addr.row_in_line);
         true
+    }
+
+    /// [`Self::scroll_to_end_in_rows`] for a buffer with no wrap index (one
+    /// beyond the index's size ceilings): propose the end of the buffer as
+    /// the top and let the scroll limit back it up to the last full page,
+    /// the way a wheel scroll to the bottom lands. Byte-based, so the walk
+    /// is bounded by one screen of lines.
+    pub fn scroll_to_end_unindexed(&mut self, buffer: &mut Buffer) {
+        self.set_top_view_line_offset(0);
+        let end = buffer.len();
+        self.set_top_byte_with_limit(buffer, &[], &[], end);
     }
 
     /// Mark viewport as needing synchronization with cursor positions
@@ -2895,16 +2932,16 @@ mod tests {
     }
 
     #[test]
-    fn ensure_column_visible_simple_uses_explicit_render_width() {
+    fn column_visible_simple_uses_explicit_render_width() {
         // Compose mode can render a narrow centered page inside a wide viewport.
         let mut vp = Viewport::new(80, 24);
         vp.line_wrap_enabled = false;
         vp.horizontal_scroll_offset = 0;
 
-        vp.ensure_column_visible_simple(12, 13, 6, 0);
+        let left_column = vp.column_visible_simple(12, 13, 6, 0);
 
         assert_eq!(
-            vp.left_column, 7,
+            left_column, 7,
             "the layout path must use its passed render width, not viewport width"
         );
     }

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -2253,6 +2253,43 @@ mod tests {
         assert_eq!(top_row(&viewport), 0);
     }
 
+    /// The same-buffer scroll sync's "show the end" is decided in row space:
+    /// the last full page, the row the wheel stops at, with no rows built.
+    #[test]
+    fn scroll_to_end_in_rows_lands_on_the_last_full_page() {
+        use crate::view::viewport::Viewport;
+
+        let text = long_line(300);
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let index = built(&mut buffer, 20);
+        let total = index.total_rows() as usize;
+
+        let mut viewport = Viewport::new(20, 10);
+        viewport.line_wrap_enabled = true;
+        let height = viewport.visible_line_count();
+        let top_row = |vp: &Viewport| {
+            let line = buffer.get_line_number(vp.top_byte());
+            index.line_first_row(line) as usize + vp.top_view_line_offset()
+        };
+
+        assert!(viewport.scroll_to_end_in_rows(&index, &buffer));
+        assert_eq!(top_row(&viewport), total.saturating_sub(height));
+        assert!(
+            !viewport.scroll_to_end_in_rows(&index, &buffer),
+            "already at the end: nothing moves"
+        );
+
+        // Where a wheel scroll to the bottom lands, exactly.
+        let mut wheel = Viewport::new(20, 10);
+        wheel.line_wrap_enabled = true;
+        wheel.scroll_visual_rows(&index, &buffer, 10_000);
+        assert_eq!(top_row(&wheel), top_row(&viewport));
+        assert_eq!(
+            (wheel.top_byte(), wheel.top_view_line_offset()),
+            (viewport.top_byte(), viewport.top_view_line_offset())
+        );
+    }
+
     /// A line with no decorations is resumable at every row — the case the whole
     /// design exists for, where the renderer never has to walk back.
     #[test]

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1577,9 +1577,23 @@ impl EditorTestHarness {
 
     /// Force a render cycle and capture output
     pub fn render(&mut self) -> anyhow::Result<()> {
+        let before = fresh::test_api::frame_counters();
         self.terminal.draw(|frame| {
             self.editor.render(frame);
         })?;
+        // A visible text pane is placed once, formatted once, and has its
+        // rows built once per frame — the invariant the retained-mode
+        // migration rests on (`split_rendering::instrument`). Asserted on
+        // every frame the corpus renders.
+        let frame = fresh::test_api::frame_counters().since(before);
+        assert_eq!(
+            frame.view_data_builds, frame.buffer_layouts,
+            "a frame built a pane's rows more than once: {frame:?}"
+        );
+        assert_eq!(
+            frame.buffer_layouts, frame.pane_placements,
+            "a frame formatted a pane it did not place, or placed one it did not format: {frame:?}"
+        );
         Ok(())
     }
 

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1587,7 +1587,8 @@ impl EditorTestHarness {
         // every frame the corpus renders.
         let frame = fresh::test_api::frame_counters().since(before);
         assert_eq!(
-            frame.view_data_builds, frame.buffer_layouts,
+            frame.view_data_builds,
+            frame.buffer_layouts + frame.composite_builds,
             "a frame built a pane's rows more than once: {frame:?}"
         );
         assert_eq!(

--- a/crates/fresh-editor/tests/e2e/frame_once_per_pane.rs
+++ b/crates/fresh-editor/tests/e2e/frame_once_per_pane.rs
@@ -1,0 +1,222 @@
+//! One placement, one format, one row build per visible text pane per frame.
+//!
+//! The retained-mode migration's Stage 1 moves every write the text
+//! formatter made during paint — viewport placement, margins, the wrap
+//! index, the scroll-to-end sync — into a pre-frame reconcile, so the
+//! formatter is a read of `(state, viewport, rect)` and `build_view_data`
+//! runs exactly once per pane per frame. The harness asserts the three
+//! counters agree around every frame the corpus renders; these tests pin
+//! the count itself to the number of panes on screen, across the paths
+//! that used to build twice (a scroll-to-end sync) and the paths that
+//! bypass the wrap index (a file beyond its ceilings).
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::test_api::{frame_counters, FrameCounters};
+use tempfile::TempDir;
+
+/// Render one frame and return what it cost.
+fn frame(harness: &mut EditorTestHarness) -> FrameCounters {
+    let before = frame_counters();
+    harness.render().unwrap();
+    frame_counters().since(before)
+}
+
+/// Assert one frame placed, formatted and built exactly `panes` panes.
+fn assert_frame_panes(harness: &mut EditorTestHarness, panes: u64, what: &str) {
+    let cost = frame(harness);
+    assert_eq!(
+        cost,
+        FrameCounters {
+            pane_placements: panes,
+            buffer_layouts: panes,
+            view_data_builds: panes,
+        },
+        "{what}: expected {panes} pane(s) placed, formatted and built once each, got {cost:?}"
+    );
+}
+
+/// Run a command palette entry — waiting for the palette to list it, so a
+/// plugin-registered command that lands late is not raced — and let the
+/// frame after it settle.
+fn palette(harness: &mut EditorTestHarness, command: &str) {
+    harness.run_palette_command(command).unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+}
+
+fn numbered_lines(count: usize, width: usize) -> String {
+    (1..=count)
+        .map(|i| format!("{:<width$}\n", format!("line {i:05}"), width = width))
+        .collect()
+}
+
+fn open_text(harness: &mut EditorTestHarness, dir: &TempDir, name: &str, text: &str) {
+    let path = dir.path().join(name);
+    std::fs::write(&path, text).unwrap();
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+}
+
+#[test]
+fn a_single_pane_is_built_once_per_frame() {
+    let dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    open_text(&mut harness, &dir, "plain.txt", &numbered_lines(200, 20));
+
+    assert_frame_panes(&mut harness, 1, "idle frame");
+
+    harness.type_text("x").unwrap();
+    assert_frame_panes(&mut harness, 1, "after an edit");
+
+    // Motion that scrolls: the cursor leaves the first page and the frame
+    // that follows it is still one build.
+    for _ in 0..40 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    assert_frame_panes(&mut harness, 1, "after scrolling motion");
+    harness.assert_screen_contains("line 00041");
+
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    assert_frame_panes(&mut harness, 1, "at the end of the document");
+    harness.assert_screen_contains("line 00200");
+}
+
+#[test]
+fn every_split_is_built_once_per_frame() {
+    let dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+    open_text(&mut harness, &dir, "split.txt", &numbered_lines(300, 20));
+    assert_frame_panes(&mut harness, 1, "one pane");
+
+    palette(&mut harness, "Split Vertical");
+    assert_frame_panes(&mut harness, 2, "two panes on one buffer");
+
+    palette(&mut harness, "Split Horizontal");
+    assert_frame_panes(&mut harness, 3, "three panes on one buffer");
+
+    for _ in 0..60 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    assert_frame_panes(&mut harness, 3, "three panes after motion in one");
+}
+
+/// A same-buffer scroll-sync frame flags the other split to show the end
+/// of the document. That used to be the second build — the rows were built
+/// to count them, then built again from the answer. It is decided in row
+/// space now, and the frame costs one build per pane.
+#[test]
+fn a_scroll_to_end_sync_frame_builds_each_pane_once() {
+    let dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    open_text(&mut harness, &dir, "sync.txt", &numbered_lines(120, 20));
+
+    palette(&mut harness, "Split Vertical");
+    palette(&mut harness, "Toggle Scroll Sync");
+    assert_frame_panes(&mut harness, 2, "two synced panes");
+
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    assert_frame_panes(&mut harness, 2, "the frame after a jump to the end");
+    assert_frame_panes(&mut harness, 2, "the frame after that");
+    // Both panes show the document's tail.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.matches("line 00120").count() >= 2,
+        "both synced panes should show the last line:\n{screen}"
+    );
+}
+
+#[test]
+fn wrapped_long_lines_are_built_once_per_frame() {
+    let dir = TempDir::new().unwrap();
+    // Wrap is on by default; every line wraps into several rows.
+    let mut harness = EditorTestHarness::new(60, 20).unwrap();
+    open_text(&mut harness, &dir, "wrapped.txt", &numbered_lines(80, 200));
+    assert_frame_panes(&mut harness, 1, "wrapped file");
+
+    for _ in 0..30 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    assert_frame_panes(&mut harness, 1, "after motion through wrapped rows");
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    assert_frame_panes(&mut harness, 1, "cursor at the end of a wrapped line");
+}
+
+/// Beyond the wrap index's line ceiling there is no row space to place in:
+/// the byte-oriented pass owns the viewport, and the pane still builds once.
+#[test]
+fn a_file_beyond_the_index_ceiling_is_built_once_per_frame() {
+    let dir = TempDir::new().unwrap();
+    let mut harness = EditorTestHarness::new_no_wrap(80, 24).unwrap();
+    // 6,000 lines: past MAX_WRAP_SCROLLBAR_LINES (5,000), under the byte ceiling.
+    open_text(&mut harness, &dir, "big.txt", &numbered_lines(6_000, 20));
+    assert_frame_panes(&mut harness, 1, "unindexed file");
+
+    for _ in 0..50 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    assert_frame_panes(&mut harness, 1, "after scrolling motion, unindexed");
+    harness.assert_screen_contains("line 00051");
+
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    assert_frame_panes(&mut harness, 1, "at the end, unindexed");
+    harness.assert_screen_contains("line 06000");
+}
+
+/// A compose-mode split beside a source split of the same buffer: two
+/// gutters, two wrap widths, one build each. The compose plugin has to be
+/// in the project's plugins directory for its command to exist.
+#[test]
+fn a_compose_split_and_its_source_are_built_once_per_frame() {
+    let dir = TempDir::new().unwrap();
+    let project_root = dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+    let text: String = (1..=40)
+        .map(|i| format!("# Heading {i}\n\nA paragraph of prose for section {i}, long enough to wrap when composed at a narrow page width.\n\n"))
+        .collect();
+    let md_path = project_root.join("doc.md");
+    std::fs::write(&md_path, &text).unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+    assert_frame_panes(&mut harness, 1, "markdown source");
+
+    palette(&mut harness, "Split Vertical");
+    // Compose in the active (right) split, the way the compose split tests
+    // do: the plugin registers its command asynchronously.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    // Compose conceals the heading markers in its pane (except on the cursor
+    // line, where the markup stays revealed); the source pane keeps them.
+    // Wait until only one pane still shows the second heading's marker.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().matches("# Heading 2").count() == 1)
+        .unwrap();
+    assert_frame_panes(&mut harness, 2, "compose beside source");
+
+    for _ in 0..20 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    assert_frame_panes(&mut harness, 2, "compose beside source, after motion");
+}

--- a/crates/fresh-editor/tests/e2e/frame_once_per_pane.rs
+++ b/crates/fresh-editor/tests/e2e/frame_once_per_pane.rs
@@ -31,6 +31,7 @@ fn assert_frame_panes(harness: &mut EditorTestHarness, panes: u64, what: &str) {
             pane_placements: panes,
             buffer_layouts: panes,
             view_data_builds: panes,
+            composite_builds: 0,
         },
         "{what}: expected {panes} pane(s) placed, formatted and built once each, got {cost:?}"
     );

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -57,6 +57,7 @@ pub mod flash;
 #[cfg(feature = "plugins")]
 pub mod floating_modal_frame_chrome;
 pub mod folding;
+pub mod frame_once_per_pane;
 pub mod glob_language_detection;
 #[cfg(feature = "gui")]
 pub mod gui;


### PR DESCRIPTION
## Summary

Stage 1 of the retained-mode migration plan (Blocker A.2): every write the text formatter made *during paint* now runs in a pre-frame reconcile, the formatter is a read of `(state, viewport, rect)`, and `build_view_data` runs exactly once per visible pane per frame.

Rebased onto master after Stage 2 ("One geometry pass per frame") landed: the reconcile takes its rects from the frame's `PaneRects` (the seam that commit left for it), so no scratch-grid layout is added.

Four commits, each green on its own:

1. **Drop the dead third `build_view_data` pass; resolve the gutter per pane.** The layout-aware ensure-visible pass has been horizontal-only since vertical placement moved to row space, so the `may_rebuild` retry could never run. Each pane's left margin is now resolved from its own line-number setting (`MarginManager::resolved_left_config`, `resolve_gutter_layout`) and threaded into the row renderer as a value instead of being read off `state.margins.left_config`, which is per buffer and can hold a sibling split's gutter once all panes are reconciled before any is painted.
2. **`orchestration::reconcile`.** Viewport resize and byte-pass `ensure_visible`, the horizontal-scrollbar clamp, the margin write, `WrapIndex::ensure_built`, `ensure_visible_in_rows` (and `row_pass_owns_placement`), and the scroll-to-end sync (now `Viewport::scroll_to_end_in_rows`, decided from the index instead of by building rows twice) run once per pane, in paint order, before the body is painted. `Editor::render` calls `shell_host::reconcile_body` right after `PaneRects::read`, before the `lines_changed` hooks; each pane is placed at `PaneRects::content(leaf)`. The preview (`render_content`), macro replay (`compute_content_layout`) and the overlay preview's phantom leaf reconcile just ahead of their own pass. `compute_buffer_layout` takes `viewport: &Viewport, folds: &FoldManager`, resolves its anchor from the reconciled index (debug-asserted), and builds once.
3. **Counters and tests.** `split_rendering::instrument` counts placements, formats, row builds and composite-side builds per thread; the e2e harness asserts `placements == formats` and `builds == formats + composite builds` around every `render`, so the whole corpus checks the invariant. `tests/e2e/frame_once_per_pane.rs` pins the count to the panes on screen (one pane, three splits, a scroll-to-end sync frame, wrapped lines, a file beyond the index ceilings, a compose split beside its source).
4. **Prepare the grid once per frame.** `reconcile_body` returns the `ContentPass` it prepared and `BodyPainter` paints that one; re-preparing it resized buffer-group inner panels back to their panel rects after the reconcile had placed them at their content rects (caught by the formatter's assert on the first CI run).

## Departures from the plan's wording, each deliberate

- **Where the reconcile runs.** After `ui.frame` and `PaneRects::read`, not before the description: the rects exist only after layout. It does not yet run after cursor-moving appliers; the next frame's reconcile settles them, as paint used to.
- **`&mut EditorState` stays.** `Buffer::line_iterator` is `&mut self` (lazy chunk loads) and `decoration_context` resolves overlays/markers through `&mut` caches. The formatter writes neither viewport, folds nor margins; dropping the last `&mut` needs a `&Buffer` read path.
- **Two values still cross the paint.** The cursor's visual column (tabs, wide chars, spliced inlay hints — `Viewport::layout_column_scroll`, the pure form of the layout pass) and the horizontal scrollbar's longest-line bound both need the built rows. The formatter returns the column; `reconcile::settle_pane` stores it and runs the scan after the pane has painted, exactly where those writes were.

## Observable differences from the old order

- `lines_changed` hooks now see the reconciled viewport (the window the frame draws) instead of the previous frame's — decorations arrive a frame earlier after a scrolling motion.
- Same-buffer scroll-sync's scroll-to-end is decided in row space (last full page, where a wheel scroll to the bottom lands) rather than from a first build's row count. Beyond the index ceilings it falls back to the byte-based scroll limit. The only test of the old path is `#[ignore]`d; the new scenario test asserts both synced panes show the tail.
- No test needed changing for the new order beyond one viewport unit test that called the now-pure column helper.

## Verification

- CI: the full corpus passed on all three platforms on the pre-rebase head (`cf30fc6`); on the rebased head, ubuntu and macOS are green and Windows was still running at the time of writing.
- Locally: `cargo test -p fresh-editor --lib` (3777 passed, pre-rebase), the six scenario tests and the command-palette e2e subset, `cargo fmt --all`, `cargo clippy -p fresh-editor --tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ixYw3SLjHTHtt2Fr7gE64