### PR TITLE
Retained-mode Stage 2b: drop the scratch grid

### DIFF
--- a/crates/fresh-editor/src/app/action_dispatch.rs
+++ b/crates/fresh-editor/src/app/action_dispatch.rs
@@ -2106,7 +2106,9 @@ impl Editor {
         // created via `create_terminal_buffer_detached` (empty scrollback set),
         // so it is live in this split; focus the terminal pane.
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
-        self.active_window_mut().resize_visible_terminals();
+        // The dock leaf was just split off; size its PTY to the pane the
+        // grid gives it now, not the pane list of the last frame.
+        self.resize_visible_terminals();
 
         let exit_key = self
             .keybindings

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -917,7 +917,7 @@ impl super::Editor {
         // Walk the grouped subtree and update the SplitNode::Leaf's
         // `buffer_id`. The renderer reads this — not the
         // SplitViewState — when collecting which buffer to draw in
-        // each panel rect (see `get_leaves_with_rects`). Without
+        // each panel rect (see `SplitNode::visible_leaves`). Without
         // this, retargeting only updates focus state and the panel
         // keeps drawing the prior (now-empty) buffer.
         for node in self.active_window_mut().grouped_subtrees.values_mut() {

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -472,7 +472,7 @@ impl Editor {
     pub fn flush_layout(&mut self) {
         use crate::view::composite_view::CompositeViewState;
 
-        // Which leaves, not where. This asked `get_visible_buffers` for
+        // Which leaves, not where. This used to ask the split manager for
         // rectangles in a box it made up — the whole terminal, which is not
         // the box the grid is laid out in — and then dropped them.
         let visible = self

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -1565,6 +1565,12 @@ impl Editor {
             .filter(|id| *id != editor.active_window)
             .collect();
 
+        // Where the panes are, before anything asks: a terminal opened before
+        // the first frame is sized to its pane, and the snapshot below
+        // carries the panes' rects. One `layout_only` of the frame, the
+        // same pass the layout funnel runs.
+        editor.refresh_pane_rects();
+
         #[cfg(feature = "plugins")]
         {
             editor.update_plugin_state_snapshot();

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -238,8 +238,9 @@ impl Editor {
     /// Restore the split layout when the just-focused buffer would be
     /// hidden behind a maximized split.
     ///
-    /// `SplitManager::get_visible_buffers` renders *only* the maximized
-    /// split. A file open focuses its buffer in the active split, which —
+    /// A maximized split is the only one the frame places
+    /// (`SplitManager::visible_leaves` reports it alone). A file open
+    /// focuses its buffer in the active split, which —
     /// after `redirect_active_split_away_from_dock_if_needed` — is a
     /// regular editor leaf, not the maximized dock. With nothing reset, the
     /// new buffer renders behind the maximized terminal: the user sees no

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -413,8 +413,24 @@ impl Editor {
         // editor-global, so every window — not just the active one —
         // sizes its terminals for the post-dock chrome, ready for a
         // dive without a stale first frame.
+        //
+        // In two steps, because where a window's panes are is a function of
+        // the screen size and the dock width it is about to adopt: every
+        // window adopts them first, then its grid is laid out at that size,
+        // and only then does it seed its viewports and size its PTYs from the
+        // result. The active window's grid is the frame's, laid out once with
+        // `layout_only`; every other window's grid the retained tree does not
+        // hold, so it is laid out offscreen from the same description.
         for window in self.windows.values_mut() {
-            window.apply_layout(width, height, dock_cols);
+            window.adopt_screen(width, height, dock_cols);
+        }
+        self.refresh_pane_rects();
+        let active = self.active_window;
+        for (id, window) in self.windows.iter_mut() {
+            if *id != active {
+                window.layout_panes_offscreen();
+            }
+            window.apply_layout();
         }
     }
 
@@ -517,31 +533,34 @@ impl Editor {
 }
 
 impl crate::app::window::Window {
-    /// Adopt the geometry handed down by [`Editor::relayout`]: cache the
-    /// screen dimensions and the editor-global dock width, reseed every
+    /// Adopt the screen dimensions and the editor-global dock width handed
+    /// down by [`Editor::relayout`] — the first half of what `apply_layout`
+    /// did, split off because the layout that places this window's panes
+    /// runs between the two: it is laid out at the size adopted here, and
+    /// [`Self::apply_layout`] reads the result.
+    pub fn adopt_screen(&mut self, width: u16, height: u16, dock_cols: u16) {
+        self.terminal_width = width;
+        self.terminal_height = height;
+        self.dock_cols = dock_cols;
+    }
+
+    /// Adopt the geometry handed down by [`Editor::relayout`]: reseed every
     /// split viewport against the pane rect that split will actually be
     /// painted into, and resize the visible terminal PTYs. Per-split
     /// viewport dimensions are refined again at paint time by
     /// `sync_viewport_to_content` (which subtracts each pane's own chrome —
     /// gutter, tab bar, scrollbars); terminals have no such paint-time sync,
     /// which is why their PTY size must be pushed here.
-    pub fn apply_layout(&mut self, width: u16, height: u16, dock_cols: u16) {
-        self.terminal_width = width;
-        self.terminal_height = height;
-        self.dock_cols = dock_cols;
+    ///
+    /// Reads the pane rects the funnel just laid out for this window
+    /// ([`Self::visible_panes`]), after [`Self::adopt_screen`].
+    pub fn apply_layout(&mut self) {
+        let height = self.terminal_height;
 
-        // Per-split pane rects, derived from the same content area the
-        // renderer and `resize_visible_terminals` lay out against — so the
-        // file explorer's columns (and a sibling split's) are already carved
-        // out of them.
-        let visible: Vec<(
-            crate::model::event::LeafId,
-            crate::model::event::BufferId,
-            ratatui::layout::Rect,
-        )> = match self.buffers.splits() {
-            Some((mgr, _)) => mgr.get_visible_buffers(self.editor_content_area()),
-            None => Vec::new(),
-        };
+        // Per-split pane rects, off the layout the funnel just ran at the
+        // adopted size — so the file explorer's columns (and a sibling
+        // split's) are already carved out of them.
+        let visible = self.visible_panes();
 
         // Seed each visible split's viewport from its own pane rect. Seeding
         // every split with the whole post-dock editor width instead — which is

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -4308,9 +4308,10 @@ mod tests {
         // Split vertically into two side-by-side panes.
         editor.split_pane_vertical();
 
+        // The panes as the split's relayout placed them.
         let panes: Vec<(crate::model::event::LeafId, u16)> = editor
-            .split_manager()
-            .get_visible_buffers(editor.active_window().editor_content_area())
+            .active_window()
+            .visible_panes()
             .into_iter()
             .map(|(leaf, _buf, area)| (leaf, area.width))
             .collect();
@@ -4333,6 +4334,101 @@ mod tests {
                 full_width
             );
         }
+    }
+
+    /// A pane created by an action is placed before the frame that would
+    /// paint it: the split's relayout lays the frame out once and the
+    /// window retains where the panes are, so the neighbour query — which
+    /// pane is beside this one, by geometry — answers off the grid as it is.
+    #[cfg(feature = "plugins")]
+    #[test]
+    fn a_new_pane_is_beside_its_source_before_any_frame() {
+        use crate::view::shell::geometry::stats;
+        let config = Config::default();
+        let (dir_context, _temp) = test_dir_context();
+        let mut editor = Editor::new(
+            config,
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap();
+        let source = editor.active_split_id();
+        assert_eq!(
+            editor.pane_beside(source),
+            None,
+            "one pane has no neighbour"
+        );
+
+        let _ = stats::take();
+        editor.split_pane_vertical();
+        // The split reflowed through the funnel: one `layout_only` of the
+        // frame, no grid laid out alone.
+        assert_eq!(
+            stats::take(),
+            stats::LayoutCounts {
+                shell: 1,
+                offscreen_grids: 0,
+            }
+        );
+
+        let panes = editor.active_window().visible_panes();
+        assert_eq!(panes.len(), 2);
+        let (left, right) = (panes[0], panes[1]);
+        assert_eq!(left.0, source, "the source keeps the first slot");
+        assert_eq!(left.2.y, right.2.y);
+        assert_eq!(left.2.height, right.2.height);
+        assert_eq!(
+            right.2.x,
+            left.2.x + left.2.width + 1,
+            "the new pane sits past the source and the separator"
+        );
+        assert_eq!(editor.pane_beside(source), Some(right.0));
+        assert_eq!(editor.pane_beside(right.0), Some(source));
+    }
+
+    /// Every window's panes are placed by the layout funnel, not only the
+    /// active window's: the active window's off the frame, another window's
+    /// off one offscreen layout of its own grid at its own body.
+    #[test]
+    fn the_funnel_places_every_windows_panes() {
+        use crate::view::shell::geometry::stats;
+        let config = Config::default();
+        let (dir_context, _temp) = test_dir_context();
+        let mut editor = Editor::new(
+            config,
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap();
+        let other_root = tempfile::tempdir().unwrap();
+        let other = editor.create_window_at(other_root.path().to_path_buf(), "other".into());
+        assert_ne!(other, editor.active_window);
+
+        let _ = stats::take();
+        editor.relayout();
+        assert_eq!(
+            stats::take(),
+            stats::LayoutCounts {
+                shell: 1,
+                offscreen_grids: 1,
+            },
+            "the frame once for the active window, one offscreen grid for the other"
+        );
+
+        let active = editor.active_window().visible_panes();
+        let theirs = editor.windows[&other].visible_panes();
+        assert_eq!(active.len(), 1);
+        assert_eq!(theirs.len(), 1);
+        // The other window's one pane fills its own body, which is the same
+        // chrome at the same screen size.
+        assert_eq!(theirs[0].2, editor.windows[&other].editor_content_area());
+        assert_eq!(theirs[0].2, active[0].2);
     }
 
     /// Regression for sinelaw/fresh#2229.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -6656,7 +6656,10 @@ impl Window {
         // Captured before the closure borrows `self`: the panes' rects are
         // derived from the same area the renderer lays out into, so the
         // geometry a plugin reads matches the cells actually drawn.
-        let content_area = self.editor_content_area();
+        // The panes as the last layout placed them, in the tree's order. The
+        // layout funnel refreshes them before this runs on a split, a
+        // resize or a chrome toggle (`relayout` refreshes the snapshot).
+        let laid_out = self.visible_panes();
         self.buffers
             .with_all_mut(|buffers_mut, mgr, vs_map| {
                 if let Some(active_vs) = vs_map.get(&active_split_id) {
@@ -6747,8 +6750,7 @@ impl Window {
                 // instead of guessing from an iteration order that used to be
                 // a HashMap's.
                 snapshot.splits.clear();
-                let laid_out = mgr.get_visible_buffers(content_area);
-                for (leaf_id, _buf, rect) in laid_out {
+                for (leaf_id, _buf, rect) in laid_out.iter().copied() {
                     let Some(vs) = vs_map.get(&leaf_id) else {
                         continue;
                     };

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4512,6 +4512,10 @@ impl Editor {
         };
         match result {
             Ok((terminal_id, buffer_id, created_split_id)) => {
+                // The spawn may have split the target's grid, and the window
+                // sized its PTYs before the new pane was placed; place the
+                // panes as the grid is now and size them again.
+                self.resize_window_terminals(target_id);
                 if is_active_target {
                     let new_active = self.active_window().active_buffer();
                     if prev_active != Some(new_active) {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -397,6 +397,9 @@ impl Editor {
             size,
         );
         self.shell_ui = Some(ui);
+        // Retained for the callers that ask between frames where a pane is —
+        // the same rects this frame paints with. See `Window::pane_rects`.
+        self.active_window_mut().set_pane_rects(pane_rects.clone());
         let region = |r: crate::view::shell::frame::HostRegion| -> ratatui::layout::Rect {
             regions
                 .iter()
@@ -6993,27 +6996,14 @@ impl Editor {
         // which is deliberately not comparable, and a hand-picked subset of it
         // is the same "replica of a layout" this call site already got wrong
         // once.
-        let split = self.compute_dock_split(size);
-        let shell = self.shell_frame(split).resolve_dock(size.width);
-        let mut ui = self
-            .shell_ui
-            .take()
+        //
+        // The panes come off this same layout — the shape every frame reads
+        // them in (`render` does the same after its `frame`). What stood here
+        // read the body's region and handed it to a pass that laid the grid
+        // out a third time to find the panes inside it.
+        let pane_rects = self
+            .layout_panes(size)
             .expect("the shell tree is taken and returned within one call");
-        crate::view::shell::geometry::stats::note_shell_layout();
-        ui.layout_only(
-            crate::view::shell::frame::frame_tree(shell),
-            fresh_ui::Size::new(size.width, size.height),
-        );
-        // The panes, off this same layout — the shape every frame reads them
-        // in (`render` does the same after its `frame`). What stood here read
-        // the body's region and handed it to a pass that laid the grid out a
-        // third time to find the panes inside it.
-        let pane_rects = crate::view::shell::geometry::PaneRects::read(
-            &ui,
-            self.window_panes().into_iter().map(|(leaf, _)| leaf),
-            size,
-        );
-        self.shell_ui = Some(ui);
 
         // Compute layout for all visible splits and update cached view_line_mappings.
         // Take one &mut borrow on the active window's splits; destructure into
@@ -7051,6 +7041,68 @@ impl Editor {
             .expect("active window must have a populated split layout");
 
         self.active_layout_mut().view_line_mappings = view_line_mappings;
+    }
+
+    /// The frame's geometry pass without the frame: build the shell's
+    /// description, lay it out at `size` with `layout_only`, and read the
+    /// panes off it — the same read `render` does after its `frame`.
+    ///
+    /// Retains the rects on the active window (see `Window::pane_rects`) and
+    /// returns them. `None` when the shell tree is not here to lay out — a
+    /// frame, or an event dispatch, is holding it; the caller inside such a
+    /// pass has the tree's own answer, and the window keeps the rects of the
+    /// last layout, which that pass wrote.
+    ///
+    /// **A geometry pass, not a frame.** `layout_only` builds the description
+    /// and lays it out and stops; a frame goes on to move focus, drain a
+    /// reveal, hand a behavior what arrived for it, and repaint a display list
+    /// nobody will draw. This runs on actions — once per relayout, once per
+    /// replayed macro action — and none of that belongs on an action.
+    /// Counted by `geometry::stats` as a shell layout, because it is one.
+    pub(crate) fn layout_panes(
+        &mut self,
+        size: ratatui::layout::Rect,
+    ) -> Option<crate::view::shell::geometry::PaneRects> {
+        let split = self.compute_dock_split(size);
+        let shell = self.shell_frame(split).resolve_dock(size.width);
+        let mut ui = self.shell_ui.take()?;
+        crate::view::shell::geometry::stats::note_shell_layout();
+        ui.layout_only(
+            crate::view::shell::frame::frame_tree(shell),
+            fresh_ui::Size::new(size.width, size.height),
+        );
+        let pane_rects = crate::view::shell::geometry::PaneRects::read(
+            &ui,
+            self.window_panes().into_iter().map(|(leaf, _)| leaf),
+            size,
+        );
+        self.shell_ui = Some(ui);
+        self.active_window_mut().set_pane_rects(pane_rects.clone());
+        Some(pane_rects)
+    }
+
+    /// The shell tree, when no frame or event dispatch is holding it.
+    ///
+    /// For tests that check a record against the tree that wrote it — the
+    /// pane rects a window retains against the frame's own layout. Not for
+    /// the editor: what it needs off the tree it reads where it lays the
+    /// tree out.
+    pub fn shell_ui(&self) -> Option<&fresh_ui::Ui<crate::view::shell::msg::UiMsg>> {
+        self.shell_ui.as_ref()
+    }
+
+    /// Bring the active window's retained pane rects up to date with the
+    /// grid as it is now, at the screen's current size — one `layout_only` of
+    /// the frame ([`Self::layout_panes`]).
+    ///
+    /// For the callers that ask where a pane is right after changing the
+    /// grid, before the frame that would lay it out: the layout funnel
+    /// (`push_layout_geometry`) runs this first, and so does every
+    /// `Editor::resize_visible_terminals`. A no-op while a frame or an event
+    /// dispatch holds the tree; see [`Self::layout_panes`].
+    pub(crate) fn refresh_pane_rects(&mut self) {
+        let size = ratatui::layout::Rect::new(0, 0, self.terminal_width, self.terminal_height);
+        let _ = self.layout_panes(size);
     }
 
     /// Clear the search history

--- a/crates/fresh-editor/src/app/shell_host.rs
+++ b/crates/fresh-editor/src/app/shell_host.rs
@@ -158,11 +158,11 @@ pub struct BodyPainter<'a> {
     /// Where the frame put every pane, read off the tree `render` just laid
     /// out — the same tree whose display list this painter is folded over.
     ///
-    /// The body's pass used to ask `SplitManager::get_visible_buffers` for
-    /// this, which laid the grid out a second time in a scratch `Ui<()>`; a
-    /// pane's box came from that grid and its `Host` rect from the tree, and
-    /// only a parity test said the two agreed. Now there is one answer, and
-    /// [`Self::pane`] asserts the fold's rect is it.
+    /// The body's pass used to ask the split manager for this, which laid
+    /// the grid out a second time in a scratch `Ui<()>`; a pane's box came
+    /// from that grid and its `Host` rect from the tree, and only a parity
+    /// test said the two agreed. Now there is one answer, and [`Self::pane`]
+    /// asserts the fold's rect is it.
     rects: PaneRects,
     /// The grid as [`reconcile_body`] prepared it for this frame, taken by
     /// [`Self::body`] so the panes are prepared once per frame — preparing

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -647,7 +647,7 @@ impl Editor {
         // in its split (so a window resize never reached it). Refresh visible
         // terminal sizes so its PTY child sees the pane it now occupies —
         // mirrors `set_active_buffer` (issue #1795).
-        self.active_window_mut().resize_visible_terminals();
+        self.resize_visible_terminals();
 
         // Keep the newly active tab scrolled into view within its split,
         // matching `switch_split` and `set_active_buffer`.
@@ -758,25 +758,23 @@ impl Editor {
             .expect("active window must have a populated split layout")
     }
 
-    /// Where a pane currently sits on screen, in editor-area cells.
-    /// `None` once the leaf is gone (closed, or collapsed by its last tab).
+    /// Where a pane currently sits on screen, as the last layout placed it.
+    /// `None` once the leaf is gone (closed, or collapsed by its last tab) or
+    /// hidden behind a maximized sibling.
+    ///
+    /// Read off the window's retained pane rects, which the layout funnel
+    /// refreshes before any caller of this runs (`split_pane_impl` ends in
+    /// `relayout`).
     pub(crate) fn split_rect(
         &self,
         leaf: crate::model::event::LeafId,
     ) -> Option<ratatui::layout::Rect> {
-        let area = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| w.editor_content_area())?;
         self.windows
-            .get(&self.active_window)
-            .and_then(|w| w.buffers.splits())
-            .and_then(|(mgr, _)| {
-                mgr.get_visible_buffers(area)
-                    .into_iter()
-                    .find(|(id, _, _)| *id == leaf)
-                    .map(|(_, _, rect)| rect)
-            })
+            .get(&self.active_window)?
+            .visible_panes()
+            .into_iter()
+            .find(|(id, _, _)| *id == leaf)
+            .map(|(_, _, rect)| rect)
     }
 
     /// Resolve a caller-supplied path against the window's root, so a script
@@ -1069,11 +1067,14 @@ impl Editor {
             .windows
             .get(&self.active_window)
             .and_then(|w| w.buffers.splits())?;
+        // Which leaves show, not where: a labeled leaf hidden behind a
+        // maximized sibling is not a destination.
+        let visible = mgr.visible_leaves();
         mgr.labels()
             .iter()
             .find(|(_, l)| l.as_str() == label)
             .map(|(id, _)| crate::model::event::LeafId(*id))
-            .filter(|leaf| self.split_rect(*leaf).is_some())
+            .filter(|leaf| visible.iter().any(|(id, _)| id == leaf))
     }
 
     /// The pane to open a target in when no label named one: the nearest
@@ -1086,14 +1087,13 @@ impl Editor {
     /// the destination is where a reader would look for it and does not depend
     /// on where focus happened to be.
     #[cfg(feature = "plugins")]
-    fn pane_beside(
+    pub(super) fn pane_beside(
         &self,
         this_one: crate::model::event::LeafId,
     ) -> Option<crate::model::event::LeafId> {
         let window = self.windows.get(&self.active_window)?;
-        let area = window.editor_content_area();
-        let (mgr, _) = window.buffers.splits()?;
-        let panes = mgr.get_visible_buffers(area);
+        // The panes as the last layout placed them, in the tree's order.
+        let panes = window.visible_panes();
         let here = panes.iter().find(|(id, _, _)| *id == this_one)?.2;
 
         let usable: Vec<_> = panes

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1548,8 +1548,22 @@ impl Editor {
     /// retained rects are refreshed with one `layout_only` of the frame
     /// first (`refresh_pane_rects`), then read.
     pub(crate) fn resize_visible_terminals(&mut self) {
-        self.refresh_pane_rects();
-        self.active_window_mut().resize_visible_terminals();
+        self.resize_window_terminals(self.active_window);
+    }
+
+    /// [`Self::resize_visible_terminals`] for `window`, active or not: the
+    /// active window's panes are placed off the frame, another window's off
+    /// one offscreen layout of its own grid — the same two ways the layout
+    /// funnel places them — and then its visible PTYs are sized to them.
+    pub(crate) fn resize_window_terminals(&mut self, window: fresh_core::WindowId) {
+        if window == self.active_window {
+            self.refresh_pane_rects();
+        } else if let Some(w) = self.windows.get_mut(&window) {
+            w.layout_panes_offscreen();
+        }
+        if let Some(w) = self.windows.get_mut(&window) {
+            w.resize_visible_terminals();
+        }
     }
 
     pub fn open_terminal(&mut self) {

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1538,6 +1538,20 @@ impl Editor {
         );
     }
 
+    /// Size the active window's visible terminal PTYs to their panes — as
+    /// the grid is *now*, laid out before the window reads it.
+    ///
+    /// The editor-side counterpart of `Window::resize_visible_terminals`,
+    /// for the callers that have just changed the grid (a dock split
+    /// created, a terminal split opened, a window dived into) and cannot
+    /// wait for the frame that would place the new pane: the window's
+    /// retained rects are refreshed with one `layout_only` of the frame
+    /// first (`refresh_pane_rects`), then read.
+    pub(crate) fn resize_visible_terminals(&mut self) {
+        self.refresh_pane_rects();
+        self.active_window_mut().resize_visible_terminals();
+    }
+
     pub fn open_terminal(&mut self) {
         let Some((terminal_id, buffer_id)) = self.active_window_mut().open_terminal_in_window()
         else {
@@ -1653,7 +1667,7 @@ impl Editor {
         // is live in this new split; other splits keep their own per-split
         // mode, so closing this split later restores them correctly (#2485).
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
-        self.active_window_mut().resize_visible_terminals();
+        self.resize_visible_terminals();
 
         // A new split changes every sibling pane's size. Reflow through the
         // single layout funnel so existing terminals fit their new panes.
@@ -2033,7 +2047,7 @@ impl Editor {
             }
 
             // Ensure terminal PTY is sized correctly for current split dimensions
-            self.active_window_mut().resize_visible_terminals();
+            self.resize_visible_terminals();
 
             self.set_status_message(t!("status.terminal_mode_enabled").to_string());
         }
@@ -2278,15 +2292,15 @@ impl Window {
 
     /// Resize all this window's visible terminal PTYs to match their
     /// current split dimensions, and re-pin the scroll-back view's grid
-    /// wrap column to the same pane width. Reads the window's cached
-    /// `terminal_width` / `terminal_height` for the screen size.
+    /// wrap column to the same pane width. Reads the panes as the last
+    /// layout placed them ([`Self::visible_panes`]); an editor-side caller
+    /// that has just changed the grid goes through
+    /// `Editor::resize_visible_terminals`, which lays it out first.
     pub fn resize_visible_terminals(&mut self) {
-        let editor_area = self.editor_content_area();
-
-        let Some((mgr, _)) = self.buffers.splits() else {
+        if self.buffers.splits().is_none() {
             return;
-        };
-        let visible_buffers = mgr.get_visible_buffers(editor_area);
+        }
+        let visible_buffers = self.visible_panes();
 
         // (split, terminal buffer, pty cols, pty rows, grid cols). Collected
         // first because applying it needs `&mut self` for both the terminal

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -633,6 +633,25 @@ pub struct Window {
     /// real placement and `relayout` recomputes this from it.
     pub(crate) dock_cols: u16,
 
+    /// Where the last layout put this window's panes.
+    ///
+    /// **A record from layout, not of a paint.** The painter records nothing
+    /// a layout could answer (the E.1 rule); this is the layout's own answer,
+    /// kept for the callers that ask *between* frames — a terminal's PTY
+    /// sized to its pane, a tab strip's width, the plugin snapshot, the pane
+    /// beside this one — which cannot read the shell tree themselves: it is
+    /// the editor's, it describes only the active window, and a frame may be
+    /// holding it. Every layout that places this window's panes writes it:
+    /// `Editor::render`, `Editor::recompute_layout`,
+    /// `Editor::refresh_pane_rects`, and the layout funnel
+    /// (`Editor::push_layout_geometry`), which lays the active window's frame
+    /// out and every other window's grid offscreen before anything reads
+    /// them. Read through [`Self::visible_panes`] or [`Self::pane_rects`].
+    ///
+    /// Empty until the first layout. `Editor::with_options` runs one, so a
+    /// window that exists has been laid out at least once.
+    pub(crate) pane_rects: crate::view::shell::geometry::PaneRects,
+
     /// Editor-global resources shared by `Arc` clone (config, theme
     /// registry, keybindings, command registry, filesystem authority,
     /// the buffer-id allocator, …). See [`WindowResources`] for the
@@ -2310,6 +2329,7 @@ impl Window {
             terminal_width: 80,
             terminal_height: 24,
             dock_cols: 0,
+            pane_rects: Default::default(),
             preview: None,
             terminal_link_hover: None,
             seen_byte_ranges: HashMap::new(),
@@ -2584,7 +2604,7 @@ impl Window {
     pub fn split_tabs_width(&self, split_id: LeafId) -> u16 {
         match self.buffers.splits() {
             Some((mgr, _)) => {
-                let visible = mgr.get_visible_buffers(self.editor_content_area());
+                let visible = self.visible_panes();
                 let Some((_, _, area)) = visible.iter().find(|(id, _, _)| *id == split_id) else {
                     return self.effective_tabs_width();
                 };
@@ -2603,6 +2623,77 @@ impl Window {
             }
             None => self.effective_tabs_width(),
         }
+    }
+
+    /// Where the last layout put this window's panes. See the field.
+    pub fn pane_rects(&self) -> &crate::view::shell::geometry::PaneRects {
+        &self.pane_rects
+    }
+
+    /// Retain `rects` as where this window's panes are. Called by every
+    /// layout that placed them; see the field.
+    pub(crate) fn set_pane_rects(&mut self, rects: crate::view::shell::geometry::PaneRects) {
+        self.pane_rects = rects;
+    }
+
+    /// The visible leaves, each with the box the last layout gave it, in the
+    /// tree's order — first child before second, so left to right and top to
+    /// bottom.
+    ///
+    /// The shape `SplitManager::get_visible_buffers` used to answer in, which
+    /// laid the grid out again to say so: only the maximized pane when one is
+    /// maximized, at the whole body; a leaf the layout did not place gets a
+    /// zero rectangle. Which leaves is the model's answer
+    /// (`SplitManager::visible_leaves`); where they are is the retained
+    /// layout's ([`Self::pane_rects`]).
+    pub fn visible_panes(&self) -> Vec<(LeafId, BufferId, ratatui::layout::Rect)> {
+        match self.buffers.splits() {
+            Some((mgr, _)) => self.pane_rects.visible(&mgr.visible_leaves()),
+            None => Vec::new(),
+        }
+    }
+
+    /// Lay this window's grid out offscreen, at the body this window's
+    /// chrome leaves it, and retain where its panes are.
+    ///
+    /// For a window the retained tree does not hold: the shell describes the
+    /// active window's frame only, and the layout funnel sizes every other
+    /// window's terminals too, so their panes come off one offscreen layout
+    /// of the same description the frame would mount (`PaneRects::offscreen`,
+    /// as the session preview does). The body is `editor_content_area`, the
+    /// window's own derivation of the frame's body from its chrome flags —
+    /// the box the scratch grid was laid out in, for every window.
+    ///
+    /// The pane *boxes* are what is read off this. The content slots come
+    /// out too, but without the plugin panel interiors the editor would mount
+    /// (those are the editor's, not the window's), so they are the slots of
+    /// a pane showing a buffer; nothing reads a non-active window's content
+    /// slots.
+    pub(crate) fn layout_panes_offscreen(&mut self) {
+        use crate::view::shell::splits::{PaneChrome, PaneControls, Splits};
+        let Some((mgr, _)) = self.buffers.splits() else {
+            self.pane_rects = Default::default();
+            return;
+        };
+        let is_maximized = mgr.is_maximized();
+        let several = mgr.visible_leaves().len() > 1;
+        let splits = Splits {
+            root: mgr.root().clone(),
+            maximized: mgr.maximized_split().map(LeafId),
+            chrome: self.pane_chrome(PaneChrome {
+                tabs: self.tab_bar_visible,
+                vscroll: self.resources.config.editor.show_vertical_scrollbar,
+                hscroll: self.resources.config.editor.show_horizontal_scrollbar,
+            }),
+            controls: PaneControls {
+                maximize: several || is_maximized,
+                close: several && !is_maximized,
+            },
+            groups: self.pane_groups(),
+            interiors: Default::default(),
+        };
+        self.pane_rects =
+            crate::view::shell::geometry::PaneRects::offscreen(&splits, self.editor_content_area());
     }
 
     /// The split id whose `SplitViewState` owns the currently-focused

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -1110,7 +1110,7 @@ impl crate::app::Editor {
         // Focus changes that bypass the usual tab-click path must restore
         // terminal mode themselves, and the PTY must match its new split.
         self.sync_terminal_mode_to_active_buffer();
-        self.active_window_mut().resize_visible_terminals();
+        self.resize_visible_terminals();
 
         self.set_status_message(
             t!("workspace.extracted_tab", name = name, label = target_label).to_string(),
@@ -1300,15 +1300,16 @@ impl crate::app::Editor {
         // replacement candidates in focus-history (LRU) order — most-recently
         // focused first, then any other open tab — mirroring the real
         // close-tab path (`resolve_close_replacement`) rather than raw tab
-        // order. The rect is a probe; only ids matter here. Owned Vecs so the
-        // `self.windows` borrow is released before the mutating loop.
-        let probe = ratatui::layout::Rect::new(0, 0, 1, 1);
+        // order. Every leaf of the tree, maximized or not: a leaf hidden
+        // behind a maximized sibling still shows the buffer and still needs
+        // retargeting. Owned Vecs so the `self.windows` borrow is released
+        // before the mutating loop.
         let showing: Vec<(crate::model::event::LeafId, Vec<fresh_core::BufferId>)> = mgr
             .root()
-            .get_leaves_with_rects(probe)
+            .visible_leaves()
             .into_iter()
-            .filter(|(_, displayed, _)| *displayed == buffer_id)
-            .map(|(leaf_id, _, _)| {
+            .filter(|(_, displayed)| *displayed == buffer_id)
+            .map(|(leaf_id, _)| {
                 let candidates = view_states
                     .get(&leaf_id)
                     .map(|vs| {

--- a/crates/fresh-editor/src/view/shell/geometry.rs
+++ b/crates/fresh-editor/src/view/shell/geometry.rs
@@ -1,34 +1,48 @@
 //! Where the frame put each pane — read once, off the `Ui` that laid the
 //! frame out.
 //!
-//! **One source of pane geometry per frame.** The render path used to lay
-//! the pane grid out more than once and three different ways: `Editor::render`
-//! laid out the shell tree, `SplitManager::get_leaves_with_rects` laid the
-//! *same* grid out again in a scratch `Ui<()>` to answer where the panes are,
-//! and the macro-replay path did a third — a `layout_only` of the shell, then
-//! `compute_content_layout`, which ran the scratch grid inside it. The scratch
-//! grid was a second implementation of the pane layout; where it disagreed
-//! with the tree by a cell, the painter's clip papered over it.
+//! **One source of pane geometry.** The pane grid used to be laid out more
+//! than once and three different ways: `Editor::render` laid out the shell
+//! tree, `SplitManager::get_leaves_with_rects` laid the *same* grid out again
+//! in a scratch `Ui<()>` to answer where the panes are — for the render path
+//! at first, and for every action that asked after it — and the macro-replay
+//! path did a third, a `layout_only` of the shell and then the scratch grid
+//! inside `compute_content_layout`. The scratch grid was a second
+//! implementation of the pane layout; where it disagreed with the tree by a
+//! cell, the painter's clip papered over it. It is gone, and nothing lays the
+//! grid out alone any more.
 //!
 //! [`PaneRects`] is the one answer. It is read off the shell's `Ui` right
-//! after the frame's layout — [`Ui::frame`](fresh_ui::Ui::frame) on the render
-//! path, [`Ui::layout_only`](fresh_ui::Ui::layout_only) on the replay path —
-//! and handed to everything that used to ask the scratch grid: the plugin
-//! `lines_changed` hooks, the body painter, and the layout-only pass. The keys
-//! it reads are the ones the description applies: [`leaf_key`] for the box a
-//! pane fills and [`content_key`] for the content slot inside it, past the
-//! strip and beside the scrollbar.
+//! after a layout — [`Ui::frame`](fresh_ui::Ui::frame) on the render path,
+//! [`Ui::layout_only`](fresh_ui::Ui::layout_only) on the replay path and on
+//! `Editor::refresh_pane_rects` — and handed to everything that used to ask
+//! the scratch grid: the plugin `lines_changed` hooks, the body painter, and
+//! the layout-only pass. The keys it reads are the ones the description
+//! applies: [`leaf_key`] for the box a pane fills and [`content_key`] for the
+//! content slot inside it, past the strip and beside the scrollbar.
 //!
-//! **Never last frame's rect.** Every chrome toggle — the dock, the explorer,
-//! the menu bar, a separator drag — changes pane widths between frames, and a
-//! pane laid out at the old width is a visibly wrong frame, not a short one.
-//! The rects here are this frame's, from this frame's layout.
+//! **Never last frame's rect, on the render path.** Every chrome toggle — the
+//! dock, the explorer, the menu bar, a separator drag — changes pane widths
+//! between frames, and a pane laid out at the old width is a visibly wrong
+//! frame, not a short one. The rects a frame paints with are this frame's,
+//! from this frame's layout.
 //!
-//! The session preview is the one caller with no tree to read: it paints
-//! *another window's* grid offscreen, where this window's tree has no nodes.
-//! [`PaneRects::offscreen`] lays that grid out once, from the same description
-//! the frame uses (`splits::overlay`), and reads it the same way — one layout
-//! of one description, rather than a scratch grid plus a per-pane interior.
+//! **Between frames, the last layout's.** The action paths that ask where a
+//! pane is — a terminal's PTY sized to its pane, a tab strip's width, the
+//! plugin snapshot, the pane beside this one — read the [`PaneRects`] the
+//! window retains (`Window::pane_rects`), which every layout writes. The
+//! layout funnel (`Editor::push_layout_geometry`) refreshes it with a
+//! `layout_only` of the frame *before* those callers run, so an action that
+//! just split, closed, maximized or dragged a pane asks about the grid as it
+//! is, not as the last frame had it.
+//!
+//! Two callers have no tree to read, and lay the grid out offscreen from the
+//! same description the frame mounts (`splits::overlay`), reading it the same
+//! way: the session preview, which paints *another window's* grid into a box
+//! of this one's frame, and the layout funnel for the windows that are not
+//! the active one, whose grids the one retained tree does not hold.
+//! [`PaneRects::offscreen`] is that — one layout of one description, rather
+//! than a scratch grid plus a per-pane interior.
 
 use std::collections::HashMap;
 
@@ -67,9 +81,9 @@ impl PaneRects {
     /// in screen coordinates.
     ///
     /// A pane with no node — one hidden behind a maximized sibling — is simply
-    /// absent. A zero-size pane is *not*: the scratch grid answered a zero
-    /// rectangle for it and the painter painted nothing in it, and this keeps
-    /// that shape rather than dropping the pane from the frame's list.
+    /// absent. A zero-size pane is *not*: the painter paints nothing in it,
+    /// and this keeps that shape rather than dropping the pane from the
+    /// frame's list.
     pub fn read(
         ui: &fresh_ui::Ui<UiMsg>,
         panes: impl IntoIterator<Item = LeafId>,
@@ -97,11 +111,12 @@ impl PaneRects {
     /// no nodes for.
     ///
     /// The session preview paints another window's panes into a rectangle of
-    /// this one's frame. That grid is described by the same `overlay` the
-    /// frame mounts, laid out once here at the preview's box, so the preview's
-    /// panes come off one layout of one description — the rule the render
-    /// path follows, applied to the one grid the render path's tree cannot
-    /// hold.
+    /// this one's frame, and the layout funnel sizes every window's terminals
+    /// to their panes, not only the active window's. Those grids are
+    /// described by the same `overlay` the frame mounts, laid out once here at
+    /// the caller's box, so their panes come off one layout of one
+    /// description — the rule the render path follows, applied to the grids
+    /// the retained tree cannot hold.
     pub fn offscreen(s: &Splits, area: Rect) -> Self {
         stats::note_offscreen_grid();
         let mut ui: fresh_ui::Ui<UiMsg> = fresh_ui::Ui::new();
@@ -119,14 +134,14 @@ impl PaneRects {
         self.by_pane.get(&pane).map(|r| r.content)
     }
 
-    /// `leaves`, each with the box it fills — the shape
-    /// `SplitManager::get_visible_buffers` answered in, so the callers that
-    /// took that list take this one.
+    /// `leaves`, each with the box it fills, in the order given — the shape
+    /// `SplitManager::get_visible_buffers` used to answer in, so the callers
+    /// that took that list take this one, in the same order (the tree's,
+    /// first child before second: left to right, top to bottom).
     ///
-    /// A leaf the tree did not place gets a zero rectangle, as the scratch
-    /// grid gave one it could not find; the set of leaves is the caller's,
-    /// and `SplitManager::visible_leaves` already leaves out what a maximized
-    /// pane hides.
+    /// A leaf the tree did not place gets a zero rectangle; the set of leaves
+    /// is the caller's, and `SplitManager::visible_leaves` already leaves out
+    /// what a maximized pane hides.
     pub fn visible(&self, leaves: &[(LeafId, BufferId)]) -> Vec<(LeafId, BufferId, Rect)> {
         leaves
             .iter()
@@ -159,10 +174,11 @@ fn panes_of(s: &Splits) -> Vec<LeafId> {
 /// How many times the pane grid was laid out, per frame.
 ///
 /// The instrument Stage 2 of the retained-mode plan asks for: a count of
-/// shell layout passes and of scratch-grid layouts, so a test can pin "one
-/// shell layout, no scratch grid" per frame and per replayed action, and so
-/// the next path to lay the grid out a second time fails a test rather than
-/// hiding behind the clip.
+/// shell layout passes and of offscreen grids, so a test can pin "one shell
+/// layout, nothing else" per frame and per replayed action, and so the next
+/// path to lay the grid out a second time fails a test rather than hiding
+/// behind the clip. The scratch grid's own counter went with the scratch
+/// grid: there is no path left that lays the grid out alone.
 ///
 /// Thread-local, because the editor renders on one thread and tests run one
 /// editor per thread. Counted only with debug assertions on; the release
@@ -174,7 +190,6 @@ pub mod stats {
     #[cfg(debug_assertions)]
     thread_local! {
         static SHELL_LAYOUTS: Cell<u32> = const { Cell::new(0) };
-        static SCRATCH_GRIDS: Cell<u32> = const { Cell::new(0) };
         static OFFSCREEN_GRIDS: Cell<u32> = const { Cell::new(0) };
     }
 
@@ -182,15 +197,14 @@ pub mod stats {
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct LayoutCounts {
         /// Layouts of the shell tree: `Ui::frame` on the render path,
-        /// `Ui::layout_only` on the replay path. One per frame is the rule.
+        /// `Ui::layout_only` on the replay path and on
+        /// `Editor::refresh_pane_rects`. One per frame is the rule.
         pub shell: u32,
-        /// Scratch layouts of the pane grid in a `Ui<()>` —
-        /// `SplitNode::get_leaves_with_rects`. Zero on the render path is
-        /// the rule; its remaining callers are model queries and tests.
-        pub scratch_grids: u32,
-        /// Offscreen layouts of another window's grid, for the session
-        /// preview ([`super::PaneRects::offscreen`]). One per embedded
-        /// window painted.
+        /// Offscreen layouts of a grid the retained tree does not hold
+        /// ([`super::PaneRects::offscreen`]): one per embedded window the
+        /// session preview paints, one per non-active window the layout
+        /// funnel sizes. Zero per frame is the rule when no preview is
+        /// painted.
         pub offscreen_grids: u32,
     }
 
@@ -198,12 +212,6 @@ pub mod stats {
     pub fn note_shell_layout() {
         #[cfg(debug_assertions)]
         SHELL_LAYOUTS.with(|c| c.set(c.get().saturating_add(1)));
-    }
-
-    #[inline]
-    pub fn note_scratch_grid() {
-        #[cfg(debug_assertions)]
-        SCRATCH_GRIDS.with(|c| c.set(c.get().saturating_add(1)));
     }
 
     #[inline]
@@ -217,7 +225,6 @@ pub mod stats {
     pub fn take() -> LayoutCounts {
         LayoutCounts {
             shell: SHELL_LAYOUTS.with(|c| c.replace(0)),
-            scratch_grids: SCRATCH_GRIDS.with(|c| c.replace(0)),
             offscreen_grids: OFFSCREEN_GRIDS.with(|c| c.replace(0)),
         }
     }
@@ -250,10 +257,14 @@ mod tests {
         }
     }
 
-    /// The tree's answer is the scratch grid's answer, pane for pane, for the
-    /// box and for the content slot — which is what lets the scratch grid go.
+    /// The tree's answer is the model's own walk's answer, pane for pane, for
+    /// the box and for the content slot — which is what let the scratch grid
+    /// go. The oracle is `reference_leaves_with_rects`, the recursion over
+    /// `split_rect_ext` that was the layout before the description was, kept
+    /// under `cfg(test)` for exactly this; and for this fixed grid the rects
+    /// are also spelled out by hand, so the oracle is checked too.
     #[test]
-    fn the_tree_places_panes_where_the_scratch_grid_did() {
+    fn the_tree_places_panes_where_the_model_walk_does() {
         let root = split(
             SplitDirection::Vertical,
             leaf(0),
@@ -279,15 +290,25 @@ mod tests {
         let _ = stats::take();
         let rects = PaneRects::offscreen(&s, area);
 
-        let want = root.get_leaves_with_rects(area);
-        assert_eq!(want.len(), 3);
-        // The instrument sees both: the one offscreen layout, and the oracle's
-        // scratch grid.
+        let want = root.reference_leaves_with_rects(area);
+        // By hand: a column is reserved for the separator, and 99 columns at
+        // 0.6 round to 59 for pane 0, leaving 40 for the right half past the
+        // separator; a row is reserved there too, and 39 rows at 0.3 round to
+        // 12 for pane 1, leaving 27 for pane 2 below the separator.
+        assert_eq!(
+            want,
+            vec![
+                (id(0), BufferId(0), Rect::new(3, 2, 59, 40)),
+                (id(1), BufferId(1), Rect::new(63, 2, 40, 12)),
+                (id(2), BufferId(2), Rect::new(63, 15, 40, 27)),
+            ]
+        );
+        // The instrument sees the one offscreen layout and nothing else: the
+        // oracle is a walk of the model, not a layout.
         assert_eq!(
             stats::take(),
             stats::LayoutCounts {
                 shell: 0,
-                scratch_grids: 1,
                 offscreen_grids: 1,
             }
         );
@@ -304,8 +325,7 @@ mod tests {
     }
 
     /// A maximized pane is the only one placed; the others are absent, not
-    /// zero — and `visible` gives a leaf the tree did not place a zero rect,
-    /// as the scratch grid did.
+    /// zero — and `visible` gives a leaf the tree did not place a zero rect.
     #[test]
     fn a_maximized_pane_is_the_only_one_placed() {
         let s = Splits {
@@ -354,8 +374,14 @@ mod tests {
         let rects = PaneRects::offscreen(&s, area);
         let outer = rects.content(id(0)).expect("the outer content slot");
         assert_eq!(outer, Rect::new(0, 1, 79, 23));
-        let want = group.get_leaves_with_rects(outer);
-        assert_eq!(want.len(), 2);
+        let want = group.reference_leaves_with_rects(outer);
+        assert_eq!(
+            want,
+            vec![
+                (id(20), BufferId(20), Rect::new(0, 1, 39, 23)),
+                (id(21), BufferId(21), Rect::new(40, 1, 39, 23)),
+            ]
+        );
         for (leaf, _, r) in want {
             assert_eq!(rects.pane(leaf), Some(r), "{leaf:?} inside the outer pane");
         }

--- a/crates/fresh-editor/src/view/shell/splits.rs
+++ b/crates/fresh-editor/src/view/shell/splits.rs
@@ -4,8 +4,10 @@
 //! layout engine — `get_leaves_with_rects` recursing over ratios and reserving
 //! a cell per separator — and everything downstream was keyed on the
 //! rectangles it produced: the separator drags, the per-pane scrollbars, the
-//! tab strips, click-to-byte. That engine is this description now, and the
-//! model's queries are reads of it (`SplitManager::get_visible_buffers`).
+//! tab strips, click-to-byte. That engine is this description now, laid out
+//! once per frame as part of the shell tree, and where the panes are is read
+//! off that layout (`view::shell::geometry::PaneRects`) — the model no longer
+//! lays anything out to answer.
 //!
 //! The rule itself does not move. `split_rect_ext` converts a ratio to cells
 //! and pins the first child so its sibling keeps `MIN_PANE_{WIDTH,HEIGHT}` —
@@ -46,8 +48,8 @@ pub fn grid<M: 'static>(root: &SplitNode, maximized: Option<LeafId>) -> Node<M> 
     if let Some(id) = maximized {
         if let Some(SplitNode::Leaf { split_id, .. }) = root.find(id.into()) {
             // A maximized pane is the whole box and there are no separators —
-            // the same two facts `get_visible_buffers` and `get_separators`
-            // state separately.
+            // the same two facts `SplitManager::visible_leaves` and
+            // `get_separators` state separately.
             return pane(*split_id);
         }
     }
@@ -208,8 +210,9 @@ mod tests {
 
     /// **The tree lays the grid out exactly as the model always did.**
     ///
-    /// This is the swap's whole safety argument: `get_leaves_with_rects` is a
-    /// layout engine, and it is being replaced by one. It shares the rule
+    /// This is the swap's whole safety argument: the model's walk
+    /// (`reference_leaves_with_rects`, the engine that was) is a layout
+    /// engine, and it was replaced by one. The two share the rule
     /// (`split_rect_ext`), so a divergence here would be the *structure*
     /// disagreeing — a reserved separator cell, or which child takes the
     /// remainder.
@@ -243,7 +246,8 @@ mod tests {
     }
 
     /// A maximized pane is the whole box, and the separators go with it —
-    /// two facts `get_visible_buffers` and `get_separators` state apart.
+    /// two facts `SplitManager::visible_leaves` and `get_separators` state
+    /// apart.
     #[test]
     fn a_maximized_pane_takes_the_whole_box() {
         let root = split(SplitDirection::Vertical, leaf(0), leaf(1), 0.5, 10);
@@ -431,8 +435,8 @@ mod tests {
 
     /// **A maximized pane is the only one the fold reaches.**
     ///
-    /// The same two facts `get_visible_buffers` states when a pane is
-    /// maximized: it is the whole box, and it is alone.
+    /// The same two facts `SplitManager::visible_leaves` and the grid state
+    /// when a pane is maximized: it is alone, and it is the whole box.
     #[test]
     fn a_maximized_pane_is_the_only_host_in_the_grid() {
         let root = split(SplitDirection::Vertical, leaf(0), leaf(1), 0.5, 10);

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -897,15 +897,19 @@ impl SplitNode {
 
     /// Get all leaf nodes (buffer views) with their rectangles.
     ///
-    /// Grouped nodes always recurse into their inner layout — the layout's
-    /// leaves get the full rect that would have been given to the Grouped
-    /// node. Visibility (which group is "active") is applied elsewhere.
-    /// **The engine the description replaced**, kept as the thing the swap is
-    /// pinned against.
+    /// Where each leaf of this subtree sits inside `rect`, by the model's own
+    /// walk: recurse over the ratios, reserving a cell per separator. Grouped
+    /// nodes always recurse into their inner layout — the layout's leaves get
+    /// the full rect that would have been given to the Grouped node.
+    /// Visibility (which group is "active") is applied elsewhere.
     ///
-    /// `view::shell::splits::grid` is the layout now; a replacement is only
-    /// as trustworthy as what it was checked against, so the original walk
-    /// stays here for the parity test and nothing else compiles it.
+    /// **The engine the description replaced**, kept as the thing the swap is
+    /// pinned against. `view::shell::splits::grid` is the layout now, and the
+    /// editor reads where the panes are off the tree it laid out
+    /// (`view::shell::geometry::PaneRects`); a replacement is only as
+    /// trustworthy as what it was checked against, so the original walk stays
+    /// here as the oracle of the parity tests in `shell::splits` and
+    /// `shell::geometry`, and nothing else compiles it.
     #[cfg(test)]
     pub fn reference_leaves_with_rects(&self, rect: Rect) -> Vec<(LeafId, BufferId, Rect)> {
         match self {
@@ -935,63 +939,16 @@ impl SplitNode {
         }
     }
 
-    /// Where each visible leaf sits inside `rect`.
+    /// The leaves this subtree shows, in the tree's order — first child before
+    /// second, so left to right and top to bottom — without their rectangles.
     ///
-    /// **A read of the layout, not a second one.** This walked the tree over
-    /// ratios and reserved a cell per separator, and every rectangle the
-    /// editor's chrome hung off — separator drags, per-pane scrollbars, tab
-    /// strips, click-to-byte — came from it. That engine is
-    /// `view::shell::splits::grid` now, laid out at whatever box the caller
-    /// has; the rule inside it (`split_rect_ext`) is unchanged and still the
-    /// model's own.
-    ///
-    /// Laying out a fresh tree per call is what makes this affordable: a
-    /// three-pane grid costs ~38µs cold in a debug build (measured in
-    /// `shell::splits`), against callers that run on a window action or on
-    /// resize.
-    ///
-    /// **Not on the render path.** A frame reads its panes off the shell
-    /// tree it laid out — `view::shell::geometry::PaneRects` — because a
-    /// second layout of the same grid is a second answer, and where the two
-    /// differed by a cell the painter's clip hid it. What is left to this is
-    /// the model's own questions (which leaves show a buffer, a probe for the
-    /// leaf set) and the tests that use it as the oracle the tree is checked
-    /// against. `geometry::stats` counts every call so a frame that reaches
-    /// it again fails a test.
-    pub fn get_leaves_with_rects(&self, rect: Rect) -> Vec<(LeafId, BufferId, Rect)> {
-        use crate::view::shell::splits::{grid, leaf_key};
-        crate::view::shell::geometry::stats::note_scratch_grid();
-        let mut ui: fresh_ui::Ui<()> = fresh_ui::Ui::new();
-        ui.frame(
-            grid::<()>(self, None),
-            fresh_ui::Size::new(rect.width, rect.height),
-        );
-        self.visible_leaves()
-            .into_iter()
-            .map(|(leaf, buffer)| {
-                let r = ui
-                    .find_by_key(&leaf_key(leaf))
-                    .map(|e| ui.rect_of(e))
-                    .unwrap_or_default();
-                (
-                    leaf,
-                    buffer,
-                    Rect::new(
-                        rect.x.saturating_add(r.x.max(0) as u16),
-                        rect.y.saturating_add(r.y.max(0) as u16),
-                        r.w,
-                        r.h,
-                    ),
-                )
-            })
-            .collect()
-    }
-
-    /// The leaves this subtree shows, without their rectangles.
-    ///
-    /// The same walk as [`Self::get_leaves_with_rects`] with the geometry
-    /// dropped — which is all of it, since the partition never changes which
-    /// leaves there are.
+    /// **The model answers which; layout answers where.** This subtree used
+    /// to lay itself out to say where its leaves are, in a scratch `Ui<()>`
+    /// that was a second layout of the grid the frame had already laid out.
+    /// Where a pane is comes off that frame's tree now
+    /// (`view::shell::geometry::PaneRects`, retained per window), and the
+    /// partition never changes which leaves there are — so what the model
+    /// still answers is this.
     pub fn visible_leaves(&self) -> Vec<(LeafId, BufferId)> {
         match self {
             Self::Leaf {
@@ -1726,32 +1683,18 @@ impl SplitManager {
         self.root.parent_container_of(leaf_id.into())
     }
 
-    /// Get all visible buffer views with their rectangles
-    pub fn get_visible_buffers(&self, viewport_rect: Rect) -> Vec<(LeafId, BufferId, Rect)> {
-        // If a split is maximized, only show that split taking up the full viewport
-        if let Some(maximized_id) = self.maximized_split {
-            if let Some(SplitNode::Leaf {
-                buffer_id,
-                split_id,
-                ..
-            }) = self.root.find(maximized_id)
-            {
-                return vec![(*split_id, *buffer_id, viewport_rect)];
-            }
-            // Maximized split no longer exists, clear it and fall through
-        }
-        self.root.get_leaves_with_rects(viewport_rect)
-    }
-
-    /// Which leaves are visible, without asking where they are.
+    /// Which leaves are visible, in the tree's order, without asking where
+    /// they are: only the maximized leaf when one is maximized (and it still
+    /// exists), otherwise every leaf of the tree.
     ///
-    /// **The set does not depend on the box.** `get_leaves_with_rects`
-    /// partitions whatever rectangle it is given, so which leaves come back is
-    /// a fact about the tree and the maximized split alone — a caller that
-    /// wants only the set had to invent a rectangle to get it, and
-    /// `flush_layout` invented the whole terminal, which is not the box the
-    /// grid is laid out in at all. An invented input whose value cannot matter
-    /// is a claim that it might.
+    /// **The set does not depend on the box.** Which leaves show is a fact
+    /// about the tree and the maximized split alone; where they are is the
+    /// layout's answer, read off the shell tree that placed them
+    /// (`view::shell::geometry::PaneRects`, which `Window::visible_panes`
+    /// pairs with this list). The model used to answer both at once by laying
+    /// the grid out again in a box the caller supplied, and a caller that
+    /// wanted only the set had to invent a rectangle to get it — an invented
+    /// input whose value cannot matter is a claim that it might.
     pub fn visible_leaves(&self) -> Vec<(LeafId, BufferId)> {
         if let Some(maximized_id) = self.maximized_split {
             if let Some(SplitNode::Leaf {

--- a/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
+++ b/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
@@ -262,8 +262,8 @@ fn maximize_focused_dock(harness: &mut EditorTestHarness) {
 /// This is the rendered-output repro of the embedded-`fresh` hang: with the
 /// docked panel maximized, forwarding a file open from a nested process (or
 /// any Quick Open — both go through `Editor::open_file`) focuses the buffer
-/// in the editor split, but `get_visible_buffers` only draws the maximized
-/// dock. The buffer renders hidden behind the dock, so the user sees no
+/// in the editor split, but the frame only places the maximized dock. The
+/// buffer renders hidden behind the dock, so the user sees no
 /// change and a blocking `fresh <file>` forward looks like it has hung.
 ///
 /// Fails on the buggy build (the opened file's content never renders) and

--- a/crates/fresh-editor/tests/geometry_pass.rs
+++ b/crates/fresh-editor/tests/geometry_pass.rs
@@ -5,11 +5,13 @@
 //! source of pane geometry per frame. Before it, the render path laid the
 //! pane grid out three ways — the shell tree, a scratch `Ui<()>` in
 //! `SplitManager::get_leaves_with_rects`, and (on macro replay) a
-//! `layout_only` of the shell followed by the scratch grid again.
+//! `layout_only` of the shell followed by the scratch grid again. The scratch
+//! grid is gone now (Stage 2b): the action paths that asked it read the pane
+//! rects the window retains from the last layout instead.
 //!
 //! `view::shell::geometry::stats` counts the passes; these tests pin the
 //! counts a frame and a replayed action are allowed: **one shell layout, no
-//! scratch grid**, over the shapes the grid takes — one pane, nested splits,
+//! offscreen grid**, over the shapes the grid takes — one pane, nested splits,
 //! a maximized pane, the explorer open and shut. The counters exist only
 //! with debug assertions on, which is what `cargo test` builds with.
 #![cfg(debug_assertions)]
@@ -37,7 +39,6 @@ fn replay(h: &mut EditorTestHarness) -> LayoutCounts {
 
 const ONE_PASS: LayoutCounts = LayoutCounts {
     shell: 1,
-    scratch_grids: 0,
     offscreen_grids: 0,
 };
 

--- a/crates/fresh-editor/tests/retained_pane_rects.rs
+++ b/crates/fresh-editor/tests/retained_pane_rects.rs
@@ -1,0 +1,141 @@
+//! The pane rects a window retains are the layout's.
+//!
+//! Stage 2b of the retained-mode migration: the scratch grid is gone, and
+//! the action paths that asked it where a pane is — a terminal sized to its
+//! pane, a tab strip's width, the plugin snapshot, the pane beside this one —
+//! read `Window::pane_rects`, which every layout writes. Two things have to
+//! hold for that to be a read of the layout and not a record of a stale one:
+//! after a frame, the retained rects are the ones the frame painted with; and
+//! after an action that changes the grid, they are refreshed before the frame
+//! that would paint it.
+//!
+//! The layout counters exist only with debug assertions on, which is what
+//! `cargo test` builds with.
+#![cfg(debug_assertions)]
+
+mod common;
+
+use common::harness::EditorTestHarness;
+use fresh::input::keybindings::Action;
+use fresh::view::shell::geometry::{stats, PaneRects};
+use ratatui::layout::Rect;
+
+/// After a frame, the retained rects are what `PaneRects::read` gives off the
+/// tree that laid the frame out — box and content slot, pane for pane.
+#[test]
+fn a_frame_retains_the_rects_it_painted_with() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitHorizontal);
+    h.render().expect("render");
+
+    let editor = h.editor();
+    let ui = editor
+        .shell_ui()
+        .expect("the tree is back once the frame is painted");
+    let panes = editor.active_window().visible_panes();
+    assert_eq!(panes.len(), 3, "a nested split");
+    let read = PaneRects::read(
+        ui,
+        panes.iter().map(|(leaf, _, _)| *leaf),
+        Rect::new(0, 0, 80, 24),
+    );
+    let retained = editor.active_window().pane_rects();
+    for (leaf, _, rect) in &panes {
+        assert_eq!(read.pane(*leaf), Some(*rect), "{leaf:?}'s box");
+        assert_ne!(rect.width, 0, "{leaf:?} was placed");
+        assert_eq!(
+            retained.content(*leaf),
+            read.content(*leaf),
+            "{leaf:?}'s content slot"
+        );
+    }
+    // Three panes, three distinct boxes.
+    let boxes: Vec<Rect> = panes.iter().map(|(_, _, r)| *r).collect();
+    assert_ne!(boxes[0], boxes[1]);
+    assert_ne!(boxes[1], boxes[2]);
+    assert_ne!(boxes[0], boxes[2]);
+}
+
+/// A split is placed before the frame that would paint it: the action's
+/// relayout lays the frame out once, and the retained rects are the grid as
+/// it is now — and are what the next frame paints with.
+#[test]
+fn a_split_refreshes_the_rects_before_the_frame() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    h.render().expect("render");
+    let before = h.editor().active_window().visible_panes();
+    assert_eq!(before.len(), 1);
+    let whole = before[0].2;
+
+    let _ = stats::take();
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    let counts = stats::take();
+    assert_eq!(
+        counts.offscreen_grids, 0,
+        "no grid is laid out alone; the frame is"
+    );
+    assert!(counts.shell >= 1, "the split's relayout laid the frame out");
+
+    let after = h.editor().active_window().visible_panes();
+    assert_eq!(after.len(), 2, "both panes are placed, no frame between");
+    let (left, right) = (after[0].2, after[1].2);
+    assert_eq!(left.y, whole.y);
+    assert_eq!(left.height, whole.height);
+    assert_eq!(right.y, whole.y);
+    assert_eq!(right.height, whole.height);
+    assert_eq!(
+        right.x,
+        left.x + left.width + 1,
+        "a separator column between"
+    );
+    assert_eq!(left.width + 1 + right.width, whole.width);
+
+    // The frame agrees: it paints with the rects the action already had.
+    h.render().expect("render");
+    assert_eq!(h.editor().active_window().visible_panes(), after);
+}
+
+/// A chrome toggle moves every pane; the toggle's relayout places them again
+/// before the frame, and a maximized pane is the only one placed, at the
+/// whole body.
+#[test]
+fn chrome_and_maximize_refresh_the_rects_before_the_frame() {
+    let mut h = EditorTestHarness::new(80, 24).expect("harness");
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::SplitVertical);
+    h.render().expect("render");
+    let shut = h.editor().active_window().visible_panes();
+    assert_eq!(shut.len(), 2);
+
+    h.editor_mut().toggle_file_explorer();
+    let open = h.editor().active_window().visible_panes();
+    assert_eq!(open.len(), 2);
+    assert!(
+        open[0].2.x > shut[0].2.x,
+        "the explorer pushed the first pane right before any frame"
+    );
+    h.render().expect("render");
+    assert_eq!(h.editor().active_window().visible_panes(), open);
+    h.editor_mut().toggle_file_explorer();
+
+    h.editor_mut()
+        .dispatch_action_for_tests(Action::ToggleMaximizeSplit);
+    let maximized = h.editor().active_window().visible_panes();
+    assert_eq!(maximized.len(), 1, "only the maximized pane is visible");
+    assert_eq!(
+        maximized[0].2,
+        Rect::new(
+            shut[0].2.x,
+            shut[0].2.y,
+            shut[0].2.width + 1 + shut[1].2.width,
+            shut[0].2.height
+        ),
+        "at the whole body"
+    );
+    h.render().expect("render");
+    assert_eq!(h.editor().active_window().visible_panes(), maximized);
+}

--- a/docs/internal/fresh-editor-ui-migration.md
+++ b/docs/internal/fresh-editor-ui-migration.md
@@ -3052,6 +3052,26 @@ list.
    A three-pane grid costs ~38µs cold in a debug build, against callers that
    run once a frame or on resize.
 
+   **And then removed (Stage 2b).** Once the frame read its panes off the
+   tree it laid out (`view::shell::geometry::PaneRects`, Stage 2), the
+   scratch grid was a second layout of the same grid for the action paths
+   only — a terminal sized to its pane, a tab strip's width, the plugin
+   snapshot, the pane beside this one, the viewport seeds on resize.
+   `get_leaves_with_rects` and `get_visible_buffers` are gone. Each window
+   retains the `PaneRects` of the last layout that placed its panes
+   (`Window::pane_rects`, read through `Window::visible_panes`), written by
+   every frame, by `recompute_layout`, and by the layout funnel:
+   `push_layout_geometry` lays the active window's frame out once with
+   `layout_only` (`Editor::refresh_pane_rects`) and every other window's grid
+   offscreen (`PaneRects::offscreen`, the session preview's mechanism) before
+   any window seeds its viewports or sizes its PTYs. Every grid mutation
+   already ended in `relayout`; the one that did not (the dock split
+   `handle_open_terminal_in_dock` creates) goes through
+   `Editor::resize_visible_terminals`, which refreshes first. The parity
+   tests keep `reference_leaves_with_rects` — the original walk, `cfg(test)`
+   — as their oracle; `tests/retained_pane_rects.rs` pins that the retained
+   rects are the frame's and are refreshed by an action before its frame.
+
    What this buys is the next step, and the first of it has landed: **the
    dividers are gestures.** A divider node knows which container it is, so
    `handle_click_split_separator` — which walked a recorded list of separator

--- a/docs/internal/tui-retained-mode-migration-plan.md
+++ b/docs/internal/tui-retained-mode-migration-plan.md
@@ -472,8 +472,9 @@ Editor state ──build──▶ Node tree ──reconcile──▶ Element tre
 **One band.** The fold runs once, in paint order.
 
 **One geometry.** Per frame: one `layout_only` to size the panes, one
-`frame`. `get_leaves_with_rects` remains for non-render callers only. Nothing
-records a rectangle for a later handler; handlers ask `rect_of`.
+`frame`. `get_leaves_with_rects` is gone (Stage 2b): the callers off the
+render path read the pane rects the window retains from the last layout.
+Nothing records a rectangle for a later handler; handlers ask `rect_of`.
 
 **The text pane is a `rows` primitive, not a reader.** A single `fresh-ui`
 element `rows(Rc<[Row]>)` that measures one cell per row, clips to the
@@ -596,6 +597,16 @@ Promote the replay geometry pass to every frame; pane content rects from
 the scratch grid on the render path. *Exit:* `get_leaves_with_rects` has
 no caller in `render.rs` or `split_rendering/orchestration`; the frame-cost
 table shows the cost of the second layout.
+
+**Stage 2b — no scratch grid at all.** `get_leaves_with_rects` and
+`get_visible_buffers` are deleted. Each window retains the `PaneRects` of
+the last layout that placed its panes (`Window::pane_rects`, read through
+`Window::visible_panes`); the layout funnel (`push_layout_geometry`) lays
+the active window's frame out once with `layout_only` and every other
+window's grid offscreen before any window seeds viewports or sizes PTYs, so
+an action that changed the grid reads it as it is. The parity tests keep the
+model's original walk (`reference_leaves_with_rects`, `cfg(test)`) as their
+oracle. See `fresh-editor-ui-migration.md`, "And then removed (Stage 2b)".
 
 ### Stage 3 — buffer content behind a gate (Blocker A.4–A.5)
 


### PR DESCRIPTION
## Summary

Stage 2b of the retained-mode migration, on master after #3133 (Stage 1) merged: **`SplitNode::get_leaves_with_rects` and `SplitManager::get_visible_buffers` are gone**, with `geometry::stats::note_scratch_grid` and the `scratch_grids` counter. Nothing lays the pane grid out alone any more: the frame reads its panes off the tree it laid out (Stage 2), and the action paths read the rects the window retains from the last layout.

Five commits: the callers moved onto retained rects; the functions and counter deleted with the parity tests re-oracled; the new tests and doc note; a follow-up for the plugin-spawned terminal path; a note in the TUI retained-mode plan master carries, which still said `get_leaves_with_rects` remains for the non-render callers.

### What replaced them

- **`Window::pane_rects`** — one `PaneRects` per window, written by every layout that places its panes: `Editor::render`, `recompute_layout`, the new `Editor::refresh_pane_rects` (one `layout_only` of the frame, factored out of `recompute_layout` as `Editor::layout_panes`, counted by `geometry::stats` as a shell layout), and the layout funnel. Read through **`Window::visible_panes()`**, which pairs `SplitManager::visible_leaves()` (which leaves, tree order, the maximized pane alone) with the retained rects — the shape `get_visible_buffers` answered in.
- **`push_layout_geometry`** (every `relayout`) now runs in two steps: every window adopts the screen size and dock width (`Window::adopt_screen`), then the active window's grid is laid out off the frame (`refresh_pane_rects`) and every other window's off one `PaneRects::offscreen` of its own description (`Window::layout_panes_offscreen`, the session preview's mechanism), and only then does each window seed viewports and size PTYs (`apply_layout`, now argument-less).
- **`Editor::resize_visible_terminals` / `resize_window_terminals`** — for the callers that size PTYs right after changing the grid without going through the funnel: the dock split `handle_open_terminal_in_dock` creates, and `Window::create_plugin_terminal`, which can split a (possibly non-active) window's grid. Both place the panes first, then size.
- `Editor::with_options` runs one `refresh_pane_rects`, so a terminal opened before the first frame is sized to its pane as before.

### Callers, one by one

| Caller | Before | Now |
|---|---|---|
| `window_actions::retarget_leaves_off_buffer` | 1×1 probe layout for the leaf set | `SplitNode::visible_leaves()` |
| `split_actions::split_rect` | scratch grid at `editor_content_area()` | retained rects (fresh: `split_pane_impl` ends in `relayout`) |
| `split_actions` labeled-leaf lookup | `split_rect(..).is_some()` | membership in `visible_leaves()` |
| `split_actions::pane_beside` | scratch grid | retained rects, same tree order |
| `Window::split_tabs_width` | scratch grid | retained rects |
| `Window::apply_layout` (resize) | scratch grid at the new size | rects the funnel laid out at the new size, before it runs |
| `Window::resize_visible_terminals` | scratch grid | retained rects; editor-side post-mutation callers refresh first |
| plugin split snapshot | scratch grid | retained rects, same visual order |
| `app::mod` test | `get_visible_buffers` | `visible_panes()` |
| `shell::geometry` parity tests (oracle) | `get_leaves_with_rects` | `reference_leaves_with_rects` (the model's original walk, `cfg(test)`, already the oracle in `shell::splits`) plus hand-computed rects for the fixed grids |

### Where the old and new answers could differ observably

- **The body rectangle.** The scratch grid was laid out in `Window::editor_content_area()`, a hand derivation of the frame's body from the window's chrome flags; the active window's rects now come from the frame's own layout. The two agree by `tests/ui_shell_frame_parity.rs`; where they ever disagreed, the new answer is the one the frame paints. Non-active windows still use `editor_content_area()` as their offscreen box, and `apply_layout`'s fallback seed for off-screen splits still reads it.
- **Between a grid mutation and its `relayout`.** Every grid mutation I found already ends in `relayout` (split, close, maximize, ratio, separator drag, tab drop, explorer/dock toggles, resize, window create/switch). Inside a mutation that reads before its own `relayout` — `open_terminal_split` sizes PTYs, then relayouts — the first read sees the pre-split rects (the new pane absent, zero rect, skipped) and the relayout two lines later sizes everything; the final PTY sizes are the same, reached one call later.
- **While a frame or event dispatch holds the shell tree**, `refresh_pane_rects` is a no-op and the window keeps the rects of the last layout, which that pass wrote. A plugin command that splits the grid from inside such a pass would size the new pane's PTY at the next frame rather than immediately. I found no such path in practice (plugin commands drain before the tree is taken).
- **Cost.** A `relayout` now costs one `layout_only` of the whole frame (~120–160µs per the migration doc's measurement) plus one offscreen grid per non-active window, instead of one scratch grid per caller. `relayout` runs on actions and on live separator drags, not per frame; `tests/geometry_pass.rs` still pins one shell layout and zero offscreen grids per frame.
- `SplitNode::get_visible_leaves_with_rects` (a predicate-driven tree walk with no callers) was left as is; it is not a scratch grid and is outside this PR's scope.

### Tests

- `tests/geometry_pass.rs`: unchanged pins minus the removed field.
- `tests/retained_pane_rects.rs` (new): after a frame, `Window::pane_rects` equals `PaneRects::read` off the shell tree that laid the frame out, box and content slot per pane (via a new `Editor::shell_ui()` accessor); a split, an explorer toggle and a maximize each refresh the rects before any frame, and the next frame paints with the same ones.
- `app::mod` (new): `a_new_pane_is_beside_its_source_before_any_frame` (one shell layout, no offscreen grid, the neighbour answered without rendering); `the_funnel_places_every_windows_panes` (the active window off the frame, a second window off one offscreen grid, at the same body).
- `shell::geometry` parity tests keep checking the tree against `reference_leaves_with_rects`, with the expected rects for the fixed grids also spelled out by hand.

### Verification

On the pre-rebase head (stacked on #3133's last commit, which master now carries rebased):
- `cargo fmt --all`; `cargo clippy -p fresh-editor --tests`: only pre-existing warnings, none in changed lines.
- `cargo test -p fresh-editor --lib`: 3782 passed, 0 failed.
- `geometry_pass` and `retained_pane_rects`: 3/3 each.
- `e2e_tests` filtered to terminal / split / dock_panel / pane / window_ / layout / resize / maximize / snapshot: 360 passed, 0 failed, 22 ignored.

After the rebase onto master (a clean rebase; master's new commit adds `view/shell/content.rs` and docs, nothing this PR touches): fmt, clippy, the geometry/split unit tests and the two geometry test binaries re-run green before the push. The full corpus is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiReWkJAt9Nt8NxNDFeYzP