### PR TITLE
fix(terminal): stop losing the scrollback just above the top of the screen (#3151)

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -2039,14 +2039,25 @@ impl Editor {
                     .get(&terminal_id)
                 {
                     if let Some(handle) = self.active_window().terminal_manager.get(terminal_id) {
-                        if let Ok(state) = handle.state.lock() {
-                            let truncate_pos = state.backing_file_history_end();
-                            // Always truncate to remove appended visible screen
-                            // (even if truncate_pos is 0, meaning no scrollback yet)
-                            if let Err(e) =
-                                terminal_backing_fs().set_file_length(backing_path, truncate_pos)
-                            {
-                                tracing::warn!("Failed to truncate terminal backing file: {}", e);
+                        if let Ok(mut state) = handle.state.lock() {
+                            // Truncate only when a visible-screen tail is
+                            // actually there. Truncating unconditionally used
+                            // to be harmless because the tail was assumed to
+                            // be the only thing past the history end — but the
+                            // PTY read loop appends there too, and cutting at
+                            // a history end that predates its writes deleted
+                            // live scrollback for good (fresh#3151).
+                            if state.backing_file_has_tail() {
+                                let truncate_pos = state.backing_file_history_end();
+                                match terminal_backing_fs()
+                                    .set_file_length(backing_path, truncate_pos)
+                                {
+                                    Ok(()) => state.set_backing_file_has_tail(false),
+                                    Err(e) => tracing::warn!(
+                                        "Failed to truncate terminal backing file: {}",
+                                        e
+                                    ),
+                                }
                             }
                         }
                     }
@@ -2415,10 +2426,28 @@ impl Window {
         let mut grid_cols: Option<usize> = None;
         if let Some(handle) = self.terminal_manager.get(terminal_id) {
             if let Ok(mut state) = handle.state.lock() {
-                use std::io::BufWriter;
+                use std::io::{BufWriter, Write};
 
                 let (cols, _) = state.size();
                 grid_cols = Some(cols as usize);
+
+                // An earlier visit (or a session checkpoint) may have left its
+                // visible-screen tail in the file. It is rewritten below, so
+                // remove it first: leaving it in place would bake a stale
+                // screen into the scrollback prefix, and — since the tail is
+                // what the truncation on the way back to live mode cuts at —
+                // would also leave real scrollback stranded past that point
+                // (fresh#3151).
+                if state.backing_file_has_tail() {
+                    let history_end = state.backing_file_history_end();
+                    match terminal_backing_fs().set_file_length(&backing_file, history_end) {
+                        Ok(()) => state.set_backing_file_has_tail(false),
+                        Err(e) => tracing::error!(
+                            "Failed to drop stale terminal visible-screen tail: {}",
+                            e
+                        ),
+                    }
+                }
 
                 // Flush any scrollback that has scrolled off but isn't in the
                 // file yet — in particular the lines a resize spilled from the
@@ -2442,8 +2471,15 @@ impl Window {
                 // Open backing file in append mode to add visible screen
                 if let Ok(mut file) = terminal_backing_fs().open_file_for_append(&backing_file) {
                     let mut writer = BufWriter::new(&mut *file);
-                    match state.append_visible_screen(&mut writer) {
-                        Ok(head) => prepended = head,
+                    let appended = state.append_visible_screen(&mut writer);
+                    // Only claim the tail once its bytes have actually reached
+                    // the file: the flag is what tells the next writer there
+                    // is something there to cut back off.
+                    match appended.and_then(|head| writer.flush().map(|()| head)) {
+                        Ok(head) => {
+                            prepended = head;
+                            state.set_backing_file_has_tail(true);
+                        }
                         Err(e) => {
                             tracing::error!(
                                 "Failed to append visible screen to backing file: {}",

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -2471,14 +2471,17 @@ impl Window {
                 // Open backing file in append mode to add visible screen
                 if let Ok(mut file) = terminal_backing_fs().open_file_for_append(&backing_file) {
                     let mut writer = BufWriter::new(&mut *file);
+                    // Claim the tail *before* writing it. `BufWriter` spills
+                    // to the file as soon as its buffer fills, so a failure
+                    // part-way through still leaves bytes past the history
+                    // end; the flag is what tells a later path to cut them
+                    // back off, so it has to err towards "something may be
+                    // there" rather than "the write succeeded".
+                    state.set_backing_file_has_tail(true);
                     let appended = state.append_visible_screen(&mut writer);
-                    // Only claim the tail once its bytes have actually reached
-                    // the file: the flag is what tells the next writer there
-                    // is something there to cut back off.
                     match appended.and_then(|head| writer.flush().map(|()| head)) {
                         Ok(head) => {
                             prepended = head;
-                            state.set_backing_file_has_tail(true);
                         }
                         Err(e) => {
                             tracing::error!(

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -2134,7 +2134,7 @@ impl crate::app::window::Window {
     /// Sync this window's active terminal visible screens to their
     /// backing files (so the snapshot captures complete terminal state).
     pub(crate) fn sync_terminal_backing_files(&self) {
-        use std::io::BufWriter;
+        use std::io::{BufWriter, Write};
 
         let terminals_to_sync: Vec<_> = self
             .terminal_buffers
@@ -2150,6 +2150,25 @@ impl crate::app::window::Window {
         for (terminal_id, backing_path) in terminals_to_sync {
             if let Some(handle) = self.terminal_manager.get(terminal_id) {
                 if let Ok(mut state) = handle.state.lock() {
+                    // Drop a visible-screen tail an earlier checkpoint or
+                    // scroll-back visit left behind: this snapshot writes a
+                    // fresh one below, and scrollback appended past a tail is
+                    // cut away by the truncation that ends the next scroll-back
+                    // visit (fresh#3151).
+                    if state.backing_file_has_tail() {
+                        let history_end = state.backing_file_history_end();
+                        match crate::app::terminal::terminal_backing_fs()
+                            .set_file_length(&backing_path, history_end)
+                        {
+                            Ok(()) => state.set_backing_file_has_tail(false),
+                            Err(e) => tracing::warn!(
+                                "Failed to drop terminal {:?} visible-screen tail: {}",
+                                terminal_id,
+                                e
+                            ),
+                        }
+                    }
+
                     // Persist any scrolled-off lines not yet in the file (e.g.
                     // lines a resize spilled into history on a terminal that was
                     // never viewed before quitting) so a restored workspace keeps
@@ -2167,16 +2186,29 @@ impl crate::app::window::Window {
                         }
                     }
 
+                    // Record the scrollback end before the tail goes in, so
+                    // the next writer knows where to cut it back off.
+                    if let Ok(metadata) =
+                        crate::app::terminal::terminal_backing_fs().metadata(&backing_path)
+                    {
+                        state.set_backing_file_history_end(metadata.size);
+                    }
+
                     if let Ok(mut file) = crate::app::terminal::terminal_backing_fs()
                         .open_file_for_append(&backing_path)
                     {
                         let mut writer = BufWriter::new(&mut *file);
-                        if let Err(e) = state.append_visible_screen(&mut writer) {
-                            tracing::warn!(
+                        let appended = state.append_visible_screen(&mut writer);
+                        // Only claim the tail once its bytes have actually
+                        // reached the file: the flag is what tells the next
+                        // writer there is something there to cut back off.
+                        match appended.and_then(|_| writer.flush()) {
+                            Ok(()) => state.set_backing_file_has_tail(true),
+                            Err(e) => tracing::warn!(
                                 "Failed to sync terminal {:?} to backing file: {}",
                                 terminal_id,
                                 e
-                            );
+                            ),
                         }
                     }
                 }

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -2198,12 +2198,13 @@ impl crate::app::window::Window {
                         .open_file_for_append(&backing_path)
                     {
                         let mut writer = BufWriter::new(&mut *file);
+                        // Claim the tail before writing it: a part-written
+                        // tail still leaves bytes past the history end, and
+                        // the flag is what gets them cut back off later.
+                        state.set_backing_file_has_tail(true);
                         let appended = state.append_visible_screen(&mut writer);
-                        // Only claim the tail once its bytes have actually
-                        // reached the file: the flag is what tells the next
-                        // writer there is something there to cut back off.
                         match appended.and_then(|_| writer.flush()) {
-                            Ok(()) => state.set_backing_file_has_tail(true),
+                            Ok(()) => {}
                             Err(e) => tracing::warn!(
                                 "Failed to sync terminal {:?} to backing file: {}",
                                 terminal_id,

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -893,20 +893,40 @@ impl ReaderLoop {
 
         // Incrementally stream new scrollback lines to the backing file.
         if let Some(writer) = self.backing_writer.as_mut() {
+            let mut failed: Option<std::io::Error> = None;
+
             match state.flush_new_scrollback(writer) {
                 Ok(lines_written) => {
                     if lines_written > 0 {
-                        if let Ok(pos) = writer.get_ref().metadata() {
-                            state.set_backing_file_history_end(pos.len());
+                        // Flush *before* measuring. `metadata()` reports what
+                        // is on disk, so reading it while the lines just
+                        // written still sat in the `BufWriter` recorded a
+                        // history end short by exactly this batch — and the
+                        // next truncation then cut them away (fresh#3151).
+                        match writer.flush().and_then(|()| writer.get_ref().metadata()) {
+                            Ok(pos) => {
+                                state.set_backing_file_history_end(pos.len());
+                                // Scrollback now sits *after* whatever
+                                // temporary visible-screen tail was in the
+                                // file, so that tail can no longer be
+                                // truncated off without taking these lines
+                                // with it. Adopt it as scrollback instead: a
+                                // duplicated screen is bounded, losing the
+                                // lines is not — the same trade
+                                // `flush_new_scrollback` makes when the grid
+                                // overruns.
+                                state.set_backing_file_has_tail(false);
+                            }
+                            Err(e) => failed = Some(e),
                         }
-                        #[allow(clippy::let_underscore_must_use)]
-                        let _ = writer.flush();
                     }
                 }
-                Err(e) => {
-                    tracing::warn!("Terminal backing file write error: {}", e);
-                    self.backing_writer = None;
-                }
+                Err(e) => failed = Some(e),
+            }
+
+            if let Some(e) = failed {
+                tracing::warn!("Terminal backing file write error: {}", e);
+                self.backing_writer = None;
             }
         }
     }

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -708,13 +708,35 @@ fn open_transcript_file(
     path: &std::path::Path,
     mode: BackingMode,
 ) -> Option<std::io::BufWriter<std::fs::File>> {
-    let mut options = std::fs::OpenOptions::new();
-    options.create(true);
-    match mode {
-        BackingMode::Continue => options.append(true),
-        BackingMode::Fresh => options.write(true).truncate(true),
-    };
-    options.open(path).ok().map(std::io::BufWriter::new)
+    // `Fresh` empties the transcript first, through a handle of its own — the
+    // one we hand back must be `O_APPEND` in *both* modes.
+    //
+    // The UI thread writes these same files through its own append handle: a
+    // scroll-back sync flushes pending scrollback and then the visible-screen
+    // tail (`sync_terminal_to_buffer`, `sync_terminal_backing_files`). A
+    // non-append handle keeps its own offset, which those writes leave behind
+    // — so this loop's next batch would land *on top of* them, overwriting
+    // scrollback that `flush_new_scrollback` has already counted as persisted
+    // and therefore never re-emits (fresh#3151). With `O_APPEND` every writer
+    // lands at the end, nothing is overwritten, and the file's length is by
+    // construction this loop's write position, which is what
+    // `backing_file_history_end` records.
+    if matches!(mode, BackingMode::Fresh) {
+        // `truncate` and `append` cannot be combined in one `open`, so the
+        // reset is a separate, immediately-dropped handle.
+        std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)
+            .ok()?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .ok()
+        .map(std::io::BufWriter::new)
 }
 
 /// Wait-thread body: block on the child's exit and fire `TerminalExited` once.
@@ -893,8 +915,6 @@ impl ReaderLoop {
 
         // Incrementally stream new scrollback lines to the backing file.
         if let Some(writer) = self.backing_writer.as_mut() {
-            let mut failed: Option<std::io::Error> = None;
-
             match state.flush_new_scrollback(writer) {
                 Ok(lines_written) => {
                     if lines_written > 0 {
@@ -903,6 +923,16 @@ impl ReaderLoop {
                         // written still sat in the `BufWriter` recorded a
                         // history end short by exactly this batch — and the
                         // next truncation then cut them away (fresh#3151).
+                        //
+                        // Neither failure justifies dropping the writer: a
+                        // failed flush leaves the bytes in the `BufWriter` for
+                        // the next call to retry (dropping it would discard
+                        // lines `flush_new_scrollback` has already counted as
+                        // persisted), and a failed `metadata()` is not a write
+                        // failure at all. Both just leave the recorded end
+                        // where it was — stale-low, which the tail flag below
+                        // keeps harmless, since nothing truncates to it unless
+                        // a tail is known to be there.
                         match writer.flush().and_then(|()| writer.get_ref().metadata()) {
                             Ok(pos) => {
                                 state.set_backing_file_history_end(pos.len());
@@ -911,22 +941,28 @@ impl ReaderLoop {
                                 // file, so that tail can no longer be
                                 // truncated off without taking these lines
                                 // with it. Adopt it as scrollback instead: a
-                                // duplicated screen is bounded, losing the
-                                // lines is not — the same trade
+                                // duplicated screen is bounded per event,
+                                // losing the lines is not — the same trade
                                 // `flush_new_scrollback` makes when the grid
-                                // overruns.
+                                // overruns. The cost is real and worth
+                                // knowing: every visit-or-checkpoint that
+                                // overlaps output splices one more screen's
+                                // worth of already-seen rows into the
+                                // transcript, and nothing removes them.
                                 state.set_backing_file_has_tail(false);
                             }
-                            Err(e) => failed = Some(e),
+                            Err(e) => tracing::warn!(
+                                "Terminal backing file sync error (scrollback kept, \
+                                 history end not advanced): {}",
+                                e
+                            ),
                         }
                     }
                 }
-                Err(e) => failed = Some(e),
-            }
-
-            if let Some(e) = failed {
-                tracing::warn!("Terminal backing file write error: {}", e);
-                self.backing_writer = None;
+                Err(e) => {
+                    tracing::warn!("Terminal backing file write error: {}", e);
+                    self.backing_writer = None;
+                }
             }
         }
     }
@@ -1040,6 +1076,107 @@ mod tests {
     fn test_terminal_id_display() {
         let id = TerminalId(42);
         assert_eq!(format!("{}", id), "Terminal-42");
+    }
+
+    /// The transcript handle the read loop streams through must be `O_APPEND`
+    /// in *both* backing modes (fresh#3151).
+    ///
+    /// The UI thread appends to the same file through a handle of its own —
+    /// a scroll-back sync flushes pending scrollback and writes the
+    /// visible-screen tail. A handle that kept its own offset would be left
+    /// behind by those writes and its next batch would land on top of them,
+    /// overwriting scrollback that `flush_new_scrollback` has already counted
+    /// as persisted and so never re-emits. `O_APPEND` makes that
+    /// unrepresentable: every write lands at the end, and the file's length is
+    /// the read loop's write position.
+    #[test]
+    fn transcript_handles_append_in_both_backing_modes() {
+        for (mode, label) in [
+            (BackingMode::Fresh, "Fresh"),
+            (BackingMode::Continue, "Continue"),
+        ] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("transcript.txt");
+
+            let mut writer = open_transcript_file(&path, mode).expect("open transcript");
+            writer
+                .write_all(
+                    b"stream-1
+",
+                )
+                .expect("write");
+            writer.flush().expect("flush");
+
+            // Someone else appends behind this handle's back, exactly as the
+            // UI thread does when a scroll-back visit writes its tail.
+            {
+                let mut other = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&path)
+                    .expect("second handle");
+                other
+                    .write_all(
+                        b"ui-tail
+",
+                    )
+                    .expect("write tail");
+            }
+
+            writer
+                .write_all(
+                    b"stream-2
+",
+                )
+                .expect("write");
+            writer.flush().expect("flush");
+
+            let contents = std::fs::read_to_string(&path).expect("read back");
+            assert_eq!(
+                contents, "stream-1\nui-tail\nstream-2\n",
+                "{label}: the streaming handle must append past the other writer's \
+                 bytes, not overwrite them"
+            );
+            assert_eq!(
+                std::fs::metadata(&path).expect("metadata").len() as usize,
+                contents.len(),
+                "{label}: file length must be the streaming handle's write position"
+            );
+        }
+    }
+
+    /// `Fresh` still starts the transcript from empty — the append handle must
+    /// not resurrect a previous terminal's scrollback.
+    #[test]
+    fn fresh_backing_mode_empties_the_transcript_first() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("transcript.txt");
+        std::fs::write(&path, b"previous terminal\n").expect("seed");
+
+        let mut writer = open_transcript_file(&path, BackingMode::Fresh).expect("open");
+        writer.write_all(b"new terminal\n").expect("write");
+        writer.flush().expect("flush");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back"),
+            "new terminal\n"
+        );
+    }
+
+    /// `Continue` keeps what is already there (workspace restore, respawn).
+    #[test]
+    fn continue_backing_mode_keeps_the_existing_transcript() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("transcript.txt");
+        std::fs::write(&path, b"earlier session\n").expect("seed");
+
+        let mut writer = open_transcript_file(&path, BackingMode::Continue).expect("open");
+        writer.write_all(b"this session\n").expect("write");
+        writer.flush().expect("flush");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back"),
+            "earlier session\nthis session\n"
+        );
     }
 
     /// Terminal ids are per-window: each manager numbers from 0, so two

--- a/crates/fresh-editor/src/services/terminal/mod.rs
+++ b/crates/fresh-editor/src/services/terminal/mod.rs
@@ -21,7 +21,8 @@
 //!
 //! 3. **Scrollback → Terminal** (terminal.rs: `enter_terminal_mode`): Truncates backing
 //!    file to `backing_file_history_end` (removes visible screen tail), resumes live
-//!    rendering. Performance: O(1) ≈ 1ms.
+//!    rendering. Performance: O(1) ≈ 1ms. The truncation is conditional on
+//!    `TerminalState::backing_file_has_tail` — see "Who owns the tail" below.
 //!
 //! 4. **Session Save** (session.rs): `sync_all_terminal_backing_files()` appends visible
 //!    screen to all terminal backing files before saving session metadata.
@@ -35,10 +36,33 @@
 //! Located at `~/.local/share/fresh/terminals/{workdir}/fresh-terminal-{id}.txt`:
 //!
 //! - **Scrollback history** (top): Append-only, grows as lines scroll off screen
-//! - **Visible screen** (bottom): Rewritable tail (~50 lines), present only in scrollback mode
+//! - **Visible screen** (bottom): Rewritable tail (~50 lines), written on scroll-back
+//!   entry and by session checkpoints
 //!
 //! The `backing_file_history_end` offset marks where scrollback ends, used for truncation
 //! when re-entering terminal mode.
+//!
+//! ## Who owns the tail
+//!
+//! Three actors write this file — the PTY read loop (on its own thread) and two
+//! UI-thread paths — and a fourth truncates it. They stay consistent through
+//! `TerminalState`, whose lock every one of them holds across its file work, and
+//! through two facts on it: `backing_file_history_end` (the byte length of the
+//! scrollback prefix) and `backing_file_has_tail`.
+//!
+//! Every handle onto these files is opened `O_APPEND` (`open_transcript_file`),
+//! so no writer can land on top of another's bytes and the file's length is
+//! always the read loop's write position.
+//!
+//! The tail is *temporary*, but only the UI thread can remove it: the read loop
+//! must not truncate a file a scroll-back view may be reading from. So when the
+//! read loop streams scrollback while a tail is present, it cannot keep the tail
+//! removable — the new lines sit past it — and instead **adopts** the tail as
+//! scrollback (advancing `backing_file_history_end` past it and clearing the
+//! flag). That leaves one duplicated screen in the transcript per overlap, which
+//! nothing later removes; the alternative is truncating those lines away for
+//! good, since `flush_new_scrollback` has already counted them as persisted and
+//! never re-emits them (fresh#3151).
 //!
 //! ## Module Responsibilities
 //!

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -466,6 +466,16 @@ pub struct TerminalState {
     pending_reflow_resync: bool,
     /// Byte offset in backing file where scrollback ends (for truncation)
     backing_file_history_end: u64,
+    /// A temporary visible-screen tail (written by `append_visible_screen`)
+    /// currently sits in the backing file past `backing_file_history_end`.
+    ///
+    /// The tail is not scrollback: it is the exit frame the scroll-back view
+    /// anchors to, and it is rewritten on every visit. Anything appended
+    /// *after* it is therefore living on borrowed time — the truncation that
+    /// ends the visit cuts the file back to `backing_file_history_end` and
+    /// takes it along. So every writer checks this flag and removes the tail
+    /// before appending real scrollback (fresh#3151).
+    backing_file_has_tail: bool,
     /// Queue of data to write back to the PTY (for DSR responses, etc.)
     pty_write_queue: Arc<Mutex<Vec<String>>>,
     /// Pending title set by the program via OSC 0/1/2 (shared with the
@@ -533,6 +543,7 @@ impl TerminalState {
             history_overrun: false,
             pending_reflow_resync: false,
             backing_file_history_end: 0,
+            backing_file_has_tail: false,
             pty_write_queue,
             pending_title,
             cwd: None,
@@ -1327,6 +1338,24 @@ impl TerminalState {
         self.backing_file_history_end = offset;
     }
 
+    /// Whether the backing file currently carries a temporary visible-screen
+    /// tail past [`Self::backing_file_history_end`].
+    ///
+    /// A writer that appends scrollback must clear the tail first (truncate
+    /// the file back to the history end), or its lines land past the
+    /// truncation point and are lost when the scroll-back visit ends.
+    pub fn backing_file_has_tail(&self) -> bool {
+        self.backing_file_has_tail
+    }
+
+    /// Record whether a temporary visible-screen tail is present in the
+    /// backing file: `true` right after [`Self::append_visible_screen`] was
+    /// written to it, `false` right after it was truncated back to
+    /// [`Self::backing_file_history_end`].
+    pub fn set_backing_file_has_tail(&mut self, present: bool) {
+        self.backing_file_has_tail = present;
+    }
+
     /// Get the number of scrollback lines that have been synced to the backing file.
     pub fn synced_history_lines(&self) -> usize {
         self.synced_history_lines
@@ -1338,6 +1367,7 @@ impl TerminalState {
         self.synced_logical_lines = 0;
         self.pending_reflow_resync = false;
         self.backing_file_history_end = 0;
+        self.backing_file_has_tail = false;
     }
 }
 

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -473,8 +473,18 @@ pub struct TerminalState {
     /// anchors to, and it is rewritten on every visit. Anything appended
     /// *after* it is therefore living on borrowed time — the truncation that
     /// ends the visit cuts the file back to `backing_file_history_end` and
-    /// takes it along. So every writer checks this flag and removes the tail
-    /// before appending real scrollback (fresh#3151).
+    /// takes it along (fresh#3151).
+    ///
+    /// The two writers handle that differently, so read the flag as "a tail is
+    /// there *unless the PTY read loop got there first*":
+    ///
+    /// * The UI-thread paths (scroll-back entry, session checkpoint) rewrite
+    ///   the tail, so they truncate the old one off first.
+    /// * The read loop cannot truncate — a scroll-back view may be reading the
+    ///   file — so when it streams scrollback while the flag is set it instead
+    ///   *adopts* the tail as scrollback and clears the flag, leaving nothing
+    ///   for a later truncation to cut at. That costs one duplicated screen
+    ///   per overlap, permanently; losing the lines would be worse.
     backing_file_has_tail: bool,
     /// Queue of data to write back to the PTY (for DSR responses, etc.)
     pty_write_queue: Arc<Mutex<Vec<String>>>,

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -5220,3 +5220,232 @@ fn test_tab_drag_split_resizes_terminal() {
         screen
     );
 }
+
+/// fresh#3151: scrollback that streams to the backing file *while the
+/// scroll-back view is open* must survive the return to live mode.
+///
+/// The backing file is `[streamed scrollback][temporary visible-screen tail]`,
+/// and returning to live mode truncates it back to the scrollback end. But the
+/// PTY read loop keeps appending scrolled-off lines the whole time, and those
+/// land past the tail — so the truncation deleted them, permanently: the
+/// stream pointer had already counted them as persisted, so no later flush
+/// re-emitted them. The symptom is a gap in the scroll-back exactly where the
+/// live screen used to start.
+///
+/// Drives: fill history with a first batch, split so one pane keeps rendering
+/// live output, drop the focused pane into scroll-back, print a second batch
+/// (which streams past the tail), return to live (the truncation), then read
+/// the whole scroll-back back by paging through it. Every line printed must
+/// still be there.
+///
+/// The split is what makes this deterministic without a timer: the focused
+/// pane stays parked in scroll-back while the *other* pane renders the second
+/// batch, so the test can wait for that batch on screen before triggering the
+/// truncation. A lost line is by construction one that scrolled off, so it can
+/// never be on the live pane's grid — the sweep below cannot pass on the live
+/// pane's rendering.
+#[test]
+#[cfg(not(windows))] // Uses a Unix shell
+fn test_scrollback_survives_output_during_a_scrollback_visit() {
+    const FIRST: usize = 60;
+    const SECOND: usize = 60;
+
+    let mut harness = harness_or_return!(100, 30);
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    assert!(harness.editor().is_terminal_mode());
+
+    // Stay in scroll-back while the shell keeps producing output; the manual
+    // Ctrl+Space below is what returns to live, so the truncation happens at a
+    // point the test controls.
+    harness
+        .editor_mut()
+        .set_terminal_jump_to_end_on_output(false);
+
+    // First batch: pushes plenty of lines into streamed scrollback.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(format!("for i in $(seq 1 {FIRST}); do echo B_$i; done\n").as_bytes());
+    harness
+        .wait_until(|h| h.screen_to_string().contains(&format!("B_{FIRST}")))
+        .unwrap();
+
+    // Split vertically: both panes show the same terminal, both live.
+    harness.editor_mut().split_pane_vertical();
+    harness.render().unwrap();
+
+    // Drop the focused pane into read-only scroll-back. This appends the
+    // temporary visible-screen tail to the backing file.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "Ctrl+Space should drop the focused split into read-only scrollback"
+    );
+
+    // Second batch, printed while the scroll-back view is open: the PTY read
+    // loop streams it into the backing file past that tail. The other (live)
+    // pane is what puts it on screen, so waiting for it needs no timer.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(
+            format!("for i in $(seq 1 {SECOND}); do echo A_$i; done\n").as_bytes(),
+        );
+    harness
+        .wait_until(|h| h.screen_to_string().contains(&format!("A_{SECOND}")))
+        .unwrap();
+
+    // Back to live — this is the truncation.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "Ctrl+Space should return the focused split to the live grid"
+    );
+
+    // ...and back into scroll-back to read the history, from the very top.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let missing = missing_markers_in_scrollback(
+        &mut harness,
+        (1..=FIRST)
+            .map(|i| format!("B_{i}"))
+            .chain((1..=SECOND).map(|i| format!("A_{i}"))),
+    );
+    assert!(
+        missing.is_empty(),
+        "{} printed lines are unreachable in scroll-back: {:?}",
+        missing.len(),
+        missing
+    );
+}
+
+/// Page down through the scroll-back view from wherever it is parked,
+/// collecting everything rendered on the way, and return the `markers` that
+/// never showed up.
+///
+/// Only rendered output is inspected, so a marker counts as reachable exactly
+/// when a user scrolling the pane would see it.
+fn missing_markers_in_scrollback(
+    harness: &mut EditorTestHarness,
+    markers: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    let mut seen = harness.screen_to_string();
+    // Each page advances by at least one row, so a page per row of content is
+    // a safe ceiling; the loop normally stops much earlier, when the view
+    // stops moving.
+    let mut pages_left = 10_000;
+    loop {
+        let before = harness.screen_to_string();
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+        let after = harness.screen_to_string();
+        seen.push_str(&after);
+        if after == before {
+            break;
+        }
+        pages_left -= 1;
+        assert!(pages_left > 0, "scroll-back paging did not terminate");
+    }
+
+    markers
+        .into_iter()
+        .filter(|m| !contains_marker(&seen, m))
+        .collect()
+}
+
+/// Whether `marker` appears in `text` as a whole token — `A_1` must not be
+/// satisfied by `A_10`.
+fn contains_marker(text: &str, marker: &str) -> bool {
+    text.match_indices(marker).any(|(idx, _)| {
+        text[idx + marker.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_ascii_digit())
+    })
+}
+
+/// fresh#3151, the trigger that needs no scroll-back visit at all: resuming a
+/// terminal that is *already* live still truncated its backing file.
+///
+/// "Focus Terminal" (and the tab-switch path behind `focus_terminal_buffer`)
+/// call `enter_terminal_mode` unconditionally — the split need not have been
+/// in scroll-back — and that cut the backing file back to the recorded end of
+/// scrollback. The PTY read loop recorded that end from `metadata()` *before*
+/// flushing its own `BufWriter`, so every recorded end was one batch short and
+/// the truncation ate the lines that had most recently scrolled off: exactly
+/// the rows just above the top of the screen.
+///
+/// Drives: print a batch into scrollback, run Focus Terminal on the live
+/// terminal, then read the scroll-back back by paging through it.
+#[test]
+#[cfg(not(windows))] // Uses a Unix shell
+fn test_focusing_an_already_live_terminal_keeps_its_scrollback() {
+    const LINES: usize = 60;
+
+    let mut harness = harness_or_return!(100, 30);
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    assert!(harness.editor().is_terminal_mode());
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(format!("for i in $(seq 1 {LINES}); do echo L_$i; done\n").as_bytes());
+    harness
+        .wait_until(|h| h.screen_to_string().contains(&format!("L_{LINES}")))
+        .unwrap();
+
+    // Resume a terminal that is already live, via the command palette. No
+    // scroll-back view is ever opened before this point.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("Focus Terminal").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "Focus Terminal should leave the terminal live. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Now read the history back.
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let missing =
+        missing_markers_in_scrollback(&mut harness, (1..=LINES).map(|i| format!("L_{i}")));
+    assert!(
+        missing.is_empty(),
+        "{} printed lines are unreachable in scroll-back: {:?}",
+        missing.len(),
+        missing
+    );
+}

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -5340,6 +5340,17 @@ fn test_scrollback_survives_output_during_a_scrollback_visit() {
 ///
 /// Only rendered output is inspected, so a marker counts as reachable exactly
 /// when a user scrolling the pane would see it.
+///
+/// Two limits worth knowing before reusing this:
+///
+/// * Entering scroll-back re-appends the current visible screen, so a marker
+///   that survives *only* in that temporary tail still scores as reachable.
+///   Fine for callers whose missing lines are older than the last screenful;
+///   not a way to tell "durably in the scrollback" from "in the volatile tail".
+/// * The sweep stops when a page renders identically to the one before it,
+///   which is end-of-buffer for dense numbered output but would stop early on
+///   a run of blank rows or a repeated frame. That direction is fail-safe — it
+///   reports markers as missing rather than passing vacuously.
 fn missing_markers_in_scrollback(
     harness: &mut EditorTestHarness,
     markers: impl IntoIterator<Item = String>,


### PR DESCRIPTION
Fixes #3151.

## Symptom

Terminal scroll-back opened on a **gap**: a block of lines that had just scrolled off the top of the screen was missing — and missing permanently. Gone from the backing file, absent from a restored session, unrecoverable by scrolling, resizing, or re-entering scroll-back. Programs that print in bursts (build tools, test runners, agent TUIs) lost a block on every burst.

Measured on the repro in the issue: **84 of 480 printed lines unreachable**, in five contiguous runs. With this branch: 0.

## Root cause

The backing file is `[streamed scrollback][temporary visible-screen tail]`, with `backing_file_history_end` as the boundary; returning to live mode truncates back to it. Three things kept that boundary from being the true end of the scrollback.

1. **The read loop recorded the boundary before flushing its own `BufWriter`.** `metadata()` reports what is on disk, so every recorded boundary was short by exactly the batch just written. `enter_terminal_mode` truncates unconditionally and is reached with the split *already live* (Focus Terminal, a tab switch, resuming after a copy), so this lost scrollback with no scroll-back view ever opened — scenario B in the issue.

2. **The read loop kept appending scrolled-off lines past a tail still in the file.** The truncation that ends the visit cuts at the scrollback end and took them along. Scenario A, which `terminal.jump_to_end_on_output` (on by default) triggers on every burst.

3. **Not every transcript handle was `O_APPEND`** (found in review). Only `BackingMode::Continue` appended; every terminal from `Open Terminal` is `BackingMode::Fresh`, opened `write(true).truncate(true)`. So the read loop wrote at an offset of its own while the UI thread appended through a separate handle — and once a scroll-back sync had written anything, the loop's next batch landed *on top of* it. Since `sync_terminal_to_buffer` and `sync_terminal_backing_files` both call `flush_new_scrollback` on their own handle, the bytes at risk included real scrollback already counted in `synced_history_lines` and therefore never re-emitted: the same permanent loss, by a third route. It also made the boundary meaningless whenever a tail was present, and made the two backing modes behave differently (CONTRIBUTING #13).

## The fix

All three are the same defect — writers disagreeing about where the scrollback ends — so the fix is to the boundary, not to each truncation:

- **Every transcript handle is `O_APPEND`.** No writer can land on another's bytes, and the file's length *is* the read loop's write position. `Fresh` still starts empty, via a separate immediately-dropped truncating handle (truncate and append cannot be combined in one open).
- **Flush before measuring**, so the recorded boundary includes the batch just written.
- **Track whether a tail is actually there** (`TerminalState::backing_file_has_tail`, set *before* the write so a part-written tail stays truncatable). Truncation happens only when there is a tail to remove, and each path that writes a tail removes the previous one first instead of stacking onto it.
- **When the read loop streams scrollback past a tail, it adopts that tail as scrollback.** It cannot truncate — a scroll-back view may be reading the file — so the alternative is deleting those lines for good. The cost is one duplicated screen per overlapping event, permanently, and is now documented on the field, at the branch, and in the module's architecture doc rather than implied.

## Tests

Two end-to-end tests, one per user-visible trigger. Both drive keys and assert only on rendered output — they page through the whole scroll-back view and require every printed line to appear.

- `test_scrollback_survives_output_during_a_scrollback_visit` — a split renders live output so the second batch can be waited for without a timer while the focused pane sits in scroll-back. Fails on `cf626fc` with 36 lines unreachable (10/10 runs, never 0).
- `test_focusing_an_already_live_terminal_keeps_its_scrollback` — no scroll-back visit at all. Fails on `cf626fc` with 36 lines unreachable.

Three unit tests pin the handle semantics. `transcript_handles_append_in_both_backing_modes` fails on the old open mode with `stream-1\nstream-2\n` instead of `stream-1\nui-tail\nstream-2\n` — the other writer's append overwritten in place.

Existing coverage is unchanged: 92 `services::terminal` unit tests and 103 terminal e2e tests green.

Also verified manually under tmux against the issue's exact steps: 84 lines lost before, 0 after (with 64 duplicated line occurrences across 8 overlapping visits — the documented adoption cost).

## Review

Reviewed adversarially; seven findings, six fixed in eb75900, one declined with reasoning and filed as #3153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBzQhDe6BRUaBfxqst9qBf