### PR TITLE
Read the whole of a long search match, and bind the keys you can name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,9 @@ crates/fresh-editor/docs/fresh.txt text eol=lf
 # checkout on Windows makes every golden test fail on the line terminator
 # rather than on anything the picture shows.
 crates/fresh-ui/tests/golden/*.txt text eol=lf
+
+# Same again for the keyboard reference: its key-name tables are generated
+# from the code and compared against a freshly rendered block, which is always
+# LF. `key_name_docs` failed the whole Windows job on the line terminator
+# while reporting the tables as out of date, which they were not.
+docs/configuration/keyboard.md text eol=lf

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2133,6 +2133,42 @@ pub struct TreeNode {
     /// Ignored when `item_height == 1`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_lines: Vec<crate::text_property::TextPropertyEntry>,
+    /// The span of `text` this row exists to show, in **chars**.
+    ///
+    /// A row wider than the panel is windowed by the host, and without this
+    /// the window can only start at the head of the line — which is exactly
+    /// where a search result's match usually is not (issue #1580). Naming the
+    /// span lets the host rest the window on it instead, and the reader pans
+    /// away from there.
+    ///
+    /// Chars rather than columns because that is the unit a plugin can count:
+    /// it has the string, not the terminal's width table. The host converts.
+    /// Out-of-range values are harmless — they resolve to the end of the text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_anchor: Option<TextWindowAnchor>,
+}
+
+/// How a row asks to be windowed when it is wider than the panel.
+/// See [`TreeNode::window_anchor`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub struct TextWindowAnchor {
+    /// Chars at the head of the row that never move.
+    ///
+    /// A row's leading pieces are usually its *identity* rather than its
+    /// content — a search result's `path:line` — and a window that slid them
+    /// away left rows that could not be told apart. They stay put and the
+    /// rest of the row slides under them, the same relationship the indent
+    /// and checkbox glyphs already have with the body.
+    #[serde(default)]
+    pub pinned: u32,
+    /// Char index, in the whole row, where the span the row exists to show
+    /// starts. Must be at or after `pinned`; a span inside the pinned head is
+    /// always visible anyway.
+    pub start: u32,
+    /// Length of the span, in chars. Zero is allowed and means a point.
+    pub len: u32,
 }
 
 /// Visual role for a `Button`. Maps to theme keys at render time —

--- a/crates/fresh-editor-core/src/widgets/actions.rs
+++ b/crates/fresh-editor-core/src/widgets/actions.rs
@@ -374,6 +374,7 @@ mod tests {
             has_children,
             checked: None,
             extra_lines: Vec::new(),
+            window_anchor: None,
         }
     }
 

--- a/crates/fresh-editor-core/src/widgets/kinds/list.rs
+++ b/crates/fresh-editor-core/src/widgets/kinds/list.rs
@@ -718,6 +718,7 @@ fn collect_list(
                     rows: visible_rows,
                     items: visible_items,
                     offset: scroll,
+                    cols: 0,
                 },
             );
         }

--- a/crates/fresh-editor-core/src/widgets/kinds/mod.rs
+++ b/crates/fresh-editor-core/src/widgets/kinds/mod.rs
@@ -139,6 +139,13 @@ pub struct Viewport {
     /// How many terminal rows the window is — the unit a `Tree`'s offset
     /// moves in.
     pub rows: u32,
+    /// How many display columns wide the window is.
+    ///
+    /// The horizontal counterpart to `rows`, and there because a sideways
+    /// pan is a question about the width: how far a row can travel before it
+    /// is showing its own end depends on how much of it is on screen. Zero
+    /// when nothing has laid the widget out yet — the spec alone cannot say.
+    pub cols: u32,
 }
 
 impl Viewport {
@@ -172,6 +179,8 @@ impl Viewport {
         Viewport {
             rows,
             items: (rows / spec_item_rows(spec)).max(1),
+            // The spec says nothing about width; the first paint will.
+            cols: 0,
         }
     }
 }

--- a/crates/fresh-editor-core/src/widgets/kinds/tree.rs
+++ b/crates/fresh-editor-core/src/widgets/kinds/tree.rs
@@ -16,6 +16,8 @@ use crate::widgets::render::{
 
 pub struct Tree;
 
+use crate::widgets::render::PAN_COLUMNS;
+
 impl WidgetImpl for Tree {
     fn on_wheel(
         &self,
@@ -208,6 +210,49 @@ impl WidgetImpl for Tree {
             }
             "Left" | "Right" => {
                 lateral(spec, widget_key, panel, key == "Right", fx);
+            }
+            // Panning. `Left`/`Right` are collapse/expand — the tree meaning
+            // every OS tree widget and the ARIA tree pattern give them — so
+            // sideways takes the one arrow chord whose conventional meaning a
+            // read-only, single-select tree does not have: extend selection.
+            // (`Alt`+arrows are back/forward, `Ctrl`+arrows word-wise; both
+            // are bound.) Issue #1580.
+            "S-Left" | "S-Right" | "S-Home" | "S-End" => {
+                let bounds = crate::widgets::render::pan_bounds(spec, viewport.cols, None);
+                // `S-End` is "the end of the row I am on", not "the end of
+                // the longest row": the pan is shared, rows of unequal length
+                // cannot all sit at their tail at once, and answering with
+                // the longest one leaves the selected row clamped with
+                // keystrokes still to spend before it moves.
+                let selected = resolve(spec, widget_key, &panel.instance_states).selected;
+                let end = usize::try_from(selected)
+                    .ok()
+                    .map(|r| crate::widgets::render::pan_bounds(spec, viewport.cols, Some(r)).1)
+                    // A row with nowhere to go — a file header among match
+                    // rows — would make the key a no-op while the rows around
+                    // it still had a tail to show. Fall back to the longest.
+                    .filter(|&r| r > 0)
+                    .unwrap_or(bounds.1);
+                let delta = match key {
+                    "S-Left" => Some(-PAN_COLUMNS),
+                    "S-Right" => Some(PAN_COLUMNS),
+                    // Home is where each row's content says it should rest —
+                    // its own match — not the head of the line. The head is a
+                    // few more `S-Left`s away, and a reader who wants the
+                    // match back should not have to pan to find it.
+                    "S-Home" => None,
+                    // Far enough that the per-row clamp lands every row on
+                    // its own tail — and no further, so `S-Left` walks back
+                    // from the end of the longest row rather than from a
+                    // number no content justifies.
+                    _ => Some(end),
+                };
+                if !panel.pan_h(widget_key, delta, bounds) {
+                    // Already home, or already at the value asked for: say so,
+                    // so the key can mean something else further out rather
+                    // than being swallowed by a tree that did nothing.
+                    return super::KeyDisposition::Pass;
+                }
             }
             "Enter" => {
                 if let Some(ev) = activate_event(spec, widget_key, panel) {
@@ -667,6 +712,10 @@ fn render_widget_tree(
     // The offset is the *last paint's*, not the tree's: the scroll fold
     // reads back its own previous value and republishes it below.
     let prev_scroll = ctx.painted(tree_key).map(|w| w.offset).unwrap_or(0);
+    // Sideways is the reader's, not the paint's — one delta for the whole
+    // tree, clamped per row against that row's own length so rows of
+    // different lengths slide together rather than drifting apart.
+    let h_pan = ctx.h_pan(tree_key);
 
     // Compute the visible (un-collapsed) flat slice of the
     // full `nodes` list. A node at depth d is visible iff
@@ -810,6 +859,7 @@ fn render_widget_tree(
                 rows: visible_rows,
                 items: visible_rows / per_node.max(1),
                 offset: scroll,
+                cols: panel_width,
             },
         );
     }
@@ -851,6 +901,7 @@ fn render_widget_tree(
             card_borders,
             panel_width,
             indent_cols,
+            h_pan,
         );
         let mut entry = rendered.entry;
         let is_selected = abs_idx as i32 == effective_sel_abs;

--- a/crates/fresh-editor-core/src/widgets/registry.rs
+++ b/crates/fresh-editor-core/src/widgets/registry.rs
@@ -222,6 +222,12 @@ pub struct PaintedWindow {
     /// `List`, rows for a `Tree`). The scroll fold's previous value: the
     /// next paint reads it back, clamps it, and republishes it.
     pub offset: u32,
+    /// Width of the window, in display columns.
+    ///
+    /// The horizontal counterpart to `rows`, and the number a sideways pan
+    /// needs: how far a row can travel is a question about the panel's
+    /// width, and nothing but the paint knows it. Zero when unknown.
+    pub cols: u32,
     // Rows one item occupies was here — the measured card band. It was the
     // fourth of the four numbers S1 moved out of `WidgetInstanceState`, and
     // the only one that never acquired a reader on this side: the division
@@ -485,6 +491,25 @@ pub struct WidgetPanelState {
     /// The hovered ROW's own key, for kinds whose rows share one widget
     /// key (`List`, `Tree`). Empty for everything else.
     pub hovered_item_key: String,
+    /// How far each keyed widget is panned sideways, in display columns,
+    /// from where its rows would rest.
+    ///
+    /// **Not in [`PaintedWindow`], and not in the instance state either.**
+    /// Not the paint's, because a pan is what the *reader* asked for rather
+    /// than what the last paint measured — and a described panel has no
+    /// painted window at all, which is precisely the panel this exists for.
+    /// Not the instance state, because it is per-widget rather than per-kind
+    /// and every kind that draws rows can honour it.
+    ///
+    /// A delta, not an absolute column: each row rests where its own content
+    /// needs it to (see `TreeNode::window_anchor`) and they slide together.
+    /// Clamped per row at paint time, so the value here can outrun the
+    /// content without the rows doing anything strange.
+    ///
+    /// Cleared when the panel's spec is replaced, which is what makes a fresh
+    /// search start back at the resting window; a streaming append does not
+    /// replace the spec, so results arriving do not yank a reader's pan.
+    pub h_pan: HashMap<String, i32>,
 }
 
 impl WidgetPanelState {
@@ -512,6 +537,9 @@ impl WidgetPanelState {
             focus_follows_cursor: false,
             hovered_widget_key: String::new(),
             hovered_item_key: String::new(),
+            // Nothing a host surface describes is wider than its own panel:
+            // its controls are forms, not rows of somebody else's text.
+            h_pan: HashMap::new(),
         }
     }
 
@@ -529,6 +557,7 @@ impl WidgetPanelState {
         self.painted.get(key).map(|w| super::kinds::Viewport {
             rows: w.rows,
             items: w.items.max(1),
+            cols: w.cols,
         })
     }
 
@@ -553,7 +582,63 @@ impl WidgetPanelState {
                 rows: viewport.rows,
                 items: viewport.items,
                 offset: 0,
+                cols: 0,
             })
+    }
+
+    /// How far the keyed widget is panned sideways, in display columns.
+    pub fn h_pan(&self, key: &str) -> i32 {
+        self.h_pan.get(key).copied().unwrap_or(0)
+    }
+
+    /// Move the keyed widget's sideways pan by `delta` columns, or home it
+    /// when `delta` is `None`. Returns whether anything changed.
+    ///
+    /// **Signed.** Zero is where each row's own content says it should rest,
+    /// which for a search result is its match — so negative is how a reader
+    /// gets back to the head of the line and positive is how they reach its
+    /// tail. How far either goes on any *given* row depends on that row,
+    /// which only the paint knows, so the clamp that decides what is drawn
+    /// stays there: letting the stored value run past what one row can use,
+    /// and clamping per row, is what keeps rows of different lengths sliding
+    /// together instead of drifting apart at the ends.
+    ///
+    /// **The bound comes from the last paint, and it has to.** A stored pan
+    /// is what the *next* keystroke moves from, so a value no row on screen
+    /// can reach is a value the reader has to press their way back through
+    /// against a screen that does not move. Only the paint knows the panel's
+    /// width, so only the paint can say where the travel ends; it publishes
+    /// that as [`PaintedWindow::pan_range`] and this holds both the current
+    /// value and the new one to it. `Shift+End` therefore lands *on* the
+    /// tail rather than past it, and a run of `Shift+Right` at the tail
+    /// accumulates no debt for `Shift+Left` to pay off.
+    ///
+    /// `bounds` is the fallback for the frame before any paint — what the
+    /// spec alone can justify, from [`pan_bounds`]. It is an over-estimate
+    /// by construction, which is exactly why it cannot be the only bound.
+    ///
+    /// [`pan_bounds`]: crate::widgets::render::pan_bounds
+    /// [`PaintedWindow::pan_range`]: PaintedWindow::pan_range
+    pub fn pan_h(&mut self, key: &str, delta: Option<i32>, bounds: (i32, i32)) -> bool {
+        let (left, right) = (bounds.0.min(0).abs(), bounds.1.max(0));
+        // Clamped on the way in as well as on the way out: a stored value
+        // from a wider window, or from the estimate used before the first
+        // paint, is one the reader would otherwise have to press their way
+        // back through against a screen that does not move.
+        let cur = self.h_pan(key).clamp(-left, right);
+        let next = match delta {
+            Some(d) => cur.saturating_add(d).clamp(-left, right),
+            None => 0,
+        };
+        if next == cur && next == self.h_pan(key) {
+            return false;
+        }
+        if next == 0 {
+            self.h_pan.remove(key);
+        } else {
+            self.h_pan.insert(key.to_string(), next);
+        }
+        true
     }
 
     /// Latch "the user moved this window by hand" on a `List` or `Tree`.
@@ -673,6 +758,36 @@ impl WidgetPanelState {
     }
 }
 
+/// Whether the keyed widget still shows the same rows it did, for the purpose
+/// of keeping a sideways pan across a repaint.
+///
+/// **First key and row count, not the whole list.** A repaint happens
+/// constantly and a streaming search can carry thousands of rows, so comparing
+/// them element-wise would put an O(rows) walk on every frame to answer a
+/// question that only ever changes when the subject does. A list that grew
+/// while keeping its first row is the streaming case; one whose first row
+/// changed, or that shrank, is a new search.
+fn rows_are_the_same_subject(prev: &WidgetSpec, next: &WidgetSpec, key: &str) -> bool {
+    fn identity<'a>(spec: &'a WidgetSpec, key: &str) -> Option<(Option<&'a String>, usize)> {
+        match crate::widgets::find_widget_by_key(spec, key)? {
+            WidgetSpec::Tree {
+                item_keys, nodes, ..
+            } => Some((item_keys.first(), nodes.len())),
+            WidgetSpec::List {
+                item_keys, items, ..
+            } => Some((item_keys.first(), items.len())),
+            _ => None,
+        }
+    }
+    match (identity(prev, key), identity(next, key)) {
+        (Some((prev_first, prev_len)), Some((next_first, next_len))) => {
+            prev_first == next_first && next_len >= prev_len
+        }
+        // The widget is gone, or was never a rows widget: nothing to keep.
+        _ => false,
+    }
+}
+
 /// Global registry of mounted widget panels, keyed by composite
 /// (plugin, panel id) identity — two plugins reusing the same local id
 /// coexist without evicting each other.
@@ -716,6 +831,23 @@ impl WidgetRegistry {
             .get(&panel_key)
             .map(|p| (p.hovered_widget_key.clone(), p.hovered_item_key.clone()))
             .unwrap_or_default();
+        // A sideways pan survives a repaint but not a change of subject: the
+        // reader panned to read *these* rows, and a fresh search that replaces
+        // them would otherwise open mid-line with every row's anchor — the
+        // whole point of the resting window — panned off screen. A streaming
+        // append is not a change of subject, so results arriving under a
+        // reader do not yank the pan; see `rows_are_the_same_subject`.
+        let h_pan = self
+            .panels
+            .get(&panel_key)
+            .map(|prev| {
+                prev.h_pan
+                    .iter()
+                    .filter(|(k, _)| rows_are_the_same_subject(&prev.spec, &spec, k))
+                    .map(|(k, v)| (k.clone(), *v))
+                    .collect()
+            })
+            .unwrap_or_default();
         self.panels.insert(
             panel_key,
             WidgetPanelState {
@@ -730,6 +862,7 @@ impl WidgetRegistry {
                 focus_follows_cursor,
                 hovered_widget_key,
                 hovered_item_key,
+                h_pan,
             },
         )
     }
@@ -776,6 +909,13 @@ impl WidgetRegistry {
     ) -> Result<BufferId, ()> {
         match self.panels.get_mut(panel_key) {
             Some(state) => {
+                // A sideways pan survives a repaint but not a change of
+                // subject — see `rows_are_the_same_subject`. This is the path
+                // every repaint takes; `mount` says the same thing for the
+                // first render of a re-mounted panel.
+                state
+                    .h_pan
+                    .retain(|k, _| rows_are_the_same_subject(&state.spec, &spec, k));
                 state.spec = spec;
                 state.instance_states = instance_states;
                 state.focus_key = focus_key;

--- a/crates/fresh-editor-core/src/widgets/render.rs
+++ b/crates/fresh-editor-core/src/widgets/render.rs
@@ -561,6 +561,12 @@ pub struct RenderContext<'a> {
     /// Settings dialog, a toolbar, most tests) starts every window at
     /// the top, exactly as an absent instance-state offset used to.
     pub prev_painted: Option<&'a HashMap<String, PaintedWindow>>,
+    /// How far each keyed rows-widget is panned sideways, in display columns.
+    /// The reader's own fold, carried here for the same reason
+    /// `prev_painted` is: the painter is where a window is resolved, and
+    /// sideways is a window like any other. `None` (a stateless render)
+    /// pans nothing, exactly as an unset entry does.
+    pub h_pan: Option<&'a HashMap<String, i32>>,
 }
 
 impl RenderContext<'_> {
@@ -571,6 +577,14 @@ impl RenderContext<'_> {
     pub fn painted(&self, key: Option<&str>) -> Option<PaintedWindow> {
         let k = key.filter(|k| !k.is_empty())?;
         self.prev_painted?.get(k).copied()
+    }
+
+    /// Sideways pan for `key`, in display columns. Zero for a keyless widget
+    /// — a pan is addressed to a widget and an unkeyed one cannot be named.
+    pub fn h_pan(&self, key: Option<&str>) -> i32 {
+        key.filter(|k| !k.is_empty())
+            .and_then(|k| self.h_pan?.get(k).copied())
+            .unwrap_or(0)
     }
 
     /// Whether `key` names the focused widget. Empty keys never match.
@@ -628,6 +642,10 @@ pub struct RenderOptions<'a> {
     /// previous render published. A host that keeps a panel mounted
     /// MUST thread it, or every repaint starts its lists at the top.
     pub prev_painted: Option<&'a HashMap<String, PaintedWindow>>,
+    /// See [`RenderContext::h_pan`] — how far each rows-widget is panned
+    /// sideways. A host that keeps a panel mounted MUST thread it, or every
+    /// repaint slides the reader's rows back to their resting window.
+    pub h_pan: Option<&'a HashMap<String, i32>>,
 }
 
 /// Render a spec to a [`RenderOutput`] under explicit [`RenderOptions`].
@@ -668,6 +686,7 @@ pub fn render_spec_with_options(
         marker_gutter: opts.marker_gutter,
         avail_height: opts.avail_height,
         prev_painted: opts.prev_painted,
+        h_pan: opts.h_pan,
     };
     let mut next_state = HashMap::new();
     let collected = render_collected(spec, prev, &mut next_state, ctx, panel_width);
@@ -2707,6 +2726,355 @@ pub struct RenderedTreeRow {
 /// checkbox glyph reuses `ui.tab_active_fg` (the same key the
 /// `Toggle` widget uses for its checked-state glyph) so it reads
 /// as a control surface against the row's text.
+/// A row body fitted to the columns it has, and where the slice came from.
+///
+/// The byte offsets are into the *original* body, so the caller can carry the
+/// plugin's overlays across the cut: an overlay is clamped into
+/// `[slice_start, slice_end)`, rebased to the slice, then shifted by
+/// `lead_bytes` (the leading `…`, when one was drawn) and by the row prefix.
+pub struct WindowedBody {
+    /// The text to draw: the slice, with `…` for each end that was cut.
+    pub text: String,
+    /// Byte offset in the body where the drawn slice starts.
+    pub slice_start: usize,
+    /// Byte offset in the body where the drawn slice ends.
+    pub slice_end: usize,
+    /// Bytes of leading marker drawn before the slice.
+    pub lead_bytes: usize,
+    /// The pans this row can actually use, as a delta from where it rests.
+    ///
+    /// The clamp the paint applied, handed back so the *stored* pan can be
+    /// held to it. Without this the panel keeps a number no row can reach —
+    /// `S-End` overshoots by however far the row rests from its own tail —
+    /// and the reader spends that difference pressing `S-Left` at a screen
+    /// that does not move. `(0, 0)` for a row that fits.
+    pub pan_range: (i32, i32),
+}
+
+/// Bytes of the char at char index `n`, or the length past the end.
+fn byte_of_char(s: &str, n: usize) -> usize {
+    s.char_indices().nth(n).map(|(b, _)| b).unwrap_or(s.len())
+}
+
+/// Byte offset `budget` display columns after `from`, never splitting a
+/// double-width cell across the edge.
+fn byte_after_cols(s: &str, from: usize, budget: usize) -> usize {
+    use crate::primitives::display_width::char_width;
+    let mut used = 0usize;
+    for (i, ch) in s[from..].char_indices() {
+        let w = char_width(ch);
+        if used + w > budget {
+            return from + i;
+        }
+        used += w;
+    }
+    s.len()
+}
+
+/// The column this row would rest at with no panning: far enough right that
+/// the anchor is on screen, and no further.
+///
+/// The anchor is the span the row exists to show — a search result's own
+/// match. When it already fits in the head there is nothing to slide, which
+/// is the overwhelmingly common case and leaves ordinary rows exactly as they
+/// were. Otherwise a third of the budget is kept as leading context, so the
+/// anchor reads in situ rather than flush against the elision marker.
+fn resting_start_col(body: &str, budget: usize, anchor: Option<(usize, usize)>) -> usize {
+    use crate::primitives::display_width::visual_column_at_byte;
+    let Some((start_chars, len_chars)) = anchor else {
+        return 0;
+    };
+    let a_col = visual_column_at_byte(body, byte_of_char(body, start_chars));
+    let b_col = visual_column_at_byte(body, byte_of_char(body, start_chars + len_chars));
+    // One column is owed to the trailing marker whenever anything is cut.
+    if b_col <= budget.saturating_sub(1) {
+        return 0;
+    }
+    a_col.saturating_sub((budget / 3).max(1))
+}
+
+/// Fit `body` into `budget` display columns, panned `pan` columns from where
+/// the row would rest.
+///
+/// **Display columns, not codepoints.** Every other width hint in this file
+/// counts codepoints, which is the same number for the ASCII a panel is
+/// usually full of and wrong by a factor of two for CJK — a `漢`-prefixed row
+/// was built half again as wide as the panel and cut by the terminal, taking
+/// the very text the row existed to show off the right edge (issue #1580).
+/// A pan has to move by what the reader sees, so this measures cells.
+///
+/// `pan` is a delta from the resting column, shared by every row in a tree:
+/// each row starts where its own content needs it to and they slide together.
+/// It is clamped per row, so panning right stops at the longest row's tail and
+/// panning left brings every row home to column zero.
+/// Where a body rests, and how far it can travel each way from there.
+///
+/// The measuring half of [`window_row_body`], split out because the pan a
+/// panel *stores* has to be held to the same limit the paint would apply —
+/// and a second copy of this arithmetic is exactly the drift that let
+/// `Shift+End` leave a number `Shift+Left` could not walk back.
+fn row_travel(body: &str, budget: usize) -> (usize, usize) {
+    use crate::primitives::display_width::str_width;
+    if budget == 0 {
+        return (0, 0);
+    }
+    let content = body.trim_end_matches(' ');
+    let total = str_width(content);
+    if total <= budget {
+        return (0, 0);
+    }
+    // The right-hand limit owes the leading marker a column; see below.
+    let max_start = total.saturating_sub(budget.saturating_sub(1));
+    (max_start, 0)
+}
+
+/// The pans `body` can use, as a delta from where it rests.
+///
+/// `(0, 0)` for a row that fits: there is nothing to its left and nothing to
+/// its right, and a row that fits never moves at any pan.
+pub fn row_pan_range(body: &str, budget: usize, anchor: Option<(usize, usize)>) -> (i32, i32) {
+    let (max_start, _) = row_travel(body, budget);
+    if max_start == 0 {
+        return (0, 0);
+    }
+    let content = body.trim_end_matches(' ');
+    let rest = resting_start_col(content, budget, anchor).min(max_start);
+    let cap = |v: usize| v.min(i32::MAX as usize) as i32;
+    (-cap(rest), cap(max_start - rest))
+}
+
+pub fn window_row_body(
+    body: &str,
+    budget: usize,
+    anchor: Option<(usize, usize)>,
+    pan: i32,
+) -> WindowedBody {
+    use crate::primitives::display_width::{byte_offset_at_visual_column, str_width};
+    const MARKER: &str = "…";
+
+    if budget == 0 {
+        return WindowedBody {
+            text: String::new(),
+            slice_start: 0,
+            slice_end: 0,
+            lead_bytes: 0,
+            pan_range: (0, 0),
+        };
+    }
+    // **Trailing padding is not content.** A row arrives padded to the width
+    // its author computed, and that number is arrived at by subtracting a
+    // prefix the author has to guess at — so a row that fits can measure a
+    // column or two over and pick up a `…` that elides nothing but spaces.
+    // Overflow and the right-hand limit are both judged on the real text;
+    // the padding still renders when it fits, so a selection band still
+    // spans the row.
+    let content = body.trim_end_matches(' ');
+    let total = str_width(content);
+    // Fits, and nobody asked to move: the row is its own text, untouched.
+    if total <= budget && pan == 0 {
+        return WindowedBody {
+            text: body.to_string(),
+            slice_start: 0,
+            slice_end: body.len(),
+            lead_bytes: 0,
+            pan_range: (0, 0),
+        };
+    }
+
+    // **The right-hand limit owes the leading marker a column.** Any window
+    // that does not start at zero spends one column on `…`, so stopping at
+    // `total - budget` leaves the last column of the line permanently
+    // unreachable — panning right ran out one character short of the end.
+    let max_start = total.saturating_sub(budget.saturating_sub(1));
+    let rest = resting_start_col(content, budget, anchor).min(max_start);
+    let start_col = (rest as i64 + pan as i64).clamp(0, max_start as i64) as usize;
+
+    let slice_start = byte_offset_at_visual_column(body, start_col);
+    let lead = start_col > 0;
+    let lead_cols = usize::from(lead);
+    let content_budget = budget - lead_cols;
+
+    // Two passes, because whether a trailing marker is owed is only known
+    // once the first pass has seen whether anything is left over.
+    //
+    // `content_budget == 0` is the one-column panel with a lead marker: the
+    // marker *is* the whole window, and a trailing one would draw a second
+    // column the row does not have. Say "no tail owed" rather than emit it.
+    let full_end = byte_after_cols(body, slice_start, content_budget);
+    let trail = content_budget > 0 && full_end < content.len();
+    let slice_end = if trail {
+        byte_after_cols(body, slice_start, content_budget.saturating_sub(1))
+    } else {
+        full_end
+    };
+
+    let mut text = String::with_capacity(body.len().min(budget * 4) + 8);
+    if lead {
+        text.push_str(MARKER);
+    }
+    text.push_str(&body[slice_start..slice_end]);
+    if trail {
+        text.push_str(MARKER);
+    }
+    WindowedBody {
+        text,
+        slice_start,
+        slice_end,
+        lead_bytes: if lead { MARKER.len() } else { 0 },
+        pan_range: row_pan_range(body, budget, anchor),
+    }
+}
+
+/// Columns of frozen gutter before a tree row's body, and the budget the
+/// body is then fitted into.
+///
+/// Written twice inside `render_tree_row` already — once as the measured
+/// width of the prefix it builds, once as the indent its continuation lines
+/// take — and [`pan_bounds`] needs the same numbers to say how far a row can
+/// travel. One definition, because a bound that disagrees with the paint by
+/// even a column is a bound the reader feels as a keypress that does nothing.
+fn tree_row_gutter_cols(node: &TreeNode, checkable: bool, indent_cols: usize) -> usize {
+    // The disclosure column is two wide whether or not a glyph is drawn
+    // (glyph + separator space, or two literal spaces), and a checkbox adds
+    // `[v]` and a space. The indent is per level of depth.
+    let checkbox = usize::from(checkable && node.checked.is_some()) * 4;
+    (node.depth as usize) * indent_cols + 2 + checkbox
+}
+
+/// A tree row's text as the paint will see it.
+///
+/// `TextPropertyEntry::text` is empty until `normalize_widths` concatenates
+/// the segments into it, and a row built from segments — which is every
+/// styled row a plugin sends — therefore measures as nothing until then.
+/// Measuring the unnormalised field said a Search & Replace row had no
+/// content and so nowhere to pan.
+fn row_text(entry: &TextPropertyEntry) -> std::borrow::Cow<'_, str> {
+    if entry.segments.is_empty() {
+        std::borrow::Cow::Borrowed(&entry.text)
+    } else {
+        std::borrow::Cow::Owned(entry.segments.iter().map(|s| s.text.as_str()).collect())
+    }
+}
+
+/// Columns one pan step moves — one key press, or one wheel notch.
+///
+/// `less(1)`'s left/right step, the closest thing to a convention a terminal
+/// has for panning sideways. The wheel used to move three, mirroring the
+/// three *lines* a vertical notch moves, but a screen is three times wider
+/// than it is tall: three columns of a hundred-and-twenty is a fifth of what
+/// three lines of forty is, and the gesture read as a dead one. One number
+/// for both, so a reader who pans with the wheel and a reader who pans with
+/// the keyboard are moving the same distance.
+pub const PAN_COLUMNS: i32 = 8;
+
+/// How far, in display columns, `widget` can usefully be panned each way.
+///
+/// The clamp that decides what is *drawn* is per row and lives in
+/// [`window_row_body`] — that is what keeps rows of different lengths sliding
+/// together instead of drifting apart at the ends. But the pan a panel
+/// *stores* is what the next keystroke moves from, so it has to be held to
+/// the same limit: `Shift+End` asks for "past the end of the longest row",
+/// and a number past what any row can reach is a number the reader spends
+/// keystrokes walking back while the screen sits still.
+///
+/// **Two bounds, because a pan is a delta from where each row rests** — its
+/// own match, not column zero. A row whose match sits 259 columns along a 403
+/// column line can go 259 columns left and only ~80 right, and one number for
+/// both is wrong on whichever side is shorter by the difference.
+///
+/// `cols` is the width the window was given. Zero means nobody has laid this
+/// widget out yet, and the answer is `(0, 0)`: a pan before the first frame
+/// has no screen to be measured against, and the first paint will answer it.
+///
+/// `(0, 0)` also for every kind whose paint does not thread the pan, which is
+/// every kind but `Tree`: a widget that cannot show a pan should not
+/// accumulate one.
+///
+/// `row` narrows the question to one node. The whole tree's range is what the
+/// stored pan is *clamped* to — it must not exclude a row that still has
+/// somewhere to go — but "pan to the end" is a question about the row the
+/// reader is on, and answering it with the longest row's travel leaves their
+/// row clamped at its own tail with keystrokes still to spend before it
+/// moves. Rows of unequal length cannot all be at their end at once; the one
+/// under the selection is the one that should be.
+pub fn pan_bounds(widget: &WidgetSpec, cols: u32, row: Option<usize>) -> (i32, i32) {
+    let WidgetSpec::Tree {
+        nodes,
+        checkable,
+        indent_cols,
+        item_height,
+        card_borders,
+        ..
+    } = widget
+    else {
+        return (0, 0);
+    };
+    // Bordered cards lay out inside their box rather than being windowed —
+    // `render_tree_row` returns before the pan is applied — so they offer a
+    // pan nothing.
+    if cols == 0 || (*card_borders && *item_height > 1) {
+        return (0, 0);
+    }
+    let (mut left, mut right) = (0i32, 0i32);
+    for (i, node) in nodes.iter().enumerate() {
+        if row.is_some_and(|r| r != i) {
+            continue;
+        }
+        let r = tree_row_pan_range(node, *checkable, *indent_cols as usize, cols);
+        left = left.min(r.0);
+        right = right.max(r.1);
+    }
+    (left, right)
+}
+
+/// One tree row's travel, measured the way `render_tree_row` will fit it.
+fn tree_row_pan_range(
+    node: &TreeNode,
+    checkable: bool,
+    indent_cols: usize,
+    cols: u32,
+) -> (i32, i32) {
+    let gutter = tree_row_gutter_cols(node, checkable, indent_cols);
+    let budget = (cols as usize).saturating_sub(gutter);
+    let w = node.window_anchor.unwrap_or_default();
+    let text = row_text(&node.text);
+    let pinned_bytes = byte_of_char(&text, w.pinned as usize);
+    let (pinned, rest) = text.split_at(pinned_bytes);
+    let anchor = node.window_anchor.map(|a| {
+        (
+            (a.start as usize).saturating_sub(a.pinned as usize),
+            a.len as usize,
+        )
+    });
+    let body_budget = budget.saturating_sub(crate::primitives::display_width::str_width(pinned));
+    let mut r = row_pan_range(rest, body_budget, anchor);
+    // Continuation lines pan with the row they continue, so they widen it.
+    // They carry no anchor of their own and rest at column zero.
+    for line in &node.extra_lines {
+        let c = row_pan_range(&row_text(line), budget, None);
+        r = (r.0.min(c.0), r.1.max(c.1));
+    }
+    r
+}
+
+/// Carry one overlay across a [`WindowedBody`] cut.
+///
+/// `None` when the overlay fell entirely outside the drawn slice — a
+/// highlight on text that is no longer on screen must not collapse onto the
+/// row's first cell.
+fn rebase_overlay(o: &InlineOverlay, w: &WindowedBody, shift: usize) -> Option<InlineOverlay> {
+    let start = o.start.clamp(w.slice_start, w.slice_end);
+    let end = o.end.clamp(w.slice_start, w.slice_end);
+    if end <= start {
+        return None;
+    }
+    let mut out = o.clone();
+    out.start = start - w.slice_start + w.lead_bytes + shift;
+    out.end = end - w.slice_start + w.lead_bytes + shift;
+    Some(out)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn render_tree_row(
     node: &TreeNode,
     expanded: bool,
@@ -2715,6 +3083,7 @@ pub fn render_tree_row(
     card_borders: bool,
     panel_width: u32,
     indent_cols: u32,
+    h_offset: i32,
 ) -> RenderedTreeRow {
     // Bordered-card trees: card nodes render inside a rounded box; the
     // other nodes (folder headers) collapse to a plain single row
@@ -2780,21 +3149,61 @@ pub fn render_tree_row(
         None
     };
     let body_start = text.len();
-    text.push_str(&node.text.text);
+    // **The host fits the row, not the plugin.** The prefix above is pinned
+    // and only the body slides, which is what makes a pan read as a frozen
+    // gutter with the content moving under it — and what lets the row keep
+    // its checkbox and disclosure glyph wherever the reader has panned to.
+    //
+    // Before this, a row longer than the panel was simply drawn past the edge
+    // and cut by the terminal, so there was nothing to pan and no marker to
+    // say anything had been cut. See `window_row_body`.
+    let prefix_cols = crate::primitives::display_width::str_width(&text);
+    let budget = (panel_width as usize).saturating_sub(prefix_cols);
+    // **The row's own pinned head.** A search result's `path:line` is its
+    // identity, not its content: a window that slid it away left rows nobody
+    // could tell apart. It stays with the prefix above and the rest of the row
+    // slides under it.
+    let w = node.window_anchor.unwrap_or_default();
+    let pinned_bytes = byte_of_char(&node.text.text, w.pinned as usize);
+    let (pinned, rest) = node.text.text.split_at(pinned_bytes);
+    let pinned_cols = crate::primitives::display_width::str_width(pinned);
+    text.push_str(pinned);
+    let rest_start = text.len();
+    let anchor = node.window_anchor.map(|a| {
+        (
+            (a.start as usize).saturating_sub(a.pinned as usize),
+            a.len as usize,
+        )
+    });
+    let window = window_row_body(rest, budget.saturating_sub(pinned_cols), anchor, h_offset);
+    text.push_str(&window.text);
 
-    // Carry over the plugin's inline overlays, shifted right by
-    // `body_start` so they land on the correct bytes after the
-    // prefix.
+    // Carry over the plugin's inline overlays. The pinned head keeps its
+    // offsets (shifted by the prefix only); everything past it is rebased onto
+    // the drawn slice. An overlay straddling the boundary contributes to both,
+    // and one wholly outside the slice is dropped rather than clamped — a
+    // match highlight on text that panned off screen must not reappear on the
+    // row's first cell.
     let mut overlays: Vec<InlineOverlay> = node
         .text
         .inline_overlays
         .iter()
-        .map(|o| {
-            let mut shifted = o.clone();
-            shifted.start += body_start;
-            shifted.end += body_start;
-            shifted
+        .flat_map(|o| {
+            let head = (o.start < pinned_bytes).then(|| {
+                let mut h = o.clone();
+                h.start += body_start;
+                h.end = o.end.min(pinned_bytes) + body_start;
+                h
+            });
+            let tail = (o.end > pinned_bytes).then(|| {
+                let mut t = o.clone();
+                t.start = o.start.max(pinned_bytes) - pinned_bytes;
+                t.end = o.end - pinned_bytes;
+                rebase_overlay(&t, &window, rest_start)
+            });
+            [head, tail.flatten()]
         })
+        .flatten()
         .collect();
 
     // Disclosure glyph color — only on internal nodes, where the
@@ -2872,18 +3281,19 @@ pub fn render_tree_row(
         for i in 0..extra_rows {
             match node.extra_lines.get(i) {
                 Some(src) => {
-                    let mut line_text = String::with_capacity(shift + src.text.len());
+                    // Same fit as the primary row, and the same pan, so a
+                    // card's continuation lines slide with the line they
+                    // continue. No anchor: only the primary row has a span it
+                    // exists to show.
+                    let cont_budget = (panel_width as usize).saturating_sub(cont_indent_cols);
+                    let cont = window_row_body(&src.text, cont_budget, None, h_offset);
+                    let mut line_text = String::with_capacity(shift + cont.text.len());
                     line_text.push_str(&indent_str);
-                    line_text.push_str(&src.text);
+                    line_text.push_str(&cont.text);
                     let shifted: Vec<InlineOverlay> = src
                         .inline_overlays
                         .iter()
-                        .map(|o| {
-                            let mut s = o.clone();
-                            s.start += shift;
-                            s.end += shift;
-                            s
-                        })
+                        .filter_map(|o| rebase_overlay(o, &cont, shift))
                         .collect();
                     extra_entries.push(TextPropertyEntry {
                         text: line_text,
@@ -4000,6 +4410,7 @@ pub mod tests {
                 rows,
                 items: rows,
                 offset,
+                cols: 0,
             },
         );
         m
@@ -4035,6 +4446,166 @@ pub mod tests {
     fn form_label_width_zero_panel_keeps_request() {
         // Auto-fit / tests (panel_width == 0) leave the requested width.
         assert_eq!(form_label_width(20, 2, 3, 0), 20);
+    }
+
+    use crate::primitives::display_width::str_width;
+
+    /// A row that fits is its own text, markers and all absent.
+    #[test]
+    fn window_row_body_leaves_a_fitting_row_alone() {
+        let w = window_row_body("hello", 20, None, 0);
+        assert_eq!(w.text, "hello");
+        assert_eq!((w.slice_start, w.slice_end, w.lead_bytes), (0, 5, 0));
+    }
+
+    /// Trailing padding is not content: a row padded past the budget by
+    /// spaces alone does not pick up a marker that elides nothing.
+    #[test]
+    fn window_row_body_ignores_trailing_padding() {
+        let padded = format!("abc{}", " ".repeat(40));
+        let w = window_row_body(&padded, 10, None, 0);
+        assert_eq!(w.text, padded, "padding is not something to elide");
+    }
+
+    /// With no anchor the window rests at the head and marks the cut tail.
+    #[test]
+    fn window_row_body_marks_a_cut_tail() {
+        let w = window_row_body("abcdefghij", 5, None, 0);
+        assert_eq!(w.text, "abcd…");
+        assert_eq!(str_width(&w.text), 5);
+    }
+
+    /// With an anchor past the budget the window slides to bring it in, and
+    /// marks both ends.
+    #[test]
+    fn window_row_body_rests_on_its_anchor() {
+        let body = format!("{}MATCH{}", "x".repeat(60), "y".repeat(60));
+        let w = window_row_body(&body, 20, Some((60, 5)), 0);
+        assert!(
+            w.text.contains("MATCH"),
+            "window missed its anchor: {}",
+            w.text
+        );
+        assert!(
+            w.text.starts_with('…') && w.text.ends_with('…'),
+            "{}",
+            w.text
+        );
+        assert_eq!(str_width(&w.text), 20);
+    }
+
+    /// The pan is a delta from that resting column: negative reaches the head
+    /// of the line, positive its tail, and each end clamps.
+    #[test]
+    fn window_row_body_pans_from_the_resting_column() {
+        let body = format!("HEAD{}MATCH{}TAIL", "x".repeat(60), "y".repeat(60));
+        let anchor = Some((64, 5));
+        assert!(!window_row_body(&body, 20, anchor, 0).text.contains("HEAD"));
+
+        let left = window_row_body(&body, 20, anchor, -1000);
+        assert!(left.text.starts_with("HEAD"), "{}", left.text);
+        assert_eq!(left.slice_start, 0, "clamped to the head, not past it");
+
+        let right = window_row_body(&body, 20, anchor, 1000);
+        assert!(right.text.ends_with("TAIL"), "{}", right.text);
+        assert_eq!(right.slice_end, body.len(), "clamped to the tail");
+    }
+
+    /// Columns, not codepoints. A CJK body is half as many characters as it
+    /// is cells, and the window has to measure what the reader sees — this is
+    /// the case an ASCII-only test cannot fail on.
+    #[test]
+    fn window_row_body_measures_display_columns() {
+        let body = format!("{}MATCH", "漢".repeat(30));
+        // 30 wide chars are 60 columns: a codepoint-counting window would
+        // think this fits in 40 and leave the row overflowing.
+        let w = window_row_body(&body, 40, Some((30, 5)), 0);
+        assert!(w.text.contains("MATCH"), "{}", w.text);
+        assert!(
+            str_width(&w.text) <= 40,
+            "{} cols: {}",
+            str_width(&w.text),
+            w.text
+        );
+        // And a pan of N moves N columns, not N characters.
+        let panned = window_row_body(&body, 40, Some((30, 5)), -8);
+        assert_eq!(
+            str_width(&w.text),
+            str_width(&panned.text),
+            "both windows fill the budget"
+        );
+        assert!(str_width(&panned.text) <= 40);
+    }
+
+    /// A window never splits a double-width cell across its edge.
+    #[test]
+    fn window_row_body_never_splits_a_wide_cell() {
+        // Panned as well as at rest. A window that has been panned owes a
+        // leading marker, which spends a column the resting window does not,
+        // so the budgets where a row can overrun are only reachable with a
+        // non-zero pan — at `budget == 1` the marker *is* the whole window
+        // and a trailing one would draw a second column.
+        for body in ["漢".repeat(20), "abcdefghij".to_string()] {
+            for budget in 1..=40usize {
+                for pan in [-40, -1, 0, 1, 5, 40] {
+                    let w = window_row_body(&body, budget, None, pan);
+                    assert!(
+                        str_width(&w.text) <= budget,
+                        "budget {budget}, pan {pan}: {:?} is {} columns",
+                        w.text,
+                        str_width(&w.text)
+                    );
+                    assert!(body.is_char_boundary(w.slice_start));
+                    assert!(body.is_char_boundary(w.slice_end));
+                }
+            }
+        }
+    }
+
+    /// An overlay on text that panned off screen is dropped, not clamped onto
+    /// the row's first cell.
+    #[test]
+    fn tree_row_overlay_outside_the_window_is_dropped() {
+        let body = format!("{}MATCH{}", "x".repeat(60), "y".repeat(60));
+        let mut node = tnode(&body, 0, false);
+        node.text.inline_overlays.push(InlineOverlay {
+            start: 60,
+            end: 65,
+            style: OverlayOptions::default(),
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        });
+        // Panned hard right: the overlay's text is no longer drawn.
+        let r = render_tree_row(&node, false, false, 1, false, 30, 2, i32::MAX / 4);
+        assert!(
+            !r.entry.text.contains("MATCH"),
+            "precondition: panned past the overlay. Row: {:?}",
+            r.entry.text
+        );
+        assert!(
+            r.entry.inline_overlays.is_empty(),
+            "an overlay outside the drawn slice must be dropped, not clamped"
+        );
+    }
+
+    /// The pinned head stays put while the rest of the row slides under it.
+    #[test]
+    fn tree_row_pins_its_declared_head() {
+        let body = format!("path.rs:1 - {}MATCH{}", "x".repeat(60), "y".repeat(60));
+        let mut node = tnode(&body, 0, false);
+        node.window_anchor = Some(fresh_core::api::TextWindowAnchor {
+            pinned: 12,
+            start: 72,
+            len: 5,
+        });
+        for pan in [0, 20, i32::MAX / 4] {
+            let r = render_tree_row(&node, false, false, 1, false, 40, 2, pan);
+            assert!(
+                r.entry.text.contains("path.rs:1 - "),
+                "pan {pan} slid the pinned head away: {:?}",
+                r.entry.text
+            );
+        }
     }
 
     #[test]
@@ -4649,6 +5220,7 @@ pub mod tests {
             has_children: false,
             checked: None,
             extra_lines: Vec::new(),
+            window_anchor: None,
         };
         let nodes = vec![node("alpha"), node("beta")];
         let spec = WidgetSpec::Tree {
@@ -5792,6 +6364,7 @@ pub mod tests {
             has_children,
             checked: None,
             extra_lines: Vec::new(),
+            window_anchor: None,
         }
     }
 
@@ -5817,9 +6390,211 @@ pub mod tests {
         }
     }
 
+    /// A pan is a delta from where each row *rests*, so the two directions
+    /// are bounded by different numbers: a row whose match is far along a long
+    /// line has a great deal to its left and little to its right.
+    ///
+    /// One number for both is what let `S-End` store a value `S-Left` could
+    /// not walk back.
+    #[test]
+    fn pan_bounds_are_measured_from_where_rows_rest() {
+        let mut node = tnode(&"x".repeat(400), 0, false);
+        node.window_anchor = Some(fresh_core::api::TextWindowAnchor {
+            pinned: 0,
+            start: 380,
+            len: 5,
+        });
+        let tree = make_tree(vec![node], vec!["a"], 0, 10, vec![], Some("t"));
+        let (left, right) = pan_bounds(&tree, 100, None);
+        assert!(
+            (0..20).contains(&right),
+            "a match 380 columns along a 400 column row, in a 100 column \
+             window, has almost nothing to its right — the bound says {right}"
+        );
+        assert!(
+            (-360..-280).contains(&left),
+            "the head of that row is roughly 320 columns to its left — the \
+             bound says {left}"
+        );
+    }
+
+    /// "Pan to the end" is a question about the row the reader is on.
+    ///
+    /// The pan is shared, so rows of unequal length cannot all sit at their
+    /// tail at once. Answering with the longest row's travel leaves the
+    /// selected row clamped at its own tail with keystrokes still to spend
+    /// before it moves — which is what a reader reports as "Shift+arrow does
+    /// nothing". The whole tree's range still bounds the *stored* value, so
+    /// panning right does not stop early for the longer row.
+    #[test]
+    fn pan_bounds_can_be_asked_about_one_row() {
+        let long = {
+            let mut n = tnode(
+                &format!("{}M{}", "x".repeat(100), "y".repeat(300)),
+                0,
+                false,
+            );
+            n.window_anchor = Some(fresh_core::api::TextWindowAnchor {
+                pinned: 0,
+                start: 100,
+                len: 1,
+            });
+            n
+        };
+        let short = {
+            let mut n = tnode(&format!("{}M{}", "x".repeat(100), "y".repeat(60)), 0, false);
+            n.window_anchor = Some(fresh_core::api::TextWindowAnchor {
+                pinned: 0,
+                start: 100,
+                len: 1,
+            });
+            n
+        };
+        let tree = make_tree(
+            vec![short.clone(), long.clone()],
+            vec!["a", "b"],
+            0,
+            10,
+            vec![],
+            Some("t"),
+        );
+        let cols = 60u32;
+        let whole = pan_bounds(&tree, cols, None).1;
+        let just_short = pan_bounds(&tree, cols, Some(0)).1;
+        let just_long = pan_bounds(&tree, cols, Some(1)).1;
+        assert!(
+            just_short < whole,
+            "the short row reaches its tail before the tree does ({just_short} vs {whole})"
+        );
+        assert_eq!(
+            just_long, whole,
+            "the long row is what sets the tree's own bound"
+        );
+        // And the row-scoped answer is the row's real clamp: panning by it
+        // lands on the tail, one step more shows nothing new.
+        let at = |pan: i32| {
+            render_tree_row(&short, false, false, 1, false, cols, 0, pan)
+                .entry
+                .text
+        };
+        assert_ne!(at(just_short), at(just_short - PAN_COLUMNS));
+        assert_eq!(
+            at(just_short),
+            at(whole),
+            "past its own tail is still its tail"
+        );
+    }
+
+    /// The bound is the clamp the paint would apply, not an estimate of it:
+    /// panning by exactly it lands on the last column the row can show, and
+    /// one more column changes nothing.
+    #[test]
+    fn pan_bounds_agree_with_what_the_window_draws() {
+        let body = format!("{}MATCH{}", "x".repeat(200), "y".repeat(200));
+        let mut node = tnode(&body, 0, false);
+        node.window_anchor = Some(fresh_core::api::TextWindowAnchor {
+            pinned: 0,
+            start: 200,
+            len: 5,
+        });
+        let tree = make_tree(vec![node.clone()], vec!["a"], 0, 10, vec![], Some("t"));
+        let cols = 60u32;
+        let (left, right) = pan_bounds(&tree, cols, None);
+        let at = |pan: i32| {
+            render_tree_row(&node, false, false, 1, false, cols, 0, pan)
+                .entry
+                .text
+        };
+        assert_eq!(
+            at(right),
+            at(right + 40),
+            "past the right bound is not further right"
+        );
+        assert_ne!(at(right), at(right - 8), "the right bound is reachable");
+        assert_eq!(
+            at(left),
+            at(left - 40),
+            "past the left bound is not further left"
+        );
+        assert_ne!(at(left), at(left + 8), "the left bound is reachable");
+        assert!(
+            at(left).contains('x'),
+            "the left bound shows the head: {}",
+            at(left)
+        );
+        assert!(
+            at(right).ends_with('y'),
+            "the right bound shows the tail: {}",
+            at(right)
+        );
+    }
+
+    /// A row with no anchor rests at column zero: nothing to its left, its
+    /// whole length to its right. A kind whose paint cannot show a pan does
+    /// not accumulate one, and neither does a widget nothing has laid out.
+    #[test]
+    fn pan_bounds_without_an_anchor_a_tree_or_a_width() {
+        let tree = make_tree(
+            vec![tnode(&"x".repeat(400), 0, false)],
+            vec!["a"],
+            0,
+            10,
+            vec![],
+            Some("t"),
+        );
+        assert_eq!(
+            pan_bounds(&tree, 100, None).0,
+            0,
+            "nothing to the left of column zero"
+        );
+        assert!(pan_bounds(&tree, 100, None).1 > 300);
+        assert_eq!(
+            pan_bounds(&tree, 0, None),
+            (0, 0),
+            "a widget nothing has laid out has no width to be panned against"
+        );
+        assert_eq!(
+            pan_bounds(
+                &WidgetSpec::Spacer {
+                    cols: 1,
+                    flex: false,
+                    key: None,
+                },
+                100,
+                None
+            ),
+            (0, 0),
+            "a kind that never threads the pan has nothing to pan"
+        );
+    }
+
+    /// Trailing padding is not content on this path either: a row padded out
+    /// to the panel's width must not claim a pan that would show only spaces.
+    #[test]
+    fn pan_bounds_ignore_trailing_padding() {
+        let node = tnode(&format!("{}{}", "x".repeat(40), " ".repeat(360)), 0, false);
+        assert_eq!(
+            pan_bounds(
+                &make_tree(vec![node], vec!["a"], 0, 10, vec![], Some("t")),
+                100,
+                None
+            ),
+            (0, 0)
+        );
+    }
+
     #[test]
     fn tree_row_renders_disclosure_glyph_for_internal_collapsed() {
-        let r = render_tree_row(&tnode("file.txt", 0, true), false, false, 1, false, 80, 2);
+        let r = render_tree_row(
+            &tnode("file.txt", 0, true),
+            false,
+            false,
+            1,
+            false,
+            80,
+            2,
+            0,
+        );
         assert!(r.entry.text.starts_with('\u{25B6}'), "starts with ▶");
         assert!(r.entry.text.contains("file.txt"));
         assert!(r.disclosure_range.is_some());
@@ -5827,13 +6602,13 @@ pub mod tests {
 
     #[test]
     fn tree_row_renders_disclosure_glyph_for_internal_expanded() {
-        let r = render_tree_row(&tnode("file.txt", 0, true), true, false, 1, false, 80, 2);
+        let r = render_tree_row(&tnode("file.txt", 0, true), true, false, 1, false, 80, 2, 0);
         assert!(r.entry.text.starts_with('\u{25BC}'), "starts with ▼");
     }
 
     #[test]
     fn tree_row_leaf_uses_two_spaces_no_disclosure_hit() {
-        let r = render_tree_row(&tnode("match", 0, false), false, false, 1, false, 80, 2);
+        let r = render_tree_row(&tnode("match", 0, false), false, false, 1, false, 80, 2, 0);
         // No glyph, just spaces for alignment.
         assert!(r.entry.text.starts_with("  "));
         assert!(r.entry.text.contains("match"));
@@ -5842,7 +6617,7 @@ pub mod tests {
 
     #[test]
     fn tree_row_indents_by_depth_times_two() {
-        let r = render_tree_row(&tnode("nested", 2, false), false, false, 1, false, 80, 2);
+        let r = render_tree_row(&tnode("nested", 2, false), false, false, 1, false, 80, 2, 0);
         // depth=2 → 4 leading spaces, then 2 alignment spaces, then "nested".
         assert!(r.entry.text.starts_with("      nested"));
     }
@@ -5860,7 +6635,7 @@ pub mod tests {
             properties: Default::default(),
             unit: OffsetUnit::Byte,
         });
-        let r = render_tree_row(&node, false, false, 1, false, 80, 2);
+        let r = render_tree_row(&node, false, false, 1, false, 80, 2, 0);
         // depth=1 → 2 indent + 2 alignment = 4 prefix bytes (ASCII).
         // The plugin's [0..5] becomes [4..9].
         let plugin_overlay = r
@@ -5878,7 +6653,7 @@ pub mod tests {
         // Even with `checked: Some(_)`, no glyph if `checkable: false`.
         let mut node = tnode("file.rs", 0, false);
         node.checked = Some(true);
-        let r = render_tree_row(&node, false, false, 1, false, 80, 2);
+        let r = render_tree_row(&node, false, false, 1, false, 80, 2, 0);
         assert!(r.checkbox_range.is_none());
         assert!(!r.entry.text.contains("[v]"));
         assert!(!r.entry.text.contains("[ ]"));
@@ -5890,7 +6665,7 @@ pub mod tests {
         // Lets a checkable tree mix non-checkbox-bearing nodes
         // (e.g. a separator or header) with checkbox rows.
         let node = tnode("section", 0, false);
-        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2, 0);
         assert!(r.checkbox_range.is_none());
         assert!(!r.entry.text.contains("[v]"));
         assert!(!r.entry.text.contains("[ ]"));
@@ -5900,7 +6675,7 @@ pub mod tests {
     fn tree_row_renders_checked_glyph_after_disclosure() {
         let mut node = tnode("file.rs", 0, true);
         node.checked = Some(true);
-        let r = render_tree_row(&node, true, true, 1, false, 80, 2);
+        let r = render_tree_row(&node, true, true, 1, false, 80, 2, 0);
         assert!(r.checkbox_range.is_some(), "checkbox range emitted");
         let (cb_start, cb_end) = r.checkbox_range.unwrap();
         // Layout: ▼(3 bytes UTF-8) + " " + [v] + " " + body
@@ -5912,7 +6687,7 @@ pub mod tests {
     fn tree_row_renders_unchecked_glyph_for_leaf() {
         let mut node = tnode("match-row", 1, false);
         node.checked = Some(false);
-        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2, 0);
         let (cb_start, cb_end) = r
             .checkbox_range
             .expect("checkbox range for leaf with checked: Some");
@@ -5927,7 +6702,7 @@ pub mod tests {
         // verbatim (no UTF-8 boundary issues from the disclosure).
         let mut node = tnode("path/with/é", 0, true);
         node.checked = Some(true);
-        let r = render_tree_row(&node, false, true, 1, false, 80, 2);
+        let r = render_tree_row(&node, false, true, 1, false, 80, 2, 0);
         let (cb_start, cb_end) = r.checkbox_range.unwrap();
         assert!(r.entry.text.is_char_boundary(cb_start));
         assert!(r.entry.text.is_char_boundary(cb_end));
@@ -8331,6 +9106,7 @@ pub mod tests {
             focus_follows_cursor: false,
             hovered_widget_key: String::new(),
             hovered_item_key: String::new(),
+            h_pan: Default::default(),
         }
     }
 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1465,6 +1465,42 @@ type TreeNode = {
 	* Ignored when `item_height == 1`.
 	*/
 	extraLines?: Array<TextPropertyEntry>;
+	/**
+	* The span of `text` this row exists to show, in **chars**.
+	*
+	* A row wider than the panel is windowed by the host, and without this
+	* the window can only start at the head of the line — which is exactly
+	* where a search result's match usually is not (issue #1580). Naming the
+	* span lets the host rest the window on it instead, and the reader pans
+	* away from there.
+	*
+	* Chars rather than columns because that is the unit a plugin can count:
+	* it has the string, not the terminal's width table. The host converts.
+	* Out-of-range values are harmless — they resolve to the end of the text.
+	*/
+	windowAnchor?: TextWindowAnchor | null;
+};
+type TextWindowAnchor = {
+	/**
+	* Chars at the head of the row that never move.
+	*
+	* A row's leading pieces are usually its *identity* rather than its
+	* content — a search result's `path:line` — and a window that slid them
+	* away left rows that could not be told apart. They stay put and the
+	* rest of the row slides under them, the same relationship the indent
+	* and checkbox glyphs already have with the body.
+	*/
+	pinned: number;
+	/**
+	* Char index, in the whole row, where the span the row exists to show
+	* starts. Must be at or after `pinned`; a span inside the pinned head is
+	* always visible anyway.
+	*/
+	start: number;
+	/**
+	* Length of the span, in chars. Zero is allowed and means a point.
+	*/
+	len: number;
 };
 type WidgetSpec = {
 	"kind": "row";

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -487,6 +487,21 @@ export function treeNode(
      * nodes so every card is the same height. Ignored when the tree
      * is single-line (`itemHeight === 1`). */
     extraLines?: TextPropertyEntry[];
+    /** The char range of `text` this row exists to show.
+     *
+     * A row wider than the panel is windowed by the host; without this
+     * the window can only start at the head of the line, which is where
+     * a search result's match usually is not. Name the span and the host
+     * rests the window on it — and the reader pans away from there with
+     * Shift+Left/Right or Shift+wheel.
+     *
+     * `pinned` keeps that many leading chars in place while the rest of the
+     * row slides under them — a row's leading pieces are usually its identity
+     * (`path:line`) rather than its content.
+     *
+     * Chars, not display columns: a plugin has the string, not the
+     * terminal's width table. Out-of-range values resolve to the end. */
+    windowAnchor?: { pinned?: number; start: number; len: number };
   },
 ): TreeNode {
   // `checked` is intentionally Optional<bool>, not a default-false
@@ -502,6 +517,16 @@ export function treeNode(
   };
   if (options?.checked !== undefined) {
     node.checked = options.checked;
+  }
+  if (options?.windowAnchor) {
+    // `pinned` is defaulted here rather than left absent: the host's
+    // `TextWindowAnchor` takes it as `#[serde(default)]`, so a missing
+    // field and a zero mean the same thing on the wire — but the
+    // generated type says `pinned: number`, and filling it in is what
+    // keeps the two spellings from being a type error for every caller
+    // that has no pinned head.
+    const { pinned, start, len } = options.windowAnchor;
+    node.windowAnchor = { pinned: pinned ?? 0, start, len };
   }
   if (options?.extraLines && options.extraLines.length > 0) {
     node.extraLines = options.extraLines;

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -371,72 +371,6 @@ function matchSpanNear(
   };
 }
 
-/** Fit `text` into `budget` display columns with the first match of
- *  `pattern` inside the window.
- *
- *  A search result whose matched text is off the right edge tells the
- *  reader nothing — and there is no horizontal scroll to go find it
- *  (issue #1580). So when the match falls past the budget, the window
- *  slides right to bring it in, marking each elided end with `…`. When
- *  the match already fits (the overwhelmingly common case) this is
- *  exactly `truncate`, so ordinary rows are unchanged.
- *
- *  `matchAt` is where this row's own match is expected to sit in
- *  `text` — see `matchSpanNear`.
- *
- *  `alreadySliced` says whether `text` is itself a mid-line window. It
- *  governs the fallbacks, not the happy path: head-truncating a slice
- *  that does not start at the beginning of the line renders it as
- *  though it did, with a trailing "..." implying nothing was cut on the
- *  left. The caller now anchors at 0 whenever it cannot locate the
- *  match, so this should not arise — but a marker costs one column and
- *  a row that silently lies about where it starts is worse than a row
- *  that is one character narrower. */
-function windowAroundMatch(
-  text: string,
-  budget: number,
-  pattern: string,
-  isRegex: boolean,
-  caseSensitive: boolean,
-  matchAt: number,
-  alreadySliced: boolean,
-): string {
-  const ELLIPSIS = "…";
-  // Head-truncation, honest about a left-hand elision when there is one.
-  const head = (t: string) =>
-    alreadySliced
-      ? ELLIPSIS + truncate(t, Math.max(1, budget - 1))
-      : truncate(t, budget);
-  // `head` (not a bare prepend) so the marker cannot push the row one
-  // column over `budget` when the text already fills it exactly.
-  if (charLen(text) <= budget) return alreadySliced ? head(text) : text;
-  const span = matchSpanNear(text, pattern, isRegex, caseSensitive, matchAt);
-  // No locatable match (empty/invalid pattern, or a hit that fell
-  // outside the capped window): keep the historical head-truncation.
-  if (!span) return head(text);
-  // The match is already visible in the head — `truncate`'s own "..."
-  // marker covers the elided tail.
-  if (span.start + span.length <= budget - 3) return head(text);
-
-  // Codepoint array: slicing it can never split a surrogate pair, and
-  // the input is capped well under a couple of thousand codepoints.
-  const cps = Array.from(text);
-  // Keep a third of the budget as leading context so the match reads in
-  // situ rather than flush against the elision marker.
-  const lead = Math.max(1, Math.floor(budget / 3));
-  const start = Math.max(0, span.start - lead);
-  // Nothing is elided on the left, so there is no window to slide: the
-  // match starts inside the first third and is simply wider than the
-  // row. Head-truncation is all this width allows.
-  if (start === 0) return head(text);
-  // One column goes to the leading `…`.
-  const room = budget - 1;
-  if (start + room >= cps.length) {
-    return ELLIPSIS + cps.slice(cps.length - room).join("");
-  }
-  return ELLIPSIS + cps.slice(start, start + room - 1).join("") + ELLIPSIS;
-}
-
 // Get the active field's text
 function getActiveFieldText(): string {
   if (!panel) return "";
@@ -830,27 +764,38 @@ function flatItemKey(item: FlatItem): string {
 // inside the context substring) ride on the relevant segment via
 // its `overlays` field, addressed in char units relative to that
 // segment alone.
-function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
-  if (!panel) return { text: "" };
+/** One rendered row: the entry, plus the char span the row exists to show.
+ *
+ *  The span is the host's to act on — it rests the row's window on it when
+ *  the row is wider than the panel, and the reader pans away from there. The
+ *  plugin no longer cuts the string itself: it sends the capped context whole
+ *  and says where the interesting part is, which is what makes panning left
+ *  able to reach the head of the line at all. See `TreeNode.windowAnchor`. */
+type RenderedRow = { entry: TextPropertyEntry; anchor?: TextWindowAnchor };
+
+function renderFlatItemEntry(item: FlatItem, W: number): RenderedRow {
+  if (!panel) return { entry: { text: "" } };
   if (item.type === "file") {
     const group = panel.fileGroups[item.fileIndex];
     const badge = getFileExtBadge(group.relPath);
     const matchCount = group.matches.length;
     const selectedInFile = group.matches.filter(m => m.selected).length;
-    return styledRow(
-      [
-        { text: badge, style: { fg: C.fileIcon, bold: true } },
-        { text: " " },
-        { text: group.relPath, style: { fg: C.filePath } },
-        { text: ` (${selectedInFile}/${matchCount})` },
-      ],
-      {
-        // Host prefix at depth 0: disclosure (▶/▼) + space + checkbox
-        // ([v]/[ ]) + space = 6 cols.
-        padToChars: Math.max(0, W - 6),
-        properties: { type: "file-row", fileIndex: item.fileIndex },
-      },
-    );
+    return {
+      entry: styledRow(
+        [
+          { text: badge, style: { fg: C.fileIcon, bold: true } },
+          { text: " " },
+          { text: group.relPath, style: { fg: C.filePath } },
+          { text: ` (${selectedInFile}/${matchCount})` },
+        ],
+        {
+          // Host prefix at depth 0: disclosure (▶/▼) + space + checkbox
+          // ([v]/[ ]) + space = 6 cols.
+          padToChars: Math.max(0, W - 6),
+          properties: { type: "file-row", fileIndex: item.fileIndex },
+        },
+      ),
+    };
   }
   // Match row. The Tree widget's prefix at depth=1 is 6 cols
   // (4 indent + 2 alignment). Use the remaining width for content.
@@ -904,46 +849,63 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   // Total: 8 cols.
   const innerWidth = Math.max(0, W - 8);
 
-  // Best-effort context budget: enough room for the fixed leading
-  // pieces plus " - " plus the context itself. JS `.length` gives
-  // UTF-16 code-unit counts which match codepoint counts for the
-  // overwhelmingly-ASCII case (paths + line numbers); slight
-  // over-counting on rare non-BMP filenames just trims a little
-  // more of the context, which is fine.
-  const maxCtx = innerWidth - location.length - 3;
   // Where this row's match sits in `context`, after the cap slice and
   // the leading trim above — used to pick between several hits on the
   // same line. Exact, since `anchor` is an index into `rawCtx`.
   const trimmedLead = capStart === 0 ? capped.length - capped.trimStart().length : 0;
   const matchAt = Math.max(0, anchor) - capStart - trimmedLead;
-  const displayCtx = windowAroundMatch(
-    context,
-    Math.max(10, maxCtx),
-    panel.searchPattern,
-    panel.useRegex,
-    panel.caseSensitive,
-    matchAt,
-    capStart > 0,
-  );
+  // **The whole capped context goes to the host, not a slice of it.**
+  //
+  // Fitting a row to the panel used to happen here, which meant the row the
+  // host received was already the only thing that could ever be read: there
+  // was nothing to the left of the window's `…` and nothing to the right, so
+  // there was nothing to pan (issue #1580). The host fits the row now, and
+  // this says where the window should rest — so panning left walks back
+  // through the head of the line and panning right runs to its tail.
+  //
+  // The cap is unchanged: `CONTEXT_HARD_CAP` still bounds every per-codepoint
+  // walk below, and it is what bounds how far a pan can travel.
+  const span = panel.searchPattern
+    ? matchSpanNear(context, panel.searchPattern, panel.useRegex, panel.caseSensitive, matchAt)
+    : null;
 
   // Pattern-match highlights inside the context substring. Emitted
   // in segment-local char units; the host shifts them by the
-  // context segment's char start during entry concatenation.
+  // context segment's char start during entry concatenation, and
+  // clips them to the drawn slice.
   const ctxOverlays: InlineOverlay[] = [];
   if (panel.searchPattern) {
-    highlightMatches(displayCtx, panel.searchPattern, panel.useRegex, panel.caseSensitive, ctxOverlays);
+    highlightMatches(context, panel.searchPattern, panel.useRegex, panel.caseSensitive, ctxOverlays);
   }
 
   const segments: StyledSegment[] = [
     { text: location, style: { fg: C.lineNum } },
     { text: " - " },
-    { text: displayCtx, overlays: ctxOverlays },
+    { text: context, overlays: ctxOverlays },
   ];
 
-  return styledRow(segments, {
+  const entry = styledRow(segments, {
     padToChars: innerWidth,
     properties: { type: "match-row", fileIndex: item.fileIndex, matchIndex: item.matchIndex },
   });
+  // The window is addressed to the whole row, so both numbers carry the
+  // leading pieces' width. `location` is a path plus a line number — the
+  // codepoint/UTF-16 distinction only bites on a non-BMP filename, where
+  // being a codepoint or two out moves the resting window by that much and
+  // nothing else.
+  //
+  // `pinned` keeps `path:line - ` in place while the context slides under it:
+  // it is which match this row *is*, and rows that pan it away cannot be told
+  // apart.
+  const pinned = charLen(location) + 3;
+  return {
+    entry,
+    anchor: {
+      pinned,
+      start: pinned + (span ? span.start : 0),
+      len: span ? span.length : 0,
+    },
+  };
 }
 
 // Convert a slice of `FlatItem`s into the corresponding TreeNodes.
@@ -957,7 +919,7 @@ function flatItemsToTreeNodes(
   W: number,
 ): TreeNode[] {
   return flatItems.map((item, i) => {
-    const entry = renderFlatItemEntry(item, W);
+    const { entry, anchor } = renderFlatItemEntry(item, W);
     if (item.type === "file") {
       const k = itemKeys[i];
       if (!panel!.knownFileKeys.has(k)) {
@@ -971,7 +933,12 @@ function flatItemsToTreeNodes(
     }
     const matchSelected = panel!.fileGroups[item.fileIndex]
       .matches[item.matchIndex!].selected;
-    return treeNode(entry, { depth: 1, hasChildren: false, checked: matchSelected });
+    return treeNode(entry, {
+      depth: 1,
+      hasChildren: false,
+      checked: matchSelected,
+      windowAnchor: anchor,
+    });
   });
 }
 

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -599,6 +599,12 @@ impl Editor {
                     .cloned()
                     .unwrap_or_default(),
             ),
+            h_pan: Rc::new(
+                self.widget_registry
+                    .get(&key)
+                    .map(|p| p.h_pan.clone())
+                    .unwrap_or_default(),
+            ),
             focus_key: self
                 .widget_registry
                 .focus_key(&key)

--- a/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
@@ -47,7 +47,23 @@ pub fn key_code_to_config_name(key_code: KeyCode) -> String {
         KeyCode::PageUp => "PageUp".to_string(),
         KeyCode::PageDown => "PageDown".to_string(),
         KeyCode::Insert => "Insert".to_string(),
+        // The one keypad key with no main-keyboard equivalent, so the one the
+        // Debug spelling (`KeypadBegin`) would strand: `parse_key` knows it by
+        // its keysym name, from the same table the input parser decodes it
+        // with. Every other name above is in `keybindings::NAMED_KEYS`, and
+        // `config_names_round_trip` is what keeps that true.
+        KeyCode::KeypadBegin => "kp_begin".to_string(),
         KeyCode::F(n) => format!("F{}", n),
+        // Media and standalone-modifier keys, from the same table the input
+        // parser decodes them with. Without this they fell to the `{:?}`
+        // spelling below — `"Media(MuteVolume)"` — which `parse_key` then
+        // refused, dropping the binding at load: issue #1128, one family
+        // over.
+        KeyCode::Media(_) | KeyCode::Modifier(_) => {
+            fresh_input_parser::media_modifier::keysym_for_code(key_code)
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{:?}", key_code))
+        }
         _ => format!("{:?}", key_code),
     }
 }

--- a/crates/fresh-editor/src/app/keybinding_editor/mod.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/mod.rs
@@ -5,7 +5,9 @@
 //! key recording, conflict detection, and keymap management.
 
 mod editor;
-mod helpers;
+// `pub(crate)` for the config-name serialiser: `keybindings::parse_key` is its
+// exact inverse, and `config_names_round_trip` holds the two together.
+pub(crate) mod helpers;
 mod types;
 
 pub use editor::KeybindingEditor;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -14,10 +14,13 @@ use crate::view::prompt::PromptType;
 use anyhow::Result as AnyhowResult;
 use std::time::{Duration, Instant};
 
-/// Columns one notch of a sideways wheel pans. Horizontal panning has
-/// no line-oriented setting to follow — `mouse_wheel_scroll_lines`
-/// counts lines — so it keeps the fixed step it always had.
-const WHEEL_COLUMNS: i32 = 3;
+/// Columns one notch of a sideways wheel pans. Horizontal panning has no
+/// line-oriented setting to follow — `mouse_wheel_scroll_lines` counts lines
+/// — so it takes the same fixed step a pan keystroke does, which is what
+/// [`PAN_COLUMNS`] is for.
+///
+/// [`PAN_COLUMNS`]: crate::widgets::render::PAN_COLUMNS
+const WHEEL_COLUMNS: i32 = crate::widgets::render::PAN_COLUMNS;
 
 /// How long one line of a smoothed wheel gesture is meant to take.
 /// Roughly a frame at 60Hz, so a three-line notch walks across about

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5278,6 +5278,8 @@ impl Editor {
         let prev_focus = String::new();
         let panel_width = self.widget_panel_width(buffer_id);
         let avail_height = self.widget_panel_height(buffer_id);
+        // A mount has nothing panned yet.
+        let h_pan = std::collections::HashMap::new();
         let out = self.render_panel_spec(
             &spec,
             &prev,
@@ -5286,6 +5288,7 @@ impl Editor {
             panel_width,
             avail_height,
             options.auto_focus_first(),
+            &h_pan,
         );
         self.record_widget_panel_render_height(&panel_key, avail_height);
         // KNOWN LIMITATION (deliberate; retired by `docs/internal/retained-mode-ui.md` §3.5):
@@ -5388,6 +5391,13 @@ impl Editor {
             .get(panel_key)
             .map(|p| p.auto_focus_first)
             .unwrap_or(true);
+        // The reader's sideways fold: a repaint that dropped it would slide
+        // every row back to its resting window under a reader who panned.
+        let h_pan = self
+            .widget_registry
+            .get(panel_key)
+            .map(|p| p.h_pan.clone())
+            .unwrap_or_default();
         let out = self.render_panel_spec(
             &spec,
             &prev,
@@ -5396,6 +5406,7 @@ impl Editor {
             panel_width,
             avail_height,
             auto_focus_first,
+            &h_pan,
         );
         self.record_widget_panel_render_height(panel_key, avail_height);
         let entries = out.entries;
@@ -5861,6 +5872,8 @@ impl Editor {
                 // Floating and dock slots keep the historical seeding;
                 // only a panel that declared otherwise at mount opts out.
                 true,
+                // A mount has nothing panned yet.
+                None,
             )
         };
         let entries = out.entries;
@@ -5970,6 +5983,8 @@ impl Editor {
                 }),
                 // As the dock: keep the historical focus seeding.
                 true,
+                // A mount has nothing panned yet.
+                None,
             )
         };
         let entries = out.entries;
@@ -6069,6 +6084,8 @@ impl Editor {
                 // Floating and dock slots keep the historical seeding;
                 // only a panel that declared otherwise at mount opts out.
                 true,
+                // A mount has nothing panned yet.
+                None,
             )
         };
         let entries = out.entries;

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -6259,6 +6259,12 @@ impl Editor {
                     .cloned()
                     .unwrap_or_default(),
             ),
+            h_pan: Rc::new(
+                self.widget_registry
+                    .get(&key)
+                    .map(|p| p.h_pan.clone())
+                    .unwrap_or_default(),
+            ),
             focus_key: self
                 .widget_registry
                 .focus_key(&key)
@@ -6350,6 +6356,12 @@ impl Editor {
                 self.widget_registry
                     .instance_states(&key)
                     .cloned()
+                    .unwrap_or_default(),
+            ),
+            h_pan: Rc::new(
+                self.widget_registry
+                    .get(&key)
+                    .map(|p| p.h_pan.clone())
                     .unwrap_or_default(),
             ),
             focus_key: self

--- a/crates/fresh-editor/src/app/shell_host.rs
+++ b/crates/fresh-editor/src/app/shell_host.rs
@@ -2151,6 +2151,36 @@ impl Editor {
                 };
                 self.wheel_widget_by_key(&key, &widget, delta);
             }
+            UiFact::WidgetPan {
+                slot,
+                widget,
+                delta,
+            } => {
+                use crate::view::shell::widgets::Slot;
+                // Every plugin-panel slot, unlike `WidgetWheel`: the panel a
+                // sideways notch is aimed at is most often a pane-mounted one
+                // (Search & Replace is the case this exists for), and a pane
+                // resolves to its panel through its buffer.
+                let key = match slot {
+                    Slot::Dock => self
+                        .panel(crate::app::PanelSlot::Dock)
+                        .map(|p| p.panel_key.clone()),
+                    Slot::Floating => self
+                        .panel(crate::app::PanelSlot::Floating)
+                        .map(|p| p.panel_key.clone()),
+                    Slot::Sidebar(i) => self
+                        .panel(crate::app::PanelSlot::Sidebar(i))
+                        .map(|p| p.panel_key.clone()),
+                    Slot::Pane(pane) => self.pane_panel_key(pane),
+                    // The settings surfaces and the prompt toolbar describe
+                    // their own specs with no plugin panel behind them —
+                    // nothing to pan.
+                    Slot::Settings | Slot::SettingsEntry | Slot::PromptToolbar => None,
+                };
+                if let Some(key) = key {
+                    self.pan_widget_by_key(&key, &widget, delta);
+                }
+            }
             UiFact::WidgetHover {
                 slot,
                 widget,

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -2360,6 +2360,44 @@ impl Editor {
         true
     }
 
+    /// Pan the keyed widget sideways by `delta` display columns.
+    ///
+    /// The runtime's counterpart to [`Self::wheel_widget_by_key`], and it does
+    /// not go through a kind: a pan moves the panel's own fold rather than a
+    /// window a kind resolves, so there is nothing for a `Tree` or a `List` to
+    /// decide. What each kind decides is whether it *honours* the fold, which
+    /// it does at paint time by threading it into `render_tree_row` — and
+    /// [`pan_bounds`] answers that same question from the spec, so a notch over
+    /// a kind that cannot show a pan falls through instead of being swallowed.
+    ///
+    /// [`pan_bounds`]: crate::widgets::render::pan_bounds
+    pub(crate) fn pan_widget_by_key(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: &str,
+        delta: i32,
+    ) -> bool {
+        if widget_key.is_empty() {
+            return false;
+        }
+        let Some(spec) = self.widget_registry.get(panel_key).map(|p| p.spec.clone()) else {
+            return false;
+        };
+        let Some(widget) = crate::widgets::find_widget_by_key(&spec, widget_key) else {
+            return false;
+        };
+        let viewport = self.widget_viewport(panel_key, widget, widget_key);
+        let bounds = crate::widgets::render::pan_bounds(widget, viewport.cols, None);
+        let Some(panel) = self.widget_registry.get_mut(panel_key) else {
+            return false;
+        };
+        if !panel.pan_h(widget_key, Some(delta), bounds) {
+            return false;
+        }
+        self.rerender_widget_panel(panel_key);
+        true
+    }
+
     /// **Does the tree describe this panel's interior** — and it does for
     /// every mounted panel. The dock, the floating modal, a sidebar section
     /// and a pane all describe what is mounted in them; the pane-mounted class

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -40,6 +40,7 @@ impl Editor {
         panel_width: u32,
         avail_height: Option<u32>,
         auto_focus_first: bool,
+        h_pan: &std::collections::HashMap<String, i32>,
     ) -> crate::widgets::RenderOutput {
         let theme_guard = self.theme.read().unwrap();
         crate::widgets::render_spec_with_options(
@@ -66,6 +67,10 @@ impl Editor {
                 // over its own previous value, so a repaint that did not
                 // carry this would start every list back at the top.
                 prev_painted: Some(prev_painted),
+                // The reader's sideways fold, for the same reason: a repaint
+                // that dropped it would slide every row back to its resting
+                // window under a reader who had panned away from it.
+                h_pan: Some(h_pan),
                 ..Default::default()
             },
         )
@@ -89,6 +94,7 @@ pub(super) fn render_floating_spec(
     hover_popup_row: &str,
     markdown: Option<crate::widgets::MarkdownCtx<'_>>,
     auto_focus_first: bool,
+    h_pan: Option<&std::collections::HashMap<String, i32>>,
 ) -> crate::widgets::RenderOutput {
     crate::widgets::render_spec_with_options(
         spec,
@@ -109,6 +115,10 @@ pub(super) fn render_floating_spec(
             markdown,
             avail_height,
             prev_painted: Some(prev_painted),
+            // The reader's sideways fold, for the same reason: a repaint that
+            // dropped it would slide every row back to its resting window
+            // under a reader who had panned away from it.
+            h_pan,
         },
     )
 }
@@ -811,6 +821,11 @@ impl Editor {
                 .get(panel_key)
                 .map(|p| p.painted.clone())
                 .unwrap_or_default();
+            let h_pan = self
+                .widget_registry
+                .get(panel_key)
+                .map(|p| p.h_pan.clone())
+                .unwrap_or_default();
             let prev_focus = self
                 .widget_registry
                 .focus_key(panel_key)
@@ -880,6 +895,7 @@ impl Editor {
                     grammars: Some(self.grammar_registry.as_ref()),
                 }),
                 auto_focus_first,
+                Some(&h_pan),
             );
             (buffer_id, is_floating, panel_width, out)
         };
@@ -1124,6 +1140,10 @@ impl Editor {
         Some(crate::widgets::kinds::Viewport {
             items: (window.h as u32).max(1),
             rows: cells as u32,
+            // `w` counts cells on both kinds of window — it is the one part
+            // of an item-scrolling rectangle that is not in items — so it is
+            // the width a sideways pan is measured against.
+            cols: window.w as u32,
         })
     }
 
@@ -2375,6 +2395,27 @@ impl Editor {
             .find(|panel_key| self.panel_focused_widget_is_text(panel_key))
     }
 
+    /// The first panel rendering into `buffer_id` that has a focused widget
+    /// of *any* kind.
+    ///
+    /// [`Self::focused_text_widget_panel_for_buffer`] answers the narrower
+    /// question the clipboard path asks; this one is for a key addressed to
+    /// whatever holds focus — a `Tree`'s pan keys, where the whole point is
+    /// that focus is *not* on a text field.
+    pub(super) fn focused_widget_panel_for_buffer(
+        &self,
+        buffer_id: crate::model::event::BufferId,
+    ) -> Option<crate::widgets::PanelKey> {
+        self.widget_registry
+            .panels_for_buffer(buffer_id)
+            .into_iter()
+            .find(|k| {
+                self.widget_registry
+                    .get(k)
+                    .is_some_and(|p| !p.focus_key.is_empty())
+            })
+    }
+
     /// True when `panel_key`'s currently-focused widget is a `Text`
     /// field (so it can accept clipboard insertion). `false` when the
     /// panel is gone, has no focus, or focus rests on a non-text
@@ -3503,6 +3544,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -3566,6 +3608,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -3725,6 +3768,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         assert_eq!(
             out.tabbable,
@@ -3798,6 +3842,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -3866,6 +3911,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         // What the collector resolved for the same list, so the two numbers
         // are visible side by side: with a plain header above it they agree
@@ -3903,6 +3949,7 @@ mod tests {
                     rows: 3,
                     items: 3,
                     offset: 0,
+                    cols: 0,
                 },
             );
 
@@ -4043,7 +4090,11 @@ mod tests {
         };
         assert_eq!(
             Viewport::from_spec(&cards),
-            Viewport { rows: 12, items: 3 },
+            Viewport {
+                rows: 12,
+                items: 3,
+                cols: 0,
+            },
             "twelve rows of four-row cards is three cards"
         );
         let lines = match cards.clone() {
@@ -4075,7 +4126,8 @@ mod tests {
             Viewport::from_spec(&lines),
             Viewport {
                 rows: 12,
-                items: 12
+                items: 12,
+                cols: 0,
             },
             "and a single-line tree's rows are its nodes"
         );
@@ -4114,6 +4166,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -4180,6 +4233,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -4239,6 +4293,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -4296,6 +4351,7 @@ mod tests {
             "",
             None,
             false,
+            None,
         );
         assert_eq!(out.focus_key, "", "nothing seeded");
         editor.widget_registry.mount(
@@ -4346,6 +4402,7 @@ mod tests {
             "",
             None,
             true,
+            None,
         );
         editor.widget_registry.mount(
             panel_key.clone(),
@@ -4411,6 +4468,7 @@ mod tests {
                 "",
                 None,
                 true,
+                None,
             )
         };
         // The dock before the dropdown: a list, and nothing else to focus.

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -1689,6 +1689,279 @@ impl BindingSource {
 /// not parse, so a rejected binding leaves a trace in the log instead of dying
 /// silently (issue #1128: `"key": "asterisk"` was ignored with no feedback
 /// anywhere).
+/// A key a config entry can name in words, and the spellings it answers to.
+///
+/// The tables below plus [`fresh_input_parser::keypad::KEYPAD_KEYS`] are the
+/// whole accepted vocabulary, and they are data rather than match arms for two
+/// reasons: `parse_key` reads them, and so does the generator that writes the
+/// table in `docs/configuration/keyboard.md`. A name that is not documented is
+/// a name nobody can find.
+pub struct KeyName {
+    /// Accepted spellings, lowercase. The first is canonical — the one the
+    /// generated documentation lists and the one to prefer in examples.
+    pub names: &'static [&'static str],
+    /// What the name resolves to.
+    pub code: KeyCode,
+}
+
+/// Keys that have a name of their own — neither a character nor the keypad.
+///
+/// Every spelling `keybinding_editor::helpers::key_code_to_config_name` can
+/// write must appear here, or the editor would record a binding that its own
+/// loader then rejects; `config_names_round_trip` holds that.
+pub const NAMED_KEYS: &[KeyName] = &[
+    KeyName {
+        names: &["enter"],
+        code: KeyCode::Enter,
+    },
+    KeyName {
+        names: &["backspace"],
+        code: KeyCode::Backspace,
+    },
+    KeyName {
+        names: &["delete", "del"],
+        code: KeyCode::Delete,
+    },
+    KeyName {
+        names: &["insert", "ins"],
+        code: KeyCode::Insert,
+    },
+    KeyName {
+        names: &["tab"],
+        code: KeyCode::Tab,
+    },
+    KeyName {
+        names: &["backtab"],
+        code: KeyCode::BackTab,
+    },
+    KeyName {
+        names: &["escape", "esc"],
+        code: KeyCode::Esc,
+    },
+    KeyName {
+        names: &["space"],
+        code: KeyCode::Char(' '),
+    },
+    KeyName {
+        names: &["left"],
+        code: KeyCode::Left,
+    },
+    KeyName {
+        names: &["right"],
+        code: KeyCode::Right,
+    },
+    KeyName {
+        names: &["up"],
+        code: KeyCode::Up,
+    },
+    KeyName {
+        names: &["down"],
+        code: KeyCode::Down,
+    },
+    KeyName {
+        names: &["home"],
+        code: KeyCode::Home,
+    },
+    KeyName {
+        names: &["end"],
+        code: KeyCode::End,
+    },
+    KeyName {
+        names: &["pageup"],
+        code: KeyCode::PageUp,
+    },
+    KeyName {
+        names: &["pagedown"],
+        code: KeyCode::PageDown,
+    },
+    // Lock and system keys. A terminal speaking the kitty keyboard protocol
+    // reports these (the input parser decodes them at codepoints 57358-57363),
+    // so the keybinding editor can record one — and without a name here it
+    // would write a `{:?}` spelling that the loader then refused, which is the
+    // `Insert` bug one line up, repeated.
+    KeyName {
+        names: &["capslock"],
+        code: KeyCode::CapsLock,
+    },
+    KeyName {
+        names: &["scrolllock"],
+        code: KeyCode::ScrollLock,
+    },
+    KeyName {
+        names: &["numlock"],
+        code: KeyCode::NumLock,
+    },
+    KeyName {
+        names: &["printscreen"],
+        code: KeyCode::PrintScreen,
+    },
+    KeyName {
+        names: &["pause"],
+        code: KeyCode::Pause,
+    },
+    KeyName {
+        names: &["menu"],
+        code: KeyCode::Menu,
+    },
+];
+
+/// X11 keysym spellings for ASCII punctuation.
+///
+/// A single-character key name is still the canonical spelling (and what the
+/// keybinding editor writes back), but people reach for the X11 keysym name
+/// they know — `"key": "asterisk"` is what issue #1128 was actually configured
+/// with, and it bound nothing at all. JSON also makes some of these awkward to
+/// write literally (`"\\"` for backslash, `"\""` for the double quote), so a
+/// name is the friendlier spelling.
+pub const PUNCTUATION_KEYS: &[KeyName] = &[
+    KeyName {
+        names: &["asterisk", "star"],
+        code: KeyCode::Char('*'),
+    },
+    KeyName {
+        names: &["plus"],
+        code: KeyCode::Char('+'),
+    },
+    KeyName {
+        names: &["minus", "hyphen"],
+        code: KeyCode::Char('-'),
+    },
+    KeyName {
+        names: &["slash"],
+        code: KeyCode::Char('/'),
+    },
+    KeyName {
+        names: &["period", "dot"],
+        code: KeyCode::Char('.'),
+    },
+    KeyName {
+        names: &["equal", "equals"],
+        code: KeyCode::Char('='),
+    },
+    KeyName {
+        names: &["backslash"],
+        code: KeyCode::Char('\\'),
+    },
+    KeyName {
+        names: &["comma"],
+        code: KeyCode::Char(','),
+    },
+    KeyName {
+        names: &["semicolon"],
+        code: KeyCode::Char(';'),
+    },
+    KeyName {
+        names: &["colon"],
+        code: KeyCode::Char(':'),
+    },
+    KeyName {
+        names: &["apostrophe", "quote"],
+        code: KeyCode::Char('\''),
+    },
+    KeyName {
+        names: &["quotedbl", "doublequote"],
+        code: KeyCode::Char('"'),
+    },
+    KeyName {
+        names: &["grave", "backtick"],
+        code: KeyCode::Char('`'),
+    },
+    KeyName {
+        names: &["tilde"],
+        code: KeyCode::Char('~'),
+    },
+    KeyName {
+        names: &["exclam", "exclamation"],
+        code: KeyCode::Char('!'),
+    },
+    KeyName {
+        names: &["at"],
+        code: KeyCode::Char('@'),
+    },
+    KeyName {
+        names: &["numbersign", "hash"],
+        code: KeyCode::Char('#'),
+    },
+    KeyName {
+        names: &["dollar"],
+        code: KeyCode::Char('$'),
+    },
+    KeyName {
+        names: &["percent"],
+        code: KeyCode::Char('%'),
+    },
+    KeyName {
+        names: &["asciicircum", "caret"],
+        code: KeyCode::Char('^'),
+    },
+    KeyName {
+        names: &["ampersand"],
+        code: KeyCode::Char('&'),
+    },
+    KeyName {
+        names: &["underscore"],
+        code: KeyCode::Char('_'),
+    },
+    KeyName {
+        names: &["bar", "pipe"],
+        code: KeyCode::Char('|'),
+    },
+    KeyName {
+        names: &["question"],
+        code: KeyCode::Char('?'),
+    },
+    KeyName {
+        names: &["less", "lessthan"],
+        code: KeyCode::Char('<'),
+    },
+    KeyName {
+        names: &["greater", "greaterthan"],
+        code: KeyCode::Char('>'),
+    },
+    KeyName {
+        names: &["parenleft"],
+        code: KeyCode::Char('('),
+    },
+    KeyName {
+        names: &["parenright"],
+        code: KeyCode::Char(')'),
+    },
+    KeyName {
+        names: &["bracketleft"],
+        code: KeyCode::Char('['),
+    },
+    KeyName {
+        names: &["bracketright"],
+        code: KeyCode::Char(']'),
+    },
+    KeyName {
+        names: &["braceleft"],
+        code: KeyCode::Char('{'),
+    },
+    KeyName {
+        names: &["braceright"],
+        code: KeyCode::Char('}'),
+    },
+];
+
+/// Resolve an already-lowercased key name against every table.
+///
+/// The last two come from the parser's own tables rather than a second
+/// hand-written list, so a name that binds and a key that arrives agree by
+/// construction: the keypad, whose names are aliases for the key the terminal
+/// actually reports (`kp_multiply` *is* `*` by the time the editor sees it),
+/// and the media and modifier keys, which are not aliases — nothing on the
+/// main keyboard means "mute".
+pub fn key_name_to_code(lower: &str) -> Option<KeyCode> {
+    NAMED_KEYS
+        .iter()
+        .chain(PUNCTUATION_KEYS)
+        .find(|k| k.names.contains(&lower))
+        .map(|k| k.code)
+        .or_else(|| fresh_input_parser::keypad::code_for_keysym(lower))
+        .or_else(|| fresh_input_parser::media_modifier::code_for_keysym(lower))
+}
+
 fn warn_invalid_key(key: &str, action: &str) {
     tracing::warn!(
         "Invalid keybinding in config: unknown key \"{key}\" for action \"{action}\" (binding ignored)"
@@ -2772,74 +3045,19 @@ impl KeybindingResolver {
         None
     }
 
-    /// Parse a key string to KeyCode
+    /// Parse a key string to KeyCode.
+    ///
+    /// Three sources, in order: the tables of names below, the numeric keypad
+    /// (via [`fresh_input_parser::keypad`], which is also what decodes those
+    /// keys off the wire — one definition, so a name that binds and a key that
+    /// arrives cannot drift apart), and finally the two open-ended forms, a
+    /// single character and `f<n>`.
     fn parse_key(key: &str) -> Option<KeyCode> {
         let lower = key.to_lowercase();
+        if let Some(code) = key_name_to_code(&lower) {
+            return Some(code);
+        }
         match lower.as_str() {
-            "enter" => Some(KeyCode::Enter),
-            "backspace" => Some(KeyCode::Backspace),
-            "delete" | "del" => Some(KeyCode::Delete),
-            "tab" => Some(KeyCode::Tab),
-            "backtab" => Some(KeyCode::BackTab),
-            "esc" | "escape" => Some(KeyCode::Esc),
-            "space" => Some(KeyCode::Char(' ')),
-
-            "left" => Some(KeyCode::Left),
-            "right" => Some(KeyCode::Right),
-            "up" => Some(KeyCode::Up),
-            "down" => Some(KeyCode::Down),
-            "home" => Some(KeyCode::Home),
-            "end" => Some(KeyCode::End),
-            "pageup" => Some(KeyCode::PageUp),
-            "pagedown" => Some(KeyCode::PageDown),
-
-            // Symbolic names for punctuation. A single-character key
-            // name is still the canonical spelling (and what the
-            // keybinding editor writes back), but people reach for the
-            // X11 keysym name they know — `"key": "asterisk"` is what
-            // issue #1128 was actually configured with, and it bound
-            // nothing at all. JSON also makes some of these awkward to
-            // write literally (`"\\"` for backslash, `"\""` for the
-            // double quote), so a name is the friendlier spelling.
-            //
-            // The keypad aliases map onto the same characters their key
-            // transmits: a terminal reports the numeric keypad through
-            // its ASCII byte, so `kp_multiply` *is* `*` by the time the
-            // editor sees it. Naming them separately documents intent
-            // without promising a distinction the terminal doesn't make.
-            "asterisk" | "kp_multiply" | "star" => Some(KeyCode::Char('*')),
-            "plus" | "kp_add" => Some(KeyCode::Char('+')),
-            "minus" | "hyphen" | "kp_subtract" => Some(KeyCode::Char('-')),
-            "slash" | "kp_divide" => Some(KeyCode::Char('/')),
-            "period" | "dot" | "kp_decimal" => Some(KeyCode::Char('.')),
-            "equal" | "equals" => Some(KeyCode::Char('=')),
-            "backslash" => Some(KeyCode::Char('\\')),
-            "comma" => Some(KeyCode::Char(',')),
-            "semicolon" => Some(KeyCode::Char(';')),
-            "colon" => Some(KeyCode::Char(':')),
-            "apostrophe" | "quote" => Some(KeyCode::Char('\'')),
-            "quotedbl" | "doublequote" => Some(KeyCode::Char('"')),
-            "grave" | "backtick" => Some(KeyCode::Char('`')),
-            "tilde" => Some(KeyCode::Char('~')),
-            "exclam" | "exclamation" => Some(KeyCode::Char('!')),
-            "at" => Some(KeyCode::Char('@')),
-            "numbersign" | "hash" => Some(KeyCode::Char('#')),
-            "dollar" => Some(KeyCode::Char('$')),
-            "percent" => Some(KeyCode::Char('%')),
-            "asciicircum" | "caret" => Some(KeyCode::Char('^')),
-            "ampersand" => Some(KeyCode::Char('&')),
-            "underscore" => Some(KeyCode::Char('_')),
-            "bar" | "pipe" => Some(KeyCode::Char('|')),
-            "question" => Some(KeyCode::Char('?')),
-            "less" | "lessthan" => Some(KeyCode::Char('<')),
-            "greater" | "greaterthan" => Some(KeyCode::Char('>')),
-            "parenleft" => Some(KeyCode::Char('(')),
-            "parenright" => Some(KeyCode::Char(')')),
-            "bracketleft" => Some(KeyCode::Char('[')),
-            "bracketright" => Some(KeyCode::Char(']')),
-            "braceleft" => Some(KeyCode::Char('{')),
-            "braceright" => Some(KeyCode::Char('}')),
-
             // Character count, not byte count: `"é"` is two bytes, and
             // spelling it out as a key name used to fall past this arm
             // into the function-key arm and out as `None` — a binding on
@@ -3574,6 +3792,49 @@ mod tests {
         assert_eq!(
             resolver.resolve(&event, KeyContext::Normal),
             Action::DuplicateLine
+        );
+    }
+
+    /// A keypad name binds the key the terminal actually sends.
+    ///
+    /// `kp_enter` is the headline gap issue #1128 left open: the name parsed
+    /// as nothing, so the entry was dropped at load and the binding silently
+    /// did nothing. It resolves on `Enter`, because that is what a terminal
+    /// reports the keypad's Enter as — the aliasing the docs spell out.
+    #[test]
+    fn keypad_name_binds_from_config() {
+        let mut config = Config::default();
+        config.keybindings.push(crate::config::Keybinding {
+            key: "kp_enter".to_string(),
+            modifiers: vec!["ctrl".to_string()],
+            keys: Vec::new(),
+            action: "duplicate_line".to_string(),
+            args: HashMap::new(),
+            when: None,
+        });
+        config.keybindings.push(crate::config::Keybinding {
+            key: "kp_begin".to_string(),
+            modifiers: Vec::new(),
+            keys: Vec::new(),
+            action: "select_all".to_string(),
+            args: HashMap::new(),
+            when: None,
+        });
+        let resolver = KeybindingResolver::new(&config);
+        assert_eq!(
+            resolver.resolve(
+                &KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+                KeyContext::Normal
+            ),
+            Action::DuplicateLine
+        );
+        // The one keypad key that is not an alias resolves on its own code.
+        assert_eq!(
+            resolver.resolve(
+                &KeyEvent::new(KeyCode::KeypadBegin, KeyModifiers::empty()),
+                KeyContext::Normal
+            ),
+            Action::SelectAll
         );
     }
 
@@ -5709,5 +5970,132 @@ mod tests {
             Action::MoveLeft,
             "inheriting-modes membership must survive reload_from_config"
         );
+    }
+
+    /// Every keypad key the input parser decodes is nameable in config.
+    ///
+    /// This is the half of issue #1128 that the first pass left open: the
+    /// table stopped at the five arithmetic keysyms, so `kp_enter`,
+    /// `kp_0`…`kp_9`, `kp_equal`, `kp_separator` and the navigation names
+    /// parsed as nothing and their bindings were dropped. Both sides now read
+    /// one table, so this cannot regress by omission.
+    #[test]
+    fn every_keypad_key_has_a_config_name() {
+        for k in fresh_input_parser::keypad::KEYPAD_KEYS {
+            assert_eq!(
+                KeybindingResolver::parse_key(k.keysym),
+                Some(k.code),
+                "keypad name {:?} does not parse",
+                k.keysym
+            );
+            // Case-insensitive, like every other name.
+            assert_eq!(
+                KeybindingResolver::parse_key(&k.keysym.to_uppercase()),
+                Some(k.code),
+                "keypad name {:?} is case-sensitive",
+                k.keysym
+            );
+        }
+    }
+
+    /// `kp_begin` is the one keypad name that does not alias a main-keyboard
+    /// key — the distinction the generated docs promise.
+    #[test]
+    fn keypad_begin_is_the_only_distinct_keypad_binding() {
+        assert_eq!(
+            KeybindingResolver::parse_key("kp_begin"),
+            Some(KeyCode::KeypadBegin)
+        );
+        assert_eq!(
+            KeybindingResolver::parse_key("kp_enter"),
+            Some(KeyCode::Enter)
+        );
+        assert_eq!(
+            KeybindingResolver::parse_key("kp_multiply"),
+            Some(KeyCode::Char('*'))
+        );
+        assert_eq!(
+            KeybindingResolver::parse_key("kp_left"),
+            Some(KeyCode::Left)
+        );
+    }
+
+    /// Anything the keybinding editor can write, the loader can read back.
+    ///
+    /// The editor records a chord and serialises it with
+    /// `key_code_to_config_name`; if `parse_key` then rejects that spelling,
+    /// the editor has written a binding that silently does nothing. `Insert`
+    /// was exactly that — emitted as `"Insert"`, and no `insert` arm existed —
+    /// and `KeypadBegin` fell through to a `{:?}` spelling nothing claimed.
+    ///
+    /// **The codes come from the decoder, not from the name tables.** Asking
+    /// the tables which codes to check only ever asks whether the names name
+    /// themselves: `Media(MuteVolume)` and `Modifier(LeftHyper)` are keys the
+    /// input parser decodes and the keybinding editor can record, and they
+    /// stayed unnamed — the same bug, one family over — while a test called
+    /// `config_names_round_trip` passed. Sweeping the Private Use Area is
+    /// what makes "the editor can write it" and "the loader can read it" two
+    /// different questions.
+    #[test]
+    fn config_names_round_trip() {
+        use crate::app::keybinding_editor::helpers::key_code_to_config_name;
+
+        let mut codes: Vec<KeyCode> = NAMED_KEYS.iter().map(|k| k.code).collect();
+        codes.extend(PUNCTUATION_KEYS.iter().map(|k| k.code));
+        // Every key the kitty keyboard protocol can deliver.
+        codes.extend((0xe000..=0xf8ff).filter_map(fresh_input_parser::kitty_functional_key));
+        codes.extend((1..=24).map(KeyCode::F));
+        codes.extend("azAZ09".chars().map(KeyCode::Char));
+
+        for code in codes {
+            let name = key_code_to_config_name(code);
+            let parsed = KeybindingResolver::parse_key(&name);
+            // `Char` is written lowercase, so an uppercase input round-trips
+            // to its lowercase self — that is the documented behaviour, not a
+            // loss (modifiers carry the shift).
+            let expected = match code {
+                KeyCode::Char(c) => KeyCode::Char(c.to_lowercase().next().unwrap_or(c)),
+                other => other,
+            };
+            assert_eq!(
+                parsed,
+                Some(expected),
+                "{code:?} serialises to {name:?}, which does not parse back"
+            );
+        }
+    }
+
+    /// No spelling is claimed twice. A duplicate would make one of the two
+    /// entries unreachable, silently, depending on table order.
+    #[test]
+    fn key_names_are_unique() {
+        let mut all: Vec<&str> = NAMED_KEYS
+            .iter()
+            .chain(PUNCTUATION_KEYS)
+            .flat_map(|k| k.names.iter().copied())
+            .chain(
+                fresh_input_parser::keypad::KEYPAD_KEYS
+                    .iter()
+                    .map(|k| k.keysym),
+            )
+            .chain(fresh_input_parser::media_modifier::all().map(|k| k.keysym))
+            .collect();
+        all.sort_unstable();
+        let total = all.len();
+        all.dedup();
+        assert_eq!(all.len(), total, "a key name is claimed by two entries");
+    }
+
+    /// Every documented name is lowercase, since `parse_key` lowercases its
+    /// input before looking it up — an upper-case entry would be dead.
+    #[test]
+    fn key_names_are_lowercase() {
+        for name in NAMED_KEYS
+            .iter()
+            .chain(PUNCTUATION_KEYS)
+            .flat_map(|k| k.names.iter().copied())
+        {
+            assert_eq!(name, &name.to_lowercase(), "{name:?} is not lowercase");
+        }
     }
 }

--- a/crates/fresh-editor/src/input/router.rs
+++ b/crates/fresh-editor/src/input/router.rs
@@ -531,7 +531,16 @@ pub fn mode_key_disposition(
         // a fix to the one thing that was broken.
         let plain = !event
             .modifiers
-            .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT);
+            .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT | KeyModifiers::CONTROL);
+        // **Control is not plain.** It used to be — `plain` excluded only
+        // Shift and Alt — and with a non-text widget focused (a results tree,
+        // say) `Ctrl+Left` fell through here, resolved to `move_word_left`,
+        // and moved the *panel document's* own cursor: a cursor nothing
+        // draws, whose line and column the status bar then reported changing
+        // under a keystroke that visibly did nothing at all. A focused field
+        // gets its word-wise motion from `widget_panel_key`, which names the
+        // chord `C-Left` for the kind to answer.
+        let ctrl = event.modifiers.contains(KeyModifiers::CONTROL);
         let nav = matches!(
             event.code,
             KeyCode::Left
@@ -540,10 +549,12 @@ pub fn mode_key_disposition(
                 | KeyCode::Down
                 | KeyCode::Home
                 | KeyCode::End
-                | KeyCode::PageUp
-                | KeyCode::PageDown
         );
-        if plain && nav {
+        // **`Ctrl`+the page keys are not navigation-in-a-document.** They are
+        // `prev_buffer` / `next_buffer` — switching tabs, which a reader
+        // expects to work from anywhere, panel included.
+        let page = matches!(event.code, KeyCode::PageUp | KeyCode::PageDown);
+        if (plain && (nav || page)) || (ctrl && page) {
             let action = kb.resolve(event, KeyContext::Normal);
             if action != Action::None {
                 return ModeKeyDisposition::Forward(action);
@@ -824,6 +835,83 @@ mod tests {
                 &event(KeyCode::Char('o'), KeyModifiers::CONTROL)
             ),
             ModeKeyDisposition::Block
+        );
+    }
+
+    #[test]
+    /// Ctrl+nav must not reach the buffer from a text-input mode.
+    ///
+    /// It used to count as "plain" — `plain` excluded only Shift and Alt — so
+    /// `Ctrl+Left` in a mode like search-replace fell through to
+    /// `kb.resolve(…, Normal)`, resolved to `move_word_left`, and moved the
+    /// *panel document's* own cursor: a cursor nothing draws, whose line and
+    /// column the status bar then reported changing under a keystroke that
+    /// visibly did nothing at all. A focused field gets its word-wise motion
+    /// from `widget_panel_key` instead, which names the chord for the kind.
+    fn text_input_mode_keeps_ctrl_nav_off_the_buffer() {
+        let kb = resolver();
+        let view = ModeKeyView {
+            effective_mode: Some("search-replace-list".to_string()),
+            allows_text_input: true,
+            global_mode_read_only: None,
+        };
+        for code in [
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Home,
+            KeyCode::End,
+        ] {
+            assert_eq!(
+                mode_key_disposition(&view, &[], &kb, &event(code, KeyModifiers::CONTROL)),
+                ModeKeyDisposition::Block,
+                "Ctrl+{code:?} must not reach the buffer from a text-input mode"
+            );
+        }
+        // Plain navigation still forwards, which is what this arm exists for.
+        assert!(matches!(
+            mode_key_disposition(&view, &[], &kb, &event(KeyCode::Down, KeyModifiers::NONE)),
+            ModeKeyDisposition::Forward(_)
+        ));
+        // And the page keys keep their Control: `Ctrl+PageUp` is
+        // `prev_buffer` — switching tabs, not moving a cursor — and a reader
+        // expects that from a panel too.
+        let page_up = mode_key_disposition(
+            &view,
+            &[],
+            &kb,
+            &event(KeyCode::PageUp, KeyModifiers::CONTROL),
+        );
+        assert!(
+            matches!(
+                page_up,
+                ModeKeyDisposition::Run(Action::PrevBuffer)
+                    | ModeKeyDisposition::Forward(Action::PrevBuffer)
+            ),
+            "Ctrl+PageUp switches buffers and must keep doing so, but resolved to {page_up:?}"
+        );
+    }
+
+    /// The word-wise half of the same chord: a focused field is reached
+    /// through the panel's own key vocabulary, where `C-Left` names it.
+    #[test]
+    fn a_focused_field_still_gets_its_word_wise_motion() {
+        let kb = resolver();
+        let view = WidgetPanelView {
+            non_modal: true,
+            pane: true,
+            focus_key: Some("search".to_string()),
+            focused_widget_is_text: true,
+            page: false,
+        };
+        assert_eq!(
+            widget_panel_key(&view, &kb, KeyCode::Left, KeyModifiers::CONTROL),
+            WidgetKeyOutcome::SmartKey("C-Left".to_string())
+        );
+        assert_eq!(
+            widget_panel_key(&view, &kb, KeyCode::Right, KeyModifiers::CONTROL),
+            WidgetKeyOutcome::SmartKey("C-Right".to_string())
         );
     }
 

--- a/crates/fresh-editor/src/view/shell/dock.rs
+++ b/crates/fresh-editor/src/view/shell/dock.rs
@@ -111,6 +111,7 @@ fn column(interior: Option<super::panel::Interior>) -> Node<UiMsg> {
                 &super::widgets::Ctx {
                     slot: super::widgets::Slot::Dock,
                     states: &i.states,
+                    h_pan: &i.h_pan,
                     focus_key: i.focus_key.clone(),
                     keyboard: i.keyboard,
 
@@ -373,6 +374,7 @@ mod tests {
                         key: None,
                     }),
                     states: Rc::new(Default::default()),
+                    h_pan: Default::default(),
                     focus_key: String::new(),
                     keyboard: true,
 
@@ -574,6 +576,7 @@ mod tests {
                 dock_interior: Some(super::super::panel::Interior {
                     spec: Rc::new(spec),
                     states: Rc::new(Default::default()),
+                    h_pan: Default::default(),
                     focus_key: String::new(),
                     keyboard: true,
 

--- a/crates/fresh-editor/src/view/shell/entry.rs
+++ b/crates/fresh-editor/src/view/shell/entry.rs
@@ -376,6 +376,7 @@ fn control(it: &Item, band: &str) -> Node<UiMsg> {
         let cx = super::widgets::Ctx {
             slot: super::widgets::Slot::SettingsEntry,
             states: &states,
+            h_pan: super::widgets::no_pan(),
             focus_key: focus_key.clone(),
             keyboard: true,
             hovered_key: None,

--- a/crates/fresh-editor/src/view/shell/frame.rs
+++ b/crates/fresh-editor/src/view/shell/frame.rs
@@ -1430,6 +1430,7 @@ mod tests {
         p.interior = Some(Interior {
             spec: std::rc::Rc::new(spec),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: "create".into(),
             keyboard: true,
 

--- a/crates/fresh-editor/src/view/shell/input.rs
+++ b/crates/fresh-editor/src/view/shell/input.rs
@@ -183,6 +183,26 @@ pub fn mouse(
         MouseEventKind::Down(b) => Input::press_n(pos, button(b), mods, clicks),
         MouseEventKind::Up(b) => Input::release(pos, button(b), mods),
         MouseEventKind::Moved | MouseEventKind::Drag(_) => Input::Move { pos, mods },
+        // **Shift turns the wheel sideways.** Terminals overwhelmingly report
+        // Shift+wheel as a vertical notch with the modifier set, not as the
+        // `ScrollLeft`/`ScrollRight` buttons below — so a reader doing the
+        // gesture every other application answers got a vertical scroll
+        // instead (issue #1580). The axis is decided once, here, where the
+        // terminal's report becomes an `Input`, so every surface downstream
+        // sees one kind of sideways notch whatever produced it. `arm_wheel_walk`
+        // already assumed this reading.
+        MouseEventKind::ScrollDown if mods.shift => Input::Wheel {
+            pos,
+            delta: columns,
+            axis: Axis::Horizontal,
+            mods,
+        },
+        MouseEventKind::ScrollUp if mods.shift => Input::Wheel {
+            pos,
+            delta: -columns,
+            axis: Axis::Horizontal,
+            mods,
+        },
         MouseEventKind::ScrollDown => Input::Wheel {
             pos,
             delta: lines,

--- a/crates/fresh-editor/src/view/shell/msg.rs
+++ b/crates/fresh-editor/src/view/shell/msg.rs
@@ -825,6 +825,7 @@ pub enum UiFact {
         widget: String,
         delta: i32,
     },
+    /// **Focus moved onto a plugin widget, and the runtime is being told.**
     /// **The tree's ring landed on a plugin widget, and the runtime is being
     /// told.**
     ///

--- a/crates/fresh-editor/src/view/shell/msg.rs
+++ b/crates/fresh-editor/src/view/shell/msg.rs
@@ -825,6 +825,22 @@ pub enum UiFact {
         widget: String,
         delta: i32,
     },
+    /// **A sideways notch on a rows widget** — Shift+wheel, or a trackpad's
+    /// horizontal scroll, over a `List` or `Tree`.
+    ///
+    /// Separate from [`UiFact::WidgetWheel`] because it moves a different
+    /// window: vertical scroll is the library's, resolved by the viewport the
+    /// description gave the element, while sideways is the runtime's — the
+    /// rows arrive fitted to the panel's width, so there is no wide content
+    /// for a `scroll.x` to move and the pan has to reach the runtime that
+    /// fits them. `delta` is in display columns, positive to reveal text on
+    /// the right. Every slot is handled here, the pane's included: a pane is
+    /// one buffer and a buffer names its panel.
+    WidgetPan {
+        slot: super::widgets::Slot,
+        widget: String,
+        delta: i32,
+    },
     /// **Focus moved onto a plugin widget, and the runtime is being told.**
     /// **The tree's ring landed on a plugin widget, and the runtime is being
     /// told.**

--- a/crates/fresh-editor/src/view/shell/overlay_prompt.rs
+++ b/crates/fresh-editor/src/view/shell/overlay_prompt.rs
@@ -442,6 +442,7 @@ fn toolbar_band(c: &Card) -> Node<UiMsg> {
             &super::widgets::Ctx {
                 slot: super::widgets::Slot::PromptToolbar,
                 states: &i.states,
+                h_pan: &i.h_pan,
                 focus_key: i.focus_key.clone(),
                 keyboard: i.keyboard,
                 hovered_key: i.hovered_key.clone(),
@@ -600,6 +601,7 @@ mod tests {
                 key: None,
             }),
             states: Rc::new(Default::default()),
+            h_pan: Rc::new(Default::default()),
             focus_key: String::new(),
             keyboard: true,
             page: None,

--- a/crates/fresh-editor/src/view/shell/panel.rs
+++ b/crates/fresh-editor/src/view/shell/panel.rs
@@ -139,6 +139,9 @@ impl Keymap {
 pub struct Interior {
     pub spec: std::rc::Rc<fresh_core::api::WidgetSpec>,
     pub states: std::rc::Rc<std::collections::HashMap<String, crate::widgets::WidgetInstanceState>>,
+    /// How far each keyed rows widget is panned sideways, in display columns.
+    /// See [`super::widgets::Ctx::h_pan`].
+    pub h_pan: std::rc::Rc<std::collections::HashMap<String, i32>>,
     pub focus_key: String,
     /// See [`super::widgets::Ctx::keyboard`].
     pub keyboard: bool,
@@ -744,6 +747,7 @@ fn body(p: &Panel) -> Node<UiMsg> {
             &super::widgets::Ctx {
                 slot: super::widgets::Slot::Floating,
                 states: &i.states,
+                h_pan: &i.h_pan,
                 focus_key: i.focus_key.clone(),
                 keyboard: i.keyboard,
 
@@ -989,6 +993,7 @@ mod tests {
                 key: None,
             }),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: "ok".into(),
             keyboard: true,
 
@@ -1227,6 +1232,7 @@ mod tests {
         p.interior = Some(Interior {
             spec: std::rc::Rc::new(spec),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: String::new(),
             keyboard: true,
 
@@ -1281,6 +1287,7 @@ mod tests {
         p.interior = Some(Interior {
             spec: std::rc::Rc::new(spec),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: String::new(),
             keyboard: true,
 
@@ -1348,6 +1355,7 @@ mod tests {
         p.interior = Some(Interior {
             spec: std::rc::Rc::new(spec),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: String::new(),
             keyboard: true,
 
@@ -1404,6 +1412,7 @@ mod tests {
                 key: None,
             }),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: String::new(),
             keyboard: true,
 

--- a/crates/fresh-editor/src/view/shell/settings.rs
+++ b/crates/fresh-editor/src/view/shell/settings.rs
@@ -935,6 +935,7 @@ fn control(c: &Card, band: &str) -> Node<UiMsg> {
         let cx = |surface: &Ink| super::widgets::Ctx {
             slot: super::widgets::Slot::Settings,
             states: &states,
+            h_pan: super::widgets::no_pan(),
             focus_key: focus_key.clone(),
             keyboard: true,
             hovered_key: None,

--- a/crates/fresh-editor/src/view/shell/sidebar.rs
+++ b/crates/fresh-editor/src/view/shell/sidebar.rs
@@ -327,6 +327,7 @@ fn panel_body(i: usize, p: &super::panel::Interior) -> Node<UiMsg> {
             &super::widgets::Ctx {
                 slot: super::widgets::Slot::Sidebar(i),
                 states: &interior.states,
+                h_pan: &interior.h_pan,
                 focus_key: interior.focus_key.clone(),
                 keyboard: interior.keyboard,
                 hovered_key: interior.hovered_key.clone(),
@@ -913,6 +914,7 @@ mod tests {
         let interior = Interior {
             spec: Rc::new(spec),
             states: Rc::new(Default::default()),
+            h_pan: Default::default(),
             focus_key: String::new(),
             // The host's focus fact for the section: an unfocused one
             // holds no keyboard and marks nothing.

--- a/crates/fresh-editor/src/view/shell/splits.rs
+++ b/crates/fresh-editor/src/view/shell/splits.rs
@@ -1511,6 +1511,7 @@ fn panel_content(id: LeafId, i: super::panel::Interior, active: bool) -> Node<Ui
             &super::widgets::Ctx {
                 slot: super::widgets::Slot::Pane(id),
                 states: &i.states,
+                h_pan: &i.h_pan,
                 focus_key: i.focus_key.clone(),
                 keyboard: active,
                 hovered_key: i.hovered_key.clone(),

--- a/crates/fresh-editor/src/view/shell/widgets.rs
+++ b/crates/fresh-editor/src/view/shell/widgets.rs
@@ -235,6 +235,13 @@ pub struct Ctx<'a> {
     /// `None` where there is genuinely no theme to render through: the unit
     /// tests, and `Ctx::plain`.
     pub markdown: Option<crate::widgets::MarkdownCtx<'a>>,
+    /// How far each keyed rows widget is panned sideways, in display columns.
+    ///
+    /// The runtime's fold, read here for the same reason `states` is: the rows
+    /// are fitted to the panel's width before the description sees them, so
+    /// the pan has to be applied where they are fitted. Empty for a surface
+    /// with no plugin panel behind it (`Ctx::plain`).
+    pub h_pan: &'a std::collections::HashMap<String, i32>,
 }
 
 /// The empty instance-state map, for a spec with no host state behind it.
@@ -247,6 +254,13 @@ pub fn no_state() -> &'static std::collections::HashMap<String, crate::widgets::
     use std::sync::OnceLock;
     static EMPTY: OnceLock<std::collections::HashMap<String, crate::widgets::WidgetInstanceState>> =
         OnceLock::new();
+    EMPTY.get_or_init(Default::default)
+}
+
+/// The empty pan map, for a surface with no plugin panel behind it.
+pub fn no_pan() -> &'static std::collections::HashMap<String, i32> {
+    use std::sync::OnceLock;
+    static EMPTY: OnceLock<std::collections::HashMap<String, i32>> = OnceLock::new();
     EMPTY.get_or_init(Default::default)
 }
 
@@ -268,6 +282,7 @@ impl Ctx<'static> {
             scrollbar_reveal: None,
             surface: panel_surface(),
             markdown: None,
+            h_pan: no_pan(),
         }
     }
 }
@@ -773,6 +788,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
             let inner = Ctx {
                 surface: band.clone().unwrap_or_else(|| cx.surface.clone()),
                 states: cx.states,
+                h_pan: cx.h_pan,
                 focus_key: cx.focus_key.clone(),
                 hovered_key: cx.hovered_key.clone(),
                 hovered_item_key: cx.hovered_item_key.clone(),
@@ -1575,6 +1591,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
                 expanded_keys.iter().cloned().collect();
             let visible = crate::widgets::collect_visible_tree_indices(nodes, item_keys, &expanded);
             let tree_key = key.clone().unwrap_or_default();
+            let h_pan = cx.h_pan.get(&tree_key).copied().unwrap_or(0);
             let mut blocks: Vec<Chunk> = Vec::with_capacity(visible.len());
             let mut at: u32 = 0;
             let mut selected: Option<usize> = None;
@@ -1594,6 +1611,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
                     true,
                     width as u32,
                     *indent_cols,
+                    h_pan,
                 );
                 let is_selected = abs as i32 == sel_abs;
                 if is_selected {
@@ -1746,6 +1764,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
             let nodes = Rc::new(nodes.clone());
             let keys = Rc::new(item_keys.clone());
             let tree_key = key.clone().unwrap_or_default();
+            let h_pan = cx.h_pan.get(&tree_key).copied().unwrap_or(0);
             let (slot, checkable, indent) = (cx.slot, *checkable, *indent_cols);
             let surface = cx.surface.clone();
             let sel_abs = live_selection(cx, key, *selected_index);
@@ -1770,6 +1789,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
                         false,
                         width as u32,
                         indent,
+                        h_pan,
                     );
                     let end = r.entry.text.len();
                     let hit = |kind: &'static str,
@@ -2145,6 +2165,8 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
                     markdown: cx.markdown,
                     marker_gutter: cx.marker_gutter,
                     avail_height: cx.avail_height,
+                    // A markdown Text has no rows to pan.
+                    h_pan: None,
                     // A shadow render of ONE markdown Text, for its
                     // reflowed rows and its caret: no list, no window,
                     // nothing to carry.
@@ -3019,6 +3041,7 @@ fn float_route(n: Node<UiMsg>, slot: Slot) -> Node<UiMsg> {
 /// completion list, whose window lives in `WidgetInstanceState::Text` — so the
 /// half the tree can do is say *which* widget was under the pointer, which is
 /// exactly what the arena was consulted for. See [`UiFact::WidgetWheel`].
+
 fn wheel_to_widget(n: Node<UiMsg>, slot: Slot, widget_key: &str) -> Node<UiMsg> {
     // An unkeyed widget has no instance state, so it has no window to move and
     // nothing to name — and claiming the notch anyway would swallow it on the
@@ -3745,6 +3768,7 @@ mod tests {
         Ctx {
             slot: Slot::Floating,
             states: no_state(),
+            h_pan: no_pan(),
             focus_key: String::new(),
             keyboard: true,
 
@@ -5126,6 +5150,7 @@ mod tests {
             has_children,
             checked: None,
             extra_lines: Vec::new(),
+            window_anchor: None,
         }
     }
 
@@ -5234,6 +5259,7 @@ mod tests {
             false,
             WIDTH as u32,
             2,
+            0,
         );
         let (gs, _) = r.disclosure_range.expect("a branch has a glyph");
         let col = r.entry.text[..gs].chars().count() as i32;
@@ -6153,6 +6179,7 @@ mod tests {
                     has_children: false,
                     checked: None,
                     extra_lines: vec![raw(&format!("branch-{i}")), raw("2 files")],
+                    window_anchor: None,
                 })
                 .collect(),
             item_keys: (0..n).map(|i| format!("s{i}")).collect(),
@@ -7016,6 +7043,7 @@ mod tests {
         let interior = super::super::panel::Interior {
             spec: spec.clone(),
             states: Default::default(),
+            h_pan: Default::default(),
             focus_key: String::new(),
             keyboard: true,
 

--- a/crates/fresh-editor/src/view/shell/widgets.rs
+++ b/crates/fresh-editor/src/view/shell/widgets.rs
@@ -1738,6 +1738,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
             // things that belong at the panel's edge, the row band and the
             // overlay scrollbar, stop with it.
             let node = node.w(Sizing::Pct(100));
+            let node = pan_to_widget(node, cx.slot, &tree_key);
             match visible_rows {
                 Some(r) => node.h(Sizing::Cells(tree_rows(at, *r))),
                 None => node.flex(1),
@@ -1903,6 +1904,7 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
             // not the element's own — see the `List` arm above.
             let list = list.selection(visible.iter().position(|&a| a as i32 == sel_abs));
             let node = keyed(fresh_ui::ComponentExt::node(list), state_key(key));
+            let node = pan_to_widget(node, slot, &tree_key);
             match visible_rows {
                 Some(r) => node.h(Sizing::Cells(tree_rows(n as u32, *r))),
                 None => node.flex(1),
@@ -3041,6 +3043,36 @@ fn float_route(n: Node<UiMsg>, slot: Slot) -> Node<UiMsg> {
 /// completion list, whose window lives in `WidgetInstanceState::Text` — so the
 /// half the tree can do is say *which* widget was under the pointer, which is
 /// exactly what the arena was consulted for. See [`UiFact::WidgetWheel`].
+/// Claim the **sideways** notch on a rows widget and send it to the runtime.
+///
+/// The vertical notch is the library's — the description gives the element a
+/// viewport and it scrolls. Sideways has no such window to move: the rows
+/// arrive fitted to the panel's width, so the only thing that can honour a pan
+/// is the runtime that fits them. This names the widget and lets the vertical
+/// notch through untouched, so the two axes keep their separate owners.
+///
+/// Issue #1580.
+fn pan_to_widget(n: Node<UiMsg>, slot: Slot, widget_key: &str) -> Node<UiMsg> {
+    if widget_key.is_empty() {
+        return n;
+    }
+    let key = widget_key.to_string();
+    fresh_ui::gesture(n).on(
+        fresh_ui::GestureKind::Wheel,
+        std::rc::Rc::new(move |e: &fresh_ui::Event| {
+            // Vertical is not ours: let it reach the viewport beneath.
+            if e.axis != fresh_ui::Axis::Horizontal {
+                return None;
+            }
+            e.stop();
+            Some(UiMsg::Ui(super::msg::UiFact::WidgetPan {
+                slot,
+                widget: key.clone(),
+                delta: e.delta,
+            }))
+        }),
+    )
+}
 
 fn wheel_to_widget(n: Node<UiMsg>, slot: Slot, widget_key: &str) -> Node<UiMsg> {
     // An unkeyed widget has no instance state, so it has no window to move and

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -3365,3 +3365,391 @@ fn test_search_replace_unlocatable_pattern_renders_line_head() {
          left-hand elision. Row:\n{row}"
     );
 }
+
+/// Drive the panel to a state where the results tree has focus and the
+/// selection sits on a match row (not the file row above it).
+///
+/// The panel puts focus on the matches tree once a search settles; `Down`
+/// then moves off the file node onto its first child. Every panning test
+/// starts here, because a pan is addressed to the focused widget.
+fn focus_first_match_row(harness: &mut EditorTestHarness, pattern: &str) {
+    open_search_replace_via_palette(harness);
+    harness.type_text(pattern).unwrap();
+    wait_for_search_finished(harness);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("long.txt:1"))
+        .unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+}
+
+/// Press Shift+`code` `n` times, rendering after each — one press is one
+/// pan step, and the steps accumulate.
+fn press_shift(harness: &mut EditorTestHarness, code: KeyCode, n: usize) {
+    for _ in 0..n {
+        harness.send_key(code, KeyModifiers::SHIFT).unwrap();
+        harness.render().unwrap();
+    }
+}
+
+fn row_containing(harness: &EditorTestHarness, needle: &str) -> String {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .find(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("no row containing {needle:?}. Screen:\n{screen}"))
+        .to_string()
+}
+
+/// A long line with a distinct marker at each end and the match far along
+/// it, so "which part of the line is on screen" is answerable from the
+/// rendered row alone.
+///
+/// Filler alone cannot distinguish the head of a line from a slice of the
+/// filler — that is how a test on #3154 passed against the bug it targeted —
+/// so each end carries a marker that appears nowhere else.
+fn write_panning_fixture(project_root: &std::path::Path) {
+    let line = format!(
+        "HEADMARK {}NEEDLE_MARKER{}TAILMARK{}",
+        "x".repeat(250),
+        "y".repeat(100),
+        "z".repeat(30),
+    );
+    fs::write(project_root.join("long.txt"), format!("{line}\n")).unwrap();
+    // A short row, to hold the "a row that fits never moves" half.
+    fs::write(project_root.join("short.txt"), "a NEEDLE_MARKER here\n").unwrap();
+}
+
+fn panning_harness(project_root: &std::path::Path) -> EditorTestHarness {
+    // Tall enough that every fixture's rows are on screen at once: these
+    // tests read the rows, so none of them may be scrolled off.
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        44,
+        Config::default(),
+        project_root.to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&project_root.join("short.txt")).unwrap();
+    harness.render().unwrap();
+    harness
+}
+
+/// Shift+Left walks back through the head of a long line — the part that no
+/// key could reach before, because the row the host received had already been
+/// cut to the panel's width around the match.
+#[test]
+fn test_search_replace_pan_left_reaches_the_line_head() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+
+    // The premise: at rest the row is windowed onto its match, so the head of
+    // the line is NOT on screen. Without this the test could pass vacuously
+    // on a build that never windowed at all.
+    let rested = row_containing(&harness, "long.txt:1");
+    assert!(
+        rested.contains("NEEDLE_MARKER"),
+        "the row should rest on its own match. Row:\n{rested}"
+    );
+    assert!(
+        !rested.contains("HEADMARK"),
+        "the head of the line should be off screen at rest, or this test \
+         cannot tell panning from doing nothing. Row:\n{rested}"
+    );
+
+    press_shift(&mut harness, KeyCode::Left, 30);
+
+    let panned = row_containing(&harness, "long.txt:1");
+    assert!(
+        panned.contains("HEADMARK"),
+        "Shift+Left did not reach the head of the line. Row:\n{panned}\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Shift+Right runs to the tail, past everything the resting window showed.
+#[test]
+fn test_search_replace_pan_right_reaches_the_line_tail() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+    let rested = row_containing(&harness, "long.txt:1");
+    assert!(
+        !rested.contains("TAILMARK"),
+        "the tail should be off screen at rest. Row:\n{rested}"
+    );
+
+    press_shift(&mut harness, KeyCode::Right, 12);
+
+    let panned = row_containing(&harness, "long.txt:1");
+    assert!(
+        panned.contains("TAILMARK"),
+        "Shift+Right did not reach the tail of the line. Row:\n{panned}\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Shift+Home returns every row to the window its own content asks for, and
+/// Shift+End takes them to their tails.
+#[test]
+fn test_search_replace_pan_home_and_end() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+
+    press_shift(&mut harness, KeyCode::Left, 30);
+    assert!(
+        row_containing(&harness, "long.txt:1").contains("HEADMARK"),
+        "precondition: panned to the head"
+    );
+
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+    let homed = row_containing(&harness, "long.txt:1");
+    assert!(
+        homed.contains("NEEDLE_MARKER") && !homed.contains("HEADMARK"),
+        "Shift+Home should rest the row back on its own match, not on \
+         column zero. Row:\n{homed}"
+    );
+
+    harness.send_key(KeyCode::End, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+    let ended = row_containing(&harness, "long.txt:1");
+    assert!(
+        ended.contains("TAILMARK"),
+        "Shift+End should reach the tail. Row:\n{ended}"
+    );
+}
+
+/// Shift+End is walkable back with Shift+Left, in a number of presses the
+/// line's own length explains.
+///
+/// The stored pan is what the *next* keystroke moves from, so "jump to the
+/// end" cannot leave a number no row can reach: it did — `i32::MAX / 4` — and
+/// eight columns a press put the head of the line sixty-seven million presses
+/// away, with `Shift+Home` the only way out.
+#[test]
+fn test_search_replace_pan_end_is_walkable_back() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+    harness.send_key(KeyCode::End, KeyModifiers::SHIFT).unwrap();
+    harness.render().unwrap();
+    assert!(
+        row_containing(&harness, "long.txt:1").contains("TAILMARK"),
+        "precondition: panned to the tail"
+    );
+
+    // **One press, not sixty.** The stored pan is held to what the paint can
+    // honour, so `Shift+End` lands *on* the tail rather than past it and the
+    // very next `Shift+Left` moves the row. Asserting on the first press is
+    // what makes this a test of the bound rather than of arithmetic: an
+    // over-estimate of any size fails here, and the earlier one was 8 presses
+    // wide on this fixture.
+    let ended = row_containing(&harness, "long.txt:1");
+    press_shift(&mut harness, KeyCode::Left, 1);
+    assert_ne!(
+        row_containing(&harness, "long.txt:1"),
+        ended,
+        "the first Shift+Left after Shift+End must move the row; the pan \
+         stored by Shift+End is past anything the row can show. Row:\n{ended}"
+    );
+
+    // And the head is still reachable: the bound is a clamp on the stored
+    // value, not a shorter leash.
+    press_shift(&mut harness, KeyCode::Left, 60);
+    let panned = row_containing(&harness, "long.txt:1");
+    assert!(
+        panned.contains("HEADMARK"),
+        "Shift+Left no longer reaches the head of the line. Row:\n{panned}\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// The row's `path:line` is pinned: it is which match the row *is*, and rows
+/// that panned it away could not be told apart.
+///
+/// A row that fits the panel is untouched by the same keystrokes.
+#[test]
+fn test_search_replace_pan_pins_the_location_and_leaves_short_rows_alone() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+    let short_before = row_containing(&harness, "short.txt:1");
+
+    press_shift(&mut harness, KeyCode::Right, 12);
+
+    let long_row = row_containing(&harness, "long.txt:1");
+    assert!(
+        long_row.contains("TAILMARK"),
+        "precondition: the long row panned. Row:\n{long_row}"
+    );
+    // `long.txt:1` is still there — `row_containing` found the row by it —
+    // and it is still at the head of the row rather than somewhere in the
+    // middle of the panned content.
+    let body = long_row.trim_start().trim_start_matches("[v] ");
+    assert!(
+        body.starts_with("long.txt:1"),
+        "the row's location should stay pinned at the head while the \
+         context slides under it. Row:\n{long_row}"
+    );
+
+    assert_eq!(
+        row_containing(&harness, "short.txt:1"),
+        short_before,
+        "a row that fits the panel must not move when the tree pans"
+    );
+}
+
+/// A wide-character row shows its match and stays inside the panel.
+///
+/// This is the case an ASCII-only fixture cannot catch: the width accounting
+/// counted codepoints on both sides while the screen counts columns, so 100
+/// CJK characters measured as 100 and drew as 200 — the row overflowed the
+/// panel and the terminal cut it, taking the match off the right edge. That
+/// is the #1580 symptom, and it survived the row-windowing fix.
+#[test]
+fn test_search_replace_wide_char_row_is_fitted_to_the_panel() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    // 60 wide characters are 60 codepoints and **120 columns**. That gap is
+    // the whole test: a budget counted in codepoints sees a match ending at
+    // codepoint 73 and concludes the head of the line fits, so it head-
+    // truncates — putting the match at column 142 of a 120-column panel,
+    // where nothing can be read and nothing could scroll to it. Counted in
+    // columns the row does not fit, so the window slides onto the match.
+    let wide = format!("{}NEEDLE_MARKER{}", "漢".repeat(60), "y".repeat(200));
+    fs::write(project_root.join("wide.txt"), format!("{wide}\n")).unwrap();
+
+    let mut harness = panning_harness(&project_root);
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+
+    let row = row_containing(&harness, "wide.txt:1");
+    assert!(
+        row.contains("NEEDLE_MARKER"),
+        "a match behind a wide-character prefix is not on screen — the row \
+         was measured in codepoints and drawn in columns, so it was built \
+         wider than the panel and cut. Row:\n{row}"
+    );
+    // And the ASCII row beside it is unaffected, so a failure above is about
+    // width accounting rather than about the search.
+    assert!(
+        row_containing(&harness, "long.txt:1").contains("NEEDLE_MARKER"),
+        "control: the ASCII long-line row still shows its match"
+    );
+}
+
+/// Shift+arrows still extend the selection in the panel's own text fields.
+///
+/// This is the reason the pan chord is routed on the focused widget rather
+/// than bound in the panel's mode: mode bindings resolve ahead of the arm
+/// that extends a widget text selection, so a `S-Left` binding would have
+/// taken the chord from the Search field too. Must pass before *and* after.
+#[test]
+fn test_search_replace_shift_arrow_still_selects_in_the_search_field() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    let mut harness = panning_harness(&project_root);
+
+    open_search_replace_via_palette(&mut harness);
+    harness.type_text("NEEDLE_MARKER").unwrap();
+    wait_for_search_finished(&mut harness);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("long.txt:1"))
+        .unwrap();
+
+    // Focus is on the Search field: Shift+Left selects, and then typing
+    // replaces the selection — which is what makes the selection observable
+    // on screen without inspecting widget state.
+    let rows_before = row_containing(&harness, "long.txt:1");
+    press_shift(&mut harness, KeyCode::Left, 6);
+    harness.type_text("Z").unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("NEEDLE_Z"),
+        "Shift+Left in the Search field should have selected the last six \
+         characters, so typing replaced them. Screen:\n{screen}"
+    );
+    // And the keystrokes went to the field alone: the results tree did not
+    // pan under them. (The rows are re-read from the pre-retype screen, so
+    // this compares like with like.)
+    assert!(
+        !rows_before.contains("TAILMARK"),
+        "precondition: the row was at its resting window. Row:\n{rows_before}"
+    );
+}
+
+/// A pan does not survive a change of subject: a fresh search opens at each
+/// row's resting window rather than wherever the last one was left.
+#[test]
+fn test_search_replace_pan_homes_on_a_new_search() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    write_panning_fixture(&project_root);
+    // A second pattern that also hits the long line, so the row survives the
+    // re-search and the only thing that can differ is where its window rests.
+    let mut harness = panning_harness(&project_root);
+
+    focus_first_match_row(&mut harness, "NEEDLE_MARKER");
+    press_shift(&mut harness, KeyCode::Right, 12);
+    assert!(
+        row_containing(&harness, "long.txt:1").contains("TAILMARK"),
+        "precondition: panned to the tail"
+    );
+
+    // Back to the Search field — the focus ring wraps from the tree to it —
+    // and retype, which replaces the tree's rows.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    for _ in 0.."NEEDLE_MARKER".len() {
+        harness
+            .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    harness.type_text("HEADMARK").unwrap();
+    // The status line still carries the *previous* search's "Found N
+    // matches", so waiting on that alone would return before this search has
+    // run. Wait for the field to hold the new pattern, then for its results.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search: [HEADMARK"))
+        .unwrap();
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("long.txt:1") && !s.contains("short.txt:1")
+        })
+        .unwrap();
+
+    let row = row_containing(&harness, "long.txt:1");
+    assert!(
+        row.contains("HEADMARK") && !row.contains("TAILMARK"),
+        "a new search should open at the new match's resting window, not \
+         where the last search was panned to. Row:\n{row}"
+    );
+}

--- a/crates/fresh-editor/tests/key_name_docs.rs
+++ b/crates/fresh-editor/tests/key_name_docs.rs
@@ -1,0 +1,181 @@
+//! The documented key names are generated from the code that parses them.
+//!
+//! `docs/configuration/keyboard.md` used to say nothing at all about which
+//! spellings `"key"` accepts, and `docs/features/keybinding-editor.md` offered
+//! four examples. A name nobody can find is a name nobody uses — issue #1128
+//! was filed by someone who guessed `asterisk` and `kp_multiply` and got
+//! silence — so the list is rendered from the tables themselves and this test
+//! fails when the two drift.
+//!
+//! Regenerate with:
+//!
+//! ```sh
+//! UPDATE_DOCS=1 cargo test -p fresh-editor --test all_tests -- key_name_docs::
+//! ```
+
+use std::fs;
+use std::path::PathBuf;
+
+use crossterm::event::KeyCode;
+use fresh::input::keybindings::{KeyName, NAMED_KEYS, PUNCTUATION_KEYS};
+use fresh_input_parser::keypad::KEYPAD_KEYS;
+use fresh_input_parser::media_modifier::{MEDIA_KEYS, MODIFIER_KEYS};
+
+const BEGIN: &str = "<!-- BEGIN GENERATED KEY NAMES -->";
+const END: &str = "<!-- END GENERATED KEY NAMES -->";
+
+fn doc_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../docs/configuration/keyboard.md")
+}
+
+/// Wrap `s` as a markdown code span that survives a table cell.
+///
+/// Two hazards: a literal backtick needs a wider fence and padding spaces, and
+/// a `|` ends the cell even inside a code span, so it is escaped.
+fn code_span(s: &str) -> String {
+    let span = if s.contains('`') {
+        format!("`` {s} ``")
+    } else {
+        format!("`{s}`")
+    };
+    span.replace('|', "\\|")
+}
+
+/// A reader-facing description of what a `KeyCode` is.
+fn describe(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(' ') => "the space bar".to_string(),
+        KeyCode::Char(c) => code_span(&c.to_string()),
+        other => code_span(&format!("{other:?}")),
+    }
+}
+
+fn names_cell(k: &KeyName) -> String {
+    k.names
+        .iter()
+        .map(|n| code_span(n))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn render() -> String {
+    let mut out = String::new();
+    out.push_str(BEGIN);
+    out.push_str("\n\n");
+    out.push_str(
+        "*This section is generated from the key tables in the source. \
+         Edit those, not this text — see `crates/fresh-editor/tests/key_name_docs.rs`.*\n\n",
+    );
+
+    out.push_str("### Named keys\n\n");
+    out.push_str("| Name | Key |\n|---|---|\n");
+    for k in NAMED_KEYS {
+        out.push_str(&format!("| {} | {} |\n", names_cell(k), describe(k.code)));
+    }
+
+    out.push_str("\nAny single character is also a key name — `\"a\"`, `\"7\"`, `\"é\"` — \
+                  as is a function key, `\"f1\"` through `\"f35\"` (F13 and up need a \
+                  terminal that reports them). Names are case-insensitive.\n\n");
+
+    out.push_str("### Punctuation\n\n");
+    out.push_str(
+        "The single character is always accepted and is what the keybinding editor \
+         writes back. These X11 keysym spellings are accepted too, for the keys that \
+         are awkward to write literally in JSON.\n\n",
+    );
+    out.push_str("| Name | Character |\n|---|---|\n");
+    for k in PUNCTUATION_KEYS {
+        out.push_str(&format!("| {} | {} |\n", names_cell(k), describe(k.code)));
+    }
+
+    out.push_str("\n### Numeric keypad\n\n");
+    out.push_str(
+        "**These are aliases, not separate keys.** A terminal reports the keypad using \
+         the same code as the main keyboard, so binding `kp_multiply` also binds `*`, \
+         and binding `kp_enter` also binds `Enter`. There is no way to tell the two \
+         apart at this layer. `kp_begin` — the `5` key with Num Lock off — is the one \
+         exception: nothing on the main keyboard sends it.\n\n",
+    );
+    out.push_str("| Name | Binds the same key as |\n|---|---|\n");
+    for k in KEYPAD_KEYS {
+        out.push_str(&format!(
+            "| {} | {} |\n",
+            code_span(k.keysym),
+            describe(k.code)
+        ));
+    }
+
+    out.push_str("\n### Media and modifier keys\n\n");
+    out.push_str(
+        "Reported only by a terminal speaking the kitty keyboard protocol, and \
+         for the modifier keys only when it is asked to report every key event. \
+         Unlike the keypad these are **not** aliases: nothing on the main \
+         keyboard means `volume_mute` or `left_hyper`, so each binds a key of \
+         its own.\n\n",
+    );
+    out.push_str("| Name | Key |\n|---|---|\n");
+    for k in MEDIA_KEYS.iter().chain(MODIFIER_KEYS) {
+        out.push_str(&format!(
+            "| {} | {} |\n",
+            code_span(k.keysym),
+            describe(k.code)
+        ));
+    }
+
+    out.push('\n');
+    out.push_str(END);
+    out
+}
+
+#[test]
+fn generated_key_name_docs_match_the_code() {
+    let path = doc_path();
+    let doc = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+    let expected = render();
+
+    let (Some(start), Some(end)) = (doc.find(BEGIN), doc.find(END)) else {
+        panic!(
+            "{} has no generated key-name block. Add\n\n{BEGIN}\n{END}\n\nand rerun with \
+             UPDATE_DOCS=1.",
+            path.display()
+        );
+    };
+    let end = end + END.len();
+    let current = &doc[start..end];
+
+    if current == expected {
+        return;
+    }
+
+    if std::env::var_os("UPDATE_DOCS").is_some() {
+        let updated = format!("{}{}{}", &doc[..start], expected, &doc[end..]);
+        fs::write(&path, updated).unwrap();
+        return;
+    }
+
+    // Say so when the only difference is the line terminator. `.gitattributes`
+    // pins this file to LF for exactly that reason, but a working copy that
+    // predates the attribute still has CRLF — and "the tables are out of date"
+    // sends whoever hits it to regenerate a block that is already correct.
+    if current.replace("\r\n", "\n") == expected.replace("\r\n", "\n") {
+        panic!(
+            "{} differs from the generated tables only in its line endings — \
+             the tables themselves match. This checkout has CRLF where the \
+             repository stores LF; `.gitattributes` pins the file, so refresh \
+             the working copy:\n  git rm --cached {} && git checkout -- {}",
+            path.display(),
+            "docs/configuration/keyboard.md",
+            "docs/configuration/keyboard.md",
+        );
+    }
+
+    panic!(
+        "the key names in {} are out of date with the tables in \
+         `input/keybindings.rs` and `fresh-input-parser`'s `keypad`.\n\n\
+         Regenerate:\n  UPDATE_DOCS=1 cargo test -p fresh-editor --test all_tests -- \
+         key_name_docs::\n\n--- documented ---\n{current}\n\n--- expected ---\n{expected}",
+        path.display()
+    );
+}

--- a/crates/fresh-input-parser/src/keypad.rs
+++ b/crates/fresh-input-parser/src/keypad.rs
@@ -1,0 +1,288 @@
+//! The numeric keypad, named once.
+//!
+//! Three things need to agree about what a keypad key *is*, and they used to
+//! be three separate hand-written tables:
+//!
+//! * the kitty keyboard protocol's Private Use Area codepoints, decoded by
+//!   `kitty_functional_key`;
+//! * the application-keypad (SS3) bytes, decoded by `feed_ss3`;
+//! * the X11 keysym spellings a user writes in `keybindings` config, parsed by
+//!   `KeybindingResolver::parse_key` over in `fresh-editor`.
+//!
+//! They describe one relation, so they are one table. [`KEYPAD_KEYS`] is that
+//! table; the decoders resolve through it and the config parser resolves
+//! through it, which is what keeps a name that binds and a key that arrives
+//! from drifting apart.
+//!
+//! **The normalisation is lossy, and deliberately so.** A terminal reports the
+//! keypad through the same code as the main keyboard — `KP_MULTIPLY` arrives
+//! as `*`, `KP_ENTER` as `Enter`, `KP_LEFT` as `Left` — so a keypad name is an
+//! *alias* for the main-keyboard key, not a distinct binding. [`KP_BEGIN`] (the
+//! `5` with Num Lock off) is the sole exception: nothing on the main keyboard
+//! means it, so it keeps a [`KeyCode`] of its own.
+
+use crossterm::event::KeyCode;
+
+/// One keypad key, in the three vocabularies that have to agree about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeypadKey {
+    /// The kitty keyboard protocol's Private Use Area codepoint.
+    pub kitty_codepoint: u32,
+    /// The X11 keysym name, lowercased — the spelling accepted in config.
+    pub keysym: &'static str,
+    /// What the key normalises to by the time the editor sees it.
+    pub code: KeyCode,
+}
+
+/// The `5` key with Num Lock off: the one keypad key with no main-keyboard
+/// equivalent, and so the one that keeps a [`KeyCode`] of its own.
+pub const KP_BEGIN: u32 = 57427;
+
+/// The keypad `0`. The ten digits are contiguous from here, in both the kitty
+/// protocol and the SS3 (`ESC O p` … `ESC O y`) encoding.
+pub const KP_0: u32 = 57399;
+
+/// Every keypad key the terminal protocols name, in kitty-codepoint order.
+///
+/// Order is load-bearing only for the doc table generated from it; lookups are
+/// by name or codepoint.
+pub const KEYPAD_KEYS: &[KeypadKey] = &[
+    KeypadKey {
+        kitty_codepoint: 57399,
+        keysym: "kp_0",
+        code: KeyCode::Char('0'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57400,
+        keysym: "kp_1",
+        code: KeyCode::Char('1'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57401,
+        keysym: "kp_2",
+        code: KeyCode::Char('2'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57402,
+        keysym: "kp_3",
+        code: KeyCode::Char('3'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57403,
+        keysym: "kp_4",
+        code: KeyCode::Char('4'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57404,
+        keysym: "kp_5",
+        code: KeyCode::Char('5'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57405,
+        keysym: "kp_6",
+        code: KeyCode::Char('6'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57406,
+        keysym: "kp_7",
+        code: KeyCode::Char('7'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57407,
+        keysym: "kp_8",
+        code: KeyCode::Char('8'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57408,
+        keysym: "kp_9",
+        code: KeyCode::Char('9'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57409,
+        keysym: "kp_decimal",
+        code: KeyCode::Char('.'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57410,
+        keysym: "kp_divide",
+        code: KeyCode::Char('/'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57411,
+        keysym: "kp_multiply",
+        code: KeyCode::Char('*'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57412,
+        keysym: "kp_subtract",
+        code: KeyCode::Char('-'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57413,
+        keysym: "kp_add",
+        code: KeyCode::Char('+'),
+    },
+    KeypadKey {
+        kitty_codepoint: 57414,
+        keysym: "kp_enter",
+        code: KeyCode::Enter,
+    },
+    KeypadKey {
+        kitty_codepoint: 57415,
+        keysym: "kp_equal",
+        code: KeyCode::Char('='),
+    },
+    KeypadKey {
+        kitty_codepoint: 57416,
+        keysym: "kp_separator",
+        code: KeyCode::Char(','),
+    },
+    KeypadKey {
+        kitty_codepoint: 57417,
+        keysym: "kp_left",
+        code: KeyCode::Left,
+    },
+    KeypadKey {
+        kitty_codepoint: 57418,
+        keysym: "kp_right",
+        code: KeyCode::Right,
+    },
+    KeypadKey {
+        kitty_codepoint: 57419,
+        keysym: "kp_up",
+        code: KeyCode::Up,
+    },
+    KeypadKey {
+        kitty_codepoint: 57420,
+        keysym: "kp_down",
+        code: KeyCode::Down,
+    },
+    KeypadKey {
+        kitty_codepoint: 57421,
+        keysym: "kp_page_up",
+        code: KeyCode::PageUp,
+    },
+    KeypadKey {
+        kitty_codepoint: 57422,
+        keysym: "kp_page_down",
+        code: KeyCode::PageDown,
+    },
+    KeypadKey {
+        kitty_codepoint: 57423,
+        keysym: "kp_home",
+        code: KeyCode::Home,
+    },
+    KeypadKey {
+        kitty_codepoint: 57424,
+        keysym: "kp_end",
+        code: KeyCode::End,
+    },
+    KeypadKey {
+        kitty_codepoint: 57425,
+        keysym: "kp_insert",
+        code: KeyCode::Insert,
+    },
+    KeypadKey {
+        kitty_codepoint: 57426,
+        keysym: "kp_delete",
+        code: KeyCode::Delete,
+    },
+    KeypadKey {
+        kitty_codepoint: KP_BEGIN,
+        keysym: "kp_begin",
+        code: KeyCode::KeypadBegin,
+    },
+];
+
+/// The `KeyCode` for an already-lowercased X11 keypad keysym name.
+pub fn code_for_keysym(name: &str) -> Option<KeyCode> {
+    KEYPAD_KEYS
+        .iter()
+        .find(|k| k.keysym == name)
+        .map(|k| k.code)
+}
+
+/// The `KeyCode` for a kitty keyboard-protocol keypad codepoint.
+pub fn code_for_kitty_codepoint(cp: u32) -> Option<KeyCode> {
+    KEYPAD_KEYS
+        .iter()
+        .find(|k| k.kitty_codepoint == cp)
+        .map(|k| k.code)
+}
+
+/// The `KeyCode` for keypad digit `digit` (`0..=9`).
+///
+/// Both encodings lay the ten digits out contiguously, so a decoder that has
+/// the digit in hand asks for it here rather than rebuilding `Char('0' + n)`
+/// and quietly disagreeing with the table on what a keypad digit is.
+pub fn code_for_digit(digit: u8) -> Option<KeyCode> {
+    if digit > 9 {
+        return None;
+    }
+    code_for_kitty_codepoint(KP_0 + digit as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every entry is reachable by both of its keys, and the two lookups agree.
+    #[test]
+    fn both_lookups_find_every_entry() {
+        for k in KEYPAD_KEYS {
+            assert_eq!(
+                code_for_keysym(k.keysym),
+                Some(k.code),
+                "keysym {}",
+                k.keysym
+            );
+            assert_eq!(
+                code_for_kitty_codepoint(k.kitty_codepoint),
+                Some(k.code),
+                "codepoint {}",
+                k.kitty_codepoint
+            );
+        }
+    }
+
+    /// No two entries claim the same name or the same codepoint — either would
+    /// make one of them unreachable through the lookup that collides.
+    #[test]
+    fn names_and_codepoints_are_unique() {
+        let mut names: Vec<&str> = KEYPAD_KEYS.iter().map(|k| k.keysym).collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count, "duplicate keysym in KEYPAD_KEYS");
+
+        let mut cps: Vec<u32> = KEYPAD_KEYS.iter().map(|k| k.kitty_codepoint).collect();
+        cps.sort_unstable();
+        let count = cps.len();
+        cps.dedup();
+        assert_eq!(cps.len(), count, "duplicate codepoint in KEYPAD_KEYS");
+    }
+
+    #[test]
+    fn digits_are_contiguous_from_kp_0() {
+        for d in 0..=9u8 {
+            assert_eq!(
+                code_for_digit(d),
+                Some(KeyCode::Char((b'0' + d) as char)),
+                "keypad digit {d}"
+            );
+        }
+        assert_eq!(code_for_digit(10), None);
+    }
+
+    /// `KeypadBegin` is the only keypad key that does not collapse onto a
+    /// main-keyboard code — the property the docs promise users.
+    #[test]
+    fn keypad_begin_is_the_only_distinct_key() {
+        let distinct: Vec<&str> = KEYPAD_KEYS
+            .iter()
+            .filter(|k| k.code == KeyCode::KeypadBegin)
+            .map(|k| k.keysym)
+            .collect();
+        assert_eq!(distinct, vec!["kp_begin"]);
+    }
+}

--- a/crates/fresh-input-parser/src/lib.rs
+++ b/crates/fresh-input-parser/src/lib.rs
@@ -43,6 +43,9 @@ use crossterm::event::{
     KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
 
+pub mod keypad;
+pub mod media_modifier;
+
 /// A key press, as the terminal reported it, plus the character the key
 /// actually types on the user's keyboard layout when the chord's own spelling
 /// hides it.
@@ -544,17 +547,23 @@ impl InputParser {
             b'F' => Some(KeyCode::End),
             // Application-keypad forms (DECPAM). Without these the numeric
             // keypad went silent whenever application keypad mode was active.
-            b'M' => Some(KeyCode::Enter),       // keypad Enter
-            b'E' => Some(KeyCode::KeypadBegin), // keypad Begin (the "5" key)
-            b'X' => Some(KeyCode::Char('=')),   // keypad Equal
-            b'j' => Some(KeyCode::Char('*')),   // keypad Multiply
-            b'k' => Some(KeyCode::Char('+')),   // keypad Add
-            b'l' => Some(KeyCode::Char(',')),   // keypad Separator
-            b'm' => Some(KeyCode::Char('-')),   // keypad Subtract
-            b'n' => Some(KeyCode::Char('.')),   // keypad Decimal
-            b'o' => Some(KeyCode::Char('/')),   // keypad Divide
+            //
+            // Which keypad key each byte *is* is this encoding's own business;
+            // what that key normalises to is `keypad`'s, so the codes come from
+            // there rather than being spelled out a second time. A name that
+            // did not resolve would take the key silently out of service, which
+            // is what `ss3_application_keypad_forms` covers byte by byte.
+            b'M' => crate::keypad::code_for_keysym("kp_enter"),
+            b'E' => crate::keypad::code_for_keysym("kp_begin"),
+            b'X' => crate::keypad::code_for_keysym("kp_equal"),
+            b'j' => crate::keypad::code_for_keysym("kp_multiply"),
+            b'k' => crate::keypad::code_for_keysym("kp_add"),
+            b'l' => crate::keypad::code_for_keysym("kp_separator"),
+            b'm' => crate::keypad::code_for_keysym("kp_subtract"),
+            b'n' => crate::keypad::code_for_keysym("kp_decimal"),
+            b'o' => crate::keypad::code_for_keysym("kp_divide"),
             // Keypad digits 0–9 (`ESC O p` … `ESC O y`).
-            b'p'..=b'y' => Some(KeyCode::Char((b'0' + (byte - b'p')) as char)),
+            b'p'..=b'y' => crate::keypad::code_for_digit(byte - b'p'),
             _ => None,
         };
         if let Some(code) = keycode {
@@ -1076,8 +1085,12 @@ fn functional_or_char(codepoint: u32) -> Option<KeyCode> {
 /// Map a kitty keyboard-protocol functional key (encoded as a Private Use Area
 /// codepoint) to a crossterm [`KeyCode`]. Returns `None` for PUA codepoints the
 /// protocol does not assign, so they are dropped rather than inserted as text.
-fn kitty_functional_key(cp: u32) -> Option<KeyCode> {
-    use crossterm::event::{MediaKeyCode as M, ModifierKeyCode as Mod};
+///
+/// Public because it is the honest answer to "which keys can arrive here",
+/// and a test that wants to check every one of them against something else —
+/// that the keybinding config can *name* each, say — has no other way to
+/// enumerate them without restating the list and testing the restatement.
+pub fn kitty_functional_key(cp: u32) -> Option<KeyCode> {
     Some(match cp {
         57358 => KeyCode::CapsLock,
         57359 => KeyCode::ScrollLock,
@@ -1087,56 +1100,17 @@ fn kitty_functional_key(cp: u32) -> Option<KeyCode> {
         57363 => KeyCode::Menu,
         // F13–F35.
         57376..=57398 => KeyCode::F(13 + (cp - 57376) as u8),
-        // Keypad digits 0–9.
-        57399..=57408 => KeyCode::Char((b'0' + (cp - 57399) as u8) as char),
-        57409 => KeyCode::Char('.'), // KP_DECIMAL
-        57410 => KeyCode::Char('/'), // KP_DIVIDE
-        57411 => KeyCode::Char('*'), // KP_MULTIPLY
-        57412 => KeyCode::Char('-'), // KP_SUBTRACT
-        57413 => KeyCode::Char('+'), // KP_ADD
-        57414 => KeyCode::Enter,     // KP_ENTER
-        57415 => KeyCode::Char('='), // KP_EQUAL
-        57416 => KeyCode::Char(','), // KP_SEPARATOR
-        57417 => KeyCode::Left,      // KP_LEFT
-        57418 => KeyCode::Right,     // KP_RIGHT
-        57419 => KeyCode::Up,        // KP_UP
-        57420 => KeyCode::Down,      // KP_DOWN
-        57421 => KeyCode::PageUp,    // KP_PAGE_UP
-        57422 => KeyCode::PageDown,  // KP_PAGE_DOWN
-        57423 => KeyCode::Home,      // KP_HOME
-        57424 => KeyCode::End,       // KP_END
-        57425 => KeyCode::Insert,    // KP_INSERT
-        57426 => KeyCode::Delete,    // KP_DELETE
-        57427 => KeyCode::KeypadBegin,
-        // Media keys.
-        57428 => KeyCode::Media(M::Play),
-        57429 => KeyCode::Media(M::Pause),
-        57430 => KeyCode::Media(M::PlayPause),
-        57431 => KeyCode::Media(M::Reverse),
-        57432 => KeyCode::Media(M::Stop),
-        57433 => KeyCode::Media(M::FastForward),
-        57434 => KeyCode::Media(M::Rewind),
-        57435 => KeyCode::Media(M::TrackNext),
-        57436 => KeyCode::Media(M::TrackPrevious),
-        57437 => KeyCode::Media(M::Record),
-        57438 => KeyCode::Media(M::LowerVolume),
-        57439 => KeyCode::Media(M::RaiseVolume),
-        57440 => KeyCode::Media(M::MuteVolume),
-        // Standalone modifier keys.
-        57441 => KeyCode::Modifier(Mod::LeftShift),
-        57442 => KeyCode::Modifier(Mod::LeftControl),
-        57443 => KeyCode::Modifier(Mod::LeftAlt),
-        57444 => KeyCode::Modifier(Mod::LeftSuper),
-        57445 => KeyCode::Modifier(Mod::LeftHyper),
-        57446 => KeyCode::Modifier(Mod::LeftMeta),
-        57447 => KeyCode::Modifier(Mod::RightShift),
-        57448 => KeyCode::Modifier(Mod::RightControl),
-        57449 => KeyCode::Modifier(Mod::RightAlt),
-        57450 => KeyCode::Modifier(Mod::RightSuper),
-        57451 => KeyCode::Modifier(Mod::RightHyper),
-        57452 => KeyCode::Modifier(Mod::RightMeta),
-        57453 => KeyCode::Modifier(Mod::IsoLevel3Shift),
-        57454 => KeyCode::Modifier(Mod::IsoLevel5Shift),
+        // The whole keypad, from the table `keypad` shares with the config
+        // key-name parser — one definition, so a name that binds and a key
+        // that arrives cannot drift apart.
+        57399..=crate::keypad::KP_BEGIN => return crate::keypad::code_for_kitty_codepoint(cp),
+        // The media and standalone-modifier keys, from the table
+        // `media_modifier` shares with the config key-name parser — same
+        // reason as the keypad above: a key that arrives and a name that
+        // binds cannot drift apart if there is only one of them.
+        crate::media_modifier::FIRST..=crate::media_modifier::LAST => {
+            return crate::media_modifier::code_for_kitty_codepoint(cp)
+        }
         _ => return None,
     })
 }

--- a/crates/fresh-input-parser/src/media_modifier.rs
+++ b/crates/fresh-input-parser/src/media_modifier.rs
@@ -1,0 +1,261 @@
+//! Media and standalone-modifier keys, named once.
+//!
+//! The same relation [`crate::keypad`] describes for the numeric keypad, for
+//! the two remaining families of kitty functional keys: the media transport
+//! and volume keys, and the modifier keys reported *as keys* when a terminal
+//! is asked for all key events.
+//!
+//! They are here for the reason the keypad is: without a name, a key the
+//! parser decodes is a key the keybinding editor writes back as a `{:?}`
+//! spelling — `"Media(MuteVolume)"` — that its own loader then refuses,
+//! dropping the binding at load with a warning badge and no explanation.
+//! That is issue #1128 exactly, and naming the keys the decoder already knows
+//! is what stops it being re-reported for the next family.
+//!
+//! **Unlike the keypad, these are not aliases.** No main-keyboard key means
+//! "mute" or "left hyper", so each name here binds a key of its own — and
+//! only a terminal that reports it (kitty's protocol, with key events for
+//! modifiers enabled) will ever deliver one.
+
+use crossterm::event::{KeyCode, MediaKeyCode, ModifierKeyCode};
+
+/// One named key, in the two vocabularies that have to agree about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NamedKey {
+    /// The kitty keyboard protocol's Private Use Area codepoint.
+    pub kitty_codepoint: u32,
+    /// The name accepted in config, lowercased.
+    pub keysym: &'static str,
+    /// What the key decodes to.
+    pub code: KeyCode,
+}
+
+/// The media transport and volume keys, in kitty-codepoint order.
+pub const MEDIA_KEYS: &[NamedKey] = &[
+    NamedKey {
+        kitty_codepoint: 57428,
+        keysym: "media_play",
+        code: KeyCode::Media(MediaKeyCode::Play),
+    },
+    NamedKey {
+        kitty_codepoint: 57429,
+        keysym: "media_pause",
+        code: KeyCode::Media(MediaKeyCode::Pause),
+    },
+    NamedKey {
+        kitty_codepoint: 57430,
+        keysym: "media_play_pause",
+        code: KeyCode::Media(MediaKeyCode::PlayPause),
+    },
+    NamedKey {
+        kitty_codepoint: 57431,
+        keysym: "media_reverse",
+        code: KeyCode::Media(MediaKeyCode::Reverse),
+    },
+    NamedKey {
+        kitty_codepoint: 57432,
+        keysym: "media_stop",
+        code: KeyCode::Media(MediaKeyCode::Stop),
+    },
+    NamedKey {
+        kitty_codepoint: 57433,
+        keysym: "media_fast_forward",
+        code: KeyCode::Media(MediaKeyCode::FastForward),
+    },
+    NamedKey {
+        kitty_codepoint: 57434,
+        keysym: "media_rewind",
+        code: KeyCode::Media(MediaKeyCode::Rewind),
+    },
+    NamedKey {
+        kitty_codepoint: 57435,
+        keysym: "media_next",
+        code: KeyCode::Media(MediaKeyCode::TrackNext),
+    },
+    NamedKey {
+        kitty_codepoint: 57436,
+        keysym: "media_previous",
+        code: KeyCode::Media(MediaKeyCode::TrackPrevious),
+    },
+    NamedKey {
+        kitty_codepoint: 57437,
+        keysym: "media_record",
+        code: KeyCode::Media(MediaKeyCode::Record),
+    },
+    NamedKey {
+        kitty_codepoint: 57438,
+        keysym: "volume_down",
+        code: KeyCode::Media(MediaKeyCode::LowerVolume),
+    },
+    NamedKey {
+        kitty_codepoint: 57439,
+        keysym: "volume_up",
+        code: KeyCode::Media(MediaKeyCode::RaiseVolume),
+    },
+    NamedKey {
+        kitty_codepoint: 57440,
+        keysym: "volume_mute",
+        code: KeyCode::Media(MediaKeyCode::MuteVolume),
+    },
+];
+
+/// The modifier keys, reported as keys in their own right, in
+/// kitty-codepoint order.
+pub const MODIFIER_KEYS: &[NamedKey] = &[
+    NamedKey {
+        kitty_codepoint: 57441,
+        keysym: "left_shift",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftShift),
+    },
+    NamedKey {
+        kitty_codepoint: 57442,
+        keysym: "left_ctrl",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftControl),
+    },
+    NamedKey {
+        kitty_codepoint: 57443,
+        keysym: "left_alt",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftAlt),
+    },
+    NamedKey {
+        kitty_codepoint: 57444,
+        keysym: "left_super",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftSuper),
+    },
+    NamedKey {
+        kitty_codepoint: 57445,
+        keysym: "left_hyper",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftHyper),
+    },
+    NamedKey {
+        kitty_codepoint: 57446,
+        keysym: "left_meta",
+        code: KeyCode::Modifier(ModifierKeyCode::LeftMeta),
+    },
+    NamedKey {
+        kitty_codepoint: 57447,
+        keysym: "right_shift",
+        code: KeyCode::Modifier(ModifierKeyCode::RightShift),
+    },
+    NamedKey {
+        kitty_codepoint: 57448,
+        keysym: "right_ctrl",
+        code: KeyCode::Modifier(ModifierKeyCode::RightControl),
+    },
+    NamedKey {
+        kitty_codepoint: 57449,
+        keysym: "right_alt",
+        code: KeyCode::Modifier(ModifierKeyCode::RightAlt),
+    },
+    NamedKey {
+        kitty_codepoint: 57450,
+        keysym: "right_super",
+        code: KeyCode::Modifier(ModifierKeyCode::RightSuper),
+    },
+    NamedKey {
+        kitty_codepoint: 57451,
+        keysym: "right_hyper",
+        code: KeyCode::Modifier(ModifierKeyCode::RightHyper),
+    },
+    NamedKey {
+        kitty_codepoint: 57452,
+        keysym: "right_meta",
+        code: KeyCode::Modifier(ModifierKeyCode::RightMeta),
+    },
+    NamedKey {
+        kitty_codepoint: 57453,
+        keysym: "iso_level3_shift",
+        code: KeyCode::Modifier(ModifierKeyCode::IsoLevel3Shift),
+    },
+    NamedKey {
+        kitty_codepoint: 57454,
+        keysym: "iso_level5_shift",
+        code: KeyCode::Modifier(ModifierKeyCode::IsoLevel5Shift),
+    },
+];
+
+/// Both tables, which is what every lookup here walks.
+pub fn all() -> impl Iterator<Item = &'static NamedKey> {
+    MEDIA_KEYS.iter().chain(MODIFIER_KEYS)
+}
+
+/// The [`KeyCode`] a config name means, or `None` when it names nothing here.
+///
+/// `name` is expected already lowercased, as [`crate::keypad::code_for_keysym`]
+/// expects it.
+pub fn code_for_keysym(name: &str) -> Option<KeyCode> {
+    all().find(|k| k.keysym == name).map(|k| k.code)
+}
+
+/// The [`KeyCode`] a kitty Private Use Area codepoint means.
+pub fn code_for_kitty_codepoint(cp: u32) -> Option<KeyCode> {
+    all().find(|k| k.kitty_codepoint == cp).map(|k| k.code)
+}
+
+/// The config name for a [`KeyCode`] this module owns.
+///
+/// The inverse of [`code_for_keysym`], and the reason the keybinding editor
+/// can record one of these keys without writing a name its own loader
+/// refuses.
+pub fn keysym_for_code(code: KeyCode) -> Option<&'static str> {
+    all().find(|k| k.code == code).map(|k| k.keysym)
+}
+
+/// First codepoint either table names — the media keys begin here.
+pub const FIRST: u32 = 57428;
+/// Last codepoint either table names — the modifier keys end here.
+pub const LAST: u32 = 57454;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn both_lookups_find_every_entry() {
+        for k in all() {
+            assert_eq!(code_for_keysym(k.keysym), Some(k.code), "{}", k.keysym);
+            assert_eq!(
+                code_for_kitty_codepoint(k.kitty_codepoint),
+                Some(k.code),
+                "{}",
+                k.keysym
+            );
+            assert_eq!(keysym_for_code(k.code), Some(k.keysym), "{}", k.keysym);
+        }
+    }
+
+    #[test]
+    fn names_and_codepoints_and_codes_are_unique() {
+        let mut names = HashSet::new();
+        let mut points = HashSet::new();
+        let mut codes = HashSet::new();
+        for k in all() {
+            assert!(names.insert(k.keysym), "duplicate name {}", k.keysym);
+            assert!(
+                points.insert(k.kitty_codepoint),
+                "duplicate codepoint {}",
+                k.kitty_codepoint
+            );
+            assert!(codes.insert(k.code), "duplicate code for {}", k.keysym);
+            assert_eq!(
+                k.keysym.to_lowercase(),
+                k.keysym,
+                "names are matched lowercased: {}",
+                k.keysym
+            );
+        }
+    }
+
+    /// The two families are contiguous and adjacent, which is what lets the
+    /// decoder delegate one range rather than twenty-seven arms.
+    #[test]
+    fn the_range_is_contiguous() {
+        let points: Vec<u32> = all().map(|k| k.kitty_codepoint).collect();
+        assert_eq!(points.first(), Some(&FIRST));
+        assert_eq!(points.last(), Some(&LAST));
+        for pair in points.windows(2) {
+            assert_eq!(pair[1], pair[0] + 1, "gap at {}", pair[0]);
+        }
+    }
+}

--- a/crates/fresh-input-parser/src/tests.rs
+++ b/crates/fresh-input-parser/src/tests.rs
@@ -1666,6 +1666,63 @@ fn ss3_application_keypad_forms() {
     ); // keypad .
 }
 
+/// Every application-keypad byte, not just the six above.
+///
+/// `feed_ss3` names its keys by keysym and takes the code from
+/// `keypad::KEYPAD_KEYS`; a name that stopped resolving would take that byte
+/// silently out of service rather than failing to compile. This is the check
+/// that turns such a typo into a test failure.
+#[test]
+fn ss3_keypad_bytes_all_resolve() {
+    let expected: &[(u8, KeyCode)] = &[
+        (b'M', KeyCode::Enter),
+        (b'E', KeyCode::KeypadBegin),
+        (b'X', KeyCode::Char('=')),
+        (b'j', KeyCode::Char('*')),
+        (b'k', KeyCode::Char('+')),
+        (b'l', KeyCode::Char(',')),
+        (b'm', KeyCode::Char('-')),
+        (b'n', KeyCode::Char('.')),
+        (b'o', KeyCode::Char('/')),
+    ];
+    let mut p = InputParser::new();
+    for (byte, code) in expected {
+        assert_eq!(
+            keys(&p.parse(&[0x1b, b'O', *byte])),
+            vec![(*code, KeyModifiers::empty())],
+            "ESC O {}",
+            *byte as char
+        );
+    }
+    for d in 0..=9u8 {
+        assert_eq!(
+            keys(&p.parse(&[0x1b, b'O', b'p' + d])),
+            vec![(KeyCode::Char((b'0' + d) as char), KeyModifiers::empty())],
+            "keypad digit {d}"
+        );
+    }
+}
+
+/// Every keypad key in the shared table decodes from its kitty codepoint.
+///
+/// `kitty_functional_key` resolves the whole keypad range through
+/// `keypad::KEYPAD_KEYS`; this is the end-to-end check that the delegation
+/// covers the range it claims, including `kp_begin` at its top edge.
+#[test]
+fn kitty_keypad_codepoints_all_decode() {
+    let mut p = InputParser::new();
+    for k in keypad::KEYPAD_KEYS {
+        let seq = format!("\x1b[{};1u", k.kitty_codepoint);
+        assert_eq!(
+            keys(&p.parse(seq.as_bytes())),
+            vec![(k.code, KeyModifiers::empty())],
+            "kitty codepoint {} ({})",
+            k.kitty_codepoint,
+            k.keysym
+        );
+    }
+}
+
 #[test]
 fn csi_e_is_keypad_begin() {
     let mut p = InputParser::new();

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -181,6 +181,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         "WidgetAction" => Some(fresh_core::api::WidgetAction::decl(&cfg)),
         "WidgetMutation" => Some(fresh_core::api::WidgetMutation::decl(&cfg)),
         "TreeNode" => Some(fresh_core::api::TreeNode::decl(&cfg)),
+        "TextWindowAnchor" => Some(fresh_core::api::TextWindowAnchor::decl(&cfg)),
 
         // Authority — payload schema for `editor.setAuthority(...)`.
         // Hand-written because the authoritative struct lives in
@@ -404,6 +405,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "HintEntry",          // Used by WidgetSpec::HintBar
     "ButtonKind",         // Used by WidgetSpec::Button.intent
     "TreeNode",           // Used by WidgetSpec::Tree.nodes
+    "TextWindowAnchor",   // Used by TreeNode::windowAnchor
     "WidgetSpec",         // Used by mountWidgetPanel/updateWidgetPanel
     "WidgetPanelOptions", // Used by mountWidgetPanel
     "ScrollAlign",        // Used by scrollToWidget

--- a/docs/configuration/keyboard.md
+++ b/docs/configuration/keyboard.md
@@ -218,6 +218,154 @@ The macOS keymap disables Alt+0-9 bindings because these key combinations are us
 
 If you find that certain Alt combinations insert characters instead of triggering editor commands, ensure your terminal's Option key is configured as Meta (see above).
 
+## Key Names
+
+The `key` field of a binding takes one of the names below.
+
+<!-- BEGIN GENERATED KEY NAMES -->
+
+*This section is generated from the key tables in the source. Edit those, not this text — see `crates/fresh-editor/tests/key_name_docs.rs`.*
+
+### Named keys
+
+| Name | Key |
+|---|---|
+| `enter` | `Enter` |
+| `backspace` | `Backspace` |
+| `delete`, `del` | `Delete` |
+| `insert`, `ins` | `Insert` |
+| `tab` | `Tab` |
+| `backtab` | `BackTab` |
+| `escape`, `esc` | `Esc` |
+| `space` | the space bar |
+| `left` | `Left` |
+| `right` | `Right` |
+| `up` | `Up` |
+| `down` | `Down` |
+| `home` | `Home` |
+| `end` | `End` |
+| `pageup` | `PageUp` |
+| `pagedown` | `PageDown` |
+| `capslock` | `CapsLock` |
+| `scrolllock` | `ScrollLock` |
+| `numlock` | `NumLock` |
+| `printscreen` | `PrintScreen` |
+| `pause` | `Pause` |
+| `menu` | `Menu` |
+
+Any single character is also a key name — `"a"`, `"7"`, `"é"` — as is a function key, `"f1"` through `"f35"` (F13 and up need a terminal that reports them). Names are case-insensitive.
+
+### Punctuation
+
+The single character is always accepted and is what the keybinding editor writes back. These X11 keysym spellings are accepted too, for the keys that are awkward to write literally in JSON.
+
+| Name | Character |
+|---|---|
+| `asterisk`, `star` | `*` |
+| `plus` | `+` |
+| `minus`, `hyphen` | `-` |
+| `slash` | `/` |
+| `period`, `dot` | `.` |
+| `equal`, `equals` | `=` |
+| `backslash` | `\` |
+| `comma` | `,` |
+| `semicolon` | `;` |
+| `colon` | `:` |
+| `apostrophe`, `quote` | `'` |
+| `quotedbl`, `doublequote` | `"` |
+| `grave`, `backtick` | `` ` `` |
+| `tilde` | `~` |
+| `exclam`, `exclamation` | `!` |
+| `at` | `@` |
+| `numbersign`, `hash` | `#` |
+| `dollar` | `$` |
+| `percent` | `%` |
+| `asciicircum`, `caret` | `^` |
+| `ampersand` | `&` |
+| `underscore` | `_` |
+| `bar`, `pipe` | `\|` |
+| `question` | `?` |
+| `less`, `lessthan` | `<` |
+| `greater`, `greaterthan` | `>` |
+| `parenleft` | `(` |
+| `parenright` | `)` |
+| `bracketleft` | `[` |
+| `bracketright` | `]` |
+| `braceleft` | `{` |
+| `braceright` | `}` |
+
+### Numeric keypad
+
+**These are aliases, not separate keys.** A terminal reports the keypad using the same code as the main keyboard, so binding `kp_multiply` also binds `*`, and binding `kp_enter` also binds `Enter`. There is no way to tell the two apart at this layer. `kp_begin` — the `5` key with Num Lock off — is the one exception: nothing on the main keyboard sends it.
+
+| Name | Binds the same key as |
+|---|---|
+| `kp_0` | `0` |
+| `kp_1` | `1` |
+| `kp_2` | `2` |
+| `kp_3` | `3` |
+| `kp_4` | `4` |
+| `kp_5` | `5` |
+| `kp_6` | `6` |
+| `kp_7` | `7` |
+| `kp_8` | `8` |
+| `kp_9` | `9` |
+| `kp_decimal` | `.` |
+| `kp_divide` | `/` |
+| `kp_multiply` | `*` |
+| `kp_subtract` | `-` |
+| `kp_add` | `+` |
+| `kp_enter` | `Enter` |
+| `kp_equal` | `=` |
+| `kp_separator` | `,` |
+| `kp_left` | `Left` |
+| `kp_right` | `Right` |
+| `kp_up` | `Up` |
+| `kp_down` | `Down` |
+| `kp_page_up` | `PageUp` |
+| `kp_page_down` | `PageDown` |
+| `kp_home` | `Home` |
+| `kp_end` | `End` |
+| `kp_insert` | `Insert` |
+| `kp_delete` | `Delete` |
+| `kp_begin` | `KeypadBegin` |
+
+### Media and modifier keys
+
+Reported only by a terminal speaking the kitty keyboard protocol, and for the modifier keys only when it is asked to report every key event. Unlike the keypad these are **not** aliases: nothing on the main keyboard means `volume_mute` or `left_hyper`, so each binds a key of its own.
+
+| Name | Key |
+|---|---|
+| `media_play` | `Media(Play)` |
+| `media_pause` | `Media(Pause)` |
+| `media_play_pause` | `Media(PlayPause)` |
+| `media_reverse` | `Media(Reverse)` |
+| `media_stop` | `Media(Stop)` |
+| `media_fast_forward` | `Media(FastForward)` |
+| `media_rewind` | `Media(Rewind)` |
+| `media_next` | `Media(TrackNext)` |
+| `media_previous` | `Media(TrackPrevious)` |
+| `media_record` | `Media(Record)` |
+| `volume_down` | `Media(LowerVolume)` |
+| `volume_up` | `Media(RaiseVolume)` |
+| `volume_mute` | `Media(MuteVolume)` |
+| `left_shift` | `Modifier(LeftShift)` |
+| `left_ctrl` | `Modifier(LeftControl)` |
+| `left_alt` | `Modifier(LeftAlt)` |
+| `left_super` | `Modifier(LeftSuper)` |
+| `left_hyper` | `Modifier(LeftHyper)` |
+| `left_meta` | `Modifier(LeftMeta)` |
+| `right_shift` | `Modifier(RightShift)` |
+| `right_ctrl` | `Modifier(RightControl)` |
+| `right_alt` | `Modifier(RightAlt)` |
+| `right_super` | `Modifier(RightSuper)` |
+| `right_hyper` | `Modifier(RightHyper)` |
+| `right_meta` | `Modifier(RightMeta)` |
+| `iso_level3_shift` | `Modifier(IsoLevel3Shift)` |
+| `iso_level5_shift` | `Modifier(IsoLevel5Shift)` |
+
+<!-- END GENERATED KEY NAMES -->
+
 ## Chord (Multi-Key) Bindings
 
 A binding can be a *sequence* of key presses instead of a single combination — the emacs keymap's `C-x C-s` for save, or `M-g g` for go-to-line. In `config.json`, a chord uses `keys` (an array of key presses) in place of `key`/`modifiers`:

--- a/docs/features/keybinding-editor.md
+++ b/docs/features/keybinding-editor.md
@@ -109,7 +109,7 @@ Each binding in `config.json` has this structure:
 
 | Field | Description |
 |-------|-------------|
-| `key` | The key name (e.g., `"s"`, `"Enter"`, `"F1"`, `"Up"`) |
+| `key` | The key name (e.g., `"s"`, `"Enter"`, `"F1"`, `"Up"`) — see [Key Names](../configuration/keyboard.md#key-names) for every accepted spelling |
 | `modifiers` | Array of modifier keys: `"ctrl"`, `"alt"`, `"shift"`, `"super"` |
 | `action` | The action to trigger (see action list via autocomplete in the editor) |
 | `when` | Context when this binding is active (optional, defaults to `"normal"`) |


### PR DESCRIPTION
## What this is for

Two things a reader could not do.

**Read a match that is not near the start of its line.** A Search & Replace row showed one window onto its line and nothing could move it — so on a minified file, a long prose line, or anything behind wide characters, the match sat off the edge with no way to bring it into view. Issue #1580; #3154 fixed where the window rests and stopped there.

**Bind a key by its name.** Most keypad names, the media keys and the modifier keys parsed as nothing, and an entry naming one was dropped at load with a warning badge and no explanation. Issue #1128.

---

## Before and after

### Reading a long match

The fixture is a 400-column line with markers at each end and the match in the middle, plus a short line and one behind 60 CJK characters.

**Before.** The long row shows the head of the line and the match is nowhere on screen; the wide-character row is drawn past the panel edge and cut by the terminal. `Shift`+arrows and `Shift`+wheel do nothing at all:

```
[v] cjk.txt:1   - 漢                                                                              needleyyyyyyyyyyyyyy
[v] long.txt:1  - HEADMARK xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
[v] plain.txt:1 - alpha needle beta
```

**After.** Every row rests on its own match and fits the panel:

```
[v] cjk.txt:1   - 漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢漢needleyyyyyyyyyyyyy…
[v] long.txt:1  - …xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxneedleyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy…
[v] plain.txt:1 - alpha needle beta
```

`Shift+Right` — the tail of the line, and the marker at the far end:

```
[v] long.txt:1  - …yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyTAILMARKzzzzzzzzzzzzzzzzzzzzzzzzzzzz…
[v] plain.txt:1 - alpha needle beta
```

`Shift+Left` — the head, which nothing could reach before:

```
[v] long.txt:1  - HEADMARK xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
[v] plain.txt:1 - alpha needle beta
```

`Shift+Home` returns every row to its own match. `Shift+End` takes the row you are on to the end of its line. `path:line` never moves — it is which match the row *is* — and `plain.txt`, which already fits, never moves either.

### `Ctrl`+arrow in the panel

The panel focuses its results tree once a search settles, so this is where a reader lands after typing.

| | |
|---|---|
| **before** | `Ctrl+Left` changes the status bar — `Ln 1, Col 17` → `Col 11` → `Col 10` — while nothing on screen moves. The key reaches the buffer behind the panel and runs a word-wise motion on a cursor nobody can see. |
| **after** | The status bar does not move. In a search field the same chord moves by word, which is what it means. `Ctrl+PageUp`/`PageDown` still switch buffers. |

### `Shift`+wheel

| | |
|---|---|
| **before** | Scrolls vertically — the same as not holding Shift. Terminals report the gesture as an ordinary vertical notch with the modifier set, and nothing read the modifier. |
| **after** | Scrolls sideways, over the results and over an ordinary buffer, one pan step a notch. |

### Binding a keypad key

With `{ "key": "kp_enter", "modifiers": ["ctrl"], "action": "duplicate_line" }` in the config:

| | |
|---|---|
| **before** | `[⚠ 1]` in the status bar — the entry did not parse and was dropped |
| **after** | No warning, and `Ctrl+Enter` duplicates the line |

The same for `kp_0`…`kp_9`, `kp_equal`, the keypad navigation keys, the media keys and the modifier keys. `docs/configuration/keyboard.md` now lists every name that parses, including the honest part: a terminal reports keypad keys as their main-keyboard equivalents, so `kp_multiply` is an alias for `*` rather than a key of its own.

---

## How, briefly

**Panning.** The plugin used to cut each row to the panel's width before the host saw it, so there was nothing to the left of the window and nothing to the right. It now sends the row whole and says which part matters; the host does the fitting. That is the division of labour the vertical axis already has, and it is why a pan costs no plugin work and no round trip — one number moves and the visible rows repaint.

The pan is one number shared by every row, applied as an offset from where each rests and clamped per row against what that row can show. Rows of different lengths slide together rather than drifting apart, and "pan to the end" is answered for the row under the selection, since rows of unequal length cannot all be at their end at once. The fit is measured in display columns rather than codepoints, which is what fixes the wide-character case.

**Key names.** "What does this key mean" was written out once per terminal encoding the input parser decodes, and again — partially — as a list of names the config accepts, so extending one never extended the others. There is now one table per family, in the parser, and both sides resolve through it. Coverage stops being something to maintain, the keyboard reference is generated from those tables, and a test fails when the two drift.

## Try it

<details>
<summary><b>Setup</b> — copy-pasteable, uses a scratch <code>HOME</code> so your own config is untouched</summary>

```sh
cargo build
FRESH=$PWD/target/debug/fresh

mkdir -p /tmp/srdemo && cd /tmp/srdemo && git init -q
printf 'alpha needle beta\n' > plain.txt
python3 - <<'EOF'
open("long.txt", "w").write("HEADMARK " + "x"*250 + "needle" + "y"*100 + "TAILMARK" + "z"*30 + "\n")
open("cjk.txt",  "w").write("漢"*60  + "needle" + "y"*200 + "ENDMARK\n")
EOF

export DEMO_HOME=/tmp/srdemo-home
mkdir -p "$DEMO_HOME/.config/fresh"
cat > "$DEMO_HOME/.config/fresh/config.json" <<'JSON'
{ "keybindings": [ { "key": "kp_enter", "modifiers": ["ctrl"], "action": "duplicate_line" } ] }
JSON

HOME="$DEMO_HOME" "$FRESH" --no-restore
```

If you compare against `master`, use a **separate `HOME` per binary**: the embedded-plugin cache is shared, and reusing one silently runs the other build's plugin.
</details>

`Alt+A`, type `needle`, `Down` onto a match row. Then `Shift+Left` / `Shift+Right`, `Shift+Home` / `Shift+End`, `Shift`+wheel, and `Ctrl`+arrows. With focus in the **Search** field instead of the tree, `Shift+Left` still extends the selection and the rows do not move.

## Notes

- **`Shift`+wheel changes ordinary buffers too**, not just this panel. Flagged because it is user-visible beyond the issue; the alternative is two rules for one gesture.
- A match row's payload grows, since a row has to carry more than the visible slice for there to be anything to pan onto. Bounded, and disclosed — the per-frame cost that amplifies it is pre-existing and filed as #3195.
- The general codepoint-versus-display-column confusion elsewhere in this layer is #3185. This change is column-correct on the path it adds, which is what fixes the symptom; changing what the existing width hints *mean* is a contract change with every widget as a consumer.
- The originally reported #1128 symptom — `Ctrl+*` stripped by a legacy-encoding terminal before Fresh sees the key — is not fixable here and is untouched.

Closes #1128, closes #3186. Refs #1580, #3185, #3195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187KwTwpiLC2xQrfFiwJtum