### PR TITLE
fix(orchestrator): the folder popup keeps the keyboard, and three on-disk names that were not names

### DIFF
--- a/crates/fresh-editor-core/src/path_encode.rs
+++ b/crates/fresh-editor-core/src/path_encode.rs
@@ -6,6 +6,73 @@
 
 use std::path::Path;
 
+/// The longest filename [`encode_path_for_filename`] will return.
+///
+/// `NAME_MAX` is 255 bytes on Linux and macOS, and **every caller appends to
+/// this** — `.json` for a workspace snapshot, `-3.txt` and `-3.log` for a
+/// terminal's scrollback — so the budget is not the whole of `NAME_MAX`. 200
+/// leaves each of them room.
+const MAX_ENCODED_LEN: usize = 200;
+
+/// Marks a name [`fold_to_max_len`] shortened.
+///
+/// A literal `~` can carry that meaning because the encoder can never emit
+/// one: `~` is not in the pass-through set, so an actual tilde in a path
+/// comes out as `%7E`. Its presence therefore means exactly one thing, which
+/// is what lets `decode_filename_to_path` decline a folded name instead of
+/// handing back a path that was never encoded.
+const FOLD_MARK: char = '~';
+
+/// FNV-1a over the path, spelled out rather than reached for.
+///
+/// The hash names a file that outlives the process, so it has to give the
+/// same answer next week and in the next release. `DefaultHasher` documents
+/// that it does not promise that across Rust versions; twelve lines here do.
+fn fold_hash(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Shorten an over-long encoding to `<head>~<hash>`, keeping it unique.
+///
+/// **Why an encoding can outgrow a filename at all.** A path is encoded whole
+/// — every separator becomes an `_` — so the name grows with the depth of the
+/// directory, and the orchestrator nests one encoded path inside another: a
+/// workspace lives under `orchestrator/<slug of the repo root>/<name>`, and
+/// naming *its* terminal directory encodes that path a second time. Two
+/// encodings of one path, plus a long workspace name, is how a real repo
+/// checked out under a long root reached `File name too long (os error 36)`
+/// and left the workspace with nowhere to write its terminals (#1971).
+///
+/// The head keeps the tail of the path readable in a directory listing; the
+/// hash is what keeps two paths sharing a 183-character prefix apart. It runs
+/// over the *path*, not the truncated head, so the digest cannot be truncated
+/// with it.
+fn fold_to_max_len(encoded: String, path_str: &str) -> String {
+    if encoded.len() <= MAX_ENCODED_LEN {
+        return encoded;
+    }
+    // 1 mark + 16 hex digits.
+    const SUFFIX_LEN: usize = 17;
+    let keep = MAX_ENCODED_LEN - SUFFIX_LEN;
+    // The encoder emits ASCII and nothing else — every other byte is
+    // percent-escaped — so cutting on a byte is cutting on a character. It
+    // can still land *inside* a `%XX` triple, which would leave a stray `%`
+    // or a half-escape that decodes as text, so back off to the escape's
+    // start.
+    let mut head = &encoded[..keep];
+    if head.ends_with('%') {
+        head = &head[..head.len() - 1];
+    } else if head.len() >= 2 && head.as_bytes()[head.len() - 2] == b'%' {
+        head = &head[..head.len() - 2];
+    }
+    format!("{head}{FOLD_MARK}{:016x}", fold_hash(path_str.as_bytes()))
+}
+
 /// Encode a path into a filesystem-safe filename using percent encoding
 ///
 /// Keeps alphanumeric chars, `-`, `.`, `_` as-is.
@@ -13,6 +80,11 @@ use std::path::Path;
 /// Percent-encodes other special characters as %XX.
 ///
 /// Example: `/home/user/my project` -> `home_user_my%20project`
+///
+/// A path whose encoding would exceed [`MAX_ENCODED_LEN`] is folded to
+/// `<head>~<hash>` — see [`fold_to_max_len`]. That form is deliberately not
+/// reversible, and `workspace::decode_filename_to_path` declines it rather
+/// than inventing a path.
 pub fn encode_path_for_filename(path: &Path) -> String {
     let path_str = path.to_string_lossy();
     let mut result = String::with_capacity(path_str.len() * 2);
@@ -57,5 +129,55 @@ pub fn encode_path_for_filename(path: &Path) -> String {
         final_result = "root".to_string();
     }
 
-    final_result
+    fold_to_max_len(final_result, &path_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_path_that_fits_is_encoded_whole() {
+        let encoded = encode_path_for_filename(Path::new("/home/user/project"));
+        assert_eq!(encoded, "home_user_project");
+        assert!(!encoded.contains(FOLD_MARK));
+    }
+
+    /// The orchestrator nests one encoded path inside another, so a workspace
+    /// under a long root ran past `NAME_MAX` and its terminal directory could
+    /// not be created at all — `File name too long (os error 36)` (#1971).
+    #[test]
+    fn an_over_long_path_folds_under_the_cap_and_stays_unique() {
+        let deep = format!("/{}/workspace", "a_very_long_directory_name/".repeat(20));
+        let sibling = format!("{deep}-two");
+        let a = encode_path_for_filename(Path::new(&deep));
+        let b = encode_path_for_filename(Path::new(&sibling));
+
+        assert!(a.len() <= MAX_ENCODED_LEN, "{} bytes", a.len());
+        assert!(b.len() <= MAX_ENCODED_LEN, "{} bytes", b.len());
+        // Long enough to have been folded, and marked as such.
+        assert!(a.contains(FOLD_MARK));
+        // Two paths sharing every one of the kept characters still differ,
+        // because the hash runs over the path and not over the head.
+        assert_ne!(a, b, "a shared prefix must not collapse two workspaces");
+        assert_eq!(a, encode_path_for_filename(Path::new(&deep)), "stable");
+    }
+
+    /// The cut is taken on the encoded form, where a `%XX` escape is three
+    /// characters that mean one byte. Landing inside one would leave a stray
+    /// `%` that reads back as literal text.
+    #[test]
+    fn folding_never_cuts_a_percent_escape_in_half() {
+        // Spaces encode to `%20`, so escapes land at every offset in turn.
+        for pad in 0..8 {
+            let path = format!("/{}{} x", "b".repeat(pad), " x".repeat(200));
+            let encoded = encode_path_for_filename(Path::new(&path));
+            let head = encoded.split(FOLD_MARK).next().unwrap();
+            assert!(!head.ends_with('%'), "{head}");
+            assert!(
+                !(head.len() >= 2 && head.as_bytes()[head.len() - 2] == b'%'),
+                "{head}"
+            );
+        }
+    }
 }

--- a/crates/fresh-editor-core/src/path_encode.rs
+++ b/crates/fresh-editor-core/src/path_encode.rs
@@ -6,13 +6,28 @@
 
 use std::path::Path;
 
-/// The longest filename [`encode_path_for_filename`] will return.
+/// The longest filename [`encode_path_for_filename`] will return: `NAME_MAX`
+/// itself.
 ///
-/// `NAME_MAX` is 255 bytes on Linux and macOS, and **every caller appends to
-/// this** — `.json` for a workspace snapshot, `-3.txt` and `-3.log` for a
-/// terminal's scrollback — so the budget is not the whole of `NAME_MAX`. 200
-/// leaves each of them room.
-const MAX_ENCODED_LEN: usize = 200;
+/// **The cap is what decides which existing names get re-keyed, so it is the
+/// largest one that changes nothing.** This value is not a budget for the
+/// callers that append to the encoding — it deliberately is not. Folding is a
+/// rename, and every place the encoding is a *key* (a workspace snapshot, the
+/// recovery scope, a terminal's scrollback directory, a daemon's socket) would
+/// stop finding what the previous release wrote. So the only names that may
+/// fold are the ones no caller could have created at all, which means the
+/// filesystem's own limit and not a byte less.
+///
+/// Leaving headroom for a suffix would have been wrong in both directions.
+/// Several callers append nothing — `terminal_dir_for`, `working_data_dir_for`,
+/// `project_state_dir` and the recovery scope each join the encoding as a whole
+/// directory name — so a 250-byte encoding is live today and must not move.
+/// And the longest suffix is not a small constant either: `workspace_path_for`
+/// builds `<encoded>.<stable_id>.json`, and a `ws-<hex>-<hex>` id makes that
+/// roughly 28 bytes. A name that overflows *with* a suffix but fits without one
+/// is a caller-specific limit, and it is no better or worse here than it was
+/// before this cap existed.
+const MAX_ENCODED_LEN: usize = 255;
 
 /// Marks a name [`fold_to_max_len`] shortened.
 ///
@@ -49,10 +64,21 @@ fn fold_hash(bytes: &[u8]) -> u64 {
 /// and left the workspace with nowhere to write its terminals (#1971).
 ///
 /// The head keeps the tail of the path readable in a directory listing; the
-/// hash is what keeps two paths sharing a 183-character prefix apart. It runs
-/// over the *path*, not the truncated head, so the digest cannot be truncated
-/// with it.
-fn fold_to_max_len(encoded: String, path_str: &str) -> String {
+/// hash is what keeps two paths sharing a 238-character prefix apart. It runs
+/// over the whole encoding, not the truncated head, so the digest cannot be
+/// truncated with it.
+///
+/// **Over the encoding rather than the path, because the encoding is the
+/// normalised form.** `encode_path_for_filename` maps several spellings of one
+/// path onto one name: both separators become `_`, runs of them collapse, and a
+/// leading one is stripped, so `/a/b`, `/a//b`, `/a/b/` and `a/b` already share
+/// a filename. Digesting the raw path would have broken that for exactly the
+/// long paths that fold — same head, different hash, two directories for one
+/// place — and neither `terminal_dir_for` nor `working_data_dir_for`
+/// canonicalises what it is given (`spawn_terminal_session_impl` passes a
+/// caller-supplied `cwd` straight through), so a trailing separator would have
+/// been enough to strand a workspace's scrollback beside itself.
+fn fold_to_max_len(encoded: String) -> String {
     if encoded.len() <= MAX_ENCODED_LEN {
         return encoded;
     }
@@ -70,7 +96,7 @@ fn fold_to_max_len(encoded: String, path_str: &str) -> String {
     } else if head.len() >= 2 && head.as_bytes()[head.len() - 2] == b'%' {
         head = &head[..head.len() - 2];
     }
-    format!("{head}{FOLD_MARK}{:016x}", fold_hash(path_str.as_bytes()))
+    format!("{head}{FOLD_MARK}{:016x}", fold_hash(encoded.as_bytes()))
 }
 
 /// Encode a path into a filesystem-safe filename using percent encoding
@@ -129,7 +155,7 @@ pub fn encode_path_for_filename(path: &Path) -> String {
         final_result = "root".to_string();
     }
 
-    fold_to_max_len(final_result, &path_str)
+    fold_to_max_len(final_result)
 }
 
 #[cfg(test)]
@@ -146,6 +172,59 @@ mod tests {
     /// The orchestrator nests one encoded path inside another, so a workspace
     /// under a long root ran past `NAME_MAX` and its terminal directory could
     /// not be created at all — `File name too long (os error 36)` (#1971).
+    /// The cap re-keys nothing a previous release could have written: a name
+    /// the filesystem accepts is returned exactly as before.
+    #[test]
+    fn a_name_the_filesystem_accepts_is_never_folded() {
+        // Grown a component at a time until the encoder has to fold. Length
+        // is not the signal here — a folded name is under the cap by
+        // construction, so waiting for one to exceed it never returns — the
+        // mark is.
+        let mut deep = String::from("/a");
+        while !encode_path_for_filename(Path::new(&deep)).contains(FOLD_MARK) {
+            deep.push_str("/bbbbbbbbbb");
+        }
+
+        // One component shorter is the longest name that fits, and it is
+        // untouched — a directory of exactly NAME_MAX bytes is live today.
+        let fits = deep.rsplit_once('/').unwrap().0.to_string();
+        let name = encode_path_for_filename(Path::new(&fits));
+        assert!(name.len() <= MAX_ENCODED_LEN);
+        assert!(
+            !name.contains(FOLD_MARK),
+            "a name that fits must be returned whole, or it stops finding what \
+             the last release wrote under it: {name}"
+        );
+    }
+
+    /// The encoder maps several spellings of one path onto one name, and a
+    /// folded name has to keep doing that — otherwise the head matches, the
+    /// digest does not, and one directory acquires two names.
+    ///
+    /// Only the equivalences the encoder actually provides are asserted. A
+    /// *trailing* separator is not among them: it becomes a trailing `_` that
+    /// nothing strips, so `/a/b/` and `/a/b` name different files here and
+    /// always have. That is worth knowing and is not folding's to fix.
+    #[test]
+    fn folding_keeps_the_encoders_normalisation() {
+        let long = format!("/{}", "a_directory_component/".repeat(30))
+            .trim_end_matches('/')
+            .to_string();
+        let canonical = encode_path_for_filename(Path::new(&long));
+        assert!(canonical.contains(FOLD_MARK), "long enough to fold");
+        for spelling in [
+            long.replace('/', "//"),             // doubled separators collapse
+            long.trim_start_matches('/').into(), // a leading one is stripped
+            long.replace('/', "\\"),             // either separator will do
+        ] {
+            assert_eq!(
+                encode_path_for_filename(Path::new(&spelling)),
+                canonical,
+                "spelling {spelling:?} names the same directory"
+            );
+        }
+    }
+
     #[test]
     fn an_over_long_path_folds_under_the_cap_and_stays_unique() {
         let deep = format!("/{}/workspace", "a_very_long_directory_name/".repeat(20));

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -785,7 +785,12 @@ export function windowEmbed(options: {
     // that value is 0. Mapping to it keeps a placeholder rendering as
     // the blanks it is meant to render, instead of taking the panel
     // down with it.
-    windowId: Number.isFinite(options.windowId) && options.windowId > 0
+    // The range is closed at *both* ends: `u32` has a top as well as a
+    // bottom, and an id above it fails to deserialise exactly as a negative
+    // one does — same rejected spec, same frozen panel.
+    windowId: Number.isFinite(options.windowId) &&
+        options.windowId > 0 &&
+        options.windowId <= 0xffff_ffff
       ? Math.trunc(options.windowId)
       : 0,
     rows: options.rows,

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -759,7 +759,9 @@ export function textInput(
  * reserved rectangle.
  *
  * `windowId` of 0 (or any unknown id) renders the placeholder
- * blanks without dispatching the per-window paint. */
+ * blanks without dispatching the per-window paint — which is also
+ * what a `windowId` that names no window at all is normalised to,
+ * see below. */
 export function windowEmbed(options: {
   windowId: number;
   rows: number;
@@ -767,7 +769,25 @@ export function windowEmbed(options: {
 }): WidgetSpec {
   return {
     kind: "windowEmbed",
-    windowId: options.windowId,
+    // **A window id the host cannot hold is "no window", not a broken
+    // panel.** The host reads this field as a `u32`, so a negative or
+    // fractional id fails to deserialise — and it fails for the *whole
+    // spec*, which the host then drops: `updateFloatingWidget` logs
+    // `invalid spec` and the panel keeps painting whatever it last
+    // showed. A plugin that embeds a placeholder row therefore froze
+    // its own panel, and the user saw a stuck card that only unstuck on
+    // the next keystroke that happened to produce a valid spec
+    // (sinelaw/fresh#1971: the orchestrator's synthetic ids for
+    // workspaces that have no window yet, which left the picker on
+    // "Archiving… / Waiting for git…" after the archive had finished).
+    //
+    // "No window" is a state this widget already has a value for, and
+    // that value is 0. Mapping to it keeps a placeholder rendering as
+    // the blanks it is meant to render, instead of taking the panel
+    // down with it.
+    windowId: Number.isFinite(options.windowId) && options.windowId > 0
+      ? Math.trunc(options.windowId)
+      : 0,
     rows: options.rows,
     key: options.key,
   };

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5875,7 +5875,13 @@ function archivedPathFor(repoRoot: string, s: AgentSession): string {
     slugify(repoRoot),
     ".archived",
   );
-  const name = editor.pathBasename(s.root) || s.hostLabel || "workspace";
+  // `s.hostLabel` is NOT a fallback here: it is a display string too (the
+  // reconcile sites write it from the window's own label, and the rename path
+  // overwrites it), so falling back to it would put the very characters this
+  // function exists to keep out of a path back into one. A root with no
+  // basename is a filesystem root, which owns no workspace; the constant is
+  // the honest answer.
+  const name = editor.pathBasename(s.root) || "workspace";
   let candidate = editor.pathJoin(graveyard, name);
   for (let n = 2; editor.fileExists(editor.localPath(candidate)); n++) {
     candidate = editor.pathJoin(graveyard, `${name}-${n}`);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5848,6 +5848,41 @@ interface LifecycleResult {
 // discovered on-disk worktrees (the latter have no window to close).
 // Does NOT trigger sync — the caller batches one sync per repo after
 // the whole run.
+// Where a workspace's worktree goes when it is archived.
+//
+// **The name is the worktree's own directory, not the row's label.** A
+// workspace's `label` is a *display* string — `workspaceDisplayName` composes
+// it from the workspace name and the terminal's live tab title — so filing
+// one produced directories like `gamma-…-test · bash — root@vm: ~/…`: spaces,
+// a middle dot, an em dash, a colon, and the `/`s of the title's path, which
+// `git worktree move` read as further directory levels and nested the
+// graveyard under (sinelaw/fresh#1971). The basename of `s.root` is the name
+// git already gave the directory, so it is a valid single component by
+// construction and the archived copy keeps the name it had while it was live.
+//
+// The manifest still records `s.label`, which is what the archive listing
+// shows and what `unarchiveWorkspace` matches a human's name against; it
+// resolves the directory from the recorded `root`, never by rebuilding this
+// path, so what the directory is called is this function's business alone.
+//
+// A repeat archive of the same workspace name would land on a directory that
+// is already there — `git worktree move` refuses that — so an occupied name
+// takes the next free `-2`, `-3`, … instead of failing the archive.
+function archivedPathFor(repoRoot: string, s: AgentSession): string {
+  const graveyard = editor.pathJoin(
+    editor.getDataDir(),
+    "orchestrator",
+    slugify(repoRoot),
+    ".archived",
+  );
+  const name = editor.pathBasename(s.root) || s.hostLabel || "workspace";
+  let candidate = editor.pathJoin(graveyard, name);
+  for (let n = 2; editor.fileExists(editor.localPath(candidate)); n++) {
+    candidate = editor.pathJoin(graveyard, `${name}-${n}`);
+  }
+  return candidate;
+}
+
 async function archiveOne(id: number): Promise<LifecycleResult> {
   const s = orchestratorSessions.get(id);
   if (!s) return { ok: false, err: editor.t("err.workspace_gone") };
@@ -5878,13 +5913,7 @@ async function archiveOne(id: number): Promise<LifecycleResult> {
     // bookkeeping stays consistent and Unarchive can move it back.
     const repoRoot = await worktreeRepoRoot(s);
     if (!repoRoot) return { ok: false, err: editor.t("err.not_git_repo") };
-    const archivedRoot = editor.pathJoin(
-      editor.getDataDir(),
-      "orchestrator",
-      slugify(repoRoot),
-      ".archived",
-      s.label,
-    );
+    const archivedRoot = archivedPathFor(repoRoot, s);
     const parent = editor.pathDirname(archivedRoot);
     if (!editor.createDir(editor.localPath(parent))) {
       return { ok: false, err: editor.t("err.could_not_create", { path: parent }), repoRoot };

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -682,6 +682,7 @@ impl Editor {
                 ui.set_store(shell_store);
                 ui
             }),
+            pending_panel_tree_focus: None,
             shell_pointer_event: None,
             shell_key_event: None,
             shell_interior_took_key: None,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1184,6 +1184,34 @@ pub struct Editor {
     /// keeping `app` and `ui` side by side in `main`.
     pub(crate) shell_ui: Option<fresh_ui::Ui<crate::view::shell::msg::UiMsg>>,
 
+    /// A panel focus move the host decided **before the tree could carry it**,
+    /// held for the one frame it takes the description to catch up.
+    ///
+    /// `Editor::focus_panel_widget_in_tree` is the imperative half of the
+    /// focus mirror: it moves the tree's focus to the widget the registry has
+    /// just been told holds the panel's. It can only move focus to an element
+    /// that *exists*, and the two writes a plugin makes when it opens an
+    /// in-panel dropdown — a new spec, then `setFocusKey` onto a row of it —
+    /// are both applied before the next frame describes that spec. So the
+    /// element the second write names is one the tree will not have until the
+    /// frame after, and the move found nothing to do.
+    ///
+    /// Nothing then re-tried it, and the mirror's *other* direction wrote the
+    /// disagreement back: the tree still held the widget focus never left, so
+    /// its `FocusGained` fact re-pointed the registry at that one and the
+    /// dropdown lost the keyboard it had just been handed. That is #3137 — the
+    /// dock's "Move to Folder…" popup, whose first ↓ dismissed it, moved the
+    /// session list underneath and live-switched the workspace.
+    ///
+    /// Recorded here instead, and replayed by
+    /// `Editor::retry_pending_panel_tree_focus` immediately after the frame
+    /// that builds the element, where the gain it raises is queued *after* the
+    /// stale one and so is the one the next dispatch settles on. One replay,
+    /// never a standing request: the frame that follows the write is built
+    /// from the very spec the write was aimed at, so a widget still absent
+    /// there is not coming.
+    pub(crate) pending_panel_tree_focus: Option<(crate::widgets::PanelKey, String)>,
+
     /// Where the shell tree's `Persisted` values live, and the handle that can
     /// drop a window's.
     ///

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -663,8 +663,19 @@ fn migrate_legacy_windows(
             Ok(e) => e,
             Err(_) => continue,
         };
-        let project_path = crate::workspace::decode_filename_to_path(&dir_name)
-            .unwrap_or_else(|| PathBuf::from(dir_name.clone()));
+        // **A directory name that does not decode leaves `project_path`
+        // unset, rather than storing the filename as if it were one.**
+        //
+        // `decode_filename_to_path` declines a name the encoder had to fold to
+        // fit `NAME_MAX` — the head plus a digest is not a path, and the deep
+        // orchestrator roots this migration walks are exactly where folding
+        // happens. The old `unwrap_or_else` would have written
+        // `…deep-directory-six~18289b17dcb27c00` into every migrated window as
+        // a relative path naming nothing, and unlike a display fallback that
+        // value is *persisted*. Left unset, the window still migrates and
+        // whoever needs a project path resolves it the way it is resolved for
+        // any entry that never carried one.
+        let project_path = crate::workspace::decode_filename_to_path(&dir_name);
 
         let mut local_renum: HashMap<u64, u64> = HashMap::new();
         for mut w in env.windows.into_iter() {
@@ -672,7 +683,7 @@ fn migrate_legacy_windows(
             // the entry already carries one (a partial migration
             // re-running on the same data).
             if w.project_path.is_none() {
-                w.project_path = Some(project_path.clone());
+                w.project_path = project_path.clone();
             }
             if used_ids.contains(&w.id) {
                 let new_id = merged_next_id;

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -379,43 +379,19 @@ impl Editor {
         // the top — is read off the column that laid the cards out.
         self.refresh_settings_body_window();
         let shell = self.shell_frame((dock_area, chrome_area));
-        // The shell's tree is retained across frames — element state, focus and
-        // the dirty set live on it — so it is moved out for the duration of the
-        // frame rather than borrowed from `self`. See `Editor::shell_ui`.
-        // `expect`, not `unwrap_or_default`: silently substituting a fresh
-        // `Ui` would discard every element's state, the focus position and the
-        // dirty set, and the frame would still render — the retained tree's
-        // whole point, lost without a symptom. If this is ever `None` a
-        // re-entrant path took it and did not put it back, which is a bug in
-        // that path.
-        let mut ui = self
+        self.lay_out_shell_tree(shell.clone(), fresh_ui::Size::new(size.width, size.height));
+        let ui = self
             .shell_ui
-            .take()
+            .as_ref()
             .expect("the shell tree is taken and returned within one frame");
-        crate::view::shell::geometry::stats::note_shell_layout();
-        ui.frame(
-            crate::view::shell::frame::frame_tree(shell.clone()),
-            fresh_ui::Size::new(size.width, size.height),
-        );
-        let regions = crate::view::shell::frame::regions_of(&ui, size);
+        let regions = crate::view::shell::frame::regions_of(ui, size);
         // **The frame's one geometry pass, for the panes.** Every pane's box
         // and content slot, off the tree just laid out. The plugin hooks below,
         // the body painter's pass and the pane `Host`s all read this; nothing
         // on the render path lays the grid out again to ask where a pane is.
         // See `view::shell::geometry`.
-        let pane_rects = crate::view::shell::geometry::PaneRects::read(
-            &ui,
-            self.window_panes().into_iter().map(|(leaf, _)| leaf),
-            size,
-        );
-        self.shell_ui = Some(ui);
-        // **A focus the host decided one frame before the tree could carry
-        // it.** The frame above is the first to describe the spec that write
-        // was aimed at, so this is the earliest moment its element exists. The
-        // gain it raises is queued behind the one the stale holder already
-        // left, and `apply_settled_shell_messages` settles on the last —
-        // which is why the replay belongs here and not at the drain.
-        self.retry_pending_panel_tree_focus();
+        let pane_rects =
+            crate::view::shell::geometry::PaneRects::read(ui, self.window_panes_leaves(), size);
         // Retained for the callers that ask between frames where a pane is —
         // the same rects this frame paints with. See `Window::pane_rects`.
         self.active_window_mut().set_pane_rects(pane_rects.clone());
@@ -4329,6 +4305,53 @@ impl Editor {
     /// rectangle this reads, so taking the size as well would be a second way
     /// to say the same thing — and the two could then disagree, which is the
     /// bug above wearing a different hat.
+    /// Lay the shell's retained tree out for one frame, and settle the focus
+    /// moves that were waiting for it.
+    ///
+    /// **One function because they are one step, and because a test that
+    /// re-spelled the step could not fail when the step changed.** The replay
+    /// has to happen on the frame that first builds the element a
+    /// `setFocusKey` named (see [`Editor::pending_panel_tree_focus`]), so it
+    /// belongs to laying the tree out, not beside it. `render` used to spell
+    /// the sequence inline and the widget-runtime tests spelled it again in a
+    /// helper — two copies, and deleting the replay from `render` left the
+    /// copy passing. Now there is one, and #3137 comes back as a test failure.
+    ///
+    /// The tree is retained across frames — element state, focus and the dirty
+    /// set live on it — so it is moved out for the duration rather than
+    /// borrowed from `self`. `expect`, not `unwrap_or_default`: silently
+    /// substituting a fresh `Ui` would discard every element's state, the
+    /// focus position and the dirty set, and the frame would still render —
+    /// the retained tree's whole point, lost without a symptom. If this is
+    /// ever `None` a re-entrant path took it and did not put it back, which is
+    /// a bug in that path.
+    pub(crate) fn lay_out_shell_tree(
+        &mut self,
+        shell: crate::view::shell::frame::Frame,
+        size: fresh_ui::Size,
+    ) {
+        let mut ui = self
+            .shell_ui
+            .take()
+            .expect("the shell tree is taken and returned within one frame");
+        crate::view::shell::geometry::stats::note_shell_layout();
+        ui.frame(crate::view::shell::frame::frame_tree(shell), size);
+        self.shell_ui = Some(ui);
+        // The gain this raises is queued behind the one the stale holder
+        // already left, and `apply_settled_shell_messages` settles on the last
+        // — which is why the replay belongs here and not at the drain.
+        self.retry_pending_panel_tree_focus();
+    }
+
+    /// The active window's pane leaves, collected so a caller can hold the
+    /// tree borrowed while it asks.
+    fn window_panes_leaves(&self) -> Vec<crate::model::event::LeafId> {
+        self.window_panes()
+            .into_iter()
+            .map(|(leaf, _)| leaf)
+            .collect()
+    }
+
     pub(crate) fn shell_frame(
         &mut self,
         split: (Option<ratatui::layout::Rect>, ratatui::layout::Rect),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -409,6 +409,13 @@ impl Editor {
             size,
         );
         self.shell_ui = Some(ui);
+        // **A focus the host decided one frame before the tree could carry
+        // it.** The frame above is the first to describe the spec that write
+        // was aimed at, so this is the earliest moment its element exists. The
+        // gain it raises is queued behind the one the stale holder already
+        // left, and `apply_settled_shell_messages` settles on the last —
+        // which is why the replay belongs here and not at the drain.
+        self.retry_pending_panel_tree_focus();
         // Retained for the callers that ask between frames where a pane is —
         // the same rects this frame paints with. See `Window::pane_rects`.
         self.active_window_mut().set_pane_rects(pane_rects.clone());

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -3334,20 +3334,20 @@ mod tests {
         }
     }
 
-    /// One frame of the shell's tree, without a terminal: the same two calls
-    /// `Editor::render` makes around it.
+    /// One frame of the shell's tree, without a terminal.
+    ///
+    /// **`Editor::lay_out_shell_tree`, not a re-spelling of it.** This used to
+    /// repeat the take/frame/put-back sequence `render` performs, which meant
+    /// a step deleted from `render` was still taken here and the tests went on
+    /// passing — including the one guarding #3137, whose whole subject is a
+    /// call `render` makes after the frame. Calling the same function is what
+    /// makes that test able to fail.
     fn frame_the_shell(editor: &mut Editor) {
         use ratatui::layout::Rect;
         let dock = Rect::new(0, 0, 30, 24);
         let chrome = Rect::new(30, 0, 50, 24);
         let shell = editor.shell_frame((Some(dock), chrome));
-        let mut ui = editor.shell_ui.take().expect("the shell tree");
-        crate::view::shell::geometry::stats::note_shell_layout();
-        ui.frame(
-            crate::view::shell::frame::frame_tree(shell),
-            fresh_ui::Size::new(80, 24),
-        );
-        editor.shell_ui = Some(ui);
+        editor.lay_out_shell_tree(shell, fresh_ui::Size::new(80, 24));
     }
 
     fn button(key: &str) -> WidgetSpec {
@@ -4166,7 +4166,6 @@ mod tests {
         );
 
         frame_the_shell(&mut editor);
-        editor.retry_pending_panel_tree_focus();
 
         let ui = editor.shell_ui.as_ref().expect("the tree");
         assert_eq!(

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -1433,9 +1433,18 @@ impl Editor {
         let holds = ui
             .find_by_key(&crate::view::shell::panel::interior_key(slot))
             .is_some_and(|el| ui.has_focus_within(el));
+        // **The one case that is not "nothing to move": the element is not
+        // there yet.** A plugin that opens an in-panel dropdown writes the
+        // spec carrying its rows and then `setFocusKey` onto one of them, and
+        // both land before the next frame describes either. So this lookup
+        // asks the tree for a widget the *previous* spec had no row for, and
+        // the move it wanted has to wait exactly one frame. See
+        // `Editor::pending_panel_tree_focus`.
+        let mut found = false;
         if holds {
             if let Some(el) = ui.find_by_key(&crate::view::shell::widgets::widget_focus_key(widget))
             {
+                found = true;
                 // `SelectAll` is what the ring's own moves ask for
                 // (`Ui::move_focus`), and a host-driven landing is not a
                 // different kind of landing.
@@ -1443,6 +1452,39 @@ impl Editor {
             }
         }
         self.shell_ui = Some(ui);
+        // A move that landed retires any request still waiting; one that could
+        // not find its element becomes the request. `!holds` is neither — the
+        // tree does not hold this panel's focus, so `autofocus` settles the
+        // landing the next time focus enters it, and a pending write would
+        // fight that.
+        self.pending_panel_tree_focus = match (holds, found) {
+            (true, false) => Some((panel_key.clone(), widget.to_string())),
+            _ => None,
+        };
+    }
+
+    /// Replay the focus move [`Editor::focus_panel_widget_in_tree`] could not
+    /// make, now that the frame has built the element it names.
+    ///
+    /// Called once per frame, immediately after the tree is rebuilt. The
+    /// request is dropped whether or not it lands: the frame just built is the
+    /// one describing the spec the write was aimed at, so a widget missing
+    /// from it is missing for good, and a standing request would keep pulling
+    /// focus back on every later frame.
+    ///
+    /// A request whose widget the registry no longer names has been overtaken
+    /// by a newer focus decision — a Tab, a click, another `setFocusKey` — and
+    /// is dropped without acting, so replaying it cannot undo the newer one.
+    pub(super) fn retry_pending_panel_tree_focus(&mut self) {
+        let Some((panel_key, widget)) = self.pending_panel_tree_focus.take() else {
+            return;
+        };
+        if self.widget_registry.focus_key(&panel_key) != Some(widget.as_str()) {
+            return;
+        }
+        self.focus_panel_widget_in_tree(&panel_key, &widget);
+        // One replay only — see the doc comment.
+        self.pending_panel_tree_focus = None;
     }
 
     /// Update the panel's focused widget AND fire a
@@ -4020,6 +4062,123 @@ mod tests {
             ui.focused(),
             ui.find_by_key(&crate::view::shell::widgets::widget_focus_key("two")),
             "the tree followed the host's write, so the next Tab starts here"
+        );
+    }
+
+    /// **A focus onto a widget the spec has only just grown (#3137).**
+    ///
+    /// The dock's "Move to Folder…" dropdown is two plugin writes: a spec
+    /// carrying the option rows, then `setFocusKey` onto the first of them.
+    /// Both are applied before the frame that describes either, so the
+    /// imperative half of the focus mirror asked the tree for an element the
+    /// tree could not have yet and quietly did nothing. The tree kept the
+    /// focus the dropdown was supposed to take, and its `FocusGained` fact
+    /// then wrote *that* back over the registry — so ↓ was routed to the
+    /// session list underneath, which dismissed the popup, moved the
+    /// selection and live-switched the workspace.
+    ///
+    /// The move is held for the one frame it takes the element to exist.
+    #[test]
+    fn a_focus_onto_a_widget_the_next_frame_builds_lands_on_that_frame() {
+        let (mut editor, _t) = make_editor();
+        let panel_key = crate::widgets::PanelKey::new("test-plugin", 1);
+        // Rendering a spec into the registry exactly as mount/update do.
+        let render = |spec: &WidgetSpec, prev_focus: &str| {
+            super::render_floating_spec(
+                false,
+                spec,
+                &Default::default(),
+                &Default::default(),
+                prev_focus,
+                30,
+                None,
+                "",
+                "",
+                "",
+                None,
+                true,
+            )
+        };
+        // The dock before the dropdown: a list, and nothing else to focus.
+        let closed = WidgetSpec::Col {
+            children: vec![button("sessions")],
+            key: None,
+        };
+        let out = render(&closed, "");
+        editor.widget_registry.mount(
+            panel_key.clone(),
+            crate::app::PanelSlot::Dock.buffer_id(),
+            closed,
+            out.hits,
+            out.instance_states,
+            out.focus_key,
+            out.tabbable,
+            out.painted,
+            out.boxes,
+            true,
+        );
+        editor.dock = Some(dock_panel(panel_key.clone()));
+        frame_the_shell(&mut editor);
+        let ui = editor.shell_ui.as_ref().expect("the tree");
+        assert_eq!(
+            ui.focused(),
+            ui.find_by_key(&crate::view::shell::widgets::widget_focus_key("sessions")),
+            "the frame settled on the list, which is all there was"
+        );
+
+        // The dropdown opens: the spec grows an option row, and the plugin
+        // hands it the keyboard. Both land before the next frame.
+        let open = WidgetSpec::Col {
+            children: vec![
+                button("sessions"),
+                WidgetSpec::Overlay {
+                    child: Box::new(WidgetSpec::Col {
+                        children: vec![button("menu-pick:move:root")],
+                        key: None,
+                    }),
+                    key: Some("move-menu".into()),
+                },
+            ],
+            key: None,
+        };
+        let out = render(&open, "sessions");
+        editor
+            .widget_registry
+            .update(
+                &panel_key,
+                open,
+                out.hits,
+                out.instance_states,
+                out.focus_key,
+                out.tabbable,
+                out.painted,
+                out.boxes,
+            )
+            .expect("the panel is mounted");
+        editor.set_panel_focus_and_notify(&panel_key, "menu-pick:move:root".to_string());
+
+        // The tree cannot carry it yet — the option row is not in the frame
+        // that is currently built — so the move is held rather than dropped.
+        assert_eq!(
+            editor.pending_panel_tree_focus,
+            Some((panel_key.clone(), "menu-pick:move:root".to_string())),
+            "a move with no element to land on is held for the next frame"
+        );
+
+        frame_the_shell(&mut editor);
+        editor.retry_pending_panel_tree_focus();
+
+        let ui = editor.shell_ui.as_ref().expect("the tree");
+        assert_eq!(
+            ui.focused(),
+            ui.find_by_key(&crate::view::shell::widgets::widget_focus_key(
+                "menu-pick:move:root"
+            )),
+            "the dropdown owns the keyboard, so ↑/↓ drive it and not the list"
+        );
+        assert_eq!(
+            editor.pending_panel_tree_focus, None,
+            "and the request retires — one replay, never a standing pull"
         );
     }
 }

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -805,6 +805,14 @@ pub fn decode_filename_to_path(encoded: &str) -> Option<PathBuf> {
     if encoded == "root" {
         return Some(PathBuf::from("/"));
     }
+    // A name the encoder had to fold to fit `NAME_MAX` keeps only the head of
+    // the path plus a digest, so there is no path to give back. The encoder
+    // can never emit a literal `~` (a real one becomes `%7E`), which is what
+    // makes its presence a reliable answer rather than a guess. Callers
+    // already handle `None` by falling back to the name itself.
+    if encoded.contains('~') {
+        return None;
+    }
 
     let mut result = String::with_capacity(encoded.len() + 1);
     // Re-add leading slash that was stripped during encoding

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -127,6 +127,8 @@ pub mod language_dialog_esc_cancels_edit;
 pub mod language_dialog_tab_size;
 pub mod language_textmate_grammar;
 pub mod mouse_session_input;
+#[cfg(feature = "plugins")]
+pub mod placeholder_window_embed;
 pub mod suspend_process;
 
 pub mod close_buffer_shared_split_cursor;

--- a/crates/fresh-editor/tests/e2e/placeholder_window_embed.rs
+++ b/crates/fresh-editor/tests/e2e/placeholder_window_embed.rs
@@ -1,0 +1,102 @@
+//! Issue #1971: a `windowEmbed` naming a window that does not exist froze
+//! the panel it lived in.
+//!
+//! `WidgetSpec::WindowEmbed::window_id` is a `u32`, and its own contract
+//! says an unknown id renders placeholder blanks. But a plugin whose row
+//! has no window *yet* — the orchestrator gives a workspace being created
+//! a synthetic id below every real one — sent a value that could not
+//! deserialise at all, and serde fails the **whole spec**: the host logged
+//! `updateFloatingWidget: invalid spec: invalid value: integer -1000000,
+//! expected u32` and dropped the update. The panel then kept painting the
+//! last spec that *had* parsed. In the orchestrator's picker that was the
+//! "Archiving… / Waiting for git…" card, still up long after the worktree
+//! had moved to `.archived/` and the manifest had been written, and the
+//! picker took no further keys.
+//!
+//! `windowEmbed()` now normalises an id that names no window to 0 — the
+//! value the widget already documents for exactly this state — so the
+//! placeholder renders as blanks and the panel keeps updating.
+//!
+//! Per CONTRIBUTING.md §2 the assertion is on rendered output only: mount
+//! a panel carrying a placeholder embed and marker V1, replace it with
+//! V2, and require V2 on screen. Before the fix neither spec crossed the
+//! boundary, so neither marker ever appeared.
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+const MARKER_V1: &str = "PLACEHOLDER-EMBED-V1";
+const MARKER_V2: &str = "PLACEHOLDER-EMBED-V2";
+
+fn install_plugin(project_root: &std::path::Path) {
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin_lib(&plugins_dir);
+
+    const SRC: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/plugins/test_placeholder_embed.ts"
+    ));
+    let dst = plugins_dir.join("test_placeholder_embed.ts");
+    fs::write(&dst, SRC)
+        .unwrap_or_else(|e| panic!("write test_placeholder_embed.ts to {dst:?}: {e}"));
+}
+
+fn run_command_and_wait(harness: &mut EditorTestHarness, name: &str, ack: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(name).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(ack))
+        .unwrap();
+}
+
+#[test]
+fn a_placeholder_window_embed_does_not_freeze_its_panel() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    install_plugin(&project_root);
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, Default::default(), project_root)
+            .unwrap();
+    harness.render().unwrap();
+
+    run_command_and_wait(&mut harness, "TestEmbed: Mount", "TestEmbed: MOUNTED");
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(MARKER_V1))
+        .unwrap();
+
+    // The update is the half that froze: with the embed's id rejected, the
+    // host dropped this spec and left V1 on screen indefinitely.
+    run_command_and_wait(&mut harness, "TestEmbed: Update", "TestEmbed: UPDATED");
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(MARKER_V2))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(MARKER_V2),
+        "issue #1971: an embed naming no window must not stop the panel \
+         from taking its next spec — screen was:\n{screen}"
+    );
+    assert!(
+        !screen.contains(MARKER_V1),
+        "the replaced spec must be gone, not painted under the new one \
+         — screen was:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/plugins/test_placeholder_embed.ts
+++ b/crates/fresh-editor/tests/plugins/test_placeholder_embed.ts
@@ -1,0 +1,71 @@
+/// <reference path="../../plugins/lib/fresh.d.ts" />
+import { col, raw, windowEmbed } from "./lib/widgets.ts";
+
+const editor = getEditor();
+
+/**
+ * Regression surface for sinelaw/fresh#1971: a `windowEmbed` naming a
+ * workspace that has no window yet froze the panel it lived in.
+ *
+ * The host reads `windowId` as a `u32`. A plugin that embeds a
+ * placeholder row — the orchestrator gives one a synthetic negative id
+ * until its workspace exists — sent a value that could not deserialise,
+ * and the failure was for the *whole spec*: `updateFloatingWidget`
+ * logged `invalid spec` and dropped it, so the panel kept painting
+ * whatever it last showed. In the picker that was the "Archiving… /
+ * Waiting for git…" card, still up long after the archive had finished.
+ *
+ * The plugin mounts a panel showing V1 next to a placeholder embed, then
+ * updates it to V2. With the bug neither spec survives the boundary and
+ * the screen never shows either marker; with the fix the placeholder
+ * renders as the blank rows it is meant to be and V2 replaces V1.
+ */
+
+const PANEL_ID = 771971;
+// The shape of an orchestrator placeholder id: below every real window.
+const PLACEHOLDER_WINDOW_ID = -1_000_000;
+
+function spec(marker: string) {
+  return col(
+    raw([{ text: marker + "\n", properties: {} }]),
+    windowEmbed({ windowId: PLACEHOLDER_WINDOW_ID, rows: 5, key: "embed" }),
+  );
+}
+
+function mount(): void {
+  // `startBlurred` — the panel is here to be looked at, not typed into, and
+  // a focused one swallows the Ctrl+P the test needs to reach the palette a
+  // second time to run the update.
+  editor.mountFloatingWidget(
+    PANEL_ID,
+    spec("PLACEHOLDER-EMBED-V1"),
+    90,
+    60,
+    false,
+    false,
+    "",
+    false,
+    true,
+  );
+  editor.setStatus("TestEmbed: MOUNTED");
+}
+registerHandler("placeholder_mount", mount);
+
+function update(): void {
+  editor.updateFloatingWidget(PANEL_ID, spec("PLACEHOLDER-EMBED-V2"));
+  editor.setStatus("TestEmbed: UPDATED");
+}
+registerHandler("placeholder_update", update);
+
+editor.registerCommand(
+  "TestEmbed: Mount",
+  "Mount a floating panel embedding a window that does not exist",
+  "placeholder_mount",
+  null,
+);
+editor.registerCommand(
+  "TestEmbed: Update",
+  "Replace that panel's contents",
+  "placeholder_update",
+  null,
+);


### PR DESCRIPTION
Fixes two orchestrator faults, both reproduced from the issues' own repro comments before anything was written, and both verified afterwards by driving the editor interactively in tmux with real keystrokes (never `--cmd script`, which would bypass the input routing under test).

Closes #3137. Addresses the two remaining items of #1971.

---

# How to validate

> ## ⚠️ Which build shows the "before" behaviour
>
> **#3137 is a regression that is in no release.** The first bad commit is `8aba3b95a`, which landed *after* `v0.4.10` — the latest tag — so on **every released version the arrow keys already work correctly in the Move-to-Folder popup**. Testing an older build and finding it fine is the expected result, not a failed repro.
>
> To see it fail you must build the PR's base:
>
> ```bash
> git checkout cf626fc06 && cargo build --bin fresh     # "before": broken
> git checkout claude/fix-orchestrator && cargo build --bin fresh   # "after": fixed
> ```
>
> The bisect's own boundary, if you want to confirm it directly: `867a0eb3b` is the last good commit, `8aba3b95a` the first bad one.
>
> **The three #1971 faults below are not regressions** — they reproduce on master `cf626fc` and I did not bisect how far back they go, so an older build may well show them too. Only #3137 is release-clean.

Four separate faults, each with its own repro. All were measured on master `cf626fc` before the fix and again after, in a 200×50 tmux pane with a debug build.

> **Reading the dock's selection.** The highlight is background `48;5;25`, so
> `tmux capture-pane -p -e | grep -n '48;5;25'` prints the selected row number,
> and the tab title on line 2 names the live workspace.

---

### 1. The "Move to Folder…" popup does not own the keyboard (#3137)

**Requires a build at or after `8aba3b95a` — see the box above. No release has this bug.**

```bash
mkdir /tmp/rt3 && cd /tmp/rt3 && git init && touch a.txt && git add -A && git commit -m init
fresh --no-restore
```

1. `Ctrl+P` → **Orchestrator: New Workspace** → Tab to `[ Create Workspace ]` → Enter. **Twice**, giving dock rows `rt3-1` and `rt3-2`.
2. `Alt+O` to focus the dock, then `↑` so the highlight sits on **`rt3-1`** — the middle of the list. *(This matters: if the live workspace is the last row, `↓` has nowhere to go and you see the dismissal without the workspace switch.)*
3. `Ctrl+P` → **Orchestrator: Move to Folder…**. The popup opens (`● Top level` / `New Folder…`, footer `↑↓ choose  Enter select  Esc cancel`) with the highlight on its first row.
4. Press `↓`.

| | before `↓` | **before fix** (`cf626fc`) | **after fix** |
|---|---|---|---|
| popup | open | **gone** | open |
| highlight row | 5 (in popup) | **7 (dock)** | 6 (in popup) |
| live workspace | `rt3-1` | **`rt3-2`** | `rt3-1` |

After the fix all four keys drive the popup and nothing leaks to the dock: `↑`/`↓` move within it, `Enter` opens the New Folder dialog, `Esc` closes it and returns the dock highlight to `rt3-1`.

*Either route reaches the same popup.* The dock's row context menu (`F2` / right-click) is its own anchored panel, but its **Move to Folder…** option closes that panel and opens this same inline dropdown — `ctx-move` calls the same `openDockMenu(...)` the palette command does, deliberately, *"so it shares the keyboard-navigable menu path and the folder list"*. So the bug reproduces through `F2 → Move to Folder…` as well; the palette is just the shorter route to it.

---

### 2. Terminal storage outgrows NAME_MAX (#1971)

Needs a repo root deep enough that the *doubly* encoded path passes 255 bytes — the orchestrator encodes the repo root into the workspace path, then encodes that path again to name the terminal directory.

```bash
R=/tmp/d-one/d-two/d-three/d-four/d-five/d-six/d-seven/work/repo   # ~160 chars
mkdir -p $R && cd $R && git init && touch a.txt && git add -A && git commit -m init
fresh --no-restore --log-file /tmp/f.log
```

1. `Ctrl+P` → **Orchestrator: New Workspace**, set **Workspace Name** to `gamma-very-long-session-name-for-truncation-test`, create it.
2. `grep -c 'File name too long' /tmp/f.log` and `ls ~/.local/share/fresh/terminals/`.

**Before:**
```
WARN fresh::app::terminal: Failed to create terminal directory: File name too long (os error 36)
WARN fresh::app::terminal: Failed to create terminal backing file: File name too long (os error 36)
```
`~/.local/share/fresh/terminals/` is empty — the workspace has nowhere to write its scrollback.

**After:** no warning, and the directory exists at exactly 255 bytes with its backing files inside:
```
…deep-directory-seven%5Fwork%5Frepo_gamma-very-long-ses~24aec60fedffac2d/
    fresh-terminal-eph-0-1788465026018338657.log
    fresh-terminal-eph-0-1788465026018338657.txt
```

**Also check nothing was re-keyed.** A workspace whose encoding is *under* 255 must keep the exact name it had before this PR — that is what the cap being `NAME_MAX` buys. A shallower repo (say `/tmp/rt3`) should produce a byte-identical terminal directory name before and after.

---

### 3. The archived directory is named after a display string (#1971)

```bash
mkdir /tmp/rt && cd /tmp/rt && git init && touch a.txt && git add -A && git commit -m init
fresh --no-restore
```

1. Create a workspace named `good` and let its terminal settle (the tab title becomes `bash — root@vm: ~/…`).
2. `Ctrl+P` → **Orchestrator: Open** → select `good` → Tab to `[ Archive ]` → Enter → `[ Confirm Archive ]` → Enter.
3. `ls ~/.local/share/fresh/orchestrator/tmp_rt/.archived/`

**Before** — the row's *display label* names the directory, spaces, middle dot, em dash and all, and the `/`s inside it are read by `git worktree move` as further directory levels:
```
.archived/gamma-very-long-session-name-for-truncation-test · bash — root@vm: ~/
```

**After:**
```
.archived/good
```

The manifest still records the display label, and `unarchiveWorkspace` resolves from the recorded `root`, so unarchiving is unaffected. Archiving a second workspace of the same name lands at `.archived/good-2` instead of failing on an occupied directory.

---

### 4. Archive freezes the picker (#1971)

The frozen card needs a workspace that has **no window yet**, and those only come from a **remote** create — a local one gets a real positive window id from `createPreparingWindow`, so it will not reproduce this. An SSH workspace pointed at a host that does not exist is the easiest way in.

```bash
fresh --no-restore --log-file /tmp/f.log
```

1. Create one ordinary local workspace (`good`).
2. `Ctrl+P` → **Orchestrator: New Workspace** → `Shift+Tab` to the **Run in** row → `→` to select **SSH** → Tab to the host field → type `nonexistent-host-xyz` → create. It fails to connect and leaves a `!` placeholder row in the dock.
3. `Ctrl+P` → **Orchestrator: Open**, then `↓`/`↑` onto that `ssh:nonexistent-host-xyz` row.

**Before** — the log fills with the error from the issue and the picker stops responding; further `↓` does nothing and the selection stays put:
```
ERROR updateFloatingWidget: invalid spec: invalid value: integer `-1000000`, expected u32
```
Reaching this through **Archive → Confirm Archive** is what the issue reported: the archive completes on disk (worktree moved to `.archived/`, `archived.json` written) while the picker stays on "Archiving… / Waiting for git…" and only recovers on the next keypress.

**After:** `grep -c 'invalid spec' /tmp/f.log` is `0`, the placeholder row renders as blank embed rows, the picker keeps taking arrow keys, and Confirm Archive completes without a stuck card.

---

# What was wrong, and why

## #3137 — the "Move to Folder…" popup did not own the keyboard

### Bisected

`git bisect` over `v0.4.10..cf626fc`, run against the interactive repro, lands on:

> **`8aba3b95a` — "Fix the CI failures and hangs, and drop the web's plugin-panel view"** (parent `867a0eb3b` verified good)

Two of the bisect's automated steps had to be re-checked by hand: at `f886c915f` the scenario could not be set up at all (the palette never opened, so the script's "no popup" reading was not the symptom), and `867a0eb3b` — the first bad commit's parent — measures cleanly good. That commit is where `focus_panel_widget_in_tree` was introduced, which is precisely the mechanism below.

Since `8aba3b95a` is contained in no tag, the regression has never shipped: it exists only on master.

### Root cause

Opening an in-panel dropdown is **two plugin writes** — a spec carrying the option rows, then `setFocusKey` onto the first of them — and both are applied before the next frame describes either.

`focus_panel_widget_in_tree` is the imperative half of the focus mirror: it moves the tree's focus to the widget the registry has just been told holds the panel's. It could only move focus to an element that *exists*, so it asked the tree for a `menu-pick:` row the previous spec had no row for, found nothing, and returned. A probe confirmed it on the running editor:

```
focus_panel_widget_in_tree: PROBE widget=menu-pick:move:root holds=true found=false
```

Nothing re-tried it, so the tree kept the focus the dropdown was meant to take — and the mirror's *other* direction wrote that disagreement back. The stale holder's `FocusGained` fact re-pointed the registry at the session list, and the router (which reads the registry to decide whether a dropdown owns the arrow keys) sent `↓` to the list:

```
set_panel_focus_and_notify: firing `focus` widget_event  old=menu-pick:move:root new=sessions
dispatch_floating_widget_key: decision code=Down focus_key=Some("sessions") outcome=SmartKey("Down")
```

Because `ctx-move` funnels into the same `openDockMenu`, the dock's three inline dropdowns — "New Task… ▾", the project scope picker and Move-to-Folder — all share this path, and all of them depend on that focus landing.

### Fix

Hold the move, and replay it immediately after the frame that builds the element. The gain it raises is queued *behind* the stale one, so `apply_settled_shell_messages` settles on the dropdown — which is what that path's existing ordering rule already says should happen. One replay, never a standing request: the frame that follows the write is built from the very spec the write was aimed at, so a widget still absent there is not coming. A request the registry no longer names has been overtaken by a newer focus decision (a Tab, a click, another `setFocusKey`) and is dropped without acting.

**Regression test:** `a_focus_onto_a_widget_the_next_frame_builds_lands_on_that_frame` (`app/widget_runtime.rs`), at the same seam as the existing `a_focus_the_host_decides_moves_the_trees_focus_too`. Confirmed to fail without the fix.

---

## #1971 — the two remaining items

Both still reproduce at HEAD; the rest of the issue's enumerated bugs are fixed, as the last status sweep found.

### 1. Terminal storage outgrew NAME_MAX

`encode_path_for_filename` encodes a path whole, so the name grows with the directory's depth, and the orchestrator nests one encoded path inside another: a workspace lives under `orchestrator/<slug of the repo root>/<name>`, and naming *its* terminal directory encodes that path a second time.

An encoding that no longer fits is now folded to `<head>~<hash>`. The head keeps the tail of the path readable in a listing; the FNV-1a digest — spelled out rather than reached for, because it names files that outlive the process — keeps two paths sharing a 238-character prefix apart. It runs over the *encoding*, which is the encoder's normalised form, so a folded name still maps doubled separators, a leading one, and either separator onto one filename the way an unfolded one does. A literal `~` can mark the fold because the encoder can never emit one (a real tilde becomes `%7E`), which is what lets `decode_filename_to_path` decline a folded name instead of handing back a path that was never encoded.

**The cap is `NAME_MAX` itself, and that is the point.** Folding is a rename, so any name that folds stops finding what the previous release wrote under it — a workspace snapshot, the recovery scope, terminal scrollback, per-workspace config, a running daemon's socket. Only names no caller could have created at all may move, which means the filesystem's limit and not a byte less. Leaving headroom for a suffix would be wrong in both directions: several callers append nothing and join the encoding as a whole directory name (so a 250-byte encoding is live today), and the longest suffix is not small either — `workspace_path_for` builds `<encoded>.<stable_id>.json`, about 28 bytes. A name that overflows *with* a suffix but fits without one stays a caller-specific limit, exactly as it was before this cap existed.

### 2. The archived directory was named after a display string

A workspace's `label` is a *display* string — `workspaceDisplayName` composes it from the workspace name and the terminal's live tab title — so filing one put spaces, a middle dot, an em dash and the `/`s of a path into a directory name, and `git worktree move` read those slashes as further directory levels to nest the graveyard under.

The basename of the worktree is the name git already gave the directory, so it is a valid single component by construction and the archived copy keeps the name it had while it was live. The manifest still records the display label, and `unarchiveWorkspace` resolves the directory from the recorded `root`, so nothing downstream moves. A repeat archive of the same name takes the next free `-2`, `-3` rather than failing on a directory that is already there.

### 3. Archive hung the picker — the same `invalid spec` the issue logged

`windowEmbed`'s `windowId` is a `u32` on the host, and serde fails the **whole spec** on a negative one — so `updateFloatingWidget` dropped it and the panel kept painting the last spec that parsed. After Confirm Archive that was the "Archiving… / Waiting for git…" card, still up long after the worktree had moved to `.archived/` and the manifest had been written.

The negative ids are the orchestrator's placeholders for a workspace that has no window yet (a remote create; `nextPendingId` counts down from `-1_000_000`, which is where the issue's `-1000002` comes from). "No window" is a state the widget already has a value for, and it is `0` — its own doc comment says an unknown id renders placeholder blanks — so the helper normalises to it and the placeholder renders as the blanks it is meant to be.

**Regression test:** `a_placeholder_window_embed_does_not_freeze_its_panel` (`tests/e2e/`) — mounts a panel carrying a placeholder embed and marker V1, replaces it with V2, and requires V2 on screen. Checked both ways: with the fix it passes in half a second; with the normalisation removed the mount spec never crosses the boundary at all, the host logs `invalid spec`, V1 never renders, and the test hangs on its first wait — which is the freeze itself.

---

## Open questions (deliberately not decided here)

- **The `_` / `%5F` mixing in one slug component** (#1971's first complaint) is *deliberate and unambiguous*: `_` is a path separator and `%5F` a literal underscore, which is what keeps `a_b/c` and `a/b/c` apart. Changing the scheme would rename every existing on-disk path — per-workspace configs, workspace snapshots, recovery state, terminal directories — and needs a migration, so this PR fixes only the overflow, which is the actual failure. Worth its own issue if the readability is judged to be worth the migration.
- **What the picker should show for a workspace that has no window yet.** It currently offers Visit / Stop / Archive / Delete against a placeholder row. The freeze is fixed, but which of those a placeholder should offer is a product decision.
- **A spec that fails to deserialise silently freezes its panel.** The host logs `invalid spec` and drops the update; the plugin gets no error back and the user sees a stuck panel. The plugin-side fault is fixed, but the host's failure mode is worth hardening on its own.

---

## Review round

Six findings, all real, fixed in `766f171`. The load-bearing one: the cap started at 200, so every encoding in **201..=255** — created without complaint today — would have folded on first run and orphaned what it named. The cap is now `NAME_MAX`. The others: the digest ran over the raw path and so dropped the encoder's own normalisation; the archive fallback reached for `s.hostLabel`, another display string, undoing the fix it sat in; the `windowId` guard closed only the low end of `u32`; the `windows.json` migration would have *persisted* an unresolvable path once the decoder began declining folded names; and the #3137 test re-spelled `render`'s sequence in a helper, so deleting the replay from `render` left it passing — `render` and the test now call one `Editor::lay_out_shell_tree`, and deleting the replay from it fails the test (checked both ways).

One correction to a review example rather than a fix: a **trailing** separator was never normalised — it becomes a trailing `_` that nothing strips, so `/a/b/` and `/a/b` have always named different files here. The test asserts the three equivalences that do hold and documents that one as pre-existing.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets` (no new warnings on the changed files), `cargo test -p fresh-editor-core --lib` (1299 passed), `cargo test -p fresh-editor --lib` (2525 passed), both regression tests re-run after the review round, the two interactive repros re-verified in tmux against the raised cap, and the plugin type-checker — which reports the same 17 pre-existing errors on `orchestrator.ts` / `lib/widgets.ts` before and after, and no new ones.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuDYEaFrM5HFjjGEnNYwia