### PR TITLE
fix ssh bootstrap when target is windows

### DIFF
--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -534,6 +534,15 @@ async fn read_ssh_stderr(stderr: Option<ChildStderr>) -> Option<String> {
         .map(str::to_string)
 }
 
+// factored out to test
+fn agent_bootstrap_python() -> String {
+    format!(
+        // read exactly N bytes, text-mode stdin can miscount CRLF
+        "import sys;exec(sys.stdin.buffer.read({}).decode('utf-8'))",
+        AGENT_SOURCE.len()
+    )
+}
+
 /// Append the shared `ssh` flags for a non-interactive agent carrier, the host
 /// target, and the python agent bootstrap onto `cmd`.
 ///
@@ -564,10 +573,7 @@ fn configure_agent_carrier_ssh(cmd: &mut Command, params: &ConnectionParams) {
     // the remote: python reads exactly N bytes (the agent source), execs it, and
     // the agent then keeps reading stdin for protocol messages. ssh runs the
     // remote command through a shell, hence the double quotes.
-    cmd.arg(format!(
-        "python3 -u -c \"import sys;exec(sys.stdin.read({}))\"",
-        AGENT_SOURCE.len()
-    ));
+    cmd.arg(format!("python3 -u -c \"{}\"", agent_bootstrap_python()));
 }
 
 /// Detach a carrier `ssh` child from the editor's controlling terminal.
@@ -918,6 +924,39 @@ mod tests {
             args.iter().any(|a| a == "me@host"),
             "ssh target missing; args = {args:?}"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn agent_bootstrap_starts_before_stdin_closes_on_windows() {
+        use std::io::{BufRead, Write};
+        use std::process::{Command as StdCommand, Stdio};
+
+        // Write exactly the embedded agent bytes and deliberately retain stdin:
+        // the ready line must not require EOF.
+        let mut child = StdCommand::new("py.exe")
+            .args(["-3", "-u", "-c"])
+            .arg(agent_bootstrap_python())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("start the Python agent bootstrap");
+        let mut stdin = child.stdin.take().expect("bootstrap stdin");
+        stdin
+            .write_all(AGENT_SOURCE.as_bytes())
+            .expect("send agent source");
+        stdin.flush().expect("flush agent source");
+
+        let stdout = child.stdout.take().expect("bootstrap stdout");
+        let mut ready = String::new();
+        std::io::BufReader::new(stdout)
+            .read_line(&mut ready)
+            .expect("read agent ready line while stdin remains open");
+
+        child.kill().expect("stop test agent");
+        child.wait().expect("reap test agent");
+        let response: AgentResponse = serde_json::from_str(&ready).expect("valid ready response");
+        assert!(response.is_ready());
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -5,6 +5,7 @@
 use crate::services::process_hidden::HideWindow;
 use crate::services::remote::channel::AgentChannel;
 use crate::services::remote::protocol::AgentResponse;
+use crate::services::remote::transport::agent_bootstrap_pycode;
 use crate::services::remote::AGENT_SOURCE;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -534,15 +535,6 @@ async fn read_ssh_stderr(stderr: Option<ChildStderr>) -> Option<String> {
         .map(str::to_string)
 }
 
-// factored out to test
-fn agent_bootstrap_python() -> String {
-    format!(
-        // read exactly N bytes, text-mode stdin can miscount CRLF
-        "import sys;exec(sys.stdin.buffer.read({}).decode('utf-8'))",
-        AGENT_SOURCE.len()
-    )
-}
-
 /// Append the shared `ssh` flags for a non-interactive agent carrier, the host
 /// target, and the python agent bootstrap onto `cmd`.
 ///
@@ -573,7 +565,7 @@ fn configure_agent_carrier_ssh(cmd: &mut Command, params: &ConnectionParams) {
     // the remote: python reads exactly N bytes (the agent source), execs it, and
     // the agent then keeps reading stdin for protocol messages. ssh runs the
     // remote command through a shell, hence the double quotes.
-    cmd.arg(format!("python3 -u -c \"{}\"", agent_bootstrap_python()));
+    cmd.arg(format!("python3 -u -c \"{}\"", agent_bootstrap_pycode()));
 }
 
 /// Detach a carrier `ssh` child from the editor's controlling terminal.
@@ -936,7 +928,7 @@ mod tests {
         // the ready line must not require EOF.
         let mut child = StdCommand::new("py.exe")
             .args(["-3", "-u", "-c"])
-            .arg(agent_bootstrap_python())
+            .arg(agent_bootstrap_pycode())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()

--- a/crates/fresh-editor/src/services/remote/transport.rs
+++ b/crates/fresh-editor/src/services/remote/transport.rs
@@ -99,8 +99,13 @@ pub(crate) fn kubectl_exec_argv(
 /// bytes from stdin and `exec` them, then the agent keeps reading stdin for
 /// protocol messages. Byte-count framing avoids any dependency on a remote
 /// shell or here-doc support — identical to the SSH bootstrap.
+///
+/// Text mode stdin can miscount, buffer decode is crossplatform.
 pub(crate) fn agent_bootstrap_pycode() -> String {
-    format!("import sys;exec(sys.stdin.read({}))", AGENT_SOURCE.len())
+    format!(
+        "import sys;exec(sys.stdin.buffer.read({}).decode())",
+        AGENT_SOURCE.len()
+    )
 }
 
 /// How the carrier's stderr is wired.
@@ -407,7 +412,10 @@ mod tests {
         let code = agent_bootstrap_pycode();
         assert_eq!(
             code,
-            format!("import sys;exec(sys.stdin.read({}))", AGENT_SOURCE.len())
+            format!(
+                "import sys;exec(sys.stdin.buffer.read({}).decode())",
+                AGENT_SOURCE.len()
+            )
         );
         // No shell metacharacters that would need quoting under `kubectl --`.
         assert!(!code.contains('\''));


### PR DESCRIPTION
fresh ssh connection was hanging on windows. `plain sys.stdin.read` behaves differently per platform which was causing the bootstrap to hang.

the added test timeouts nextest without the fix