### PR TITLE
highlight-engine: syntax colours for plugin-composed diff buffers, host-side, by text property (#3104, #2871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* **Review Diff and Git Log are syntax highlighted** - the diff bodies were painted in flat add/remove colours plus plain text, while the identical lines one tab over got the language's keyword, function and punctuation colours. A plugin-composed buffer can now tell the host where its rows carry code and in what language (a new plugin API, `editor.setSyntaxRegions`), and the host's own highlighter colours those rows like any buffer - incrementally, viewport-bounded, following the theme - with each side of a hunk read as the contiguous text it is, so a docstring or block comment spanning several rows is one construct. A `.diff` buffer, such as the Git Log detail, gets the same treatment from a diff grammar that hands each file's rows to that file's language (#3104, reported by @tinchoz49; #2871).
 * **A `deno.json` no longer takes TypeScript away from a project without Deno installed** (#2981, reported by @atk).
 * **A single-key binding on a keymap chord's prefix now fires**, and deleting a built-in keybinding actually frees the key (#3171).
 * **LSP requests that time out now say so** instead of silently reporting "no results" while the status bar claims the server is ready; a stuck server now shows `LSP (stuck)` (#2197).

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1342,9 +1342,22 @@ pub struct CompositePaneStyle {
 /// both sides share (context) lists both. An empty list means one parser
 /// shared by every region that says nothing.
 ///
-/// Regions replace the buffer's previous set, and setting the buffer's
-/// content clears them. They are anchored to the text, so an edit moves
-/// them the way it moves overlays.
+/// The contract:
+/// - Only a plugin-composed (virtual) buffer can be told this; a file has
+///   a grammar of its own, and the call is ignored, with a log line, for
+///   anything else.
+/// - A region starts at a row's first byte and ends just past a row's
+///   newline. A row is coloured when its first byte lies in a region.
+/// - Regions replace the buffer's previous set and must not overlap: a
+///   region that overlaps the one before it (in byte order) is dropped,
+///   with a log line. Setting the buffer's content clears them all.
+/// - The first stream a region names colours its rows; the others are fed
+///   for their state. The host keeps the four most recently fed parsers;
+///   a stream fed again after four others starts afresh.
+/// - A language nothing in the grammar set claims leaves the rows as the
+///   plugin styled them, with a log line.
+/// - Regions follow the text: an edit inside the buffer moves them the
+///   way it moves overlays.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[ts(export, rename = "TsSyntaxRegion", rename_all = "camelCase")]
@@ -1360,7 +1373,8 @@ pub struct SyntaxRegion {
     /// Bytes at the start of every row that are not code.
     #[serde(default)]
     pub prefix: usize,
-    /// Parsers the rows feed; see the type docs.
+    /// Parsers the rows feed, in order; the first colours the rows. Empty
+    /// means the shared stream `0`. See the type docs.
     #[serde(default)]
     pub streams: Vec<u32>,
 }

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1325,6 +1325,57 @@ pub struct CompositePaneStyle {
     pub gutter_style: Option<String>,
 }
 
+/// A run of rows in a plugin-composed buffer that carry code, for the
+/// host's highlighter (`setSyntaxRegions`).
+///
+/// A composed buffer — a diff stream, a log — is not a document any
+/// grammar can parse, so the plugin says where the code is instead. A
+/// region is a byte range of whole rows; every row in it is handed to the
+/// language's parser with its first `prefix` bytes skipped (a gutter, a
+/// diff marker), and rows outside every region keep whatever the plugin
+/// styled them with and never advance a parser.
+///
+/// `streams` name the parsers a row feeds, and regions that share a
+/// stream id continue one parse across the rows between them: the old
+/// and new side of a hunk interleave, and a comment box can sit inside a
+/// hunk, yet each side is still read as the contiguous text it is. A row
+/// both sides share (context) lists both. An empty list means one parser
+/// shared by every region that says nothing.
+///
+/// Regions replace the buffer's previous set, and setting the buffer's
+/// content clears them. They are anchored to the text, so an edit moves
+/// them the way it moves overlays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[ts(export, rename = "TsSyntaxRegion", rename_all = "camelCase")]
+pub struct SyntaxRegion {
+    /// Byte offset of the first row's first byte.
+    pub start: usize,
+    /// Byte offset one past the last row's newline.
+    pub end: usize,
+    /// What the rows are written in: a path (`src/main.rs`, `Makefile`)
+    /// or a language token (`py`, `rust`). Nothing is opened or read;
+    /// it only selects the grammar.
+    pub language: String,
+    /// Bytes at the start of every row that are not code.
+    #[serde(default)]
+    pub prefix: usize,
+    /// Parsers the rows feed; see the type docs.
+    #[serde(default)]
+    pub streams: Vec<u32>,
+}
+
+#[cfg(feature = "plugins")]
+impl<'js> rquickjs::FromJs<'js> for SyntaxRegion {
+    fn from_js(_ctx: &rquickjs::Ctx<'js>, value: rquickjs::Value<'js>) -> rquickjs::Result<Self> {
+        rquickjs_serde::from_value(value).map_err(|e| rquickjs::Error::FromJs {
+            from: "object",
+            to: "SyntaxRegion",
+            message: Some(e.to_string()),
+        })
+    }
+}
+
 /// Diff hunk for composite buffer alignment
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
@@ -4499,6 +4550,14 @@ pub enum PluginCommand {
     UpdateCompositeAlignment {
         buffer_id: BufferId,
         hunks: Vec<CompositeHunk>,
+    },
+
+    /// Say where a plugin-composed buffer carries code, and in what
+    /// language, so the host highlights it (see [`SyntaxRegion`]).
+    /// Replaces the buffer's previous regions.
+    SetSyntaxRegions {
+        buffer_id: BufferId,
+        regions: Vec<SyntaxRegion>,
     },
 
     /// Close a composite buffer

--- a/crates/fresh-editor-core/build.rs
+++ b/crates/fresh-editor-core/build.rs
@@ -205,6 +205,7 @@ fn generate_syntax_packdump() -> Result<(), Box<dyn std::error::Error>> {
             "src/grammars/gitattributes.sublime-syntax",
             "Git Attributes",
         ),
+        ("src/grammars/diff.sublime-syntax", "Fresh Diff"),
         ("src/grammars/typst.sublime-syntax", "Typst"),
         ("src/grammars/dockerfile.sublime-syntax", "Dockerfile"),
         ("src/grammars/ini.sublime-syntax", "INI"),

--- a/crates/fresh-editor-core/src/grammars/diff.sublime-syntax
+++ b/crates/fresh-editor-core/src/grammars/diff.sublime-syntax
@@ -1,0 +1,58 @@
+%YAML 1.2
+---
+# Unified diff grammar with file regions for embedded source highlighting.
+#
+# `meta.embedded.block.diff` stays active from a `diff --git` header to the
+# next file header. The target path is scoped as a language token; Fresh's
+# embedded-language highlighter resolves its basename/extension and parses
+# hunk content with that file's source grammar.
+name: Fresh Diff
+file_extensions:
+  - diff
+  - patch
+scope: source.diff
+
+contexts:
+  main:
+    # Git quotes paths containing spaces or unusual bytes.
+    - match: '^diff --git\s+"a/.*"\s+"b/(.*)"\s*$'
+      scope: meta.diff.header.git
+      captures:
+        1: constant.other.language-name.diff
+      push: diff-file
+    - match: '^diff --git\s+a/\S+\s+b/(\S+)\s*$'
+      scope: meta.diff.header.git
+      captures:
+        1: constant.other.language-name.diff
+      push: diff-file
+    # Keep a region even when a non-standard header does not expose a path.
+    - match: '^diff --git\b.*$'
+      scope: meta.diff.header.git
+      push: diff-file
+    - include: diff-body
+
+  diff-file:
+    - meta_scope: meta.embedded.block.diff
+    # A zero-width pop lets the same line be reconsidered by `main`, where it
+    # opens the next file region and selects that file's language.
+    - match: '(?=^diff --git\b)'
+      pop: true
+    - include: diff-body
+
+  diff-body:
+    - match: '^@@@?.*?@@@?'
+      scope: meta.diff.range.unified
+    - match: '^\+\+\+.*$'
+      scope: meta.diff.header.to-file
+    - match: '^---.*$'
+      scope: meta.diff.header.from-file
+    - match: '^\+.*$'
+      scope: markup.inserted.diff
+    - match: '^-.*$'
+      scope: markup.deleted.diff
+    - match: '^Binary files .* differ$'
+      scope: meta.diff.header.binary
+    - match: '^GIT binary patch$'
+      scope: meta.diff.header.binary
+    - match: '^(?:index|new file mode|deleted file mode|old mode|new mode|similarity index|dissimilarity index|rename from|rename to|copy from|copy to)\b.*$'
+      scope: meta.diff.header.git

--- a/crates/fresh-editor-core/src/grammars/diff.sublime-syntax
+++ b/crates/fresh-editor-core/src/grammars/diff.sublime-syntax
@@ -25,9 +25,14 @@ contexts:
       captures:
         1: constant.other.language-name.diff
       push: diff-file
-    # Keep a region even when a non-standard header does not expose a path.
-    - match: '^diff --git\b.*$'
+    # A header the rules above cannot parse (a path with a space and
+    # `core.quotePath` off) still opens a region and still names it: the
+    # whole tail is the token, and resolving it by its extension is what
+    # keeps the previous file's parser from running on into this one.
+    - match: '^diff --git\b(.*)$'
       scope: meta.diff.header.git
+      captures:
+        1: constant.other.language-name.diff
       push: diff-file
     - include: diff-body
 
@@ -42,10 +47,13 @@ contexts:
   diff-body:
     - match: '^@@@?.*?@@@?'
       scope: meta.diff.range.unified
+      push: hunk
     - match: '^\+\+\+.*$'
       scope: meta.diff.header.to-file
     - match: '^---.*$'
       scope: meta.diff.header.from-file
+    # Change rows before any hunk header — a diff arriving in pieces, or
+    # one with the header cut off — still get their wash.
     - match: '^\+.*$'
       scope: markup.inserted.diff
     - match: '^-.*$'
@@ -56,3 +64,15 @@ contexts:
       scope: meta.diff.header.binary
     - match: '^(?:index|new file mode|deleted file mode|old mode|new mode|similarity index|dissimilarity index|rename from|rename to|copy from|copy to)\b.*$'
       scope: meta.diff.header.git
+
+  # Inside a hunk every row is source or a marker note: a removed line
+  # beginning `--` or an added one beginning `++` is code, not a file
+  # header, and is fed to the file's parser like any other row. The next
+  # hunk header or file header ends the hunk.
+  hunk:
+    - match: '(?=^(?:diff --git\b|@@))'
+      pop: true
+    - match: '^\+.*$'
+      scope: markup.inserted.diff
+    - match: '^-.*$'
+      scope: markup.deleted.diff

--- a/crates/fresh-editor-core/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor-core/src/primitives/grammar/types.rs
@@ -1311,6 +1311,37 @@ impl GrammarRegistry {
     /// are indexed directly in `catalog_by_name` during `rebuild_catalog` /
     /// `register_alias` / `apply_language_config`, so a single lookup covers
     /// every case.
+    /// The syntect grammar a declared region's language resolves to (see
+    /// `DeclaredRegion`): the catalog entry for the path, so a region
+    /// named by a file picks the grammar the editor would open that file
+    /// with, user mappings included — or, when that entry has no syntect
+    /// grammar (TypeScript and JavaScript are served by tree-sitter for
+    /// real buffers) or the token is not a path at all (`py`), the grammar
+    /// the token, its basename or its extension names. Plain text is not
+    /// an answer: `None` leaves the rows as they are.
+    pub fn embedded_syntax_index(&self, language: &str) -> Option<usize> {
+        if let Some(index) = self
+            .find_by_path(Path::new(language), None)
+            .and_then(|entry| entry.engines.syntect)
+        {
+            return Some(index);
+        }
+        let plain = self.syntax_set.find_syntax_plain_text();
+        let basename = language.rsplit(['/', '\\']).next().unwrap_or(language);
+        let extension = basename.rsplit_once('.').map(|(_, ext)| ext);
+        std::iter::once(language)
+            .chain((basename != language).then_some(basename))
+            .chain(extension)
+            .find_map(|candidate| self.syntax_set.find_syntax_by_token(candidate))
+            .filter(|found| !std::ptr::eq(*found, plain))
+            .and_then(|found| {
+                self.syntax_set
+                    .syntaxes()
+                    .iter()
+                    .position(|s| std::ptr::eq(s, found))
+            })
+    }
+
     pub fn find_by_name(&self, name: &str) -> Option<&GrammarEntry> {
         self.catalog_by_name
             .get(&name.to_lowercase())

--- a/crates/fresh-editor-core/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor-core/src/primitives/grammar/types.rs
@@ -169,6 +169,9 @@ pub const GITCONFIG_GRAMMAR: &str = include_str!("../../grammars/gitconfig.subli
 /// Embedded Git Attributes grammar for .gitattributes
 pub const GITATTRIBUTES_GRAMMAR: &str = include_str!("../../grammars/gitattributes.sublime-syntax");
 
+/// Unified diff grammar with dynamically highlighted source-file regions.
+pub const DIFF_GRAMMAR: &str = include_str!("../../grammars/diff.sublime-syntax");
+
 /// Embedded Typst grammar (syntect doesn't include one)
 pub const TYPST_GRAMMAR: &str = include_str!("../../grammars/typst.sublime-syntax");
 
@@ -740,6 +743,17 @@ impl GrammarRegistry {
             }
         }
 
+        // Unified diff grammar
+        match SyntaxDefinition::load_from_str(DIFF_GRAMMAR, true, Some("Fresh Diff")) {
+            Ok(syntax) => {
+                builder.add(syntax);
+                tracing::debug!("Loaded embedded Fresh Diff grammar");
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load embedded Fresh Diff grammar: {}", e);
+            }
+        }
+
         // Typst grammar
         match SyntaxDefinition::load_from_str(TYPST_GRAMMAR, true, Some("Typst")) {
             Ok(syntax) => {
@@ -1101,7 +1115,8 @@ impl GrammarRegistry {
         let mut catalog: Vec<GrammarEntry> = Vec::new();
         let mut scope_to_index: HashMap<String, usize> = HashMap::new();
 
-        // Syntect-backed entries (skip Plain Text and JavaScript).
+        // Syntect-backed entries (skip Plain Text, JavaScript, and the stock
+        // Diff grammar).
         //
         // Syntect's `file_extensions` is a hybrid list: real extensions like
         // "rb" sit alongside bare filenames like "Gemfile", "Rakefile",
@@ -1126,10 +1141,15 @@ impl GrammarRegistry {
         // grammar exists only for embedded contexts (Vue `lang="ts"`,
         // Markdown ```ts fences, resolved via `find_syntax_by_token`), and
         // `.ts` buffers must keep the richer tree-sitter highlighting.
+        //
+        // Syntect's stock Diff grammar is superseded by Fresh Diff, which
+        // exposes per-file embedded regions so patch bodies can use their
+        // source language's token colors.
         for (idx, syntax) in self.syntax_set.syntaxes().iter().enumerate() {
             if syntax.name == "Plain Text"
                 || syntax.name == "JavaScript"
                 || syntax.name == "TypeScript"
+                || syntax.name == "Diff"
             {
                 continue;
             }

--- a/crates/fresh-editor-core/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor-core/src/primitives/highlight_engine.rs
@@ -43,6 +43,7 @@ use crate::primitives::highlighter::{
     highlight_bg, highlight_color, HighlightCategory, HighlightSpan, Highlighter, Language,
 };
 use crate::theme::Theme;
+use fresh_core::api::SyntaxRegion;
 use fresh_core::hooks::{RegionLine, TableLine, TableRole};
 use std::collections::HashMap;
 use std::ops::Range;
@@ -288,7 +289,35 @@ pub struct TextMateEngine {
     // Scope→Category memo. Syntect Scope atoms are append-only-interned
     // globally, so entries never need invalidation.
     scope_category_cache: HashMap<syntect::parsing::Scope, Option<HighlightCategory>>,
+    // A region host highlights a buffer a plugin composed, whose code
+    // rows the plugin declared (`set_syntax_regions`) rather than a
+    // grammar found. Its own syntax is plain text; every colour comes
+    // from a region's child parser.
+    region_host: bool,
+    // One span marker per declared region, so the bounds follow the text
+    // through edits the way checkpoints do; `regions` holds what each
+    // marker's region parses as.
+    region_markers: MarkerList,
+    regions: HashMap<MarkerId, RegionInfo>,
 }
+
+/// What a declared region's rows parse as; see `SyntaxRegion`.
+struct RegionInfo {
+    /// Resolved once, when the region is declared. `None` when nothing in
+    /// the set claims the language, and the rows stay as the plugin
+    /// styled them.
+    syntax_index: Option<usize>,
+    prefix: usize,
+    streams: Arc<[u32]>,
+}
+
+/// Stream a region that names none feeds; see `SyntaxRegion::streams`.
+const DEFAULT_REGION_STREAM: u32 = u32::MAX;
+
+/// Parsers a region host carries between rows. The diff panels interleave
+/// the two sides of one hunk and never need more than that; anything
+/// older is dropped rather than cloned into every checkpoint.
+const MAX_REGION_STREAMS: usize = 4;
 
 /// Counters for monitoring highlighting performance in tests.
 #[derive(Debug, Default, Clone)]
@@ -541,6 +570,9 @@ struct ParseSnapshot {
     state: syntect::parsing::ParseState,
     scopes: syntect::parsing::ScopeStack,
     embedded: Option<EmbeddedParseState>,
+    /// A region host's live parsers, most recently fed last; empty for
+    /// every grammar host. See `SyntaxRegion::streams`.
+    streams: Vec<(u32, EmbeddedParseState)>,
 }
 
 impl ParseSnapshot {
@@ -549,6 +581,38 @@ impl ParseSnapshot {
             state: syntect::parsing::ParseState::new(syntax),
             scopes: syntect::parsing::ScopeStack::new(),
             embedded: None,
+            streams: Vec::new(),
+        }
+    }
+
+    /// The parser for `stream`, taken out of the snapshot for the
+    /// duration of a row, or a fresh one when the stream is new — or was
+    /// last parsing a different language, which cannot continue.
+    fn take_stream(
+        &mut self,
+        stream: u32,
+        syntax_index: usize,
+        syntax_set: &SyntaxSet,
+    ) -> EmbeddedParseState {
+        if let Some(pos) = self.streams.iter().position(|(id, _)| *id == stream) {
+            let (_, parser) = self.streams.remove(pos);
+            if parser.syntax_index == syntax_index {
+                return parser;
+            }
+        }
+        EmbeddedParseState {
+            syntax_index,
+            state: syntect::parsing::ParseState::new(&syntax_set.syntaxes()[syntax_index]),
+            scopes: syntect::parsing::ScopeStack::new(),
+        }
+    }
+
+    /// Put a stream's parser back, as the most recent; the oldest goes
+    /// once there are more than a hunk's two sides could need.
+    fn keep_stream(&mut self, stream: u32, parser: EmbeddedParseState) {
+        self.streams.push((stream, parser));
+        if self.streams.len() > MAX_REGION_STREAMS {
+            self.streams.remove(0);
         }
     }
 }
@@ -599,6 +663,23 @@ struct PreparedLine {
     ends_with_newline: bool,
 }
 
+/// A row as its embedded language parser should see it: the first
+/// `prefix` bytes — a gutter, a diff marker — removed and nothing else,
+/// so the parser's offsets land on the code. `None` for a row too short
+/// to hold the prefix (a filler row) or whose prefix ends inside a
+/// character; such a row keeps the styling it has and advances no parser.
+fn prepare_row_content(prepared: &PreparedLine, prefix: usize) -> Option<PreparedLine> {
+    if prepared.line_content_len < prefix {
+        return None;
+    }
+    let rest = prepared.line_for_syntect.get(prefix..)?;
+    Some(PreparedLine {
+        line_for_syntect: rest.to_string(),
+        line_content_len: prepared.line_content_len - prefix,
+        ends_with_newline: prepared.ends_with_newline,
+    })
+}
+
 /// Prepare one unified-diff source row for its embedded language parser.
 ///
 /// Added, removed, and context rows carry a one-byte patch marker that is
@@ -614,11 +695,7 @@ fn prepare_unified_diff_content(prepared: &PreparedLine) -> Option<PreparedLine>
     if bytes.starts_with(b"+++") || bytes.starts_with(b"---") {
         return None;
     }
-    Some(PreparedLine {
-        line_for_syntect: prepared.line_for_syntect.get(1..)?.to_string(),
-        line_content_len: prepared.line_content_len.saturating_sub(1),
-        ends_with_newline: prepared.ends_with_newline,
-    })
+    prepare_row_content(prepared, 1)
 }
 
 /// Longest logical line highlighted in full. Beyond this, only the
@@ -873,7 +950,70 @@ impl TextMateEngine {
             host_span_scratch: Vec::new(),
             child_span_scratch: Vec::new(),
             scope_category_cache: HashMap::new(),
+            region_host: false,
+            region_markers: MarkerList::new(),
+            regions: HashMap::new(),
         }
+    }
+
+    /// An engine for a buffer a plugin composed: plain text of its own,
+    /// coloured only where `set_syntax_regions` says there is code.
+    pub fn region_host(syntax_set: Arc<SyntaxSet>) -> Self {
+        let plain = syntax_set.find_syntax_plain_text();
+        let index = syntax_set
+            .syntaxes()
+            .iter()
+            .position(|s| std::ptr::eq(s, plain))
+            .unwrap_or(0);
+        let mut engine = Self::new(syntax_set, index);
+        engine.region_host = true;
+        engine
+    }
+
+    /// Whether this engine takes its regions from a plugin rather than a
+    /// grammar (see [`Self::region_host`]).
+    pub fn hosts_syntax_regions(&self) -> bool {
+        self.region_host
+    }
+
+    /// Replace the declared regions (see `SyntaxRegion`). Each becomes a
+    /// span marker, so an edit moves it with the text; the language is
+    /// resolved here, once, and every cached span is dropped since any of
+    /// them may now be wrong.
+    pub fn set_syntax_regions(&mut self, regions: Vec<SyntaxRegion>) {
+        let stale: Vec<MarkerId> = self.regions.keys().copied().collect();
+        for id in stale {
+            self.region_markers.delete(id);
+        }
+        self.regions.clear();
+        for region in regions {
+            if region.end <= region.start {
+                continue;
+            }
+            let syntax_index = self.resolve_embedded_syntax(&region.language);
+            let id = self.region_markers.create_span(region.start, region.end);
+            self.regions.insert(
+                id,
+                RegionInfo {
+                    syntax_index,
+                    prefix: region.prefix,
+                    streams: Arc::from(region.streams),
+                },
+            );
+        }
+        self.invalidate_all();
+    }
+
+    /// The declared region a row belongs to, by the row's first byte.
+    /// Regions are meant not to overlap; if they do, the one that starts
+    /// last wins, as an inner overlay would.
+    fn region_at(&self, row_start: usize) -> Option<MarkerId> {
+        self.region_markers
+            .query_range(row_start, row_start + 1)
+            .into_iter()
+            .filter(|&(_, start, end)| start <= row_start && row_start < end)
+            .max_by_key(|&(_, start, _)| start)
+            .map(|(id, _, _)| id)
     }
 
     /// Get performance stats for testing and diagnostics.
@@ -895,6 +1035,7 @@ impl TextMateEngine {
     /// the cache dirty so the partial-update path runs on next render.
     pub fn notify_insert(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_insert(position, length);
+        self.region_markers.adjust_for_insert(position, length);
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             for span in &mut cache.spans {
@@ -917,6 +1058,7 @@ impl TextMateEngine {
     /// Buffer-delete notification. Mirror of `notify_insert`.
     pub fn notify_delete(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_delete(position, length);
+        self.region_markers.adjust_for_delete(position, length);
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             let delete_end = position + length;
@@ -1103,6 +1245,9 @@ impl TextMateEngine {
         current_offset: usize,
         mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
+        if self.region_host {
+            return self.parse_region_line(snapshot, prepared, current_offset, on_span);
+        }
         if self.embedding.is_empty() {
             return self
                 .parse_line_into_spans(
@@ -1293,6 +1438,76 @@ impl TextMateEngine {
         }
         self.host_span_scratch = host_spans;
         true
+    }
+
+    /// One row of a region host (see [`Self::region_host`]). A row inside
+    /// a declared region is handed, prefix removed, to the parser of each
+    /// stream the region names, and coloured by the first; a row outside
+    /// every region is left as the plugin styled it and touches no
+    /// parser, so a header or a comment box between two runs of one
+    /// stream does not break the construct they are in the middle of.
+    fn parse_region_line(
+        &mut self,
+        snapshot: &mut ParseSnapshot,
+        prepared: &PreparedLine,
+        current_offset: usize,
+        mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
+    ) -> bool {
+        let Some(id) = self.region_at(current_offset) else {
+            return true;
+        };
+        let (syntax_index, prefix, streams) = {
+            let info = &self.regions[&id];
+            (info.syntax_index, info.prefix, Arc::clone(&info.streams))
+        };
+        let Some(syntax_index) = syntax_index else {
+            return true;
+        };
+        let stripped;
+        let line = if prefix == 0 {
+            prepared
+        } else {
+            match prepare_row_content(prepared, prefix) {
+                Some(rest) => {
+                    stripped = rest;
+                    &stripped
+                }
+                None => return true,
+            }
+        };
+        let child_offset = current_offset + prefix;
+        let streams: &[u32] = if streams.is_empty() {
+            &[DEFAULT_REGION_STREAM]
+        } else {
+            &streams
+        };
+        let mut child_spans = std::mem::take(&mut self.child_span_scratch);
+        child_spans.clear();
+        let mut ok = true;
+        for (k, &stream) in streams.iter().enumerate() {
+            let mut parser = snapshot.take_stream(stream, syntax_index, &self.syntax_set);
+            let (child_ok, _) = self.parse_line_into_spans(
+                &mut parser.state,
+                &mut parser.scopes,
+                line,
+                child_offset,
+                &[],
+                |start, end, category| {
+                    if k == 0 {
+                        child_spans.push((start, end, category));
+                    }
+                },
+            );
+            ok &= child_ok;
+            snapshot.keep_stream(stream, parser);
+        }
+        if ok {
+            for &(start, end, category) in &child_spans {
+                on_span(start, end, category, None);
+            }
+        }
+        self.child_span_scratch = child_spans;
+        ok
     }
 
     /// Index of the spec whose region scope is on the host stack, if any.
@@ -2555,6 +2770,28 @@ impl HighlightEngine {
     /// Check if this engine has highlighting available
     pub fn has_highlighting(&self) -> bool {
         !matches!(self, Self::None)
+    }
+
+    /// An engine for a buffer a plugin composed; see
+    /// [`TextMateEngine::region_host`].
+    pub fn region_host(syntax_set: Arc<SyntaxSet>) -> Self {
+        Self::TextMate(Box::new(TextMateEngine::region_host(syntax_set)))
+    }
+
+    /// Whether this engine takes its regions from a plugin rather than a
+    /// grammar.
+    pub fn hosts_syntax_regions(&self) -> bool {
+        matches!(self, Self::TextMate(h) if h.hosts_syntax_regions())
+    }
+
+    /// Replace the regions a plugin declared (see `SyntaxRegion`). A
+    /// no-op for engines that take their regions from a grammar.
+    pub fn set_syntax_regions(&mut self, regions: Vec<SyntaxRegion>) {
+        if let Self::TextMate(h) = self {
+            if h.hosts_syntax_regions() {
+                h.set_syntax_regions(regions);
+            }
+        }
     }
 
     /// Get a description of the active backend
@@ -4632,5 +4869,169 @@ diff --git a/tools/check.py b/tools/check.py
              (got {:?})",
             backtick_cat,
         );
+    }
+    fn region_host_for_test() -> (HighlightEngine, Theme) {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let engine = HighlightEngine::region_host(registry.syntax_set_arc());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        (engine, theme)
+    }
+
+    fn category_at(
+        spans: &[HighlightSpan],
+        content: &str,
+        needle: &str,
+    ) -> Option<HighlightCategory> {
+        let pos = content.find(needle).expect("needle in content");
+        spans
+            .iter()
+            .find(|span| span.range.contains(&pos))
+            .and_then(|span| span.category)
+    }
+
+    fn region(start: usize, end: usize, prefix: usize, streams: &[u32]) -> SyntaxRegion {
+        SyntaxRegion {
+            start,
+            end,
+            language: "calc.py".to_string(),
+            prefix,
+            streams: streams.to_vec(),
+        }
+    }
+
+    /// A region host colours the rows a plugin declared, past their
+    /// prefix, and nothing else: the header above them and the comment
+    /// box between them stay uncoloured, and the docstring the box
+    /// interrupts is still one docstring on the row after it.
+    #[test]
+    fn test_syntax_regions_colour_declared_rows_across_a_gap() {
+        let (mut engine, theme) = region_host_for_test();
+        let header = "UNSTAGED\n";
+        let code_a = "   1 +def f():\n   2 +    \"\"\"doc\n";
+        let note = "  [ a note ]\n";
+        let code_b = "   3 +    more\"\"\"\n   4 +    return 1\n";
+        let content = format!("{header}{code_a}{note}{code_b}");
+        let a = header.len()..header.len() + code_a.len();
+        let b = a.end + note.len()..content.len();
+        engine.set_syntax_regions(vec![
+            region(a.start, a.end, 6, &[1]),
+            region(b.start, b.end, 6, &[1]),
+        ]);
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+
+        assert_eq!(
+            category_at(&spans, &content, "def"),
+            Some(HighlightCategory::Keyword)
+        );
+        assert_eq!(
+            category_at(&spans, &content, "more"),
+            Some(HighlightCategory::Comment)
+        );
+        assert_eq!(
+            category_at(&spans, &content, "return"),
+            Some(HighlightCategory::Keyword)
+        );
+        assert_eq!(category_at(&spans, &content, "UNSTAGED"), None);
+        assert_eq!(category_at(&spans, &content, "a note"), None);
+        // The gutter is not code: nothing is painted before the marker.
+        let gutter = content.find("   1 +").unwrap();
+        assert!(
+            spans
+                .iter()
+                .all(|s| s.range.end <= gutter || s.range.start >= gutter + 6),
+            "a span reached into the gutter: {spans:?}"
+        );
+    }
+
+    /// The two sides of a hunk interleave row by row, and each is the
+    /// contiguous text it came from: a docstring opened on an old-side
+    /// row is still open on the next old-side row, while the new-side
+    /// rows between them are code.
+    #[test]
+    fn test_syntax_regions_keep_one_parser_per_stream() {
+        let (mut engine, theme) = region_host_for_test();
+        let rows = ["-\"\"\"old\n", "+x = 1\n", "-still old\"\"\"\n", "+y = 2\n"];
+        let content: String = rows.concat();
+        let mut regions = Vec::new();
+        let mut at = 0;
+        for (i, row) in rows.iter().enumerate() {
+            let stream = if row.starts_with('-') { 0 } else { 1 };
+            regions.push(region(at, at + row.len(), 1, &[stream]));
+            at += row.len();
+            let _ = i;
+        }
+        engine.set_syntax_regions(regions);
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+
+        assert_eq!(
+            category_at(&spans, &content, "still old"),
+            Some(HighlightCategory::Comment)
+        );
+        assert_eq!(
+            category_at(&spans, &content, "1\n"),
+            Some(HighlightCategory::Number)
+        );
+        assert_eq!(
+            category_at(&spans, &content, "2\n"),
+            Some(HighlightCategory::Number)
+        );
+    }
+
+    /// Regions ride the text: an insertion before them moves them, and
+    /// the rows they meant are still the ones coloured.
+    #[test]
+    fn test_syntax_regions_follow_an_edit() {
+        let (mut engine, theme) = region_host_for_test();
+        let code = "+def f():\n";
+        engine.set_syntax_regions(vec![region(0, code.len(), 1, &[])]);
+        let buffer = Buffer::from_str(code, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, code, "def"),
+            Some(HighlightCategory::Keyword)
+        );
+
+        let inserted = "HEADER\n";
+        let content = format!("{inserted}{code}");
+        engine.notify_insert(0, inserted.len());
+        engine.invalidate_range(0..inserted.len());
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, &content, "def"),
+            Some(HighlightCategory::Keyword)
+        );
+        assert_eq!(category_at(&spans, &content, "HEADER"), None);
+    }
+
+    /// A language nothing in the set claims leaves the rows as they are,
+    /// and replacing the content's regions with none paints nothing.
+    #[test]
+    fn test_syntax_regions_unknown_language_and_clearing() {
+        let (mut engine, theme) = region_host_for_test();
+        let code = "+def f():\n";
+        engine.set_syntax_regions(vec![SyntaxRegion {
+            start: 0,
+            end: code.len(),
+            language: "notes.nosuchlanguage".to_string(),
+            prefix: 1,
+            streams: Vec::new(),
+        }]);
+        let buffer = Buffer::from_str(code, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
+        assert!(spans.is_empty(), "{spans:?}");
+
+        engine.set_syntax_regions(vec![region(0, code.len(), 1, &[])]);
+        let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, code, "def"),
+            Some(HighlightCategory::Keyword)
+        );
+        engine.set_syntax_regions(Vec::new());
+        let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
+        assert!(spans.is_empty(), "{spans:?}");
     }
 }

--- a/crates/fresh-editor-core/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor-core/src/primitives/highlight_engine.rs
@@ -318,6 +318,10 @@ struct TextMateCache {
 struct CachedSpan {
     range: Range<usize>,
     category: crate::primitives::highlighter::HighlightCategory,
+    /// Optional independent background category. Embedded source tokens in
+    /// unified diffs keep their language category for the foreground while
+    /// inheriting Inserted/Deleted from the host diff row.
+    background_category: Option<crate::primitives::highlighter::HighlightCategory>,
 }
 
 /// Declares how a host syntax delimits embedded-language regions whose
@@ -341,6 +345,18 @@ struct EmbeddingSpecDef {
     /// JS is the standard approximation). `None` = keep the host's own
     /// styling for such regions (Markdown's raw-code look).
     default_language: Option<&'static str>,
+    /// How content rows are presented to the embedded parser.
+    content_mode: EmbeddedContentMode,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum EmbeddedContentMode {
+    /// Parse the complete region-content line (Markdown, Vue).
+    WholeLine,
+    /// Parse unified-diff source rows after removing their one-byte patch
+    /// marker. Diff metadata stays host-styled and does not advance the
+    /// source parser.
+    UnifiedDiff,
 }
 
 /// A host may declare several region kinds (Vue: `<script>` and
@@ -352,18 +368,28 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
         region_scope: "markup.raw.code-fence",
         language_scope: "constant.other.language-name",
         default_language: None,
+        content_mode: EmbeddedContentMode::WholeLine,
     },
     EmbeddingSpecDef {
         host_syntax: "Vue",
         region_scope: "meta.embedded.block.script",
         language_scope: "constant.other.language-name",
         default_language: Some("js"),
+        content_mode: EmbeddedContentMode::WholeLine,
     },
     EmbeddingSpecDef {
         host_syntax: "Vue",
         region_scope: "meta.embedded.block.style",
         language_scope: "constant.other.language-name",
         default_language: Some("css"),
+        content_mode: EmbeddedContentMode::WholeLine,
+    },
+    EmbeddingSpecDef {
+        host_syntax: "Fresh Diff",
+        region_scope: "meta.embedded.block.diff",
+        language_scope: "constant.other.language-name",
+        default_language: None,
+        content_mode: EmbeddedContentMode::UnifiedDiff,
     },
 ];
 
@@ -469,6 +495,7 @@ struct EmbeddingSpec {
     region_scope: syntect::parsing::Scope,
     language_scope: syntect::parsing::Scope,
     default_language: Option<&'static str>,
+    content_mode: EmbeddedContentMode,
 }
 
 impl EmbeddingSpec {
@@ -481,6 +508,7 @@ impl EmbeddingSpec {
                     region_scope: syntect::parsing::Scope::new(d.region_scope).ok()?,
                     language_scope: syntect::parsing::Scope::new(d.language_scope).ok()?,
                     default_language: d.default_language,
+                    content_mode: d.content_mode,
                 })
             })
             .collect()
@@ -569,6 +597,28 @@ struct PreparedLine {
     /// Whether the original line ended with `\n` (true for every line
     /// except the streaming tail).
     ends_with_newline: bool,
+}
+
+/// Prepare one unified-diff source row for its embedded language parser.
+///
+/// Added, removed, and context rows carry a one-byte patch marker that is
+/// not part of the source language. File headers (`+++` / `---`) and all
+/// other diff metadata return `None` so they retain host-grammar styling
+/// without advancing the embedded parser.
+fn prepare_unified_diff_content(prepared: &PreparedLine) -> Option<PreparedLine> {
+    let bytes = prepared.line_for_syntect.as_bytes();
+    let marker = *bytes.first()?;
+    if !matches!(marker, b'+' | b'-' | b' ') {
+        return None;
+    }
+    if bytes.starts_with(b"+++") || bytes.starts_with(b"---") {
+        return None;
+    }
+    Some(PreparedLine {
+        line_for_syntect: prepared.line_for_syntect.get(1..)?.to_string(),
+        line_content_len: prepared.line_content_len.saturating_sub(1),
+        ends_with_newline: prepared.ends_with_newline,
+    })
 }
 
 /// Longest logical line highlighted in full. Beyond this, only the
@@ -721,13 +771,11 @@ fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<Pr
 ///
 /// The guarantee stops at "unclaimed": a span that *does* claim a range
 /// inside a washed row keeps its own category, background or none, so
-/// the bar still breaks across it. That is reachable — syntect's `Diff`
-/// grammar matches `meta.diff.header.to-file` mid-row, so a section
-/// name shaped like `- foo ====` inside a hunk header is scoped as a
-/// file header — but not by anything `git diff` emits, so the sink is
-/// deliberately not scope-aware. See
-/// `test_diff_hunk_header_inner_span_is_a_known_wash_hole`.
-struct RowWash<F: FnMut(usize, usize, HighlightCategory)> {
+/// the bar can still break across it. Fresh's diff grammar anchors its
+/// non-wash row rules, so supported diff output does not currently
+/// trigger that limitation; the sink is nevertheless deliberately not
+/// scope-aware.
+struct RowWash<F: FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>)> {
     row_start: usize,
     row_end: usize,
     /// The wash to fill gaps with; `None` until the span covering
@@ -741,7 +789,7 @@ struct RowWash<F: FnMut(usize, usize, HighlightCategory)> {
     inner: F,
 }
 
-impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
+impl<F: FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>)> RowWash<F> {
     fn new(row_start: usize, row_end: usize, inner: F) -> Self {
         Self {
             row_start,
@@ -753,7 +801,13 @@ impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
         }
     }
 
-    fn emit(&mut self, start: usize, end: usize, category: HighlightCategory) {
+    fn emit(
+        &mut self,
+        start: usize,
+        end: usize,
+        category: HighlightCategory,
+        background_category: Option<HighlightCategory>,
+    ) {
         // Decide from the span that *covers* `row_start`, not from
         // whichever span happens to arrive first: an empty leading
         // segment (`start == end == row_start`) must not decide the
@@ -767,11 +821,11 @@ impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
         }
         if let Some(wash) = self.wash {
             if start > self.covered {
-                (self.inner)(self.covered, start, wash);
+                (self.inner)(self.covered, start, wash, None);
             }
         }
         self.covered = self.covered.max(end);
-        (self.inner)(start, end, category);
+        (self.inner)(start, end, category, background_category);
     }
 
     /// Emit the trailing filler, if any. Must be called once the row's
@@ -779,7 +833,7 @@ impl<F: FnMut(usize, usize, HighlightCategory)> RowWash<F> {
     fn finish(mut self) {
         if let Some(wash) = self.wash {
             if self.covered < self.row_end {
-                (self.inner)(self.covered, self.row_end, wash);
+                (self.inner)(self.covered, self.row_end, wash, None);
             }
         }
     }
@@ -1026,7 +1080,7 @@ impl TextMateEngine {
         snapshot: &mut ParseSnapshot,
         prepared: &PreparedLine,
         current_offset: usize,
-        on_span: impl FnMut(usize, usize, HighlightCategory),
+        on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
         let mut wash = RowWash::new(
             current_offset,
@@ -1034,8 +1088,8 @@ impl TextMateEngine {
             on_span,
         );
         let parsed =
-            self.parse_snapshot_line_spans(snapshot, prepared, current_offset, |s, e, c| {
-                wash.emit(s, e, c)
+            self.parse_snapshot_line_spans(snapshot, prepared, current_offset, |s, e, c, bg| {
+                wash.emit(s, e, c, bg)
             });
         wash.finish();
         parsed
@@ -1047,7 +1101,7 @@ impl TextMateEngine {
         snapshot: &mut ParseSnapshot,
         prepared: &PreparedLine,
         current_offset: usize,
-        mut on_span: impl FnMut(usize, usize, HighlightCategory),
+        mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
         if self.embedding.is_empty() {
             return self
@@ -1057,25 +1111,27 @@ impl TextMateEngine {
                     prepared,
                     current_offset,
                     &[],
-                    on_span,
+                    |start, end, category| on_span(start, end, category, None),
                 )
                 .0;
         }
 
         let was_in = self.active_region_spec(&snapshot.scopes);
-        // Watch for a language token only on lines that could open a
-        // region. Copy the (deduplicated) language scopes to the stack so
-        // no borrow of self outlives the parse call below.
+        // Watch for a language token on every line. Most hosts only emit one
+        // while opening a region; a unified diff can close one file region
+        // and open the next on the same `diff --git` line, leaving the same
+        // region scope active at both line boundaries. Seeing the new token
+        // is what lets us retarget the child parser in that case.
+        // Copy the (deduplicated) language scopes to the stack so no borrow
+        // of self outlives the parse call below.
         let mut watch_buf = [self.embedding[0].language_scope; MAX_WATCH_SCOPES];
         let mut watch_len = 0;
-        if was_in.is_none() {
-            for spec in &self.embedding {
-                if watch_len < MAX_WATCH_SCOPES
-                    && !watch_buf[..watch_len].contains(&spec.language_scope)
-                {
-                    watch_buf[watch_len] = spec.language_scope;
-                    watch_len += 1;
-                }
+        for spec in &self.embedding {
+            if watch_len < MAX_WATCH_SCOPES
+                && !watch_buf[..watch_len].contains(&spec.language_scope)
+            {
+                watch_buf[watch_len] = spec.language_scope;
+                watch_len += 1;
             }
         }
 
@@ -1109,28 +1165,101 @@ impl TextMateEngine {
         // neither arises for the current hosts.
         if let (Some(i), Some(j)) = (was_in, now_in) {
             if i == j {
+                // A host may replace one same-kind region with another on a
+                // single line (unified diff file headers). A newly scoped
+                // language token restarts the child for the new region; the
+                // transition line itself remains host-styled.
+                if language_range.is_some() {
+                    snapshot.embedded =
+                        self.embedded_state_for_region(prepared, current_offset, language_range, j);
+                    for &(start, end, category) in &host_spans {
+                        on_span(start, end, category, None);
+                    }
+                    self.host_span_scratch = host_spans;
+                    return true;
+                }
                 // Region content line.
                 if snapshot.embedded.is_some() {
                     let mut embedded = snapshot
                         .embedded
                         .take()
                         .expect("checked embedded.is_some() above");
+                    let stripped;
+                    let (child_line, child_offset) = match self.embedding[i].content_mode {
+                        EmbeddedContentMode::WholeLine => (Some(prepared), current_offset),
+                        EmbeddedContentMode::UnifiedDiff => {
+                            stripped = prepare_unified_diff_content(prepared);
+                            (stripped.as_ref(), current_offset + 1)
+                        }
+                    };
+                    // Metadata and hunk-header rows inside a diff region stay
+                    // host-styled and do not disturb the source parser state.
+                    let Some(child_line) = child_line else {
+                        for &(start, end, category) in &host_spans {
+                            on_span(start, end, category, None);
+                        }
+                        snapshot.embedded = Some(embedded);
+                        self.host_span_scratch = host_spans;
+                        return true;
+                    };
                     let mut child_spans = std::mem::take(&mut self.child_span_scratch);
                     child_spans.clear();
                     let (child_ok, _) = self.parse_line_into_spans(
                         &mut embedded.state,
                         &mut embedded.scopes,
-                        prepared,
-                        current_offset,
+                        child_line,
+                        child_offset,
                         &[],
                         |start, end, category| child_spans.push((start, end, category)),
                     );
                     // On a child parse error, fall back to the host's
                     // raw styling for the line rather than leaving it
                     // unstyled.
-                    let chosen = if child_ok { &child_spans } else { &host_spans };
-                    for &(start, end, category) in chosen {
-                        on_span(start, end, category);
+                    if child_ok {
+                        let background_category = match self.embedding[i].content_mode {
+                            EmbeddedContentMode::UnifiedDiff => host_spans
+                                .iter()
+                                .map(|&(_, _, category)| category)
+                                .find(|category| {
+                                    matches!(
+                                        category,
+                                        HighlightCategory::Inserted | HighlightCategory::Deleted
+                                    )
+                                }),
+                            EmbeddedContentMode::WholeLine => None,
+                        };
+                        // Preserve the diff marker's host category while
+                        // source syntax owns the remainder of the row.
+                        for &(start, end, category) in &host_spans {
+                            let clipped_end = end.min(child_offset);
+                            if start < clipped_end {
+                                on_span(start, clipped_end, category, None);
+                            }
+                        }
+                        let mut covered_to = child_offset;
+                        for &(start, end, category) in &child_spans {
+                            if let Some(bg_category) = background_category {
+                                if covered_to < start {
+                                    // Source grammars commonly leave plain
+                                    // identifiers/whitespace unscoped. Emit
+                                    // host-category spans for those gaps so
+                                    // the diff background remains continuous.
+                                    on_span(covered_to, start, bg_category, None);
+                                }
+                            }
+                            on_span(start, end, category, background_category);
+                            covered_to = covered_to.max(end);
+                        }
+                        if let Some(bg_category) = background_category {
+                            let content_end = child_offset + child_line.line_content_len;
+                            if covered_to < content_end {
+                                on_span(covered_to, content_end, bg_category, None);
+                            }
+                        }
+                    } else {
+                        for &(start, end, category) in &host_spans {
+                            on_span(start, end, category, None);
+                        }
                     }
                     snapshot.embedded = Some(embedded);
                     self.child_span_scratch = child_spans;
@@ -1143,7 +1272,7 @@ impl TextMateEngine {
         }
 
         for &(start, end, category) in &host_spans {
-            on_span(start, end, category);
+            on_span(start, end, category, None);
         }
         match (was_in, now_in) {
             (None, Some(j)) => {
@@ -1223,9 +1352,16 @@ impl TextMateEngine {
             return *cached;
         }
         let plain = self.syntax_set.find_syntax_plain_text();
-        let resolved = self
-            .syntax_set
-            .find_syntax_by_token(token)
+        // Region tokens are usually short language names (`rust`, `ts`).
+        // Diff regions instead provide a target path (`src/main.rs`), so
+        // also try its basename and extension. This covers extensionless
+        // grammar tokens such as Makefile as well as ordinary source files.
+        let basename = token.rsplit(['/', '\\']).next().unwrap_or(token);
+        let extension = basename.rsplit_once('.').map(|(_, ext)| ext);
+        let resolved = std::iter::once(token)
+            .chain((basename != token).then_some(basename))
+            .chain(extension)
+            .find_map(|candidate| self.syntax_set.find_syntax_by_token(candidate))
             .filter(|found| !std::ptr::eq(*found, plain))
             .and_then(|found| {
                 self.syntax_set
@@ -1359,7 +1495,10 @@ impl TextMateEngine {
             .map(|span| HighlightSpan {
                 range: span.range.clone(),
                 color: highlight_color(span.category, theme),
-                bg: highlight_bg(span.category, theme),
+                bg: span
+                    .background_category
+                    .and_then(|category| highlight_bg(category, theme))
+                    .or_else(|| highlight_bg(span.category, theme)),
                 category: Some(span.category),
             })
             .collect()
@@ -1444,7 +1583,7 @@ impl TextMateEngine {
                     &mut snapshot,
                     &prepared,
                     current_offset,
-                    |byte_start, byte_end, category| {
+                    |byte_start, byte_end, category, background_category| {
                         if !collect_spans {
                             return;
                         }
@@ -1453,6 +1592,7 @@ impl TextMateEngine {
                             new_spans.push(CachedSpan {
                                 range: clamped_start..byte_end,
                                 category,
+                                background_category,
                             });
                         }
                     },
@@ -1618,10 +1758,11 @@ impl TextMateEngine {
                     &mut windowed,
                     &window,
                     window_offset,
-                    |byte_start, byte_end, category| {
+                    |byte_start, byte_end, category, background_category| {
                         new_spans.push(CachedSpan {
                             range: byte_start..byte_end,
                             category,
+                            background_category,
                         });
                     },
                 );
@@ -1633,10 +1774,11 @@ impl TextMateEngine {
                     &mut snapshot,
                     &prepared,
                     current_offset,
-                    |byte_start, byte_end, category| {
+                    |byte_start, byte_end, category, background_category| {
                         new_spans.push(CachedSpan {
                             range: byte_start..byte_end,
                             category,
+                            background_category,
                         });
                     },
                 );
@@ -1696,11 +1838,17 @@ impl TextMateEngine {
             unsafe_spans
                 .into_iter()
                 .filter(|s| s.range.start < viewport_end && s.range.end > viewport_start)
-                .map(|s| HighlightSpan {
-                    range: s.range,
-                    color: highlight_color(s.category, theme),
-                    bg: highlight_bg(s.category, theme),
-                    category: Some(s.category),
+                .map(|s| {
+                    let bg = s
+                        .background_category
+                        .and_then(|category| highlight_bg(category, theme))
+                        .or_else(|| highlight_bg(s.category, theme));
+                    HighlightSpan {
+                        range: s.range,
+                        color: highlight_color(s.category, theme),
+                        bg,
+                        category: Some(s.category),
+                    }
                 }),
         );
         result
@@ -1776,7 +1924,7 @@ impl TextMateEngine {
                     &mut windowed,
                     &window,
                     window_offset,
-                    |byte_start, byte_end, category| {
+                    |byte_start, byte_end, category, background_category| {
                         if !collect_spans {
                             return;
                         }
@@ -1785,6 +1933,7 @@ impl TextMateEngine {
                             spans.push(CachedSpan {
                                 range: clamped_start..byte_end,
                                 category,
+                                background_category,
                             });
                         }
                     },
@@ -1795,7 +1944,7 @@ impl TextMateEngine {
                     &mut snapshot,
                     &prepared,
                     current_offset,
-                    |byte_start, byte_end, category| {
+                    |byte_start, byte_end, category, background_category| {
                         if !collect_spans {
                             return;
                         }
@@ -1804,6 +1953,7 @@ impl TextMateEngine {
                             spans.push(CachedSpan {
                                 range: clamped_start..byte_end,
                                 category,
+                                background_category,
                             });
                         }
                     },
@@ -1892,10 +2042,14 @@ impl TextMateEngine {
             .filter(|span| span.range.start < viewport_end && span.range.end > viewport_start)
             .map(|span| {
                 let cat = span.category;
+                let bg = span
+                    .background_category
+                    .and_then(|category| highlight_bg(category, theme))
+                    .or_else(|| highlight_bg(cat, theme));
                 HighlightSpan {
                     range: span.range,
                     color: highlight_color(cat, theme),
-                    bg: highlight_bg(cat, theme),
+                    bg,
                     category: Some(cat),
                 }
             })
@@ -2108,7 +2262,7 @@ impl TextMateEngine {
                     &mut snapshot,
                     &prepared,
                     current_offset,
-                    |_, _, _| {},
+                    |_, _, _, _| {},
                 );
                 if !parsed {
                     // A host parse error leaves region membership untouched
@@ -2177,7 +2331,7 @@ impl TextMateEngine {
         out
     }
 
-    /// Merge adjacent spans with same category
+    /// Merge adjacent spans with the same foreground and background categories.
     fn merge_adjacent_spans(spans: &mut Vec<CachedSpan>) {
         if spans.len() < 2 {
             return;
@@ -2186,6 +2340,7 @@ impl TextMateEngine {
         let mut write_idx = 0;
         for read_idx in 1..spans.len() {
             if spans[write_idx].category == spans[read_idx].category
+                && spans[write_idx].background_category == spans[read_idx].background_category
                 && spans[write_idx].range.end == spans[read_idx].range.start
             {
                 spans[write_idx].range.end = spans[read_idx].range.end;
@@ -3068,6 +3223,69 @@ mod tests {
         assert!(engine.region_lines_in(&buffer, 0..buffer.len()).is_empty());
     }
 
+    /// Unified diffs select a source grammar from each target path and parse
+    /// hunk rows without their one-byte patch marker.
+    #[test]
+    fn test_diff_embeds_target_file_syntax() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        assert_eq!(engine.backend_name(), "textmate");
+        assert_eq!(engine.syntax_name(), Some("Fresh Diff"));
+
+        let content = "\
+diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-pub fn old() -> u32 { 1 }
++pub fn new() -> u32 { 2 }
+diff --git a/tools/check.py b/tools/check.py
+--- a/tools/check.py
++++ b/tools/check.py
+@@ -1 +1 @@
+-def old():
++def new():
+";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+
+        let category_at = |needle: &str| {
+            let position = content.find(needle).unwrap();
+            spans
+                .iter()
+                .find(|span| span.range.start <= position && position < span.range.end)
+                .and_then(|span| span.category)
+        };
+
+        assert_eq!(
+            category_at("pub fn new"),
+            Some(HighlightCategory::Keyword),
+            "Rust added lines must retain Rust token colors"
+        );
+        assert_eq!(
+            category_at("def new"),
+            Some(HighlightCategory::Keyword),
+            "the next file header must switch the embedded parser to Python"
+        );
+        let added_marker = content.find("+pub fn new").unwrap();
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.start <= added_marker && added_marker < span.range.end)
+                .and_then(|span| span.category),
+            Some(HighlightCategory::Inserted),
+            "the patch marker itself must retain diff styling"
+        );
+        assert_eq!(
+            category_at("@@ -1"),
+            Some(HighlightCategory::Changed),
+            "hunk headers stay styled by the host diff grammar"
+        );
+    }
+
     /// Fences naming an unknown language keep the host's raw-code styling.
     #[test]
     fn test_markdown_unknown_fence_language_keeps_raw_style() {
@@ -3764,21 +3982,11 @@ mod tests {
         }
     }
 
-    /// Pins the known limitation of the `RowWash` gap fill: it fills
-    /// only the byte ranges of a washed row that *no* span claims. A
-    /// span that does claim its range keeps its own (bg-less)
-    /// category, so the bar still breaks across it.
-    ///
-    /// This is reachable with the shipped `Diff` grammar because its
-    /// `meta.diff.header.to-file` rule is not `^`-anchored: a
-    /// hunk-header section name shaped like `- foo ====` is scoped as
-    /// a file header mid-row and maps to `Type`, which carries no
-    /// background (asserted below). `git diff` never emits a
-    /// section name of that shape, so the algorithm is deliberately
-    /// left as is rather than made scope-aware. If that ever changes,
-    /// this test and the `RowWash` doc comment are what to update.
+    /// Fresh's diff grammar anchors file-header rules, so text resembling
+    /// a file header inside a hunk-header section remains unclaimed and
+    /// receives the row wash instead of punching a hole in it.
     #[test]
-    fn test_diff_hunk_header_inner_span_is_a_known_wash_hole() {
+    fn test_diff_hunk_header_unclaimed_section_is_washed() {
         let registry =
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
         let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
@@ -3814,26 +4022,14 @@ mod tests {
                 "byte {byte_pos} of `{RANGE}` should carry diff_modify_bg",
             );
         }
-        // …but the section name is *claimed* by a non-wash span, so the
-        // gap fill does not reach it. Documented limitation, not a
-        // shape `git diff` produces.
+        // The section resembles a file header, but the corresponding grammar
+        // rule is line-anchored. It therefore remains unclaimed and inherits
+        // the hunk header's wash.
         for byte_pos in header_start + RANGE.len()..header_start + RANGE.len() + SECTION.len() {
-            let span = span_at(byte_pos);
-            // `Type` is what `meta.diff.header.*` maps to in
-            // `scope_to_category` — i.e. the run really is claimed by
-            // the unanchored to-file header rule, not merely unstyled.
             assert_eq!(
-                span.and_then(|s| s.category),
-                Some(HighlightCategory::Type),
-                "byte {byte_pos} of `{SECTION}` should be claimed by the \
-                 `meta.diff.header.*` rule",
-            );
-            assert_ne!(
                 bg_at(byte_pos),
                 Some(theme.diff_modify_bg),
-                "byte {byte_pos} of `{SECTION}` is claimed, so the gap fill \
-                 does not reach it; if it now carries the wash, the \
-                 limitation was fixed — update this test and the `RowWash` docs",
+                "byte {byte_pos} of `{SECTION}` should inherit the hunk-header wash",
             );
         }
     }

--- a/crates/fresh-editor-core/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor-core/src/primitives/highlight_engine.rs
@@ -293,10 +293,17 @@ pub struct TextMateEngine {
     // than a grammar found. Its own syntax is plain text; every colour
     // comes from a region's child parser.
     declared_host: bool,
-    // The declared regions, sorted by start and disjoint (see
-    // `set_declared_regions`): a row finds its region by binary search,
-    // and an edit shifts them all in one pass.
-    declared: Vec<DeclaredRegion>,
+    // One span marker per declared region, in the engine's own marker
+    // list — the same list, and the same `notify_insert` / `notify_delete`
+    // hooks, that carry its parse checkpoints through an edit. `declared`
+    // holds what each marker's region parses as.
+    region_markers: MarkerList,
+    declared: HashMap<MarkerId, DeclaredRegion>,
+    // The region the last row fell in. Regions are runs of rows, so the
+    // marker tree is asked once per run rather than once per row; a row
+    // outside this range re-queries. Dropped whenever the markers move,
+    // since it caches their positions.
+    active_region: Option<(MarkerId, usize, usize)>,
 }
 
 /// A run of rows a plugin declared as code, as the host resolved it. The
@@ -304,9 +311,10 @@ pub struct TextMateEngine {
 /// its language already looked up in the syntax set.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclaredRegion {
-    /// Byte offset of the first row's first byte.
+    /// Byte offset of the first row's first byte, as declared. The live
+    /// bounds are the region's marker's: an edit moves them.
     pub start: usize,
-    /// Byte offset one past the last row's newline.
+    /// Byte offset one past the last row's newline, as declared.
     pub end: usize,
     /// Index into the syntax set of the language the rows are written
     /// in. `None` when nothing in the set claims it, in which case the
@@ -980,7 +988,9 @@ impl TextMateEngine {
             child_span_scratch: Vec::new(),
             scope_category_cache: HashMap::new(),
             declared_host: false,
-            declared: Vec::new(),
+            region_markers: MarkerList::new(),
+            declared: HashMap::new(),
+            active_region: None,
         }
     }
 
@@ -1010,83 +1020,96 @@ impl TextMateEngine {
     /// dropped with a warning rather than left to fight over rows. Every
     /// cached span is dropped, since any of them may now be wrong.
     pub fn set_declared_regions(&mut self, mut regions: Vec<DeclaredRegion>) {
+        let stale: Vec<MarkerId> = self.declared.keys().copied().collect();
+        for id in stale {
+            self.region_markers.delete(id);
+        }
+        self.declared.clear();
+        self.active_region = None;
         regions.sort_by_key(|region| region.start);
-        let mut kept: Vec<DeclaredRegion> = Vec::with_capacity(regions.len());
+        let mut previous_end = 0;
         for mut region in regions {
             if region.end <= region.start {
                 continue;
             }
-            if let Some(previous) = kept.last() {
-                if region.start < previous.end {
-                    tracing::warn!(
-                        "declared region {}..{} overlaps {}..{}; dropped",
-                        region.start,
-                        region.end,
-                        previous.start,
-                        previous.end
-                    );
-                    continue;
-                }
+            if region.start < previous_end {
+                tracing::warn!(
+                    "declared region {}..{} overlaps the one ending at {}; dropped",
+                    region.start,
+                    region.end,
+                    previous_end
+                );
+                continue;
             }
+            previous_end = region.end;
             if region.streams.is_empty() {
                 region.streams.push(DEFAULT_REGION_STREAM);
             }
-            kept.push(region);
+            let id = self.region_markers.create_span(region.start, region.end);
+            self.declared.insert(id, region);
         }
-        self.declared = kept;
         self.invalidate_all();
     }
 
     /// The declared regions and the syntax set they index, for a caller
-    /// that is replacing this engine and must not lose them.
+    /// that is replacing this engine and must not lose them. The regions
+    /// come back at their live bounds, so an engine rebuilt from them
+    /// picks up where this one left off.
     pub fn take_declared_regions(&mut self) -> (Arc<SyntaxSet>, Vec<DeclaredRegion>) {
-        (
-            Arc::clone(&self.syntax_set),
-            std::mem::take(&mut self.declared),
-        )
+        let mut regions: Vec<DeclaredRegion> = std::mem::take(&mut self.declared)
+            .into_iter()
+            .filter_map(|(id, mut region)| {
+                let (start, end) = self.region_bounds(id)?;
+                region.start = start;
+                region.end = end;
+                Some(region)
+            })
+            .collect();
+        regions.sort_by_key(|region| region.start);
+        self.region_markers = MarkerList::new();
+        self.active_region = None;
+        (Arc::clone(&self.syntax_set), regions)
+    }
+
+    /// A region's live bounds, or `None` once an edit has swallowed it.
+    fn region_bounds(&self, id: MarkerId) -> Option<(usize, usize)> {
+        let start = self.region_markers.get_position(id)?;
+        let (_, start, end) = self
+            .region_markers
+            .query_range(start, start + 1)
+            .into_iter()
+            .find(|&(found, _, _)| found == id)?;
+        (end > start).then_some((start, end))
     }
 
     /// The declared region a row belongs to, by the row's first byte.
-    fn declared_region_at(&self, row_start: usize) -> Option<usize> {
-        let index = self
-            .declared
-            .partition_point(|region| region.start <= row_start)
-            .checked_sub(1)?;
-        (row_start < self.declared[index].end).then_some(index)
-    }
-
-    /// Move the declared regions for an insertion, as the buffer's own
-    /// markers would: text inserted at a region's first byte lands before
-    /// it, text inserted anywhere inside it grows it.
-    fn shift_declared_regions_for_insert(&mut self, position: usize, length: usize) {
-        for region in &mut self.declared {
-            if region.start >= position {
-                region.start += length;
-            }
-            if region.end > position {
-                region.end += length;
+    ///
+    /// Regions come in runs of rows, so the answer is remembered and the
+    /// marker tree is consulted once per run rather than once per row.
+    fn declared_region_at(&mut self, row_start: usize) -> Option<MarkerId> {
+        if let Some((id, start, end)) = self.active_region {
+            if start <= row_start && row_start < end {
+                return Some(id);
             }
         }
-    }
-
-    /// Move the declared regions for a deletion; a region the deletion
-    /// swallows whole is gone.
-    fn shift_declared_regions_for_delete(&mut self, position: usize, length: usize) {
-        let deleted_end = position + length;
-        let shift = |offset: usize| {
-            if offset <= position {
-                offset
-            } else if offset >= deleted_end {
-                offset - length
-            } else {
-                position
+        let found = self
+            .region_markers
+            .query_range(row_start, row_start + 1)
+            .into_iter()
+            .filter(|&(id, start, end)| {
+                start <= row_start && row_start < end && self.declared.contains_key(&id)
+            })
+            .max_by_key(|&(_, start, _)| start);
+        match found {
+            Some((id, start, end)) => {
+                self.active_region = Some((id, start, end));
+                Some(id)
             }
-        };
-        for region in &mut self.declared {
-            region.start = shift(region.start);
-            region.end = shift(region.end);
+            None => {
+                self.active_region = None;
+                None
+            }
         }
-        self.declared.retain(|region| region.end > region.start);
     }
 
     /// Get performance stats for testing and diagnostics.
@@ -1108,7 +1131,8 @@ impl TextMateEngine {
     /// the cache dirty so the partial-update path runs on next render.
     pub fn notify_insert(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_insert(position, length);
-        self.shift_declared_regions_for_insert(position, length);
+        self.region_markers.adjust_for_insert(position, length);
+        self.active_region = None;
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             for span in &mut cache.spans {
@@ -1131,7 +1155,8 @@ impl TextMateEngine {
     /// Buffer-delete notification. Mirror of `notify_insert`.
     pub fn notify_delete(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_delete(position, length);
-        self.shift_declared_regions_for_delete(position, length);
+        self.region_markers.adjust_for_delete(position, length);
+        self.active_region = None;
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             let delete_end = position + length;
@@ -1522,11 +1547,11 @@ impl TextMateEngine {
         current_offset: usize,
         mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
-        let Some(index) = self.declared_region_at(current_offset) else {
+        let Some(id) = self.declared_region_at(current_offset) else {
             return true;
         };
         let (syntax_index, prefix, stream_count) = {
-            let region = &self.declared[index];
+            let region = &self.declared[&id];
             (region.syntax_index, region.prefix, region.streams.len())
         };
         let Some(syntax_index) = syntax_index else {
@@ -1549,7 +1574,7 @@ impl TextMateEngine {
         child_spans.clear();
         let mut ok = true;
         for k in 0..stream_count {
-            let stream = self.declared[index].streams[k];
+            let stream = self.declared[&id].streams[k];
             let mut parser = snapshot.take_stream(stream, syntax_index, &self.syntax_set);
             let (child_ok, _) = self.parse_line_into_spans(
                 &mut parser.state,
@@ -5064,8 +5089,10 @@ diff --git a/tools/check.py b/tools/check.py
         );
     }
 
-    /// Regions ride the text: an insertion before them moves them, and
-    /// the rows they meant are still the ones coloured.
+    /// Regions ride the text on the engine's own marker list, the one
+    /// that carries its parse checkpoints: an insertion before a region
+    /// moves it, an insertion inside it grows it, and either way the rows
+    /// it meant are still the ones coloured.
     #[test]
     fn test_declared_regions_follow_an_edit() {
         let (registry, theme) = declared_host_for_test();
@@ -5092,6 +5119,21 @@ diff --git a/tools/check.py b/tools/check.py
             Some(HighlightCategory::Keyword)
         );
         assert_eq!(category_at(&spans, &content, "HEADER"), None);
+
+        // A row inserted *inside* the region grows it, so the new row is
+        // code too — the marker span's own semantics, not arithmetic here.
+        let at = content.find("+def").unwrap() + "+def f():\n".len();
+        let added = "+    return 1\n";
+        let content = format!("{}{}{}", &content[..at], added, &content[at..]);
+        engine.notify_insert(at, added.len());
+        engine.invalidate_range(at..at + added.len());
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, &content, "return"),
+            Some(HighlightCategory::Keyword),
+            "a row inserted inside a region is still inside it afterwards"
+        );
     }
 
     /// A language nothing in the set claims leaves the rows as they are;

--- a/crates/fresh-editor-core/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor-core/src/primitives/highlight_engine.rs
@@ -43,7 +43,6 @@ use crate::primitives::highlighter::{
     highlight_bg, highlight_color, HighlightCategory, HighlightSpan, Highlighter, Language,
 };
 use crate::theme::Theme;
-use fresh_core::api::SyntaxRegion;
 use fresh_core::hooks::{RegionLine, TableLine, TableRole};
 use std::collections::HashMap;
 use std::ops::Range;
@@ -289,35 +288,44 @@ pub struct TextMateEngine {
     // Scope→Category memo. Syntect Scope atoms are append-only-interned
     // globally, so entries never need invalidation.
     scope_category_cache: HashMap<syntect::parsing::Scope, Option<HighlightCategory>>,
-    // A region host highlights a buffer a plugin composed, whose code
-    // rows the plugin declared (`set_syntax_regions`) rather than a
-    // grammar found. Its own syntax is plain text; every colour comes
-    // from a region's child parser.
-    region_host: bool,
-    // One span marker per declared region, so the bounds follow the text
-    // through edits the way checkpoints do; `regions` holds what each
-    // marker's region parses as.
-    region_markers: MarkerList,
-    regions: HashMap<MarkerId, RegionInfo>,
+    // A host for declared regions highlights a buffer a plugin composed,
+    // whose code rows the plugin declared (`set_declared_regions`) rather
+    // than a grammar found. Its own syntax is plain text; every colour
+    // comes from a region's child parser.
+    declared_host: bool,
+    // The declared regions, sorted by start and disjoint (see
+    // `set_declared_regions`): a row finds its region by binary search,
+    // and an edit shifts them all in one pass.
+    declared: Vec<DeclaredRegion>,
 }
 
-/// What a declared region's rows parse as; see `SyntaxRegion`.
-struct RegionInfo {
-    /// Resolved once, when the region is declared. `None` when nothing in
-    /// the set claims the language, and the rows stay as the plugin
-    /// styled them.
-    syntax_index: Option<usize>,
-    prefix: usize,
-    streams: Arc<[u32]>,
+/// A run of rows a plugin declared as code, as the host resolved it. The
+/// contract the plugin sees is `SyntaxRegion` in the plugin API; this is
+/// its language already looked up in the syntax set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredRegion {
+    /// Byte offset of the first row's first byte.
+    pub start: usize,
+    /// Byte offset one past the last row's newline.
+    pub end: usize,
+    /// Index into the syntax set of the language the rows are written
+    /// in. `None` when nothing in the set claims it, in which case the
+    /// rows keep the styling they have.
+    pub syntax_index: Option<usize>,
+    /// Bytes at the start of every row that are not code.
+    pub prefix: usize,
+    /// Parsers the rows feed, in order; the first colours the row. Empty
+    /// means [`DEFAULT_REGION_STREAM`].
+    pub streams: Vec<u32>,
 }
 
-/// Stream a region that names none feeds; see `SyntaxRegion::streams`.
-const DEFAULT_REGION_STREAM: u32 = u32::MAX;
+/// Stream a region that names none feeds.
+pub const DEFAULT_REGION_STREAM: u32 = 0;
 
-/// Parsers a region host carries between rows. The diff panels interleave
-/// the two sides of one hunk and never need more than that; anything
-/// older is dropped rather than cloned into every checkpoint.
-const MAX_REGION_STREAMS: usize = 4;
+/// Parsers a declared-region host carries between rows. The diff panels
+/// interleave the two sides of one hunk and never need more than that;
+/// anything older is dropped rather than cloned into every checkpoint.
+pub const MAX_REGION_STREAMS: usize = 4;
 
 /// Counters for monitoring highlighting performance in tests.
 #[derive(Debug, Default, Clone)]
@@ -376,6 +384,11 @@ struct EmbeddingSpecDef {
     default_language: Option<&'static str>,
     /// How content rows are presented to the embedded parser.
     content_mode: EmbeddedContentMode,
+    /// Whether one region of this kind can end and the next begin on a
+    /// single line, so the language token has to be watched on every
+    /// line rather than only where a region could open. A unified diff
+    /// does that at each `diff --git`; fences and tags never do.
+    retargets_on_same_line: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -398,6 +411,7 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
         language_scope: "constant.other.language-name",
         default_language: None,
         content_mode: EmbeddedContentMode::WholeLine,
+        retargets_on_same_line: false,
     },
     EmbeddingSpecDef {
         host_syntax: "Vue",
@@ -405,6 +419,7 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
         language_scope: "constant.other.language-name",
         default_language: Some("js"),
         content_mode: EmbeddedContentMode::WholeLine,
+        retargets_on_same_line: false,
     },
     EmbeddingSpecDef {
         host_syntax: "Vue",
@@ -412,6 +427,7 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
         language_scope: "constant.other.language-name",
         default_language: Some("css"),
         content_mode: EmbeddedContentMode::WholeLine,
+        retargets_on_same_line: false,
     },
     EmbeddingSpecDef {
         host_syntax: "Fresh Diff",
@@ -419,6 +435,7 @@ const EMBEDDING_SPECS: &[EmbeddingSpecDef] = &[
         language_scope: "constant.other.language-name",
         default_language: None,
         content_mode: EmbeddedContentMode::UnifiedDiff,
+        retargets_on_same_line: true,
     },
 ];
 
@@ -525,6 +542,7 @@ struct EmbeddingSpec {
     language_scope: syntect::parsing::Scope,
     default_language: Option<&'static str>,
     content_mode: EmbeddedContentMode,
+    retargets_on_same_line: bool,
 }
 
 impl EmbeddingSpec {
@@ -538,6 +556,7 @@ impl EmbeddingSpec {
                     language_scope: syntect::parsing::Scope::new(d.language_scope).ok()?,
                     default_language: d.default_language,
                     content_mode: d.content_mode,
+                    retargets_on_same_line: d.retargets_on_same_line,
                 })
             })
             .collect()
@@ -570,8 +589,8 @@ struct ParseSnapshot {
     state: syntect::parsing::ParseState,
     scopes: syntect::parsing::ScopeStack,
     embedded: Option<EmbeddedParseState>,
-    /// A region host's live parsers, most recently fed last; empty for
-    /// every grammar host. See `SyntaxRegion::streams`.
+    /// A declared-region host's live parsers, most recently fed last;
+    /// empty for every grammar host. See `DeclaredRegion::streams`.
     streams: Vec<(u32, EmbeddedParseState)>,
 }
 
@@ -683,16 +702,26 @@ fn prepare_row_content(prepared: &PreparedLine, prefix: usize) -> Option<Prepare
 /// Prepare one unified-diff source row for its embedded language parser.
 ///
 /// Added, removed, and context rows carry a one-byte patch marker that is
-/// not part of the source language. File headers (`+++` / `---`) and all
-/// other diff metadata return `None` so they retain host-grammar styling
-/// without advancing the embedded parser.
-fn prepare_unified_diff_content(prepared: &PreparedLine) -> Option<PreparedLine> {
-    let bytes = prepared.line_for_syntect.as_bytes();
-    let marker = *bytes.first()?;
-    if !matches!(marker, b'+' | b'-' | b' ') {
-        return None;
-    }
-    if bytes.starts_with(b"+++") || bytes.starts_with(b"---") {
+/// not part of the source language. Which rows those are is the diff
+/// grammar's call, read off the row's host spans: a row it scoped as an
+/// insertion or deletion is source, and so is one that begins with the
+/// context marker. File headers (`+++` / `---`), hunk headers and the
+/// rest of the metadata return `None` so they retain host-grammar
+/// styling without advancing the embedded parser — a removed line that
+/// happens to begin `--` is source, not a header, and the grammar knows
+/// the difference because it knows whether it is inside a hunk.
+fn prepare_unified_diff_content(
+    prepared: &PreparedLine,
+    host_spans: &[(usize, usize, HighlightCategory)],
+) -> Option<PreparedLine> {
+    let marker = *prepared.line_for_syntect.as_bytes().first()?;
+    let is_change = host_spans.iter().any(|&(_, _, category)| {
+        matches!(
+            category,
+            HighlightCategory::Inserted | HighlightCategory::Deleted
+        )
+    });
+    if !(is_change || marker == b' ') {
         return None;
     }
     prepare_row_content(prepared, 1)
@@ -950,15 +979,14 @@ impl TextMateEngine {
             host_span_scratch: Vec::new(),
             child_span_scratch: Vec::new(),
             scope_category_cache: HashMap::new(),
-            region_host: false,
-            region_markers: MarkerList::new(),
-            regions: HashMap::new(),
+            declared_host: false,
+            declared: Vec::new(),
         }
     }
 
     /// An engine for a buffer a plugin composed: plain text of its own,
-    /// coloured only where `set_syntax_regions` says there is code.
-    pub fn region_host(syntax_set: Arc<SyntaxSet>) -> Self {
+    /// coloured only where the declared regions say there is code.
+    pub fn declared_region_host(syntax_set: Arc<SyntaxSet>, regions: Vec<DeclaredRegion>) -> Self {
         let plain = syntax_set.find_syntax_plain_text();
         let index = syntax_set
             .syntaxes()
@@ -966,54 +994,99 @@ impl TextMateEngine {
             .position(|s| std::ptr::eq(s, plain))
             .unwrap_or(0);
         let mut engine = Self::new(syntax_set, index);
-        engine.region_host = true;
+        engine.declared_host = true;
+        engine.set_declared_regions(regions);
         engine
     }
 
     /// Whether this engine takes its regions from a plugin rather than a
-    /// grammar (see [`Self::region_host`]).
-    pub fn hosts_syntax_regions(&self) -> bool {
-        self.region_host
+    /// grammar (see [`Self::declared_region_host`]).
+    pub fn hosts_declared_regions(&self) -> bool {
+        self.declared_host
     }
 
-    /// Replace the declared regions (see `SyntaxRegion`). Each becomes a
-    /// span marker, so an edit moves it with the text; the language is
-    /// resolved here, once, and every cached span is dropped since any of
-    /// them may now be wrong.
-    pub fn set_syntax_regions(&mut self, regions: Vec<SyntaxRegion>) {
-        let stale: Vec<MarkerId> = self.regions.keys().copied().collect();
-        for id in stale {
-            self.region_markers.delete(id);
-        }
-        self.regions.clear();
-        for region in regions {
+    /// Replace the declared regions. They are kept sorted and disjoint:
+    /// an empty region, or one that overlaps the region before it, is
+    /// dropped with a warning rather than left to fight over rows. Every
+    /// cached span is dropped, since any of them may now be wrong.
+    pub fn set_declared_regions(&mut self, mut regions: Vec<DeclaredRegion>) {
+        regions.sort_by_key(|region| region.start);
+        let mut kept: Vec<DeclaredRegion> = Vec::with_capacity(regions.len());
+        for mut region in regions {
             if region.end <= region.start {
                 continue;
             }
-            let syntax_index = self.resolve_embedded_syntax(&region.language);
-            let id = self.region_markers.create_span(region.start, region.end);
-            self.regions.insert(
-                id,
-                RegionInfo {
-                    syntax_index,
-                    prefix: region.prefix,
-                    streams: Arc::from(region.streams),
-                },
-            );
+            if let Some(previous) = kept.last() {
+                if region.start < previous.end {
+                    tracing::warn!(
+                        "declared region {}..{} overlaps {}..{}; dropped",
+                        region.start,
+                        region.end,
+                        previous.start,
+                        previous.end
+                    );
+                    continue;
+                }
+            }
+            if region.streams.is_empty() {
+                region.streams.push(DEFAULT_REGION_STREAM);
+            }
+            kept.push(region);
         }
+        self.declared = kept;
         self.invalidate_all();
     }
 
+    /// The declared regions and the syntax set they index, for a caller
+    /// that is replacing this engine and must not lose them.
+    pub fn take_declared_regions(&mut self) -> (Arc<SyntaxSet>, Vec<DeclaredRegion>) {
+        (
+            Arc::clone(&self.syntax_set),
+            std::mem::take(&mut self.declared),
+        )
+    }
+
     /// The declared region a row belongs to, by the row's first byte.
-    /// Regions are meant not to overlap; if they do, the one that starts
-    /// last wins, as an inner overlay would.
-    fn region_at(&self, row_start: usize) -> Option<MarkerId> {
-        self.region_markers
-            .query_range(row_start, row_start + 1)
-            .into_iter()
-            .filter(|&(_, start, end)| start <= row_start && row_start < end)
-            .max_by_key(|&(_, start, _)| start)
-            .map(|(id, _, _)| id)
+    fn declared_region_at(&self, row_start: usize) -> Option<usize> {
+        let index = self
+            .declared
+            .partition_point(|region| region.start <= row_start)
+            .checked_sub(1)?;
+        (row_start < self.declared[index].end).then_some(index)
+    }
+
+    /// Move the declared regions for an insertion, as the buffer's own
+    /// markers would: text inserted at a region's first byte lands before
+    /// it, text inserted anywhere inside it grows it.
+    fn shift_declared_regions_for_insert(&mut self, position: usize, length: usize) {
+        for region in &mut self.declared {
+            if region.start >= position {
+                region.start += length;
+            }
+            if region.end > position {
+                region.end += length;
+            }
+        }
+    }
+
+    /// Move the declared regions for a deletion; a region the deletion
+    /// swallows whole is gone.
+    fn shift_declared_regions_for_delete(&mut self, position: usize, length: usize) {
+        let deleted_end = position + length;
+        let shift = |offset: usize| {
+            if offset <= position {
+                offset
+            } else if offset >= deleted_end {
+                offset - length
+            } else {
+                position
+            }
+        };
+        for region in &mut self.declared {
+            region.start = shift(region.start);
+            region.end = shift(region.end);
+        }
+        self.declared.retain(|region| region.end > region.start);
     }
 
     /// Get performance stats for testing and diagnostics.
@@ -1035,7 +1108,7 @@ impl TextMateEngine {
     /// the cache dirty so the partial-update path runs on next render.
     pub fn notify_insert(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_insert(position, length);
-        self.region_markers.adjust_for_insert(position, length);
+        self.shift_declared_regions_for_insert(position, length);
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             for span in &mut cache.spans {
@@ -1058,7 +1131,7 @@ impl TextMateEngine {
     /// Buffer-delete notification. Mirror of `notify_insert`.
     pub fn notify_delete(&mut self, position: usize, length: usize) {
         self.checkpoint_markers.adjust_for_delete(position, length);
-        self.region_markers.adjust_for_delete(position, length);
+        self.shift_declared_regions_for_delete(position, length);
         self.dirty_from = Some(self.dirty_from.map_or(position, |d| d.min(position)));
         if let Some(cache) = &mut self.cache {
             let delete_end = position + length;
@@ -1245,8 +1318,8 @@ impl TextMateEngine {
         current_offset: usize,
         mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
-        if self.region_host {
-            return self.parse_region_line(snapshot, prepared, current_offset, on_span);
+        if self.declared_host {
+            return self.parse_declared_row(snapshot, prepared, current_offset, on_span);
         }
         if self.embedding.is_empty() {
             return self
@@ -1262,21 +1335,27 @@ impl TextMateEngine {
         }
 
         let was_in = self.active_region_spec(&snapshot.scopes);
-        // Watch for a language token on every line. Most hosts only emit one
-        // while opening a region; a unified diff can close one file region
-        // and open the next on the same `diff --git` line, leaving the same
-        // region scope active at both line boundaries. Seeing the new token
-        // is what lets us retarget the child parser in that case.
-        // Copy the (deduplicated) language scopes to the stack so no borrow
-        // of self outlives the parse call below.
+        // Watch for a language token on lines that could open a region —
+        // and, for a host whose regions can hand over on a single line (a
+        // unified diff at each `diff --git`), on every line, since the
+        // region scope is active at both ends of that line and only the
+        // new token says the child parser must be retargeted. Copy the
+        // (deduplicated) language scopes to the stack so no borrow of
+        // self outlives the parse call below.
+        let watch_everywhere = self
+            .embedding
+            .iter()
+            .any(|spec| spec.retargets_on_same_line);
         let mut watch_buf = [self.embedding[0].language_scope; MAX_WATCH_SCOPES];
         let mut watch_len = 0;
-        for spec in &self.embedding {
-            if watch_len < MAX_WATCH_SCOPES
-                && !watch_buf[..watch_len].contains(&spec.language_scope)
-            {
-                watch_buf[watch_len] = spec.language_scope;
-                watch_len += 1;
+        if was_in.is_none() || watch_everywhere {
+            for spec in &self.embedding {
+                if watch_len < MAX_WATCH_SCOPES
+                    && !watch_buf[..watch_len].contains(&spec.language_scope)
+                {
+                    watch_buf[watch_len] = spec.language_scope;
+                    watch_len += 1;
+                }
             }
         }
 
@@ -1314,7 +1393,7 @@ impl TextMateEngine {
                 // single line (unified diff file headers). A newly scoped
                 // language token restarts the child for the new region; the
                 // transition line itself remains host-styled.
-                if language_range.is_some() {
+                if language_range.is_some() && self.embedding[i].retargets_on_same_line {
                     snapshot.embedded =
                         self.embedded_state_for_region(prepared, current_offset, language_range, j);
                     for &(start, end, category) in &host_spans {
@@ -1333,7 +1412,7 @@ impl TextMateEngine {
                     let (child_line, child_offset) = match self.embedding[i].content_mode {
                         EmbeddedContentMode::WholeLine => (Some(prepared), current_offset),
                         EmbeddedContentMode::UnifiedDiff => {
-                            stripped = prepare_unified_diff_content(prepared);
+                            stripped = prepare_unified_diff_content(prepared, &host_spans);
                             (stripped.as_ref(), current_offset + 1)
                         }
                     };
@@ -1381,25 +1460,14 @@ impl TextMateEngine {
                                 on_span(start, clipped_end, category, None);
                             }
                         }
-                        let mut covered_to = child_offset;
+                        // The sink is a `RowWash`, and the marker span above
+                        // carries the row's Inserted/Deleted category from
+                        // its first byte, so the wash fills every gap the
+                        // source grammar leaves unscoped and the run after
+                        // the last token. The child spans only need the
+                        // background to ride along on the ranges they claim.
                         for &(start, end, category) in &child_spans {
-                            if let Some(bg_category) = background_category {
-                                if covered_to < start {
-                                    // Source grammars commonly leave plain
-                                    // identifiers/whitespace unscoped. Emit
-                                    // host-category spans for those gaps so
-                                    // the diff background remains continuous.
-                                    on_span(covered_to, start, bg_category, None);
-                                }
-                            }
                             on_span(start, end, category, background_category);
-                            covered_to = covered_to.max(end);
-                        }
-                        if let Some(bg_category) = background_category {
-                            let content_end = child_offset + child_line.line_content_len;
-                            if covered_to < content_end {
-                                on_span(covered_to, content_end, bg_category, None);
-                            }
                         }
                     } else {
                         for &(start, end, category) in &host_spans {
@@ -1440,25 +1508,26 @@ impl TextMateEngine {
         true
     }
 
-    /// One row of a region host (see [`Self::region_host`]). A row inside
-    /// a declared region is handed, prefix removed, to the parser of each
-    /// stream the region names, and coloured by the first; a row outside
-    /// every region is left as the plugin styled it and touches no
-    /// parser, so a header or a comment box between two runs of one
-    /// stream does not break the construct they are in the middle of.
-    fn parse_region_line(
+    /// One row of a declared-region host (see
+    /// [`Self::declared_region_host`]). A row inside a declared region is
+    /// handed, prefix removed, to the parser of each stream the region
+    /// names, and coloured by the first; a row outside every region is
+    /// left as the plugin styled it and touches no parser, so a header or
+    /// a comment box between two runs of one stream does not break the
+    /// construct they are in the middle of.
+    fn parse_declared_row(
         &mut self,
         snapshot: &mut ParseSnapshot,
         prepared: &PreparedLine,
         current_offset: usize,
         mut on_span: impl FnMut(usize, usize, HighlightCategory, Option<HighlightCategory>),
     ) -> bool {
-        let Some(id) = self.region_at(current_offset) else {
+        let Some(index) = self.declared_region_at(current_offset) else {
             return true;
         };
-        let (syntax_index, prefix, streams) = {
-            let info = &self.regions[&id];
-            (info.syntax_index, info.prefix, Arc::clone(&info.streams))
+        let (syntax_index, prefix, stream_count) = {
+            let region = &self.declared[index];
+            (region.syntax_index, region.prefix, region.streams.len())
         };
         let Some(syntax_index) = syntax_index else {
             return true;
@@ -1476,15 +1545,11 @@ impl TextMateEngine {
             }
         };
         let child_offset = current_offset + prefix;
-        let streams: &[u32] = if streams.is_empty() {
-            &[DEFAULT_REGION_STREAM]
-        } else {
-            &streams
-        };
         let mut child_spans = std::mem::take(&mut self.child_span_scratch);
         child_spans.clear();
         let mut ok = true;
-        for (k, &stream) in streams.iter().enumerate() {
+        for k in 0..stream_count {
+            let stream = self.declared[index].streams[k];
             let mut parser = snapshot.take_stream(stream, syntax_index, &self.syntax_set);
             let (child_ok, _) = self.parse_line_into_spans(
                 &mut parser.state,
@@ -2773,24 +2838,36 @@ impl HighlightEngine {
     }
 
     /// An engine for a buffer a plugin composed; see
-    /// [`TextMateEngine::region_host`].
-    pub fn region_host(syntax_set: Arc<SyntaxSet>) -> Self {
-        Self::TextMate(Box::new(TextMateEngine::region_host(syntax_set)))
+    /// [`TextMateEngine::declared_region_host`].
+    pub fn declared_region_host(syntax_set: Arc<SyntaxSet>, regions: Vec<DeclaredRegion>) -> Self {
+        Self::TextMate(Box::new(TextMateEngine::declared_region_host(
+            syntax_set, regions,
+        )))
     }
 
     /// Whether this engine takes its regions from a plugin rather than a
     /// grammar.
-    pub fn hosts_syntax_regions(&self) -> bool {
-        matches!(self, Self::TextMate(h) if h.hosts_syntax_regions())
+    pub fn hosts_declared_regions(&self) -> bool {
+        matches!(self, Self::TextMate(h) if h.hosts_declared_regions())
     }
 
-    /// Replace the regions a plugin declared (see `SyntaxRegion`). A
-    /// no-op for engines that take their regions from a grammar.
-    pub fn set_syntax_regions(&mut self, regions: Vec<SyntaxRegion>) {
+    /// Replace the regions a plugin declared. A no-op for engines that
+    /// take their regions from a grammar.
+    pub fn set_declared_regions(&mut self, regions: Vec<DeclaredRegion>) {
         if let Self::TextMate(h) = self {
-            if h.hosts_syntax_regions() {
-                h.set_syntax_regions(regions);
+            if h.hosts_declared_regions() {
+                h.set_declared_regions(regions);
             }
+        }
+    }
+
+    /// The declared regions and their syntax set, taken out of a host
+    /// that is about to be replaced so the replacement can carry them;
+    /// `None` for every other engine.
+    pub fn take_declared_regions(&mut self) -> Option<(Arc<SyntaxSet>, Vec<DeclaredRegion>)> {
+        match self {
+            Self::TextMate(h) if h.hosts_declared_regions() => Some(h.take_declared_regions()),
+            _ => None,
         }
     }
 
@@ -4870,12 +4947,11 @@ diff --git a/tools/check.py b/tools/check.py
             backtick_cat,
         );
     }
-    fn region_host_for_test() -> (HighlightEngine, Theme) {
+    fn declared_host_for_test() -> (GrammarRegistry, Theme) {
         let registry =
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
-        let engine = HighlightEngine::region_host(registry.syntax_set_arc());
         let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
-        (engine, theme)
+        (registry, theme)
     }
 
     fn category_at(
@@ -4890,23 +4966,29 @@ diff --git a/tools/check.py b/tools/check.py
             .and_then(|span| span.category)
     }
 
-    fn region(start: usize, end: usize, prefix: usize, streams: &[u32]) -> SyntaxRegion {
-        SyntaxRegion {
+    fn python_region(
+        registry: &GrammarRegistry,
+        start: usize,
+        end: usize,
+        prefix: usize,
+        streams: &[u32],
+    ) -> DeclaredRegion {
+        DeclaredRegion {
             start,
             end,
-            language: "calc.py".to_string(),
+            syntax_index: registry.embedded_syntax_index("calc.py"),
             prefix,
             streams: streams.to_vec(),
         }
     }
 
-    /// A region host colours the rows a plugin declared, past their
-    /// prefix, and nothing else: the header above them and the comment
-    /// box between them stay uncoloured, and the docstring the box
-    /// interrupts is still one docstring on the row after it.
+    /// A declared-region host colours the rows a plugin declared, past
+    /// their prefix, and nothing else: the header above them and the
+    /// comment box between them stay uncoloured, and the docstring the
+    /// box interrupts is still one docstring on the row after it.
     #[test]
-    fn test_syntax_regions_colour_declared_rows_across_a_gap() {
-        let (mut engine, theme) = region_host_for_test();
+    fn test_declared_regions_colour_declared_rows_across_a_gap() {
+        let (registry, theme) = declared_host_for_test();
         let header = "UNSTAGED\n";
         let code_a = "   1 +def f():\n   2 +    \"\"\"doc\n";
         let note = "  [ a note ]\n";
@@ -4914,10 +4996,13 @@ diff --git a/tools/check.py b/tools/check.py
         let content = format!("{header}{code_a}{note}{code_b}");
         let a = header.len()..header.len() + code_a.len();
         let b = a.end + note.len()..content.len();
-        engine.set_syntax_regions(vec![
-            region(a.start, a.end, 6, &[1]),
-            region(b.start, b.end, 6, &[1]),
-        ]);
+        let mut engine = HighlightEngine::declared_region_host(
+            registry.syntax_set_arc(),
+            vec![
+                python_region(&registry, a.start, a.end, 6, &[1]),
+                python_region(&registry, b.start, b.end, 6, &[1]),
+            ],
+        );
         let buffer = Buffer::from_str(&content, 0, test_fs());
         let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
 
@@ -4950,19 +5035,18 @@ diff --git a/tools/check.py b/tools/check.py
     /// row is still open on the next old-side row, while the new-side
     /// rows between them are code.
     #[test]
-    fn test_syntax_regions_keep_one_parser_per_stream() {
-        let (mut engine, theme) = region_host_for_test();
+    fn test_declared_regions_keep_one_parser_per_stream() {
+        let (registry, theme) = declared_host_for_test();
         let rows = ["-\"\"\"old\n", "+x = 1\n", "-still old\"\"\"\n", "+y = 2\n"];
         let content: String = rows.concat();
         let mut regions = Vec::new();
         let mut at = 0;
-        for (i, row) in rows.iter().enumerate() {
+        for row in &rows {
             let stream = if row.starts_with('-') { 0 } else { 1 };
-            regions.push(region(at, at + row.len(), 1, &[stream]));
+            regions.push(python_region(&registry, at, at + row.len(), 1, &[stream]));
             at += row.len();
-            let _ = i;
         }
-        engine.set_syntax_regions(regions);
+        let mut engine = HighlightEngine::declared_region_host(registry.syntax_set_arc(), regions);
         let buffer = Buffer::from_str(&content, 0, test_fs());
         let spans = engine.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
 
@@ -4983,10 +5067,13 @@ diff --git a/tools/check.py b/tools/check.py
     /// Regions ride the text: an insertion before them moves them, and
     /// the rows they meant are still the ones coloured.
     #[test]
-    fn test_syntax_regions_follow_an_edit() {
-        let (mut engine, theme) = region_host_for_test();
+    fn test_declared_regions_follow_an_edit() {
+        let (registry, theme) = declared_host_for_test();
         let code = "+def f():\n";
-        engine.set_syntax_regions(vec![region(0, code.len(), 1, &[])]);
+        let mut engine = HighlightEngine::declared_region_host(
+            registry.syntax_set_arc(),
+            vec![python_region(&registry, 0, code.len(), 1, &[])],
+        );
         let buffer = Buffer::from_str(code, 0, test_fs());
         let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
         assert_eq!(
@@ -5007,31 +5094,135 @@ diff --git a/tools/check.py b/tools/check.py
         assert_eq!(category_at(&spans, &content, "HEADER"), None);
     }
 
-    /// A language nothing in the set claims leaves the rows as they are,
-    /// and replacing the content's regions with none paints nothing.
+    /// A language nothing in the set claims leaves the rows as they are;
+    /// an overlapping region is dropped rather than fought over; and
+    /// replacing the regions with none paints nothing.
     #[test]
-    fn test_syntax_regions_unknown_language_and_clearing() {
-        let (mut engine, theme) = region_host_for_test();
+    fn test_declared_regions_unknown_language_overlap_and_clearing() {
+        let (registry, theme) = declared_host_for_test();
+        assert_eq!(registry.embedded_syntax_index("notes.nosuchlanguage"), None);
         let code = "+def f():\n";
-        engine.set_syntax_regions(vec![SyntaxRegion {
-            start: 0,
-            end: code.len(),
-            language: "notes.nosuchlanguage".to_string(),
-            prefix: 1,
-            streams: Vec::new(),
-        }]);
+        let mut engine = HighlightEngine::declared_region_host(
+            registry.syntax_set_arc(),
+            vec![DeclaredRegion {
+                start: 0,
+                end: code.len(),
+                syntax_index: None,
+                prefix: 1,
+                streams: Vec::new(),
+            }],
+        );
         let buffer = Buffer::from_str(code, 0, test_fs());
         let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
         assert!(spans.is_empty(), "{spans:?}");
 
-        engine.set_syntax_regions(vec![region(0, code.len(), 1, &[])]);
+        // A second region starting inside the first is dropped; the first
+        // still paints.
+        engine.set_declared_regions(vec![
+            python_region(&registry, 0, code.len(), 1, &[]),
+            DeclaredRegion {
+                start: 2,
+                end: code.len(),
+                syntax_index: None,
+                prefix: 0,
+                streams: Vec::new(),
+            },
+        ]);
         let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
         assert_eq!(
             category_at(&spans, code, "def"),
             Some(HighlightCategory::Keyword)
         );
-        engine.set_syntax_regions(Vec::new());
+
+        engine.set_declared_regions(Vec::new());
         let spans = engine.highlight_viewport(&buffer, 0, code.len(), &theme, 0);
         assert!(spans.is_empty(), "{spans:?}");
+    }
+
+    /// The host resolves a region's language through the catalog first,
+    /// so a path picks the same grammar the editor would open it with,
+    /// and falls back to the grammar a bare token or extension names.
+    #[test]
+    fn test_embedded_syntax_index_resolves_paths_and_tokens() {
+        let (registry, _) = declared_host_for_test();
+        let names =
+            |index: Option<usize>| index.map(|i| registry.syntax_set().syntaxes()[i].name.clone());
+        assert_eq!(
+            names(registry.embedded_syntax_index("src/main.rs")).as_deref(),
+            Some("Rust")
+        );
+        assert_eq!(
+            names(registry.embedded_syntax_index("py")).as_deref(),
+            Some("Python")
+        );
+        // TypeScript is served by tree-sitter for real buffers; a declared
+        // region still gets its TextMate grammar, not plain text.
+        assert_eq!(
+            names(registry.embedded_syntax_index("app.ts")).as_deref(),
+            Some("TypeScript")
+        );
+        assert_eq!(registry.embedded_syntax_index("README"), None);
+    }
+
+    /// Inside a hunk, a removed line beginning `--` or an added one
+    /// beginning `++` is source, not a file header: it is fed to the
+    /// file's parser, so a construct it closes is closed for the rows
+    /// after it.
+    #[test]
+    fn test_diff_hunk_rows_that_look_like_headers_are_source() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let content = "\
+diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ /* open
+--- close */
++let x = 1;
+";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, content, "let x"),
+            Some(HighlightCategory::Keyword),
+            "the removed `-- close */` row must close the comment for the row after it"
+        );
+        // The real `+++` header, before any hunk, is still a header: it
+        // keeps the metadata category rather than the insertion wash a
+        // hunk row would get.
+        assert_eq!(
+            category_at(&spans, content, "+++ b/src"),
+            Some(HighlightCategory::Type),
+            "a file header outside a hunk keeps its header styling"
+        );
+    }
+
+    /// A `diff --git` header the path rules cannot parse still hands the
+    /// next file its own parser — resolved from the header's tail when
+    /// an extension is in it — rather than running the previous file's.
+    #[test]
+    fn test_diff_unparsed_header_does_not_leak_the_previous_parser() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let content = "\
+diff --git a/src/lib.rs b/src/lib.rs
+@@ -1 +1 @@
++/* open
+diff --git a/has space.py b/has space.py
+@@ -1 +1 @@
++def f():
+";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+        let spans = engine.highlight_viewport(&buffer, 0, buffer.len(), &theme, 0);
+        assert_eq!(
+            category_at(&spans, content, "def f"),
+            Some(HighlightCategory::Keyword),
+            "the second file must not be parsed by the first file's Rust parser"
+        );
     }
 }

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -14,6 +14,7 @@ import {
   buildCommitDetailEntries,
   buildCommitLogEntries,
   buildDetailPlaceholderEntries,
+  commitDetailSyntaxRegions,
   fetchCommitShow,
   fetchGitLog,
 } from "./lib/git_history.ts";
@@ -1335,12 +1336,14 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
         for (const hunk of fileHunks) {
         // The hunk's two sides are two parser streams for the host's
         // highlighter: its rows interleave, but each side is contiguous
-        // text and is parsed as such. Context rows feed both.
+        // text and is parsed as such. A context row feeds both, and is
+        // coloured by the first it names — the new side, the one the
+        // reader is looking at.
         const oldStream = 2 * (hunkOrdinal.get(hunk) ?? 0);
         const newStream = oldStream + 1;
         const oldSyntax: RowSyntax = { language: hunk.file, streams: [oldStream] };
         const newSyntax: RowSyntax = { language: hunk.file, streams: [newStream] };
-        const bothSyntax: RowSyntax = { language: hunk.file, streams: [oldStream, newStream] };
+        const bothSyntax: RowSyntax = { language: hunk.file, streams: [newStream, oldStream] };
         // Hunk header — always emit the expanded triangle; collapse
         // overlays a `▸` replacement-conceal (see `applyFolds`).
         const headerInner = hunk.contextHeader
@@ -8144,6 +8147,14 @@ function branchByteOffsetOfFirstCommit(): number {
     return branchState.logRowByteOffsets.length > 1 ? branchState.logRowByteOffsets[1] : 0;
 }
 
+/** Tell the host where the detail panel's rows are code, and in what
+ *  (#2871): the `+` / `-` / context rows of each hunk, in the language
+ *  of the file the hunk belongs to. */
+function branchDeclareDetailSyntax(entries: TextPropertyEntry[]): void {
+    if (branchState.detailBufferId === null) return;
+    editor.setSyntaxRegions(branchState.detailBufferId, commitDetailSyntaxRegions(entries));
+}
+
 async function branchRefreshDetail(): Promise<void> {
     if (branchState.groupId === null) return;
     if (branchState.commits.length === 0) {
@@ -8162,6 +8173,7 @@ async function branchRefreshDetail(): Promise<void> {
     if (branchState.detailCache && branchState.detailCache.hash === commit.hash) {
         const entries = buildCommitDetailEntries(commit, branchState.detailCache.output, {});
         editor.setPanelContent(branchState.groupId, "detail", entries);
+        branchDeclareDetailSyntax(entries);
         return;
     }
     const myId = ++branchState.pendingDetailId;
@@ -8176,11 +8188,9 @@ async function branchRefreshDetail(): Promise<void> {
     if (myId !== branchState.pendingDetailId) return;
     if (branchState.groupId === null) return;
     branchState.detailCache = { hash: commit.hash, output };
-    editor.setPanelContent(
-        branchState.groupId,
-        "detail",
-        buildCommitDetailEntries(commit, output, {}),
-    );
+    const entries = buildCommitDetailEntries(commit, output, {});
+    editor.setPanelContent(branchState.groupId, "detail", entries);
+    branchDeclareDetailSyntax(entries);
 }
 
 async function start_branch_log(): Promise<void> {

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -989,18 +989,18 @@ interface DiffLine {
     commentId?: string;
 }
 
-/** Language and parser streams of a code row; see `DiffLine.syntax`. */
+/** Language, parser streams and gutter width of a code row; see
+ *  `DiffLine.syntax`. */
 interface RowSyntax {
     language: string;
     streams: number[];
-}
-
-/**
- * Bytes at the start of every code row that are not code: the
- * line-number gutter and the one-byte diff marker.
- */
-function codeRowPrefixBytes(): number {
-    return getByteLength(lineNumPrefix(undefined, undefined)) + 1;
+    /** Bytes before the code: this row's line-number gutter plus its
+     *  one-byte diff marker. Measured from the text actually emitted,
+     *  never assumed — `lineNumPrefix` pads a number to `LINE_NUM_W` but
+     *  does not truncate one, so a file past 9,999 lines has a wider
+     *  gutter, and a row of it whose prefix was guessed would hand the
+     *  language parser the tail of its own line number. */
+    prefix: number;
 }
 
 /** Compute +N / -M line counts for a file. */
@@ -1341,9 +1341,11 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
         // reader is looking at.
         const oldStream = 2 * (hunkOrdinal.get(hunk) ?? 0);
         const newStream = oldStream + 1;
-        const oldSyntax: RowSyntax = { language: hunk.file, streams: [oldStream] };
-        const newSyntax: RowSyntax = { language: hunk.file, streams: [newStream] };
-        const bothSyntax: RowSyntax = { language: hunk.file, streams: [newStream, oldStream] };
+        const oldStreams = [oldStream];
+        const newStreams = [newStream];
+        const bothStreams = [newStream, oldStream];
+        const rowSyntax = (streams: number[], contentStart: number): RowSyntax =>
+            ({ language: hunk.file, streams, prefix: contentStart });
         // Hunk header — always emit the expanded triangle; collapse
         // overlays a `▸` replacement-conceal (see `applyFolds`).
         const headerInner = hunk.contextHeader
@@ -1419,7 +1421,8 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                 const removeOverlays: InlineOverlay[] = [
                     { start: 0, end: removePrefixLen, style: { fg: STYLE_LINE_NUM_FG } },
                 ];
-                let rOffset = removePrefixLen + getByteLength(line[0]); // skip diff prefix
+                const removeContentStart = removePrefixLen + getByteLength(line[0]); // skip diff marker
+                let rOffset = removeContentStart;
                 for (const part of parts) {
                     const pLen = getByteLength(part.text);
                     if (part.type === 'removed') {
@@ -1433,7 +1436,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType: 'remove', oldLine: curOldLine, newLine: undefined, lineContent: line,
                     inlineOverlays: removeOverlays,
-                    syntax: oldSyntax,
+                    syntax: rowSyntax(oldStreams, removeContentStart),
                 });
                 // Inline comments for the removed line
                 pushLineComments(lines, hunk, 'remove', curOldLine, undefined);
@@ -1446,7 +1449,8 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                 const addOverlays: InlineOverlay[] = [
                     { start: 0, end: addPrefixLen, style: { fg: STYLE_LINE_NUM_FG } },
                 ];
-                let aOffset = addPrefixLen + getByteLength(nextLine[0]);
+                const addContentStart = addPrefixLen + getByteLength(nextLine[0]);
+                let aOffset = addContentStart;
                 for (const part of parts) {
                     const pLen = getByteLength(part.text);
                     if (part.type === 'added') {
@@ -1460,7 +1464,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType: 'add', oldLine: undefined, newLine: newLineNum, lineContent: nextLine,
                     inlineOverlays: addOverlays,
-                    syntax: newSyntax,
+                    syntax: rowSyntax(newStreams, addContentStart),
                 });
                 pushLineComments(lines, hunk, 'add', undefined, newLineNum);
                 newLineNum++;
@@ -1474,6 +1478,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
             const dimNumOverlay: InlineOverlay = {
                 start: 0, end: numPrefixLen, style: { fg: STYLE_LINE_NUM_FG },
             };
+            const contentStart = numPrefixLen + getByteLength(line[0]);
 
             if (prefix === '+') {
                 lines.push({
@@ -1482,7 +1487,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
-                    syntax: newSyntax,
+                    syntax: rowSyntax(newStreams, contentStart),
                 });
                 newLineNum++;
             } else if (prefix === '-') {
@@ -1492,7 +1497,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
-                    syntax: oldSyntax,
+                    syntax: rowSyntax(oldStreams, contentStart),
                 });
                 oldLineNum++;
             } else {
@@ -1501,7 +1506,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
-                    syntax: bothSyntax,
+                    syntax: rowSyntax(bothStreams, contentStart),
                 });
                 oldLineNum++;
                 newLineNum++;
@@ -1644,7 +1649,6 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
     // consecutive rows with the same language and streams share one
     // region, so a hunk is a handful of regions, not one per row.
     const syntaxRegions: TsSyntaxRegion[] = [];
-    const prefix = codeRowPrefixBytes();
     let openRegion: (TsSyntaxRegion & { key: string }) | null = null;
     // Byte ranges of collapsible bodies, captured in this same single
     // pass so collapse later just registers a host fold (no rebuild).
@@ -1671,7 +1675,9 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
         runningByte += getByteLength(entry.text);
         entries.push(entry);
         row++;
-        const key = syntax ? `${syntax.language}\0${syntax.streams.join(',')}` : null;
+        const key = syntax
+            ? `${syntax.language}\0${syntax.streams.join(',')}\0${syntax.prefix}`
+            : null;
         if (openRegion && openRegion.key === key) {
             openRegion.end = runningByte;
             return;
@@ -1682,7 +1688,10 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
             openRegion = null;
         }
         if (syntax && key !== null) {
-            openRegion = { key, start, end: runningByte, language: syntax.language, prefix, streams: syntax.streams };
+            openRegion = {
+                key, start, end: runningByte,
+                language: syntax.language, prefix: syntax.prefix, streams: syntax.streams,
+            };
         }
     };
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -220,6 +220,10 @@ interface ReviewState {
   // editor.getTextPropertiesAtCursor (which can return the previous
   // row's props when the cursor sits at a row-boundary byte).
   entryPropsByRow: Record<number, Record<string, unknown>>;
+  // Where the stream carries code, for the host's highlighter (#3104):
+  // built with the rows, declared on the buffer right after they are
+  // mounted. See `SyntaxRegion` in the plugin API.
+  syntaxRegions: TsSyntaxRegion[];
   // Byte ranges of collapsible bodies, captured at build time. Tab /
   // mouse / z a / z r register these as host folds (see applyFolds)
   // — no buffer rebuild on collapse / expand.
@@ -365,6 +369,7 @@ const state: ReviewState = {
   hunkRowByHunkId: {},
   diffLineRowByCommentId: {},
   entryPropsByRow: {},
+  syntaxRegions: [],
   sectionBodyRange: {},
   fileBodyRange: {},
   hunkBodyRange: {},
@@ -970,6 +975,9 @@ interface DiffLine {
     fileIndex?: number;  // for file-header rows
     style?: Partial<OverlayOptions>;
     inlineOverlays?: InlineOverlay[];
+    // For a code row: what it is written in and which parser streams
+    // (one per hunk side) it feeds. See `SyntaxRegion` in the plugin API.
+    syntax?: RowSyntax;
     // Line metadata for comment attachment
     hunkId?: string;
     file?: string;
@@ -978,6 +986,20 @@ interface DiffLine {
     newLine?: number;
     lineContent?: string;
     commentId?: string;
+}
+
+/** Language and parser streams of a code row; see `DiffLine.syntax`. */
+interface RowSyntax {
+    language: string;
+    streams: number[];
+}
+
+/**
+ * Bytes at the start of every code row that are not code: the
+ * line-number gutter and the one-byte diff marker.
+ */
+function codeRowPrefixBytes(): number {
+    return getByteLength(lineNumPrefix(undefined, undefined)) + 1;
 }
 
 /** Compute +N / -M line counts for a file. */
@@ -1214,6 +1236,8 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
     }
 
     let lastCategory: string | undefined;
+    const hunkOrdinal = new Map<Hunk, number>();
+    state.hunks.forEach((h, i) => hunkOrdinal.set(h, i));
     for (let fi = 0; fi < state.files.length; fi++) {
         const file = state.files[fi];
 
@@ -1309,6 +1333,14 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
         }
 
         for (const hunk of fileHunks) {
+        // The hunk's two sides are two parser streams for the host's
+        // highlighter: its rows interleave, but each side is contiguous
+        // text and is parsed as such. Context rows feed both.
+        const oldStream = 2 * (hunkOrdinal.get(hunk) ?? 0);
+        const newStream = oldStream + 1;
+        const oldSyntax: RowSyntax = { language: hunk.file, streams: [oldStream] };
+        const newSyntax: RowSyntax = { language: hunk.file, streams: [newStream] };
+        const bothSyntax: RowSyntax = { language: hunk.file, streams: [oldStream, newStream] };
         // Hunk header — always emit the expanded triangle; collapse
         // overlays a `▸` replacement-conceal (see `applyFolds`).
         const headerInner = hunk.contextHeader
@@ -1398,6 +1430,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType: 'remove', oldLine: curOldLine, newLine: undefined, lineContent: line,
                     inlineOverlays: removeOverlays,
+                    syntax: oldSyntax,
                 });
                 // Inline comments for the removed line
                 pushLineComments(lines, hunk, 'remove', curOldLine, undefined);
@@ -1424,6 +1457,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType: 'add', oldLine: undefined, newLine: newLineNum, lineContent: nextLine,
                     inlineOverlays: addOverlays,
+                    syntax: newSyntax,
                 });
                 pushLineComments(lines, hunk, 'add', undefined, newLineNum);
                 newLineNum++;
@@ -1445,6 +1479,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
+                    syntax: newSyntax,
                 });
                 newLineNum++;
             } else if (prefix === '-') {
@@ -1454,6 +1489,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
+                    syntax: oldSyntax,
                 });
                 oldLineNum++;
             } else {
@@ -1462,6 +1498,7 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
                     hunkId: hunk.id, file: hunk.file,
                     lineType, oldLine: curOldLine, newLine: curNewLine, lineContent: line,
                     inlineOverlays: [dimNumOverlay],
+                    syntax: bothSyntax,
                 });
                 oldLineNum++;
                 newLineNum++;
@@ -1600,6 +1637,12 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
     const hunkRowByHunkId: Record<string, number> = {};
     const diffLineRowByCommentId: Record<string, number> = {};
     const entryPropsByRow: Record<number, Record<string, unknown>> = {};
+    // Runs of code rows for the host's highlighter (see `RowSyntax`):
+    // consecutive rows with the same language and streams share one
+    // region, so a hunk is a handful of regions, not one per row.
+    const syntaxRegions: TsSyntaxRegion[] = [];
+    const prefix = codeRowPrefixBytes();
+    let openRegion: (TsSyntaxRegion & { key: string }) | null = null;
     // Byte ranges of collapsible bodies, captured in this same single
     // pass so collapse later just registers a host fold (no rebuild).
     // The "body" of an entity is the byte range from the byte after
@@ -1619,11 +1662,25 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
     let row = 0; // 0-indexed counter; row + 1 is the 1-indexed line number
     let lastDiffLineRow = 0; // 1-indexed row of the most recent +/-/context line
 
-    const pushEntry = (entry: TextPropertyEntry) => {
+    const pushEntry = (entry: TextPropertyEntry, syntax?: RowSyntax) => {
         diffLineByteOffsets.push(runningByte);
+        const start = runningByte;
         runningByte += getByteLength(entry.text);
         entries.push(entry);
         row++;
+        const key = syntax ? `${syntax.language}\0${syntax.streams.join(',')}` : null;
+        if (openRegion && openRegion.key === key) {
+            openRegion.end = runningByte;
+            return;
+        }
+        if (openRegion) {
+            const { key: _key, ...region } = openRegion;
+            syntaxRegions.push(region);
+            openRegion = null;
+        }
+        if (syntax && key !== null) {
+            openRegion = { key, start, end: runningByte, language: syntax.language, prefix, streams: syntax.streams };
+        }
     };
 
     const lines = buildDiffLines(state.viewportWidth);
@@ -1687,7 +1744,7 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
             style: line.style,
             inlineOverlays: line.inlineOverlays,
             properties: props,
-        });
+        }, line.syntax);
 
         // After the header is pushed, runningByte points to the first
         // byte of the body that follows.
@@ -1702,7 +1759,12 @@ function buildDiffPanelEntries(): TextPropertyEntry[] {
     if (curSection) sectionBodyRange[curSection] = { start: sectionBodyStart, end: runningByte };
 
     diffLineByteOffsets.push(runningByte);
+    if (openRegion) {
+        const { key: _key, ...region } = openRegion as TsSyntaxRegion & { key: string };
+        syntaxRegions.push(region);
+    }
 
+    state.syntaxRegions = syntaxRegions;
     state.hunkHeaderRows = hunkHeaderRows;
     state.diffLineByteOffsets = diffLineByteOffsets;
     state.fileHeaderRows = fileHeaderRows;
@@ -5170,6 +5232,11 @@ function mountStreamContent(): void {
     const signature = streamSignature();
     if (state.streamMountedSignature === signature) return;
     editor.setPanelContent(state.groupId, "diff", buildDiffPanelEntries());
+    // The rows are up; say which of them are code, and in what, so the
+    // host colours them (#3104). Content replacement cleared the previous
+    // set, and the regions are byte ranges of *this* content.
+    const diffId = state.panelBuffers["diff"];
+    if (diffId !== undefined) editor.setSyntaxRegions(diffId, state.syntaxRegions);
     state.streamMountedSignature = signature;
     // Fresh content, so the host's folds went with the old rows.
     applyFolds();
@@ -7093,6 +7160,7 @@ function resetPerSessionState(): void {
     state.diffCursorRow = 1;
     state.hunkHeaderRows = [];
     state.diffLineByteOffsets = [];
+    state.syntaxRegions = [];
     state.fileHeaderRows = {};
     state.collapsedFiles = new Set();
     state.collapsedSections = new Set();

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -223,6 +223,30 @@ type TsCompositeHunk = {
 	*/
 	ops?: string;
 };
+type TsSyntaxRegion = {
+	/**
+	* Byte offset of the first row's first byte.
+	*/
+	start: number;
+	/**
+	* Byte offset one past the last row's newline.
+	*/
+	end: number;
+	/**
+	* What the rows are written in: a path (`src/main.rs`, `Makefile`)
+	* or a language token (`py`, `rust`). Nothing is opened or read;
+	* it only selects the grammar.
+	*/
+	language: string;
+	/**
+	* Bytes at the start of every row that are not code.
+	*/
+	prefix: number;
+	/**
+	* Parsers the rows feed; see the type docs.
+	*/
+	streams: Array<number>;
+};
 type TsCreateCompositeBufferOptions = {
 	/**
 	* Buffer name (displayed in tabs/title)
@@ -3673,6 +3697,14 @@ interface EditorAPI {
 	* Uses typed Vec<CompositeHunk> - serde validates field names at runtime
 	*/
 	updateCompositeAlignment(bufferId: number, hunks: TsCompositeHunk[]): boolean;
+	/**
+	* Say where a buffer this plugin composed carries code, and in what
+	* language, so the host highlights it. Replaces the buffer's
+	* previous regions; setting the buffer's content clears them.
+	* 
+	* Uses typed Vec<SyntaxRegion> - serde validates field names at runtime
+	*/
+	setSyntaxRegions(bufferId: number, regions: TsSyntaxRegion[]): boolean;
 	/**
 	* Close a composite buffer
 	*/

--- a/crates/fresh-editor/plugins/lib/git_history.ts
+++ b/crates/fresh-editor/plugins/lib/git_history.ts
@@ -594,6 +594,54 @@ export function buildCommitDetailEntries(
 // loaded yet (e.g. during initial render or when the log is empty).
 // =============================================================================
 
+/**
+ * Where the entries from `buildCommitDetailEntries` carry code, for
+ * `editor.setSyntaxRegions`: every `+`, `-` and context row of a hunk,
+ * one marker byte of prefix, in the language of the file the hunk
+ * belongs to. Each hunk's two sides are two parser streams, so a
+ * construct spanning several rows of one side is read as one construct
+ * however the other side's rows interleave with it; a context row feeds
+ * both and is coloured by the new side. Consecutive rows of one file and
+ * stream set share a region.
+ */
+export function commitDetailSyntaxRegions(entries: TextPropertyEntry[]): TsSyntaxRegion[] {
+  const regions: TsSyntaxRegion[] = [];
+  let at = 0;
+  let hunk = -1;
+  let open: TsSyntaxRegion | null = null;
+  let openKey = "";
+  for (const entry of entries) {
+    const start = at;
+    at += byteLength(entry.text);
+    const type = entry.properties?.type as string | undefined;
+    const file = entry.properties?.file as string | undefined;
+    if (type === "detail-hunk-header") hunk++;
+    let streams: number[] | null = null;
+    if (file && hunk >= 0) {
+      const oldSide = 2 * hunk;
+      const newSide = oldSide + 1;
+      if (type === "detail-add") streams = [newSide];
+      else if (type === "detail-remove") streams = [oldSide];
+      else if (type === "detail-context") streams = [newSide, oldSide];
+    }
+    const key = streams && file ? `${file}\0${streams.join(",")}` : "";
+    if (open && key !== "" && key === openKey) {
+      open.end = at;
+      continue;
+    }
+    if (open) {
+      regions.push(open);
+      open = null;
+    }
+    if (streams && file) {
+      open = { start, end: at, language: file, prefix: 1, streams };
+      openKey = key;
+    }
+  }
+  if (open) regions.push(open);
+  return regions;
+}
+
 export function buildDetailPlaceholderEntries(message: string): TextPropertyEntry[] {
   return [
     {

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -150,6 +150,35 @@ impl Editor {
         }
     }
 
+    /// Handle SetSyntaxRegions: a plugin-composed buffer says where its
+    /// code is and in what language (see `SyntaxRegion`). The buffer's
+    /// highlighter becomes a region host if it is not one yet — it has no
+    /// grammar of its own to lose, only whatever its name happened to
+    /// suggest — and the regions replace the ones it held.
+    pub(super) fn handle_set_syntax_regions(
+        &mut self,
+        buffer_id: BufferId,
+        regions: Vec<fresh_core::api::SyntaxRegion>,
+    ) {
+        let syntax_set = self.grammar_registry.syntax_set_arc();
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .expect("active window present")
+            .buffer_state_mut(buffer_id)
+        {
+            if !state.highlighter.hosts_syntax_regions() {
+                state.highlighter =
+                    crate::primitives::highlight_engine::HighlightEngine::region_host(syntax_set);
+            }
+            state.highlighter.set_syntax_regions(regions);
+            #[cfg(feature = "plugins")]
+            {
+                self.plugin_render_requested = true;
+            }
+        }
+    }
+
     /// Handle SetCursorLineOverlay command
     pub(super) fn handle_set_cursor_line_overlay(
         &mut self,

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -151,27 +151,68 @@ impl Editor {
     }
 
     /// Handle SetSyntaxRegions: a plugin-composed buffer says where its
-    /// code is and in what language (see `SyntaxRegion`). The buffer's
-    /// highlighter becomes a region host if it is not one yet — it has no
-    /// grammar of its own to lose, only whatever its name happened to
-    /// suggest — and the regions replace the ones it held.
+    /// code is and in what language (see `SyntaxRegion`). Only a virtual
+    /// buffer can be told this — a file has a grammar of its own that a
+    /// plugin must not take away — and each language is resolved here,
+    /// through the catalog, so a region named by a path gets the grammar
+    /// the editor would open that file with.
     pub(super) fn handle_set_syntax_regions(
         &mut self,
         buffer_id: BufferId,
         regions: Vec<fresh_core::api::SyntaxRegion>,
     ) {
-        let syntax_set = self.grammar_registry.syntax_set_arc();
-        if let Some(state) = self
+        use crate::primitives::highlight_engine::{DeclaredRegion, HighlightEngine};
+
+        let registry = std::sync::Arc::clone(&self.grammar_registry);
+        let window = self
             .windows
             .get_mut(&self.active_window)
-            .expect("active window present")
-            .buffer_state_mut(buffer_id)
-        {
-            if !state.highlighter.hosts_syntax_regions() {
+            .expect("active window present");
+        let is_virtual = window
+            .buffer_metadata
+            .get(&buffer_id)
+            .is_some_and(|meta| meta.is_virtual());
+        if !is_virtual {
+            tracing::warn!(
+                "SetSyntaxRegions: {:?} is not a plugin-composed buffer; ignored",
+                buffer_id
+            );
+            return;
+        }
+        let mut resolved: std::collections::HashMap<String, Option<usize>> =
+            std::collections::HashMap::new();
+        let declared: Vec<DeclaredRegion> = regions
+            .into_iter()
+            .map(|region| {
+                let syntax_index =
+                    *resolved
+                        .entry(region.language)
+                        .or_insert_with_key(|language| {
+                            let found = registry.embedded_syntax_index(language);
+                            if found.is_none() {
+                                tracing::warn!(
+                                    "SetSyntaxRegions: no grammar for {:?}; its rows stay plain",
+                                    language
+                                );
+                            }
+                            found
+                        });
+                DeclaredRegion {
+                    start: region.start,
+                    end: region.end,
+                    syntax_index,
+                    prefix: region.prefix,
+                    streams: region.streams,
+                }
+            })
+            .collect();
+        if let Some(state) = window.buffer_state_mut(buffer_id) {
+            if state.highlighter.hosts_declared_regions() {
+                state.highlighter.set_declared_regions(declared);
+            } else {
                 state.highlighter =
-                    crate::primitives::highlight_engine::HighlightEngine::region_host(syntax_set);
+                    HighlightEngine::declared_region_host(registry.syntax_set_arc(), declared);
             }
-            state.highlighter.set_syntax_regions(regions);
             #[cfg(feature = "plugins")]
             {
                 self.plugin_render_requested = true;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1634,6 +1634,9 @@ impl Editor {
             PluginCommand::CloseCompositeBuffer { buffer_id } => {
                 self.active_window_mut().close_composite_buffer(buffer_id);
             }
+            PluginCommand::SetSyntaxRegions { buffer_id, regions } => {
+                self.handle_set_syntax_regions(buffer_id, regions);
+            }
             PluginCommand::FlushLayout => {
                 self.flush_layout();
             }

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -468,6 +468,10 @@ impl crate::app::window::Window {
         // Set text properties
         state.text_properties = properties;
 
+        // Regions a plugin declared on the previous content pointed into
+        // it; the new content brings its own (see `SetSyntaxRegions`).
+        state.highlighter.set_syntax_regions(Vec::new());
+
         // Create inline overlays for the new content. Build the full vec
         // first and bulk-add it so the OverlayManager sorts exactly once;
         // a per-overlay `add` re-sorts every time and is O(n² log n) for

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -470,7 +470,7 @@ impl crate::app::window::Window {
 
         // Regions a plugin declared on the previous content pointed into
         // it; the new content brings its own (see `SetSyntaxRegions`).
-        state.highlighter.set_syntax_regions(Vec::new());
+        state.highlighter.set_declared_regions(Vec::new());
 
         // Create inline overlays for the new content. Build the full vec
         // first and bulk-add it so the OverlayManager sorts exactly once;

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -448,7 +448,15 @@ impl EditorState {
     pub fn apply_language(&mut self, detected: DetectedLanguage) {
         self.language = detected.name;
         self.display_name = detected.display_name;
-        self.highlighter = detected.highlighter;
+        // A buffer a plugin composed keeps the regions it declared through
+        // any change of grammar — a Set Language, a config reload: they
+        // describe its rows, not its name.
+        self.highlighter = match self.highlighter.take_declared_regions() {
+            Some((syntax_set, regions)) => {
+                HighlightEngine::declared_region_host(syntax_set, regions)
+            }
+            None => detected.highlighter,
+        };
         if let Some(lang) = &detected.ts_language {
             self.reference_highlighter.set_language(lang);
         }

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -4813,9 +4813,11 @@ fn test_issue3126_reopening_review_diff_does_not_stack_a_second_panel() {
 fn test_issue3104_diff_body_carries_syntax_colours() {
     init_tracing_from_env();
     let (repo, calc) = repo_with_committed_python();
+    // `add` is edited on one token so the diff has a changed pair with a
+    // word-level highlight; `sub` is new.
     fs::write(
         &calc,
-        "def add(a, b):\n    return a + b\n\ndef sub(a, b):\n    return a - b\n",
+        "def add(a, b):\n    return a * b\n\ndef sub(a, b):\n    return a - b\n",
     )
     .unwrap();
 
@@ -4859,6 +4861,20 @@ fn test_issue3104_diff_body_carries_syntax_colours() {
     // A context row (unchanged line) is tokenised too — #3104 called those
     // out separately.
     wait_for_fg(&mut harness, "def add", 0, keyword);
+
+    // On a changed row the word-level diff still wins: the `*` that
+    // replaced `+` carries the word-diff foreground, not the operator
+    // colour, while the `return` beside it is a keyword. What changed on
+    // the row stays its strongest signal.
+    let word_diff = harness.editor().theme().diagnostic_info_fg;
+    wait_for_fg(&mut harness, "return a * b", 0, keyword);
+    let (x, y) = harness.find_text_on_screen("return a * b").unwrap();
+    assert_eq!(harness.get_cell(x + 9, y).as_deref(), Some("*"));
+    assert_eq!(
+        harness.get_cell_style(x + 9, y).and_then(|s| s.fg),
+        Some(word_diff),
+        "the changed token should keep the word-diff colour over the syntax colour"
+    );
 }
 
 /// A construct spanning several rows of a hunk — here a block comment —

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -4519,7 +4519,7 @@ fn test_branch_log_detail_enter_opens_file_at_commit() {
 
 // ---------------------------------------------------------------------------
 // Review Diff against a working tree that moves under it, and the actions
-// that claim to have changed it: #2318, #3126.
+// that claim to have changed it: #2318, #3126, #3104.
 // ---------------------------------------------------------------------------
 
 /// `git status --porcelain` for the repo, trimmed. The tests below assert on
@@ -4802,6 +4802,117 @@ fn test_issue3126_reopening_review_diff_does_not_stack_a_second_panel() {
         "re-running the command must reuse the open panel, not add another \
          tab. Screen:\n{screen}"
     );
+}
+
+/// Issue #3104: the diff body was drawn as plain text — the add/remove
+/// colours and nothing else — while the same lines one tab over in the
+/// editor carried the language's keyword, function and punctuation
+/// colours. The stream now declares where its code is and the host's
+/// highlighter colours it like any buffer.
+#[test]
+fn test_issue3104_diff_body_carries_syntax_colours() {
+    init_tracing_from_env();
+    let (repo, calc) = repo_with_committed_python();
+    fs::write(
+        &calc,
+        "def add(a, b):\n    return a + b\n\ndef sub(a, b):\n    return a - b\n",
+    )
+    .unwrap();
+
+    // Tests get an empty grammar registry by default (fast startup); this
+    // one is about grammars, so it opts into the real thing.
+    let mut harness = EditorTestHarness::create(
+        120,
+        40,
+        HarnessOptions::new()
+            .with_config(Config::default())
+            .with_working_dir(repo.path.clone())
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("def sub"))
+        .unwrap();
+
+    // `def` — a keyword — in the added row of the diff. A plain `def`
+    // here is the bug, and a never-satisfied wait is how it fails.
+    let keyword = harness.editor().theme().syntax_keyword;
+    let function = harness.editor().theme().syntax_function;
+    wait_for_fg(&mut harness, "def sub", 0, keyword);
+
+    // The function name right after it is a *different* colour — proof the
+    // row is tokenised rather than washed in one colour.
+    let (x, y) = harness.find_text_on_screen("def sub").unwrap();
+    assert_eq!(
+        harness.get_cell(x + 4, y).as_deref(),
+        Some("s"),
+        "expected the `s` of `sub` four columns after `def`"
+    );
+    assert_eq!(
+        harness.get_cell_style(x + 4, y).and_then(|s| s.fg),
+        Some(function),
+        "the function name should carry the theme's function colour"
+    );
+
+    // A context row (unchanged line) is tokenised too — #3104 called those
+    // out separately.
+    wait_for_fg(&mut harness, "def add", 0, keyword);
+}
+
+/// A construct spanning several rows of a hunk — here a block comment —
+/// colours every row it covers, not just the one it opens on: the
+/// hunk's side is parsed as the contiguous text it is.
+#[test]
+fn test_issue3104_multi_line_constructs_colour_every_row() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    let app = repo.create_file("app.ts", "const x = 1;\n");
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+    fs::write(
+        &app,
+        "const x = 1;\n/* alpha\n   BRAVO_MARKER\n   omega */\n",
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        40,
+        HarnessOptions::new()
+            .with_config(Config::default())
+            .with_working_dir(repo.path.clone())
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("BRAVO_MARKER"))
+        .unwrap();
+
+    // A row in the middle of a block comment carries the comment colour
+    // rather than falling back to plain text.
+    let comment = harness.editor().theme().syntax_comment;
+    wait_for_fg(&mut harness, "BRAVO_MARKER", 0, comment);
+}
+
+/// Wait until the cell `dx` columns into the first on-screen occurrence of
+/// `text` is painted with foreground `fg`. The colours are the host's
+/// highlighter's, painted on the render after the rows are mounted, so
+/// waiting for them rather than asserting on one frame keeps the test
+/// independent of how many frames the mount takes.
+fn wait_for_fg(harness: &mut EditorTestHarness, text: &str, dx: u16, fg: ratatui::style::Color) {
+    harness
+        .wait_until(|h| {
+            h.find_text_on_screen(text)
+                .and_then(|(x, y)| h.get_cell_style(x + dx, y))
+                .and_then(|s| s.fg)
+                == Some(fg)
+        })
+        .unwrap();
 }
 
 /// The same, from the *other* row. `git status` reports a file added to

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -4915,6 +4915,56 @@ fn test_issue3104_multi_line_constructs_colour_every_row() {
     wait_for_fg(&mut harness, "BRAVO_MARKER", 0, comment);
 }
 
+/// A file past 9,999 lines widens the line-number gutter: `lineNumPrefix`
+/// pads a number to `LINE_NUM_W` but never truncates one. The bytes before
+/// the code are therefore not a constant, and a row whose gutter width is
+/// assumed rather than measured hands its own diff marker to the language
+/// parser as if it were source.
+///
+/// Markdown shows it, because its grammar anchors a heading to the start
+/// of a line: fed `+## ...` instead of `## ...`, the `#` is no longer at
+/// the start and the row stops being a heading.
+#[test]
+fn test_issue3104_a_five_digit_gutter_still_colours_the_code() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    // Past 10,000 lines, so the changed row carries a five-digit number
+    // and its gutter is wider than a short file's.
+    let mut body = String::new();
+    for i in 0..10_000 {
+        body.push_str(&format!("Filler paragraph {i}.\n"));
+    }
+    body.push_str("## Section Before\n");
+    let notes = repo.create_file("notes.md", &body);
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+    fs::write(
+        &notes,
+        body.replace("## Section Before\n", "## Section AFTER_EDIT\n"),
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        40,
+        HarnessOptions::new()
+            .with_config(Config::default())
+            .with_working_dir(repo.path.clone())
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+    open_review_diff(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("AFTER_EDIT"))
+        .unwrap();
+
+    // The added row is a heading, and headings are coloured as keywords.
+    let keyword = harness.editor().theme().syntax_keyword;
+    wait_for_fg(&mut harness, "## Section AFTER_EDIT", 0, keyword);
+}
+
 /// Wait until the cell `dx` columns into the first on-screen occurrence of
 /// `text` is painted with foreground `fg`. The colours are the host's
 /// highlighter's, painted on the render after the rows are mounted, so

--- a/crates/fresh-plugin-api-macros/src/lib.rs
+++ b/crates/fresh-plugin-api-macros/src/lib.rs
@@ -468,6 +468,7 @@ fn rust_to_typescript(ty: &Type, attrs: &[Attribute]) -> String {
 
                 // Types renamed by ts-rs — map Rust name to TypeScript name
                 "CompositeHunk" => "TsCompositeHunk".to_string(),
+                "SyntaxRegion" => "TsSyntaxRegion".to_string(),
                 "CreateCompositeBufferOptions" => "TsCreateCompositeBufferOptions".to_string(),
                 "Suggestion" => "PromptSuggestion".to_string(),
                 "LspMenuItem" => "TsLspMenuItem".to_string(),

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -91,7 +91,7 @@ use fresh_core::api::{
     ActionSpec, BufferInfo, CompositeHunk, CreateCompositeBufferOptions, EditorStateSnapshot,
     GrammarInfoSnapshot, JsCallbackId, LanguagePackConfig, LspServerPackConfig, OverlayOptions,
     PluginCommand, PluginMarker, PluginResponse, ScrollbarMarker, SearchHandleRegistry,
-    SearchHandleState, SearchTakeResult, SplitWindowOptions,
+    SearchHandleState, SearchTakeResult, SplitWindowOptions, SyntaxRegion,
 };
 use fresh_core::command::Command;
 use fresh_core::overlay::OverlayNamespace;
@@ -3786,6 +3786,20 @@ impl JsEditorApi {
             .send(PluginCommand::UpdateCompositeAlignment {
                 buffer_id: BufferId(buffer_id as usize),
                 hunks,
+            })
+            .is_ok()
+    }
+
+    /// Say where a buffer this plugin composed carries code, and in what
+    /// language, so the host highlights it. Replaces the buffer's
+    /// previous regions; setting the buffer's content clears them.
+    ///
+    /// Uses typed Vec<SyntaxRegion> - serde validates field names at runtime
+    pub fn set_syntax_regions(&self, buffer_id: u32, regions: Vec<SyntaxRegion>) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetSyntaxRegions {
+                buffer_id: BufferId(buffer_id as usize),
+                regions,
             })
             .is_ok()
     }

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -108,6 +108,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         }
         "TsCompositePaneStyle" | "CompositePaneStyle" => Some(CompositePaneStyle::decl(&cfg)),
         "TsCompositeHunk" | "CompositeHunk" => Some(CompositeHunk::decl(&cfg)),
+        "TsSyntaxRegion" | "SyntaxRegion" => Some(fresh_core::api::SyntaxRegion::decl(&cfg)),
         "TsCreateCompositeBufferOptions" | "CreateCompositeBufferOptions" => {
             Some(CreateCompositeBufferOptions::decl(&cfg))
         }
@@ -345,6 +346,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "TsCompositeSourceConfig",         // Used in createCompositeBuffer opts.sources
     "TsCompositePaneStyle",            // Used in TsCompositeSourceConfig.style
     "TsCompositeHunk",                 // Used in createCompositeBuffer opts.hunks
+    "TsSyntaxRegion",                  // Used by setSyntaxRegions
     "TsCreateCompositeBufferOptions",  // Options for createCompositeBuffer
     "ViewportInfo",                    // Used by plugins for viewport queries
     "ScreenSize",                      // Used by editor.getScreenSize()
@@ -1010,6 +1012,7 @@ mod tests {
             "TsCompositeSourceConfig",
             "TsCompositePaneStyle",
             "TsCompositeHunk",
+            "TsSyntaxRegion",
             "TsCreateCompositeBufferOptions",
             "ViewTokenWireKind",
             "TokenColor",
@@ -1050,6 +1053,7 @@ mod tests {
         // Rust name aliases should produce the same declaration as ts-rs name
         let alias_pairs = vec![
             ("CompositeHunk", "TsCompositeHunk"),
+            ("SyntaxRegion", "TsSyntaxRegion"),
             ("CompositeLayoutConfig", "TsCompositeLayoutConfig"),
             ("CompositeSourceConfig", "TsCompositeSourceConfig"),
             ("CompositePaneStyle", "TsCompositePaneStyle"),
@@ -1156,6 +1160,7 @@ mod tests {
             "TsCompositeSourceConfig",
             "TsCompositePaneStyle",
             "TsCompositeHunk",
+            "TsSyntaxRegion",
             "TsCreateCompositeBufferOptions",
             "PromptSuggestion",
             "BufferInfo",
@@ -1486,6 +1491,7 @@ mod tests {
             "pluginTranslate",
             "createCompositeBuffer",
             "updateCompositeAlignment",
+            "setSyntaxRegions",
             "closeCompositeBuffer",
             "flushLayout",
             "compositeNextHunk",

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -55,6 +55,19 @@ There are now three ways to get a second language highlighted, and they are
    (hover popups, the markdown *preview* renderer). Never use it for
    buffer content — it has no incrementality and no cache.
 
+4. **Regions declared by the plugin** (`setSyntaxRegions`): for buffers a
+   plugin *composes* — the Review Diff stream, a log — which are not
+   documents any grammar can parse (a gutter, headers, comment boxes, rows
+   from many files and two sides of each). The plugin declares byte-range
+   regions, each with a language (a path or token), a per-row prefix to
+   skip, and the parser *streams* its rows feed; the engine becomes a
+   "region host" (plain text of its own) and runs the child parsers over
+   the declared rows through the same checkpointed, viewport-windowed
+   path as tools 1 and 2. Regions are span markers, so edits move them.
+   Streams are what make an interleaved diff correct: the old and new
+   side of a hunk each keep their own parser across the other side's rows
+   and across anything else in between, so a docstring is one docstring.
+
 ## How the engine-level mechanism works
 
 The TextMate engine's resumable parse state is a **composite snapshot**:

--- a/docs/internal/embedded-language-highlighting.md
+++ b/docs/internal/embedded-language-highlighting.md
@@ -22,9 +22,9 @@ and turns itself off above a size threshold breaks both design rules
 ("avoid full-buffer scans", no size cliff) — that's what this mechanism
 replaces.
 
-## Three existing tools, and when to use which
+## Four tools, and when to use which
 
-There are now three ways to get a second language highlighted, and they are
+There are now four ways to get a second language highlighted, and they are
 **not** interchangeable. Rule of thumb for future mixed-language cases:
 
 1. **The grammar itself embeds the other language** (via the shared


### PR DESCRIPTION
Syntax colours for the Review Diff stream (#3104) and the Git Log detail (#2871), done entirely on the host side: no plugin API for highlighting, no round trip, no overlays painted by a plugin. One highlighting mechanism, the engine's own.

Rebased onto `master` after #3160 merged (it was stacked on that branch).

## Design

A plugin-composed diff buffer is not a document any grammar can parse: its rows carry a line-number gutter, collapse triangles, section and file headers, inline comment boxes, and rows from many files and two sides of each. So instead of asking a grammar where the code is, **the plugin says where it is**, and the engine does the rest.

`editor.setSyntaxRegions(bufferId, regions)` declares byte-range regions on a buffer. Each names its language (a path such as `src/main.rs`, or a token), the bytes at the start of every row that are not code (`prefix`: the gutter and the diff marker), and the parser **streams** its rows feed. The buffer's highlighter becomes a *region host*: a TextMate engine over plain text whose colours all come from the regions' child parsers, running through the same checkpointed, viewport-windowed, theme-resolved path a Markdown fence or Vue block uses. Rows outside every region keep the plugin's styling and advance no parser.

Streams are what make an interleaved diff correct. The old and new side of a hunk alternate row by row, and a comment box can sit between two rows of one side, yet each side is the contiguous text it came from. A region names the streams its rows feed — old, new, or both for a context row — and the engine keeps one parser per stream across the other side's rows and across anything else in between, so a docstring opened on one old-side row is still open on the next. Live parsers are bounded to four, all a hunk's two sides can need, so checkpoints stay small.

Regions are span markers in the engine's own marker list, adjusted by the same edit notifications as its parse checkpoints, so an edit moves them with the text. Setting a buffer's content clears them; the new content declares its own. `audit_mode.ts` builds them with the rows — consecutive rows of one language and stream set share a region, so a hunk is a handful of regions rather than one per row — and declares them right after the mount. Where a changed row carries the word-level diff, that overlay still wins over the syntax colour.

The Git Log detail is a different kind of buffer: a raw `git show` dump streamed into a `.diff` file. That is a document a grammar *can* parse, so it takes the diff-grammar path from #2873: a `Fresh Diff` TextMate grammar scopes each file's hunks as an embedded region named by the target path, and the engine hands those rows, marker stripped, to the file's language, keeping the diff background under the source foreground. Both paths share one seam, `prepare_row_content(prepared, prefix)`: the diff grammar strips one marker byte, a composed row its whole gutter.

## Commits

1. **`Highlight source code embedded in unified diffs`** — #2873's engine-and-grammar commit, cherry-picked with its author preserved. This is the git-log half and the child-parser groundwork the second commit builds on.
2. **Region hosts** — `SyntaxRegion` and `SetSyntaxRegions` in `fresh-core`, the `setSyntaxRegions` binding and typings, the engine's region host (markers, streams, prefix stripping), the host handler and content-reset, `audit_mode.ts` declaring its regions, tests, changelog, and a section in `docs/internal/embedded-language-highlighting.md`.
3. A test that the word-diff overlay keeps winning on a changed token.

## Verification

* Engine unit tests: a declared row is coloured past its prefix while the header above and the comment box between rows are not, and the docstring the box interrupts is still one docstring; interleaved old/new rows keep one parser per stream (`still old"""` on the old side is a comment while `x = 1` between them is code); an insertion before a region moves it; an unknown language leaves rows alone and clearing paints nothing. All 58 `highlight_engine` tests green.
* e2e: `test_issue3104_diff_body_carries_syntax_colours` (keyword, function, context-row and word-diff cells) and `test_issue3104_multi_line_constructs_colour_every_row` (a row in the middle of a TypeScript block comment), both of which hang when the plugin does not declare its regions. Suites green: `audit_mode` 52, `review_diff` 80, `git_log` 33, `diff` 179, `theme` 74, `view_transform` 3.
* Release build driven in tmux on `Review Diff: Range` over `HEAD~100..HEAD` of this repository (7.9 MB stream, 14,185 regions): installing the regions took 27ms and the first viewport highlight 14ms, later renders microseconds; back to back with master, open 8.3s vs 8.7s, `n` 22–76ms on both, RSS 817 vs 826 MB. On screen: YAML keys and strings on the first page, shell rows after `Ctrl+End`, word-diff tokens keeping their colour inside coloured rows, side-by-side panes coloured, and the Git Log detail showing Rust doc-comment rows in the comment colour over the diff background.
* `cargo fmt`, `cargo clippy --all-features --all-targets` (no new diagnostics), `plugins/check-types.sh audit_mode.ts` (only the pre-existing `lib/widgets.ts` errors), `fresh.d.ts` regenerated, `ts_export` and `fresh-plugin-api-macros` tests green.

Related: #3160, #2873.

Fixes #3104, #2871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uXJ7dBKoq6BeqyvQPZ8NE