### PR TITLE
Two wrap-index repair bugs around conceals: a char-boundary panic and a mis-spliced tail

### DIFF
--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -984,12 +984,16 @@ impl WrapIndex {
             Some(resume_byte),
         );
 
-        // The *new* stream may open this row with injected content the resume
-        // cannot reconstruct (an edit can move a hint or a soft break onto a row
-        // that previously started with plain source), or the resume byte may no
-        // longer address anything while the line still has content.
-        let tail = tokens_from(&stream, resume_byte);
-        if !resume_is_safe(&stream, resume_byte) || (tail.is_empty() && !stream.is_empty()) {
+        // The *new* stream may not be resumable at this byte at all — it can
+        // open the row with injected content the carry cannot reconstruct, or
+        // reach into it with a conceal's replacement — and the resume byte may
+        // no longer address anything while the line still has content. Either
+        // way the line is laid out from its start instead.
+        let Some(tail) = stream.resume_at(resume_byte) else {
+            self.rebuild_one(buffer, line, rule, line_ending);
+            return;
+        };
+        if tail.is_empty() && !stream.is_empty() {
             self.rebuild_one(buffer, line, rule, line_ending);
             return;
         }
@@ -1168,7 +1172,7 @@ fn line_token_stream(
     line_ending: LineEnding,
     decorations: &IndexDecorations,
     from_byte: Option<usize>,
-) -> Vec<ViewTokenWire> {
+) -> LineStream {
     use crate::view::ui::split_rendering::transforms::{
         apply_conceal_ranges, apply_soft_breaks, splice_inline_virtual_text,
     };
@@ -1176,7 +1180,7 @@ fn line_token_stream(
     let mut tokens =
         build_line_tokens_from(buffer, line, line_ending, &decorations.folds, from_byte);
     if decorations.is_empty() {
-        return tokens;
+        return LineStream::verbatim(tokens);
     }
     let line_start = buffer.line_start_offset(line).unwrap_or(0);
     let line_end = buffer
@@ -1193,7 +1197,10 @@ fn line_token_stream(
     if !hints.is_empty() {
         tokens = splice_inline_virtual_text(tokens, &hints);
     }
-    tokens
+    // Only the conceal pass substitutes text for source bytes: soft breaks and
+    // inline hints inject tokens with no anchor at all, and both split source
+    // text without disturbing the bytes it stands for.
+    LineStream::new(tokens, &conceals)
 }
 
 /// Wrap one logical line from scratch.
@@ -1217,7 +1224,7 @@ pub(crate) fn line_drawn_row_starts(
     decorations: &IndexDecorations,
 ) -> Vec<u32> {
     let line_start = buffer.line_start_offset(line).unwrap_or(0);
-    let tokens = line_token_stream(buffer, line, line_ending, decorations, None);
+    let tokens = line_token_stream(buffer, line, line_ending, decorations, None).into_tokens();
     let out = WrapMachine::run(tokens, rule);
     let (row_starts, _, _) = rows_to_starts(&out, line_start, 0);
     row_starts
@@ -1232,7 +1239,7 @@ fn build_line(
     decorations: &IndexDecorations,
 ) -> LineWrap {
     let line_start = buffer.line_start_offset(line).unwrap_or(0);
-    let tokens = line_token_stream(buffer, line, line_ending, decorations, None);
+    let tokens = line_token_stream(buffer, line, line_ending, decorations, None).into_tokens();
     let out = WrapMachine::run(tokens, rule);
     let (row_starts, carries, resumable) = rows_to_starts(&out, line_start, 0);
     let line_end = buffer
@@ -1305,68 +1312,181 @@ fn row_is_resumable(row: &RowInfo, tokens: &[ViewTokenWire]) -> bool {
     tokens.get(idx).and_then(|t| t.source_offset) == Some(source_byte)
 }
 
-/// Is `byte` a valid resume point in this token stream?
+/// What a token's `source_offset` claims about its text.
 ///
-/// Only when the first source token at or after `byte` is not preceded by
-/// injected tokens. Decorations move with the text on an edit, so a hint or a
-/// soft break can land on a row that previously started with plain source; the
-/// row's stored flag describes the *old* stream, and this checks the new one.
-fn resume_is_safe(tokens: &[ViewTokenWire], byte: usize) -> bool {
-    let mut prev_injected = false;
-    for token in tokens {
-        let Some(offset) = token.source_offset else {
-            prev_injected = true;
-            continue;
-        };
-        if offset >= byte {
-            return !prev_injected;
-        }
-        let end = offset
-            + match &token.kind {
-                ViewTokenWireKind::Text(s) => s.len(),
-                _ => 1,
-            };
-        if end > byte {
-            return !prev_injected;
-        }
-        prev_injected = false;
-    }
-    true
+/// [`ViewTokenWire`] records *where* a token is anchored and says nothing about
+/// whether its text is the bytes found there, yet a decorated stream carries
+/// both kinds: plain source text *is* the buffer's bytes, while a conceal's
+/// replacement is anchored at the range it hides and draws glyphs that are not
+/// those bytes at all (a whole `---` renders as one `─`). Resuming a layout
+/// part-way through a token means cutting its text at a source byte, which is
+/// meaningful only for the first kind — on the second the cut landed inside a
+/// multi-byte glyph and panicked the editor on a keystroke. Carrying the
+/// distinction in the type is what makes the meaningless cut unwritable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceExtent {
+    /// Injected by a decoration or by wrapping: no source bytes at all.
+    Injected,
+    /// The token's text *is* the buffer's bytes from its `source_offset`, so a
+    /// source byte inside it addresses the same character in both.
+    Verbatim,
+    /// The token stands in for source bytes up to `end`, and its text is not
+    /// those bytes. All or nothing: there is no "rest of it" to resume from.
+    Substituted { end: usize },
 }
 
-/// Sub-stream beginning at absolute `byte`, splitting a `Text` token if needed.
+/// One token of a [`LineStream`], with what its anchor means.
+#[derive(Debug, Clone)]
+struct StreamToken {
+    token: ViewTokenWire,
+    extent: SourceExtent,
+}
+
+/// One logical line's token stream, addressable by source byte.
 ///
-/// Strictly source-addressed: injected tokens before the first source token at
-/// or after `byte` are not included. Rows that open with injected content are
-/// marked non-resumable and never reach this function.
-fn tokens_from(tokens: &[ViewTokenWire], byte: usize) -> Vec<ViewTokenWire> {
-    let mut out = Vec::new();
-    let mut started = false;
-    for token in tokens {
-        if started {
-            out.push(token.clone());
-            continue;
+/// Built once, where the decoration transforms run and the conceal ranges that
+/// substituted text are still in hand — nothing downstream can recover that
+/// from the tokens alone.
+#[derive(Debug)]
+struct LineStream {
+    tokens: Vec<StreamToken>,
+}
+
+impl LineStream {
+    /// Classify `tokens` against the `conceals` that were applied to them.
+    ///
+    /// Conceals are sorted by start and may overlap, so containment is decided
+    /// against a running maximum of their ends: any range that starts at or
+    /// before a token and ends after it contains it. Erring towards
+    /// `Substituted` only costs a line rebuild; erring the other way would
+    /// hand the resume a token it must not cut, which is the bug.
+    fn new(
+        tokens: Vec<ViewTokenWire>,
+        conceals: &[(std::ops::Range<usize>, Option<&str>)],
+    ) -> Self {
+        let mut max_end: Vec<usize> = Vec::with_capacity(conceals.len());
+        let mut running = 0usize;
+        for (r, _) in conceals {
+            running = running.max(r.end);
+            max_end.push(running);
         }
-        let Some(offset) = token.source_offset else {
-            continue;
-        };
-        if offset >= byte {
-            started = true;
-            out.push(token.clone());
-            continue;
-        }
-        if let ViewTokenWireKind::Text(s) = &token.kind {
-            if offset + s.len() > byte {
-                started = true;
-                out.push(ViewTokenWire {
-                    source_offset: Some(byte),
-                    kind: ViewTokenWireKind::Text(s[byte - offset..].to_string()),
-                    style: token.style.clone(),
-                });
+        let extent_of = |offset: usize| -> SourceExtent {
+            let i = conceals.partition_point(|(r, _)| r.start <= offset);
+            match i.checked_sub(1) {
+                Some(i) if max_end[i] > offset => SourceExtent::Substituted { end: max_end[i] },
+                _ => SourceExtent::Verbatim,
             }
+        };
+        Self {
+            tokens: tokens
+                .into_iter()
+                .map(|token| {
+                    let extent = match token.source_offset {
+                        None => SourceExtent::Injected,
+                        Some(offset) => extent_of(offset),
+                    };
+                    StreamToken { token, extent }
+                })
+                .collect(),
         }
     }
-    out
+
+    /// A stream nothing has substituted into: every anchored token is source.
+    fn verbatim(tokens: Vec<ViewTokenWire>) -> Self {
+        Self::new(tokens, &[])
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// The tokens themselves, for a layout that starts at the line's own start
+    /// and so never addresses the stream by byte.
+    fn into_tokens(self) -> Vec<ViewTokenWire> {
+        self.tokens.into_iter().map(|t| t.token).collect()
+    }
+
+    /// The sub-stream to resume layout from at absolute source `byte`, or
+    /// `None` when this stream cannot be resumed there and the line has to be
+    /// laid out from its start instead.
+    ///
+    /// Strictly source-addressed: injected tokens before the first source token
+    /// at or after `byte` are not included, and a row that opens with injected
+    /// content the carry cannot reconstruct — a hint, a soft break's prefix —
+    /// is not resumable at all. Decorations move with the text on an edit, so
+    /// such content can land on a row that previously started with plain
+    /// source; the row's stored flag describes the *old* stream and this checks
+    /// the new one.
+    ///
+    /// `byte` inside a [`SourceExtent::Substituted`] token is the case that
+    /// used to panic: a conceal reaching across a line start (a compose-mode
+    /// paragraph join does exactly that) leaves the line's stream opening with
+    /// a replacement anchored on the line above, and the line's own first byte
+    /// falls inside it.
+    fn resume_at(&self, byte: usize) -> Option<Vec<ViewTokenWire>> {
+        let mut out: Vec<ViewTokenWire> = Vec::new();
+        let mut prev_injected = false;
+        for st in &self.tokens {
+            if !out.is_empty() {
+                out.push(st.token.clone());
+                continue;
+            }
+            // No source bytes at all: a wrap break, a hanging indent, an
+            // inline hint. A row opening with one cannot be resumed into.
+            let (Some(offset), SourceExtent::Verbatim | SourceExtent::Substituted { .. }) =
+                (st.token.source_offset, st.extent)
+            else {
+                prev_injected = true;
+                continue;
+            };
+            let substituted_until = match st.extent {
+                SourceExtent::Substituted { end } => Some(end),
+                _ => None,
+            };
+            if offset >= byte {
+                if prev_injected {
+                    return None;
+                }
+                out.push(st.token.clone());
+                continue;
+            }
+            match substituted_until {
+                // Ends before the resume point: already laid out, skip it.
+                Some(end) if end <= byte => prev_injected = false,
+                // `byte` is inside the bytes this token stands in for. Its
+                // glyphs are not those bytes, so no suffix of it is the tail.
+                Some(_) => return None,
+                None => {
+                    let ViewTokenWireKind::Text(text) = &st.token.kind else {
+                        // Every other kind is one source byte wide, and
+                        // `offset < byte` puts it wholly behind the resume.
+                        prev_injected = false;
+                        continue;
+                    };
+                    let cut = byte - offset;
+                    if cut >= text.len() {
+                        prev_injected = false;
+                        continue;
+                    }
+                    // The boundary check is about `byte`, not about this
+                    // token: a row start is recorded at a character boundary,
+                    // but it comes from the *old* layout and is shifted
+                    // arithmetically, so this is the one place that can prove
+                    // it still addresses a character. Verbatim text mirrors the
+                    // buffer, so its boundaries are the buffer's.
+                    if prev_injected || !text.is_char_boundary(cut) {
+                        return None;
+                    }
+                    out.push(ViewTokenWire {
+                        source_offset: Some(byte),
+                        kind: ViewTokenWireKind::Text(text[cut..].to_string()),
+                        style: st.token.style.clone(),
+                    });
+                }
+            }
+        }
+        Some(out)
+    }
 }
 
 /// Seal rows the machine has completed; return the old row index resynced to.
@@ -1754,6 +1874,79 @@ mod tests {
             index.is_built_for(&geometry(20), bumped),
             "and the bump must still be adopted, or every later frame re-diffs"
         );
+    }
+
+    /// A conceal whose range spans a line break must not corrupt the line
+    /// below it.
+    ///
+    /// Repair resumes a line from a row start — for the first row, the line's
+    /// own start byte. That byte can sit *inside* a conceal range, because a
+    /// conceal is free to span the newline (markdown_compose joins a wrapped
+    /// paragraph's source lines exactly that way). The stream for such a line
+    /// opens with the conceal's replacement text, anchored at the range's
+    /// start, which is on the line above.
+    ///
+    /// The resume then tried to take "the rest" of that token by subtracting
+    /// source bytes — `text[byte - source_offset..]` — but a replacement's
+    /// glyphs are not the bytes it hides, and the cut landed inside the `─`,
+    /// panicking the editor on a keystroke.
+    #[test]
+    fn an_edit_below_a_conceal_that_spans_a_line_break_does_not_panic() {
+        use crate::model::cursor::Cursors;
+        use crate::model::event::Event;
+        use fresh_core::overlay::OverlayNamespace;
+
+        let text = "aaaa\nbbbb\n";
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+        let cursor_id = cursors.primary_id();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: text.to_string(),
+                cursor_id,
+            },
+        );
+
+        // `aaa[a\nb]bbb`: the range covers the newline, so the second line's
+        // stream opens with the replacement anchored two bytes before it.
+        let ns = OverlayNamespace::from_string("test".to_string());
+        state
+            .conceals
+            .add(&mut state.marker_list, ns, 3..7, Some("─".to_string()));
+
+        let geom = geometry(20);
+        build_index(&mut state, geom);
+
+        // Type on the concealed line — the keystroke that crashed.
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 8,
+                text: "x".to_string(),
+                cursor_id,
+            },
+        );
+        build_index(&mut state, geom);
+
+        let maintained = state
+            .wrap_indices
+            .get(&geom)
+            .map(|i| (structure(i), i.total_rows()))
+            .expect("index present");
+        let fresh = fresh_index(&mut state, geom);
+        assert_eq!(
+            maintained.0,
+            structure(&fresh),
+            "maintained index disagrees with a fresh build"
+        );
+        assert_eq!(maintained.1, fresh.total_rows());
     }
 
     /// **The spec, in one sentence: an index that has been maintained across

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -1516,17 +1516,23 @@ fn absorb_rows(
                 None => *prev_rel,
             }
         };
+        let resumable = *sealed == 1 || row_is_resumable(&row, machine.tokens_so_far());
         new_starts.push(rel);
         new_carries.push(row.carry);
-        new_resumable.push(if *sealed == 1 {
-            true
-        } else {
-            row_is_resumable(&row, machine.tokens_so_far())
-        });
+        new_resumable.push(resumable);
         *prev_rel = rel;
-        if new_starts.len() > 1 {
+        // Resync claims that from here on the old layout is the new one shifted
+        // by `delta`, which holds only if "this byte, this carry" *identifies*
+        // the row — that is, if the row is a resume point on both sides. A row
+        // opening with injected content is not: its start is the first source
+        // byte it happens to contain, while its columns begin with a
+        // decoration's spill-over (a conceal replacement wider than the row's
+        // remaining width leaves its tail at the head of the next row). Two such
+        // rows can share a start byte and a carry and still run out of width at
+        // different bytes, which spliced a tail that was three bytes off.
+        if new_starts.len() > 1 && resumable {
             for k in (resume_idx + 1)..old.row_starts.len() {
-                if old.row_starts[k] < resync_floor {
+                if old.row_starts[k] < resync_floor || !old.resumable[k] {
                     continue;
                 }
                 if (old.row_starts[k] as i64 + delta) == rel as i64 && old.carries[k] == row.carry {
@@ -1947,6 +1953,218 @@ mod tests {
             "maintained index disagrees with a fresh build"
         );
         assert_eq!(maintained.1, fresh.total_rows());
+    }
+
+    /// A row that opens with a decoration's spill-over is not a resync point.
+    ///
+    /// Repair rewraps forward from the damaged row and stops as soon as a new
+    /// row boundary lands on an old one — same start byte once shifted by the
+    /// edit's delta, same carry — then splices the old tail. That claim rests
+    /// on the pair *identifying* the row, which holds only for a row a layout
+    /// can be resumed at: one that opens with the source token at its own start
+    /// byte.
+    ///
+    /// A conceal replacement wider than the width left on its row leaves its
+    /// tail at the head of the next row, and that row's recorded start is the
+    /// first source byte it *contains*, several columns in. Two such rows can
+    /// share a start byte and a carry while running out of width at different
+    /// bytes — so the spliced tail was three bytes off, and every row start
+    /// after it in the line was wrong.
+    #[test]
+    fn a_row_opening_with_a_decoration_spill_is_not_a_resync_point() {
+        use crate::model::cursor::Cursors;
+        use crate::model::event::Event;
+        use fresh_core::overlay::OverlayNamespace;
+
+        let text = format!(
+            "{}\n{}\n{}\n",
+            "a".repeat(60),
+            "b".repeat(60),
+            "c".repeat(60)
+        );
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+        let cursor_id = cursors.primary_id();
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text: text.clone(),
+                cursor_id,
+            },
+        );
+
+        // Two conceals on the third line, each hiding source bytes behind a
+        // four-column rule. The second one's replacement is what spills.
+        let ns = OverlayNamespace::from_string("test".to_string());
+        for range in [126..133, 148..152] {
+            state.conceals.add(
+                &mut state.marker_list,
+                ns.clone(),
+                range,
+                Some("────".to_string()),
+            );
+        }
+
+        let geom = geometry(20);
+        build_index(&mut state, geom);
+
+        // Type at the second conceal's start: it rides forward with the text,
+        // and the row after it now opens with the tail of its replacement.
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 148,
+                text: "xxx".to_string(),
+                cursor_id,
+            },
+        );
+        build_index(&mut state, geom);
+
+        let maintained = state
+            .wrap_indices
+            .get(&geom)
+            .map(|i| (structure(i), i.total_rows()))
+            .expect("index present");
+        let fresh = fresh_index(&mut state, geom);
+        assert_eq!(
+            maintained.0,
+            structure(&fresh),
+            "the spliced tail must be what a fresh build lays out"
+        );
+        assert_eq!(maintained.1, fresh.total_rows());
+    }
+
+    /// The same spec as `a_maintained_index_answers_like_a_fresh_build`, swept
+    /// over generated conceal sets and edit sequences instead of hand-picked
+    /// ones.
+    ///
+    /// Conceals are where maintenance is hardest: their replacements are not
+    /// the bytes they hide, they can span a line break, they can overlap, and
+    /// they ride the edit like any other marker. Both bugs this net was written
+    /// for were invisible to the hand-written cases — one panicked the editor
+    /// on a keystroke (a resume cutting a replacement at a source byte), the
+    /// other spliced a tail three bytes off (a resync onto a row that opens
+    /// with a replacement's spill-over).
+    ///
+    /// Deterministic: the generator is a fixed-seed LCG, so a failure names the
+    /// seed and reproduces exactly.
+    #[test]
+    fn a_maintained_index_answers_like_a_fresh_build_under_conceals() {
+        use crate::model::cursor::Cursors;
+        use crate::model::event::Event;
+        use fresh_core::overlay::OverlayNamespace;
+
+        const WIDTH: usize = 20;
+        const LINE: usize = 60;
+
+        fn rand(state: &mut u64) -> usize {
+            *state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (*state >> 33) as usize
+        }
+
+        let text = format!(
+            "{}\n{}\n{}\n",
+            "a".repeat(LINE),
+            "b".repeat(LINE),
+            "c".repeat(LINE)
+        );
+
+        for seed in 0..500u64 {
+            let mut rng = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(12345);
+            let mut state = EditorState::new(
+                80,
+                24,
+                crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+                test_fs(),
+            );
+            let mut cursors = Cursors::new();
+            let cursor_id = cursors.primary_id();
+            state.apply(
+                &mut cursors,
+                &Event::Insert {
+                    position: 0,
+                    text: text.clone(),
+                    cursor_id,
+                },
+            );
+
+            // Multi-byte replacements on purpose: a byte-indexed cut into one
+            // is what panicked, and a single-byte glyph would have hidden it.
+            let ns = OverlayNamespace::from_string("test".to_string());
+            let mut conceals = Vec::new();
+            for _ in 0..(1 + rand(&mut rng) % 4) {
+                let start = rand(&mut rng) % (text.len() - 8);
+                let end = start + 1 + rand(&mut rng) % 8;
+                let replacement = match rand(&mut rng) % 3 {
+                    0 => None,
+                    n => Some("─".repeat(n * (1 + rand(&mut rng) % 3))),
+                };
+                conceals.push((start..end, replacement.clone()));
+                state
+                    .conceals
+                    .add(&mut state.marker_list, ns.clone(), start..end, replacement);
+            }
+
+            let geom = geometry(WIDTH);
+            build_index(&mut state, geom);
+
+            let mut edits = Vec::new();
+            for _ in 0..4 {
+                let len = state.buffer.len();
+                let position = rand(&mut rng) % len;
+                if rand(&mut rng).is_multiple_of(2) {
+                    let inserted = "x".repeat(1 + rand(&mut rng) % 4);
+                    edits.push((position, 0, inserted.clone()));
+                    state.apply(
+                        &mut cursors,
+                        &Event::Insert {
+                            position,
+                            text: inserted,
+                            cursor_id,
+                        },
+                    );
+                } else {
+                    let removed = (1 + rand(&mut rng) % 5).min(len - position);
+                    let whole = state.buffer.to_string().expect("buffer is utf-8");
+                    let deleted_text = whole[position..position + removed].to_string();
+                    edits.push((position, removed, String::new()));
+                    state.apply(
+                        &mut cursors,
+                        &Event::Delete {
+                            range: position..position + removed,
+                            deleted_text,
+                            cursor_id,
+                        },
+                    );
+                }
+
+                build_index(&mut state, geom);
+                let maintained = state
+                    .wrap_indices
+                    .get(&geom)
+                    .map(|i| (structure(i), i.total_rows()))
+                    .expect("index present");
+                let fresh = fresh_index(&mut state, geom);
+                assert_eq!(
+                    maintained.0,
+                    structure(&fresh),
+                    "seed {seed}: conceals {conceals:?}, edits {edits:?}"
+                );
+                assert_eq!(
+                    maintained.1,
+                    fresh.total_rows(),
+                    "seed {seed}: conceals {conceals:?}, edits {edits:?}"
+                );
+            }
+        }
     }
 
     /// **The spec, in one sentence: an index that has been maintained across

--- a/crates/fresh-editor/tests/e2e/conceal_spanning_line_break.rs
+++ b/crates/fresh-editor/tests/e2e/conceal_spanning_line_break.rs
@@ -1,0 +1,104 @@
+//! E2E: typing on a line that a conceal reaches into from the line above.
+//!
+//! A conceal range is free to span a line break — markdown_compose's paragraph
+//! *joins* are exactly that, one conceal from the end of a source line to the
+//! start of the next — and its replacement glyphs have nothing to do with the
+//! bytes it hides (`---` renders as a single `─`).
+//!
+//! The wrap index repairs an edited line by resuming its layout from a row
+//! start, and a line's first row starts at the line's own first byte. When a
+//! conceal reaches across that byte, the line's token stream opens with the
+//! replacement, anchored back on the line above. The repair used to take "the
+//! rest" of that token by subtracting source offsets — `text[byte - offset..]`
+//! — which is meaningless for a replacement, and lands inside a multi-byte
+//! glyph:
+//!
+//! ```text
+//! start byte index 2 is not a char boundary; it is inside '─' (bytes 0..3)
+//! ```
+//!
+//! The editor aborted on the keystroke. This drives the real plugin runtime
+//! and asserts only on what the screen shows.
+
+#![cfg(feature = "plugins")]
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+/// Conceals `aaa[a\nbb]bb` — four bytes straddling the line break — and renders
+/// them as one `─`, the shape a compose-mode join takes.
+const PLUGIN: &str = r#"
+const editor = getEditor();
+
+globalThis.span_lines_changed = function(data: { buffer_id: number }): void {
+  editor.clearConcealNamespace(data.buffer_id, "test-span");
+  editor.addConceal(data.buffer_id, "test-span", 3, 7, "─");
+};
+editor.on("lines_changed", "span_lines_changed");
+"#;
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn typing_below_a_conceal_that_spans_a_line_break_keeps_the_editor_alive() {
+    let temp = tempfile::tempdir().unwrap();
+    let project_root = temp.path().join("project");
+    fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    fs::write(plugins_dir.join("test_conceal_span.ts"), PLUGIN).unwrap();
+
+    let file = project_root.join("span.txt");
+    fs::write(&file, "aaaa\nbbbb\n").unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        100,
+        12,
+        HarnessOptions::new()
+            .with_working_dir(project_root.clone())
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+    harness.open_file(&file).unwrap();
+    harness.render().unwrap();
+
+    // The conceal has landed once its replacement is on screen: the fourth
+    // `a`, the newline and the first two `b`s are hidden behind the one glyph,
+    // so the two source lines are drawn as `aaa─bb`.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("aaa─"))
+        .unwrap();
+
+    // Walk the cursor into the second line — the concealed newline joins the
+    // two into one drawn row, so `Down` would step over it.
+    for _ in 0..8 {
+        if harness.screen_to_string().contains("Ln 2,") {
+            break;
+        }
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 2,"),
+        "precondition: the cursor must reach the concealed line.\nScreen:\n{screen}"
+    );
+
+    // Type on the line the conceal reaches into. This is the keystroke that
+    // used to abort the process.
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.type_text("Z").unwrap();
+    harness.render().unwrap();
+
+    // `aaa─bbZ`: the first line's tail, the replacement standing in for the
+    // four hidden bytes (`a`, the newline and two `b`s), then what is left of
+    // the second line with the typed character at its end.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("aaa─bbZ"),
+        "the typed character must reach the concealed line.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -19,6 +19,7 @@ pub mod capslock_shortcuts;
 pub mod cargo_config_editing;
 pub mod code_tour_dock;
 pub mod command_palette;
+pub mod conceal_spanning_line_break;
 pub mod config_language_selector;
 pub mod copy_buffer_path;
 pub mod crash_repro;


### PR DESCRIPTION
Two bugs in how the wrap index repairs a line whose layout a conceal touches. The first aborts the editor on a keystroke; the second silently leaves the index describing a layout the renderer never draws.

## 1. A resume cut a conceal's replacement at a source byte

```
thread 'main' panicked at crates/fresh-editor/src/view/wrap_index.rs:1363:52:
start byte index 2 is not a char boundary; it is inside '─' (bytes 0..3) of `─`
```

Repair resumes a damaged line's layout from a row start, and took the rest of the token it lands in by subtracting source offsets — `text[byte - source_offset..]`. That is meaningful only when a token's text *is* the buffer's bytes at that offset. A conceal's replacement is anchored at the range it hides and draws something else entirely (a whole `---` renders as one `─`), so the cut indexed display bytes with a source byte and landed inside a multi-byte glyph.

A conceal is free to span a line break — markdown_compose's paragraph joins are exactly that — which puts a line's *own first byte* inside one, so the first keystroke on such a line crashed.

**Fix.** `ViewTokenWire` records *where* a token is anchored and cannot express whether its text is the bytes found there, so the repair path no longer addresses bare tokens. `LineStream` pairs each token with a `SourceExtent`:

- `Injected` — no source bytes at all (a wrap break, a hanging indent, an inline hint);
- `Verbatim` — the text *is* the buffer's bytes from its anchor;
- `Substituted { end }` — stands in for source bytes up to `end`, drawing something that is not them.

Classification happens once, in `line_token_stream`, where the conceal ranges that did the substituting are still in hand — nothing downstream can recover it from the tokens alone. Only `Verbatim` text can be cut by a source byte; `Substituted` is all or nothing, so a resume landing inside one returns `None` and the line is laid out from its start instead. The meaningless cut is unwritable rather than guarded against.

## 2. Resync spliced a tail onto a row that does not identify itself

Repair rewraps forward and stops as soon as a new row boundary lands on an old one — same start byte once shifted by the edit's delta, same carry — then splices the old tail unchanged. That claim holds only when the pair *identifies* the row, which is what `resumable` already records: the row opens with the source token at its own start byte.

A row that opens with injected content does not. A conceal replacement wider than the width left on its row leaves its tail at the head of the next one, and that row's recorded start is the first source byte it happens to *contain*, several columns in. Two such rows can share a start byte and a carry and still run out of width at different bytes — so the spliced tail came out three bytes off, and every row start after it in the line was wrong.

**Fix.** Resync now requires the row to be a resume point on both sides.

## Tests

Everything was reproduced before being fixed; each test fails without its change.

- `tests/e2e/conceal_spanning_line_break.rs` — drives the real plugin runtime (a small plugin conceals four bytes across a newline and renders them as one `─`), walks the cursor in with arrow keys, types, and asserts only on the rendered screen. Panics with the exact message above without the fix.
- `an_edit_below_a_conceal_that_spans_a_line_break_does_not_panic` — the same shape on a real `EditorState`: real markers, real edit events, the same build call the renderer makes.
- `a_row_opening_with_a_decoration_spill_is_not_a_resync_point` — the smallest case of bug 2: two conceals on one line, typing at the second one's start.
- `a_maintained_index_answers_like_a_fresh_build_under_conceals` — a deterministic generated sweep over conceal sets and edit sequences, comparing the maintained index against a fresh build after every edit. It is what found both bugs; a failure names its seed and reproduces exactly.

Full `fresh-editor` lib suite passes (3791 tests), `cargo clippy --all-targets` clean of new warnings, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti2w24xCRkZUXA7XqsbgQk