### PR TITLE
Feature clips live next to the features they film, and one for the chrome migration

### DIFF
--- a/scripts/clips/README.md
+++ b/scripts/clips/README.md
@@ -29,6 +29,7 @@ specific to filming *this* program.
 | `fresh-markdown-compose.json` | comparison | Compose mode against a released build |
 | `fresh-markdown-compose-solo.json` | solo | the same, with nothing to compare against |
 | `fresh-markdown-toc.json` | solo | the table-of-contents panel following the cursor |
+| `fresh-popup-rect.json` | solo, before/after | one popup placed by arithmetic, then declared |
 | `fresh-review-syntax.json` | comparison | source highlighted inside a Review Diff stream |
 | `fresh-ui-anatomy.json` | explode | the retained UI tree, one element at a time |
 
@@ -36,7 +37,10 @@ specific to filming *this* program.
 capture gets a deliberate theme and a known set of enabled plugins instead of
 whatever the machine happens to have. `assets/fresh-review-syntax/make-repo.sh`
 builds the demo repo that clip reviews — Review Diff reads a working tree, so
-the diff on screen has to come from a real one.
+the diff on screen has to come from a real one — and
+`assets/fresh-popup-rect/make-files.sh` writes two versions of one function
+straight out of git, checking that the lines it films are still the ones it
+means to.
 
 ## Filming fresh specifically
 
@@ -72,6 +76,13 @@ or an explode piece wants:
 Bind a key rather than running the command from the palette: the dump is of the
 frame the *last* paint built, which for a palette invocation is the frame with
 the palette open over everything.
+
+**Filming code? Open the file past the function, not at it.** The editor puts
+the caret's line in the middle of the viewport, so opening at `file:N+20` lands
+line `N` at the top — which is how a function's doc comment ends up above the
+screen rather than on it. A clip makes its own argument in its own captions;
+the source's comments are not evidence, and reading them is not what the eye
+should be doing.
 
 **Park the caret on a blank line.** Compose mode and other rendering modes
 reveal the raw source of the caret's line, which reads as a rendering flaw to

--- a/scripts/clips/README.md
+++ b/scripts/clips/README.md
@@ -1,0 +1,81 @@
+# Feature clips
+
+Short annotated videos of a fresh feature — a before/after of one change, one
+screen on its own, or one screen taken apart into the elements behind it. Each
+`.json` here is a spec for [tui-clips](https://github.com/sinelaw/tui-clips),
+which drives a real fresh in a headless terminal, screenshots it, and renders
+the result. The specs live here, next to the features they film; the renderer
+lives there.
+
+```sh
+git clone https://github.com/sinelaw/tui-clips ~/repos/tui-clips
+~/repos/tui-clips/bin/tui-clip ~/repos/fresh/scripts/clips/fresh-review-syntax.json
+```
+
+Needs `Xvfb`, `xfce4-terminal`, `xdotool`, ImageMagick, `ffmpeg`, and Python
+with Pillow. It runs headless, so nothing touches the terminal or the editor
+you have open. Captures and the finished mp4 land under `tui-clips/out/`, not
+here. While iterating, `--stills` captures without rendering and
+`--skip-capture` re-renders from what it already captured.
+
+The spec format — the three clip shapes, how a beat is framed, shots, explode
+trees — is documented in the tui-clips README. What follows is only what is
+specific to filming *this* program.
+
+## The clips
+
+| Spec | Shape | Shows |
+|---|---|---|
+| `fresh-markdown-compose.json` | comparison | Compose mode against a released build |
+| `fresh-markdown-compose-solo.json` | solo | the same, with nothing to compare against |
+| `fresh-markdown-toc.json` | solo | the table-of-contents panel following the cursor |
+| `fresh-review-syntax.json` | comparison | source highlighted inside a Review Diff stream |
+| `fresh-ui-anatomy.json` | explode | the retained UI tree, one element at a time |
+
+`assets/<clip>/fresh/config.json` is a config directory a spec copies in, so a
+capture gets a deliberate theme and a known set of enabled plugins instead of
+whatever the machine happens to have. `assets/fresh-review-syntax/make-repo.sh`
+builds the demo repo that clip reviews — Review Diff reads a working tree, so
+the diff on screen has to come from a real one.
+
+## Filming fresh specifically
+
+**Point it at a debug build, and check the build is current.** The specs run
+`~/repos/fresh/target/debug/fresh`. Plugins are embedded into the binary at
+build time (`include_dir!` over `crates/fresh-editor/plugins`), so a stale
+binary silently films the *old* plugin — the feature simply will not be there,
+with nothing on screen to say why. `cargo build -p fresh-editor` first, and if
+a clip is meant to show a plugin change, confirm the binary has it:
+
+```sh
+strings -a target/debug/fresh | grep -c setSyntaxRegions
+```
+
+Debug builds paint slowly; give the pane a `settle` of 16-18s.
+
+**Give every pane its own `XDG_RUNTIME_DIR`.** Shared, the second pane attaches
+to the daemon the first one left running and shows that pane's project root
+rather than its own — a comparison clip where both sides film the same build.
+`{scratch}/run-{pane}` is the fix, alongside per-pane `XDG_DATA_HOME` and
+`XDG_STATE_HOME`.
+
+**Read the band rows off the UI tree, not off a grid.** Bind a key to
+`dump_ui_tree` in the clip's config asset, press it while the screen you are
+filming is up, and `ctrl+s` on the read-only `*ui-tree*` buffer offers Save As.
+That gives you every laid-out rect in cells, which is what an annotation band
+or an explode piece wants:
+
+```sh
+~/repos/tui-clips/bin/tui-tree tree.json --list
+```
+
+Bind a key rather than running the command from the palette: the dump is of the
+frame the *last* paint built, which for a palette invocation is the frame with
+the palette open over everything.
+
+**Park the caret on a blank line.** Compose mode and other rendering modes
+reveal the raw source of the caret's line, which reads as a rendering flaw to
+anyone who does not know the editor.
+
+**Capture more rows than fit.** The camera pans vertically over the capture, so
+a screen that exactly fills the frame has nowhere to travel.

--- a/scripts/clips/assets/fresh-markdown-toc/fresh/config.json
+++ b/scripts/clips/assets/fresh-markdown-toc/fresh/config.json
@@ -1,0 +1,37 @@
+{
+  "theme": "builtin://dracula",
+  "check_for_updates": false,
+  "file_explorer": {
+    "width": "36"
+  },
+  "languages": {
+    "markdown": {
+      "page_width": 104
+    }
+  },
+  "plugins": {
+    "markdown_compose": {
+      "enabled": true
+    },
+    "markdown_toc": {
+      "enabled": true,
+      "settings": {
+        "rows": 26,
+        "follow": "cursor",
+        "autoOpen": true
+      }
+    },
+    "dashboard": {
+      "enabled": false
+    },
+    "git_heatmap": {
+      "enabled": false
+    },
+    "orchestrator": {
+      "enabled": false
+    },
+    "vi_mode": {
+      "enabled": false
+    }
+  }
+}

--- a/scripts/clips/assets/fresh-popup-rect/fresh/config.json
+++ b/scripts/clips/assets/fresh-popup-rect/fresh/config.json
@@ -1,0 +1,11 @@
+{
+  "theme": "builtin://dracula",
+  "check_for_updates": false,
+  "plugins": {
+    "dashboard": { "enabled": false },
+    "git_heatmap": { "enabled": false },
+    "orchestrator": { "enabled": false },
+    "vi_mode": { "enabled": false },
+    "markdown_compose": { "enabled": false }
+  }
+}

--- a/scripts/clips/assets/fresh-popup-rect/fresh/config.json
+++ b/scripts/clips/assets/fresh-popup-rect/fresh/config.json
@@ -2,10 +2,23 @@
   "theme": "builtin://dracula",
   "check_for_updates": false,
   "plugins": {
-    "dashboard": { "enabled": false },
-    "git_heatmap": { "enabled": false },
-    "orchestrator": { "enabled": false },
-    "vi_mode": { "enabled": false },
-    "markdown_compose": { "enabled": false }
+    "dashboard": {
+      "enabled": false
+    },
+    "git_heatmap": {
+      "enabled": false
+    },
+    "orchestrator": {
+      "enabled": false
+    },
+    "vi_mode": {
+      "enabled": false
+    },
+    "markdown_compose": {
+      "enabled": false
+    }
+  },
+  "editor": {
+    "line_numbers": false
   }
 }

--- a/scripts/clips/assets/fresh-popup-rect/make-files.sh
+++ b/scripts/clips/assets/fresh-popup-rect/make-files.sh
@@ -1,31 +1,99 @@
 #!/usr/bin/env bash
-# Materialise the two files the fresh-popup-rect clip films.
+# Materialise the files the fresh-popup-rect clip films.
 #
-# One job — place a popup near a screen edge — spelled twice, four months
-# apart. BEFORE is the commit #3028 branched from; AFTER is what master has
-# today (the file has not changed since that PR merged, so "after" and "now"
-# are the same thing). Both come straight out of git: no excerpting, no
-# editing, so what the clip shows is what shipped.
+# One job — put a popup on screen near an edge, and take it away again — as
+# it was written before #3028 and as it is written now. BEFORE is the commit
+# that PR branched from; AFTER is what master has today, the file being
+# unchanged since it merged, so "after" and "now" are the same thing.
+#
+# Whole files, straight out of git, with two mechanical edits.
+#
+# Comments are stripped: the clip makes its argument in its own captions, and
+# a reader who stops to read a `// +2 for borders` has stopped looking at the
+# shape of the code, which is the only thing the clip is about.
+#
+# Then rustfmt re-wraps at MAXCOL. A line wider than the terminal wraps on
+# screen, which puts a continuation row in the middle of a beat and makes a
+# line look like two — and a beat framed on a rect of rows cannot survive
+# that. Re-wrapping is rustfmt's own judgement about the same code, not an
+# edit to it; no excerpting, no rewriting, so every line on screen is a line
+# that shipped.
+#
+# Basenames are distinct because the tab bar shows basenames, and two tabs
+# reading `theme_info.rs` would be a puzzle rather than a comparison.
 #
 #   ./make-files.sh /path/to/dir
 set -euo pipefail
 OUT="${1:?usage: make-files.sh <dir>}"
 REPO="${FRESH_REPO:-$HOME/repos/fresh}"
 BEFORE_REF=93741f1e
+MAXCOL=68
 AFTER_REF=origin/master
 
 rm -rf "$OUT"
 mkdir -p "$OUT/before" "$OUT/after"
-git -C "$REPO" show "$BEFORE_REF:crates/fresh-editor/src/app/theme_inspect.rs" \
-  > "$OUT/before/theme_inspect.rs"
-git -C "$REPO" show "$AFTER_REF:crates/fresh-editor/src/view/shell/theme_info.rs" \
-  > "$OUT/after/theme_info.rs"
 
-# The line each screen opens on, checked here rather than trusted: a rebase
-# upstream moves them, and a clip that silently films the wrong function is
-# worse than one that fails to build.
-grep -q '^fn compute_popup_rect($' <(sed -n '338p' "$OUT/before/theme_inspect.rs") \
-  || { echo "before/theme_inspect.rs:338 is not compute_popup_rect" >&2; exit 1; }
-grep -q '^pub fn layer(t: &ThemeInfo) -> Node<UiMsg> {$' <(sed -n '73p' "$OUT/after/theme_info.rs") \
-  || { echo "after/theme_info.rs:73 is not layer()" >&2; exit 1; }
+strip() {
+  python3 -c '
+import sys, re
+out, blanks = [], 0
+for line in sys.stdin.read().splitlines():
+    t = line.strip()
+    if t.startswith("//"):            # a whole line of comment: gone
+        continue
+    # a trailing comment, but only where the "//" is not inside a string
+    i = line.find("//")
+    while i != -1:
+        if line[:i].count(chr(34)) % 2 == 0:
+            line = line[:i].rstrip()
+            break
+        i = line.find("//", i + 2)
+    if not line.strip():
+        blanks += 1
+        if blanks > 1:                 # the gaps comments leave behind
+            continue
+    else:
+        blanks = 0
+    out.append(line)
+while out and not out[-1].strip():
+    out.pop()
+print("\n".join(out))
+'
+}
+
+emit() {   # <ref>:<path> <out>
+  git -C "$REPO" show "$1" | strip > "$2"
+  rustfmt --edition 2021 --config max_width=$MAXCOL "$2"
+  # A handful of lines have nothing to break on -- a long string literal, a
+  # deep path -- and rustfmt leaves them. They only matter if one lands in a
+  # filmed region, where a wrap would put a continuation row in the middle of
+  # a beat, so this reports them and the anchors are checked separately.
+  awk -v m=$MAXCOL -v f="$2" 'length>m {print "  wide: "f":"FNR" ("length")"}' "$2"
+}
+emit "$BEFORE_REF:crates/fresh-editor/src/app/chrome/theme_info.rs" \
+     "$OUT/before/chrome_theme_info.rs"
+emit "$BEFORE_REF:crates/fresh-editor/src/app/theme_inspect.rs" \
+     "$OUT/before/theme_inspect.rs"
+emit "$AFTER_REF:crates/fresh-editor/src/view/shell/theme_info.rs" \
+     "$OUT/after/shell_theme_info.rs"
+
+# Where each screen opens. Stripping moves every line, so the clip cannot
+# hold line numbers: it asks for these anchors and gets told where they are.
+# A rebase upstream that moves the code fails here rather than filming the
+# wrong function.
+echo "anchors:"
+anchor() {
+  local f="$1" pat="$2"
+  local n
+  n=$(grep -n -m1 -- "$pat" "$OUT/$f" | cut -d: -f1) \
+    || { echo "not found in $f: $pat" >&2; exit 1; }
+  [ -n "$n" ] || { echo "not found in $f: $pat" >&2; exit 1; }
+  printf '  %-28s %-34s %s\n' "$(basename "$f")" "$pat" "$n"
+}
+anchor before/chrome_theme_info.rs 'fn collect'
+anchor before/chrome_theme_info.rs 'theme_info_guard", PointerPress::Left'
+anchor before/theme_inspect.rs     'let height = lines.len()'
+anchor before/theme_inspect.rs     'let height = line_count'
+anchor before/theme_inspect.rs     'fn compute_popup_rect'
+anchor after/shell_theme_info.rs   'pub fn layer'
 echo "files ready: $OUT"

--- a/scripts/clips/assets/fresh-popup-rect/make-files.sh
+++ b/scripts/clips/assets/fresh-popup-rect/make-files.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Materialise the two files the fresh-popup-rect clip films.
+#
+# One job — place a popup near a screen edge — spelled twice, four months
+# apart. BEFORE is the commit #3028 branched from; AFTER is what master has
+# today (the file has not changed since that PR merged, so "after" and "now"
+# are the same thing). Both come straight out of git: no excerpting, no
+# editing, so what the clip shows is what shipped.
+#
+#   ./make-files.sh /path/to/dir
+set -euo pipefail
+OUT="${1:?usage: make-files.sh <dir>}"
+REPO="${FRESH_REPO:-$HOME/repos/fresh}"
+BEFORE_REF=93741f1e
+AFTER_REF=origin/master
+
+rm -rf "$OUT"
+mkdir -p "$OUT/before" "$OUT/after"
+git -C "$REPO" show "$BEFORE_REF:crates/fresh-editor/src/app/theme_inspect.rs" \
+  > "$OUT/before/theme_inspect.rs"
+git -C "$REPO" show "$AFTER_REF:crates/fresh-editor/src/view/shell/theme_info.rs" \
+  > "$OUT/after/theme_info.rs"
+
+# The line each screen opens on, checked here rather than trusted: a rebase
+# upstream moves them, and a clip that silently films the wrong function is
+# worse than one that fails to build.
+grep -q '^fn compute_popup_rect($' <(sed -n '338p' "$OUT/before/theme_inspect.rs") \
+  || { echo "before/theme_inspect.rs:338 is not compute_popup_rect" >&2; exit 1; }
+grep -q '^pub fn layer(t: &ThemeInfo) -> Node<UiMsg> {$' <(sed -n '73p' "$OUT/after/theme_info.rs") \
+  || { echo "after/theme_info.rs:73 is not layer()" >&2; exit 1; }
+echo "files ready: $OUT"

--- a/scripts/clips/assets/fresh-review-syntax/fresh/config.json
+++ b/scripts/clips/assets/fresh-review-syntax/fresh/config.json
@@ -1,0 +1,19 @@
+{
+  "theme": "builtin://dracula",
+  "check_for_updates": false,
+  "keybindings": [
+    {
+      "key": "F9",
+      "modifiers": [],
+      "action": "dump_ui_tree",
+      "when": "normal"
+    }
+  ],
+  "plugins": {
+    "audit_mode": { "enabled": true },
+    "dashboard": { "enabled": false },
+    "git_heatmap": { "enabled": false },
+    "orchestrator": { "enabled": false },
+    "vi_mode": { "enabled": false }
+  }
+}

--- a/scripts/clips/assets/fresh-review-syntax/make-repo.sh
+++ b/scripts/clips/assets/fresh-review-syntax/make-repo.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Materialise the demo repo the fresh-review-syntax clip reviews.
+#
+# Review Diff shows the working tree against HEAD, so the repo is built in two
+# passes: commit the "before" files, then overwrite them with the "after" ones.
+# Rebuild it from scratch any time; nothing here is precious.
+#
+# Every line is kept to MAXCOL columns, and the script checks it: the clip
+# captures 64 cells, the diff gutter takes twelve of them and the fold column
+# and scrollbar two more, so a longer line is a line the viewer sees cut off.
+#
+#   ./make-repo.sh /path/to/repo
+set -euo pipefail
+REPO="${1:?usage: make-repo.sh <dir>}"
+MAXCOL=49
+rm -rf "$REPO"
+mkdir -p "$REPO/src" "$REPO/web" "$REPO/scripts"
+
+# ---------------------------------------------------------------- before ----
+cat > "$REPO/src/limiter.rs" <<'EOF'
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// One token bucket per client key.
+#[derive(Debug, Clone)]
+pub struct Bucket {
+    tokens: f64,
+    last: Instant,
+}
+
+impl Bucket {
+    fn new(tokens: f64, last: Instant) -> Self {
+        Self { tokens, last }
+    }
+}
+
+pub struct RateLimiter {
+    buckets: HashMap<String, Bucket>,
+    rate: f64,
+    burst: f64,
+}
+
+impl RateLimiter {
+    /// Take a token, if one is there to take.
+    pub fn allow(&mut self, k: &str) -> bool {
+        let b = self.fill(k);
+        if b.tokens >= 1.0 {
+            b.tokens -= 1.0;
+            return true;
+        }
+        false
+    }
+
+    fn fill(&mut self, k: &str) -> &mut Bucket {
+        let burst = self.burst;
+        let rate = self.rate;
+        let at = Instant::now();
+        let b = self.buckets.entry(k.to_owned())
+            .or_insert(Bucket::new(burst, at));
+        let dt = at - b.last;
+        b.tokens += dt.as_secs_f64() * rate;
+        b.tokens = b.tokens.min(burst);
+        b.last = at;
+        b
+    }
+}
+EOF
+
+cat > "$REPO/web/dashboard.ts" <<'EOF'
+export interface Sample {
+  at: number;
+  allowed: number;
+  denied: number;
+}
+
+const WINDOW_MS = 60_000;
+
+const sum = (rows: Sample[], k: keyof Sample) =>
+  rows.reduce((n, s) => n + (s[k] ?? 0), 0);
+
+export function summary(rows: Sample[]): string {
+  const cut = Date.now() - WINDOW_MS;
+  const live = rows.filter((s) => s.at >= cut);
+  const ok = sum(live, "allowed");
+  const no = sum(live, "denied");
+  return `${ok} allowed, ${no} denied`;
+}
+EOF
+
+cat > "$REPO/scripts/replay.py" <<'EOF'
+"""Replay a request log through the limiter."""
+
+import json
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class Request:
+    key: str
+    at: float
+
+
+def load(path: str) -> list[Request]:
+    with open(path) as fh:
+        rows = json.load(fh)
+    return [Request(**r) for r in rows]
+
+
+def main() -> int:
+    for req in load(sys.argv[1]):
+        print(f"{req.at:>10.3f} {req.key}")
+    return 0
+EOF
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "demo@example.com"
+git -C "$REPO" config user.name "Demo"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "Token-bucket rate limiter"
+
+# ----------------------------------------------------------------- after ----
+cat > "$REPO/src/limiter.rs" <<'EOF'
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// One token bucket per client key.
+#[derive(Debug, Clone)]
+pub struct Bucket {
+    tokens: f64,
+    last: Instant,
+}
+
+impl Bucket {
+    fn new(tokens: f64, last: Instant) -> Self {
+        Self { tokens, last }
+    }
+}
+
+pub struct RateLimiter {
+    buckets: HashMap<String, Bucket>,
+    rate: f64,
+    burst: f64,
+}
+
+/// What a caller is told when the bucket is dry.
+#[derive(Debug, PartialEq)]
+pub enum Verdict {
+    Allow,
+    Deny { retry_after: Duration },
+}
+
+impl RateLimiter {
+    /// Take a token, or say when one turns up.
+    pub fn allow(&mut self, k: &str) -> Verdict {
+        let rate = self.rate;
+        let b = self.fill(k);
+        if b.tokens >= 1.0 {
+            b.tokens -= 1.0;
+            return Verdict::Allow;
+        }
+        let short_by = 1.0 - b.tokens;
+        Verdict::Deny {
+            retry_after: Duration::from_secs_f64(
+                short_by / rate,
+            ),
+        }
+    }
+
+    fn fill(&mut self, k: &str) -> &mut Bucket {
+        let burst = self.burst;
+        let rate = self.rate;
+        let at = Instant::now();
+        let b = self.buckets.entry(k.to_owned())
+            .or_insert(Bucket::new(burst, at));
+        let dt = at - b.last;
+        b.tokens += dt.as_secs_f64() * rate;
+        b.tokens = b.tokens.min(burst);
+        b.last = at;
+        b
+    }
+
+    /// Drop buckets left full and idle.
+    pub fn sweep(&mut self, idle: Duration) {
+        let burst = self.burst;
+        let now = Instant::now();
+        self.buckets.retain(|_, b| {
+            let idled = now - b.last;
+            b.tokens < burst || idled < idle
+        });
+    }
+}
+EOF
+
+cat > "$REPO/web/dashboard.ts" <<'EOF'
+export interface Sample {
+  at: number;
+  allowed: number;
+  denied: number;
+  retryMs?: number;
+}
+
+const WINDOW_MS = 60_000;
+
+const sum = (rows: Sample[], k: keyof Sample) =>
+  rows.reduce((n, s) => n + (s[k] ?? 0), 0);
+
+const backoff = (s: Sample) => s.retryMs ?? 0;
+
+export function summary(rows: Sample[]): string {
+  const cut = Date.now() - WINDOW_MS;
+  const live = rows.filter((s) => s.at >= cut);
+  const ok = sum(live, "allowed");
+  const no = sum(live, "denied");
+  if (no === 0) return `${ok} allowed, 0 denied`;
+  const ms = Math.max(0, ...live.map(backoff));
+  return `${ok} ok, ${no} denied, wait ${ms}ms`;
+}
+EOF
+
+cat > "$REPO/scripts/replay.py" <<'EOF'
+"""Replay a request log through the limiter.
+
+Rows are read as JSON so one log replays against
+a capture taken from production, where the clock
+is the only thing that differs.
+"""
+
+import json
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class Request:
+    key: str
+    at: float
+    weight: int = 1
+
+
+def load(path: str) -> list[Request]:
+    with open(path) as fh:
+        rows = json.load(fh)
+    return [Request(**r) for r in rows]
+
+
+def main() -> int:
+    for req in load(sys.argv[1]):
+        w = req.weight
+        print(f"{req.at:>10.3f} {req.key} x{w}")
+    return 0
+EOF
+
+over=$(awk -v m="$MAXCOL" 'length>m {print FILENAME":"FNR" is "length" columns"}' \
+  "$REPO/src/limiter.rs" "$REPO/web/dashboard.ts" "$REPO/scripts/replay.py")
+if [[ -n "$over" ]]; then
+  echo "lines over $MAXCOL columns:" >&2; echo "$over" >&2; exit 1
+fi
+echo "repo ready: $REPO"

--- a/scripts/clips/fresh-markdown-compose-solo.json
+++ b/scripts/clips/fresh-markdown-compose-solo.json
@@ -1,0 +1,50 @@
+{
+  "name": "fresh-markdown-compose-solo",
+  "capture": {
+    "geometry": "64x50",
+    "font": "JetBrains Mono 21",
+    "screen": "1600x2200x24",
+    "display": ":99",
+    "copy_files": ["~/repos/fresh/CONTRIBUTING.md"],
+    "env": {
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run"
+    },
+    "keys": [
+      {"key": "ctrl+p"},
+      {"type": "toggle compose"},
+      {"key": "Return"}
+    ],
+    "panes": {
+      "compose": {
+        "argv": ["~/repos/fresh/target/debug/fresh", "--no-restore",
+                 "--no-upgrade-check", "CONTRIBUTING.md:39:1"],
+        "settle": 16
+      }
+    }
+  },
+  "render": {
+    "size": [1080, 1080],
+    "fps": 60,
+    "rows": 50,
+    "cols": 64,
+    "title": "fresh · markdown compose",
+    "labels": {"solo": "NEW"},
+    "intro_caption": ["Compose mode",
+                      "markdown laid out as markdown, in the editor"],
+    "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
+    "timing": {"intro": 1.8, "zoom": 0.8, "hold": 1.8, "pan": 0.4, "outro": 1.0},
+    "annotations": [
+      {"rows": [3, 7],   "cols": [0.2, 62.5],
+       "head": "Hard wraps rejoin",
+       "sub": "one paragraph, filled to the measure"},
+      {"rows": [15, 22], "cols": [2.3, 62.5],
+       "head": "Continuations hang",
+       "sub": "wrapped list text keeps the item's column"},
+      {"rows": [27, 33], "cols": [2.5, 59.5],
+       "head": "Code blocks sit inline",
+       "sub": "framed at the column of the block itself"}
+    ]
+  },
+  "encode": {"crf": 18, "preset": "slow"}
+}

--- a/scripts/clips/fresh-markdown-compose.json
+++ b/scripts/clips/fresh-markdown-compose.json
@@ -1,0 +1,56 @@
+{
+  "name": "fresh-markdown-compose",
+  "capture": {
+    "geometry": "64x50",
+    "font": "JetBrains Mono 21",
+    "screen": "1600x2200x24",
+    "display": ":99",
+    "settle": 8,
+    "copy_files": ["~/repos/fresh/CONTRIBUTING.md"],
+    "env": {
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run"
+    },
+    "keys": [
+      {"key": "ctrl+p"},
+      {"type": "toggle compose"},
+      {"key": "Return"}
+    ],
+    "panes": {
+      "before": {
+        "argv": ["~/.local/bin/fresh", "--no-restore", "--no-upgrade-check",
+                 "CONTRIBUTING.md:39:1"],
+        "settle": 8
+      },
+      "after": {
+        "argv": ["~/repos/fresh/target/debug/fresh", "--no-restore",
+                 "--no-upgrade-check", "CONTRIBUTING.md:39:1"],
+        "settle": 16
+      }
+    }
+  },
+  "render": {
+    "size": [1080, 1080],
+    "fps": 60,
+    "rows": 50,
+    "cols": 64,
+    "title": "fresh · markdown compose",
+    "labels": {"before": "BEFORE", "after": "AFTER"},
+    "intro_caption": ["Same file, same width",
+                      "only the markdown rendering changed"],
+    "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
+    "timing": {"intro": 2.1, "swipe": 0.8, "hold": 1.8, "pan": 0.4, "outro": 1.0},
+    "annotations": [
+      {"rows": [3, 7],   "cols": [0.2, 62.5],
+       "head": "Hard wraps rejoin",
+       "sub": "one paragraph, filled to the measure"},
+      {"rows": [15, 22], "cols": [2.3, 62.5],
+       "head": "Continuations hang",
+       "sub": "wrapped list text keeps the item's column"},
+      {"rows": [27, 33], "cols": [2.5, 59.5],
+       "head": "Code blocks sit inline",
+       "sub": "framed at the column of the block itself"}
+    ]
+  },
+  "encode": {"crf": 18, "preset": "slow"}
+}

--- a/scripts/clips/fresh-markdown-toc.json
+++ b/scripts/clips/fresh-markdown-toc.json
@@ -1,0 +1,482 @@
+{
+  "name": "fresh-markdown-toc",
+  "capture": {
+    "geometry": "147x46",
+    "font": "JetBrains Mono 17",
+    "screen": "2400x1900x24",
+    "display": ":99",
+    "settle": 18,
+    "copy_files": [
+      {
+        "src": "~/repos/fresh/docs/configuration/index.md",
+        "as": "configuration.md"
+      },
+      {
+        "src": "~/repos/fresh/docs/configuration/keyboard.md",
+        "as": "keybindings.md"
+      },
+      {
+        "src": "~/repos/fresh/docs/features/session-persistence.md",
+        "as": "daemon-mode.md"
+      },
+      "~/repos/fresh/docs/features/lsp.md",
+      "~/repos/fresh/docs/features/editing.md",
+      "~/repos/fresh/docs/architecture.md",
+      "~/repos/fresh/docs/troubleshooting.md",
+      "~/repos/fresh/docs/i18n.md",
+      "~/repos/fresh/README.md",
+      "~/repos/fresh/CONTRIBUTING.md"
+    ],
+    "copy_dirs": {
+      "~/repos/fresh/scripts/clips/assets/fresh-markdown-toc/fresh": "{scratch}/config/fresh"
+    },
+    "env": {
+      "XDG_CONFIG_HOME": "{scratch}/config",
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_STATE_HOME": "{scratch}/state-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run"
+    },
+    "keys": [
+      {
+        "key": "ctrl+e"
+      },
+      {
+        "sleep": 2
+      },
+      {
+        "key": "Escape"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "key": "ctrl+p"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "type": "toggle compose"
+      },
+      {
+        "sleep": 1.5
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 3
+      },
+      {
+        "shot": "rest"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s1"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s2"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s3"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s4"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s5"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s6"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s7"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s8"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s9"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s10"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s11"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s12"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s13"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s14"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s15"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s16"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s17"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s18"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s19"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s20"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s21"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s22"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s23"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s24"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s25"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s26"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s27"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s28"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s29"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s30"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s31"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s32"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s33"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s34"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s35"
+      },
+      {
+        "key": "Down",
+        "repeat": 5
+      },
+      {
+        "shot": "s36"
+      },
+      {
+        "sleep": 1
+      }
+    ],
+    "panes": {
+      "toc": {
+        "argv": [
+          "~/repos/fresh/target/debug/fresh",
+          "--no-restore",
+          "--no-upgrade-check",
+          "configuration.md:37:1"
+        ]
+      }
+    }
+  },
+  "render": {
+    "size": [
+      1920,
+      1080
+    ],
+    "fps": 60,
+    "rows": 46,
+    "cols": 147,
+    "title": "fresh \u00b7 markdown contents",
+    "labels": {
+      "solo": "NEW"
+    },
+    "intro_caption": [
+      "Contents, in the sidebar",
+      "the Markdown outline, following your caret"
+    ],
+    "outro_caption": [
+      "fresh",
+      "github.com/sinelaw/fresh"
+    ],
+    "timing": {
+      "intro": 1.0,
+      "zoom": 0.45,
+      "hold": 1.1,
+      "pan": 0.275,
+      "outro": 0.6
+    },
+    "theme": {
+      "bg": [
+        18,
+        19,
+        26
+      ],
+      "caption_bg": [
+        28,
+        29,
+        40
+      ],
+      "panel_border": [
+        68,
+        71,
+        90
+      ],
+      "muted": [
+        150,
+        157,
+        192
+      ],
+      "fg": [
+        248,
+        248,
+        242
+      ],
+      "after": [
+        80,
+        250,
+        123
+      ]
+    },
+    "annotations": [
+      {
+        "shot": "rest",
+        "rows": [
+          7.4,
+          44.8
+        ],
+        "cols": [
+          35.6,
+          146.6
+        ],
+        "head": "Markdown, laid out as markdown",
+        "sub": "compose mode: code framed, tables drawn, notes railed"
+      },
+      {
+        "shot": "rest",
+        "rows": [
+          17,
+          44
+        ],
+        "cols": [
+          0.25,
+          35
+        ],
+        "camera": "fit",
+        "head": "A Contents section",
+        "sub": "every heading of the buffer, as a tree, under the file explorer"
+      },
+      {
+        "shots": [
+          "rest",
+          "s1",
+          "s2",
+          "s3",
+          "s4",
+          "s5",
+          "s6",
+          "s7",
+          "s8",
+          "s9",
+          "s10",
+          "s11",
+          "s12",
+          "s13",
+          "s14",
+          "s15",
+          "s16",
+          "s17",
+          "s18",
+          "s19",
+          "s20",
+          "s21",
+          "s22",
+          "s23",
+          "s24",
+          "s25",
+          "s26",
+          "s27",
+          "s28",
+          "s29",
+          "s30",
+          "s31",
+          "s32",
+          "s33",
+          "s34",
+          "s35",
+          "s36"
+        ],
+        "band": false,
+        "hold": 2.2,
+        "rows": [
+          19,
+          42
+        ],
+        "head": "The outline follows the caret",
+        "sub": "hold Down, and the lit row walks the outline with you"
+      }
+    ]
+  },
+  "encode": {
+    "crf": 18,
+    "preset": "slow"
+  }
+}

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -186,7 +186,7 @@
       "footer": {
         "added": 63164,
         "removed": 27662,
-        "note": "One example, out of two hundred and sixteen files",
+        "note": "Example: popups",
         "at": 0.0
       }
     },
@@ -256,8 +256,8 @@
       }
     },
     "intro_caption": [
-      "Show a popup, then dismiss it",
-      "what that took, before and after"
+      "",
+      ""
     ],
     "outro_caption": [
       "fresh",
@@ -323,7 +323,7 @@
           0,
           67
         ],
-        "note": "🧱 hand-stacked",
+        "note": "🧱 Old code: hand-stacked",
         "note_at": "below-right"
       },
       {
@@ -407,7 +407,7 @@
           0,
           62
         ],
-        "note": "✨ declarative and clean",
+        "note": "😍 New code: declarative",
         "note_at": "below-right",
         "transition": "push",
         "hold": 1.6

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -170,24 +170,24 @@
         {
           "text": "Horrible Code",
           "effect": "sick",
-          "at": 0.04
+          "at": 0.0
         },
         {
           "text": "to",
-          "at": 0.34,
+          "at": 0.0,
           "small": true
         },
         {
           "text": "Declarative",
           "effect": "shine",
-          "at": 0.5
+          "at": 0.0
         }
       ],
       "footer": {
         "added": 63164,
         "removed": 27662,
         "note": "One example, out of two hundred and sixteen files",
-        "at": 0.62
+        "at": 0.0
       }
     },
     "labels": {
@@ -323,7 +323,7 @@
           0,
           67
         ],
-        "note": "☠ hand-stacked",
+        "note": "🧱 hand-stacked",
         "note_at": "below-right"
       },
       {
@@ -331,7 +331,6 @@
         "view": "dismiss",
         "label": "BEFORE",
         "tone": "before",
-        "transition": "push",
         "rows": [
           7,
           25
@@ -340,15 +339,15 @@
           0,
           66
         ],
-        "note": "↻ duplicated",
-        "note_at": "below-right"
+        "note": "🔁 duplicated",
+        "note_at": "below-right",
+        "transition": "push"
       },
       {
         "shot": "measure",
         "view": "measure",
         "label": "BEFORE",
         "tone": "before",
-        "transition": "push",
         "rows": [
           6,
           17
@@ -357,15 +356,15 @@
           0,
           52
         ],
-        "note": "⚠ manual",
-        "note_at": "below-right"
+        "note": "📐 manual",
+        "note_at": "below-right",
+        "transition": "push"
       },
       {
         "shot": "again",
         "view": "again",
         "label": "BEFORE",
         "tone": "before",
-        "transition": "push",
         "rows": [
           6,
           18
@@ -374,15 +373,15 @@
           0,
           62
         ],
-        "note": "☹ again",
-        "note_at": "below-right"
+        "note": "😵 again",
+        "note_at": "below-right",
+        "transition": "push"
       },
       {
         "shot": "clamp",
         "view": "clamp",
         "label": "BEFORE",
         "tone": "before",
-        "transition": "push",
         "rows": [
           11,
           22
@@ -391,42 +390,26 @@
           0,
           62
         ],
-        "note": "☠ again",
-        "note_at": "below-right"
+        "note": "🤯 again",
+        "note_at": "below-right",
+        "transition": "push"
       },
       {
         "shot": "after",
         "view": "after",
         "label": "AFTER",
         "tone": "after",
+        "rows": [
+          4,
+          20
+        ],
+        "cols": [
+          0,
+          62
+        ],
+        "note": "✨ declarative and clean",
+        "note_at": "below-right",
         "transition": "push",
-        "rows": [
-          4,
-          20
-        ],
-        "cols": [
-          0,
-          62
-        ],
-        "note": "★ declarative and clean",
-        "note_at": "below-right",
-        "hold": 1.6
-      },
-      {
-        "shot": "after",
-        "view": "after",
-        "label": "AFTER",
-        "tone": "after",
-        "rows": [
-          4,
-          20
-        ],
-        "cols": [
-          0,
-          62
-        ],
-        "note": "✓ position",
-        "note_at": "below-right",
         "hold": 1.6
       },
       {
@@ -442,7 +425,7 @@
           8,
           48
         ],
-        "note": "✓ layout",
+        "note": "✅ position",
         "note_at": "below-right"
       },
       {
@@ -458,7 +441,7 @@
           8,
           28
         ],
-        "note": "✓ input handling",
+        "note": "✅ layout",
         "note_at": "below-right"
       },
       {
@@ -474,7 +457,7 @@
           8,
           40
         ],
-        "note": "✓ sizing",
+        "note": "✅ input handling",
         "note_at": "below-right"
       },
       {
@@ -490,7 +473,7 @@
           8,
           60
         ],
-        "note": "✓ sizing",
+        "note": "✅ sizing",
         "note_at": "below-right"
       }
     ],

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -1,0 +1,121 @@
+{
+  "name": "fresh-popup-rect",
+
+  "_note": [
+    "Run assets/fresh-popup-rect/make-files.sh first; it writes the two",
+    "versions of one job — put a popup on screen near an edge — straight out",
+    "of git, so the clip films what shipped rather than an excerpt.",
+    "",
+    "Both screens come from one run of one editor: the two files open as tabs,",
+    "a shot is taken of the second, ctrl+PageUp switches to the first, and the",
+    "run ends there, so the establishing shot is the old code.",
+    "",
+    "Each file is opened twenty lines past the function, because the editor",
+    "puts the caret line in the middle: that lands the function's first line",
+    "at the top of the viewport and leaves its doc comment above it, off",
+    "screen. The clip argues in its own captions; the source's comments are",
+    "not evidence, and reading them is not what the eye should be doing."
+  ],
+
+  "capture": {
+    "geometry": "72x40",
+    "font": "JetBrains Mono 27",
+    "screen": "2000x2400x24",
+    "display": ":99",
+    "settle": 16,
+    "workdir": "~/repos/tui-clips/out/fresh-popup-rect-src",
+    "copy_dirs": {
+      "~/repos/fresh/scripts/clips/assets/fresh-popup-rect/fresh":
+        "{scratch}/config/fresh"
+    },
+    "env": {
+      "XDG_CONFIG_HOME": "{scratch}/config",
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_STATE_HOME": "{scratch}/state-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run-{pane}"
+    },
+    "keys": [
+      {"sleep": 2},
+      {"shot": "after"},
+      {"key": "ctrl+Prior"},
+      {"sleep": 2},
+      {"shot": "before"}
+    ],
+    "panes": {
+      "popup": {
+        "argv": ["~/repos/fresh/target/debug/fresh", "--no-restore",
+                 "--no-upgrade-check",
+                 "before/theme_inspect.rs:358", "after/theme_info.rs:93"]
+      }
+    }
+  },
+
+  "render": {
+    "size": [1080, 1080],
+    "header_height": 80,
+    "caption_height": 130,
+    "fps": 60,
+    "rows": 40,
+    "cols": 72,
+    "title": "fresh · one popup, near an edge",
+    "labels": {"solo": "BEFORE"},
+    "intro_caption": ["Put a popup on screen, near an edge",
+                      "the same job, two years apart"],
+    "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
+    "timing": {"intro": 2.0, "zoom": 0.7, "hold": 1.5, "pan": 0.35,
+               "push": 0.9, "outro": 1.0},
+    "theme": {
+      "bg": [21, 22, 30],
+      "caption_bg": [30, 31, 41],
+      "panel_border": [56, 58, 74],
+      "muted": [140, 142, 160],
+      "fg": [240, 240, 246],
+      "before": [255, 121, 128],
+      "after": [80, 250, 123]
+    },
+    "annotations": [
+      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+       "head": "app/theme_inspect.rs",
+       "rows": [2, 9], "cols": [6, 31],
+       "note": "five numbers in, one rect out", "note_at": "below-right"},
+
+      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+       "head": "app/theme_inspect.rs",
+       "rows": [9, 14], "cols": [10, 54],
+       "note": "off the right edge: shove it left", "note_at": "below-right"},
+
+      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+       "head": "app/theme_inspect.rs",
+       "rows": [14, 19], "cols": [10, 54],
+       "note": "off the bottom: flip it above", "note_at": "below-right"},
+
+      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+       "head": "app/theme_inspect.rs",
+       "rows": [19, 20], "cols": [29, 69],
+       "note": "then clamp, twice more", "note_at": "below-left"},
+
+      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+       "transition": "push",
+       "head": "view/shell/theme_info.rs",
+       "rows": [4, 5], "cols": [14, 55],
+       "note": "where it wants to be", "note_at": "below-right"},
+
+      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+       "head": "view/shell/theme_info.rs",
+       "rows": [5, 7], "cols": [14, 36],
+       "note": "the flip and the clamp, named", "note_at": "below-right"},
+
+      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+       "head": "view/shell/theme_info.rs",
+       "rows": [7, 15], "cols": [14, 40],
+       "note": "dismissal comes with it", "note_at": "below-right"},
+
+      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+       "head": "view/shell/theme_info.rs",
+       "rows": [16, 17], "cols": [14, 66],
+       "note": "nothing counts lines for a height", "note_at": "below-right"}
+    ]
+  },
+
+  "encode": {"crf": 18, "preset": "slow"}
+}

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -264,8 +264,8 @@
       "github.com/sinelaw/fresh"
     ],
     "timing": {
-      "intro": 2.0,
-      "zoom": 0.7,
+      "intro": 0,
+      "zoom": 0,
       "hold": 1.2,
       "pan": 0.3,
       "push": 0.65,
@@ -323,7 +323,7 @@
           0,
           67
         ],
-        "note": "🧱 Old code: hand-stacked",
+        "note": "🤮 Old code: hand-stacked",
         "note_at": "below-right"
       },
       {
@@ -339,7 +339,7 @@
           0,
           66
         ],
-        "note": "🔁 duplicated",
+        "note": "😩 duplicated",
         "note_at": "below-right",
         "transition": "push"
       },
@@ -356,7 +356,7 @@
           0,
           52
         ],
-        "note": "📐 manual",
+        "note": "😓 manual",
         "note_at": "below-right",
         "transition": "push"
       },

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -1,22 +1,23 @@
 {
   "name": "fresh-popup-rect",
-
   "_note": [
-    "Run assets/fresh-popup-rect/make-files.sh first; it writes the two",
-    "versions of one job — put a popup on screen near an edge — straight out",
-    "of git, so the clip films what shipped rather than an excerpt.",
+    "Run assets/fresh-popup-rect/make-files.sh first. It writes three files:",
+    "the two the old popup was spread across, and the one that replaced them.",
+    "Comments are stripped and rustfmt re-wraps at 68 columns, so nothing on",
+    "screen wraps and nothing on screen is prose. It prints the line each",
+    "anchor landed on, which is what the goto-line steps below are set from —",
+    "the stripping moves every line, so the clip cannot hold line numbers of",
+    "its own, and a rebase upstream fails there rather than filming the wrong",
+    "function.",
     "",
-    "Both screens come from one run of one editor: the two files open as tabs,",
-    "a shot is taken of the second, ctrl+PageUp switches to the first, and the",
-    "run ends there, so the establishing shot is the old code.",
+    "Six screens out of one run. Each ctrl+g lands the caret twenty lines past",
+    "what the screen is about, because the editor centres the caret's line:",
+    "that puts the region's first line at the top of the viewport. The run",
+    "ends on the first BEFORE screen, so that is the establishing shot.",
     "",
-    "Each file is opened twenty lines past the function, because the editor",
-    "puts the caret line in the middle: that lands the function's first line",
-    "at the top of the viewport and leaves its doc comment above it, off",
-    "screen. The clip argues in its own captions; the source's comments are",
-    "not evidence, and reading them is not what the eye should be doing."
+    "Five of the six are BEFORE, which is the shape of the argument: the after",
+    "is one function, and every line of it used to be a place you had to go."
   ],
-
   "capture": {
     "geometry": "72x40",
     "font": "JetBrains Mono 27",
@@ -25,8 +26,7 @@
     "settle": 16,
     "workdir": "~/repos/tui-clips/out/fresh-popup-rect-src",
     "copy_dirs": {
-      "~/repos/fresh/scripts/clips/assets/fresh-popup-rect/fresh":
-        "{scratch}/config/fresh"
+      "~/repos/fresh/scripts/clips/assets/fresh-popup-rect/fresh": "{scratch}/config/fresh"
     },
     "env": {
       "XDG_CONFIG_HOME": "{scratch}/config",
@@ -35,91 +35,417 @@
       "XDG_RUNTIME_DIR": "{scratch}/run-{pane}"
     },
     "keys": [
-      {"sleep": 2},
-      {"shot": "after"},
-      {"key": "ctrl+Prior"},
-      {"sleep": 2},
-      {"shot": "before"}
+      {
+        "sleep": 2
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "54"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "after"
+      },
+      {
+        "key": "ctrl+Prior"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "404"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "clamp"
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "383"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "again"
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "221"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "measure"
+      },
+      {
+        "key": "ctrl+Prior"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "109"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "dismiss"
+      },
+      {
+        "key": "ctrl+g"
+      },
+      {
+        "type": "28"
+      },
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 1
+      },
+      {
+        "shot": "boxes"
+      }
     ],
     "panes": {
       "popup": {
-        "argv": ["~/repos/fresh/target/debug/fresh", "--no-restore",
-                 "--no-upgrade-check",
-                 "before/theme_inspect.rs:358", "after/theme_info.rs:93"]
+        "argv": [
+          "~/repos/fresh/target/debug/fresh",
+          "--no-restore",
+          "--no-upgrade-check",
+          "before/chrome_theme_info.rs",
+          "before/theme_inspect.rs",
+          "after/shell_theme_info.rs"
+        ]
       }
     }
   },
-
   "render": {
-    "size": [1080, 1080],
+    "size": [
+      1080,
+      1080
+    ],
     "header_height": 80,
     "caption_height": 130,
     "fps": 60,
     "rows": 40,
     "cols": 72,
-    "title": "fresh · one popup, near an edge",
-    "labels": {"solo": "BEFORE"},
-    "views": {
-      "old": {"rows": [2, 24], "cols": [0, 62]},
-      "new": {"rows": [2, 21], "cols": [0, 59]}
+    "title": "fresh · one popup, declared",
+    "labels": {
+      "solo": "BEFORE"
     },
-    "intro_caption": ["Put a popup on screen, near an edge",
-                      "the same job, two years apart"],
-    "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
-    "timing": {"intro": 2.0, "zoom": 0.7, "hold": 1.5, "pan": 0.3,
-               "push": 0.9, "outro": 1.0},
+    "views": {
+      "boxes": {
+        "rows": [
+          2,
+          24
+        ],
+        "cols": [
+          0,
+          67
+        ]
+      },
+      "dismiss": {
+        "rows": [
+          2,
+          31
+        ],
+        "cols": [
+          0,
+          66
+        ]
+      },
+      "measure": {
+        "rows": [
+          2,
+          21
+        ],
+        "cols": [
+          0,
+          64
+        ]
+      },
+      "again": {
+        "rows": [
+          2,
+          21
+        ],
+        "cols": [
+          0,
+          64
+        ]
+      },
+      "clamp": {
+        "rows": [
+          2,
+          25
+        ],
+        "cols": [
+          0,
+          64
+        ]
+      },
+      "after": {
+        "rows": [
+          2,
+          23
+        ],
+        "cols": [
+          0,
+          62
+        ]
+      }
+    },
+    "intro_caption": [
+      "Show a popup, then dismiss it",
+      "what that took, before and after"
+    ],
+    "outro_caption": [
+      "fresh",
+      "github.com/sinelaw/fresh"
+    ],
+    "timing": {
+      "intro": 2.0,
+      "zoom": 0.7,
+      "hold": 1.2,
+      "pan": 0.3,
+      "push": 0.65,
+      "outro": 1.0
+    },
     "theme": {
-      "bg": [21, 22, 30],
-      "caption_bg": [30, 31, 41],
-      "panel_border": [56, 58, 74],
-      "muted": [140, 142, 160],
-      "fg": [240, 240, 246],
-      "before": [255, 121, 128],
-      "after": [80, 250, 123]
+      "bg": [
+        21,
+        22,
+        30
+      ],
+      "caption_bg": [
+        30,
+        31,
+        41
+      ],
+      "panel_border": [
+        56,
+        58,
+        74
+      ],
+      "muted": [
+        140,
+        142,
+        160
+      ],
+      "fg": [
+        240,
+        240,
+        246
+      ],
+      "before": [
+        255,
+        121,
+        128
+      ],
+      "after": [
+        80,
+        250,
+        123
+      ]
     },
     "annotations": [
-      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
-       "head": "app/theme_inspect.rs",
-       "rows": [2, 9], "cols": [0, 23],
-       "note": "five numbers in, one rect out", "note_at": "below-right"},
-
-      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
-       "head": "app/theme_inspect.rs",
-       "rows": [9, 14], "cols": [0, 46],
-       "note": "off the right edge: shove it left", "note_at": "below-right"},
-
-      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
-       "head": "app/theme_inspect.rs",
-       "rows": [14, 19], "cols": [0, 46],
-       "note": "off the bottom: flip it above", "note_at": "below-right"},
-
-      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
-       "head": "app/theme_inspect.rs",
-       "rows": [19, 20], "cols": [19, 62],
-       "note": "then clamp, twice more", "note_at": "below-left"},
-
-      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
-       "transition": "push",
-       "head": "view/shell/theme_info.rs",
-       "rows": [4, 5], "cols": [7, 47],
-       "note": "where it wants to be", "note_at": "below-right"},
-
-      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
-       "head": "view/shell/theme_info.rs",
-       "rows": [5, 7], "cols": [7, 28],
-       "note": "the flip and the clamp, named", "note_at": "below-right"},
-
-      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
-       "head": "view/shell/theme_info.rs",
-       "rows": [7, 15], "cols": [7, 39],
-       "note": "dismissal comes with it", "note_at": "below-right"},
-
-      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
-       "head": "view/shell/theme_info.rs",
-       "rows": [16, 17], "cols": [7, 59],
-       "note": "nothing counts lines for a height", "note_at": "below-right"}
+      {
+        "shot": "boxes",
+        "view": "boxes",
+        "label": "BEFORE",
+        "tone": "before",
+        "head": "app/chrome/theme_info.rs",
+        "rows": [
+          5,
+          20
+        ],
+        "cols": [
+          0,
+          67
+        ],
+        "note": "three rectangles, and two z numbers",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "dismiss",
+        "view": "dismiss",
+        "label": "BEFORE",
+        "tone": "before",
+        "transition": "push",
+        "head": "app/chrome/theme_info.rs",
+        "rows": [
+          7,
+          25
+        ],
+        "cols": [
+          0,
+          66
+        ],
+        "note": "dismissal, written twice",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "measure",
+        "view": "measure",
+        "label": "BEFORE",
+        "tone": "before",
+        "transition": "push",
+        "head": "app/theme_inspect.rs",
+        "rows": [
+          6,
+          17
+        ],
+        "cols": [
+          0,
+          52
+        ],
+        "note": "it counts its own lines for a height",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "again",
+        "view": "again",
+        "label": "BEFORE",
+        "tone": "before",
+        "transition": "push",
+        "head": "app/theme_inspect.rs",
+        "rows": [
+          6,
+          18
+        ],
+        "cols": [
+          0,
+          62
+        ],
+        "note": "and the hit-test path counts them again",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "clamp",
+        "view": "clamp",
+        "label": "BEFORE",
+        "tone": "before",
+        "transition": "push",
+        "head": "app/theme_inspect.rs",
+        "rows": [
+          11,
+          22
+        ],
+        "cols": [
+          0,
+          62
+        ],
+        "note": "the edges, by hand",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
+        "transition": "push",
+        "head": "view/shell/theme_info.rs",
+        "rows": [
+          6,
+          7
+        ],
+        "cols": [
+          8,
+          48
+        ],
+        "note": "where it wants to be",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
+        "head": "view/shell/theme_info.rs",
+        "rows": [
+          7,
+          9
+        ],
+        "cols": [
+          8,
+          28
+        ],
+        "note": "and what to do at the edge",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
+        "head": "view/shell/theme_info.rs",
+        "rows": [
+          9,
+          17
+        ],
+        "cols": [
+          8,
+          40
+        ],
+        "note": "dismissal, declared",
+        "note_at": "below-right"
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
+        "head": "view/shell/theme_info.rs",
+        "rows": [
+          18,
+          19
+        ],
+        "cols": [
+          8,
+          60
+        ],
+        "note": "and nothing counts lines",
+        "note_at": "below-right"
+      }
     ]
   },
-
-  "encode": {"crf": 18, "preset": "slow"}
+  "encode": {
+    "crf": 18,
+    "preset": "slow"
+  }
 }

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -165,6 +165,31 @@
     "rows": 40,
     "cols": 72,
     "title": "fresh · one popup, declared",
+    "title_card": {
+      "lines": [
+        {
+          "text": "Horrible Code",
+          "effect": "sick",
+          "at": 0.04
+        },
+        {
+          "text": "to",
+          "at": 0.34,
+          "small": true
+        },
+        {
+          "text": "Declarative",
+          "effect": "shine",
+          "at": 0.5
+        }
+      ],
+      "footer": {
+        "added": 63164,
+        "removed": 27662,
+        "note": "One example, out of two hundred and sixteen files",
+        "at": 0.62
+      }
+    },
     "labels": {
       "solo": "BEFORE"
     },
@@ -222,7 +247,7 @@
       "after": {
         "rows": [
           2,
-          23
+          29
         ],
         "cols": [
           0,
@@ -244,7 +269,8 @@
       "hold": 1.2,
       "pan": 0.3,
       "push": 0.65,
-      "outro": 1.0
+      "outro": 1.0,
+      "title": 3.2
     },
     "theme": {
       "bg": [
@@ -289,7 +315,6 @@
         "view": "boxes",
         "label": "BEFORE",
         "tone": "before",
-        "head": "app/chrome/theme_info.rs",
         "rows": [
           5,
           20
@@ -298,7 +323,7 @@
           0,
           67
         ],
-        "note": "three rectangles, and two z numbers",
+        "note": "☠ hand-stacked",
         "note_at": "below-right"
       },
       {
@@ -307,7 +332,6 @@
         "label": "BEFORE",
         "tone": "before",
         "transition": "push",
-        "head": "app/chrome/theme_info.rs",
         "rows": [
           7,
           25
@@ -316,7 +340,7 @@
           0,
           66
         ],
-        "note": "dismissal, written twice",
+        "note": "↻ duplicated",
         "note_at": "below-right"
       },
       {
@@ -325,7 +349,6 @@
         "label": "BEFORE",
         "tone": "before",
         "transition": "push",
-        "head": "app/theme_inspect.rs",
         "rows": [
           6,
           17
@@ -334,7 +357,7 @@
           0,
           52
         ],
-        "note": "it counts its own lines for a height",
+        "note": "⚠ manual",
         "note_at": "below-right"
       },
       {
@@ -343,7 +366,6 @@
         "label": "BEFORE",
         "tone": "before",
         "transition": "push",
-        "head": "app/theme_inspect.rs",
         "rows": [
           6,
           18
@@ -352,7 +374,7 @@
           0,
           62
         ],
-        "note": "and the hit-test path counts them again",
+        "note": "☹ again",
         "note_at": "below-right"
       },
       {
@@ -361,7 +383,6 @@
         "label": "BEFORE",
         "tone": "before",
         "transition": "push",
-        "head": "app/theme_inspect.rs",
         "rows": [
           11,
           22
@@ -370,7 +391,7 @@
           0,
           62
         ],
-        "note": "the edges, by hand",
+        "note": "☠ again",
         "note_at": "below-right"
       },
       {
@@ -379,7 +400,40 @@
         "label": "AFTER",
         "tone": "after",
         "transition": "push",
-        "head": "view/shell/theme_info.rs",
+        "rows": [
+          4,
+          20
+        ],
+        "cols": [
+          0,
+          62
+        ],
+        "note": "★ declarative and clean",
+        "note_at": "below-right",
+        "hold": 1.6
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
+        "rows": [
+          4,
+          20
+        ],
+        "cols": [
+          0,
+          62
+        ],
+        "note": "✓ position",
+        "note_at": "below-right",
+        "hold": 1.6
+      },
+      {
+        "shot": "after",
+        "view": "after",
+        "label": "AFTER",
+        "tone": "after",
         "rows": [
           6,
           7
@@ -388,7 +442,7 @@
           8,
           48
         ],
-        "note": "where it wants to be",
+        "note": "✓ layout",
         "note_at": "below-right"
       },
       {
@@ -396,7 +450,6 @@
         "view": "after",
         "label": "AFTER",
         "tone": "after",
-        "head": "view/shell/theme_info.rs",
         "rows": [
           7,
           9
@@ -405,7 +458,7 @@
           8,
           28
         ],
-        "note": "and what to do at the edge",
+        "note": "✓ input handling",
         "note_at": "below-right"
       },
       {
@@ -413,7 +466,6 @@
         "view": "after",
         "label": "AFTER",
         "tone": "after",
-        "head": "view/shell/theme_info.rs",
         "rows": [
           9,
           17
@@ -422,7 +474,7 @@
           8,
           40
         ],
-        "note": "dismissal, declared",
+        "note": "✓ sizing",
         "note_at": "below-right"
       },
       {
@@ -430,7 +482,6 @@
         "view": "after",
         "label": "AFTER",
         "tone": "after",
-        "head": "view/shell/theme_info.rs",
         "rows": [
           18,
           19
@@ -439,10 +490,17 @@
           8,
           60
         ],
-        "note": "and nothing counts lines",
+        "note": "✓ sizing",
         "note_at": "below-right"
       }
-    ]
+    ],
+    "note_size": 54,
+    "vignette": {
+      "edge": 0.16,
+      "side": 0.05,
+      "blur": 8,
+      "fade": 0.62
+    }
   },
   "encode": {
     "crf": 18,

--- a/scripts/clips/fresh-popup-rect.json
+++ b/scripts/clips/fresh-popup-rect.json
@@ -59,10 +59,14 @@
     "cols": 72,
     "title": "fresh · one popup, near an edge",
     "labels": {"solo": "BEFORE"},
+    "views": {
+      "old": {"rows": [2, 24], "cols": [0, 62]},
+      "new": {"rows": [2, 21], "cols": [0, 59]}
+    },
     "intro_caption": ["Put a popup on screen, near an edge",
                       "the same job, two years apart"],
     "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
-    "timing": {"intro": 2.0, "zoom": 0.7, "hold": 1.5, "pan": 0.35,
+    "timing": {"intro": 2.0, "zoom": 0.7, "hold": 1.5, "pan": 0.3,
                "push": 0.9, "outro": 1.0},
     "theme": {
       "bg": [21, 22, 30],
@@ -74,45 +78,45 @@
       "after": [80, 250, 123]
     },
     "annotations": [
-      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
        "head": "app/theme_inspect.rs",
-       "rows": [2, 9], "cols": [6, 31],
+       "rows": [2, 9], "cols": [0, 23],
        "note": "five numbers in, one rect out", "note_at": "below-right"},
 
-      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
        "head": "app/theme_inspect.rs",
-       "rows": [9, 14], "cols": [10, 54],
+       "rows": [9, 14], "cols": [0, 46],
        "note": "off the right edge: shove it left", "note_at": "below-right"},
 
-      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
        "head": "app/theme_inspect.rs",
-       "rows": [14, 19], "cols": [10, 54],
+       "rows": [14, 19], "cols": [0, 46],
        "note": "off the bottom: flip it above", "note_at": "below-right"},
 
-      {"shot": "before", "camera": "fit", "label": "BEFORE", "tone": "before",
+      {"shot": "before", "view": "old", "label": "BEFORE", "tone": "before",
        "head": "app/theme_inspect.rs",
-       "rows": [19, 20], "cols": [29, 69],
+       "rows": [19, 20], "cols": [19, 62],
        "note": "then clamp, twice more", "note_at": "below-left"},
 
-      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
        "transition": "push",
        "head": "view/shell/theme_info.rs",
-       "rows": [4, 5], "cols": [14, 55],
+       "rows": [4, 5], "cols": [7, 47],
        "note": "where it wants to be", "note_at": "below-right"},
 
-      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
        "head": "view/shell/theme_info.rs",
-       "rows": [5, 7], "cols": [14, 36],
+       "rows": [5, 7], "cols": [7, 28],
        "note": "the flip and the clamp, named", "note_at": "below-right"},
 
-      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
        "head": "view/shell/theme_info.rs",
-       "rows": [7, 15], "cols": [14, 40],
+       "rows": [7, 15], "cols": [7, 39],
        "note": "dismissal comes with it", "note_at": "below-right"},
 
-      {"shot": "after", "camera": "fit", "label": "AFTER", "tone": "after",
+      {"shot": "after", "view": "new", "label": "AFTER", "tone": "after",
        "head": "view/shell/theme_info.rs",
-       "rows": [16, 17], "cols": [14, 66],
+       "rows": [16, 17], "cols": [7, 59],
        "note": "nothing counts lines for a height", "note_at": "below-right"}
     ]
   },

--- a/scripts/clips/fresh-review-syntax.json
+++ b/scripts/clips/fresh-review-syntax.json
@@ -1,0 +1,92 @@
+{
+  "name": "fresh-review-syntax",
+
+  "_note": [
+    "Run assets/fresh-review-syntax/make-repo.sh first; it builds the",
+    "repo `workdir` points at, and Review Diff reads the working tree, so the",
+    "diff on screen IS that repo's uncommitted state. Re-run it before every",
+    "capture: review mode drops a .review session dir in the tree it reviews.",
+    "",
+    "The band rows come off the UI tree (bin/tui-tree on a Dump UI Tree of",
+    "this same screen): chrome_column is menu 0, tabs 1, review keys 2-3,",
+    "divider 4, the Review Diff header 5, divider 6, and pane:4 — the diff",
+    "stream itself — rows 7..48, with the status bar on 49. Everything a",
+    "beat frames is a row of that one pane."
+  ],
+
+  "capture": {
+    "geometry": "64x50",
+    "font": "JetBrains Mono 21",
+    "screen": "1600x2200x24",
+    "display": ":99",
+    "workdir": "~/repos/fresh/target/clips/fresh-review-syntax-repo",
+    "copy_dirs": {
+      "~/repos/fresh/scripts/clips/assets/fresh-review-syntax/fresh":
+        "{scratch}/config/fresh"
+    },
+    "env": {
+      "XDG_CONFIG_HOME": "{scratch}/config",
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_STATE_HOME": "{scratch}/state-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run-{pane}"
+    },
+    "keys": [
+      {"key": "ctrl+p"},
+      {"sleep": 1},
+      {"type": "Review Diff"},
+      {"sleep": 1.5},
+      {"key": "Return"},
+      {"sleep": 8}
+    ],
+    "panes": {
+      "before": {
+        "argv": ["~/.local/bin/fresh", "--no-restore", "--no-upgrade-check"],
+        "settle": 12
+      },
+      "after": {
+        "argv": ["~/repos/fresh/target/debug/fresh", "--no-restore",
+                 "--no-upgrade-check"],
+        "settle": 18
+      }
+    }
+  },
+
+  "render": {
+    "size": [1080, 1080],
+    "fps": 60,
+    "rows": 50,
+    "cols": 64,
+    "title": "fresh · syntax inside the diff",
+    "labels": {"before": "BEFORE", "after": "AFTER"},
+    "intro_caption": ["Same review, same repo",
+                      "the diff is code now, and reads as code"],
+    "outro_caption": ["fresh", "github.com/sinelaw/fresh"],
+    "timing": {"intro": 1.9, "zoom": 0.7, "hold": 1.5, "pan": 0.35,
+               "outro": 0.9},
+    "theme": {
+      "bg": [21, 22, 30],
+      "caption_bg": [30, 31, 41],
+      "panel_border": [56, 58, 74],
+      "muted": [140, 142, 160],
+      "fg": [240, 240, 246],
+      "before": [255, 85, 85],
+      "after": [80, 250, 123]
+    },
+    "annotations": [
+      {"rows": [20, 28], "cols": [0.2, 62.5],
+       "head": "It knows it is Python",
+       "sub": "the hunk is coloured in the language of the file it came from"},
+      {"rows": [9, 17], "cols": [0.2, 62.5],
+       "head": "One docstring, six rows",
+       "sub": "each side of a hunk is its own parser, streamed past the other"},
+      {"rows": [31, 36], "cols": [0.2, 62.5],
+       "head": "The word diff still wins",
+       "sub": "what changed inside the line stays on top of the colour"},
+      {"rows": [37, 48], "cols": [0.2, 62.5],
+       "head": "Next file, next language",
+       "sub": "Rust under Python, in the one composed buffer"}
+    ]
+  },
+
+  "encode": {"crf": 18, "preset": "slow"}
+}

--- a/scripts/clips/fresh-ui-anatomy.json
+++ b/scripts/clips/fresh-ui-anatomy.json
@@ -1,0 +1,774 @@
+{
+  "name": "fresh-ui-anatomy",
+  "capture": {
+    "geometry": "127x36",
+    "font": "JetBrains Mono 27",
+    "screen": "3400x2200x24",
+    "display": ":99",
+    "settle": 14,
+    "workdir": "~/repos/fresh",
+    "env": {
+      "XDG_DATA_HOME": "{scratch}/data-{pane}",
+      "XDG_CONFIG_HOME": "{scratch}/config",
+      "XDG_STATE_HOME": "{scratch}/state-{pane}",
+      "XDG_RUNTIME_DIR": "{scratch}/run"
+    },
+    "keys": [
+      {
+        "key": "Return"
+      },
+      {
+        "sleep": 2
+      },
+      {
+        "key": "ctrl+e"
+      },
+      {
+        "sleep": 1.5
+      },
+      {
+        "key": "ctrl+p"
+      },
+      {
+        "sleep": 2.5
+      }
+    ],
+    "panes": {
+      "shell": {
+        "argv": [
+          "~/repos/fresh/target/debug/fresh",
+          "--no-restore",
+          "--no-upgrade-check",
+          "crates/fresh-ui/src/diagnose.rs"
+        ]
+      }
+    },
+    "copy_dirs": {
+      "~/.config/fresh": "{scratch}/config/fresh"
+    }
+  },
+  "render": {
+    "size": [
+      1920,
+      1080
+    ],
+    "fps": 60,
+    "rows": 36,
+    "cols": 127,
+    "title": "fresh \u00b7 retained UI tree",
+    "labels": {
+      "explode": "ANATOMY"
+    },
+    "intro_caption": [
+      "One editor screen",
+      "and behind it, a tree of elements that outlives the frame"
+    ],
+    "survey_caption": [
+      "Five regions",
+      "the shell places them; each one rebuilds on its own"
+    ],
+    "outro_caption": [
+      "fresh",
+      "github.com/sinelaw/fresh"
+    ],
+    "timing": {
+      "intro": 1.5,
+      "explode": 1.4,
+      "survey": 1.3,
+      "move": 0.45,
+      "hold": 1.1,
+      "dive": 0.7,
+      "rise": 0.5,
+      "regroup": 0.5,
+      "implode": 1.0,
+      "outro": 1.5
+    },
+    "explode": {
+      "spread": 0.4,
+      "pieces": [
+        {
+          "rows": [
+            0,
+            1
+          ],
+          "cols": [
+            0,
+            127
+          ],
+          "label": "Menu bar",
+          "label_at": "above",
+          "offset": [
+            0,
+            -3
+          ],
+          "head": "The menu bar is a region",
+          "sub": "a memoised component: it rebuilds only when its own state moves"
+        },
+        {
+          "rows": [
+            1,
+            35
+          ],
+          "cols": [
+            0,
+            38
+          ],
+          "label": "File explorer",
+          "label_at": "left",
+          "offset": [
+            -46,
+            1
+          ],
+          "spread": [
+            0,
+            0.28
+          ],
+          "head": "The file explorer is another",
+          "sub": "38 columns of chrome, laid out beside the editor, not inside it",
+          "dive_head": "Every row is an element",
+          "dive_sub": "one gesture target each, kept between frames and reused",
+          "stagger": [
+            1.15,
+            0
+          ],
+          "pieces": [
+            {
+              "rows": [
+                2,
+                3
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                3,
+                4
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                4,
+                5
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                5,
+                6
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                6,
+                7
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                7,
+                8
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                8,
+                9
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                9,
+                10
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                10,
+                11
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                11,
+                12
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                12,
+                13
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                13,
+                14
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                14,
+                15
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                15,
+                16
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                16,
+                17
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                17,
+                18
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                18,
+                19
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                19,
+                20
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                20,
+                21
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                21,
+                22
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                22,
+                23
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                23,
+                24
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                24,
+                25
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                25,
+                26
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                26,
+                27
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                27,
+                28
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                28,
+                29
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                29,
+                30
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                30,
+                31
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                31,
+                32
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                32,
+                33
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                33,
+                34
+              ],
+              "cols": [
+                1,
+                37
+              ],
+              "label": ""
+            }
+          ]
+        },
+        {
+          "rows": [
+            1,
+            35
+          ],
+          "cols": [
+            38,
+            127
+          ],
+          "label": "Editor pane",
+          "label_at": "right",
+          "offset": [
+            46,
+            1
+          ],
+          "head": "The editor pane holds the buffer",
+          "sub": "the text itself is a host: the shell reserves the rect and stands back",
+          "dive_head": "Tabs, text, scrollbar",
+          "dive_sub": "three children, and the layout pass decides what each one gets",
+          "pieces": [
+            {
+              "rows": [
+                1,
+                2
+              ],
+              "cols": [
+                38,
+                127
+              ],
+              "label": "Tab strip",
+              "label_at": "above",
+              "offset": [
+                0,
+                -8
+              ]
+            },
+            {
+              "rows": [
+                2,
+                35
+              ],
+              "cols": [
+                38,
+                126
+              ],
+              "label": "Buffer",
+              "label_at": "left",
+              "offset": [
+                0,
+                1
+              ]
+            },
+            {
+              "rows": [
+                2,
+                35
+              ],
+              "cols": [
+                126,
+                127
+              ],
+              "label": "Scrollbar",
+              "label_at": "right",
+              "offset": [
+                18,
+                1
+              ]
+            }
+          ]
+        },
+        {
+          "rows": [
+            35,
+            36
+          ],
+          "cols": [
+            0,
+            127
+          ],
+          "label": "Prompt",
+          "label_at": "below",
+          "offset": [
+            0,
+            2
+          ],
+          "head": "One row is the prompt",
+          "sub": "what you type goes here, whatever it is going to mean"
+        },
+        {
+          "rows": [
+            22,
+            35
+          ],
+          "cols": [
+            0,
+            127
+          ],
+          "label": "Command palette",
+          "label_at": "below",
+          "offset": [
+            0,
+            17
+          ],
+          "spread": [
+            0,
+            0.95
+          ],
+          "head": "The palette is a layer",
+          "sub": "it floats over the rest, so nothing underneath had to make room",
+          "dive_head": "Ten rows, ranked",
+          "dive_sub": "the list is virtualised: only what fits is ever built",
+          "pieces": [
+            {
+              "rows": [
+                23,
+                24
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                24,
+                25
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": "one row",
+              "head": "And a row is three fields",
+              "sub": "name, description, and where the command came from",
+              "dive_head": "Name, description, source",
+              "dive_sub": "fixed columns, so the eye can run straight down any of them",
+              "pieces": [
+                {
+                  "rows": [
+                    24,
+                    25
+                  ],
+                  "cols": [
+                    3,
+                    33
+                  ],
+                  "label": "Name",
+                  "label_at": "above",
+                  "offset": [
+                    0,
+                    -5
+                  ]
+                },
+                {
+                  "rows": [
+                    24,
+                    25
+                  ],
+                  "cols": [
+                    35,
+                    109
+                  ],
+                  "label": "Description",
+                  "label_at": "below",
+                  "offset": [
+                    0,
+                    3
+                  ]
+                },
+                {
+                  "rows": [
+                    24,
+                    25
+                  ],
+                  "cols": [
+                    111,
+                    126
+                  ],
+                  "label": "Source",
+                  "label_at": "below",
+                  "offset": [
+                    0,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "rows": [
+                25,
+                26
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                26,
+                27
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                27,
+                28
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                28,
+                29
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                29,
+                30
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                30,
+                31
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                31,
+                32
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            },
+            {
+              "rows": [
+                32,
+                33
+              ],
+              "cols": [
+                1,
+                126
+              ],
+              "label": ""
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "encode": {
+    "crf": 18,
+    "preset": "slow"
+  }
+}

--- a/scripts/clips/fresh-ui-anatomy.plan.json
+++ b/scripts/clips/fresh-ui-anatomy.plan.json
@@ -1,0 +1,157 @@
+[
+  {
+    "key": "region:2",
+    "label": "Menu bar",
+    "label_at": "above",
+    "offset": [
+      0,
+      -3
+    ],
+    "head": "The menu bar is a region",
+    "sub": "a memoised component: it rebuilds only when its own state moves"
+  },
+  {
+    "key": "region:3",
+    "label": "File explorer",
+    "label_at": "left",
+    "offset": [
+      -46,
+      1
+    ],
+    "spread": [
+      0,
+      0.28
+    ],
+    "head": "The file explorer is another",
+    "sub": "38 columns of chrome, laid out beside the editor, not inside it",
+    "dive_head": "Every row is an element",
+    "dive_sub": "one gesture target each, kept between frames and reused",
+    "children": [
+      {
+        "key": "explorer_row:*",
+        "label": ""
+      }
+    ],
+    "stagger": [
+      1.15,
+      0
+    ]
+  },
+  {
+    "key": "region:4",
+    "label": "Editor pane",
+    "label_at": "right",
+    "offset": [
+      46,
+      1
+    ],
+    "head": "The editor pane holds the buffer",
+    "sub": "the text itself is a host: the shell reserves the rect and stands back",
+    "dive_head": "Tabs, text, scrollbar",
+    "dive_sub": "three children, and the layout pass decides what each one gets",
+    "children": [
+      {
+        "key": "pane_tabs:0",
+        "label": "Tab strip",
+        "label_at": "above",
+        "offset": [
+          0,
+          -8
+        ]
+      },
+      {
+        "key": "pane_content:0",
+        "label": "Buffer",
+        "label_at": "left",
+        "offset": [
+          0,
+          1
+        ]
+      },
+      {
+        "key": "pane_vscroll:0",
+        "label": "Scrollbar",
+        "label_at": "right",
+        "offset": [
+          18,
+          1
+        ]
+      }
+    ]
+  },
+  {
+    "key": "region:7",
+    "label": "Prompt",
+    "label_at": "below",
+    "offset": [
+      0,
+      2
+    ],
+    "head": "One row is the prompt",
+    "sub": "what you type goes here, whatever it is going to mean"
+  },
+  {
+    "key": "prompt_suggestions",
+    "label": "Command palette",
+    "label_at": "below",
+    "offset": [
+      0,
+      17
+    ],
+    "spread": [
+      0,
+      0.95
+    ],
+    "head": "The palette is a layer",
+    "sub": "it floats over the rest, so nothing underneath had to make room",
+    "dive_head": "Ten rows, ranked",
+    "dive_sub": "the list is virtualised: only what fits is ever built",
+    "children": [
+      {
+        "key": "suggestion:0",
+        "label": ""
+      },
+      {
+        "key": "suggestion:1",
+        "label": "",
+        "head": "And a row is three fields",
+        "sub": "name, description, and where the command came from",
+        "dive_head": "Name, description, source",
+        "dive_sub": "fixed columns, so the eye can run straight down any of them",
+        "children": [
+          {
+            "key": "suggestion_name:1",
+            "label": "Name",
+            "label_at": "above",
+            "offset": [
+              0,
+              -5
+            ]
+          },
+          {
+            "id": "E194",
+            "label": "Description",
+            "label_at": "below",
+            "offset": [
+              0,
+              3
+            ]
+          },
+          {
+            "id": "E348",
+            "label": "Source",
+            "label_at": "below",
+            "offset": [
+              0,
+              7
+            ]
+          }
+        ]
+      },
+      {
+        "key": "suggestion:[2-9]",
+        "label": ""
+      }
+    ]
+  }
+]

--- a/scripts/clips/fresh-ui-anatomy.tree.json
+++ b/scripts/clips/fresh-ui-anatomy.tree.json
@@ -1,0 +1,2522 @@
+{
+  "id": "E0",
+  "type": "Gesture",
+  "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+  "cause": "mount",
+  "children": [
+    {
+      "id": "E1",
+      "type": "Gesture",
+      "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+      "cause": "parent E0",
+      "children": [
+        {
+          "id": "E2",
+          "type": "Box",
+          "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+          "cause": "parent E1",
+          "children": [
+            {
+              "id": "E3",
+              "type": "Host",
+              "key": "region:1",
+              "rect": {"x": 0, "y": 0, "w": 0, "h": 36},
+              "cause": "parent E2",
+              "children": []
+            },
+            {
+              "id": "E4",
+              "type": "Provide",
+              "key": "window:9",
+              "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+              "cause": "parent E2",
+              "children": [
+                {
+                  "id": "E5",
+                  "type": "Box",
+                  "key": "chrome_column",
+                  "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+                  "cause": "parent E4",
+                  "children": [
+                    {
+                      "id": "E6",
+                      "type": "Memo<fresh::view::shell::menu::MenuBar, fresh::view::shell::msg::UiMsg>",
+                      "key": "region:2",
+                      "rect": {"x": 0, "y": 0, "w": 127, "h": 1},
+                      "state": "()",
+                      "builds": 1,
+                      "cause": "parent E5",
+                      "children": [
+                        {
+                          "id": "E7",
+                          "type": "Gesture",
+                          "rect": {"x": 0, "y": 0, "w": 127, "h": 1},
+                          "cause": "mount",
+                          "children": [
+                            {
+                              "id": "E8",
+                              "type": "Box",
+                              "rect": {"x": 0, "y": 0, "w": 127, "h": 1},
+                              "cause": "mount",
+                              "children": [
+                                {
+                                  "id": "E9",
+                                  "type": "Gesture",
+                                  "rect": {"x": 0, "y": 0, "w": 7, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E10",
+                                      "type": "TextRun",
+                                      "rect": {"x": 0, "y": 0, "w": 7, "h": 1},
+                                      "text": " File  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E11",
+                                  "type": "Gesture",
+                                  "rect": {"x": 7, "y": 0, "w": 7, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E12",
+                                      "type": "TextRun",
+                                      "rect": {"x": 7, "y": 0, "w": 7, "h": 1},
+                                      "text": " Edit  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E13",
+                                  "type": "Gesture",
+                                  "rect": {"x": 14, "y": 0, "w": 7, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E14",
+                                      "type": "TextRun",
+                                      "rect": {"x": 14, "y": 0, "w": 7, "h": 1},
+                                      "text": " View  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E15",
+                                  "type": "Gesture",
+                                  "rect": {"x": 21, "y": 0, "w": 12, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E16",
+                                      "type": "TextRun",
+                                      "rect": {"x": 21, "y": 0, "w": 12, "h": 1},
+                                      "text": " Selection  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E17",
+                                  "type": "Gesture",
+                                  "rect": {"x": 33, "y": 0, "w": 5, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E18",
+                                      "type": "TextRun",
+                                      "rect": {"x": 33, "y": 0, "w": 5, "h": 1},
+                                      "text": " Go  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E19",
+                                  "type": "Gesture",
+                                  "rect": {"x": 38, "y": 0, "w": 6, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E20",
+                                      "type": "TextRun",
+                                      "rect": {"x": 38, "y": 0, "w": 6, "h": 1},
+                                      "text": " LSP  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E21",
+                                  "type": "Gesture",
+                                  "rect": {"x": 44, "y": 0, "w": 7, "h": 1},
+                                  "cause": "mount",
+                                  "children": [
+                                    {
+                                      "id": "E22",
+                                      "type": "TextRun",
+                                      "rect": {"x": 44, "y": 0, "w": 7, "h": 1},
+                                      "text": " Help  ",
+                                      "cause": "mount",
+                                      "children": []
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "E23",
+                      "type": "Box",
+                      "rect": {"x": 0, "y": 1, "w": 127, "h": 34},
+                      "cause": "parent E5",
+                      "children": [
+                        {
+                          "id": "E24",
+                          "type": "Memo<fresh::view::shell::file_explorer::Explorer, fresh::view::shell::msg::UiMsg>",
+                          "key": "region:3",
+                          "rect": {"x": 0, "y": 1, "w": 38, "h": 34},
+                          "state": "()",
+                          "builds": 3,
+                          "cause": "parent E23",
+                          "children": [
+                            {
+                              "id": "E25",
+                              "type": "Box",
+                              "rect": {"x": 0, "y": 1, "w": 38, "h": 34},
+                              "cause": "parent E24",
+                              "children": [
+                                {
+                                  "id": "E26",
+                                  "type": "Gesture",
+                                  "rect": {"x": 0, "y": 1, "w": 38, "h": 34},
+                                  "cause": "parent E25",
+                                  "children": [
+                                    {
+                                      "id": "E27",
+                                      "type": "Box",
+                                      "rect": {"x": 0, "y": 1, "w": 38, "h": 34},
+                                      "cause": "parent E26",
+                                      "children": [
+                                        {
+                                          "id": "E28",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:0",
+                                          "rect": {"x": 1, "y": 2, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E29",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 2, "w": 36, "h": 1},
+                                              "cause": "parent E28",
+                                              "children": [
+                                                {
+                                                  "id": "E30",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 2, "w": 7, "h": 1},
+                                                  "text": "▼ fresh",
+                                                  "cause": "parent E29",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E31",
+                                                  "type": "Box",
+                                                  "rect": {"x": 8, "y": 2, "w": 28, "h": 1},
+                                                  "cause": "parent E29",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E209",
+                                                  "type": "Gesture",
+                                                  "key": "explorer_slot:0",
+                                                  "rect": {"x": 36, "y": 2, "w": 1, "h": 1},
+                                                  "cause": "parent E29",
+                                                  "children": [
+                                                    {
+                                                      "id": "E210",
+                                                      "type": "TextRun",
+                                                      "rect": {"x": 36, "y": 2, "w": 1, "h": 1},
+                                                      "text": "●",
+                                                      "cause": "parent E209",
+                                                      "children": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E32",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:1",
+                                          "rect": {"x": 1, "y": 3, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E33",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 3, "w": 36, "h": 1},
+                                              "cause": "parent E32",
+                                              "children": [
+                                                {
+                                                  "id": "E34",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 3, "w": 11, "h": 1},
+                                                  "text": "  > .agents",
+                                                  "cause": "parent E33",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E35",
+                                                  "type": "Box",
+                                                  "rect": {"x": 12, "y": 3, "w": 25, "h": 1},
+                                                  "cause": "parent E33",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E36",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:2",
+                                          "rect": {"x": 1, "y": 4, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E37",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 4, "w": 36, "h": 1},
+                                              "cause": "parent E36",
+                                              "children": [
+                                                {
+                                                  "id": "E38",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 4, "w": 11, "h": 1},
+                                                  "text": "  > .claude",
+                                                  "cause": "parent E37",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E39",
+                                                  "type": "Box",
+                                                  "rect": {"x": 12, "y": 4, "w": 25, "h": 1},
+                                                  "cause": "parent E37",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E40",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:3",
+                                          "rect": {"x": 1, "y": 5, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E41",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 5, "w": 36, "h": 1},
+                                              "cause": "parent E40",
+                                              "children": [
+                                                {
+                                                  "id": "E42",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 5, "w": 10, "h": 1},
+                                                  "text": "  > .codex",
+                                                  "cause": "parent E41",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E43",
+                                                  "type": "Box",
+                                                  "rect": {"x": 11, "y": 5, "w": 26, "h": 1},
+                                                  "cause": "parent E41",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E44",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:4",
+                                          "rect": {"x": 1, "y": 6, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E45",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 6, "w": 36, "h": 1},
+                                              "cause": "parent E44",
+                                              "children": [
+                                                {
+                                                  "id": "E46",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 6, "w": 13, "h": 1},
+                                                  "text": "  > · .config",
+                                                  "cause": "parent E45",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E47",
+                                                  "type": "Box",
+                                                  "rect": {"x": 14, "y": 6, "w": 23, "h": 1},
+                                                  "cause": "parent E45",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E48",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:5",
+                                          "rect": {"x": 1, "y": 7, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E49",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 7, "w": 36, "h": 1},
+                                              "cause": "parent E48",
+                                              "children": [
+                                                {
+                                                  "id": "E50",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 7, "w": 10, "h": 1},
+                                                  "text": "  > .fresh",
+                                                  "cause": "parent E49",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E51",
+                                                  "type": "Box",
+                                                  "rect": {"x": 11, "y": 7, "w": 26, "h": 1},
+                                                  "cause": "parent E49",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E52",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:6",
+                                          "rect": {"x": 1, "y": 8, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E53",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 8, "w": 36, "h": 1},
+                                              "cause": "parent E52",
+                                              "children": [
+                                                {
+                                                  "id": "E54",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 8, "w": 8, "h": 1},
+                                                  "text": "  > .git",
+                                                  "cause": "parent E53",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E55",
+                                                  "type": "Box",
+                                                  "rect": {"x": 9, "y": 8, "w": 28, "h": 1},
+                                                  "cause": "parent E53",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E56",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:7",
+                                          "rect": {"x": 1, "y": 9, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E57",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 9, "w": 36, "h": 1},
+                                              "cause": "parent E56",
+                                              "children": [
+                                                {
+                                                  "id": "E58",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 9, "w": 13, "h": 1},
+                                                  "text": "  > ▄ .github",
+                                                  "cause": "parent E57",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E59",
+                                                  "type": "Box",
+                                                  "rect": {"x": 14, "y": 9, "w": 23, "h": 1},
+                                                  "cause": "parent E57",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E60",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:8",
+                                          "rect": {"x": 1, "y": 10, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E61",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 10, "w": 36, "h": 1},
+                                              "cause": "parent E60",
+                                              "children": [
+                                                {
+                                                  "id": "E62",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 10, "w": 14, "h": 1},
+                                                  "text": "  > .worktrees",
+                                                  "cause": "parent E61",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E63",
+                                                  "type": "Box",
+                                                  "rect": {"x": 15, "y": 10, "w": 22, "h": 1},
+                                                  "cause": "parent E61",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E64",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:9",
+                                          "rect": {"x": 1, "y": 11, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E65",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 11, "w": 36, "h": 1},
+                                              "cause": "parent E64",
+                                              "children": [
+                                                {
+                                                  "id": "E66",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 11, "w": 12, "h": 1},
+                                                  "text": "  > █ crates",
+                                                  "cause": "parent E65",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E67",
+                                                  "type": "Box",
+                                                  "rect": {"x": 13, "y": 11, "w": 23, "h": 1},
+                                                  "cause": "parent E65",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E211",
+                                                  "type": "Gesture",
+                                                  "key": "explorer_slot:9",
+                                                  "rect": {"x": 36, "y": 11, "w": 1, "h": 1},
+                                                  "cause": "parent E65",
+                                                  "children": [
+                                                    {
+                                                      "id": "E212",
+                                                      "type": "TextRun",
+                                                      "rect": {"x": 36, "y": 11, "w": 1, "h": 1},
+                                                      "text": "●",
+                                                      "cause": "parent E211",
+                                                      "children": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E68",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:10",
+                                          "rect": {"x": 1, "y": 12, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E69",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 12, "w": 36, "h": 1},
+                                              "cause": "parent E68",
+                                              "children": [
+                                                {
+                                                  "id": "E70",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 12, "w": 12, "h": 1},
+                                                  "text": "  > ▃ debian",
+                                                  "cause": "parent E69",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E71",
+                                                  "type": "Box",
+                                                  "rect": {"x": 13, "y": 12, "w": 24, "h": 1},
+                                                  "cause": "parent E69",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E72",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:11",
+                                          "rect": {"x": 1, "y": 13, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E73",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 13, "w": 36, "h": 1},
+                                              "cause": "parent E72",
+                                              "children": [
+                                                {
+                                                  "id": "E74",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 13, "w": 8, "h": 1},
+                                                  "text": "  > dist",
+                                                  "cause": "parent E73",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E75",
+                                                  "type": "Box",
+                                                  "rect": {"x": 9, "y": 13, "w": 28, "h": 1},
+                                                  "cause": "parent E73",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E76",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:12",
+                                          "rect": {"x": 1, "y": 14, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E77",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 14, "w": 36, "h": 1},
+                                              "cause": "parent E76",
+                                              "children": [
+                                                {
+                                                  "id": "E78",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 14, "w": 10, "h": 1},
+                                                  "text": "  > ▆ docs",
+                                                  "cause": "parent E77",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E79",
+                                                  "type": "Box",
+                                                  "rect": {"x": 11, "y": 14, "w": 26, "h": 1},
+                                                  "cause": "parent E77",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E80",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:13",
+                                          "rect": {"x": 1, "y": 15, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E81",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 15, "w": 36, "h": 1},
+                                              "cause": "parent E80",
+                                              "children": [
+                                                {
+                                                  "id": "E82",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 15, "w": 14, "h": 1},
+                                                  "text": "  > ▂ homepage",
+                                                  "cause": "parent E81",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E83",
+                                                  "type": "Box",
+                                                  "rect": {"x": 15, "y": 15, "w": 22, "h": 1},
+                                                  "cause": "parent E81",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E84",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:14",
+                                          "rect": {"x": 1, "y": 16, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E85",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 16, "w": 36, "h": 1},
+                                              "cause": "parent E84",
+                                              "children": [
+                                                {
+                                                  "id": "E86",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 16, "w": 16, "h": 1},
+                                                  "text": "  > node_modules",
+                                                  "cause": "parent E85",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E87",
+                                                  "type": "Box",
+                                                  "rect": {"x": 17, "y": 16, "w": 20, "h": 1},
+                                                  "cause": "parent E85",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E88",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:15",
+                                          "rect": {"x": 1, "y": 17, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E89",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 17, "w": 36, "h": 1},
+                                              "cause": "parent E88",
+                                              "children": [
+                                                {
+                                                  "id": "E90",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 17, "w": 13, "h": 1},
+                                                  "text": "  > ▃ scripts",
+                                                  "cause": "parent E89",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E91",
+                                                  "type": "Box",
+                                                  "rect": {"x": 14, "y": 17, "w": 23, "h": 1},
+                                                  "cause": "parent E89",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E92",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:16",
+                                          "rect": {"x": 1, "y": 18, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E93",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 18, "w": 36, "h": 1},
+                                              "cause": "parent E92",
+                                              "children": [
+                                                {
+                                                  "id": "E94",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 18, "w": 10, "h": 1},
+                                                  "text": "  > target",
+                                                  "cause": "parent E93",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E95",
+                                                  "type": "Box",
+                                                  "rect": {"x": 11, "y": 18, "w": 26, "h": 1},
+                                                  "cause": "parent E93",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E96",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:17",
+                                          "rect": {"x": 1, "y": 19, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E97",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 19, "w": 36, "h": 1},
+                                              "cause": "parent E96",
+                                              "children": [
+                                                {
+                                                  "id": "E98",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 19, "w": 11, "h": 1},
+                                                  "text": "  > ▃ tests",
+                                                  "cause": "parent E97",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E99",
+                                                  "type": "Box",
+                                                  "rect": {"x": 12, "y": 19, "w": 25, "h": 1},
+                                                  "cause": "parent E97",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E100",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:18",
+                                          "rect": {"x": 1, "y": 20, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E101",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 20, "w": 36, "h": 1},
+                                              "cause": "parent E100",
+                                              "children": [
+                                                {
+                                                  "id": "E102",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 20, "w": 12, "h": 1},
+                                                  "text": "  > ▅ web-ui",
+                                                  "cause": "parent E101",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E103",
+                                                  "type": "Box",
+                                                  "rect": {"x": 13, "y": 20, "w": 24, "h": 1},
+                                                  "cause": "parent E101",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E104",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:19",
+                                          "rect": {"x": 1, "y": 21, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E105",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 21, "w": 36, "h": 1},
+                                              "cause": "parent E104",
+                                              "children": [
+                                                {
+                                                  "id": "E106",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 21, "w": 12, "h": 1},
+                                                  "text": "    · .envrc",
+                                                  "cause": "parent E105",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E107",
+                                                  "type": "Box",
+                                                  "rect": {"x": 13, "y": 21, "w": 24, "h": 1},
+                                                  "cause": "parent E105",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E108",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:20",
+                                          "rect": {"x": 1, "y": 22, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E109",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 22, "w": 36, "h": 1},
+                                              "cause": "parent E108",
+                                              "children": [
+                                                {
+                                                  "id": "E110",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 22, "w": 22, "h": 1},
+                                                  "text": "    · .fresh-tour.json",
+                                                  "cause": "parent E109",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E111",
+                                                  "type": "Box",
+                                                  "rect": {"x": 23, "y": 22, "w": 14, "h": 1},
+                                                  "cause": "parent E109",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E112",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:21",
+                                          "rect": {"x": 1, "y": 23, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E113",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 23, "w": 36, "h": 1},
+                                              "cause": "parent E112",
+                                              "children": [
+                                                {
+                                                  "id": "E114",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 23, "w": 20, "h": 1},
+                                                  "text": "    ▂ .gitattributes",
+                                                  "cause": "parent E113",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E115",
+                                                  "type": "Box",
+                                                  "rect": {"x": 21, "y": 23, "w": 16, "h": 1},
+                                                  "cause": "parent E113",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E116",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:22",
+                                          "rect": {"x": 1, "y": 24, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E117",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 24, "w": 36, "h": 1},
+                                              "cause": "parent E116",
+                                              "children": [
+                                                {
+                                                  "id": "E118",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 24, "w": 16, "h": 1},
+                                                  "text": "    ▂ .gitignore",
+                                                  "cause": "parent E117",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E119",
+                                                  "type": "Box",
+                                                  "rect": {"x": 17, "y": 24, "w": 20, "h": 1},
+                                                  "cause": "parent E117",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E120",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:23",
+                                          "rect": {"x": 1, "y": 25, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E121",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 25, "w": 36, "h": 1},
+                                              "cause": "parent E120",
+                                              "children": [
+                                                {
+                                                  "id": "E122",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 25, "w": 14, "h": 1},
+                                                  "text": "    · bun.lock",
+                                                  "cause": "parent E121",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E123",
+                                                  "type": "Box",
+                                                  "rect": {"x": 15, "y": 25, "w": 22, "h": 1},
+                                                  "cause": "parent E121",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E124",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:24",
+                                          "rect": {"x": 1, "y": 26, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E125",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 26, "w": 36, "h": 1},
+                                              "cause": "parent E124",
+                                              "children": [
+                                                {
+                                                  "id": "E126",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 26, "w": 16, "h": 1},
+                                                  "text": "    ▅ Cargo.lock",
+                                                  "cause": "parent E125",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E127",
+                                                  "type": "Box",
+                                                  "rect": {"x": 17, "y": 26, "w": 20, "h": 1},
+                                                  "cause": "parent E125",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E128",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:25",
+                                          "rect": {"x": 1, "y": 27, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E129",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 27, "w": 36, "h": 1},
+                                              "cause": "parent E128",
+                                              "children": [
+                                                {
+                                                  "id": "E130",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 27, "w": 16, "h": 1},
+                                                  "text": "    ▄ Cargo.toml",
+                                                  "cause": "parent E129",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E131",
+                                                  "type": "Box",
+                                                  "rect": {"x": 17, "y": 27, "w": 20, "h": 1},
+                                                  "cause": "parent E129",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E132",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:26",
+                                          "rect": {"x": 1, "y": 28, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E133",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 28, "w": 36, "h": 1},
+                                              "cause": "parent E132",
+                                              "children": [
+                                                {
+                                                  "id": "E134",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 28, "w": 18, "h": 1},
+                                                  "text": "    ▇ CHANGELOG.md",
+                                                  "cause": "parent E133",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E135",
+                                                  "type": "Box",
+                                                  "rect": {"x": 19, "y": 28, "w": 18, "h": 1},
+                                                  "cause": "parent E133",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E136",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:27",
+                                          "rect": {"x": 1, "y": 29, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E137",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 29, "w": 36, "h": 1},
+                                              "cause": "parent E136",
+                                              "children": [
+                                                {
+                                                  "id": "E138",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 29, "w": 21, "h": 1},
+                                                  "text": "    ▁ CONTRIBUTING.md",
+                                                  "cause": "parent E137",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E139",
+                                                  "type": "Box",
+                                                  "rect": {"x": 22, "y": 29, "w": 15, "h": 1},
+                                                  "cause": "parent E137",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E140",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:28",
+                                          "rect": {"x": 1, "y": 30, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E141",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 30, "w": 36, "h": 1},
+                                              "cause": "parent E140",
+                                              "children": [
+                                                {
+                                                  "id": "E142",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 30, "w": 17, "h": 1},
+                                                  "text": "    · default.nix",
+                                                  "cause": "parent E141",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E143",
+                                                  "type": "Box",
+                                                  "rect": {"x": 18, "y": 30, "w": 19, "h": 1},
+                                                  "cause": "parent E141",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E144",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:29",
+                                          "rect": {"x": 1, "y": 31, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E145",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 31, "w": 36, "h": 1},
+                                              "cause": "parent E144",
+                                              "children": [
+                                                {
+                                                  "id": "E146",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 31, "w": 25, "h": 1},
+                                                  "text": "    ▁ dist-workspace.toml",
+                                                  "cause": "parent E145",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E147",
+                                                  "type": "Box",
+                                                  "rect": {"x": 26, "y": 31, "w": 11, "h": 1},
+                                                  "cause": "parent E145",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E148",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:30",
+                                          "rect": {"x": 1, "y": 32, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E149",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 32, "w": 36, "h": 1},
+                                              "cause": "parent E148",
+                                              "children": [
+                                                {
+                                                  "id": "E150",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 32, "w": 16, "h": 1},
+                                                  "text": "    · flake.lock",
+                                                  "cause": "parent E149",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E151",
+                                                  "type": "Box",
+                                                  "rect": {"x": 17, "y": 32, "w": 20, "h": 1},
+                                                  "cause": "parent E149",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E152",
+                                          "type": "Gesture",
+                                          "key": "explorer_row:31",
+                                          "rect": {"x": 1, "y": 33, "w": 36, "h": 1},
+                                          "cause": "parent E27",
+                                          "children": [
+                                            {
+                                              "id": "E153",
+                                              "type": "Box",
+                                              "rect": {"x": 1, "y": 33, "w": 36, "h": 1},
+                                              "cause": "parent E152",
+                                              "children": [
+                                                {
+                                                  "id": "E154",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 1, "y": 33, "w": 15, "h": 1},
+                                                  "text": "    ▂ flake.nix",
+                                                  "cause": "parent E153",
+                                                  "children": []
+                                                },
+                                                {
+                                                  "id": "E155",
+                                                  "type": "Box",
+                                                  "rect": {"x": 16, "y": 33, "w": 21, "h": 1},
+                                                  "cause": "parent E153",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "id": "E156",
+                                  "type": "Box",
+                                  "rect": {"x": 0, "y": 1, "w": 38, "h": 34},
+                                  "cause": "parent E25",
+                                  "children": [
+                                    {
+                                      "id": "E157",
+                                      "type": "Box",
+                                      "rect": {"x": 0, "y": 1, "w": 38, "h": 1},
+                                      "cause": "parent E156",
+                                      "children": [
+                                        {
+                                          "id": "E158",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 1, "w": 1, "h": 1},
+                                          "cause": "parent E157",
+                                          "children": []
+                                        },
+                                        {
+                                          "id": "E159",
+                                          "type": "TextRun",
+                                          "rect": {"x": 1, "y": 1, "w": 24, "h": 1},
+                                          "text": " File Explorer (Ctrl+E) ",
+                                          "cause": "parent E157",
+                                          "children": []
+                                        },
+                                        {
+                                          "id": "E160",
+                                          "type": "Box",
+                                          "rect": {"x": 25, "y": 1, "w": 10, "h": 1},
+                                          "cause": "parent E157",
+                                          "children": []
+                                        },
+                                        {
+                                          "id": "E161",
+                                          "type": "Gesture",
+                                          "key": "explorer_close",
+                                          "rect": {"x": 35, "y": 1, "w": 3, "h": 1},
+                                          "cause": "parent E157",
+                                          "children": [
+                                            {
+                                              "id": "E162",
+                                              "type": "Box",
+                                              "rect": {"x": 35, "y": 1, "w": 3, "h": 1},
+                                              "cause": "parent E161",
+                                              "children": [
+                                                {
+                                                  "id": "E163",
+                                                  "type": "TextRun",
+                                                  "rect": {"x": 35, "y": 1, "w": 1, "h": 1},
+                                                  "text": "×",
+                                                  "cause": "parent E162",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "id": "E164",
+                                      "type": "Box",
+                                      "rect": {"x": 0, "y": 2, "w": 38, "h": 33},
+                                      "cause": "parent E156",
+                                      "children": [
+                                        {
+                                          "id": "E165",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 2, "w": 38, "h": 32},
+                                          "cause": "parent E164",
+                                          "children": [
+                                            {
+                                              "id": "E166",
+                                              "type": "Box",
+                                              "rect": {"x": 0, "y": 2, "w": 37, "h": 32},
+                                              "cause": "parent E165",
+                                              "children": []
+                                            },
+                                            {
+                                              "id": "E167",
+                                              "type": "Gesture",
+                                              "key": "explorer_grip",
+                                              "rect": {"x": 37, "y": 2, "w": 1, "h": 32},
+                                              "cause": "parent E165",
+                                              "children": [
+                                                {
+                                                  "id": "E168",
+                                                  "type": "Box",
+                                                  "rect": {"x": 37, "y": 2, "w": 1, "h": 32},
+                                                  "cause": "parent E167",
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E169",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 34, "w": 38, "h": 1},
+                                          "cause": "parent E164",
+                                          "children": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "id": "E170",
+                          "type": "Box",
+                          "key": "region:4",
+                          "rect": {"x": 38, "y": 1, "w": 89, "h": 34},
+                          "cause": "parent E23",
+                          "children": [
+                            {
+                              "id": "E171",
+                              "type": "Host",
+                              "rect": {"x": 38, "y": 1, "w": 89, "h": 34},
+                              "cause": "parent E170",
+                              "children": []
+                            },
+                            {
+                              "id": "E172",
+                              "type": "Box",
+                              "key": "pane:0",
+                              "rect": {"x": 38, "y": 1, "w": 89, "h": 34},
+                              "cause": "parent E170",
+                              "children": [
+                                {
+                                  "id": "E173",
+                                  "type": "Host",
+                                  "rect": {"x": 38, "y": 1, "w": 89, "h": 34},
+                                  "cause": "parent E172",
+                                  "children": []
+                                },
+                                {
+                                  "id": "E174",
+                                  "type": "Box",
+                                  "rect": {"x": 38, "y": 1, "w": 89, "h": 34},
+                                  "cause": "parent E172",
+                                  "children": [
+                                    {
+                                      "id": "E175",
+                                      "type": "Box",
+                                      "key": "pane_tabs:0",
+                                      "rect": {"x": 38, "y": 1, "w": 89, "h": 1},
+                                      "cause": "parent E174",
+                                      "children": [
+                                        {
+                                          "id": "E176",
+                                          "type": "Gesture",
+                                          "rect": {"x": 38, "y": 1, "w": 89, "h": 1},
+                                          "cause": "parent E175",
+                                          "children": [
+                                            {
+                                              "id": "E177",
+                                              "type": "Box",
+                                              "rect": {"x": 38, "y": 1, "w": 89, "h": 1},
+                                              "cause": "parent E176",
+                                              "children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E178",
+                                          "type": "Box",
+                                          "rect": {"x": 127, "y": 1, "w": 0, "h": 1},
+                                          "cause": "parent E175",
+                                          "children": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "id": "E179",
+                                      "type": "Box",
+                                      "rect": {"x": 38, "y": 2, "w": 89, "h": 33},
+                                      "cause": "parent E174",
+                                      "children": [
+                                        {
+                                          "id": "E180",
+                                          "type": "Gesture",
+                                          "key": "pane_content:0",
+                                          "rect": {"x": 38, "y": 2, "w": 88, "h": 33},
+                                          "cause": "parent E179",
+                                          "children": [
+                                            {
+                                              "id": "E181",
+                                              "type": "Box",
+                                              "rect": {"x": 38, "y": 2, "w": 88, "h": 33},
+                                              "cause": "parent E180",
+                                              "children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E182",
+                                          "type": "Gesture",
+                                          "key": "pane_vscroll:0",
+                                          "rect": {"x": 126, "y": 2, "w": 1, "h": 33},
+                                          "cause": "parent E179",
+                                          "children": [
+                                            {
+                                              "id": "E183",
+                                              "type": "Box",
+                                              "rect": {"x": 126, "y": 2, "w": 1, "h": 33},
+                                              "cause": "parent E182",
+                                              "children": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "id": "E184",
+                                      "type": "Box",
+                                      "rect": {"x": 38, "y": 35, "w": 89, "h": 0},
+                                      "cause": "parent E174",
+                                      "children": [
+                                        {
+                                          "id": "E185",
+                                          "type": "Gesture",
+                                          "key": "pane_hscroll:0",
+                                          "rect": {"x": 38, "y": 35, "w": 88, "h": 0},
+                                          "cause": "parent E184",
+                                          "children": [
+                                            {
+                                              "id": "E186",
+                                              "type": "Box",
+                                              "rect": {"x": 38, "y": 35, "w": 88, "h": 0},
+                                              "cause": "parent E185",
+                                              "children": []
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E187",
+                                          "type": "Box",
+                                          "rect": {"x": 126, "y": 35, "w": 1, "h": 0},
+                                          "cause": "parent E184",
+                                          "children": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "E205",
+                      "type": "Host",
+                      "key": "region:5",
+                      "rect": {"x": 0, "y": 35, "w": 127, "h": 0},
+                      "cause": "parent E5",
+                      "children": []
+                    },
+                    {
+                      "id": "E206",
+                      "type": "Box",
+                      "key": "region:6",
+                      "rect": {"x": 0, "y": 35, "w": 127, "h": 0},
+                      "cause": "parent E5",
+                      "children": [
+                        {
+                          "id": "E207",
+                          "type": "Box",
+                          "rect": {"x": 0, "y": 35, "w": 1, "h": 0},
+                          "cause": "parent E206",
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "id": "E208",
+                      "type": "Host",
+                      "key": "region:7",
+                      "rect": {"x": 0, "y": 35, "w": 127, "h": 1},
+                      "cause": "parent E5",
+                      "children": []
+                    },
+                    {
+                      "id": "E217",
+                      "type": "Layer",
+                      "key": "prompt_suggestions",
+                      "rect": {"x": 0, "y": 22, "w": 127, "h": 13},
+                      "cause": "parent E5",
+                      "children": [
+                        {
+                          "id": "E218",
+                          "type": "Box",
+                          "rect": {"x": 0, "y": 22, "w": 127, "h": 13},
+                          "cause": "parent E217",
+                          "children": [
+                            {
+                              "id": "E219",
+                              "type": "Gesture",
+                              "rect": {"x": 0, "y": 22, "w": 127, "h": 12},
+                              "cause": "parent E218",
+                              "children": [
+                                {
+                                  "id": "E220",
+                                  "type": "Box",
+                                  "key": "prompt_suggestion_popup",
+                                  "rect": {"x": 0, "y": 22, "w": 127, "h": 12},
+                                  "cause": "parent E219",
+                                  "children": [
+                                    {
+                                      "id": "E221",
+                                      "type": "Box",
+                                      "rect": {"x": 0, "y": 22, "w": 127, "h": 12},
+                                      "cause": "parent E220",
+                                      "children": []
+                                    },
+                                    {
+                                      "id": "E222",
+                                      "type": "Box",
+                                      "rect": {"x": 0, "y": 22, "w": 127, "h": 12},
+                                      "cause": "parent E220",
+                                      "children": [
+                                        {
+                                          "id": "E223",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 22, "w": 127, "h": 1},
+                                          "cause": "parent E222",
+                                          "children": []
+                                        },
+                                        {
+                                          "id": "E224",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 23, "w": 127, "h": 10},
+                                          "cause": "parent E222",
+                                          "children": [
+                                            {
+                                              "id": "E225",
+                                              "type": "Box",
+                                              "rect": {"x": 0, "y": 23, "w": 1, "h": 10},
+                                              "cause": "parent E224",
+                                              "children": []
+                                            },
+                                            {
+                                              "id": "E226",
+                                              "type": "Box",
+                                              "key": "prompt_suggestion_list",
+                                              "rect": {"x": 1, "y": 23, "w": 126, "h": 10},
+                                              "cause": "parent E224",
+                                              "children": [
+                                                {
+                                                  "id": "E227",
+                                                  "type": "List<fresh::view::shell::msg::UiMsg>",
+                                                  "rect": {"x": 1, "y": 23, "w": 126, "h": 10},
+                                                  "state": "ListState",
+                                                  "state_detail": "sel=0",
+                                                  "builds": 10,
+                                                  "behaviors": ["Anchor"],
+                                                  "cause": "parent E226",
+                                                  "children": [
+                                                    {
+                                                      "id": "E228",
+                                                      "type": "Viewport",
+                                                      "rect": {"x": 1, "y": 23, "w": 126, "h": 10},
+                                                      "cause": "parent E227",
+                                                      "children": [
+                                                        {
+                                                          "id": "E229",
+                                                          "type": "LayoutReader",
+                                                          "rect": {"x": 1, "y": 23, "w": 125, "h": 10},
+                                                          "cause": "parent E228",
+                                                          "children": [
+                                                            {
+                                                              "id": "E188",
+                                                              "type": "Box",
+                                                              "rect": {"x": 1, "y": 23, "w": 125, "h": 10},
+                                                              "cause": "parent E229",
+                                                              "children": [
+                                                                {
+                                                                  "id": "E189",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 23, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E190",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:0",
+                                                                      "rect": {"x": 1, "y": 23, "w": 125, "h": 1},
+                                                                      "cause": "parent E189",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E216",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 23, "w": 2, "h": 1},
+                                                                          "cause": "parent E190",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E215",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:0",
+                                                                          "rect": {"x": 3, "y": 23, "w": 30, "h": 1},
+                                                                          "text": "Dump Config",
+                                                                          "cause": "parent E190",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E213",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 23, "w": 2, "h": 1},
+                                                                          "cause": "parent E190",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E214",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 23, "w": 74, "h": 1},
+                                                                          "text": "Save the current configuration to the user config file",
+                                                                          "cause": "parent E190",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E204",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 23, "w": 2, "h": 1},
+                                                                          "cause": "parent E190",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E337",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 23, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E338",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 23, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E346",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 23, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E198",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 24, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E196",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:1",
+                                                                      "rect": {"x": 1, "y": 24, "w": 125, "h": 1},
+                                                                      "cause": "parent E198",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E197",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 24, "w": 2, "h": 1},
+                                                                          "cause": "parent E196",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E195",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:1",
+                                                                          "rect": {"x": 3, "y": 24, "w": 30, "h": 1},
+                                                                          "text": "Dump UI Tree",
+                                                                          "cause": "parent E196",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E193",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 24, "w": 2, "h": 1},
+                                                                          "cause": "parent E196",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E194",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 24, "w": 74, "h": 1},
+                                                                          "text": "Open this window's retained UI tree as JSON in a read-only buffer",
+                                                                          "cause": "parent E196",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E192",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 24, "w": 2, "h": 1},
+                                                                          "cause": "parent E196",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E348",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 24, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E347",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 24, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E345",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 24, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E241",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 25, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E242",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:2",
+                                                                      "rect": {"x": 1, "y": 25, "w": 125, "h": 1},
+                                                                      "cause": "parent E241",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E243",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 25, "w": 2, "h": 1},
+                                                                          "cause": "parent E242",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E244",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:2",
+                                                                          "rect": {"x": 3, "y": 25, "w": 30, "h": 1},
+                                                                          "text": "Go to LSP Symbol",
+                                                                          "cause": "parent E242",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E245",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 25, "w": 2, "h": 1},
+                                                                          "cause": "parent E242",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E246",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 25, "w": 74, "h": 1},
+                                                                          "text": "List document symbols from LSP and navigate to selected",
+                                                                          "cause": "parent E242",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E247",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 25, "w": 2, "h": 1},
+                                                                          "cause": "parent E242",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E344",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 25, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E343",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 25, "w": 1, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E342",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 112, "y": 25, "w": 14, "h": 1},
+                                                                              "text": "lsp_navigation",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E253",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 26, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E254",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:3",
+                                                                      "rect": {"x": 1, "y": 26, "w": 125, "h": 1},
+                                                                      "cause": "parent E253",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E255",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 26, "w": 2, "h": 1},
+                                                                          "cause": "parent E254",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E256",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:3",
+                                                                          "rect": {"x": 3, "y": 26, "w": 30, "h": 1},
+                                                                          "text": "Add Ruler",
+                                                                          "cause": "parent E254",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E257",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 26, "w": 2, "h": 1},
+                                                                          "cause": "parent E254",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E258",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 26, "w": 74, "h": 1},
+                                                                          "text": "Add a vertical ruler line at a specific column position",
+                                                                          "cause": "parent E254",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E259",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 26, "w": 2, "h": 1},
+                                                                          "cause": "parent E254",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E341",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 26, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E340",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 26, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E339",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 26, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E265",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 27, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E266",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:4",
+                                                                      "rect": {"x": 1, "y": 27, "w": 125, "h": 1},
+                                                                      "cause": "parent E265",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E267",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 27, "w": 2, "h": 1},
+                                                                          "cause": "parent E266",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E268",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:4",
+                                                                          "rect": {"x": 3, "y": 27, "w": 30, "h": 1},
+                                                                          "text": "Env: Use System (Deactivate Environment)",
+                                                                          "cause": "parent E266",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E269",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 27, "w": 2, "h": 1},
+                                                                          "cause": "parent E266",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E270",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 27, "w": 74, "h": 1},
+                                                                          "text": "Deactivate the project environment and use the system environment for new processes",
+                                                                          "cause": "parent E266",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E271",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 27, "w": 2, "h": 1},
+                                                                          "cause": "parent E266",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E349",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 27, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E350",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 27, "w": 4, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E358",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 115, "y": 27, "w": 11, "h": 1},
+                                                                              "text": "env-manager",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E277",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 28, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E278",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:5",
+                                                                      "rect": {"x": 1, "y": 28, "w": 125, "h": 1},
+                                                                      "cause": "parent E277",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E279",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 28, "w": 2, "h": 1},
+                                                                          "cause": "parent E278",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E280",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:5",
+                                                                          "rect": {"x": 3, "y": 28, "w": 30, "h": 1},
+                                                                          "text": "Toggle Orchestrator Dock Focus",
+                                                                          "cause": "parent E278",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E281",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 28, "w": 2, "h": 1},
+                                                                          "cause": "parent E278",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E282",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 28, "w": 74, "h": 1},
+                                                                          "text": "Move keyboard focus to or from the orchestrator workspace dock (opens it if hidden)",
+                                                                          "cause": "parent E278",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E283",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 28, "w": 2, "h": 1},
+                                                                          "cause": "parent E278",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E360",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 28, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E359",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 28, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E357",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 28, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E289",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 29, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E290",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:6",
+                                                                      "rect": {"x": 1, "y": 29, "w": 125, "h": 1},
+                                                                      "cause": "parent E289",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E291",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 29, "w": 2, "h": 1},
+                                                                          "cause": "parent E290",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E292",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:6",
+                                                                          "rect": {"x": 3, "y": 29, "w": 30, "h": 1},
+                                                                          "text": "Suspend Process",
+                                                                          "cause": "parent E290",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E293",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 29, "w": 2, "h": 1},
+                                                                          "cause": "parent E290",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E294",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 29, "w": 74, "h": 1},
+                                                                          "text": "Suspend the editor with SIGTSTP (Unix); resume with `fg` in the parent shell",
+                                                                          "cause": "parent E290",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E295",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 29, "w": 2, "h": 1},
+                                                                          "cause": "parent E290",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E356",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 29, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E355",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 29, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E354",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 29, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E301",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 30, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E302",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:7",
+                                                                      "rect": {"x": 1, "y": 30, "w": 125, "h": 1},
+                                                                      "cause": "parent E301",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E303",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 30, "w": 2, "h": 1},
+                                                                          "cause": "parent E302",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E304",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:7",
+                                                                          "rect": {"x": 3, "y": 30, "w": 30, "h": 1},
+                                                                          "text": "Toggle Utility Dock",
+                                                                          "cause": "parent E302",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E305",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 30, "w": 2, "h": 1},
+                                                                          "cause": "parent E302",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E306",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 30, "w": 74, "h": 1},
+                                                                          "text": "Move keyboard focus to/from the shared bottom dock (diagnostics, search-replace, quickfix, …)",
+                                                                          "cause": "parent E302",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E307",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 30, "w": 2, "h": 1},
+                                                                          "cause": "parent E302",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E353",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 30, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E352",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 30, "w": 8, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E351",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 119, "y": 30, "w": 7, "h": 1},
+                                                                              "text": "builtin",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E313",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 31, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E314",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:8",
+                                                                      "rect": {"x": 1, "y": 31, "w": 125, "h": 1},
+                                                                      "cause": "parent E313",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E315",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 31, "w": 2, "h": 1},
+                                                                          "cause": "parent E314",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E316",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:8",
+                                                                          "rect": {"x": 3, "y": 31, "w": 30, "h": 1},
+                                                                          "text": "K8s: Disconnect Environment",
+                                                                          "cause": "parent E314",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E317",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 31, "w": 2, "h": 1},
+                                                                          "cause": "parent E314",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E318",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 31, "w": 74, "h": 1},
+                                                                          "text": "Disconnect / detach from the Kubernetes environment and restore local editing. Keywords: kubernetes k8s kubectl pod cluster remote cloud disconnect detach.",
+                                                                          "cause": "parent E314",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E319",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 31, "w": 2, "h": 1},
+                                                                          "cause": "parent E314",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E361",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 31, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E362",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 31, "w": 2, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E363",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 113, "y": 31, "w": 13, "h": 1},
+                                                                              "text": "k8s-workspace",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "id": "E325",
+                                                                  "type": "Gesture",
+                                                                  "rect": {"x": 1, "y": 32, "w": 125, "h": 1},
+                                                                  "cause": "parent E188",
+                                                                  "children": [
+                                                                    {
+                                                                      "id": "E326",
+                                                                      "type": "Box",
+                                                                      "key": "suggestion:9",
+                                                                      "rect": {"x": 1, "y": 32, "w": 125, "h": 1},
+                                                                      "cause": "parent E325",
+                                                                      "children": [
+                                                                        {
+                                                                          "id": "E327",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 1, "y": 32, "w": 2, "h": 1},
+                                                                          "cause": "parent E326",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E328",
+                                                                          "type": "TextRun",
+                                                                          "key": "suggestion_name:9",
+                                                                          "rect": {"x": 3, "y": 32, "w": 30, "h": 1},
+                                                                          "text": "K8s: Connect Environment",
+                                                                          "cause": "parent E326",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E329",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 33, "y": 32, "w": 2, "h": 1},
+                                                                          "cause": "parent E326",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E330",
+                                                                          "type": "TextRun",
+                                                                          "rect": {"x": 35, "y": 32, "w": 74, "h": 1},
+                                                                          "text": "Connect / attach to a Kubernetes environment via kubectl exec — edit inside a remote pod on any cluster: EKS, GKE, AKS, k3d, minikube, kind. Keywords: kubernetes k8s kubectl pod container cluster remote cloud environment workspace attach.",
+                                                                          "cause": "parent E326",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E331",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 109, "y": 32, "w": 2, "h": 1},
+                                                                          "cause": "parent E326",
+                                                                          "children": []
+                                                                        },
+                                                                        {
+                                                                          "id": "E364",
+                                                                          "type": "Box",
+                                                                          "rect": {"x": 111, "y": 32, "w": 15, "h": 1},
+                                                                          "cause": "mount",
+                                                                          "children": [
+                                                                            {
+                                                                              "id": "E365",
+                                                                              "type": "Box",
+                                                                              "rect": {"x": 111, "y": 32, "w": 2, "h": 1},
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            },
+                                                                            {
+                                                                              "id": "E366",
+                                                                              "type": "TextRun",
+                                                                              "rect": {"x": 113, "y": 32, "w": 13, "h": 1},
+                                                                              "text": "k8s-workspace",
+                                                                              "cause": "mount",
+                                                                              "children": []
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "id": "E230",
+                                          "type": "Box",
+                                          "rect": {"x": 0, "y": 33, "w": 127, "h": 1},
+                                          "cause": "parent E222",
+                                          "children": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "id": "E231",
+                              "type": "Box",
+                              "rect": {"x": 0, "y": 34, "w": 127, "h": 1},
+                              "cause": "parent E218",
+                              "children": [
+                                {
+                                  "id": "E232",
+                                  "type": "Box",
+                                  "rect": {"x": 0, "y": 34, "w": 2, "h": 1},
+                                  "cause": "parent E231",
+                                  "children": []
+                                },
+                                {
+                                  "id": "E233",
+                                  "type": "TextRun",
+                                  "rect": {"x": 2, "y": 34, "w": 39, "h": 1},
+                                  "text": "file  |  >command  |  :line  |  #buffer",
+                                  "cause": "parent E231",
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "E234",
+                      "type": "Layer",
+                      "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+                      "cause": "parent E5",
+                      "children": [
+                        {
+                          "id": "E235",
+                          "type": "Focusable",
+                          "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+                          "cause": "parent E234",
+                          "children": [
+                            {
+                              "id": "E236",
+                              "type": "Box",
+                              "rect": {"x": 0, "y": 0, "w": 127, "h": 36},
+                              "cause": "parent E235",
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Two things: the five [tui-clips](https://github.com/sinelaw/tui-clips) specs that film fresh move into this repo, and a sixth is added for the chrome migration.

## The move

The specs were living in the renderer's repo. A spec names one program's screens, keys, and the rows a caption points at — it goes stale when that program's layout moves, and the thing that moves it is this tree, so this is where it has to live to be maintained. They land in `scripts/clips/`, next to `record-asciinema`, `frames-to-gif.sh` and `generate-theme-screenshots.sh`, which is where the demo tooling already lives. tui-clips keeps the lib, the bin, and the spec format; a spec path was always any path, so nothing in its `bin/` changes. The other half is sinelaw/tui-clips#4, already merged.

Two path edits came with it: the config-directory assets are referenced from here now, and the review-diff demo repo materialises under `target/` instead of in the renderer's output directory.

## The new clip: `fresh-popup-rect.json`

A before/after of #3028 on one job — put a popup on screen near an edge, and take it away again. Five BEFORE screens, one two-word note each, each shoving the last off the frame; then one push into `layer()`, which gets five of its own.

| | screen | note |
|---|---|---|
| 1 | `chrome/theme_info.rs` `collect()` | 🤮 Old code: hand-stacked |
| 2 | `chrome/theme_info.rs` guard arm + `on_key` | 😩 duplicated |
| 3 | `theme_inspect.rs` painter | 😓 manual |
| 4 | `theme_inspect.rs` hit-test path | 😵 again |
| 5 | `theme_inspect.rs` `compute_popup_rect` | 🤯 again |
| 6 | `view/shell/theme_info.rs` `layer()` | 😍 New code: declarative |
| 7-10 | its four calls | ✅ position · layout · input handling · sizing |

**Why five screens for the before.** Because every line of `layer()` was a place you had to go. `.anchor` was `popup.position` passed into `compute_popup_rect`; `.place(Over)` was `b.z = 190` against everyone else's numbers; `.fit(CLAMP)` was two `if` branches and two `.min()`s; `.child(popup(t).w(Cells(WIDTH)))` was the caller counting its own lines and adding two for the border; `.dismiss(outside_pointer)` was a second full-frame box at a lower z plus the arm that fired on it; `.dismiss(any_key)` was `fn on_key`; `.passing_through()` was `Disposition::PassAfter`; and `.on_dismiss` was `theme_info_popup = None`, written in both dismissal paths.

**Screens 3 and 4 are the payoff.** `theme_info_popup_rect` spells `let width` / `let height` / `compute_popup_rect(…)` a second time, because hit-testing needed the rectangle and had nothing to ask for it — same `+ 2 // +2 for borders`, same call. The two shots are framed identically so the repetition lands as a repetition. The tree has no second spelling: what placed the popup is what is hit.

Of everything the migration deleted, this is the pair that fits in a frame. The settings dialog's 320-line `hit_test` is the more damning picture, but what replaced it is an absence — every surface is a node that answers its own press — and an absence does not cut to.

### How it films real code

`assets/fresh-popup-rect/make-files.sh` takes all three files out of git and makes two mechanical edits. Comments are stripped, because a reader who stops for a `// +2 for borders` has stopped looking at the shape of the code, which is the only thing the clip is about. Then rustfmt re-wraps at 68 columns, because a line wider than the terminal wraps on screen and a beat framed on a rect of rows cannot survive a continuation row appearing inside it. Neither edit rewrites anything, and the script greps its anchors out of the result rather than hard-coding line numbers, so a rebase upstream fails loudly instead of filming the wrong function.

## What the clips README carries

The part specific to filming *this* program, and three of its four entries cost an afternoon each:

- **Plugins are embedded into the binary at build time**, so a stale debug build films the *old* plugin — the feature is simply absent, with nothing on screen to say why.
- **Two panes sharing an `XDG_RUNTIME_DIR` share a daemon**, and the second one films the first one's project root.
- **`dump_ui_tree` reports the last frame painted**, so invoking it from the palette dumps the frame with the palette over everything. Bind a key; `ctrl+s` on the read-only buffer offers Save As.
- **Open a file past the function, not at it** — the editor centres the caret's line, so `file:N+17` lands line `N` at the top and leaves the doc comment above the screen.

## Testing

No code changes: this is data plus one shell script, and nothing in the build reads any of it. Both clips were rendered end to end and checked frame by frame; `make-files.sh` and `make-repo.sh` were run from the new paths and their anchor checks verified against a deliberate miss.

`fresh-popup-rect.json` needs sinelaw/tui-clips#5 to render — the notes, the push, the still camera and the title card are all new there. The other five specs render against tui-clips `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4EC8ssdo7rjk7YwQy6ido
