### PR TITLE
input: bracketed paste into buffer-mounted panels, search rows windowed onto their match, symbolic key names

### DIFF
--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -273,6 +273,38 @@ function truncate(s: string, maxLen: number): string {
   return result + "...";
 }
 
+/** Matches a string containing any non-ASCII scalar. Non-global so it
+ *  carries no `lastIndex` state between calls. */
+const NON_ASCII_RE = /[^\x00-\x7F]/;
+
+/** Convert a 0-based UTF-8 *byte* offset into a line to the UTF-16 index
+ *  the same line is sliced by.
+ *
+ *  `SearchMatch.column` is documented as a byte column
+ *  (`fresh-editor-core/src/model/filesystem.rs`), while every `slice`
+ *  here counts UTF-16 units. On an ASCII line the two coincide, which is
+ *  why the mismatch hid: it only bites when the text before the match is
+ *  multibyte, and then it overstates the position by up to 3x (CJK) —
+ *  enough to slide the window clean past the match it was meant to
+ *  centre on.
+ *
+ *  The ASCII fast path is a native regex scan with early exit, so the
+ *  common case (source code, minified assets) costs no per-codepoint
+ *  work. The slow path walks only as far as the match. */
+function byteColumnToIndex(line: string, byteCol: number): number {
+  if (byteCol <= 0) return 0;
+  if (!NON_ASCII_RE.test(line)) return Math.min(byteCol, line.length);
+  let bytes = 0;
+  let index = 0;
+  for (const ch of line) {
+    if (bytes >= byteCol) break;
+    const cp = ch.codePointAt(0)!;
+    bytes += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
+    index += ch.length;
+  }
+  return index;
+}
+
 /** Codepoint index and length of the `pattern` hit in `text` nearest to
  *  `preferAt`, or `null` when the pattern is empty, invalid, or doesn't
  *  occur. A line with several matches yields one row per match, so the
@@ -791,16 +823,19 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // of a 290-char line rendered as `start xxxx…`, with the matched
   // text nowhere on screen).
   //
-  // `match.column` is a 1-based *byte* column; the slice indices here
-  // are UTF-16 units. They coincide for the ASCII-dominated case, and
-  // a multibyte prefix only pushes the window right — which is why the
-  // window keeps half a cap of slack on the left and `windowAroundMatch`
-  // re-locates the match in the sliced text rather than trusting the
-  // column arithmetic (falling back to head-truncation, the old
-  // behaviour, when the match isn't in the window after all). The
-  // window is still one cap wide, so the per-codepoint work downstream
-  // is bounded exactly as it was.
-  const matchCol = Math.max(0, (result.match.column || 1) - 1);
+  // `match.column` is a 1-based *byte* column and every slice here counts
+  // UTF-16 units, so it is converted before use. Half a cap of slack does
+  // NOT absorb the difference — a CJK prefix inflates the byte column 3x,
+  // so ~128 such characters ahead of the match are enough to put the
+  // window past it entirely; `windowAroundMatch` then finds no match and
+  // falls back to truncating a window centred on the wrong part of the
+  // line, which is worse than the head-truncation it replaced.
+  //
+  // `windowAroundMatch` still re-locates the match in the sliced text
+  // rather than trusting this arithmetic, and still degrades to
+  // head-truncation if it isn't there. The window stays one cap wide, so
+  // the per-codepoint work downstream is bounded as it was.
+  const matchCol = byteColumnToIndex(rawCtx, Math.max(0, (result.match.column || 1) - 1));
   const capStart = rawCtx.length > CONTEXT_HARD_CAP
     ? Math.max(0, Math.min(matchCol - CONTEXT_HARD_CAP / 2, rawCtx.length - CONTEXT_HARD_CAP))
     : 0;

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -273,36 +273,71 @@ function truncate(s: string, maxLen: number): string {
   return result + "...";
 }
 
-/** Matches a string containing any non-ASCII scalar. Non-global so it
- *  carries no `lastIndex` state between calls. */
-const NON_ASCII_RE = /[^\x00-\x7F]/;
-
-/** Convert a 0-based UTF-8 *byte* offset into a line to the UTF-16 index
- *  the same line is sliced by.
+/** UTF-16 index of the `pattern` hit in `line` nearest to (at or before)
+ *  `byteHint`, or -1 when the pattern is empty, invalid, or absent.
  *
- *  `SearchMatch.column` is documented as a byte column
- *  (`fresh-editor-core/src/model/filesystem.rs`), while every `slice`
- *  here counts UTF-16 units. On an ASCII line the two coincide, which is
- *  why the mismatch hid: it only bites when the text before the match is
- *  multibyte, and then it overstates the position by up to 3x (CJK) —
- *  enough to slide the window clean past the match it was meant to
- *  centre on.
+ *  This is how a row learns where its own match sits, and it deliberately
+ *  does NOT convert `match.column` to a UTF-16 index. Three reasons:
  *
- *  The ASCII fast path is a native regex scan with early exit, so the
- *  common case (source code, minified assets) costs no per-codepoint
- *  work. The slow path walks only as far as the match. */
-function byteColumnToIndex(line: string, byteCol: number): number {
-  if (byteCol <= 0) return 0;
-  if (!NON_ASCII_RE.test(line)) return Math.min(byteCol, line.length);
-  let bytes = 0;
-  let index = 0;
-  for (const ch of line) {
-    if (bytes >= byteCol) break;
-    const cp = ch.codePointAt(0)!;
-    bytes += cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
-    index += ch.length;
+ *  1. A conversion has to walk the line codepoint by codepoint, and on the
+ *     very files `CONTEXT_HARD_CAP` was written for — 5 000-50 000 char
+ *     minified bundles — that walk is tens of thousands of QuickJS
+ *     iterations per row, per re-render. One `©` anywhere on the line puts
+ *     every row on it onto that path. Native string search is two to three
+ *     orders of magnitude cheaper and is all this needs.
+ *  2. `column` and `context` are not guaranteed to describe the same
+ *     string: `resolveMatchTarget` rewrites `line`/`column` from the live
+ *     interval marker after a jump or replace and leaves `context` at its
+ *     grep-time value. Searching `context` itself cannot drift from it.
+ *  3. A byte offset is never smaller than the UTF-16 index of the same
+ *     position, so `column` is a soundupper bound to search back from —
+ *     which is what makes it useful as a hint without being trusted as a
+ *     position. Picking the hit at or before it is what keeps several
+ *     matches on one line anchored to their own rows.
+ *
+ *  Returns -1 rather than guessing when the pattern isn't on the line at
+ *  all — the stale-row case, where the tree renders the previous search's
+ *  results against the pattern currently being typed. The caller reads
+ *  that as "no anchor" and falls back to the head of the line. */
+function matchIndexNearByteColumn(
+  line: string,
+  pattern: string,
+  isRegex: boolean,
+  caseSensitive: boolean,
+  byteHint: number,
+): number {
+  if (!pattern) return -1;
+  // The hint is a byte offset; clamping to the UTF-16 length keeps it a
+  // valid search position and costs nothing when they coincide.
+  const hint = Math.max(0, Math.min(byteHint, line.length));
+  try {
+    if (!isRegex) {
+      const hay = caseSensitive ? line : line.toLowerCase();
+      const needle = caseSensitive ? pattern : pattern.toLowerCase();
+      const before = hay.lastIndexOf(needle, hint);
+      // Nothing at or before the hint: the byte column overstated the
+      // position past the last hit (a heavily multibyte prefix), so take
+      // the first hit on the line instead of reporting none.
+      return before >= 0 ? before : hay.indexOf(needle);
+    }
+    const re = new RegExp(pattern, caseSensitive ? "g" : "gi");
+    let best = -1;
+    let first = -1;
+    let m;
+    while ((m = re.exec(line)) !== null) {
+      if (m[0].length === 0) {
+        re.lastIndex++;
+        continue;
+      }
+      if (first < 0) first = m.index;
+      if (m.index > hint) break;
+      best = m.index;
+    }
+    return best >= 0 ? best : first;
+  } catch (_e) {
+    // Invalid regex mid-typing: no anchor, same as no hit.
+    return -1;
   }
-  return index;
 }
 
 /** Codepoint index and length of the `pattern` hit in `text` nearest to
@@ -347,7 +382,16 @@ function matchSpanNear(
  *  exactly `truncate`, so ordinary rows are unchanged.
  *
  *  `matchAt` is where this row's own match is expected to sit in
- *  `text` — see `matchSpanNear`. */
+ *  `text` — see `matchSpanNear`.
+ *
+ *  `alreadySliced` says whether `text` is itself a mid-line window. It
+ *  governs the fallbacks, not the happy path: head-truncating a slice
+ *  that does not start at the beginning of the line renders it as
+ *  though it did, with a trailing "..." implying nothing was cut on the
+ *  left. The caller now anchors at 0 whenever it cannot locate the
+ *  match, so this should not arise — but a marker costs one column and
+ *  a row that silently lies about where it starts is worse than a row
+ *  that is one character narrower. */
 function windowAroundMatch(
   text: string,
   budget: number,
@@ -355,17 +399,25 @@ function windowAroundMatch(
   isRegex: boolean,
   caseSensitive: boolean,
   matchAt: number,
+  alreadySliced: boolean,
 ): string {
-  if (charLen(text) <= budget) return text;
+  const ELLIPSIS = "…";
+  // Head-truncation, honest about a left-hand elision when there is one.
+  const head = (t: string) =>
+    alreadySliced
+      ? ELLIPSIS + truncate(t, Math.max(1, budget - 1))
+      : truncate(t, budget);
+  // `head` (not a bare prepend) so the marker cannot push the row one
+  // column over `budget` when the text already fills it exactly.
+  if (charLen(text) <= budget) return alreadySliced ? head(text) : text;
   const span = matchSpanNear(text, pattern, isRegex, caseSensitive, matchAt);
   // No locatable match (empty/invalid pattern, or a hit that fell
   // outside the capped window): keep the historical head-truncation.
-  if (!span) return truncate(text, budget);
+  if (!span) return head(text);
   // The match is already visible in the head — `truncate`'s own "..."
   // marker covers the elided tail.
-  if (span.start + span.length <= budget - 3) return truncate(text, budget);
+  if (span.start + span.length <= budget - 3) return head(text);
 
-  const ELLIPSIS = "…";
   // Codepoint array: slicing it can never split a surrogate pair, and
   // the input is capped well under a couple of thousand codepoints.
   const cps = Array.from(text);
@@ -376,7 +428,7 @@ function windowAroundMatch(
   // Nothing is elided on the left, so there is no window to slide: the
   // match starts inside the first third and is simply wider than the
   // row. Head-truncation is all this width allows.
-  if (start === 0) return truncate(text, budget);
+  if (start === 0) return head(text);
   // One column goes to the leading `…`.
   const room = budget - 1;
   if (start + room >= cps.length) {
@@ -823,21 +875,22 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // of a 290-char line rendered as `start xxxx…`, with the matched
   // text nowhere on screen).
   //
-  // `match.column` is a 1-based *byte* column and every slice here counts
-  // UTF-16 units, so it is converted before use. Half a cap of slack does
-  // NOT absorb the difference — a CJK prefix inflates the byte column 3x,
-  // so ~128 such characters ahead of the match are enough to put the
-  // window past it entirely; `windowAroundMatch` then finds no match and
-  // falls back to truncating a window centred on the wrong part of the
-  // line, which is worse than the head-truncation it replaced.
-  //
-  // `windowAroundMatch` still re-locates the match in the sliced text
-  // rather than trusting this arithmetic, and still degrades to
-  // head-truncation if it isn't there. The window stays one cap wide, so
-  // the per-codepoint work downstream is bounded as it was.
-  const matchCol = byteColumnToIndex(rawCtx, Math.max(0, (result.match.column || 1) - 1));
-  const capStart = rawCtx.length > CONTEXT_HARD_CAP
-    ? Math.max(0, Math.min(matchCol - CONTEXT_HARD_CAP / 2, rawCtx.length - CONTEXT_HARD_CAP))
+  // The anchor is a hit located in `rawCtx` itself, not arithmetic on
+  // `match.column` — see `matchIndexNearByteColumn` for why (bounded
+  // work, and immune to `column` drifting out of step with `context`).
+  // -1 means the pattern is not on this line at all, which happens
+  // routinely: the tree renders the previous search's rows against the
+  // pattern currently being typed. Anchor at 0 then, so the row shows
+  // the head of the line exactly as it did before this feature existed.
+  const anchor = matchIndexNearByteColumn(
+    rawCtx,
+    panel.searchPattern,
+    panel.useRegex,
+    panel.caseSensitive,
+    Math.max(0, (result.match.column || 1) - 1),
+  );
+  const capStart = anchor >= 0 && rawCtx.length > CONTEXT_HARD_CAP
+    ? Math.max(0, Math.min(anchor - CONTEXT_HARD_CAP / 2, rawCtx.length - CONTEXT_HARD_CAP))
     : 0;
   const capped = rawCtx.slice(capStart, capStart + CONTEXT_HARD_CAP);
   // Leading indentation is noise worth trimming when the window starts
@@ -859,10 +912,10 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // more of the context, which is fine.
   const maxCtx = innerWidth - location.length - 3;
   // Where this row's match sits in `context`, after the cap slice and
-  // the leading trim above. Byte-vs-UTF-16 again: an approximation used
-  // only to pick between several hits on the same line.
+  // the leading trim above — used to pick between several hits on the
+  // same line. Exact, since `anchor` is an index into `rawCtx`.
   const trimmedLead = capStart === 0 ? capped.length - capped.trimStart().length : 0;
-  const matchAt = matchCol - capStart - trimmedLead;
+  const matchAt = Math.max(0, anchor) - capStart - trimmedLead;
   const displayCtx = windowAroundMatch(
     context,
     Math.max(10, maxCtx),
@@ -870,6 +923,7 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
     panel.useRegex,
     panel.caseSensitive,
     matchAt,
+    capStart > 0,
   );
 
   // Pattern-match highlights inside the context substring. Emitted

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -273,6 +273,86 @@ function truncate(s: string, maxLen: number): string {
   return result + "...";
 }
 
+/** Codepoint index and length of the `pattern` hit in `text` nearest to
+ *  `preferAt`, or `null` when the pattern is empty, invalid, or doesn't
+ *  occur. A line with several matches yields one row per match, so the
+ *  row anchors on *its own* match rather than always on the first —
+ *  otherwise every row on that line would window to the same place.
+ *
+ *  `highlightMatches` reports UTF-16 indices; those are converted here
+ *  so callers can slice codepoint arrays without splitting a surrogate
+ *  pair. Only ever called on an already-capped window, so the
+ *  conversion walk is bounded. */
+function matchSpanNear(
+  text: string,
+  pattern: string,
+  isRegex: boolean,
+  caseSensitive: boolean,
+  preferAt: number,
+): { start: number; length: number } | null {
+  if (!pattern) return null;
+  const overlays: InlineOverlay[] = [];
+  highlightMatches(text, pattern, isRegex, caseSensitive, overlays);
+  if (overlays.length === 0) return null;
+  let o = overlays[0];
+  for (const cand of overlays) {
+    if (Math.abs(cand.start - preferAt) < Math.abs(o.start - preferAt)) o = cand;
+  }
+  return {
+    start: charLen(text.slice(0, o.start)),
+    length: charLen(text.slice(o.start, o.end)),
+  };
+}
+
+/** Fit `text` into `budget` display columns with the first match of
+ *  `pattern` inside the window.
+ *
+ *  A search result whose matched text is off the right edge tells the
+ *  reader nothing — and there is no horizontal scroll to go find it
+ *  (issue #1580). So when the match falls past the budget, the window
+ *  slides right to bring it in, marking each elided end with `…`. When
+ *  the match already fits (the overwhelmingly common case) this is
+ *  exactly `truncate`, so ordinary rows are unchanged.
+ *
+ *  `matchAt` is where this row's own match is expected to sit in
+ *  `text` — see `matchSpanNear`. */
+function windowAroundMatch(
+  text: string,
+  budget: number,
+  pattern: string,
+  isRegex: boolean,
+  caseSensitive: boolean,
+  matchAt: number,
+): string {
+  if (charLen(text) <= budget) return text;
+  const span = matchSpanNear(text, pattern, isRegex, caseSensitive, matchAt);
+  // No locatable match (empty/invalid pattern, or a hit that fell
+  // outside the capped window): keep the historical head-truncation.
+  if (!span) return truncate(text, budget);
+  // The match is already visible in the head — `truncate`'s own "..."
+  // marker covers the elided tail.
+  if (span.start + span.length <= budget - 3) return truncate(text, budget);
+
+  const ELLIPSIS = "…";
+  // Codepoint array: slicing it can never split a surrogate pair, and
+  // the input is capped well under a couple of thousand codepoints.
+  const cps = Array.from(text);
+  // Keep a third of the budget as leading context so the match reads in
+  // situ rather than flush against the elision marker.
+  const lead = Math.max(1, Math.floor(budget / 3));
+  const start = Math.max(0, span.start - lead);
+  // Nothing is elided on the left, so there is no window to slide: the
+  // match starts inside the first third and is simply wider than the
+  // row. Head-truncation is all this width allows.
+  if (start === 0) return truncate(text, budget);
+  // One column goes to the leading `…`.
+  const room = budget - 1;
+  if (start + room >= cps.length) {
+    return ELLIPSIS + cps.slice(cps.length - room).join("");
+  }
+  return ELLIPSIS + cps.slice(start, start + room - 1).join("") + ELLIPSIS;
+}
+
 // Get the active field's text
 function getActiveFieldText(): string {
   if (!panel) return "";
@@ -704,9 +784,31 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // past ~512 chars is invisible anyway.
   const CONTEXT_HARD_CAP = 512;
   const rawCtx = result.match.context;
-  const context = (rawCtx.length > CONTEXT_HARD_CAP
-    ? rawCtx.slice(0, CONTEXT_HARD_CAP)
-    : rawCtx).trim();
+  // Anchor that cap on the *match*, not on the start of the line.
+  // Slicing from 0 threw away the only part of the row anyone opened
+  // it for whenever the match sat past the cap — and the same for the
+  // display-width truncation below (issue #1580: a match at column 257
+  // of a 290-char line rendered as `start xxxx…`, with the matched
+  // text nowhere on screen).
+  //
+  // `match.column` is a 1-based *byte* column; the slice indices here
+  // are UTF-16 units. They coincide for the ASCII-dominated case, and
+  // a multibyte prefix only pushes the window right — which is why the
+  // window keeps half a cap of slack on the left and `windowAroundMatch`
+  // re-locates the match in the sliced text rather than trusting the
+  // column arithmetic (falling back to head-truncation, the old
+  // behaviour, when the match isn't in the window after all). The
+  // window is still one cap wide, so the per-codepoint work downstream
+  // is bounded exactly as it was.
+  const matchCol = Math.max(0, (result.match.column || 1) - 1);
+  const capStart = rawCtx.length > CONTEXT_HARD_CAP
+    ? Math.max(0, Math.min(matchCol - CONTEXT_HARD_CAP / 2, rawCtx.length - CONTEXT_HARD_CAP))
+    : 0;
+  const capped = rawCtx.slice(capStart, capStart + CONTEXT_HARD_CAP);
+  // Leading indentation is noise worth trimming when the window starts
+  // at the beginning of the line; a window that already starts mid-line
+  // must not shift further, or the offsets below drift.
+  const context = capStart === 0 ? capped.trim() : capped.replace(/\s+$/, "");
   // Host prefix consumes:
   //   indent (depth=1) = 2
   //   leaf-alignment   = 2 (in lieu of disclosure glyph)
@@ -721,7 +823,19 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // over-counting on rare non-BMP filenames just trims a little
   // more of the context, which is fine.
   const maxCtx = innerWidth - location.length - 3;
-  const displayCtx = truncate(context, Math.max(10, maxCtx));
+  // Where this row's match sits in `context`, after the cap slice and
+  // the leading trim above. Byte-vs-UTF-16 again: an approximation used
+  // only to pick between several hits on the same line.
+  const trimmedLead = capStart === 0 ? capped.length - capped.trimStart().length : 0;
+  const matchAt = matchCol - capStart - trimmedLead;
+  const displayCtx = windowAroundMatch(
+    context,
+    Math.max(10, maxCtx),
+    panel.searchPattern,
+    panel.useRegex,
+    panel.caseSensitive,
+    matchAt,
+  );
 
   // Pattern-match highlights inside the context substring. Emitted
   // in segment-local char units; the host shifts them by the

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1156,7 +1156,8 @@ impl Editor {
 
     /// Route a terminal-initiated bracketed paste to a focused
     /// floating panel (Orchestrator picker / New-Session form / plugin
-    /// overlay) or focused dock when one owns the keyboard.
+    /// overlay), focused dock, or a panel mounted into the active
+    /// buffer (Search & Replace) when one owns the keyboard.
     ///
     /// Bracketed paste arrives as a single `Event::Paste` rather than
     /// per-key events, so — unlike typed characters and `Ctrl+V` — it
@@ -1203,7 +1204,32 @@ impl Editor {
         } else if let Some(i) = self.focused_sidebar_panel() {
             super::PanelSlot::Sidebar(i)
         } else {
-            return false;
+            // No floating panel or dock owns the keyboard — but a panel
+            // mounted *into the active buffer* still can. The Search &
+            // Replace panel is one: a widget panel rendered into a
+            // read-only widget buffer in a split, so it matches none of
+            // the slots above. Its `Ctrl+V` works because the key event
+            // reaches `Action::Paste`, which routes to the focused Text
+            // widget via `focused_text_widget_panel_for_buffer`; a
+            // bracketed paste never passes through there, fell through
+            // to `paste_text`, and was refused by the read-only gate
+            // ("Editing disabled in this buffer" — issue #1960). Route
+            // it to the same widget the key path targets.
+            //
+            // An open prompt still wins, as it does in `paste_text`: the
+            // Ctrl+F prompt floats over whatever buffer is active and owns
+            // the keyboard while it is up.
+            if self.active_window().prompt.is_some() {
+                return false;
+            }
+            let buffer_id = self.active_buffer();
+            let Some(panel_id) = self.focused_text_widget_panel_for_buffer(buffer_id) else {
+                return false;
+            };
+            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+            self.handle_widget_insert_str(&panel_id, &normalized);
+            self.set_status_message(t!("clipboard.pasted").to_string());
+            return true;
         };
         let Some(panel_id) = self.panel(slot).map(|f| f.panel_key.clone()) else {
             return false;

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1216,10 +1216,27 @@ impl Editor {
             // ("Editing disabled in this buffer" — issue #1960). Route
             // it to the same widget the key path targets.
             //
-            // An open prompt still wins, as it does in `paste_text`: the
-            // Ctrl+F prompt floats over whatever buffer is active and owns
-            // the keyboard while it is up.
-            if self.active_window().prompt.is_some() {
+            // Only when the editor pane itself owns the keyboard. A panel
+            // mounted into a buffer owns the paste only while nothing is
+            // layered over that buffer: with the menu open (or a prompt,
+            // modal, context menu or key-capturing popup up) the paste is
+            // that layer's, and letting it through to the panel underneath
+            // would be the very bug the doc comment above says this
+            // function exists to prevent — text landing in a field the
+            // user cannot see. Ask the overlay stack rather than naming
+            // the layers here, so a new overlay is covered by declaring
+            // itself and not by being added to a list.
+            if !self.editor_base_owns_keyboard() {
+                return false;
+            }
+            // The file explorer is inside the editor's own layer, so the
+            // check above does not speak for it. `Action::Paste` routes it
+            // to `file_explorer_paste`; a bracketed paste there has never
+            // been wired up, and this is not the change that should wire
+            // it — decline and leave that path exactly as it was.
+            if self.active_window().key_context
+                == crate::input::keybindings::KeyContext::FileExplorer
+            {
                 return false;
             }
             let buffer_id = self.active_buffer();

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -120,6 +120,23 @@ pub(crate) fn any_layer_blocks_terminal_input(layers: impl IntoIterator<Item = L
     layers.into_iter().any(|l| l.blocks_terminal_input)
 }
 
+/// True iff some layer other than the editor base owns the keyboard — a
+/// menu, prompt, modal, context menu, dock, floating panel or a popup
+/// that captures keys.
+///
+/// A membership question, and takes an iterator for the reason the gate
+/// above does: the editor base is the owner of last resort and ranks
+/// below every other layer, so "some other layer owns the keyboard" and
+/// "the topmost owner is not the editor" are the same statement — this
+/// one needs no order to say it.
+pub(crate) fn any_layer_above_editor_owns_keyboard(
+    layers: impl IntoIterator<Item = Layer>,
+) -> bool {
+    layers
+        .into_iter()
+        .any(|l| l.owns_keyboard && l.kind != LayerKind::Editor)
+}
+
 /// True iff a layer ranked *above* the popup layer currently owns the
 /// keyboard. Used by the unfocused-popup key interception: while one of those
 /// owns the keyboard the popup must not intercept keys. Callers guarantee a
@@ -294,6 +311,17 @@ impl Editor {
     /// blocks the PTY without being modal.
     pub(crate) fn presents_blocking_overlay(&self) -> bool {
         crate::app::overlay::any_layer_blocks_terminal_input(self.overlay_layer_set())
+    }
+
+    /// True iff the editor pane itself owns the keyboard — nothing above
+    /// it (menu, prompt, modal, context menu, dock, floating panel, a
+    /// key-capturing popup) has claimed it.
+    ///
+    /// Asked by the bracketed-paste routing: a paste belongs to whatever
+    /// owns the keyboard, and a panel mounted *into a buffer* only owns it
+    /// when nothing is layered over that buffer.
+    pub(crate) fn editor_base_owns_keyboard(&self) -> bool {
+        !crate::app::overlay::any_layer_above_editor_owns_keyboard(self.overlay_layer_set())
     }
 
     /// True iff a modal overlay — a prompt (Open File dialog, command

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -2624,6 +2624,53 @@ impl KeybindingResolver {
             "pageup" => Some(KeyCode::PageUp),
             "pagedown" => Some(KeyCode::PageDown),
 
+            // Symbolic names for punctuation. A single-character key
+            // name is still the canonical spelling (and what the
+            // keybinding editor writes back), but people reach for the
+            // X11 keysym name they know — `"key": "asterisk"` is what
+            // issue #1128 was actually configured with, and it bound
+            // nothing at all. JSON also makes some of these awkward to
+            // write literally (`"\\"` for backslash, `"\""` for the
+            // double quote), so a name is the friendlier spelling.
+            //
+            // The keypad aliases map onto the same characters their key
+            // transmits: a terminal reports the numeric keypad through
+            // its ASCII byte, so `kp_multiply` *is* `*` by the time the
+            // editor sees it. Naming them separately documents intent
+            // without promising a distinction the terminal doesn't make.
+            "asterisk" | "kp_multiply" | "star" => Some(KeyCode::Char('*')),
+            "plus" | "kp_add" => Some(KeyCode::Char('+')),
+            "minus" | "hyphen" | "kp_subtract" => Some(KeyCode::Char('-')),
+            "slash" | "kp_divide" => Some(KeyCode::Char('/')),
+            "period" | "dot" | "kp_decimal" => Some(KeyCode::Char('.')),
+            "equal" | "equals" => Some(KeyCode::Char('=')),
+            "backslash" => Some(KeyCode::Char('\\')),
+            "comma" => Some(KeyCode::Char(',')),
+            "semicolon" => Some(KeyCode::Char(';')),
+            "colon" => Some(KeyCode::Char(':')),
+            "apostrophe" | "quote" => Some(KeyCode::Char('\'')),
+            "quotedbl" | "doublequote" => Some(KeyCode::Char('"')),
+            "grave" | "backtick" => Some(KeyCode::Char('`')),
+            "tilde" => Some(KeyCode::Char('~')),
+            "exclam" | "exclamation" => Some(KeyCode::Char('!')),
+            "at" => Some(KeyCode::Char('@')),
+            "numbersign" | "hash" => Some(KeyCode::Char('#')),
+            "dollar" => Some(KeyCode::Char('$')),
+            "percent" => Some(KeyCode::Char('%')),
+            "asciicircum" | "caret" => Some(KeyCode::Char('^')),
+            "ampersand" => Some(KeyCode::Char('&')),
+            "underscore" => Some(KeyCode::Char('_')),
+            "bar" | "pipe" => Some(KeyCode::Char('|')),
+            "question" => Some(KeyCode::Char('?')),
+            "less" | "lessthan" => Some(KeyCode::Char('<')),
+            "greater" | "greaterthan" => Some(KeyCode::Char('>')),
+            "parenleft" => Some(KeyCode::Char('(')),
+            "parenright" => Some(KeyCode::Char(')')),
+            "bracketleft" => Some(KeyCode::Char('[')),
+            "bracketright" => Some(KeyCode::Char(']')),
+            "braceleft" => Some(KeyCode::Char('{')),
+            "braceright" => Some(KeyCode::Char('}')),
+
             s if s.len() == 1 => s.chars().next().map(KeyCode::Char),
             // Handle function keys like "f1", "f2", ..., "f12"
             s if s.starts_with('f') && s.len() >= 2 => s[1..].parse::<u8>().ok().map(KeyCode::F),
@@ -3291,6 +3338,67 @@ mod tests {
         assert_eq!(KeybindingResolver::parse_key("a"), Some(KeyCode::Char('a')));
     }
 
+    /// Issue #1128: the reporter wrote `"key": "asterisk"` (the X11
+    /// keysym spelling) and got a binding that did nothing. Symbolic
+    /// punctuation names parse to the character they name, alongside the
+    /// single-character spelling that remains canonical, and the keypad
+    /// aliases land on the same characters their key transmits.
+    #[test]
+    fn test_parse_key_symbolic_names() {
+        for (name, ch) in [
+            ("asterisk", '*'),
+            ("kp_multiply", '*'),
+            ("plus", '+'),
+            ("minus", '-'),
+            ("kp_subtract", '-'),
+            ("slash", '/'),
+            ("backslash", '\\'),
+            ("period", '.'),
+            ("comma", ','),
+            ("underscore", '_'),
+            ("quotedbl", '"'),
+            ("grave", '`'),
+            ("bracketleft", '['),
+            ("bracketright", ']'),
+        ] {
+            assert_eq!(
+                KeybindingResolver::parse_key(name),
+                Some(KeyCode::Char(ch)),
+                "key name {name:?}"
+            );
+        }
+        // Case-insensitive, like every other name in the table.
+        assert_eq!(
+            KeybindingResolver::parse_key("Asterisk"),
+            Some(KeyCode::Char('*'))
+        );
+        // The single-character spelling still wins where the two overlap,
+        // and unrelated names are still rejected.
+        assert_eq!(KeybindingResolver::parse_key("*"), Some(KeyCode::Char('*')));
+        assert_eq!(KeybindingResolver::parse_key("asterix"), None);
+    }
+
+    /// The end of the same issue: a config entry spelled with a symbolic
+    /// name must actually register, not merely parse.
+    #[test]
+    fn test_symbolic_key_name_binds_from_config() {
+        let mut config = Config::default();
+        config.keybindings.push(crate::config::Keybinding {
+            key: "asterisk".to_string(),
+            modifiers: vec!["ctrl".to_string()],
+            keys: Vec::new(),
+            action: "duplicate_line".to_string(),
+            args: HashMap::new(),
+            when: None,
+        });
+        let resolver = KeybindingResolver::new(&config);
+        let event = KeyEvent::new(KeyCode::Char('*'), KeyModifiers::CONTROL);
+        assert_eq!(
+            resolver.resolve(&event, KeyContext::Normal),
+            Action::DuplicateLine
+        );
+    }
+
     #[test]
     fn test_parse_modifiers() {
         let mods = vec!["ctrl".to_string()];
@@ -3427,17 +3535,22 @@ mod tests {
         assert_eq!(action.to_qualified_action_str(), "menu_open:Edit");
     }
 
-    /// Issue #1128: a keybinding whose key name doesn't parse (e.g.
-    /// "asterisk", "kp_multiply") is rejected — the entry must be dropped
-    /// (binding nothing) while a `tracing::warn!` at load time names the key
-    /// and action, and the rest of the config must still load. The warning
-    /// itself is emitted by `warn_invalid_key`; here we assert the
-    /// dropped-but-load-continues behavior.
+    /// Issue #1128: a keybinding whose key name doesn't parse is rejected —
+    /// the entry must be dropped (binding nothing) while a `tracing::warn!`
+    /// at load time names the key and action, and the rest of the config
+    /// must still load. The warning itself is emitted by
+    /// `warn_invalid_key`; here we assert the dropped-but-load-continues
+    /// behavior.
+    ///
+    /// The names that started that issue — "asterisk" / "kp_multiply" —
+    /// are no longer in this group: they parse now (see
+    /// `test_parse_key_symbolic_names`). This test needs a name nothing
+    /// claims, so it uses one.
     #[test]
     fn test_unknown_key_name_entry_is_dropped_but_load_continues() {
         let mut config = Config::default();
         config.keybindings.push(crate::config::Keybinding {
-            key: "asterisk".to_string(),
+            key: "no_such_key_name".to_string(),
             modifiers: vec!["ctrl".to_string()],
             keys: Vec::new(),
             action: "duplicate_line".to_string(),
@@ -3454,7 +3567,7 @@ mod tests {
                     modifiers: vec!["ctrl".to_string()],
                 },
                 crate::config::KeyPress {
-                    key: "kp_multiply".to_string(),
+                    key: "also_not_a_key".to_string(),
                     modifiers: Vec::new(),
                 },
             ],

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -2671,7 +2671,12 @@ impl KeybindingResolver {
             "braceleft" => Some(KeyCode::Char('{')),
             "braceright" => Some(KeyCode::Char('}')),
 
-            s if s.len() == 1 => s.chars().next().map(KeyCode::Char),
+            // Character count, not byte count: `"é"` is two bytes, and
+            // spelling it out as a key name used to fall past this arm
+            // into the function-key arm and out as `None` — a binding on
+            // a non-ASCII character silently did nothing, the same class
+            // of quiet drop as the names above (issue #1128).
+            s if s.chars().count() == 1 => s.chars().next().map(KeyCode::Char),
             // Handle function keys like "f1", "f2", ..., "f12"
             s if s.starts_with('f') && s.len() >= 2 => s[1..].parse::<u8>().ok().map(KeyCode::F),
             _ => None,
@@ -3376,6 +3381,10 @@ mod tests {
         // and unrelated names are still rejected.
         assert_eq!(KeybindingResolver::parse_key("*"), Some(KeyCode::Char('*')));
         assert_eq!(KeybindingResolver::parse_key("asterix"), None);
+        // A single non-ASCII character is one key name, not two bytes'
+        // worth of nothing.
+        assert_eq!(KeybindingResolver::parse_key("é"), Some(KeyCode::Char('é')));
+        assert_eq!(KeybindingResolver::parse_key("ñ"), Some(KeyCode::Char('ñ')));
     }
 
     /// The end of the same issue: a config entry spelled with a symbolic

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -3226,3 +3226,65 @@ fn test_search_replace_long_line_match_is_visible() {
          Row:\n{short_row}"
     );
 }
+
+/// The same windowing, on lines whose prefix is not ASCII.
+///
+/// `SearchMatch.column` is a UTF-8 *byte* column while the plugin slices
+/// its context in UTF-16 units. On an ASCII line the two coincide, so a
+/// test built only from ASCII fixtures passes while the feature is broken
+/// for a whole class of real files: a CJK prefix inflates the column 3x
+/// and a non-BMP one 2x, sliding the window past the match. The row then
+/// renders the region *after* the match — strictly worse than the
+/// head-truncation the windowing replaced.
+#[test]
+fn test_search_replace_multibyte_prefix_match_is_visible() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    // Both lines run past the 512-char context cap, so the match-anchored
+    // cap slice is exercised as well as the display window.
+    for (name, lead) in [("cjk.txt", "漢"), ("emoji.txt", "😀")] {
+        let line = format!(
+            "{}{}NEEDLE_MARKER{}",
+            lead.repeat(200),
+            "x".repeat(900),
+            "y".repeat(900)
+        );
+        fs::write(project_root.join(name), format!("{line}\n")).unwrap();
+    }
+    fs::write(project_root.join("plain.txt"), "a NEEDLE_MARKER here\n").unwrap();
+
+    let start_file = project_root.join("plain.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        44,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("NEEDLE_MARKER").unwrap();
+    wait_for_search_finished(&mut harness);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("emoji.txt:1"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    for name in ["cjk.txt", "emoji.txt"] {
+        let row = screen
+            .lines()
+            .find(|l| l.contains(&format!("{name}:1")))
+            .unwrap_or_else(|| panic!("no row for the {name} match. Screen:\n{screen}"))
+            .to_string();
+        assert!(
+            row.contains("NEEDLE_MARKER"),
+            "the match is not shown on a line with a multibyte prefix — \
+             the byte column has to be converted to the unit the context \
+             is sliced by before it anchors the window. Row:\n{row}\n\
+             Screen:\n{screen}"
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -3052,3 +3052,124 @@ fn test_search_replace_bracketed_paste_reaches_fields() {
          Screen:\n{screen}"
     );
 }
+
+/// Issue #1580: a match far along a long line must still be visible in
+/// its result row.
+///
+/// The row used to render the head of the line and truncate, so a match
+/// past the panel's width was never shown — and there is no horizontal
+/// scroll in the results tree to go find it. The window now slides to
+/// bring the match in, marking the elided head with a leading ellipsis.
+#[test]
+fn test_search_replace_long_line_match_is_visible() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    // The match sits at column 257 of a 290-column line — well past
+    // anything a 120-column panel can show from the start of the line.
+    let long_line = format!("{}NEEDLE_MARKER{}", "x".repeat(256), "y".repeat(21));
+    assert_eq!(long_line.chars().count(), 290);
+    fs::write(
+        project_root.join("long.txt"),
+        format!("start {long_line}\n"),
+    )
+    .unwrap();
+    // And one past the 512-char cap the plugin applies before any
+    // per-codepoint work: that cap used to be anchored at the start of
+    // the line, so a match beyond it was discarded before the row was
+    // even laid out.
+    let huge_line = format!("{}NEEDLE_MARKER{}", "x".repeat(2000), "y".repeat(1000));
+    fs::write(project_root.join("huge.txt"), format!("{huge_line}\n")).unwrap();
+    // Two matches far apart on one long line: each gets its own row, and
+    // each row must window onto *its own* match rather than both landing
+    // on the first one.
+    let multi_line = format!(
+        "{}NEEDLE_MARKER{}NEEDLE_MARKER{}",
+        "a".repeat(40),
+        "b".repeat(300),
+        "c".repeat(40),
+    );
+    fs::write(project_root.join("multi.txt"), format!("{multi_line}\n")).unwrap();
+    // A short match too, so the ordinary (unwindowed) row is covered by
+    // the same assertion pass.
+    fs::write(project_root.join("short.txt"), "a NEEDLE_MARKER here\n").unwrap();
+
+    let start_file = project_root.join("short.txt");
+    // Tall enough that every file's rows are on screen at once — this
+    // test reads the rows, so none of them may be scrolled off.
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        44,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("NEEDLE_MARKER").unwrap();
+    wait_for_search_finished(&mut harness);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("long.txt:1"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let long_row = screen
+        .lines()
+        .find(|l| l.contains("long.txt:1"))
+        .unwrap_or_else(|| panic!("no row for the long-line match. Screen:\n{screen}"))
+        .to_string();
+    assert!(
+        long_row.contains("NEEDLE_MARKER"),
+        "the matched text is not in its own result row — the row shows \
+         the head of the line and truncates before reaching the match, \
+         and nothing scrolls the row horizontally. Row:\n{long_row}\n\
+         Screen:\n{screen}"
+    );
+    let huge_row = screen
+        .lines()
+        .find(|l| l.contains("huge.txt:1"))
+        .unwrap_or_else(|| panic!("no row for the past-the-cap match. Screen:\n{screen}"))
+        .to_string();
+    assert!(
+        huge_row.contains("NEEDLE_MARKER"),
+        "a match past the 512-char context cap is still not shown — the \
+         cap must be anchored on the match, not on the start of the \
+         line. Row:\n{huge_row}\nScreen:\n{screen}"
+    );
+    let multi_rows: Vec<String> = screen
+        .lines()
+        .filter(|l| l.contains("multi.txt:1"))
+        .map(|l| l.to_string())
+        .collect();
+    assert_eq!(
+        multi_rows.len(),
+        2,
+        "expected one row per match on the shared line. Screen:\n{screen}"
+    );
+    assert!(
+        multi_rows.iter().all(|r| r.contains("NEEDLE_MARKER")),
+        "both rows on the shared line must show their match. \
+         Rows:\n{multi_rows:#?}"
+    );
+    assert_ne!(
+        multi_rows[0].trim(),
+        multi_rows[1].trim(),
+        "the two matches on one line must window onto different parts of \
+         it, not both onto the first hit. Rows:\n{multi_rows:#?}"
+    );
+
+    // The short match still renders from the start of its line: the
+    // window only slides when it has to.
+    let short_row = screen
+        .lines()
+        .find(|l| l.contains("short.txt:1"))
+        .unwrap_or_else(|| panic!("no row for the short match. Screen:\n{screen}"))
+        .to_string();
+    assert!(
+        short_row.contains("a NEEDLE_MARKER here"),
+        "a match that already fits must render its line unwindowed. \
+         Row:\n{short_row}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -3053,6 +3053,59 @@ fn test_search_replace_bracketed_paste_reaches_fields() {
     );
 }
 
+/// The other half of #1960's routing: a bracketed paste belongs to
+/// whatever owns the keyboard, so a panel mounted into a buffer must NOT
+/// take one while a menu (or any other layer) is open over it.
+///
+/// Routing the paste to the panel without asking who owns the keyboard
+/// reintroduces, in mirror image, the bug
+/// `paste_bracketed_into_focused_panel` exists to prevent: text landing
+/// in a field the user cannot see.
+#[test]
+fn test_search_replace_bracketed_paste_declines_under_an_open_menu() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("gamma.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("hello").unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("Search: [hello"))
+        .unwrap();
+
+    // Alt+F opens the File menu over the panel.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("New File"))
+        .unwrap();
+
+    harness.send_paste("LEAKED").unwrap();
+    // Give the paste every chance to land in the field before asserting
+    // it didn't: drive the plugin round trip the accepting path needs.
+    for _ in 0..8 {
+        harness.tick_and_render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("LEAKED"),
+        "the paste reached the search field behind an open menu. \
+         Screen:\n{screen}"
+    );
+}
+
 /// Issue #1580: a match far along a long line must still be visible in
 /// its result row.
 ///

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -3235,7 +3235,8 @@ fn test_search_replace_long_line_match_is_visible() {
 /// for a whole class of real files: a CJK prefix inflates the column 3x
 /// and a non-BMP one 2x, sliding the window past the match. The row then
 /// renders the region *after* the match — strictly worse than the
-/// head-truncation the windowing replaced.
+/// head-truncation the windowing replaced. The column is now a hint that
+/// bounds a search, never a position that is trusted.
 #[test]
 fn test_search_replace_multibyte_prefix_match_is_visible() {
     init_tracing_from_env();
@@ -3282,9 +3283,85 @@ fn test_search_replace_multibyte_prefix_match_is_visible() {
         assert!(
             row.contains("NEEDLE_MARKER"),
             "the match is not shown on a line with a multibyte prefix — \
-             the byte column has to be converted to the unit the context \
-             is sliced by before it anchors the window. Row:\n{row}\n\
-             Screen:\n{screen}"
+             the window must anchor on a hit located in the line itself, \
+             not on arithmetic over a byte column the slicing does not \
+             count in. Row:\n{row}\nScreen:\n{screen}"
         );
     }
+}
+
+/// A row whose pattern the renderer cannot locate must show the HEAD of
+/// the line, not a slice from the middle of it dressed up as the head.
+///
+/// The window is anchored on a hit found in the line itself, and when
+/// there is no such hit the anchor collapses to 0. Without that, the
+/// anchor came from `match.column` arithmetic, which is happy to point
+/// into a line the renderer can't confirm — so the row rendered
+/// characters from the middle of a long line with a trailing `...`
+/// implying nothing had been cut on the left. It reads as the start of
+/// the line when it isn't.
+///
+/// Driven with a regex Rust's engine accepts and JavaScript's rejects:
+/// the search finds the matches, the plugin's `new RegExp` throws, and
+/// the renderer is left with no locatable hit. That is the same state
+/// the panel is in whenever it renders the previous search's rows
+/// against a pattern that is still being typed, but reached
+/// deterministically instead of through a race.
+#[test]
+fn test_search_replace_unlocatable_pattern_renders_line_head() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    // Past the 512-char context cap, with the match far along it. The
+    // head carries a distinctive marker: filler alone cannot tell "the
+    // head of the line" apart from "a slice of the filler", which is
+    // exactly how this test first passed against the bug it targets.
+    let long_line = format!(
+        "HEAD_MARKER{}NEEDLE_MARKER{}",
+        "a".repeat(1700),
+        "b".repeat(1700)
+    );
+    fs::write(project_root.join("long.txt"), format!("{long_line}\n")).unwrap();
+
+    let start_file = project_root.join("long.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    // Alt+R turns on Regex; the inline `(?i)` flag is valid in the Rust
+    // regex crate and a SyntaxError in JavaScript.
+    harness
+        .send_key(KeyCode::Char('r'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("(?i)NEEDLE_MARKER").unwrap();
+    wait_for_search_finished(&mut harness);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("long.txt:1"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let row = screen
+        .lines()
+        .find(|l| l.contains("long.txt:1"))
+        .unwrap_or_else(|| panic!("no row for the long-line match. Screen:\n{screen}"))
+        .to_string();
+    let body = row.split(" - ").nth(1).unwrap_or("").trim();
+    assert!(
+        body.starts_with("HEAD_MARKER"),
+        "with no locatable hit the row must fall back to the head of the \
+         line; it rendered a slice from elsewhere in it. Row:\n{row}"
+    );
+    assert!(
+        !body.starts_with('\u{2026}'),
+        "a row that starts at the head of the line must not claim a \
+         left-hand elision. Row:\n{row}"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -2985,3 +2985,70 @@ fn test_search_results_grow_with_the_panel_on_resize() {
          before the resize, {after} after. Screen:\n{screen}"
     );
 }
+
+/// Issue #1960: a terminal-initiated bracketed paste (right-click /
+/// middle-click / Ctrl+Shift+V) must land in the panel's focused field.
+///
+/// It arrives as a single `Event::Paste`, not as key events, so it never
+/// passes through the widget key routing that makes `Ctrl+V` work here.
+/// Before the fix it fell through to `paste_text`, which targeted the
+/// panel's own read-only widget buffer and refused with "Editing disabled
+/// in this buffer" — nothing reached the field.
+#[test]
+fn test_search_replace_bracketed_paste_reaches_fields() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("gamma.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Config::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+
+    // Search field is focused on open: the paste is the whole pattern.
+    // Wait on either outcome — the text landing, or the refusal the bug
+    // produced — so a regression fails with the screen rather than
+    // hanging on a condition that will never come true.
+    harness.send_paste("hello").unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("Search: [hello") || s.contains("Editing disabled")
+        })
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Search: [hello") && !screen.contains("Editing disabled"),
+        "the bracketed paste did not reach the focused search field. \
+         Screen:\n{screen}"
+    );
+    // And it is a real pattern, not just glyphs in a box: the search runs.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("alpha.txt:1"))
+        .unwrap();
+
+    // Same for the Replace field, one Tab away.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.send_paste("goodbye").unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("Replace: [goodbye") || s.contains("Editing disabled")
+        })
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Replace: [goodbye") && !screen.contains("Editing disabled"),
+        "the bracketed paste did not reach the focused replace field. \
+         Screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Try it

Everything below is copy-pasteable and non-destructive — it uses a scratch `HOME`, so your own config is untouched. The before/after output is captured from real runs of `master` (`cf626fc`) and this branch (`1d46cb9`), same fixture, same terminal size, not written from memory.

<details open>
<summary><b>Setup</b></summary>

```sh
cargo build                     # -> target/debug/fresh
FRESH=$PWD/target/debug/fresh

mkdir -p /tmp/srdemo && cd /tmp/srdemo && git init -q
printf 'alpha needle beta\n' > plain.txt
python3 - <<'EOF'
# match at column 263 of a 296-column line — past what the panel can show
open("long.txt", "w").write("start " + "x"*256 + "needle" + "y"*28 + "\n")
# same, behind a multibyte prefix (200 CJK chars = 600 bytes)
open("cjk.txt",  "w").write("漢"*200 + "x"*900 + "needle" + "y"*900 + "\n")
EOF

export DEMO_HOME=/tmp/srdemo-home
mkdir -p "$DEMO_HOME/.config/fresh"
cat > "$DEMO_HOME/.config/fresh/config.json" <<'JSON'
{ "keybindings": [ { "key": "kp_multiply", "action": "select_all" } ] }
JSON

HOME="$DEMO_HOME" "$FRESH" --no-restore
```
</details>

### 1. Terminal paste into Search & Replace — #1960

**Steps:** `Alt+A` to open the panel (the Search field has focus), then paste from the terminal — `Ctrl+Shift+V`, middle-click, or right-click → Paste. (Scripted: `tmux paste-buffer -p`.)

| | |
|---|---|
| **before** | Field stays empty. Status bar: `Editing disabled in this buffer` |
| **after** | `Search: [needle              ]  (3 matches / 3 files)`, status `Found 3 matches` |

`Tab` to the Replace field and paste again — same result. Two controls that should be unaffected: pasting into a normal buffer, and into the `Ctrl+F` prompt.

### 2. A match far along a long line is visible — #1580

**Steps:** with the panel open, type `needle`. Look at the `long.txt` and `cjk.txt` rows.

**before** — the match is nowhere on screen; the row shows the head of the line and truncates:
```
[v] cjk.txt:1   - 漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢…
[v] long.txt:1  - start xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
[v] plain.txt:1 - alpha needle beta
```

**after** — the window slides to bring the match in, `…` marking what was cut:
```
[v] cjk.txt:1   - …xxxxxxxxxxxxxxxxxxxxxxxneedleyyyyyyyyyyyyyyyyyyyyyyyyyy
[v] long.txt:1  - …xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxneedleyyyyyyyyyyyyyyy
[v] plain.txt:1 - alpha needle beta
```

`cjk.txt` is the one worth checking: the match position arrives as a *byte* column while the row is sliced in UTF-16 units, so an ASCII-only test passes while this case is broken. A short row like `plain.txt` must stay exactly as it was — the window only moves when it has to.

### 3. A symbolic key name actually binds — #1128

**Steps:** the setup config binds `kp_multiply` (the X11 keysym spelling) to `select_all`. Open a file and press `*`.

| | |
|---|---|
| **before** | A literal `*` is typed into the buffer; the binding never fires. `[⚠ 1]` sits in the status bar — the entry was dropped |
| **after** | The buffer is selected (cursor jumps to the end, whitespace shown as `·`); nothing is inserted, and no `⚠` badge |

The reported symptom of #1128, `Ctrl+*`, is **not** fixed and can't be — see that section below.

### 4. Two things that must NOT change

- **Paste must not leak under an overlay.** With the panel focused, press `Alt+F` to open the File menu, then terminal-paste. The Search field must be unchanged. (An earlier revision of this PR appended the text to the field *behind* the menu; that's what the third commit fixes.)
- **`Alt+]` still switches splits** from the panel. It was broken when #1580 was filed, but #2930's fix already landed on master — there is no change here, and it's listed so you can confirm nothing regressed.

---

Three input-routing fixes, plus four follow-up commits fixing defects that review found in the first three. Every issue was re-reproduced on master before any code was written, driving the editor interactively in tmux with real keystrokes.

## #1960 — bracketed paste is not routed to the Search & Replace panel

**Reproduced.** `Alt+A`, then `tmux paste-buffer -p`: nothing lands in the search field and the status bar reads `Editing disabled in this buffer`. Same in the Replace field. `Ctrl+V` works in both.

A bracketed paste arrives as a single `Event::Paste`, so it never passes through the widget key routing that `Action::Paste` (`Ctrl+V`) uses to reach a focused `Text` widget. `paste_bracketed_into_focused_panel` handled the Settings modal, floating panels and docks — the S&R panel is none of those (it is a widget panel rendered into a read-only widget buffer in a split), so the paste fell through to `paste_text` and hit that buffer's read-only gate.

It now routes to the same widget target the key path uses, `focused_text_widget_panel_for_buffer` on the active buffer, **gated on who owns the keyboard**. My first attempt guarded only on `prompt.is_some()`, which was the wrong question: with the File menu open over the panel, a terminal paste was appended to the search field *behind the menu* and the search re-ran — in mirror image the bug this function exists to prevent. It now asks the overlay stack, so a menu, prompt, modal, context menu or key-capturing popup all decline by declaring themselves rather than by being named in a list here.

Two deliberate non-changes, so the claim is not broader than the code: the file explorer sits inside the editor's own layer and is declined explicitly rather than silently redirected — `Action::Paste` sends it to `file_explorer_paste`, and wiring a bracketed paste there is a separate change. So the two paste paths agree on the *widget target*, not on every arm.

## #1580 — the two remaining Search & Replace defects

### 1. A match far along a long line was never visible — **fixed**

**Reproduced.** A match at column 257 of a 290-column line rendered as `long.txt:1 - start xxxx…xx..`, with the matched text nowhere on screen; `Right`, `End` and Shift+WheelDown changed nothing.

Two truncations discarded it: the plugin's 512-char context cap sliced from the start of the line, and the display-width truncation then cut the head of what was left. Both are now anchored on the match, which slides the window right when the match falls past the row's width, marking each elided end with `…`. A line with several matches yields one row per match and each anchors on its own.

**Corrections to earlier revisions of this description**, since review disproved two of its claims:

- It said the window "carries half a cap of slack" and was therefore safe against `match.column` being a byte column while the slicing counts UTF-16 units. Wrong: a CJK prefix inflates the column 3x, so ~128 such characters ahead of a match put the window past it entirely, and the row then rendered the text *after* the match. The ASCII-only test suite passed throughout.
- The replacement — converting the column — then reintroduced the unbounded per-row work `CONTEXT_HARD_CAP` exists to prevent (14.9 ms per flush on a 50 KB minified line, against 0.83 ms for the native search that replaced it).

The anchor is now a hit **located in the line itself**, with the byte column used only as an upper bound to search back from — sound because a byte offset is never smaller than the UTF-16 index of the same position. That also removes a dependence review caught: `resolveMatchTarget` rewrites `line`/`column` after a jump or replace and leaves `context` at its grep-time value, so the two can describe different strings. No locatable hit means no anchor, and the row falls back to the head of the line rather than presenting a mid-line slice as one.

Also correcting a performance claim: the per-codepoint work downstream is bounded as before, but locating the match adds a native scan per long row. Roughly double, not unchanged.

**Open question for the maintainer — this does not add horizontal scrolling.** Making the results tree pan sideways is a design decision I did not want to make unilaterally:

- `Left` / `Right` are already the Tree's collapse/expand (`lateral` in `widgets/kinds/tree.rs`), which is what the issue asks to rebind. Some other chord would have to own panning, in a mode whose bindings are already dense.
- No widget kind has a horizontal offset today — `PaintedWindow::offset` counts rows only — so Shift+wheel has nothing to move.
- The plugin truncates each row to the panel width before the host sees it, so a host-side h-offset would scroll onto padding. Real panning means the plugin sends full-width rows and the host slices, which changes the row-building contract.

Auto-windowing removes the reason most people reach for horizontal scroll — seeing the match — so it seemed worth landing on its own. Happy to follow up with panning given a preference on the keys.

### 2. `Alt+]` does not switch splits from the panel — **no longer reproduces; not fixed here**

Same root cause as #2930 (`ESC ]` swallowed as an OSC introducer), and #2930's fix is on master. Re-checked on `cf626fc` in a plain tmux with no kitty keyboard protocol:

- `Alt+]` from the S&R panel switches to the editor split (`Switched to next split`), and again back.
- The keybinding editor's record mode captures it: `Record Key: Alt+]`, filtering to the two `Alt+]` bindings — the repro comment's evidence was that it recorded *nothing*.

No code change for this one.

## #1128 — symbolic key names in config

The reported symptom (`Ctrl+*` not firing) is not fixable in Fresh — a legacy-encoding terminal strips the modifier before Fresh sees the key — and is untouched here.

Of the actionable secondary finding, **half is already on master**: an unparseable key name is no longer silent. `warn_invalid_key` logs at load and that lights the status bar's `[⚠ N]` badge.

Missing was the other half — the names. `"key": "asterisk"` (what the issue was configured with) parsed as nothing, and so did `kp_multiply`, `backslash`, `quotedbl` and the rest. `parse_key` now accepts the X11 keysym spellings for ASCII punctuation, alongside the single-character name, which stays canonical. Keypad aliases resolve to the characters their key transmits, since a terminal reports the numeric keypad through its ASCII byte — so binding `kp_multiply` also binds the main-keyboard `*`; they are not distinguishable at this layer.

A separate quiet drop one line below that table is fixed too: the single-character arm measured *bytes*, so `"é"` was two bytes and fell through to `None`.

Verified in tmux: `{"key": "asterisk", "modifiers": ["ctrl"], …}` fires on the CSI-u encoding `ESC[42;5u` (note: that is CTRL only — a kitty-protocol terminal on a US layout would send CTRL|SHIFT, which this binding would not match; unverified either way).

Not done, and arguably should be: `docs/features/keybinding-editor.md` still documents `key` as `"s" / "Enter" / "F1" / "Up"` with no list of the accepted names, and the keypad coverage stops at the arithmetic keys (`kp_enter`, `kp_0`…`kp_9` are not there). Say the word and I'll add both.

## Tests

Each new test verified to fail on master, or without its specific fix, and pass with it:

- `test_search_replace_bracketed_paste_reaches_fields` — `Event::Paste` into both panel fields; fails on master with the `Editing disabled` screen.
- `test_search_replace_bracketed_paste_declines_under_an_open_menu` — fails against the `prompt.is_some()` gate with `LEAKED` in the field behind the menu.
- `test_search_replace_long_line_match_is_visible` — a match past the row width, one past the 512-char cap, two matches on one line rendering differently, and a short match still unwindowed.
- `test_search_replace_multibyte_prefix_match_is_visible` — CJK and non-BMP prefixes.
- `test_search_replace_unlocatable_pattern_renders_line_head` — drives the no-hit fallback deterministically with `(?i)…`, a regex the Rust engine accepts and JavaScript rejects.
- `test_parse_key_symbolic_names`, `test_symbolic_key_name_binds_from_config` — the names parse and a config entry using one registers.
- `test_unknown_key_name_entry_is_dropped_but_load_continues` moves to a name nothing claims, since the two it used now bind.

Two of these first passed against the bug they targeted — the multibyte one because every fixture was ASCII, the head-fallback one because filler alone cannot distinguish "the head of the line" from "a slice of the filler". Both were caught by running each new test against the unfixed code, which is the only reason they are load-bearing now.

Checks: `cargo fmt --all --check`, `cargo clippy --all-targets` (no warnings in the changed files; the one `sort_by_key` note in `overlay.rs` is on master too), `cargo build`, `check-types.sh search_replace.ts` (adds no errors; the four in `lib/widgets.ts` are on master too), and the `e2e::search_replace` (51), `paste`/`menu_bar`/`markdown_compose` (281) and `overlay`/`explorer`/`keybinding` (308) suites.

Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMy6GBN9N5HLMGe8oUvUQX