### PR TITLE
fix(welcome): a startup surface — opens once, as a tab, and touches nothing else

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4253,6 +4253,12 @@ pub enum PluginCommand {
         /// in a tab bar to be background *in*.
         #[serde(default)]
         background: bool,
+        /// Per-buffer current-line highlight. `None` follows the editor's
+        /// `highlight_current_line` setting; `Some(false)` switches it off
+        /// for a buffer where a lit row is noise — a page laid out by a
+        /// widget panel, where the caret's line means nothing to the reader.
+        #[serde(default)]
+        highlight_current_line: Option<bool>,
         /// Optional initial cursor line (0-indexed). Applied before the
         /// new buffer becomes the active buffer, so plugins can land the
         /// cursor atomically with creation rather than chasing a race
@@ -6091,6 +6097,13 @@ pub struct CreateVirtualBufferOptions {
     #[serde(default)]
     #[ts(optional)]
     pub background: Option<bool>,
+    /// Current-line highlight for this buffer (default: follow the editor
+    /// setting). Pass `false` for a page whose rows are laid out by a widget
+    /// panel — the caret's line means nothing to the reader there, and a
+    /// lit band across a centred wordmark is noise.
+    #[serde(default, rename = "highlightCurrentLine")]
+    #[ts(optional, rename = "highlightCurrentLine")]
+    pub highlight_current_line: Option<bool>,
     /// Initial content as **spans, concatenated verbatim** — a span is a run
     /// of text with optional styling, not a line. Nothing inserts newlines
     /// for you, so `[{text:"a"},{text:"b"}]` is the single line `ab`. Include
@@ -7209,6 +7222,7 @@ impl PluginApi {
             editing_disabled: false,
             hidden_from_tabs: false,
             background: false,
+            highlight_current_line: None,
             initial_cursor_line: None,
             indentation_guide: None,
             request_id: None,

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -4244,6 +4244,15 @@ pub enum PluginCommand {
         editing_disabled: bool,
         /// Whether this buffer should be hidden from tabs (for composite source buffers)
         hidden_from_tabs: bool,
+        /// Open the buffer as a tab in the active split *without* making it
+        /// the active buffer. Creation otherwise switches to the new buffer,
+        /// which is right for a panel the reader just asked for and wrong for
+        /// one the editor offers unbidden — a startup page, say, which should
+        /// be there to turn to without displacing the file being restored.
+        /// Ignored when `hidden_from_tabs` is set: a detached buffer is not
+        /// in a tab bar to be background *in*.
+        #[serde(default)]
+        background: bool,
         /// Optional initial cursor line (0-indexed). Applied before the
         /// new buffer becomes the active buffer, so plugins can land the
         /// cursor atomically with creation rather than chasing a race
@@ -6067,6 +6076,21 @@ pub struct CreateVirtualBufferOptions {
     #[serde(default, rename = "hiddenFromTabs")]
     #[ts(optional, rename = "hiddenFromTabs")]
     pub hidden_from_tabs: Option<bool>,
+    /// Open as a tab without taking the view (default: false).
+    ///
+    /// Creating a virtual buffer otherwise makes it the active buffer, and
+    /// there is no quiet way back: switching away afterwards is a second
+    /// visible switch, and the layout the panel composed while it briefly
+    /// held the pane is not the one it gets later. Set this when the buffer
+    /// is one the editor offers rather than one the reader asked for — a
+    /// startup page beside a restored session — and it appears in the tab
+    /// bar with the current buffer left alone.
+    ///
+    /// Ignored together with `hiddenFromTabs`, which has no tab bar to be
+    /// background in.
+    #[serde(default)]
+    #[ts(optional)]
+    pub background: Option<bool>,
     /// Initial content as **spans, concatenated verbatim** — a span is a run
     /// of text with optional styling, not a line. Nothing inserts newlines
     /// for you, so `[{text:"a"},{text:"b"}]` is the single line `ab`. Include
@@ -7184,6 +7208,7 @@ impl PluginApi {
             show_cursors: true,
             editing_disabled: false,
             hidden_from_tabs: false,
+            background: false,
             initial_cursor_line: None,
             indentation_guide: None,
             request_id: None,

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2450,6 +2450,21 @@ type CreateVirtualBufferOptions = {
 	*/
 	hiddenFromTabs?: boolean;
 	/**
+	* Open as a tab without taking the view (default: false).
+	*
+	* Creating a virtual buffer otherwise makes it the active buffer, and
+	* there is no quiet way back: switching away afterwards is a second
+	* visible switch, and the layout the panel composed while it briefly
+	* held the pane is not the one it gets later. Set this when the buffer
+	* is one the editor offers rather than one the reader asked for — a
+	* startup page beside a restored session — and it appears in the tab
+	* bar with the current buffer left alone.
+	*
+	* Ignored together with `hiddenFromTabs`, which has no tab bar to be
+	* background in.
+	*/
+	background?: boolean;
+	/**
 	* Initial content as **spans, concatenated verbatim** — a span is a run
 	* of text with optional styling, not a line. Nothing inserts newlines
 	* for you, so `[{text:"a"},{text:"b"}]` is the single line `ab`. Include

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2465,6 +2465,13 @@ type CreateVirtualBufferOptions = {
 	*/
 	background?: boolean;
 	/**
+	* Current-line highlight for this buffer (default: follow the editor
+	* setting). Pass `false` for a page whose rows are laid out by a widget
+	* panel — the caret's line means nothing to the reader there, and a
+	* lit band across a centred wordmark is noise.
+	*/
+	highlightCurrentLine?: boolean;
+	/**
 	* Initial content as **spans, concatenated verbatim** — a span is a run
 	* of text with optional styling, not a line. Nothing inserts newlines
 	* for you, so `[{text:"a"},{text:"b"}]` is the single line `ab`. Include

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -1476,7 +1476,8 @@ function hasOtherBuffers(): boolean {
  *  command — which both overrides `showOnStartup` and brings the page to
  *  the front. Startup passes `false` and lets `hasOtherBuffers` decide
  *  the second half: an empty workspace lands on the page, a workspace
- *  with work in it gets a tab and keeps looking at the work. */
+ *  with work in it gets a tab and keeps looking at the work — the page
+ *  is never made active and then unmade. */
 async function openWelcome(force: boolean): Promise<void> {
   if (bufferId !== null) {
     editor.showBuffer(bufferId);
@@ -1485,11 +1486,6 @@ async function openWelcome(force: boolean): Promise<void> {
   if (opening) return;
   if (!force && !showOnStartup()) return;
   const foreground = force || !hasOtherBuffers();
-
-  // `createVirtualBuffer` tabs the new buffer into the focused pane and
-  // makes it active — there is no "open it quietly" option — so a
-  // background open is an open followed by putting the reader back.
-  const restoreTo = foreground ? 0 : editor.getActiveBufferId();
   opening = true;
   readActiveTheme();
   try {
@@ -1510,6 +1506,12 @@ async function openWelcome(force: boolean): Promise<void> {
       // lit its occurrences and the reader could see no reason why.
       showCursors: true,
       editingDisabled: true,
+      // Never take the view from a workspace that already has something
+      // in it. The page arrives as a tab, in one step: opening and then
+      // switching back is two visible switches, and the reader watches
+      // their file get displaced and returned for no reason they asked
+      // for.
+      background: !foreground,
     });
     bufferId = res.bufferId;
     // Nothing focused is this page's resting state: it opens as
@@ -1539,11 +1541,7 @@ async function openWelcome(force: boolean): Promise<void> {
     probeThemes();
     probeWorkspaces();
     render();
-    if (foreground) {
-      editor.showBuffer(bufferId);
-    } else if (restoreTo !== 0 && restoreTo !== bufferId) {
-      editor.showBuffer(restoreTo);
-    }
+    if (foreground) editor.showBuffer(bufferId);
     void probeRepoFiles();
     void probeGit();
   } catch (e) {

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -22,8 +22,10 @@ const editor = getEditor();
 // ═════════════════════════════════════════════════════════════════════
 //   WELCOME SCREEN
 //
-//   The empty-workspace surface: a scrollable buffer that onboards
-//   three audiences on one page without overwhelming the simplest.
+//   The startup surface: a scrollable buffer that onboards three
+//   audiences on one page without overwhelming the simplest. It opens
+//   when Fresh launches with nothing to restore, and otherwise only on
+//   request — closing buffers never summons it.
 //   Design note: docs/internal/welcome-screen-design.md.
 //
 //   Structure is a ladder. The first viewport is a zero-anxiety zone
@@ -150,18 +152,6 @@ let opening = false;
  *  auto-opened screen nobody touched steps aside when a real file
  *  opens; one the reader engaged with is theirs to close. */
 let engaged = false;
-/** Set when the reader closes the page — by Escape, by the tab's `×`,
- *  by `Ctrl+W`. It answers one question only: *this* emptying of the
- *  workspace has been answered. Closing the screen must never be undone
- *  by the very `buffer_closed` event the close itself produced.
- *
- *  It is cleared the moment the workspace stops being empty, because
- *  the next time it empties is a new question. It used to hold for the
- *  rest of the session, which read as the screen appearing at random:
- *  close it once and it never came back, however many times you emptied
- *  the workspace afterwards. */
-let dismissed = false;
-
 const folded = new Set<string>();
 
 let finderQuery = "";
@@ -1445,7 +1435,7 @@ function probeWorkspaces(): void {
 
 editor.defineConfigBoolean("showOnStartup", {
   default: true,
-  description: "Open the welcome screen when Fresh starts with nothing to restore, and after the last buffer is closed.",
+  description: "Open the welcome screen when Fresh starts with nothing to restore.",
 });
 
 /** The footer toggle writes plugin global state, which persists across
@@ -1463,10 +1453,9 @@ function showOnStartup(): boolean {
 
 /** Is anything at all open besides this page?
  *
- *  Anything: a file, a terminal, an agent session, another plugin's
- *  panel. This is the *empty workspace* screen, and a workspace with a
- *  shell running in it is not empty — closing the last text buffer
- *  while a terminal is still open used to pop the page up over it.
+ *  Asked once, at startup: the page stands in for an empty workspace, so
+ *  a restored session with anything in it — a file, a terminal, an agent
+ *  session, another plugin's panel — is not one to stand in for.
  *
  *  Two buffers do not count: this page itself, and the host's empty
  *  untitled seed, which is the very thing the page stands in for. */
@@ -1485,8 +1474,7 @@ async function openWelcome(force: boolean): Promise<void> {
     return;
   }
   if (opening) return;
-  if (force) dismissed = false;
-  if (!force && (dismissed || !showOnStartup())) return;
+  if (!force && !showOnStartup()) return;
   opening = true;
   readActiveTheme();
   try {
@@ -1549,13 +1537,9 @@ async function openWelcome(force: boolean): Promise<void> {
   opening = false;
 }
 
-/** `dismiss` distinguishes the reader closing the page (stay away)
- *  from the page stepping aside for a file it had nothing to do with
- *  (stay available). */
-function closeWelcome(dismiss: boolean): void {
+function closeWelcome(): void {
   if (bufferId === null) return;
   const id = bufferId;
-  if (dismiss) dismissed = true;
   panel?.unmount();
   panel = null;
   bufferId = null;
@@ -1574,31 +1558,27 @@ editor.registerCommand(
 registerHandler("welcomeOnReady", async () => {
   if (!hasOtherBuffers()) await openWelcome(false);
 });
-registerHandler("welcomeOnBufferClosed", async (e: { buffer_id: number }) => {
+/** Only ever housekeeping for *this* page's own buffer.
+ *
+ *  Emptying the workspace deliberately does nothing. The page is a
+ *  startup surface, not an empty-workspace surface: it used to reopen
+ *  itself whenever the last buffer went away, which made closing your
+ *  final file feel like the editor undoing the close — and made
+ *  "close everything" impossible to express. Startup is the one moment
+ *  the reader has not just told us what they wanted. */
+registerHandler("welcomeOnBufferClosed", (e: { buffer_id: number }) => {
   // The tab's `×` / `Ctrl+W` route: the buffer is gone and we were not
-  // the ones who asked, so treat it as the reader dismissing the page.
+  // the ones who asked, so drop our handle on it.
   if (bufferId !== null && e.buffer_id === bufferId) {
     panel = null;
     bufferId = null;
-    dismissed = true;
-    return;
   }
-  if (hasOtherBuffers()) {
-    // Still something open: whatever answer the reader gave the last
-    // time the workspace emptied has expired.
-    dismissed = false;
-    return;
-  }
-  await openWelcome(false);
 });
 registerHandler("welcomeOnAfterFileOpen", (_e: { buffer_id: number; path: string }) => {
-  // The workspace is not empty any more, so a previous "I closed it"
-  // no longer answers anything.
-  dismissed = false;
   // An auto-opened screen nobody touched was ambient — step aside. One
   // the reader engaged with is a document they are reading; leave it.
   if (bufferId === null || engaged) return;
-  closeWelcome(false);
+  closeWelcome();
 });
 /** Everything about the page's shape a resize can change: the measure,
  *  the three widths the layout switches on, and whether there is room
@@ -1758,7 +1738,7 @@ registerHandler("welcome_close", () => {
     render();
     return;
   }
-  closeWelcome(true);
+  closeWelcome();
 });
 
 // A mode that declares `allowTextInput` owns the keyboard: the host

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -153,6 +153,16 @@ let opening = false;
  *  auto-opened screen nobody touched steps aside when a real file
  *  opens; one the reader engaged with is theirs to close. */
 let engaged = false;
+/** True once the page has actually been on screen — opened in the
+ *  foreground, or switched to since.
+ *
+ *  The step-aside rule was written for a page *occupying the pane*: an
+ *  ambient screen you ignored gets out of the way of the file you asked
+ *  for. A background tab is not occupying anything, so closing it is not
+ *  politeness — it is deleting a tab the reader never asked to close,
+ *  and it deleted the startup tab on their first file open, before they
+ *  had ever seen it. */
+let shown = false;
 const folded = new Set<string>();
 
 let finderQuery = "";
@@ -1480,6 +1490,12 @@ function hasOtherBuffers(): boolean {
  *  is never made active and then unmade. */
 async function openWelcome(force: boolean): Promise<void> {
   if (bufferId !== null) {
+    // Asking for the page by name is engagement even when it is already
+    // open. Startup now always creates the buffer, so this is the path
+    // the `Welcome` command takes for the rest of the session — leave
+    // `engaged` false here and the page the reader just summoned is
+    // ambient again, closed by their next file open.
+    if (force) engaged = true;
     editor.showBuffer(bufferId);
     return;
   }
@@ -1537,6 +1553,7 @@ async function openWelcome(force: boolean): Promise<void> {
     // the reader's buffers is a plugin exceeding its brief either way.
     // The page opens; it does not clear the table first.
     engaged = force;
+    shown = foreground;
     applyComposeWidth();
     probeThemes();
     probeWorkspaces();
@@ -1590,7 +1607,8 @@ registerHandler("welcomeOnBufferClosed", (e: { buffer_id: number }) => {
 registerHandler("welcomeOnAfterFileOpen", (_e: { buffer_id: number; path: string }) => {
   // An auto-opened screen nobody touched was ambient — step aside. One
   // the reader engaged with is a document they are reading; leave it.
-  if (bufferId === null || engaged) return;
+  // A tab they have never even seen has nothing to step aside from.
+  if (bufferId === null || engaged || !shown) return;
   closeWelcome();
 });
 /** Everything about the page's shape a resize can change: the measure,
@@ -1626,6 +1644,36 @@ function layoutKey(): string {
 // it is this buffer's pane, where `getViewport()` is whichever split
 // happens to be active.
 let lastKey = "";
+/** `viewport_changed` reaches the *active* buffer of a split only, so a
+ *  page sitting behind a file hears nothing — not a resize, not the
+ *  switch that finally shows it. Its `composeWidth` hint and its spec
+ *  are then whatever the terminal was when it was created: resize from
+ *  140 columns to 70 while the page is a background tab and it paints,
+ *  when you turn to it, at a measure the pane cannot hold.
+ *
+ *  Coming to the front is the moment to catch up. `layoutKey` is
+ *  recomputed from scratch — `paneWidth` is cleared first, because the
+ *  cached one belongs to a pane this buffer may never have had — and
+ *  the page repaints if anything about its shape moved. */
+registerHandler("welcomeOnBufferActivated", (e: { buffer_id: number }) => {
+  if (bufferId === null || e.buffer_id !== bufferId) return;
+  if (editor.getActiveBufferId() !== bufferId) return;
+  shown = true;
+  editor.setTimeout(0, "welcomeCatchUpOnShow");
+});
+registerHandler("welcomeCatchUpOnShow", async () => {
+  if (bufferId === null || editor.getActiveBufferId() !== bufferId) return;
+  paneWidth = 0;
+  const key = layoutKey();
+  if (key === lastKey) return;
+  lastKey = key;
+  applyComposeWidth();
+  // The hint has to be *in* before the panel is laid out against it:
+  // `widget_panel_width` reads it while it processes the update, and a
+  // repaint issued in the same breath as the hint reads the old one.
+  await editor.flush();
+  render();
+});
 registerHandler(
   "welcomeOnViewportChanged",
   (d: { buffer_id: number; width: number }) => {
@@ -1640,6 +1688,7 @@ registerHandler(
 );
 
 editor.on("ready", "welcomeOnReady");
+editor.on("buffer_activated", "welcomeOnBufferActivated");
 editor.on("buffer_closed", "welcomeOnBufferClosed");
 editor.on("after_file_open", "welcomeOnAfterFileOpen");
 editor.on("viewport_changed", "welcomeOnViewportChanged");

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -24,8 +24,9 @@ const editor = getEditor();
 //
 //   The startup surface: a scrollable buffer that onboards three
 //   audiences on one page without overwhelming the simplest. It opens
-//   when Fresh launches with nothing to restore, and otherwise only on
-//   request — closing buffers never summons it.
+//   once, when Fresh launches, and takes the foreground only when there
+//   is nothing else to look at — otherwise it waits in a tab. Closing
+//   buffers never summons it, and it closes nothing to make room.
 //   Design note: docs/internal/welcome-screen-design.md.
 //
 //   Structure is a ladder. The first viewport is a zero-anxiety zone
@@ -1435,7 +1436,7 @@ function probeWorkspaces(): void {
 
 editor.defineConfigBoolean("showOnStartup", {
   default: true,
-  description: "Open the welcome screen when Fresh starts with nothing to restore.",
+  description: "Open the welcome screen when Fresh starts. It takes the foreground only when there is nothing else open.",
 });
 
 /** The footer toggle writes plugin global state, which persists across
@@ -1453,12 +1454,15 @@ function showOnStartup(): boolean {
 
 /** Is anything at all open besides this page?
  *
- *  Asked once, at startup: the page stands in for an empty workspace, so
- *  a restored session with anything in it — a file, a terminal, an agent
- *  session, another plugin's panel — is not one to stand in for.
+ *  Asked once, at startup, and it decides one thing only: whether the
+ *  page comes to the front. It used to decide whether the page opened at
+ *  all, which meant restoring a session — or plain `fresh note.txt` —
+ *  hid it until you closed every buffer and relaunched.
  *
- *  Two buffers do not count: this page itself, and the host's empty
- *  untitled seed, which is the very thing the page stands in for. */
+ *  Anything counts: a file, a terminal, an agent session, another
+ *  plugin's panel. Two buffers do not: this page itself, and the host's
+ *  empty untitled seed, which is the very thing the page stands in
+ *  for — a workspace holding only that is an empty one. */
 function hasOtherBuffers(): boolean {
   return editor.listBuffers().some((b) => {
     if (bufferId !== null && b.id === bufferId) return false;
@@ -1468,6 +1472,11 @@ function hasOtherBuffers(): boolean {
   });
 }
 
+/** `force` is the reader asking for the page by name — the `Welcome`
+ *  command — which both overrides `showOnStartup` and brings the page to
+ *  the front. Startup passes `false` and lets `hasOtherBuffers` decide
+ *  the second half: an empty workspace lands on the page, a workspace
+ *  with work in it gets a tab and keeps looking at the work. */
 async function openWelcome(force: boolean): Promise<void> {
   if (bufferId !== null) {
     editor.showBuffer(bufferId);
@@ -1475,6 +1484,12 @@ async function openWelcome(force: boolean): Promise<void> {
   }
   if (opening) return;
   if (!force && !showOnStartup()) return;
+  const foreground = force || !hasOtherBuffers();
+
+  // `createVirtualBuffer` tabs the new buffer into the focused pane and
+  // makes it active — there is no "open it quietly" option — so a
+  // background open is an open followed by putting the reader back.
+  const restoreTo = foreground ? 0 : editor.getActiveBufferId();
   opening = true;
   readActiveTheme();
   try {
@@ -1512,23 +1527,30 @@ async function openWelcome(force: boolean): Promise<void> {
     // cursor reached the viewport edge and the page finally scrolled.
     // This is the order `setBufferShowCursors`'s own docs prescribe.
     editor.setBufferShowCursors(bufferId, true);
-    // Fresh seeds an empty untitled buffer when it has nothing else to
-    // show. The welcome screen is what that seed was standing in for, so
-    // retire it rather than leaving a `[No Name]` tab beside this one.
-    for (const b of editor.listBuffers()) {
-      if (
-        b.id !== bufferId && !b.is_virtual && !b.modified &&
-        (!b.path || b.path.length === 0)
-      ) {
-        editor.closeBuffer(b.id);
-      }
-    }
+    // Nothing else is closed to make room. Retiring the host's empty
+    // `[No Name]` seed here looked tidy — the page is what that seed
+    // stands in for — but the test it selected on (unnamed, unmodified,
+    // not virtual) is also every scratch buffer anyone ever opened with
+    // `Ctrl+N` and had not yet typed into, and a plugin buffer closing
+    // the reader's buffers is a plugin exceeding its brief either way.
+    // The page opens; it does not clear the table first.
     engaged = force;
     applyComposeWidth();
     probeThemes();
     probeWorkspaces();
     render();
-    editor.showBuffer(bufferId);
+    if (foreground) {
+      editor.showBuffer(bufferId);
+    } else if (restoreTo !== 0 && restoreTo !== bufferId) {
+      // A frame later, not now. The widget layout is sized from the
+      // split the buffer is painted in, and a buffer that has never been
+      // painted has no width to read — the host falls back to the whole
+      // terminal, which centres every row half a pane too far right and
+      // wraps the wordmark against the compose column. So let this
+      // frame paint the page properly, then hand the pane back.
+      handBackTo = restoreTo;
+      editor.setTimeout(0, "welcomeHandBackPane");
+    }
     void probeRepoFiles();
     void probeGit();
   } catch (e) {
@@ -1556,7 +1578,7 @@ editor.registerCommand(
 );
 
 registerHandler("welcomeOnReady", async () => {
-  if (!hasOtherBuffers()) await openWelcome(false);
+  await openWelcome(false);
 });
 /** Only ever housekeeping for *this* page's own buffer.
  *
@@ -1613,6 +1635,16 @@ function layoutKey(): string {
 // it is this buffer's pane, where `getViewport()` is whichever split
 // happens to be active.
 let lastKey = "";
+/** The buffer a background open owes the pane back to; see `openWelcome`. */
+let handBackTo = 0;
+registerHandler("welcomeHandBackPane", () => {
+  const to = handBackTo;
+  handBackTo = 0;
+  // Only if the reader has not moved in the meantime.
+  if (to === 0 || bufferId === null) return;
+  if (editor.getActiveBufferId() !== bufferId) return;
+  editor.showBuffer(to);
+});
 registerHandler(
   "welcomeOnViewportChanged",
   (d: { buffer_id: number; width: number }) => {

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -26,7 +26,9 @@ const editor = getEditor();
 //   audiences on one page without overwhelming the simplest. It opens
 //   once, when Fresh launches, and takes the foreground only when there
 //   is nothing else to look at — otherwise it waits in a tab. Closing
-//   buffers never summons it, and it closes nothing to make room.
+//   buffers never summons it. The one buffer it will close is the
+//   host's untitled seed, and only when the reader's own setting says
+//   they want no empty buffer; then the page is what replaces it.
 //   Design note: docs/internal/welcome-screen-design.md.
 //
 //   Structure is a ladder. The first viewport is a zero-anxiety zone
@@ -1462,6 +1464,30 @@ function showOnStartup(): boolean {
 
 // ── Lifecycle ────────────────────────────────────────────────────────
 
+/** The host's own answer to "what do I show when there is nothing to
+ *  show": `editor.auto_create_empty_buffer_on_last_buffer_close`. With it
+ *  on, the reader wants a `[No Name]` scratch buffer in an empty
+ *  workspace; with it off they want nothing. Fresh seeds one untitled
+ *  buffer at launch either way, so this page reads the setting to decide
+ *  what that seed *means* — a buffer the reader asked for, or a
+ *  placeholder this page replaces. */
+function seedWanted(): boolean {
+  const cfg = editor.getConfig() as
+    | { editor?: { auto_create_empty_buffer_on_last_buffer_close?: boolean } }
+    | null;
+  return cfg?.editor?.auto_create_empty_buffer_on_last_buffer_close !== false;
+}
+
+/** The host's empty untitled seed: not a file, no name, never typed
+ *  into. Anything else unnamed and unmodified is a scratch buffer the
+ *  reader opened with `Ctrl+N` — but so is the seed, structurally, and
+ *  at startup the two are told apart only by the setting above. */
+function isSeed(b: { id: number; path: string; is_virtual: boolean; modified: boolean }): boolean {
+  if (bufferId !== null && b.id === bufferId) return false;
+  const unnamed = !b.path || b.path.length === 0;
+  return !b.is_virtual && unnamed && !b.modified;
+}
+
 /** Is anything at all open besides this page?
  *
  *  Asked once, at startup, and it decides one thing only: whether the
@@ -1470,14 +1496,16 @@ function showOnStartup(): boolean {
  *  hid it until you closed every buffer and relaunched.
  *
  *  Anything counts: a file, a terminal, an agent session, another
- *  plugin's panel. Two buffers do not: this page itself, and the host's
- *  empty untitled seed, which is the very thing the page stands in
- *  for — a workspace holding only that is an empty one. */
+ *  plugin's panel. The host's untitled seed counts exactly when the
+ *  reader has said they want one (`seedWanted`): then it is *their*
+ *  scratch buffer and keeps the pane, with this page a tab beside it.
+ *  When they have said they want nothing, the seed is the placeholder
+ *  this page stands in for, and a workspace holding only that is empty. */
 function hasOtherBuffers(): boolean {
+  const seedCounts = seedWanted();
   return editor.listBuffers().some((b) => {
     if (bufferId !== null && b.id === bufferId) return false;
-    const unnamed = !b.path || b.path.length === 0;
-    if (!b.is_virtual && unnamed && !b.modified) return false;
+    if (isSeed(b)) return seedCounts;
     return true;
   });
 }
@@ -1522,6 +1550,9 @@ async function openWelcome(force: boolean): Promise<void> {
       // lit its occurrences and the reader could see no reason why.
       showCursors: true,
       editingDisabled: true,
+      // The caret's row means nothing on a page laid out by widgets, and a
+      // lit band across the centred wordmark reads as a selection.
+      highlightCurrentLine: false,
       // Never take the view from a workspace that already has something
       // in it. The page arrives as a tab, in one step: opening and then
       // switching back is two visible switches, and the reader watches
@@ -1545,13 +1576,20 @@ async function openWelcome(force: boolean): Promise<void> {
     // cursor reached the viewport edge and the page finally scrolled.
     // This is the order `setBufferShowCursors`'s own docs prescribe.
     editor.setBufferShowCursors(bufferId, true);
-    // Nothing else is closed to make room. Retiring the host's empty
-    // `[No Name]` seed here looked tidy — the page is what that seed
-    // stands in for — but the test it selected on (unnamed, unmodified,
-    // not virtual) is also every scratch buffer anyone ever opened with
-    // `Ctrl+N` and had not yet typed into, and a plugin buffer closing
-    // the reader's buffers is a plugin exceeding its brief either way.
-    // The page opens; it does not clear the table first.
+    // Retire the host's seed only when the reader has said they want no
+    // empty buffer (`seedWanted` false) *and* this page is what the
+    // workspace is opening to. Then the seed is the placeholder the page
+    // replaces, and leaving it is a `[No Name]` tab the reader has
+    // explicitly asked not to see. Anything else unnamed is theirs — a
+    // scratch buffer, or the seed they *do* want — and stays: a plugin
+    // buffer closing the reader's buffers is a plugin exceeding its
+    // brief. The `Welcome` command never does this; the palette is not
+    // startup.
+    if (!force && foreground && !seedWanted()) {
+      for (const b of editor.listBuffers()) {
+        if (isSeed(b)) editor.closeBuffer(b.id);
+      }
+    }
     engaged = force;
     shown = foreground;
     applyComposeWidth();

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -23,12 +23,12 @@ const editor = getEditor();
 //   WELCOME SCREEN
 //
 //   The startup surface: a scrollable buffer that onboards three
-//   audiences on one page without overwhelming the simplest. It opens
-//   once, when Fresh launches, and takes the foreground only when there
-//   is nothing else to look at — otherwise it waits in a tab. Closing
-//   buffers never summons it. The one buffer it will close is the
-//   host's untitled seed, and only when the reader's own setting says
-//   they want no empty buffer; then the page is what replaces it.
+//   audiences on one page without overwhelming the simplest. It has one
+//   automatic behaviour, and one setting to govern it: when Fresh
+//   launches, open as a tab behind whatever is already there. It never
+//   takes the foreground on its own, never closes another buffer, and
+//   never reopens because something else went away — closing it is the
+//   reader's, and `Welcome` in the palette brings it back.
 //   Design note: docs/internal/welcome-screen-design.md.
 //
 //   Structure is a ladder. The first viewport is a zero-anxiety zone
@@ -151,20 +151,6 @@ type Workspace = {
 let bufferId: number | null = null;
 let panel: WidgetPanel | null = null;
 let opening = false;
-/** True once the user has scrolled, clicked or typed here. An
- *  auto-opened screen nobody touched steps aside when a real file
- *  opens; one the reader engaged with is theirs to close. */
-let engaged = false;
-/** True once the page has actually been on screen — opened in the
- *  foreground, or switched to since.
- *
- *  The step-aside rule was written for a page *occupying the pane*: an
- *  ambient screen you ignored gets out of the way of the file you asked
- *  for. A background tab is not occupying anything, so closing it is not
- *  politeness — it is deleting a tab the reader never asked to close,
- *  and it deleted the startup tab on their first file open, before they
- *  had ever seen it. */
-let shown = false;
 const folded = new Set<string>();
 
 let finderQuery = "";
@@ -1448,7 +1434,7 @@ function probeWorkspaces(): void {
 
 editor.defineConfigBoolean("showOnStartup", {
   default: true,
-  description: "Open the welcome screen when Fresh starts. It takes the foreground only when there is nothing else open.",
+  description: "Open the welcome screen when Fresh starts, as a tab behind whatever is already open.",
 });
 
 /** The footer toggle writes plugin global state, which persists across
@@ -1464,72 +1450,20 @@ function showOnStartup(): boolean {
 
 // ── Lifecycle ────────────────────────────────────────────────────────
 
-/** The host's own answer to "what do I show when there is nothing to
- *  show": `editor.auto_create_empty_buffer_on_last_buffer_close`. With it
- *  on, the reader wants a `[No Name]` scratch buffer in an empty
- *  workspace; with it off they want nothing. Fresh seeds one untitled
- *  buffer at launch either way, so this page reads the setting to decide
- *  what that seed *means* — a buffer the reader asked for, or a
- *  placeholder this page replaces. */
-function seedWanted(): boolean {
-  const cfg = editor.getConfig() as
-    | { editor?: { auto_create_empty_buffer_on_last_buffer_close?: boolean } }
-    | null;
-  return cfg?.editor?.auto_create_empty_buffer_on_last_buffer_close !== false;
-}
-
-/** The host's empty untitled seed: not a file, no name, never typed
- *  into. Anything else unnamed and unmodified is a scratch buffer the
- *  reader opened with `Ctrl+N` — but so is the seed, structurally, and
- *  at startup the two are told apart only by the setting above. */
-function isSeed(b: { id: number; path: string; is_virtual: boolean; modified: boolean }): boolean {
-  if (bufferId !== null && b.id === bufferId) return false;
-  const unnamed = !b.path || b.path.length === 0;
-  return !b.is_virtual && unnamed && !b.modified;
-}
-
-/** Is anything at all open besides this page?
- *
- *  Asked once, at startup, and it decides one thing only: whether the
- *  page comes to the front. It used to decide whether the page opened at
- *  all, which meant restoring a session — or plain `fresh note.txt` —
- *  hid it until you closed every buffer and relaunched.
- *
- *  Anything counts: a file, a terminal, an agent session, another
- *  plugin's panel. The host's untitled seed counts exactly when the
- *  reader has said they want one (`seedWanted`): then it is *their*
- *  scratch buffer and keeps the pane, with this page a tab beside it.
- *  When they have said they want nothing, the seed is the placeholder
- *  this page stands in for, and a workspace holding only that is empty. */
-function hasOtherBuffers(): boolean {
-  const seedCounts = seedWanted();
-  return editor.listBuffers().some((b) => {
-    if (bufferId !== null && b.id === bufferId) return false;
-    if (isSeed(b)) return seedCounts;
-    return true;
-  });
-}
-
 /** `force` is the reader asking for the page by name — the `Welcome`
  *  command — which both overrides `showOnStartup` and brings the page to
- *  the front. Startup passes `false` and lets `hasOtherBuffers` decide
- *  the second half: an empty workspace lands on the page, a workspace
- *  with work in it gets a tab and keeps looking at the work — the page
- *  is never made active and then unmade. */
+ *  the front. Startup passes `false`: the page is created as a tab
+ *  behind whatever is already open and nothing else about the workspace
+ *  is consulted — not how many buffers there are, not what the host's
+ *  untitled seed means, not any other setting. One concern: open at
+ *  startup, or don't. */
 async function openWelcome(force: boolean): Promise<void> {
   if (bufferId !== null) {
-    // Asking for the page by name is engagement even when it is already
-    // open. Startup now always creates the buffer, so this is the path
-    // the `Welcome` command takes for the rest of the session — leave
-    // `engaged` false here and the page the reader just summoned is
-    // ambient again, closed by their next file open.
-    if (force) engaged = true;
     editor.showBuffer(bufferId);
     return;
   }
   if (opening) return;
   if (!force && !showOnStartup()) return;
-  const foreground = force || !hasOtherBuffers();
   opening = true;
   readActiveTheme();
   try {
@@ -1553,12 +1487,11 @@ async function openWelcome(force: boolean): Promise<void> {
       // The caret's row means nothing on a page laid out by widgets, and a
       // lit band across the centred wordmark reads as a selection.
       highlightCurrentLine: false,
-      // Never take the view from a workspace that already has something
-      // in it. The page arrives as a tab, in one step: opening and then
-      // switching back is two visible switches, and the reader watches
-      // their file get displaced and returned for no reason they asked
-      // for.
-      background: !foreground,
+      // Startup never takes the view. The page arrives as a tab, in one
+      // step: opening and then switching back is two visible switches,
+      // and the reader watches their buffer get displaced and returned
+      // for no reason they asked for. Only the palette brings it forward.
+      background: !force,
     });
     bufferId = res.bufferId;
     // Nothing focused is this page's resting state: it opens as
@@ -1576,27 +1509,11 @@ async function openWelcome(force: boolean): Promise<void> {
     // cursor reached the viewport edge and the page finally scrolled.
     // This is the order `setBufferShowCursors`'s own docs prescribe.
     editor.setBufferShowCursors(bufferId, true);
-    // Retire the host's seed only when the reader has said they want no
-    // empty buffer (`seedWanted` false) *and* this page is what the
-    // workspace is opening to. Then the seed is the placeholder the page
-    // replaces, and leaving it is a `[No Name]` tab the reader has
-    // explicitly asked not to see. Anything else unnamed is theirs — a
-    // scratch buffer, or the seed they *do* want — and stays: a plugin
-    // buffer closing the reader's buffers is a plugin exceeding its
-    // brief. The `Welcome` command never does this; the palette is not
-    // startup.
-    if (!force && foreground && !seedWanted()) {
-      for (const b of editor.listBuffers()) {
-        if (isSeed(b)) editor.closeBuffer(b.id);
-      }
-    }
-    engaged = force;
-    shown = foreground;
     applyComposeWidth();
     probeThemes();
     probeWorkspaces();
     render();
-    if (foreground) editor.showBuffer(bufferId);
+    if (force) editor.showBuffer(bufferId);
     void probeRepoFiles();
     void probeGit();
   } catch (e) {
@@ -1633,7 +1550,13 @@ registerHandler("welcomeOnReady", async () => {
  *  itself whenever the last buffer went away, which made closing your
  *  final file feel like the editor undoing the close — and made
  *  "close everything" impossible to express. Startup is the one moment
- *  the reader has not just told us what they wanted. */
+ *  the reader has not just told us what they wanted.
+ *
+ *  Nor does opening a file close the page. It used to "step aside" for
+ *  a file when nobody had touched it, which needed the plugin to keep
+ *  score of engagement and of whether the page had ever been on screen,
+ *  and still deleted a tab the reader had not asked to close. A tab is
+ *  a tab: the reader closes it. */
 registerHandler("welcomeOnBufferClosed", (e: { buffer_id: number }) => {
   // The tab's `×` / `Ctrl+W` route: the buffer is gone and we were not
   // the ones who asked, so drop our handle on it.
@@ -1641,13 +1564,6 @@ registerHandler("welcomeOnBufferClosed", (e: { buffer_id: number }) => {
     panel = null;
     bufferId = null;
   }
-});
-registerHandler("welcomeOnAfterFileOpen", (_e: { buffer_id: number; path: string }) => {
-  // An auto-opened screen nobody touched was ambient — step aside. One
-  // the reader engaged with is a document they are reading; leave it.
-  // A tab they have never even seen has nothing to step aside from.
-  if (bufferId === null || engaged || !shown) return;
-  closeWelcome();
 });
 /** Everything about the page's shape a resize can change: the measure,
  *  the three widths the layout switches on, and whether there is room
@@ -1696,7 +1612,6 @@ let lastKey = "";
 registerHandler("welcomeOnBufferActivated", (e: { buffer_id: number }) => {
   if (bufferId === null || e.buffer_id !== bufferId) return;
   if (editor.getActiveBufferId() !== bufferId) return;
-  shown = true;
   editor.setTimeout(0, "welcomeCatchUpOnShow");
 });
 registerHandler("welcomeCatchUpOnShow", async () => {
@@ -1728,18 +1643,15 @@ registerHandler(
 editor.on("ready", "welcomeOnReady");
 editor.on("buffer_activated", "welcomeOnBufferActivated");
 editor.on("buffer_closed", "welcomeOnBufferClosed");
-editor.on("after_file_open", "welcomeOnAfterFileOpen");
 editor.on("viewport_changed", "welcomeOnViewportChanged");
 
 // ── Keyboard ─────────────────────────────────────────────────────────
 
 function dispatch(action: ReturnType<typeof widgetKey>): void {
-  engaged = true;
   panel?.command(action);
 }
 
 function jumpTo(level: string): void {
-  engaged = true;
   if (bufferId === null) return;
   editor.scrollToWidget(bufferId, `level:${level}`);
 }
@@ -1757,7 +1669,6 @@ registerHandler("welcome_jump_1", () => jumpTo("1"));
 registerHandler("welcome_jump_2", () => jumpTo("2"));
 registerHandler("welcome_jump_3", () => jumpTo("3"));
 registerHandler("welcome_jump_top", () => {
-  engaged = true;
   if (bufferId === null) return;
   // The startup switch is the first widget on the page, so "go to the
   // top" is the same request as every other jump.
@@ -1790,12 +1701,10 @@ function activateFocused(): boolean {
 }
 
 registerHandler("welcome_enter", () => {
-  engaged = true;
   if (activateFocused()) return;
   dispatch(widgetKey("Enter"));
 });
 registerHandler("welcome_space", () => {
-  engaged = true;
   if (activateFocused()) return;
   dispatch(widgetKey("Space"));
 });
@@ -1815,12 +1724,10 @@ function moveFinder(delta: number): void {
  *  mean something the host cannot know: with the finder focused they
  *  walk its *hits*, which are plugin state, not text in the field. */
 registerHandler("welcome_up", () => {
-  engaged = true;
   if (finderFocused()) moveFinder(-1);
   else editor.executeAction("move_up");
 });
 registerHandler("welcome_down", () => {
-  engaged = true;
   if (finderFocused()) moveFinder(1);
   else editor.executeAction("move_down");
 });
@@ -1857,9 +1764,6 @@ const FORWARDED: Array<[string, string]> = [
   ["F1", "show_help"],
 ];
 for (const [, action] of FORWARDED) {
-  // Deliberately does NOT mark the page engaged: reaching past it for
-  // the palette is the ambient case, not a reader settling in. If the
-  // key you pressed opens a file, this screen should still step aside.
   registerHandler(`welcome_do_${action}`, () => editor.executeAction(action));
 }
 
@@ -1868,7 +1772,6 @@ for (const [, action] of FORWARDED) {
  *  runtime's own focus mutation, so the host stays the single owner of
  *  focus. */
 registerHandler("welcome_focus_find", () => {
-  engaged = true;
   if (!panel) return;
   if (folded.has("finder")) {
     folded.delete("finder");
@@ -1884,7 +1787,6 @@ registerHandler("mode_text_input", (args: { text: string }) => {
   // Every character typed into a focused field arrives here, including
   // the ones this page also binds: the host gives a focused text widget
   // the key before it consults the mode's bindings.
-  engaged = true;
   panel.command(textInputChar(args.text));
 });
 
@@ -1920,7 +1822,6 @@ editor.defineMode(
 // ── Widget events ────────────────────────────────────────────────────
 
 function activateKey(k: string): void {
-  engaged = true;
   if (k.startsWith("fold:")) {
     const id = k.slice(5);
     if (folded.has(id)) folded.delete(id);
@@ -2027,7 +1928,6 @@ function openFinderHit(index: number): void {
 
 editor.on("widget_event", (args) => {
   if (!panel || args.panel_id !== panel.id()) return;
-  engaged = true;
   const k = typeof args.widget_key === "string" ? args.widget_key : "";
   if (k.length > 0) lastFocusedWidget = k;
 

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -1542,14 +1542,7 @@ async function openWelcome(force: boolean): Promise<void> {
     if (foreground) {
       editor.showBuffer(bufferId);
     } else if (restoreTo !== 0 && restoreTo !== bufferId) {
-      // A frame later, not now. The widget layout is sized from the
-      // split the buffer is painted in, and a buffer that has never been
-      // painted has no width to read — the host falls back to the whole
-      // terminal, which centres every row half a pane too far right and
-      // wraps the wordmark against the compose column. So let this
-      // frame paint the page properly, then hand the pane back.
-      handBackTo = restoreTo;
-      editor.setTimeout(0, "welcomeHandBackPane");
+      editor.showBuffer(restoreTo);
     }
     void probeRepoFiles();
     void probeGit();
@@ -1635,16 +1628,6 @@ function layoutKey(): string {
 // it is this buffer's pane, where `getViewport()` is whichever split
 // happens to be active.
 let lastKey = "";
-/** The buffer a background open owes the pane back to; see `openWelcome`. */
-let handBackTo = 0;
-registerHandler("welcomeHandBackPane", () => {
-  const to = handBackTo;
-  handBackTo = 0;
-  // Only if the reader has not moved in the meantime.
-  if (to === 0 || bufferId === null) return;
-  if (editor.getActiveBufferId() !== bufferId) return;
-  editor.showBuffer(to);
-});
 registerHandler(
   "welcomeOnViewportChanged",
   (d: { buffer_id: number; width: number }) => {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1359,6 +1359,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 hidden_from_tabs,
+                background,
                 initial_cursor_line,
                 indentation_guide,
                 request_id,
@@ -1372,6 +1373,7 @@ impl Editor {
                     show_cursors,
                     editing_disabled,
                     hidden_from_tabs,
+                    background,
                     initial_cursor_line,
                     indentation_guide,
                     request_id,
@@ -3563,6 +3565,7 @@ impl Editor {
         show_cursors: bool,
         editing_disabled: bool,
         hidden_from_tabs: bool,
+        background: bool,
         initial_cursor_line: Option<u32>,
         indentation_guide: Option<bool>,
         request_id: Option<u64>,
@@ -3622,8 +3625,12 @@ impl Editor {
             Ok(()) => {
                 tracing::debug!("Set virtual buffer content for {:?}", buffer_id);
                 // Switch to the new buffer to display it — but only when it's
-                // attached (a detached hidden buffer must not steal the view).
-                if !hidden_from_tabs {
+                // attached (a detached hidden buffer must not steal the view)
+                // and the caller did not ask for a background tab. A
+                // `background` buffer is already in the tab bar by now:
+                // `create_virtual_buffer` adds it and seeds its view state,
+                // and only this line makes it the one on screen.
+                if !hidden_from_tabs && !background {
                     self.set_active_buffer(buffer_id);
                     tracing::debug!("Switched to virtual buffer {:?}", buffer_id);
                 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1360,6 +1360,7 @@ impl Editor {
                 editing_disabled,
                 hidden_from_tabs,
                 background,
+                highlight_current_line,
                 initial_cursor_line,
                 indentation_guide,
                 request_id,
@@ -1374,6 +1375,7 @@ impl Editor {
                     editing_disabled,
                     hidden_from_tabs,
                     background,
+                    highlight_current_line,
                     initial_cursor_line,
                     indentation_guide,
                     request_id,
@@ -3566,6 +3568,7 @@ impl Editor {
         editing_disabled: bool,
         hidden_from_tabs: bool,
         background: bool,
+        highlight_current_line: Option<bool>,
         initial_cursor_line: Option<u32>,
         indentation_guide: Option<bool>,
         request_id: Option<u64>,
@@ -3614,7 +3617,16 @@ impl Editor {
                 .expect("active window must have a populated split layout")
                 .get_mut(&active_split)
             {
-                view_state.ensure_buffer_state(buffer_id).show_line_numbers = show_line_numbers;
+                let bs = view_state.ensure_buffer_state(buffer_id);
+                bs.show_line_numbers = show_line_numbers;
+                // Both the live value and the override: the live one is
+                // what this frame paints, the override is what survives
+                // `apply_config_defaults` re-resolving the view against the
+                // editor setting on the next config change.
+                if let Some(lit) = highlight_current_line {
+                    bs.highlight_current_line = lit;
+                    bs.highlight_current_line_override = Some(lit);
+                }
             }
         } else if let Some(meta) = self.active_window_mut().buffer_metadata.get_mut(&buffer_id) {
             meta.hidden_from_tabs = true;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -510,7 +510,23 @@ impl Editor {
             // and a `divider` ruled across the pane instead of the
             // page. Plugins were left computing their own pads from a
             // width the host already knew.
-            .map(|vs| (vs.compose_width, vs.viewport.width))
+            //
+            // Read it from *this buffer's* state, not from the split's:
+            // `SplitViewState` derefs to whichever buffer is active
+            // there, so `vs.compose_width` was the neighbouring tab's
+            // answer whenever the panel was not the one on screen. A
+            // panel opened behind another buffer therefore laid out to
+            // the whole split and then had its centred rows wrapped
+            // against a compose column it never saw — and it stayed
+            // that way, because nothing repaints a background tab. The
+            // pane width beside it is a property of the split, so that
+            // one is right to read through the deref.
+            .map(|vs| {
+                (
+                    vs.buffer_state(buffer_id).and_then(|b| b.compose_width),
+                    vs.viewport.width,
+                )
+            })
             .unwrap_or((None, self.terminal_width.max(1) as u16));
         match raw {
             // Composing, the compose layout has already flanked the

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -6182,7 +6182,12 @@ where
         // spinner is wall-clock-derived (see
         // `lsp_status::compose_lsp_status`) and needs a periodic
         // re-render to advance even when no other event fires.
-        let animations_active = editor.active_window().animations.is_active();
+        // `take_settle_frame` is the frame owed after the last effect retires:
+        // that frame was the effect's own composite (a slide's final position,
+        // a fade's last step), and with `is_active` already false nothing else
+        // would ask for the frame that paints the true content underneath.
+        let animations_active = editor.active_window().animations.is_active()
+            || editor.active_window_mut().animations.take_settle_frame();
         let lsp_progress_active = editor.active_window().has_active_lsp_progress();
         // Same for a wheel gesture still walking its lines: each frame
         // hands over the next one.

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -614,6 +614,7 @@ impl EditorServer {
                 // frame hands over the next one, so without this a
                 // multi-line notch would stop part-way through.
                 if editor.active_window().animations.is_active()
+                    || editor.active_window_mut().animations.take_settle_frame()
                     || editor.has_pending_wheel_scroll()
                 {
                     needs_render = true;

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -155,24 +155,30 @@ impl FrameEffect for SlideIn {
     }
 
     fn apply(&mut self, buf: &mut Buffer, area: Rect, elapsed: Duration) -> EffectStatus {
-        // First apply captures the post-paint "after" snapshot. The
-        // "before" snapshot, if any, was captured at the top of this
-        // render pass via the trait hook.
-        if self.after.is_none() {
-            self.after = Some(Self::snapshot_area(buf, area));
+        // The "after" snapshot is taken from `buf` on *every* apply. By the
+        // time the runner reaches this effect the frame's content pass has
+        // already painted the incoming pane into `buf`, so what is read here
+        // is the pane as it is *now* — which is the only thing a slide may
+        // show shifted. It used to be captured once, on the first apply, and
+        // held for the slide's whole duration: a pane whose content changed
+        // mid-slide (a plugin panel catching up to a new width on
+        // `buffer_activated`, ~100ms in) kept showing the first frame's
+        // cells, and because the slide's final frame is its own composite
+        // and the runner asked for no frame after it, the stale picture
+        // outlived the slide until the next input. A snapshot is 69×37 cells
+        // for a pane; copying it per frame for 260ms costs nothing worth
+        // a stale screen.
+        //
+        // The "before" snapshot, if any, was captured at the top of this
+        // render pass via the trait hook; it is dropped if the area moved
+        // under it (a resize mid-slide), which falls back to the
+        // slide-in-with-blanks path.
+        let area_changed = self.after.as_ref().is_some_and(|s| s.area != area);
+        if area_changed {
+            self.before = None;
         }
-        let after = match &self.after {
-            Some(s) if s.area == area => s,
-            Some(_) => {
-                // Area changed mid-animation (resize) — re-snapshot the
-                // after, and drop the before whose dimensions no longer
-                // match. Falls back to the slide-in-with-blanks path.
-                self.after = Some(Self::snapshot_area(buf, area));
-                self.before = None;
-                self.after.as_ref().unwrap()
-            }
-            None => unreachable!(),
-        };
+        self.after = Some(Self::snapshot_area(buf, area));
+        let after = self.after.as_ref().expect("snapshot just taken");
         let before = self.before.as_ref().filter(|b| b.area == area);
 
         let t = if self.duration.is_zero() {
@@ -1049,6 +1055,13 @@ struct ActiveEffect {
 pub struct AnimationRunner {
     next_id: u64,
     active: Vec<ActiveEffect>,
+    /// An effect finished during the last `apply_all`, so the frame it
+    /// finished on is its own composite and one more frame is owed to
+    /// paint the true content. Read once by the frame loop through
+    /// [`Self::take_settle_frame`]; without it the loop's "animations are
+    /// active" test is already false when it next asks, and the screen
+    /// is left showing whatever the effect's last frame drew.
+    settle_owed: bool,
     /// Cumulative count of effects accepted by either `start` or
     /// `start_with_id`. Monotonic; increments before the effect is
     /// pushed so a sample taken any time after the call sees the
@@ -1070,6 +1083,7 @@ impl AnimationRunner {
             next_id: 1,
             active: Vec::new(),
             total_started: 0,
+            settle_owed: false,
         }
     }
 
@@ -1200,8 +1214,19 @@ impl AnimationRunner {
             }
             let elapsed = now - effective_start;
             e.status = e.effect.apply(buf, e.area, elapsed);
+            if e.status == EffectStatus::Done {
+                self.settle_owed = true;
+            }
         }
         self.active.retain(|e| e.status == EffectStatus::Running);
+    }
+
+    /// Whether an effect finished on the last frame, so one more frame is
+    /// owed to paint the content it was drawn over. Clears on read: the
+    /// frame loop asks once per iteration and the debt is paid by the frame
+    /// that follows.
+    pub fn take_settle_frame(&mut self) -> bool {
+        std::mem::take(&mut self.settle_owed)
     }
 
     pub fn is_active(&self) -> bool {
@@ -1238,6 +1263,41 @@ impl AnimationRunner {
 
 #[cfg(test)]
 mod tests {
+    /// The frame an effect finishes on is its own composite, so the runner
+    /// owes one more frame to paint the content underneath. `is_active` is
+    /// already false by the time the loop asks; this is the signal that
+    /// carries the debt across, and it is paid exactly once.
+    #[test]
+    fn a_finished_effect_owes_exactly_one_settle_frame() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let area = Rect::new(0, 0, 8, 2);
+        let mut runner = super::AnimationRunner::new();
+        assert!(
+            !runner.take_settle_frame(),
+            "nothing owed before any effect"
+        );
+        runner.start(
+            area,
+            super::AnimationKind::SlideIn {
+                from: super::Edge::Right,
+                duration: std::time::Duration::ZERO,
+                delay: std::time::Duration::ZERO,
+            },
+        );
+        let mut buf = Buffer::empty(area);
+        runner.apply_all(&mut buf);
+        assert!(
+            !runner.is_active(),
+            "a zero-duration slide finishes on its first apply"
+        );
+        assert!(
+            runner.take_settle_frame(),
+            "the finishing frame owes a settle frame"
+        );
+        assert!(!runner.take_settle_frame(), "the debt is paid once");
+    }
+
     use super::*;
     use ratatui::style::Color;
 

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -1433,6 +1433,45 @@ mod tests {
         }
     }
 
+    /// The incoming snapshot is retaken from `buf` on every apply. It used to
+    /// be captured once, on the first apply, and shifted for the slide's whole
+    /// duration — so a pane whose content changed mid-slide kept showing its
+    /// first frame's cells until the slide ended, and past it (the runner asked
+    /// for no frame after). The content pass paints the pane into `buf` before
+    /// the runner applies, so `buf` at apply time *is* the incoming content.
+    #[test]
+    fn slide_in_retakes_the_incoming_snapshot_every_apply() {
+        let area = Rect::new(0, 0, 3, 4);
+        let mut effect = SlideIn::new(Edge::Right, Duration::from_millis(100));
+
+        // First frame of the slide: the pane still holds its stale cells.
+        let mut stale = make_buf(3, 4);
+        paint(&mut stale, area, 'S', Color::Red);
+        effect.apply(&mut stale, area, Duration::ZERO);
+
+        // A few frames in, the content pass has repainted the pane.
+        let mut fresh = make_buf(3, 4);
+        paint(&mut fresh, area, 'N', Color::Blue);
+        effect.apply(&mut fresh, area, Duration::from_millis(50));
+        for dy in 0..area.height {
+            for dx in 0..area.width {
+                let sym = fresh.cell((area.x + dx, area.y + dy)).unwrap().symbol();
+                assert_ne!(
+                    sym, "S",
+                    "the slide painted the first frame's cell at ({dx},{dy}) over content \
+                     that has since changed"
+                );
+            }
+        }
+        // ...and at least some of the new content is on its way in.
+        let any_new = (0..area.height)
+            .any(|dy| (0..area.width).any(|dx| fresh.cell((dx, dy)).unwrap().symbol() == "N"));
+        assert!(
+            any_new,
+            "mid-slide, the incoming content should be partly visible"
+        );
+    }
+
     #[test]
     fn runner_pushes_out_the_caller_supplied_previous_frame() {
         // Simulate two frames:

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -1368,9 +1368,16 @@ mod tests {
 
         // Construct SlideIn directly so we can drive its clock.
         let mut effect = SlideIn::new(Edge::Bottom, Duration::from_millis(100));
-        // First apply at t=0 snapshots the buffer.
+        // Frame 1, t=0: the content pass has painted the pane; the slide
+        // shifts it fully off the bottom edge.
         effect.apply(&mut buf, area, Duration::ZERO);
-        // Now drive it to t=duration: result should equal the original painted content.
+        // Frame 2, t=duration. The runner only ever applies to a buffer the
+        // content pass has just repainted — that is what lets the effect
+        // snapshot the pane as it is *now* on every apply, which is how a
+        // pane that changed mid-slide gets shown (see `SlideIn::apply`). A
+        // test that skipped the repaint would hand the effect its own
+        // previous composite, a frame that never happens.
+        paint(&mut buf, area, 'X', Color::Red);
         let status = effect.apply(&mut buf, area, Duration::from_millis(100));
         assert_eq!(status, EffectStatus::Done);
         for dy in 0..area.height {
@@ -1412,7 +1419,10 @@ mod tests {
                 );
             }
         }
-        // And: at t=duration, the AFTER content is fully in place.
+        // And: at t=duration, the AFTER content is fully in place. The next
+        // frame's content pass repaints the pane before the runner applies
+        // (see `slide_in_bottom_at_duration_matches_snapshot`).
+        let mut work = after_buf.clone();
         let status = effect.apply(&mut work, area, Duration::from_millis(100));
         assert_eq!(status, EffectStatus::Done);
         for dy in 0..area.height {

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -791,6 +791,7 @@ fn test_next_buffer_skips_hidden_buffers() {
         editing_disabled: true,
         hidden_from_tabs: true, // <-- This makes it hidden
         background: false,
+        highlight_current_line: None,
         initial_cursor_line: None,
         indentation_guide: None,
         request_id: None,

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -790,6 +790,7 @@ fn test_next_buffer_skips_hidden_buffers() {
         show_cursors: true,
         editing_disabled: true,
         hidden_from_tabs: true, // <-- This makes it hidden
+        background: false,
         initial_cursor_line: None,
         indentation_guide: None,
         request_id: None,

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -344,6 +344,7 @@ pub mod vertical_scrollbar_cursor_extent;
 pub mod vi_mode;
 #[cfg(feature = "plugins")]
 pub mod vi_mode_bugs;
+pub mod virtual_buffer_repaint;
 pub mod virtual_space;
 pub mod visual_regression;
 pub mod warning_indicators;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -344,6 +344,7 @@ pub mod vertical_scrollbar_cursor_extent;
 pub mod vi_mode;
 #[cfg(feature = "plugins")]
 pub mod vi_mode_bugs;
+#[cfg(feature = "plugins")]
 pub mod virtual_buffer_repaint;
 pub mod virtual_space;
 pub mod visual_regression;

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -133,23 +133,21 @@ fn leaving_the_finder_does_not_park_focus_on_the_startup_switch() {
 /// a startup surface now, and this is the difference.
 #[test]
 fn closing_the_last_buffer_does_not_reopen_the_welcome_screen() {
-    let (mut harness, tmp) = harness_with_welcome();
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
 
-    // Start with something open, so `ready` finds a non-empty workspace
-    // and the page never auto-opens in the first place.
-    let path = tmp.path().join("work").join("note.txt");
-    fs::write(&path, "the only file\n").unwrap();
-    harness.open_file(&path).unwrap();
-    harness.editor_mut().fire_ready_hook();
+    // Escape closes the page: the reader's own dismissal.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
     harness.wait_for_async_quiescence(4).unwrap();
     assert!(
         !harness.screen_to_string().contains("JUST EDIT TEXT"),
-        "the page opened over a restored workspace"
+        "precondition: Escape closes the page"
     );
 
     // Now empty the workspace the way `Ctrl+W` on the last tab does.
-    let id = harness.editor().active_buffer_id();
-    harness.editor_mut().close_buffer(id).unwrap();
+    for id in harness.editor().all_buffer_ids_for_tests() {
+        let _ = harness.editor_mut().close_buffer(id);
+    }
     harness.wait_for_async_quiescence(4).unwrap();
 
     let screen = harness.screen_to_string();
@@ -166,4 +164,127 @@ fn closing_the_last_buffer_does_not_reopen_the_welcome_screen() {
 fn an_empty_startup_still_opens_the_welcome_screen() {
     let (mut harness, _tmp) = harness_with_welcome();
     open_welcome(&mut harness);
+}
+
+/// **Startup means startup — not "startup that found an empty
+/// workspace".** The page asked whether anything else was open and gave
+/// up if anything was, so restoring a session, or plain `fresh
+/// note.txt`, meant never seeing it again: the only way back was to
+/// close every buffer and relaunch. Opening is now unconditional. What a
+/// non-empty workspace changes is only whether the page comes to the
+/// front, which is the next test.
+#[test]
+fn startup_with_a_file_already_open_still_gets_a_welcome_tab() {
+    let (mut harness, tmp) = harness_with_welcome();
+    let path = tmp.path().join("work").join("note.txt");
+    fs::write(&path, "alpha\nbeta\n").unwrap();
+    harness.open_file(&path).unwrap();
+
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Welcome"),
+        "no Welcome tab: the page skipped startup because the workspace \
+         was not empty. Screen:\n{screen}"
+    );
+}
+
+/// The other half of the same rule: a workspace that already has
+/// something in it keeps looking at it. The page is a tab you can turn
+/// to, not a thing that lands on top of the file you asked for.
+#[test]
+fn a_welcome_tab_beside_a_file_does_not_take_the_foreground() {
+    let (mut harness, tmp) = harness_with_welcome();
+    let path = tmp.path().join("work").join("note.txt");
+    fs::write(&path, "alpha\nbeta\n").unwrap();
+    harness.open_file(&path).unwrap();
+
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("alpha"),
+        "the file the reader asked for is no longer on screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("JUST EDIT TEXT"),
+        "the welcome page took the foreground from a buffer that was \
+         already open:\n{screen}"
+    );
+}
+
+/// **It opens; it does not clear the table first.** The page used to
+/// reap the host's empty `[No Name]` seed on the way up, on the reasoning
+/// that the seed was the placeholder it replaces. But the reaping loop's
+/// test — unnamed, unmodified, not virtual — is also every scratch buffer
+/// anyone ever opened with `Ctrl+N` and had not yet typed into, and a
+/// plugin buffer closing the reader's buffers is a plugin exceeding its
+/// brief either way.
+#[test]
+fn opening_the_welcome_screen_closes_no_other_buffer() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    let before = harness.editor().all_buffer_ids_for_tests();
+    assert!(
+        !before.is_empty(),
+        "precondition: the host seeds a buffer to open into"
+    );
+
+    open_welcome(&mut harness);
+
+    let after = harness.editor().all_buffer_ids_for_tests();
+    for id in &before {
+        assert!(
+            after.contains(id),
+            "the welcome screen closed buffer {id:?} to make room for \
+             itself: {before:?} became {after:?}"
+        );
+    }
+}
+
+/// **A page composed off screen composed against the wrong pane.** The
+/// layout is measured from `getViewport()`, which reports the *active*
+/// split — so a page opened behind a file took that file's pane geometry
+/// and, once the reader switched to it, painted at a measure the pane
+/// could not hold: the wordmark wrapped mid-glyph and every centred row
+/// sat far right. `viewport_changed` could not save it either, because
+/// the stale key it recorded while hidden equals the key it computes
+/// when shown. Bringing the page to the front repaints it once.
+#[test]
+fn a_welcome_tab_opened_behind_a_file_paints_correctly_when_shown() {
+    let (mut harness, tmp) = harness_with_welcome();
+    let path = tmp.path().join("work").join("note.txt");
+    fs::write(&path, "alpha\nbeta\n").unwrap();
+    harness.open_file(&path).unwrap();
+
+    let before = harness.editor().all_buffer_ids_for_tests();
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    // Switch to the Welcome tab, the way `Ctrl+PageDown` does. It is the
+    // one buffer startup added.
+    let welcome = harness
+        .editor()
+        .all_buffer_ids_for_tests()
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("startup opened a Welcome buffer");
+    harness.editor_mut().switch_buffer(welcome);
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    // The three doors sit side by side on one row at this width. If the
+    // page composed against a wider pane they wrap and the row breaks up.
+    let screen = harness.screen_to_string();
+    let doors = screen
+        .lines()
+        .find(|l| l.contains("JUST EDIT TEXT"))
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        doors.contains("CLASSIC IDE") && doors.contains("ORCHESTRATE"),
+        "the page painted at a measure its pane cannot hold — the three \
+         doors are no longer one row. Screen:\n{screen}"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -123,3 +123,47 @@ fn leaving_the_finder_does_not_park_focus_on_the_startup_switch() {
          was re-seeded onto it. Screen:\n{screen}"
     );
 }
+
+/// **The reopen loop.** The page used to read `buffer_closed` on an
+/// emptied workspace as an invitation, on the reasoning that "launched
+/// with nothing" and "left with nothing" are the same state. They are
+/// not: closing your last file is something you asked for, and getting a
+/// full-page document back instead of an empty pane reads as the editor
+/// undoing the close — with no way left to say "close everything". It is
+/// a startup surface now, and this is the difference.
+#[test]
+fn closing_the_last_buffer_does_not_reopen_the_welcome_screen() {
+    let (mut harness, tmp) = harness_with_welcome();
+
+    // Start with something open, so `ready` finds a non-empty workspace
+    // and the page never auto-opens in the first place.
+    let path = tmp.path().join("work").join("note.txt");
+    fs::write(&path, "the only file\n").unwrap();
+    harness.open_file(&path).unwrap();
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+    assert!(
+        !harness.screen_to_string().contains("JUST EDIT TEXT"),
+        "the page opened over a restored workspace"
+    );
+
+    // Now empty the workspace the way `Ctrl+W` on the last tab does.
+    let id = harness.editor().active_buffer_id();
+    harness.editor_mut().close_buffer(id).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("JUST EDIT TEXT"),
+        "closing the last buffer summoned the welcome screen:\n{screen}"
+    );
+}
+
+/// The startup path is the one that survives: a launch with nothing to
+/// restore still brings the page up. Guards the fix above against being
+/// "fixed" into a page that never opens by itself at all.
+#[test]
+fn an_empty_startup_still_opens_the_welcome_screen() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+}

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -9,22 +9,21 @@
 //!
 //! So these assert behaviours that were *observed broken*, not the
 //! happy path: what the finder does with the characters the page also
-//! binds, and where focus goes when the reader leaves it.
+//! binds, where focus goes when the reader leaves it, and the one
+//! lifecycle rule the plugin has — open at startup as a tab, and touch
+//! nothing else.
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::Config;
+use fresh::config::{Config, PluginConfig};
+use fresh::model::event::BufferId;
 use std::fs;
 
 const TAB_BAR_ROW: u16 = 1;
 
-/// A harness rooted in a scratch directory holding the real plugin.
-///
-/// `seed_wanted` is `editor.auto_create_empty_buffer_on_last_buffer_close`,
-/// the setting the page reads to decide what the host's untitled seed
-/// means. Most tests here want the page in the foreground of a bare start,
-/// which is the *off* case: the seed is a placeholder the page replaces.
-fn harness_with_welcome_seed(seed_wanted: bool) -> (EditorTestHarness, tempfile::TempDir) {
+/// A harness rooted in a scratch directory holding the real plugin, under
+/// the caller's config.
+fn harness_with_welcome_config(config: Config) -> (EditorTestHarness, tempfile::TempDir) {
     let temp = tempfile::TempDir::new().expect("tempdir");
     let working_dir = temp.path().join("work");
     fs::create_dir_all(&working_dir).unwrap();
@@ -33,22 +32,33 @@ fn harness_with_welcome_seed(seed_wanted: bool) -> (EditorTestHarness, tempfile:
     copy_plugin(&plugins_dir, "welcome_screen");
     copy_plugin_lib(&plugins_dir);
 
-    let mut config = Config::default();
-    config.editor.auto_create_empty_buffer_on_last_buffer_close = seed_wanted;
     let harness = EditorTestHarness::with_config_and_working_dir(120, 40, config, working_dir)
         .expect("harness");
     (harness, temp)
 }
 
-/// The common case for these tests: the reader wants no empty buffer, so a
-/// bare start lands on the page.
 fn harness_with_welcome() -> (EditorTestHarness, tempfile::TempDir) {
-    harness_with_welcome_seed(false)
+    harness_with_welcome_config(Config::default())
 }
 
-/// Bring the page up the way a bare `fresh` does.
-fn open_welcome(harness: &mut EditorTestHarness) {
+/// Fire startup and return the one buffer it added.
+fn startup_welcome_tab(harness: &mut EditorTestHarness) -> BufferId {
+    let before = harness.editor().all_buffer_ids_for_tests();
     harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+    harness
+        .editor()
+        .all_buffer_ids_for_tests()
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("startup opened a Welcome buffer")
+}
+
+/// Bring the page to the front the way a reader does: startup adds the
+/// tab behind the host's `[No Name]` seed, and the palette turns to it.
+fn open_welcome(harness: &mut EditorTestHarness) {
+    startup_welcome_tab(harness);
+    harness.run_palette_command("Welcome").unwrap();
     harness
         .wait_until(|h| h.screen_to_string().contains("JUST EDIT TEXT"))
         .expect("welcome screen renders its three doors");
@@ -174,22 +184,110 @@ fn closing_the_last_buffer_does_not_reopen_the_welcome_screen() {
     );
 }
 
-/// The startup path is the one that survives: a launch with nothing to
-/// restore still brings the page up. Guards the fix above against being
-/// "fixed" into a page that never opens by itself at all.
+/// **A bare start adds a tab and changes nothing else.** The host seeds
+/// one untitled `[No Name]` buffer at launch; the page appears beside it
+/// and leaves it the pane and the focus. The page used to close that seed,
+/// then to close it only under one setting — and each rule needed the
+/// plugin to know what the seed *meant*. It no longer asks.
 #[test]
-fn an_empty_startup_still_opens_the_welcome_screen() {
+fn a_bare_startup_adds_a_welcome_tab_behind_the_empty_buffer() {
     let (mut harness, _tmp) = harness_with_welcome();
-    open_welcome(&mut harness);
+    let before = harness.editor().all_buffer_ids_for_tests();
+    let active_before = harness.editor().active_buffer_id();
+    assert_eq!(before.len(), 1, "precondition: the host seeds one buffer");
+
+    startup_welcome_tab(&mut harness);
+
+    let after = harness.editor().all_buffer_ids_for_tests();
+    for id in &before {
+        assert!(
+            after.contains(id),
+            "the welcome screen closed buffer {id:?}: {before:?} became {after:?}"
+        );
+    }
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        active_before,
+        "the page took the focus from the reader's empty buffer"
+    );
+    let tab_bar = harness.screen_row_text(TAB_BAR_ROW);
+    assert!(
+        tab_bar.contains("[No Name]") && tab_bar.contains("Welcome"),
+        "expected `[No Name]` and a Welcome tab side by side, got: {tab_bar}"
+    );
+    assert!(
+        !harness.screen_to_string().contains("JUST EDIT TEXT"),
+        "the page is in the foreground of a workspace it should have \
+         joined quietly"
+    );
+}
+
+/// **The empty-buffer setting is not this plugin's business.** With
+/// `auto_create_empty_buffer_on_last_buffer_close` off, the page used to
+/// read the seed as a placeholder and close it. Whatever the host does
+/// with its own seed is the host's call; the page does exactly what it
+/// does under the default.
+#[test]
+fn the_empty_buffer_setting_changes_nothing_about_startup() {
+    let mut config = Config::default();
+    config.editor.auto_create_empty_buffer_on_last_buffer_close = false;
+    let (mut harness, _tmp) = harness_with_welcome_config(config);
+    let before = harness.editor().all_buffer_ids_for_tests();
+    let active_before = harness.editor().active_buffer_id();
+
+    let welcome = startup_welcome_tab(&mut harness);
+
+    let after = harness.editor().all_buffer_ids_for_tests();
+    for id in &before {
+        assert!(
+            after.contains(id),
+            "the welcome screen closed buffer {id:?} because of a setting \
+             that is not its own: {before:?} became {after:?}"
+        );
+    }
+    assert!(after.contains(&welcome));
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        active_before,
+        "startup changed which buffer is active"
+    );
+}
+
+/// **`showOnStartup` is the one switch, and off means off.** Nothing
+/// opens at launch; `Welcome` in the palette still works.
+#[test]
+fn show_on_startup_off_opens_nothing_until_asked() {
+    let mut config = Config::default();
+    config.plugins.insert(
+        "welcome_screen".to_string(),
+        PluginConfig {
+            enabled: true,
+            path: None,
+            settings: serde_json::json!({ "showOnStartup": false }),
+        },
+    );
+    let (mut harness, _tmp) = harness_with_welcome_config(config);
+    let before = harness.editor().all_buffer_ids_for_tests();
+
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+    assert_eq!(
+        harness.editor().all_buffer_ids_for_tests(),
+        before,
+        "the page opened at startup with showOnStartup off"
+    );
+
+    harness.run_palette_command("Welcome").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("JUST EDIT TEXT"))
+        .expect("the palette command still opens the page");
 }
 
 /// **Startup means startup — not "startup that found an empty
 /// workspace".** The page asked whether anything else was open and gave
 /// up if anything was, so restoring a session, or plain `fresh
 /// note.txt`, meant never seeing it again: the only way back was to
-/// close every buffer and relaunch. Opening is now unconditional. What a
-/// non-empty workspace changes is only whether the page comes to the
-/// front, which is the next test.
+/// close every buffer and relaunch. Opening is unconditional now.
 #[test]
 fn startup_with_a_file_already_open_still_gets_a_welcome_tab() {
     let (mut harness, tmp) = harness_with_welcome();
@@ -245,81 +343,6 @@ fn a_welcome_tab_beside_a_file_does_not_take_the_foreground() {
     );
 }
 
-/// **When the reader wants an empty buffer, the page touches nothing.**
-/// With `auto_create_empty_buffer_on_last_buffer_close` on, the host's
-/// `[No Name]` seed is the reader's scratch buffer: it keeps the pane and
-/// the focus, and the page is a tab beside it. Closing it — as the page
-/// once did unconditionally — would be a plugin deleting the very buffer
-/// the reader's setting asked for.
-#[test]
-fn a_workspace_that_wants_an_empty_buffer_keeps_it_focused() {
-    let (mut harness, _tmp) = harness_with_welcome_seed(true);
-    // The harness draws no tab bar for a lone buffer, so the seed is
-    // observed by id, not by its `[No Name]` label.
-    let before = harness.editor().all_buffer_ids_for_tests();
-    let active_before = harness.editor().active_buffer_id();
-    assert_eq!(before.len(), 1, "precondition: the host seeds one buffer");
-
-    harness.editor_mut().fire_ready_hook();
-    harness.wait_for_async_quiescence(4).unwrap();
-
-    let after = harness.editor().all_buffer_ids_for_tests();
-    for id in &before {
-        assert!(
-            after.contains(id),
-            "the welcome screen closed buffer {id:?}: {before:?} became {after:?}"
-        );
-    }
-    assert_eq!(
-        harness.editor().active_buffer_id(),
-        active_before,
-        "the page took the focus from the reader's empty buffer"
-    );
-    let tab_bar = harness.screen_row_text(TAB_BAR_ROW);
-    assert!(
-        tab_bar.contains("[No Name]") && tab_bar.contains("Welcome"),
-        "expected `[No Name]` and a Welcome tab side by side, got: {tab_bar}"
-    );
-    assert!(
-        !harness.screen_to_string().contains("JUST EDIT TEXT"),
-        "the page is in the foreground of a workspace whose reader asked \
-         for an empty buffer"
-    );
-}
-
-/// **When the reader wants no empty buffer, the page replaces the seed.**
-/// With the setting off, Fresh still seeds one untitled buffer at launch;
-/// leaving it beside the page is a `[No Name]` tab the reader explicitly
-/// asked never to see. The page closes it and takes the pane — the one
-/// buffer this plugin will ever close, and only here.
-#[test]
-fn a_workspace_that_wants_no_empty_buffer_gets_only_the_welcome_page() {
-    let (mut harness, _tmp) = harness_with_welcome_seed(false);
-    let seed = harness.editor().all_buffer_ids_for_tests();
-    assert_eq!(
-        seed.len(),
-        1,
-        "precondition: the host seeds one buffer regardless of the setting"
-    );
-
-    open_welcome(&mut harness);
-
-    let after = harness.editor().all_buffer_ids_for_tests();
-    assert!(
-        !after.contains(&seed[0]),
-        "the seed survived a start the reader asked to be empty: {seed:?} -> {after:?}"
-    );
-    assert_eq!(
-        after.len(),
-        1,
-        "expected the page to be the only buffer: {after:?}"
-    );
-    assert!(
-        !harness.screen_to_string().contains("[No Name]"),
-        "a `[No Name]` label is still on screen"
-    );
-}
-
 /// **A page composed off screen composed against the wrong pane.** The
 /// layout is measured from `getViewport()`, which reports the *active*
 /// split — so a page opened behind a file took that file's pane geometry
@@ -335,18 +358,9 @@ fn a_welcome_tab_opened_behind_a_file_paints_correctly_when_shown() {
     fs::write(&path, "alpha\nbeta\n").unwrap();
     harness.open_file(&path).unwrap();
 
-    let before = harness.editor().all_buffer_ids_for_tests();
-    harness.editor_mut().fire_ready_hook();
-    harness.wait_for_async_quiescence(4).unwrap();
+    let welcome = startup_welcome_tab(&mut harness);
 
-    // Switch to the Welcome tab, the way `Ctrl+PageDown` does. It is the
-    // one buffer startup added.
-    let welcome = harness
-        .editor()
-        .all_buffer_ids_for_tests()
-        .into_iter()
-        .find(|id| !before.contains(id))
-        .expect("startup opened a Welcome buffer");
+    // Switch to the Welcome tab, the way `Ctrl+PageDown` does.
     harness.editor_mut().switch_buffer(welcome);
     harness.wait_for_async_quiescence(4).unwrap();
 
@@ -365,32 +379,20 @@ fn a_welcome_tab_opened_behind_a_file_paints_correctly_when_shown() {
     );
 }
 
-/// **The startup tab did not survive being ignored.** `engaged` is only
-/// set by a keystroke or click *on the page*, and the step-aside rule
-/// closes an unengaged page when a file opens — a rule written for a page
-/// occupying the pane. The background tab never occupies anything, so the
-/// reader's first `Ctrl+P` deleted a tab they had not yet seen, and the
-/// only way back was a palette command that produced another one just as
-/// short-lived.
+/// **Opening a file never closes the tab.** The page used to "step aside"
+/// for a file when nobody had touched it, which took an engagement score
+/// and a was-it-ever-shown flag to get even half right, and still deleted
+/// a tab the reader had not asked to close. Here the reader has never
+/// turned to it.
 #[test]
-fn a_welcome_tab_the_reader_has_not_seen_survives_their_first_file_open() {
+fn opening_a_file_leaves_a_welcome_tab_the_reader_has_not_seen() {
     let (mut harness, tmp) = harness_with_welcome();
     let first = tmp.path().join("work").join("note.txt");
     fs::write(&first, "alpha\n").unwrap();
     harness.open_file(&first).unwrap();
 
-    let before = harness.editor().all_buffer_ids_for_tests();
-    harness.editor_mut().fire_ready_hook();
-    harness.wait_for_async_quiescence(4).unwrap();
-    let welcome = harness
-        .editor()
-        .all_buffer_ids_for_tests()
-        .into_iter()
-        .find(|id| !before.contains(id))
-        .expect("startup opened a Welcome buffer");
+    let welcome = startup_welcome_tab(&mut harness);
 
-    // The reader opens something. The page is not in their way — it has
-    // never been on screen — so it has nothing to step aside from.
     let second = tmp.path().join("work").join("other.txt");
     fs::write(&second, "beta\n").unwrap();
     harness.open_file(&second).unwrap();
@@ -405,33 +407,23 @@ fn a_welcome_tab_the_reader_has_not_seen_survives_their_first_file_open() {
     );
 }
 
-/// **Summoning the page counts as engagement.** `openWelcome`'s
-/// already-open path brings the buffer forward and used to leave
-/// `engaged` false — and since startup now always creates the buffer,
-/// that is the path `Welcome` takes for the rest of the session. The
-/// reader asked for the page by name, read it, opened a file, and the
-/// step-aside rule destroyed it as if nobody had touched it.
+/// The same rule for a page the reader *has* turned to and not touched —
+/// exactly the case the old step-aside rule fired on. It stays; the
+/// reader closes tabs, not the plugin.
 #[test]
-fn asking_for_the_page_by_name_keeps_it_through_the_next_file_open() {
+fn opening_a_file_leaves_a_welcome_page_the_reader_was_looking_at() {
     let (mut harness, tmp) = harness_with_welcome();
     let first = tmp.path().join("work").join("note.txt");
     fs::write(&first, "alpha\n").unwrap();
     harness.open_file(&first).unwrap();
 
-    let before = harness.editor().all_buffer_ids_for_tests();
-    harness.editor_mut().fire_ready_hook();
-    harness.wait_for_async_quiescence(4).unwrap();
-    let welcome = harness
-        .editor()
-        .all_buffer_ids_for_tests()
-        .into_iter()
-        .find(|id| !before.contains(id))
-        .expect("startup opened a Welcome buffer");
-
-    harness.run_palette_command("Welcome").unwrap();
+    let welcome = startup_welcome_tab(&mut harness);
+    // Turn to the tab the way `Ctrl+PageDown` does — not the palette,
+    // which the old rule counted as "engagement" and spared.
+    harness.editor_mut().switch_buffer(welcome);
     harness
         .wait_until(|h| h.screen_to_string().contains("JUST EDIT TEXT"))
-        .expect("the palette command brings the page forward");
+        .expect("switching to the tab shows the page");
 
     let second = tmp.path().join("work").join("other.txt");
     fs::write(&second, "beta\n").unwrap();
@@ -443,7 +435,7 @@ fn asking_for_the_page_by_name_keeps_it_through_the_next_file_open() {
             .editor()
             .all_buffer_ids_for_tests()
             .contains(&welcome),
-        "the page the reader summoned by name was closed by their next \
-         file open, as if it had been ambient"
+        "the page the reader was looking at was closed by their next file \
+         open, as if the plugin still stepped aside"
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -300,3 +300,86 @@ fn a_welcome_tab_opened_behind_a_file_paints_correctly_when_shown() {
          doors are no longer one row. Screen:\n{screen}"
     );
 }
+
+/// **The startup tab did not survive being ignored.** `engaged` is only
+/// set by a keystroke or click *on the page*, and the step-aside rule
+/// closes an unengaged page when a file opens — a rule written for a page
+/// occupying the pane. The background tab never occupies anything, so the
+/// reader's first `Ctrl+P` deleted a tab they had not yet seen, and the
+/// only way back was a palette command that produced another one just as
+/// short-lived.
+#[test]
+fn a_welcome_tab_the_reader_has_not_seen_survives_their_first_file_open() {
+    let (mut harness, tmp) = harness_with_welcome();
+    let first = tmp.path().join("work").join("note.txt");
+    fs::write(&first, "alpha\n").unwrap();
+    harness.open_file(&first).unwrap();
+
+    let before = harness.editor().all_buffer_ids_for_tests();
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+    let welcome = harness
+        .editor()
+        .all_buffer_ids_for_tests()
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("startup opened a Welcome buffer");
+
+    // The reader opens something. The page is not in their way — it has
+    // never been on screen — so it has nothing to step aside from.
+    let second = tmp.path().join("work").join("other.txt");
+    fs::write(&second, "beta\n").unwrap();
+    harness.open_file(&second).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    assert!(
+        harness
+            .editor()
+            .all_buffer_ids_for_tests()
+            .contains(&welcome),
+        "opening a file closed a Welcome tab the reader had never seen"
+    );
+}
+
+/// **Summoning the page counts as engagement.** `openWelcome`'s
+/// already-open path brings the buffer forward and used to leave
+/// `engaged` false — and since startup now always creates the buffer,
+/// that is the path `Welcome` takes for the rest of the session. The
+/// reader asked for the page by name, read it, opened a file, and the
+/// step-aside rule destroyed it as if nobody had touched it.
+#[test]
+fn asking_for_the_page_by_name_keeps_it_through_the_next_file_open() {
+    let (mut harness, tmp) = harness_with_welcome();
+    let first = tmp.path().join("work").join("note.txt");
+    fs::write(&first, "alpha\n").unwrap();
+    harness.open_file(&first).unwrap();
+
+    let before = harness.editor().all_buffer_ids_for_tests();
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
+    let welcome = harness
+        .editor()
+        .all_buffer_ids_for_tests()
+        .into_iter()
+        .find(|id| !before.contains(id))
+        .expect("startup opened a Welcome buffer");
+
+    harness.run_palette_command("Welcome").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("JUST EDIT TEXT"))
+        .expect("the palette command brings the page forward");
+
+    let second = tmp.path().join("work").join("other.txt");
+    fs::write(&second, "beta\n").unwrap();
+    harness.open_file(&second).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    assert!(
+        harness
+            .editor()
+            .all_buffer_ids_for_tests()
+            .contains(&welcome),
+        "the page the reader summoned by name was closed by their next \
+         file open, as if it had been ambient"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -13,10 +13,18 @@
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
 use std::fs;
 
+const TAB_BAR_ROW: u16 = 1;
+
 /// A harness rooted in a scratch directory holding the real plugin.
-fn harness_with_welcome() -> (EditorTestHarness, tempfile::TempDir) {
+///
+/// `seed_wanted` is `editor.auto_create_empty_buffer_on_last_buffer_close`,
+/// the setting the page reads to decide what the host's untitled seed
+/// means. Most tests here want the page in the foreground of a bare start,
+/// which is the *off* case: the seed is a placeholder the page replaces.
+fn harness_with_welcome_seed(seed_wanted: bool) -> (EditorTestHarness, tempfile::TempDir) {
     let temp = tempfile::TempDir::new().expect("tempdir");
     let working_dir = temp.path().join("work");
     fs::create_dir_all(&working_dir).unwrap();
@@ -25,8 +33,17 @@ fn harness_with_welcome() -> (EditorTestHarness, tempfile::TempDir) {
     copy_plugin(&plugins_dir, "welcome_screen");
     copy_plugin_lib(&plugins_dir);
 
-    let harness = EditorTestHarness::with_working_dir(120, 40, working_dir).expect("harness");
+    let mut config = Config::default();
+    config.editor.auto_create_empty_buffer_on_last_buffer_close = seed_wanted;
+    let harness = EditorTestHarness::with_config_and_working_dir(120, 40, config, working_dir)
+        .expect("harness");
     (harness, temp)
+}
+
+/// The common case for these tests: the reader wants no empty buffer, so a
+/// bare start lands on the page.
+fn harness_with_welcome() -> (EditorTestHarness, tempfile::TempDir) {
+    harness_with_welcome_seed(false)
 }
 
 /// Bring the page up the way a bare `fresh` does.
@@ -228,32 +245,79 @@ fn a_welcome_tab_beside_a_file_does_not_take_the_foreground() {
     );
 }
 
-/// **It opens; it does not clear the table first.** The page used to
-/// reap the host's empty `[No Name]` seed on the way up, on the reasoning
-/// that the seed was the placeholder it replaces. But the reaping loop's
-/// test — unnamed, unmodified, not virtual — is also every scratch buffer
-/// anyone ever opened with `Ctrl+N` and had not yet typed into, and a
-/// plugin buffer closing the reader's buffers is a plugin exceeding its
-/// brief either way.
+/// **When the reader wants an empty buffer, the page touches nothing.**
+/// With `auto_create_empty_buffer_on_last_buffer_close` on, the host's
+/// `[No Name]` seed is the reader's scratch buffer: it keeps the pane and
+/// the focus, and the page is a tab beside it. Closing it — as the page
+/// once did unconditionally — would be a plugin deleting the very buffer
+/// the reader's setting asked for.
 #[test]
-fn opening_the_welcome_screen_closes_no_other_buffer() {
-    let (mut harness, _tmp) = harness_with_welcome();
+fn a_workspace_that_wants_an_empty_buffer_keeps_it_focused() {
+    let (mut harness, _tmp) = harness_with_welcome_seed(true);
+    // The harness draws no tab bar for a lone buffer, so the seed is
+    // observed by id, not by its `[No Name]` label.
     let before = harness.editor().all_buffer_ids_for_tests();
-    assert!(
-        !before.is_empty(),
-        "precondition: the host seeds a buffer to open into"
-    );
+    let active_before = harness.editor().active_buffer_id();
+    assert_eq!(before.len(), 1, "precondition: the host seeds one buffer");
 
-    open_welcome(&mut harness);
+    harness.editor_mut().fire_ready_hook();
+    harness.wait_for_async_quiescence(4).unwrap();
 
     let after = harness.editor().all_buffer_ids_for_tests();
     for id in &before {
         assert!(
             after.contains(id),
-            "the welcome screen closed buffer {id:?} to make room for \
-             itself: {before:?} became {after:?}"
+            "the welcome screen closed buffer {id:?}: {before:?} became {after:?}"
         );
     }
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        active_before,
+        "the page took the focus from the reader's empty buffer"
+    );
+    let tab_bar = harness.screen_row_text(TAB_BAR_ROW);
+    assert!(
+        tab_bar.contains("[No Name]") && tab_bar.contains("Welcome"),
+        "expected `[No Name]` and a Welcome tab side by side, got: {tab_bar}"
+    );
+    assert!(
+        !harness.screen_to_string().contains("JUST EDIT TEXT"),
+        "the page is in the foreground of a workspace whose reader asked \
+         for an empty buffer"
+    );
+}
+
+/// **When the reader wants no empty buffer, the page replaces the seed.**
+/// With the setting off, Fresh still seeds one untitled buffer at launch;
+/// leaving it beside the page is a `[No Name]` tab the reader explicitly
+/// asked never to see. The page closes it and takes the pane — the one
+/// buffer this plugin will ever close, and only here.
+#[test]
+fn a_workspace_that_wants_no_empty_buffer_gets_only_the_welcome_page() {
+    let (mut harness, _tmp) = harness_with_welcome_seed(false);
+    let seed = harness.editor().all_buffer_ids_for_tests();
+    assert_eq!(
+        seed.len(),
+        1,
+        "precondition: the host seeds one buffer regardless of the setting"
+    );
+
+    open_welcome(&mut harness);
+
+    let after = harness.editor().all_buffer_ids_for_tests();
+    assert!(
+        !after.contains(&seed[0]),
+        "the seed survived a start the reader asked to be empty: {seed:?} -> {after:?}"
+    );
+    assert_eq!(
+        after.len(),
+        1,
+        "expected the page to be the only buffer: {after:?}"
+    );
+    assert!(
+        !harness.screen_to_string().contains("[No Name]"),
+        "a `[No Name]` label is still on screen"
+    );
 }
 
 /// **A page composed off screen composed against the wrong pane.** The

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -193,17 +193,29 @@ fn startup_with_a_file_already_open_still_gets_a_welcome_tab() {
 
 /// The other half of the same rule: a workspace that already has
 /// something in it keeps looking at it. The page is a tab you can turn
-/// to, not a thing that lands on top of the file you asked for.
+/// to, not a thing that lands on top of the file you asked for — and
+/// not one that lands on top of it and then gets out of the way again,
+/// which is what opening-then-switching-back looked like: the tab bar
+/// appeared without the page, the page took the pane, and the file came
+/// back. Creation itself now leaves the active buffer alone
+/// (`background` on `createVirtualBuffer`), so there is no moment in
+/// between to see.
 #[test]
 fn a_welcome_tab_beside_a_file_does_not_take_the_foreground() {
     let (mut harness, tmp) = harness_with_welcome();
     let path = tmp.path().join("work").join("note.txt");
     fs::write(&path, "alpha\nbeta\n").unwrap();
     harness.open_file(&path).unwrap();
+    let active_before = harness.editor().active_buffer_id();
 
     harness.editor_mut().fire_ready_hook();
     harness.wait_for_async_quiescence(4).unwrap();
 
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        active_before,
+        "startup changed which buffer is active"
+    );
     let screen = harness.screen_to_string();
     assert!(
         screen.contains("alpha"),

--- a/crates/fresh-editor/tests/e2e/virtual_buffer_repaint.rs
+++ b/crates/fresh-editor/tests/e2e/virtual_buffer_repaint.rs
@@ -1,0 +1,144 @@
+//! Two things a widget-panel repaint exposed about the host, neither of
+//! which is about widget panels.
+//!
+//! Both were found on the welcome screen: a page opened behind a file,
+//! brought forward with `Ctrl+PageDown` after the terminal was resized,
+//! catching up to its new width ~100ms into the tab-switch slide. The slide
+//! kept showing the first frame's cells for its whole duration, and then
+//! the screen kept showing the slide's last frame until the next keystroke.
+
+use crate::common::harness::EditorTestHarness;
+use fresh::config::Config;
+use fresh_core::api::PluginCommand;
+use fresh_core::text_property::TextPropertyEntry;
+use std::collections::HashMap;
+
+fn entry(text: &str) -> TextPropertyEntry {
+    TextPropertyEntry {
+        text: text.to_string(),
+        properties: HashMap::new(),
+        style: None,
+        inline_overlays: Vec::new(),
+        segments: Vec::new(),
+        pad_to_chars: None,
+        truncate_to_chars: None,
+    }
+}
+
+fn create(harness: &mut EditorTestHarness, text: &str, highlight_current_line: Option<bool>) {
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::CreateVirtualBufferWithContent {
+            name: "*Panel*".to_string(),
+            mode: "panel-test".to_string(),
+            read_only: true,
+            entries: vec![entry(text)],
+            show_line_numbers: false,
+            show_cursors: true,
+            editing_disabled: true,
+            hidden_from_tabs: false,
+            background: false,
+            highlight_current_line,
+            initial_cursor_line: None,
+            indentation_guide: None,
+            request_id: None,
+        })
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// **A tab-switch slide froze the incoming pane at its first frame.**
+/// `SlideIn` took its "after" snapshot once, on its first apply, and shifted
+/// that for the slide's 260ms. Content that changed during the slide — here
+/// a panel repainted right after the switch — was invisible until the slide
+/// ended, and (see the design note's finding 34) beyond. The snapshot is now
+/// retaken from the freshly painted frame on every apply, so a slide shows
+/// the pane as it is, shifted.
+///
+/// The animation runs on the wall clock, so this drives frames for a bounded
+/// stretch and asks whether the new content was ever visible *while the
+/// slide was still running*. With the old capture it never is: every frame
+/// of the slide is the pre-repaint cells.
+#[test]
+fn a_pane_repainted_mid_slide_shows_its_new_content_during_the_slide() {
+    let mut config = Config::default();
+    config.editor.animations = true;
+    let mut harness = EditorTestHarness::with_config(60, 12, config).unwrap();
+
+    create(&mut harness, "OLD CONTENT\n", None);
+    let panel = harness.editor().active_buffer_id();
+    create(&mut harness, "OTHER TAB\n", None);
+    assert_ne!(harness.editor().active_buffer_id(), panel);
+
+    // Switch back: this is what starts the slide. The harness seeds a
+    // `[No Name]` tab first, so the order is seed, panel, other — from
+    // `other`, *previous* is the panel.
+    harness.editor_mut().prev_buffer();
+    assert_eq!(harness.editor().active_buffer_id(), panel);
+    // The slide's first frame. This is the frame the old capture took its
+    // one and only snapshot from — the pane as it was *before* the repaint
+    // below. That is the order the real page saw too: a plugin's catch-up
+    // lands a few frames after the switch, not before it.
+    harness.render().unwrap();
+    assert!(
+        harness.editor().active_window().animations.is_active(),
+        "precondition: the tab switch started a slide"
+    );
+    // ...and then the pane's content changes under the slide.
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::SetVirtualBufferContent {
+            buffer_id: panel,
+            entries: vec![entry("NEW CONTENT\n")],
+        })
+        .unwrap();
+
+    let mut seen_new_while_sliding = false;
+    for _ in 0..60 {
+        harness.render().unwrap();
+        if !harness.editor().active_window().animations.is_active() {
+            break;
+        }
+        if harness.screen_to_string().contains("NEW CONTENT") {
+            seen_new_while_sliding = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        seen_new_while_sliding,
+        "the slide kept showing the pane's first-frame cells; the repaint \
+         made during it never reached the screen while it ran"
+    );
+}
+
+/// `highlightCurrentLine: false` on `createVirtualBuffer` leaves the
+/// caret's row unlit. The caret's row means nothing on a page laid out by
+/// widgets, and a lit band across a centred wordmark reads as a selection.
+#[test]
+fn a_virtual_buffer_can_opt_out_of_the_current_line_highlight() {
+    let mut config = Config::default();
+    config.editor.highlight_current_line = true;
+
+    // Control: with no opinion the buffer follows the setting, so the
+    // caret's row (the first) is painted differently from the row below.
+    let mut harness = EditorTestHarness::with_config(60, 12, config.clone()).unwrap();
+    create(&mut harness, "first\nsecond\n", None);
+    let lit = harness.get_cell_style(20, 2).map(|s| s.bg);
+    let plain = harness.get_cell_style(20, 3).map(|s| s.bg);
+    assert_ne!(
+        lit, plain,
+        "control: with the setting on and no override, the cursor row should \
+         carry the highlight background"
+    );
+
+    // Opted out: the two rows paint alike.
+    let mut harness = EditorTestHarness::with_config(60, 12, config).unwrap();
+    create(&mut harness, "first\nsecond\n", Some(false));
+    let cursor_row = harness.get_cell_style(20, 2).map(|s| s.bg);
+    let other_row = harness.get_cell_style(20, 3).map(|s| s.bg);
+    assert_eq!(
+        cursor_row, other_row,
+        "highlightCurrentLine: false still lit the cursor row"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/virtual_buffer_repaint.rs
+++ b/crates/fresh-editor/tests/e2e/virtual_buffer_repaint.rs
@@ -47,20 +47,22 @@ fn create(harness: &mut EditorTestHarness, text: &str, highlight_current_line: O
     harness.render().unwrap();
 }
 
-/// **A tab-switch slide froze the incoming pane at its first frame.**
-/// `SlideIn` took its "after" snapshot once, on its first apply, and shifted
-/// that for the slide's 260ms. Content that changed during the slide — here
-/// a panel repainted right after the switch — was invisible until the slide
-/// ended, and (see the design note's finding 34) beyond. The snapshot is now
-/// retaken from the freshly painted frame on every apply, so a slide shows
-/// the pane as it is, shifted.
+/// **A tab-switch slide froze the incoming pane at its first frame, and the
+/// screen kept that frame after the slide.** `SlideIn` took its snapshot once
+/// and shifted it for 260ms; when it finished, the frame it finished on was
+/// its own composite and nothing asked for another. Content that changed
+/// under the slide — a panel repainting right after the switch — was hidden
+/// until the reader's next keystroke.
 ///
-/// The animation runs on the wall clock, so this drives frames for a bounded
-/// stretch and asks whether the new content was ever visible *while the
-/// slide was still running*. With the old capture it never is: every frame
-/// of the slide is the pre-repaint cells.
+/// The slide runs on the wall clock, so the mid-slide half of this is pinned
+/// in `view::animation::tests::slide_in_retakes_the_incoming_snapshot_every_apply`,
+/// where `elapsed` is a parameter. What this end-to-end test asserts is the
+/// half a harness can observe without racing a 260ms window on a slow
+/// runner: once the slide is over, the pane shows the content it has, not
+/// the content it had when the slide began. `harness.render()` after the
+/// slide is the settle frame the runner now owes (see finding 34).
 #[test]
-fn a_pane_repainted_mid_slide_shows_its_new_content_during_the_slide() {
+fn a_pane_repainted_mid_slide_settles_on_its_new_content() {
     let mut config = Config::default();
     config.editor.animations = true;
     let mut harness = EditorTestHarness::with_config(60, 12, config).unwrap();
@@ -75,10 +77,7 @@ fn a_pane_repainted_mid_slide_shows_its_new_content_during_the_slide() {
     // `other`, *previous* is the panel.
     harness.editor_mut().prev_buffer();
     assert_eq!(harness.editor().active_buffer_id(), panel);
-    // The slide's first frame. This is the frame the old capture took its
-    // one and only snapshot from — the pane as it was *before* the repaint
-    // below. That is the order the real page saw too: a plugin's catch-up
-    // lands a few frames after the switch, not before it.
+    // The slide's first frame, with the pane still holding OLD CONTENT.
     harness.render().unwrap();
     assert!(
         harness.editor().active_window().animations.is_active(),
@@ -93,22 +92,26 @@ fn a_pane_repainted_mid_slide_shows_its_new_content_during_the_slide() {
         })
         .unwrap();
 
-    let mut seen_new_while_sliding = false;
-    for _ in 0..60 {
+    // Drive frames until the slide retires (bounded: 260ms of slide against
+    // up to ~6s of budget, so a slow runner cannot time this out).
+    let mut ran_out = true;
+    for _ in 0..600 {
         harness.render().unwrap();
         if !harness.editor().active_window().animations.is_active() {
-            break;
-        }
-        if harness.screen_to_string().contains("NEW CONTENT") {
-            seen_new_while_sliding = true;
+            ran_out = false;
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
+    assert!(!ran_out, "the slide never finished");
+
+    // The settle frame.
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
     assert!(
-        seen_new_while_sliding,
-        "the slide kept showing the pane's first-frame cells; the repaint \
-         made during it never reached the screen while it ran"
+        screen.contains("NEW CONTENT") && !screen.contains("OLD CONTENT"),
+        "after the slide the pane still shows the content it had when the \
+         slide began:\n{screen}"
     );
 }
 

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -32,6 +32,7 @@ fn reproduce_cursor_panic() {
         editing_disabled: false,
         hidden_from_tabs: false,
         background: false,
+        highlight_current_line: None,
         initial_cursor_line: None,
         indentation_guide: None,
         request_id: None,

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -31,6 +31,7 @@ fn reproduce_cursor_panic() {
         show_cursors: false, // <--- The trigger: hiding cursors
         editing_disabled: false,
         hidden_from_tabs: false,
+        background: false,
         initial_cursor_line: None,
         indentation_guide: None,
         request_id: None,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6445,6 +6445,7 @@ impl JsEditorApi {
                 show_cursors: opts.show_cursors.unwrap_or(true),
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 hidden_from_tabs: opts.hidden_from_tabs.unwrap_or(false),
+                background: opts.background.unwrap_or(false),
                 initial_cursor_line: opts.initial_cursor_line,
                 indentation_guide: opts.indentation_guide,
                 request_id: Some(id),

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6446,6 +6446,7 @@ impl JsEditorApi {
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 hidden_from_tabs: opts.hidden_from_tabs.unwrap_or(false),
                 background: opts.background.unwrap_or(false),
+                highlight_current_line: opts.highlight_current_line,
                 initial_cursor_line: opts.initial_cursor_line,
                 indentation_guide: opts.indentation_guide,
                 request_id: Some(id),

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -497,6 +497,16 @@ already load-bearing across the test suite.
   produced nothing, and as a tab beside the work when it produced anything.
 - On demand: `Welcome` in the palette, or **Help ▸ Welcome**.
 
+**It never takes the view and gives it back.** A background open is a
+`background: true` on `createVirtualBuffer`, not an open followed by a switch
+back. Creation used to make the new buffer active unconditionally, so the
+only way to leave a restored session alone was to switch away afterwards —
+and that is two visible switches: the tab bar came up without the page, the
+page took the pane, the file returned. Worse, the panel composed its layout
+during that flicker and kept it. The host now gates the one
+`set_active_buffer` call on the flag, so the page is added to the tab bar
+and the current buffer is left alone.
+
 **Startup means startup, not "startup that found an empty workspace".** The
 page used to ask whether anything else was open and give up if anything was,
 so restoring a session — or plain `fresh note.txt` — meant never seeing it

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -469,8 +469,9 @@ underline stays an honest affordance.
 }
 ```
 
-`showOnStartup` governs **both** empty-workspace paths — launch with nothing
-to restore, and closing the last buffer — because they are the same state.
+`showOnStartup` governs the one automatic path: launch with nothing to
+restore. Emptying the workspace later is *not* that state — see "When it
+opens" below — so the two older empty states stay exactly as they were.
 The startup toggle on the page writes a plugin *global state* override that
 wins over the config field, so flipping it in the UI persists without
 rewriting `config.json`; the config field is what the Settings UI edits and
@@ -491,8 +492,18 @@ already load-bearing across the test suite.
 **When it opens.**
 
 - At startup, when the session restore produced no buffers.
-- After the last buffer is closed.
 - On demand: `Welcome` in the palette, or **Help ▸ Welcome**.
+
+**Closing buffers never opens it.** It is a *startup* surface, not an
+empty-workspace surface. It used to take the second path too, on the
+reasoning that "launched with nothing" and "left with nothing" are the same
+state. They are not: startup is the one moment the reader has not just told
+us what they want, and every other emptying of the workspace is a close they
+asked for. Reopening the page there read as the editor undoing that close,
+and left no way to say "close everything" — you closed the last file and got
+a full-page document back. The `buffer_closed` handler now does nothing but
+drop this plugin's handle on its own buffer when that buffer is the one that
+went away.
 
 **When it gets out of the way.** This is the ruling that decides whether the
 screen is a good citizen or a nuisance:
@@ -506,9 +517,9 @@ An ambient screen you ignored was ambient; a document you started reading is
 yours. This also means `fresh src/main.rs` never leaves a Welcome tab behind,
 without needing the Dashboard's blunt "close on any file open".
 
-**Closing it never reopens it.** Closing the last tab when the welcome buffer
-was the thing you just closed leaves the plain placeholder for the rest of the
-session. There is no loop, and no way to get trapped.
+**Closing it never reopens it.** Closing the welcome buffer leaves whichever
+empty state the core settings choose. There is no loop, and no way to get
+trapped.
 
 **The startup toggle.** `[✓] Show this screen on startup` sits on its own
 line directly under the chips, at the head of the first viewport. A control
@@ -675,13 +686,13 @@ Eleven things the wireframes did not know:
    are the theme names.
 
 8. **Closing the page reopened it.** `closeBuffer` fires `buffer_closed`,
-   which — with no other buffer left — is exactly the condition the ambient
-   open path watches for. Escape, the tab's `×` and `Ctrl+W` were all
-   unclosable. A `dismissed` flag now records that the *reader* closed it and
-   the ambient paths stay quiet for the session; the `Welcome` command clears
-   it. Stepping aside for a file deliberately does not set it — that is the
-   page being polite, not the reader dismissing it. §8's "closing it never
-   reopens it" was a design rule; it needed code.
+   which — with no other buffer left — was exactly the condition the ambient
+   open path watched for. Escape, the tab's `×` and `Ctrl+W` were all
+   unclosable, and a `dismissed` flag was added to hold the ambient path off
+   for as long as the workspace stayed empty. The flag was a patch on the
+   ambient path, and the ambient path is now gone (§8, "closing buffers never
+   opens it"), so both are: nothing reopens the page but startup and the
+   `Welcome` command.
 
 9. **A `List` inside a `labeledSection` cannot reach the section's right
    border.** Its items are emitted at their natural width, so every finder
@@ -807,8 +818,9 @@ Eleven things the wireframes did not know:
 25. **The empty-workspace screen has to mean empty.** The ambient-open
     condition asked whether any *file* buffer was open, so closing the
     last text buffer with a terminal or an agent still running popped the
-    page up over a workspace that was plainly in use. It now counts every
-    buffer except this page and the host's own untitled seed.
+    page up over a workspace that was plainly in use. It was fixed to count
+    every buffer except this page and the host's own untitled seed — which
+    is still the test the startup path uses, now the only path that asks.
 
 26. **`hoverStyle` had no sibling.** A bare button is just its label, so
     the only way to mark a word as clickable was to spend a colour on
@@ -866,14 +878,14 @@ Eleven things the wireframes did not know:
     dropped from the Tab cycle can never be what focus is on, so it must
     not look like it.
 
-31. **"I closed it" answers one question, not the session.** The
-    dismissal flag was set for good, so closing the page once meant it
-    never returned however many times the workspace emptied afterwards —
-    which reads exactly like a screen that appears at random. It is
-    cleared the moment anything opens: the next emptying is a new
-    question. The flag still does the job it was added for, which is to
-    stop the `buffer_closed` event fired by the close itself from
-    undoing the close.
+31. **"I closed it" answers one question, not the session.** The dismissal
+    flag was set for good, so closing the page once meant it never returned
+    however many times the workspace emptied afterwards — which reads
+    exactly like a screen that appears at random. Scoping it to a single
+    emptying fixed that symptom and kept the cause: a page that comes back
+    when you close things. Dropping the reopen-on-empty behaviour outright
+    (§8) retired the flag with it — there is no longer a question for "I
+    closed it" to answer.
 
 ### Still aspirational
 

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -515,13 +515,30 @@ not a thing anyone does on purpose. Opening is unconditional now.
 `hasOtherBuffers` survives, demoted: it decides the foreground, so
 `fresh note.txt` still lands on `note.txt`.
 
-**It closes nothing to make room.** The page used to reap the host's empty
-`[No Name]` seed on the way up, on the reasoning that the seed is the
-placeholder the page replaces. But the test it selected on — unnamed,
-unmodified, not virtual — is also every scratch buffer anyone ever opened
-with `Ctrl+N` and had not yet typed into, and a plugin buffer closing the
-reader's buffers is a plugin exceeding its brief either way. A bare `fresh`
-now shows `[No Name]` and `Welcome` side by side.
+**The seed follows the reader's own setting.** Fresh seeds one untitled
+`[No Name]` buffer at launch. Whether the reader wants it is a question the
+editor already asks — `editor.auto_create_empty_buffer_on_last_buffer_close`
+— and this page reads the answer rather than inventing its own:
+
+- **Setting on** (the default): the seed is the reader's scratch buffer. It
+  keeps the pane and the focus; the page opens as a tab beside it. A bare
+  `fresh` lands on `[No Name]` with `Welcome ×` in the tab bar.
+- **Setting off**: the reader has said they want no empty buffer, so the seed
+  is the placeholder this page replaces. The page closes it and takes the
+  pane. A bare `fresh` shows one tab, `Welcome`, and no `[No Name]` anywhere.
+
+For a while the page reaped the seed unconditionally, and then — after that
+closed scratch buffers too — not at all. Both were wrong for the same reason:
+the seed's meaning is not the page's to decide. The test for "seed" is
+structural (not a file, no name, never modified) and is applied only at
+startup and only on the foreground path; the `Welcome` palette command
+closes nothing, because the palette is not startup.
+
+**No lit cursor row.** The page passes `highlightCurrentLine: false` to
+`createVirtualBuffer`. The caret's row means nothing on a page laid out by
+widgets, and a highlighted band across the centred wordmark read as a
+selection. The option is new and general: any panel whose rows are not lines
+of a document can use it.
 
 **Closing buffers never opens it.** It is a *startup* surface, not an
 empty-workspace surface. It used to take the second path too, on the
@@ -961,9 +978,8 @@ Eleven things the wireframes did not know:
     behind a file is told nothing: not a resize, and not the switch that
     finally shows it, because the split's tuple after the switch is the
     same pane it already was. So a page created at 140 columns and brought
-    forward after the terminal shrank to 70 painted at a measure the pane
-    could not hold, its `composeWidth` hint still describing a terminal
-    that no longer existed.
+    forward after the terminal shrank to 70 kept a `composeWidth` hint
+    describing a terminal that no longer existed.
 
     The page now catches up when it comes to the front: `buffer_activated`
     schedules a repaint one tick later — `getViewport()` at the moment of
@@ -975,14 +991,40 @@ Eleven things the wireframes did not know:
     the update, so a repaint issued in the same breath as the hint is laid
     out against the previous one.
 
-    **Residual:** the corrected content reaches the buffer but not the
-    screen until the reader's next input. An idle editor draws no frame,
-    and nothing in the repaint path wakes one — `invalidate_layouts_for_buffer`
-    on the content write was tried and does not (it marks the layout stale
-    without asking for a draw). So switching to the tab after a background
-    resize shows the old layout until the next keystroke. That is a
-    main-loop question rather than a welcome-screen one, and it is left
-    open here.
+34. **The tab-switch slide froze the pane at its first frame, and the
+    screen kept that frame after the slide.** Even with 33 fixed, the
+    corrected page did not appear until the reader's next keystroke, and
+    for a while the note here blamed an idle editor drawing no frame, and
+    then a stale row index. Probing one frame end to end settled it: the
+    buffer held the new text, the tokeniser read it, the content pass
+    painted it (toggle at column 36) — and `animations.apply_all`, a few
+    lines later in `Editor::render`, painted the old cells (57) back over
+    the pane.
+
+    `Ctrl+PageDown` starts a 260ms `SlideIn` over the pane. Two things it
+    did were wrong, both general, neither about this page:
+
+    - It took its "after" snapshot **once, on its first apply** — the first
+      frame after the switch, when the pane still held the stale layout —
+      and shifted that for the slide's whole duration. The plugin's catch-up
+      (33) lands ~100ms in and was painted every frame, and covered every
+      frame. It now retakes the snapshot from the freshly painted frame on
+      every apply: the content pass runs before the runner, so `buf` is the
+      pane as it is *now*, which is the only thing a slide may show shifted.
+      A snapshot is 69×37 cells; per frame for 260ms that is nothing.
+    - When the last effect finished, the frame it finished on was its own
+      composite, the runner retired it, `is_active()` went false, and no one
+      asked for another frame. The runner now owes one settle frame after an
+      effect retires (`take_settle_frame`), and the frame loop treats it as
+      "animations active" for that one iteration. This is what "a repaint
+      with no input behind it" actually was: not a missing frame, but a
+      frame painted from a snapshot, followed by no frame at all.
+
+    A wrong turn worth recording: `set_virtual_buffer_content` skipping
+    `wrap_indices.damage_all()` looked like this bug and is not — the row
+    index is rebuilt on the version bump regardless. The e2e test written
+    for it passed with the change reverted, which is how the theory was
+    caught; it is not in this PR.
 
 ### Still aspirational
 

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -906,20 +906,28 @@ Eleven things the wireframes did not know:
     (§8) retired the flag with it — there is no longer a question for "I
     closed it" to answer.
 
-32. **A buffer that has never been painted has no width.**
-    `widget_panel_width` sizes a panel from the split its buffer is painted
-    in and falls back to the whole terminal when it finds none — so a page
-    composed while another buffer held the pane centred every row against
-    ~140 columns instead of the 89-column compose measure, and the host then
-    wrapped the wordmark in half against the compose column. (The host says
-    as much in that function's own comment, measured on this page.) Nothing
-    the plugin can do afterwards repairs it: a re-render, a panel remount and
-    a deferred repaint on `buffer_activated` were all tried and all still
-    read the same missing width, and `viewport_changed` never fires for this
-    buffer at all. So a background open is now an ordinary foreground open —
-    `createVirtualBuffer` makes the new buffer active, which is exactly the
-    geometry the layout needs — followed by handing the pane back one tick
-    later, once the frame that measures it has been painted.
+32. **A background tab was laid out to its neighbour's width.** A page
+    opened behind a file painted at a measure its pane could not hold: the
+    wordmark wrapped mid-glyph, the doors broke across two rows, every
+    centred row sat far right. `widget_panel_width` sizes a panel from
+    `compose_width` — correctly, and its own comment says why, measured on
+    this page — but it read `vs.compose_width`, and `SplitViewState` derefs
+    to whichever buffer is *active* in that split. So the panel was sized
+    from the neighbouring tab's answer (`None`, hence the whole split)
+    whenever it was not the one on screen, and nothing repaints a
+    background tab afterwards, so it stayed wrong until a resize. It now
+    reads `vs.buffer_state(buffer_id).compose_width` — this buffer's own.
+    The pane width beside it is a property of the split and still comes
+    through the deref.
+
+    This was worth chasing to the host rather than papering over. The
+    plugin-side workarounds all failed, each for the same reason: a
+    re-render, a panel remount and a repaint armed on `buffer_activated`
+    read the same wrong width, and `viewport_changed` never fires for this
+    buffer at all. Opening in the foreground and handing the pane back a
+    tick later did work — on Linux and macOS, while Windows CI, where a
+    later repaint landed after the hand-back, showed the bug unchanged.
+    A fix that depends on which repaint wins is not a fix.
 
 ### Still aspirational
 

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -469,9 +469,11 @@ underline stays an honest affordance.
 }
 ```
 
-`showOnStartup` governs the one automatic path: launch with nothing to
-restore. Emptying the workspace later is *not* that state — see "When it
-opens" below — so the two older empty states stay exactly as they were.
+`showOnStartup` governs the one automatic path: launch. Not "launch with
+nothing to restore" — the page opens either way, and what an already-busy
+workspace changes is only whether it comes to the front. Emptying the
+workspace later is not a path at all; see "When it opens" below, so the two
+older empty states stay exactly as they were.
 The startup toggle on the page writes a plugin *global state* override that
 wins over the config field, so flipping it in the UI persists without
 rewriting `config.json`; the config field is what the Settings UI edits and
@@ -491,8 +493,25 @@ already load-bearing across the test suite.
 
 **When it opens.**
 
-- At startup, when the session restore produced no buffers.
+- At startup, always — as the foreground buffer when the session restore
+  produced nothing, and as a tab beside the work when it produced anything.
 - On demand: `Welcome` in the palette, or **Help ▸ Welcome**.
+
+**Startup means startup, not "startup that found an empty workspace".** The
+page used to ask whether anything else was open and give up if anything was,
+so restoring a session — or plain `fresh note.txt` — meant never seeing it
+again: the only way back was to close every buffer and relaunch, which is
+not a thing anyone does on purpose. Opening is unconditional now.
+`hasOtherBuffers` survives, demoted: it decides the foreground, so
+`fresh note.txt` still lands on `note.txt`.
+
+**It closes nothing to make room.** The page used to reap the host's empty
+`[No Name]` seed on the way up, on the reasoning that the seed is the
+placeholder the page replaces. But the test it selected on — unnamed,
+unmodified, not virtual — is also every scratch buffer anyone ever opened
+with `Ctrl+N` and had not yet typed into, and a plugin buffer closing the
+reader's buffers is a plugin exceeding its brief either way. A bare `fresh`
+now shows `[No Name]` and `Welcome` side by side.
 
 **Closing buffers never opens it.** It is a *startup* surface, not an
 empty-workspace surface. It used to take the second path too, on the
@@ -886,6 +905,21 @@ Eleven things the wireframes did not know:
     when you close things. Dropping the reopen-on-empty behaviour outright
     (§8) retired the flag with it — there is no longer a question for "I
     closed it" to answer.
+
+32. **A buffer that has never been painted has no width.**
+    `widget_panel_width` sizes a panel from the split its buffer is painted
+    in and falls back to the whole terminal when it finds none — so a page
+    composed while another buffer held the pane centred every row against
+    ~140 columns instead of the 89-column compose measure, and the host then
+    wrapped the wordmark in half against the compose column. (The host says
+    as much in that function's own comment, measured on this page.) Nothing
+    the plugin can do afterwards repairs it: a re-render, a panel remount and
+    a deferred repaint on `buffer_activated` were all tried and all still
+    read the same missing width, and `viewport_changed` never fires for this
+    buffer at all. So a background open is now an ordinary foreground open —
+    `createVirtualBuffer` makes the new buffer active, which is exactly the
+    geometry the layout needs — followed by handing the pane back one tick
+    later, once the frame that measures it has been painted.
 
 ### Still aspirational
 

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -537,14 +537,30 @@ went away.
 **When it gets out of the way.** This is the ruling that decides whether the
 screen is a good citizen or a nuisance:
 
-> A welcome buffer that was **auto-opened and never interacted with** —
-> never scrolled, never focused, no widget touched — closes itself when a
-> real file opens. One the user **engaged with** stays open until they close
-> it.
+> A welcome buffer that was **on screen, auto-opened and never interacted
+> with** — never scrolled, never focused, no widget touched — closes itself
+> when a real file opens. One the user **engaged with** stays open until they
+> close it. One that has never been on screen is not in the way of anything,
+> and stays.
 
 An ambient screen you ignored was ambient; a document you started reading is
-yours. This also means `fresh src/main.rs` never leaves a Welcome tab behind,
-without needing the Dashboard's blunt "close on any file open".
+yours. The third case is new with the background tab, and the rule had to
+learn it: "step aside" was written for a page *occupying the pane*, and a tab
+the reader has never seen has nothing to step aside from — closing it is not
+politeness but deleting a tab they never asked to close. It used to do
+exactly that, on the very first file they opened.
+
+So `fresh src/main.rs` *does* leave a Welcome tab behind now, deliberately.
+CLI file arguments are drained before `fire_ready_hook` (`main.rs`,
+`process_pending_file_opens`), so the `after_file_open` for `main.rs` arrives
+while there is no page yet and is ignored; `ready` then opens the page as a
+background tab, and nothing later removes it. Turning to that tab and then
+opening a file does close it, which is the original rule doing its job.
+
+Asking for the page by name — `Welcome` in the palette — counts as
+engagement whether or not the buffer already exists. Otherwise the startup
+tab stays ambient for the whole session and evaporates on the next file open,
+however many times the reader summons it.
 
 **Closing it never reopens it.** Closing the welcome buffer leaves whichever
 empty state the core settings choose. There is no loop, and no way to get
@@ -938,6 +954,35 @@ Eleven things the wireframes did not know:
     tick later did work — on Linux and macOS, while Windows CI, where a
     later repaint landed after the hand-back, showed the bug unchanged.
     A fix that depends on which repaint wins is not a fix.
+
+33. **A background tab hears nothing about geometry.** `viewport_changed`
+    is fired per *split*, against a `previous_viewports` tuple read through
+    `SplitViewState`'s deref — i.e. the active buffer's. A page sitting
+    behind a file is told nothing: not a resize, and not the switch that
+    finally shows it, because the split's tuple after the switch is the
+    same pane it already was. So a page created at 140 columns and brought
+    forward after the terminal shrank to 70 painted at a measure the pane
+    could not hold, its `composeWidth` hint still describing a terminal
+    that no longer existed.
+
+    The page now catches up when it comes to the front: `buffer_activated`
+    schedules a repaint one tick later — `getViewport()` at the moment of
+    activation still reports the viewport this buffer had when it was last
+    on screen, and only the following frame corrects it — which clears
+    `paneWidth`, recomputes `layoutKey` and repaints if the shape moved.
+    The `await editor.flush()` between the hint and the repaint is load
+    bearing: `widget_panel_width` reads `compose_width` while it processes
+    the update, so a repaint issued in the same breath as the hint is laid
+    out against the previous one.
+
+    **Residual:** the corrected content reaches the buffer but not the
+    screen until the reader's next input. An idle editor draws no frame,
+    and nothing in the repaint path wakes one — `invalidate_layouts_for_buffer`
+    on the content write was tried and does not (it marks the layout stale
+    without asking for a draw). So switching to the tab after a background
+    resize shows the old layout until the next keystroke. That is a
+    main-loop question rather than a welcome-screen one, and it is left
+    open here.
 
 ### Still aspirational
 

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -461,7 +461,7 @@ underline stays an honest affordance.
     }
   },
   "editor": {
-    // what you fall back to once the welcome screen stands down
+    // the host's own empty state, which this plugin neither reads nor changes
     //   true  — the historical [No Name] scratch buffer
     //   false — the blank pane with the one-line hint
     "auto_create_empty_buffer_on_last_buffer_close": true
@@ -470,8 +470,8 @@ underline stays an honest affordance.
 ```
 
 `showOnStartup` governs the one automatic path: launch. Not "launch with
-nothing to restore" — the page opens either way, and what an already-busy
-workspace changes is only whether it comes to the front. Emptying the
+nothing to restore" — the page opens either way, as a tab behind whatever
+is already there, and it never comes to the front on its own. Emptying the
 workspace later is not a path at all; see "When it opens" below, so the two
 older empty states stay exactly as they were.
 The startup toggle on the page writes a plugin *global state* override that
@@ -493,9 +493,23 @@ already load-bearing across the test suite.
 
 **When it opens.**
 
-- At startup, always — as the foreground buffer when the session restore
-  produced nothing, and as a tab beside the work when it produced anything.
-- On demand: `Welcome` in the palette, or **Help ▸ Welcome**.
+- At startup, always — as a tab behind whatever is already open, whether
+  that is the host's untitled seed, a restored session or the file named on
+  the command line. Never in the foreground.
+- On demand: `Welcome` in the palette, or **Help ▸ Welcome**. This is the
+  one path that brings it to the front.
+
+**One concern.** The plugin decides one thing: open at startup, or don't.
+It does not count the other buffers, does not ask what the host's `[No Name]`
+seed means, does not read `auto_create_empty_buffer_on_last_buffer_close`,
+and closes nothing but its own buffer when the reader asks. Every earlier
+revision took on one more of those questions and got it wrong in a new way —
+the seed reaped unconditionally, then only under one setting; the page hidden
+whenever anything was open; the page deleted on the reader's first file open
+— and each answer needed state (`engaged`, `shown`, a structural test for
+"seed") that the next answer had to be reconciled with. The reader's own
+buffers are the host's and the reader's; a welcome tab is a tab, and the
+reader closes it.
 
 **It never takes the view and gives it back.** A background open is a
 `background: true` on `createVirtualBuffer`, not an open followed by a switch
@@ -512,27 +526,6 @@ page used to ask whether anything else was open and give up if anything was,
 so restoring a session — or plain `fresh note.txt` — meant never seeing it
 again: the only way back was to close every buffer and relaunch, which is
 not a thing anyone does on purpose. Opening is unconditional now.
-`hasOtherBuffers` survives, demoted: it decides the foreground, so
-`fresh note.txt` still lands on `note.txt`.
-
-**The seed follows the reader's own setting.** Fresh seeds one untitled
-`[No Name]` buffer at launch. Whether the reader wants it is a question the
-editor already asks — `editor.auto_create_empty_buffer_on_last_buffer_close`
-— and this page reads the answer rather than inventing its own:
-
-- **Setting on** (the default): the seed is the reader's scratch buffer. It
-  keeps the pane and the focus; the page opens as a tab beside it. A bare
-  `fresh` lands on `[No Name]` with `Welcome ×` in the tab bar.
-- **Setting off**: the reader has said they want no empty buffer, so the seed
-  is the placeholder this page replaces. The page closes it and takes the
-  pane. A bare `fresh` shows one tab, `Welcome`, and no `[No Name]` anywhere.
-
-For a while the page reaped the seed unconditionally, and then — after that
-closed scratch buffers too — not at all. Both were wrong for the same reason:
-the seed's meaning is not the page's to decide. The test for "seed" is
-structural (not a file, no name, never modified) and is applied only at
-startup and only on the foreground path; the `Welcome` palette command
-closes nothing, because the palette is not startup.
 
 **No lit cursor row.** The page passes `highlightCurrentLine: false` to
 `createVirtualBuffer`. The caret's row means nothing on a page laid out by
@@ -551,33 +544,14 @@ a full-page document back. The `buffer_closed` handler now does nothing but
 drop this plugin's handle on its own buffer when that buffer is the one that
 went away.
 
-**When it gets out of the way.** This is the ruling that decides whether the
-screen is a good citizen or a nuisance:
-
-> A welcome buffer that was **on screen, auto-opened and never interacted
-> with** — never scrolled, never focused, no widget touched — closes itself
-> when a real file opens. One the user **engaged with** stays open until they
-> close it. One that has never been on screen is not in the way of anything,
-> and stays.
-
-An ambient screen you ignored was ambient; a document you started reading is
-yours. The third case is new with the background tab, and the rule had to
-learn it: "step aside" was written for a page *occupying the pane*, and a tab
-the reader has never seen has nothing to step aside from — closing it is not
-politeness but deleting a tab they never asked to close. It used to do
-exactly that, on the very first file they opened.
-
-So `fresh src/main.rs` *does* leave a Welcome tab behind now, deliberately.
-CLI file arguments are drained before `fire_ready_hook` (`main.rs`,
-`process_pending_file_opens`), so the `after_file_open` for `main.rs` arrives
-while there is no page yet and is ignored; `ready` then opens the page as a
-background tab, and nothing later removes it. Turning to that tab and then
-opening a file does close it, which is the original rule doing its job.
-
-Asking for the page by name — `Welcome` in the palette — counts as
-engagement whether or not the buffer already exists. Otherwise the startup
-tab stays ambient for the whole session and evaporates on the next file open,
-however many times the reader summons it.
+**Opening files never closes it.** There was a "step aside" rule: an
+auto-opened page nobody had touched closed itself when a real file opened.
+It was written for a page occupying the pane, and once the page became a
+background tab it needed a second flag to avoid deleting a tab the reader had
+never seen, and a third rule so that summoning it by name counted as
+touching it. All of that is gone. `fresh src/main.rs` leaves a Welcome tab
+behind; so does turning to the tab and then opening a file. A tab the reader
+does not want is one `Ctrl+W` away, which is what tabs are for.
 
 **Closing it never reopens it.** Closing the welcome buffer leaves whichever
 empty state the core settings choose. There is no loop, and no way to get
@@ -733,9 +707,7 @@ Eleven things the wireframes did not know:
    Ctrl-/Alt-modified keys so a focused text field can never be hijacked by
    Open or Save. That is the right default, and it means the accelerators this
    page promises have to be named — `FORWARDED` lists them and each one
-   forwards to the real action, so a rebound key keeps working. Notably they
-   do *not* mark the page engaged: reaching past it for the palette is the
-   ambient case.
+   forwards to the real action, so a rebound key keeps working.
 
 6. **Tab moves widget focus, but the host only scrolls the pane for a focused
    *text* widget.** A focused button further down a long document was
@@ -881,8 +853,9 @@ Eleven things the wireframes did not know:
     condition asked whether any *file* buffer was open, so closing the
     last text buffer with a terminal or an agent still running popped the
     page up over a workspace that was plainly in use. It was fixed to count
-    every buffer except this page and the host's own untitled seed — which
-    is still the test the startup path uses, now the only path that asks.
+    every buffer except this page and the host's own untitled seed. Both
+    the ambient path and the counting are gone now (§8): the page opens
+    at startup as a background tab and asks nothing about the workspace.
 
 26. **`hoverStyle` had no sibling.** A bare button is just its label, so
     the only way to mark a word as clickable was to spend a colour on
@@ -1050,5 +1023,5 @@ and jump keys, `/` to the finder, live fuzzy-find over `git ls-files` and
 by click (status bar confirms), the startup toggle flipping and **persisting
 across a restart** (the screen then stays away, and the `Welcome` command
 brings it back), `Ctrl+P` opening the palette from the page, the `[No Name]`
-seed being retired on open, `fresh notes.txt` never leaving a Welcome tab
-behind, and both responsive breakpoints.
+seed keeping the pane with `Welcome ×` beside it, `fresh notes.txt` leaving a
+Welcome tab behind `notes.txt`, and both responsive breakpoints.


### PR DESCRIPTION
The welcome screen decided when to appear from "is the workspace empty?", asked at two moments. Both readings were wrong, and every attempt to refine them added a concern the plugin had no business owning. Fixing the flicker and the stale layout underneath also turned up four host bugs — the last two in the renderer, and general.

The plugin now has **one concern**: `showOnStartup`. When Fresh launches, the page opens as a tab behind whatever is already open. It never takes the foreground on its own, never counts the other buffers, never reads `auto_create_empty_buffer_on_last_buffer_close`, never closes any buffer but its own on the reader's request, and never closes itself because a file opened or reopens because one closed. `Welcome` in the palette is the one path that brings it to the front.

## Behaviour

| | before | now |
|---|---|---|
| `fresh` in an empty dir | page opens, `[No Name]` seed closed | `[No Name]` keeps the pane and focus; `Welcome ×` beside it |
| same, empty-buffer setting **off** | page opens, seed closed | identical — the setting is the host's, not the plugin's |
| `fresh note.txt` / restored session | never appears again until you close everything and relaunch | `Welcome` tab beside the work; `note.txt` stays in front, never displaced |
| close the last buffer | page reopens over the empty pane | empty pane, as asked |
| open a file with the page open or behind | page silently deleted unless "engaged" | tab stays — the reader closes tabs |
| `showOnStartup: false` | — | nothing opens; palette still works |
| resize while the page is a background tab, then switch to it | stale layout until the next keystroke | correct layout, no input needed |

## Host changes

All four found by driving the real binary under tmux.

- **`widget_panel_width` sized a panel from its neighbour's compose width.** It read `vs.compose_width`, and `SplitViewState` derefs to whichever buffer is *active* in that split — so a panel that is not on screen was sized from another tab's answer. It now reads the panel's own buffer state.

- **`createVirtualBuffer` could not open a tab quietly.** Creation made the new buffer active unconditionally. `background: true` adds it to the tab bar and skips the one `set_active_buffer` call — no open-then-switch-back flicker. Also new: `highlightCurrentLine`, for a buffer whose rows are laid out by widgets and whose caret row means nothing.

- **The tab-switch `SlideIn` froze the incoming pane at its first frame.** It took its snapshot once, on its first apply, and shifted that for 260 ms; anything that changed under the slide (a panel catching up to its geometry ~100 ms in) was painted every frame and covered every frame. The snapshot is now retaken from the freshly painted frame on every apply.

- **No frame after the last effect retired.** The frame an effect finishes on is its own composite; the runner retired it, `is_active()` went false, and nothing asked for the frame that paints the true content. The runner now owes one settle frame (`take_settle_frame`), honoured by both frame loops (direct and server).

The design note (`docs/internal/welcome-screen-design.md`, §8 and findings 32–34) records the wrong turns — the seed rules, the step-aside rules, an idle-loop theory and a wrap-index theory — and how each was ruled out.

## Plugin changes

- `openWelcome(force)`: `background: !force`; nothing else about the workspace is consulted. `engaged`, `shown`, `seedWanted`, `isSeed`, `hasOtherBuffers` and the `after_file_open` handler are gone.
- `welcomeOnBufferClosed` only drops this plugin's handle on its own buffer.
- A background tab hears nothing about geometry (`viewport_changed` is per split, against the active buffer), so the page catches up on `buffer_activated`, one tick later, with a `flush` between the compose hint and the repaint.
- `highlightCurrentLine: false`.

## Tests

- `tests/e2e/plugins/welcome_screen.rs` — 12. The seed survives under either setting, the page survives a file open whether or not the reader has turned to it (both red against the previous plugin), `showOnStartup: false` opens nothing until asked, startup never changes the active buffer.
- `view::animation::tests` — `slide_in_retakes_the_incoming_snapshot_every_apply` and `a_finished_effect_owes_exactly_one_settle_frame`.
- `tests/e2e/virtual_buffer_repaint.rs` — the slide settles on the pane's current content, and a control-and-treatment test for `highlightCurrentLine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkWt9oBvQfnVJFsgBFooip