### PR TITLE
A signalled editor hands the terminal back before it goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Settings: `Delete` works in a text field again** in the Edit Item dialog (#2875, reported by @asukaminato0721).
 * **Dim text in the integrated terminal is dim again** (#3123, reported by @fiatcode-gh).
 * **Quitting no longer panics** while a plugin's off-loop work is still in flight.
+* **A signal no longer leaves the terminal unusable** - an editor stopped from outside (a `pkill`, a container stop) exited straight out of raw mode and the alternate screen, so the shell that got the terminal back echoed nothing and printed an escape burst on every click. The modes are now undone before the process goes.
 * **Git and review commands are grouped under two palette prefixes**, `Review Diff:` and `Git Log:` (#3098).
 * **Review Diff works with an external difftool** instead of showing an empty diff (#3066, by @asukaminato0721).
 * **Review Diff's `D` on a fully staged file now actually discards it**, with an honest report if it can't (#2318).

--- a/crates/fresh-editor/src/services/signal_handler.rs
+++ b/crates/fresh-editor/src/services/signal_handler.rs
@@ -20,6 +20,10 @@
 //! Rust with no restrictions, and the interrupted thread carries on and
 //! releases whatever it was holding.
 //!
+//! The terminal is handed back first, ahead of the dump: the process leaves
+//! through `process::exit`, which runs no destructors, so nothing else
+//! undoes raw mode and the alternate screen.
+//!
 //! Three things guarantee the process still dies, which is the part that
 //! must not depend on the dump working:
 //!
@@ -273,6 +277,8 @@ mod unix {
     /// Everything the old handler did, on an ordinary thread where it is
     /// allowed to allocate, lock, log and call into plugin code.
     fn report_and_exit(signal: libc::c_int) -> ! {
+        restore_terminal();
+
         tracing::error!("=== SIGNAL {signal} RECEIVED - Dumping debug info ===");
 
         tracing::error!("--- JavaScript State ---");
@@ -295,6 +301,24 @@ mod unix {
 
         tracing::error!("=== Debug dump complete, terminating process ===");
         std::process::exit(EXIT_CODE);
+    }
+
+    /// Hand the terminal back, before the report rather than after it.
+    ///
+    /// The process leaves here through `process::exit` — no destructors, so
+    /// the `TerminalModes` guard that normally undoes raw mode, the
+    /// alternate screen, mouse capture and bracketed paste never runs — and
+    /// the watchdog's `_exit` can cut in earlier still. Undoing the modes
+    /// first means both exits give the shell back a usable terminal instead
+    /// of one that echoes nothing and prints mouse reports at the prompt.
+    ///
+    /// Only when the terminal is ours to restore: a headless run (the
+    /// daemon under systemd, a `--cmd` invocation in a pipeline) would
+    /// otherwise write escape sequences into whatever is reading its stdout.
+    fn restore_terminal() {
+        if nix::unistd::isatty(std::io::stdout()).unwrap_or(false) {
+            crate::services::terminal_modes::emergency_cleanup();
+        }
     }
 
     fn install_termination_handler() {

--- a/crates/fresh-editor/tests/common/pty.rs
+++ b/crates/fresh-editor/tests/common/pty.rs
@@ -199,6 +199,27 @@ impl PtyChild {
         self.child.id()
     }
 
+    /// The modes the child has put the terminal in — alternate screen,
+    /// mouse reporting, bracketed paste — as a terminal emulator sees them.
+    pub fn modes(&self) -> &vt100::Screen {
+        self.parser.screen()
+    }
+
+    /// Whether the pty is in cooked mode: keystrokes echoed and lines
+    /// buffered, which is what a shell needs and what raw mode takes away.
+    ///
+    /// Read from the master end, so it is still answerable after the child
+    /// has gone — which is the moment a test cares about.
+    pub fn cooked(&self) -> bool {
+        // SAFETY: `tcgetattr` only fills the struct it is handed, and the
+        // fd is our own live master end.
+        let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+        if unsafe { libc::tcgetattr(self.master.as_raw_fd(), &mut termios) } != 0 {
+            return false;
+        }
+        termios.c_lflag & libc::ECHO != 0 && termios.c_lflag & libc::ICANON != 0
+    }
+
     /// Kill the child and reap it. Safe to call after it already exited.
     pub fn kill(&mut self) {
         let _ = self.child.kill();

--- a/crates/fresh-editor/tests/signal_termination.rs
+++ b/crates/fresh-editor/tests/signal_termination.rs
@@ -9,8 +9,9 @@
 //! used to leave `SIGTERM` ending in `SIGABRT`, `SIGSEGV`, or nothing at all.
 //!
 //! These drive the real binary, because the behaviour is the process's
-//! rather than the library's, and read the log the run produced — that log
-//! *is* the feature.
+//! rather than the library's, and read what the run left behind: the log,
+//! which *is* the diagnostic, and the terminal the editor was handed, which
+//! it has to give back on the way out.
 //!
 //! Linux-gated with `common::pty`, which needs `ptsname_r`.
 #![cfg(target_os = "linux")]
@@ -105,6 +106,55 @@ fn a_terminating_signal_is_reported_without_sweeping_every_thread() {
     assert!(
         !log.contains(SWEPT),
         "the per-thread sweep should not run unless asked for; log was:\n{log}"
+    );
+}
+
+/// A signalled editor hands the terminal back before it goes.
+///
+/// The reporting thread leaves through `process::exit`, which runs no
+/// destructors, so the guard that normally undoes the modes never gets to:
+/// the shell came back in raw mode, still on the alternate screen, with
+/// mouse reporting on. Typing echoed nothing and a click pasted an escape
+/// burst at the prompt, and `reset` was the only way out.
+///
+/// The modes going *on* are asserted first, so a run where the editor never
+/// took the terminal cannot pass this by leaving nothing to restore.
+#[test]
+fn a_terminating_signal_leaves_the_terminal_usable() {
+    if !pty_available() {
+        eprintln!("Skipping: no PTY available in this environment");
+        return;
+    }
+    let home = tempfile::tempdir().unwrap();
+    let mut editor = running_editor(isolated_fresh(home.path()));
+
+    assert!(
+        !editor.cooked(),
+        "the editor should hold the terminal in raw mode while it runs"
+    );
+    assert!(
+        editor.modes().alternate_screen(),
+        "the editor should be drawing on the alternate screen"
+    );
+
+    sigterm_and_reap(&mut editor);
+
+    assert!(
+        editor.cooked(),
+        "raw mode should be undone, or the shell that gets the terminal back echoes nothing"
+    );
+    assert!(
+        !editor.modes().alternate_screen(),
+        "the alternate screen should be left, or the shell draws over the editor's last frame"
+    );
+    assert_eq!(
+        editor.modes().mouse_protocol_mode(),
+        vt100::MouseProtocolMode::None,
+        "mouse reporting should be off, or every click types an escape burst at the prompt"
+    );
+    assert!(
+        !editor.modes().bracketed_paste(),
+        "bracketed paste should be off, or a paste arrives at the shell wrapped in markers"
     );
 }
 


### PR DESCRIPTION
## What

`SIGINT`/`SIGTERM` are reported by a thread that then calls `process::exit`, which runs no destructors — so the `TerminalModes` guard that undoes raw mode, the alternate screen, mouse capture and bracketed paste never ran. The shell that got the terminal back echoed nothing and printed an escape burst on every click; `reset` was the only way out. The watchdog's `_exit` had the same gap, so a wedged dump left the same mess.

The panic hook already called `terminal_modes::emergency_cleanup()`; the signal path was the one exit that didn't.

This undoes the modes first, ahead of the dump, so both exits hand back a usable terminal — and only when stdout is a tty, so a daemon under systemd or a `--cmd` run in a pipeline doesn't write escape sequences into whatever is reading it.

## How it turned up

An editor vanished mid-session with no panic and no backtrace. The logs said why:

```
ERROR fresh::services::signal_handler::unix: === SIGNAL 15 RECEIVED - Dumping debug info ===
ERROR fresh::services::signal_handler::unix: === Debug dump complete, terminating process ===
```

No panic, so nothing to print — an external `SIGTERM`, from a neighbouring script running `for pid in $(pgrep -x fresh); do kill "$pid"; done` to clear the copies a screenshot harness leaves behind. `pgrep -x fresh` also matched the one being typed in. Clean exits end with `Disabled raw mode` / `Left alternate screen`; the signalled ones had neither line, which is the bug this fixes.

## Test

`a_terminating_signal_leaves_the_terminal_usable` drives the real binary on a pty, `SIGTERM`s it, and reads the terminal it left behind: raw mode off (`tcgetattr` on the master end, so it is still answerable after the child is gone), alternate screen left, mouse reporting and bracketed paste off. The modes going *on* are asserted first, so a run that never took the terminal cannot pass by leaving nothing to restore. It fails on `master` at the raw-mode assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQws7hLm1DvvbKZ3pQBvgn