### PR TITLE
update: resolve releases the way the install script does

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -262,7 +262,7 @@ impl From<Cli> for Args {
             && cli
                 .cmd
                 .iter()
-                .any(|a| a == fresh_update::engine::SKIP_ATTESTATION_FLAG);
+                .any(|a| a == fresh_update::SKIP_ATTESTATION_FLAG);
         // Value flags: `--flag VALUE`. Point the update at a mirror of the
         // release feed — an air-gapped/enterprise mirror in production, and the
         // way the packaging containers exercise the real install flow in tests.

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -201,6 +201,7 @@ struct Args {
     update_yes: bool,
     update_allow_downgrade: bool,
     update_pre: bool,
+    update_skip_attestation: bool,
     update_print_command: bool,
     update_download_only: bool,
     update_force: bool,
@@ -243,7 +244,8 @@ impl From<Cli> for Args {
         };
 
         // `fresh --cmd update [--check] [--yes] [--allow-downgrade] [--force]
-        //                     [--print-command] [--releases-url U] [--download-base U]`
+        //                     [--print-command] [--skip-attestation]
+        //                     [--releases-url U] [--download-base U]`
         let update = cli.cmd.first().map(String::as_str) == Some("update");
         let update_check = update && cli.cmd.iter().any(|a| a == "--check");
         let update_yes = update && cli.cmd.iter().any(|a| a == "--yes" || a == "-y");
@@ -252,6 +254,15 @@ impl From<Cli> for Args {
         let update_download_only = update && cli.cmd.iter().any(|a| a == "--download-only");
         let update_force = update && cli.cmd.iter().any(|a| a == "--force");
         let update_pre = update && cli.cmd.iter().any(|a| a == "--pre");
+        // Verification down to the checksum alone — what `install.sh` does.
+        // Only useful when the attestation lookup itself is refused (GitHub's
+        // API rate limit), which is why the failure names it and nothing else
+        // advertises it.
+        let update_skip_attestation = update
+            && cli
+                .cmd
+                .iter()
+                .any(|a| a == fresh_update::engine::SKIP_ATTESTATION_FLAG);
         // Value flags: `--flag VALUE`. Point the update at a mirror of the
         // release feed — an air-gapped/enterprise mirror in production, and the
         // way the packaging containers exercise the real install flow in tests.
@@ -537,6 +548,7 @@ impl From<Cli> for Args {
             update_yes,
             update_allow_downgrade,
             update_pre,
+            update_skip_attestation,
             update_print_command,
             update_download_only,
             update_force,
@@ -4959,6 +4971,7 @@ fn show_paths_command() -> AnyhowResult<()> {
 
 /// Handle `fresh update [--check] [--yes] [--allow-downgrade] [--force]
 ///                       [--download-only] [--print-command]
+///                       [--skip-attestation]
 ///                       [--releases-url U] [--download-base U]`.
 fn update_command(args: &Args) -> AnyhowResult<()> {
     #[cfg(feature = "self-update")]
@@ -4993,6 +5006,7 @@ fn update_command(args: &Args) -> AnyhowResult<()> {
             yes: args.update_yes,
             allow_downgrade: args.update_allow_downgrade,
             allow_prerelease: args.update_pre,
+            skip_attestation: args.update_skip_attestation,
             // Three rungs, most automatic first. `--print-command` wins if
             // both are given: it is the one that promises to touch nothing,
             // and a promise like that should not be overridden by accident.

--- a/crates/fresh-editor/src/services/release_checker.rs
+++ b/crates/fresh-editor/src/services/release_checker.rs
@@ -338,7 +338,13 @@ pub fn plan_for(prov: &Provenance) -> UpdatePlan {
 /// rate limit is how the indicator goes quiet for an hour at a time.
 #[cfg(feature = "http")]
 fn fetch_release(releases_url: &str) -> Result<fresh_update::feed::Release, String> {
-    let mut endpoints = fresh_update::endpoint::Endpoints::production();
+    // From the environment, so both overrides are honoured: which route the
+    // check takes depends on the download base too — a mirror's own feed is
+    // authoritative for a mirror, and GitHub's redirect is not.
+    let mut endpoints = fresh_update::endpoint::Endpoints::from_env().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "ignoring an unusable release endpoint override");
+        fresh_update::endpoint::Endpoints::production()
+    });
     if releases_url != endpoints.releases_url {
         // A URL the policy refuses cannot reach here in a release build —
         // `releases_url()` above already sanitised the env override — but a

--- a/crates/fresh-editor/src/services/release_checker.rs
+++ b/crates/fresh-editor/src/services/release_checker.rs
@@ -327,14 +327,46 @@ pub fn plan_for(prov: &Provenance) -> UpdatePlan {
     fresh_update::plan(prov)
 }
 
+/// Resolve the latest release, over the network.
+///
+/// With the `http` feature this goes through `fresh_update::fetch`, which is
+/// the same path `fresh --cmd update` takes: it sends a `GITHUB_TOKEN` from
+/// the environment if there is one, and when GitHub's API refuses because the
+/// address's hourly budget is spent it reads the version from the
+/// `releases/latest` redirect instead. Sharing that matters here — the daily
+/// check is *also* an API request, and a check that silently gave up on a
+/// rate limit is how the indicator goes quiet for an hour at a time.
+#[cfg(feature = "http")]
+fn fetch_release(releases_url: &str) -> Result<fresh_update::feed::Release, String> {
+    let mut endpoints = fresh_update::endpoint::Endpoints::production();
+    if releases_url != endpoints.releases_url {
+        // A URL the policy refuses cannot reach here in a release build —
+        // `releases_url()` above already sanitised the env override — but a
+        // background check is not worth an error either way.
+        if let Err(e) = endpoints.set_releases_url(releases_url.to_string()) {
+            tracing::warn!(error = %e, "ignoring an unusable release endpoint; using the default");
+            endpoints = fresh_update::endpoint::Endpoints::production();
+        }
+    }
+    let transport = fresh_update::net::Transport::new(&endpoints);
+    Ok(fresh_update::fetch::latest(&transport, &endpoints, false)?.release)
+}
+
+/// Without the `http` feature there is no transport; `services::http` says so.
+#[cfg(not(feature = "http"))]
+fn fetch_release(releases_url: &str) -> Result<fresh_update::feed::Release, String> {
+    fresh_update::feed::Release::parse(&super::http::get_release_json(releases_url)?)
+}
+
 /// Check for a new release (blocking).
 ///
-/// Fetches the release feed here (HTTP lives in `services::http`) and hands the
-/// body to `fresh_update::check::evaluate`, which parses it, compares versions,
-/// and resolves provenance.
+/// Fetches the release feed and hands the result to
+/// `fresh_update::check::evaluate_release`, which compares versions and pairs
+/// them with this copy's provenance.
 pub fn check_for_update(releases_url: &str) -> Result<ReleaseCheckResult, String> {
-    let body = super::http::get_release_json(releases_url)?;
-    let check = fresh_update::check::evaluate(CURRENT_VERSION, &body)?;
+    let release = fetch_release(releases_url)?;
+    let check =
+        fresh_update::check::evaluate_release(CURRENT_VERSION, &release, fresh_update::resolve());
 
     tracing::debug!(
         current = CURRENT_VERSION,

--- a/crates/fresh-editor/tests/self_update_spine.rs
+++ b/crates/fresh-editor/tests/self_update_spine.rs
@@ -109,12 +109,17 @@ fn place_binary(to: &Path) {
 /// writes a private name and renames into place, so the losers of the race
 /// overwrite identical content and any reader holds a complete file.
 ///
+/// The cache is only reused while it is newer than the binary it was stripped
+/// from. Without that check a rebuilt `fresh` is silently ignored and every
+/// case here tests the previous build — which is worse than no cache: the
+/// tests still pass, against code that is no longer the code.
+///
 /// Falls back to the unstripped binary if `strip` is unavailable.
 fn stripped_binary() -> PathBuf {
     let original = PathBuf::from(env!("CARGO_BIN_EXE_fresh"));
     let cache_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
     let cached = cache_dir.join("fresh-stripped");
-    if cached.is_file() {
+    if is_fresher(&cached, &original) {
         return cached;
     }
 
@@ -132,6 +137,20 @@ fn stripped_binary() -> PathBuf {
     }
     let _ = std::fs::remove_file(&staging);
     original
+}
+
+/// Whether `cached` exists and was written after `source` — i.e. whether it
+/// still describes the binary under test.
+///
+/// A missing timestamp on either side answers "no": re-stripping costs a few
+/// seconds, and reusing a cache we cannot date costs a green run that proved
+/// nothing.
+fn is_fresher(cached: &Path, source: &Path) -> bool {
+    let modified = |p: &Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+    match (modified(cached), modified(source)) {
+        (Some(cached), Some(source)) => cached >= source,
+        _ => false,
+    }
 }
 
 /// Build the release archive in whichever format this target publishes, using
@@ -227,6 +246,80 @@ fn report(what: &str, out: &Output) -> String {
     )
 }
 
+/// Serve the fabricated release the way GitHub serves a real one: the version
+/// comes from a 302 on `releases/latest`, and the assets sit beside it under
+/// `releases/download/vX.Y.Z/`. No release feed at all — this server answers
+/// 404 for anything else, so a run that reached for one fails here.
+fn serve_redirect(archive: Vec<u8>, asset: String, sha256_line: String) -> String {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+    let port = server.server_addr().to_ip().unwrap().port();
+    let base = format!("http://127.0.0.1:{port}");
+    let location = format!("{base}/releases/tag/v{NEW_VERSION}");
+
+    std::thread::spawn(move || {
+        for request in server.incoming_requests() {
+            let url = request.url().to_string();
+            let response = if url == "/releases/latest" {
+                // Absolute `Location`, the way GitHub answers it.
+                tiny_http::Response::from_data(Vec::new())
+                    .with_status_code(302)
+                    .with_header(
+                        tiny_http::Header::from_bytes(&b"Location"[..], location.as_bytes())
+                            .expect("header"),
+                    )
+            } else if url.ends_with(&format!("{asset}.sha256")) {
+                tiny_http::Response::from_data(sha256_line.clone().into_bytes())
+                    .with_status_code(200)
+                    .with_header(
+                        tiny_http::Header::from_bytes(&b"X-Served"[..], &b"sha256"[..])
+                            .expect("header"),
+                    )
+            } else if url.ends_with(&asset) {
+                tiny_http::Response::from_data(archive.clone())
+                    .with_status_code(200)
+                    .with_header(
+                        tiny_http::Header::from_bytes(&b"X-Served"[..], &b"asset"[..])
+                            .expect("header"),
+                    )
+            } else {
+                tiny_http::Response::from_data(b"not found".to_vec())
+                    .with_status_code(404)
+                    .with_header(
+                        tiny_http::Header::from_bytes(&b"X-Served"[..], &b"none"[..])
+                            .expect("header"),
+                    )
+            };
+            let _ = request.respond(response);
+        }
+    });
+
+    base
+}
+
+/// Run the installed binary with only the download base pointed at the fake
+/// release, so the version is resolved through the redirect beside it — the
+/// route a real install takes, and the one that spends no API budget.
+///
+/// Deliberately no `--releases-url`: naming a feed is what takes the redirect
+/// out of play. If the redirect route ever regresses, this run falls through
+/// to GitHub's real feed, reports the real version, and the assertions below
+/// fail on the version comparison. That is the failure, not a flake.
+fn run_update_via_redirect(install: &Install, base: &str, extra: &[&str]) -> Output {
+    let mut cmd = Command::new(&install.exe);
+    cmd.arg("--cmd")
+        .arg("update")
+        .arg("--download-base")
+        .arg(format!("{base}/releases/download"))
+        .args(extra)
+        .env("HOME", install.root.join("home"))
+        .env("XDG_DATA_HOME", install.root.join("home"))
+        .env("XDG_CONFIG_HOME", install.root.join("home"))
+        .env_remove("FRESH_INSTALL_CHANNEL")
+        .env_remove("FRESH_RELEASES_URL")
+        .env_remove("FRESH_DOWNLOAD_BASE");
+    cmd.output().expect("run fresh --cmd update")
+}
+
 /// Set up an install serving a well-formed release, ready to update.
 fn ready(with_receipt: bool) -> (Install, String) {
     let install = install(with_receipt);
@@ -264,6 +357,67 @@ fn fresh_updates_itself_in_place() {
         .output()
         .expect("run replacement");
     assert_eq!(String::from_utf8_lossy(&ran.stdout).trim(), "updated-ok");
+}
+
+/// The same update, resolved the way every real install resolves it: through
+/// the `releases/latest` redirect rather than the API feed.
+///
+/// This is the production route — `fresh --cmd update` asks GitHub's web host
+/// for the version precisely so an exhausted API rate limit cannot refuse an
+/// update — and the server here answers 404 to everything but the redirect and
+/// the assets, so a run that fell back to a feed could not succeed.
+#[test]
+fn fresh_updates_itself_through_the_release_redirect() {
+    let install = install(true);
+    let archive = build_archive(&install);
+    let line = sha256_line(&archive, &install.asset);
+    let base = serve_redirect(archive, install.asset.clone(), line);
+    let before = std::fs::read(&install.exe).unwrap();
+
+    let out = run_update_via_redirect(&install, &base, &["--yes"]);
+    assert!(
+        out.status.success(),
+        "{}",
+        report("update through the redirect failed", &out)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains(NEW_VERSION),
+        "{}",
+        report("the redirect did not name the release", &out)
+    );
+
+    let after = std::fs::read(&install.exe).unwrap();
+    assert_ne!(before, after, "binary was not replaced");
+    assert_eq!(after, NEW_BINARY, "binary is not the payload we published");
+
+    let ran = Command::new(&install.exe)
+        .output()
+        .expect("run replacement");
+    assert_eq!(String::from_utf8_lossy(&ran.stdout).trim(), "updated-ok");
+}
+
+/// `--check` over the same route, which is what the editor's daily check does:
+/// it must report the version without ever reaching for the API.
+#[test]
+fn check_through_the_redirect_reports_without_replacing_anything() {
+    let install = install(true);
+    let archive = build_archive(&install);
+    let line = sha256_line(&archive, &install.asset);
+    let base = serve_redirect(archive, install.asset.clone(), line);
+    let before = std::fs::read(&install.exe).unwrap();
+
+    let out = run_update_via_redirect(&install, &base, &["--check"]);
+    assert!(out.status.success(), "{}", report("--check failed", &out));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains(NEW_VERSION),
+        "{}",
+        report("--check did not report the available version", &out)
+    );
+    assert_eq!(
+        std::fs::read(&install.exe).unwrap(),
+        before,
+        "--check replaced the binary"
+    );
 }
 
 /// `--check` reports and stops. The binary must be untouched, because this is

--- a/crates/fresh-editor/tests/self_update_spine.rs
+++ b/crates/fresh-editor/tests/self_update_spine.rs
@@ -420,6 +420,37 @@ fn check_through_the_redirect_reports_without_replacing_anything() {
     );
 }
 
+/// The attestation bypass reaches the engine and says so.
+///
+/// An overridden endpoint has no attestations to look up, so this cannot prove
+/// the check was skipped — what it pins is the wiring: the flag parses, it
+/// reaches `UpdateOptions`, and the run tells the user which verification it
+/// gave up rather than doing it quietly.
+#[test]
+fn skipping_the_attestation_is_wired_through_and_announced() {
+    let (install, base) = ready(true);
+
+    let out = run_update(&install, &base, &["--yes", "--skip-attestation"]);
+    assert!(out.status.success(), "{}", report("update failed", &out));
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Skipping the release attestation check"),
+        "{}",
+        report("the skipped check was not announced", &out)
+    );
+    assert!(
+        stdout.contains("catches corruption but not tampering"),
+        "{}",
+        report("the announcement did not say what was given up", &out)
+    );
+    assert_eq!(
+        std::fs::read(&install.exe).unwrap(),
+        NEW_BINARY,
+        "the update still has to happen"
+    );
+}
+
 /// `--check` reports and stops. The binary must be untouched, because this is
 /// the mode the editor's background check uses.
 #[test]

--- a/crates/fresh-editor/tests/self_update_spine.rs
+++ b/crates/fresh-editor/tests/self_update_spine.rs
@@ -439,8 +439,9 @@ fn skipping_the_attestation_is_wired_through_and_announced() {
         "{}",
         report("the skipped check was not announced", &out)
     );
+    // Wrapped across lines in the output, so match the halves.
     assert!(
-        stdout.contains("catches corruption but not tampering"),
+        stdout.contains("catches corruption") && stdout.contains("not tampering"),
         "{}",
         report("the announcement did not say what was given up", &out)
     );

--- a/crates/fresh-update/src/attestation.rs
+++ b/crates/fresh-update/src/attestation.rs
@@ -356,6 +356,30 @@ mod tests {
         );
     }
 
+    /// The one API request an update still makes is this one, so a rate limit
+    /// here is the one that can stop an install. It has to say that: what was
+    /// verified, what was not, and that re-running is the fix — not "403".
+    #[test]
+    fn a_rate_limited_lookup_explains_the_stop_rather_than_the_status() {
+        let limited = crate::net::FetchError::RateLimited {
+            url: attestation_url("sinelaw/fresh", &"a".repeat(64)),
+            wait: Some(std::time::Duration::from_secs(600)),
+            authenticated: false,
+        };
+        assert!(limited.is_rate_limited());
+        let message = AttestationError::RateLimited(limited.to_string()).to_string();
+        assert!(message.contains("10 minutes"), "{message}");
+        assert!(message.contains("GITHUB_TOKEN"), "{message}");
+        assert!(
+            message.contains("matched its checksum"),
+            "the message must say what did verify: {message}"
+        );
+        assert!(
+            message.contains("does not install unverified bytes"),
+            "the message must say the install stopped: {message}"
+        );
+    }
+
     #[test]
     fn url_is_on_the_pinned_api_host() {
         let url = attestation_url("sinelaw/fresh", &"a".repeat(64));

--- a/crates/fresh-update/src/attestation.rs
+++ b/crates/fresh-update/src/attestation.rs
@@ -76,10 +76,8 @@ impl std::fmt::Display for AttestationError {
             // that is the thing this module exists to refuse.
             AttestationError::RateLimited(detail) => write!(
                 f,
-                "{detail}\n\nThe download matched its checksum, but the release \
-                 attestation could not be checked, and fresh does not install \
-                 unverified bytes. Re-run once the limit resets, or set a token as \
-                 above and re-run now."
+                "{detail} The release attestation could not be checked, so nothing \
+                 was installed."
             ),
         }
     }
@@ -371,11 +369,7 @@ mod tests {
         assert!(message.contains("10 minutes"), "{message}");
         assert!(message.contains("GITHUB_TOKEN"), "{message}");
         assert!(
-            message.contains("matched its checksum"),
-            "the message must say what did verify: {message}"
-        );
-        assert!(
-            message.contains("does not install unverified bytes"),
+            message.contains("nothing was installed"),
             "the message must say the install stopped: {message}"
         );
     }

--- a/crates/fresh-update/src/attestation.rs
+++ b/crates/fresh-update/src/attestation.rs
@@ -44,6 +44,10 @@ pub enum AttestationError {
     /// Attestations exist for this digest, but none records it under the asset
     /// name we asked for.
     NameMismatch { asset: String, digest: String },
+    /// The attestation endpoint refused because GitHub's API rate limit for
+    /// this address is spent. Distinct from [`AttestationError::Fetch`]
+    /// because it is temporary and has remedies nothing else here has.
+    RateLimited(String),
 }
 
 impl std::fmt::Display for AttestationError {
@@ -64,6 +68,18 @@ impl std::fmt::Display for AttestationError {
                 f,
                 "the release attestation for sha256:{digest} does not record it \
                  as {asset}; refusing to install it"
+            ),
+            // Fail-closed is the whole design (see the module note), so this
+            // reports a stop, not a warning — and then says how to get past it.
+            // The download itself is fine: it matched its checksum. What could
+            // not happen is the second origin agreeing, and installing without
+            // that is the thing this module exists to refuse.
+            AttestationError::RateLimited(detail) => write!(
+                f,
+                "{detail}\n\nThe download matched its checksum, but the release \
+                 attestation could not be checked, and fresh does not install \
+                 unverified bytes. Re-run once the limit resets, or set a token as \
+                 above and re-run now."
             ),
         }
     }
@@ -96,13 +112,15 @@ pub fn verify(
     // redirect away from it would defeat the point of asking a second host.
     crate::endpoint::check(&url).map_err(|e| AttestationError::Fetch(e.to_string()))?;
 
-    let body = transport
-        .get_text_optional(&url, ATTESTATION_MAX_BYTES)
-        .map_err(AttestationError::Fetch)?
-        .ok_or_else(|| AttestationError::NotAttested {
-            asset: asset.to_string(),
-            digest: digest.clone(),
-        })?;
+    let body = match transport.get_text_optional(&url, ATTESTATION_MAX_BYTES) {
+        Ok(body) => body,
+        Err(e) if e.is_rate_limited() => return Err(AttestationError::RateLimited(e.to_string())),
+        Err(e) => return Err(AttestationError::Fetch(e.to_string())),
+    }
+    .ok_or_else(|| AttestationError::NotAttested {
+        asset: asset.to_string(),
+        digest: digest.clone(),
+    })?;
 
     if attests(&body, asset, &digest)? {
         Ok(())

--- a/crates/fresh-update/src/check.rs
+++ b/crates/fresh-update/src/check.rs
@@ -23,13 +23,31 @@ pub struct ReleaseCheck {
 /// from the live environment. Returns an error string if the body has no
 /// parseable `tag_name`.
 pub fn evaluate(current_version: &str, release_json: &str) -> Result<ReleaseCheck, String> {
-    let latest_version = Release::parse(release_json)?.version().to_string();
+    Ok(evaluate_release(
+        current_version,
+        &Release::parse(release_json)?,
+        provenance::resolve(),
+    ))
+}
+
+/// Evaluate an already-resolved release.
+///
+/// The caller that fetches over HTTP resolves the release itself — it may have
+/// come from the feed or, when the API is rate-limited, from the release
+/// redirect (see `fresh_update::fetch`) — so there is no document left to
+/// parse and nothing that can fail here.
+pub fn evaluate_release(
+    current_version: &str,
+    release: &Release,
+    provenance: Provenance,
+) -> ReleaseCheck {
+    let latest_version = release.version().to_string();
     let update_available = version::is_newer(current_version, &latest_version);
-    Ok(ReleaseCheck {
+    ReleaseCheck {
         latest_version,
         update_available,
-        provenance: provenance::resolve(),
-    })
+        provenance,
+    }
 }
 
 /// Like [`evaluate`] but with an explicit provenance (for tests / callers that
@@ -39,13 +57,11 @@ pub fn evaluate_with(
     release_json: &str,
     provenance: Provenance,
 ) -> Result<ReleaseCheck, String> {
-    let latest_version = Release::parse(release_json)?.version().to_string();
-    let update_available = version::is_newer(current_version, &latest_version);
-    Ok(ReleaseCheck {
-        latest_version,
-        update_available,
+    Ok(evaluate_release(
+        current_version,
+        &Release::parse(release_json)?,
         provenance,
-    })
+    ))
 }
 
 #[cfg(test)]

--- a/crates/fresh-update/src/endpoint.rs
+++ b/crates/fresh-update/src/endpoint.rs
@@ -131,6 +131,16 @@ pub struct Endpoints {
     pub releases_url: String,
     /// Base URL that release asset names are appended to.
     pub download_base: String,
+    /// Where the `releases/latest` redirect that names the newest release
+    /// lives — the route that costs no API budget (see [`crate::fetch`]).
+    ///
+    /// Derived from [`Endpoints::download_base`], because that is where it
+    /// sits: GitHub serves `…/releases/latest` beside `…/releases/download`,
+    /// and so does anything mirroring that layout. `None` once a feed has been
+    /// named explicitly — a caller who points `--releases-url` at a document
+    /// chose where versions come from, and resolving them somewhere else would
+    /// ignore that — or when the base has a shape we do not recognise.
+    pub redirect_url: Option<String>,
     /// `false` when either endpoint was overridden away from the pinned
     /// defaults. An untrusted endpoint may still be used — that is the point
     /// of the override — but the engine will not run a privileged install with
@@ -147,9 +157,11 @@ impl Default for Endpoints {
 impl Endpoints {
     /// The pinned defaults: GitHub, over TLS.
     pub fn production() -> Self {
+        let download_base = format!("https://github.com/{REPO}/releases/download");
         Endpoints {
             releases_url: DEFAULT_RELEASES_URL.to_string(),
-            download_base: format!("https://github.com/{REPO}/releases/download"),
+            redirect_url: redirect_beside(&download_base),
+            download_base,
             trusted: true,
         }
     }
@@ -183,12 +195,22 @@ impl Endpoints {
     pub fn set_releases_url(&mut self, url: String) -> Result<(), EndpointError> {
         self.trusted &= accept(&url)?;
         self.releases_url = url;
+        // A named feed is the answer to "which release?", so the redirect is
+        // no longer consulted — whichever order the two overrides arrive in.
+        self.redirect_url = None;
         Ok(())
     }
 
     /// Point asset downloads elsewhere, under the same policy.
+    ///
+    /// The redirect moves with them: it lives beside the downloads, so a base
+    /// that keeps GitHub's layout keeps the cheap route to the version, and one
+    /// that does not falls back to the feed.
     pub fn set_download_base(&mut self, base: String) -> Result<(), EndpointError> {
         self.trusted &= accept(&base)?;
+        if self.redirect_url.is_some() {
+            self.redirect_url = redirect_beside(&base);
+        }
         self.download_base = base;
         Ok(())
     }
@@ -216,20 +238,13 @@ impl Endpoints {
     }
 
     /// The web redirect that names the latest release without spending any of
-    /// the API's rate-limit budget: `github.com/<repo>/releases/latest` is a
-    /// 302 to that release's page, and the tag is in the `Location` header.
+    /// the API's rate-limit budget: `…/releases/latest` answers 302 with that
+    /// release's page, and the tag is in the `Location` header.
     ///
-    /// `None` unless the endpoints are the pinned production ones. An override
-    /// points at a mirror or a tag endpoint whose shape we were handed and do
-    /// not get to reinterpret — and the whole point of this URL is that it is
-    /// the *same repository* the feed describes, reached another way.
-    ///
-    /// See [`crate::fetch`] for when this is used and what it cannot answer.
+    /// See [`Endpoints::redirect_url`] for when there is one, and
+    /// [`crate::fetch`] for what it can and cannot answer.
     pub fn latest_redirect_url(&self) -> Option<String> {
-        let pinned = self.trusted
-            && self.releases_url == DEFAULT_RELEASES_URL
-            && self.download_base == Endpoints::production().download_base;
-        pinned.then(|| format!("https://github.com/{REPO}/releases/latest"))
+        self.redirect_url.clone()
     }
 
     /// The URL of a release asset, given its filename.
@@ -237,6 +252,18 @@ impl Endpoints {
         let base = self.download_base.trim_end_matches('/');
         format!("{base}/v{version}/{file_name}")
     }
+}
+
+/// The `releases/latest` redirect that sits beside a `releases/download` base.
+///
+/// One rule, applied to whatever base is in effect: replace the final
+/// `download` segment with `latest`. It yields GitHub's own redirect for the
+/// pinned base, the matching one for a mirror that keeps that layout, and
+/// `None` for a base shaped some other way — which reads as "ask the feed".
+fn redirect_beside(download_base: &str) -> Option<String> {
+    let base = download_base.trim_end_matches('/');
+    base.strip_suffix("/download")
+        .map(|stem| format!("{stem}/latest"))
 }
 
 /// Decide whether an overridden endpoint may be used at all.
@@ -297,22 +324,22 @@ mod endpoint_list_tests {
 }
 
 #[cfg(test)]
-mod redirect_fallback_tests {
+mod redirect_tests {
     use super::*;
 
     #[test]
-    fn the_pinned_default_has_a_web_redirect_to_fall_back_on() {
+    fn the_pinned_default_resolves_versions_through_the_web_redirect() {
         let url = Endpoints::production()
             .latest_redirect_url()
             .expect("the pinned endpoints have one");
         assert_eq!(url, format!("https://github.com/{REPO}/releases/latest"));
-        check(&url).expect("the fallback must satisfy the same policy");
+        check(&url).expect("the redirect must satisfy the same policy");
     }
 
-    /// A mirror's `latest` is not this repository's `latest`, and a tag
-    /// endpoint is not asking for `latest` at all.
+    /// A named feed is the caller's answer to "which release?", whichever
+    /// order the two overrides arrive in.
     #[test]
-    fn an_overridden_feed_has_none() {
+    fn naming_a_feed_takes_the_redirect_out_of_play() {
         let mut ep = Endpoints::production();
         ep.set_releases_url(format!(
             "https://api.github.com/repos/{REPO}/releases/tags/v0.4.7"
@@ -320,10 +347,39 @@ mod redirect_fallback_tests {
         .expect("an allowlisted host is within policy");
         assert_eq!(ep.latest_redirect_url(), None);
 
-        let mut ep = Endpoints::production();
-        ep.releases_url = "https://example.invalid/feed/latest".to_string();
-        ep.trusted = false;
+        // …and the download base moving afterwards does not bring it back.
+        ep.set_download_base(format!("https://github.com/{REPO}/releases/download"))
+            .expect("within policy");
         assert_eq!(ep.latest_redirect_url(), None);
+    }
+
+    /// The redirect lives beside the downloads, so it follows them: a mirror
+    /// keeping GitHub's layout keeps the route that costs no API budget.
+    #[test]
+    fn the_redirect_follows_the_download_base() {
+        let mut ep = Endpoints::production();
+        ep.set_download_base("https://github.com/other/repo/releases/download".to_string())
+            .expect("an allowlisted host is within policy");
+        assert_eq!(
+            ep.latest_redirect_url().as_deref(),
+            Some("https://github.com/other/repo/releases/latest")
+        );
+
+        // A base shaped some other way has no redirect beside it to guess at.
+        let mut ep = Endpoints::production();
+        match ep.set_download_base("https://github.com/other/repo/dl".to_string()) {
+            Ok(()) => assert_eq!(ep.latest_redirect_url(), None),
+            Err(e) => panic!("an allowlisted host should be accepted: {e}"),
+        }
+    }
+
+    #[test]
+    fn a_trailing_slash_does_not_hide_the_redirect() {
+        assert_eq!(
+            redirect_beside("https://github.com/a/b/releases/download/").as_deref(),
+            Some("https://github.com/a/b/releases/latest")
+        );
+        assert_eq!(redirect_beside("https://example.invalid/files"), None);
     }
 }
 
@@ -401,6 +457,7 @@ mod tests {
         let ep = Endpoints {
             releases_url: DEFAULT_RELEASES_URL.to_string(),
             download_base: "https://github.com/x/releases/download/".to_string(),
+            redirect_url: None,
             trusted: true,
         };
         assert_eq!(

--- a/crates/fresh-update/src/endpoint.rs
+++ b/crates/fresh-update/src/endpoint.rs
@@ -215,6 +215,23 @@ impl Endpoints {
         }
     }
 
+    /// The web redirect that names the latest release without spending any of
+    /// the API's rate-limit budget: `github.com/<repo>/releases/latest` is a
+    /// 302 to that release's page, and the tag is in the `Location` header.
+    ///
+    /// `None` unless the endpoints are the pinned production ones. An override
+    /// points at a mirror or a tag endpoint whose shape we were handed and do
+    /// not get to reinterpret — and the whole point of this URL is that it is
+    /// the *same repository* the feed describes, reached another way.
+    ///
+    /// See [`crate::fetch`] for when this is used and what it cannot answer.
+    pub fn latest_redirect_url(&self) -> Option<String> {
+        let pinned = self.trusted
+            && self.releases_url == DEFAULT_RELEASES_URL
+            && self.download_base == Endpoints::production().download_base;
+        pinned.then(|| format!("https://github.com/{REPO}/releases/latest"))
+    }
+
     /// The URL of a release asset, given its filename.
     pub fn asset_url(&self, version: &str, file_name: &str) -> String {
         let base = self.download_base.trim_end_matches('/');
@@ -276,6 +293,37 @@ mod endpoint_list_tests {
         ep.releases_url = "https://example.invalid/feed/latest".to_string();
         ep.trusted = false;
         assert_eq!(ep.list_url(), "https://example.invalid/feed/latest");
+    }
+}
+
+#[cfg(test)]
+mod redirect_fallback_tests {
+    use super::*;
+
+    #[test]
+    fn the_pinned_default_has_a_web_redirect_to_fall_back_on() {
+        let url = Endpoints::production()
+            .latest_redirect_url()
+            .expect("the pinned endpoints have one");
+        assert_eq!(url, format!("https://github.com/{REPO}/releases/latest"));
+        check(&url).expect("the fallback must satisfy the same policy");
+    }
+
+    /// A mirror's `latest` is not this repository's `latest`, and a tag
+    /// endpoint is not asking for `latest` at all.
+    #[test]
+    fn an_overridden_feed_has_none() {
+        let mut ep = Endpoints::production();
+        ep.set_releases_url(format!(
+            "https://api.github.com/repos/{REPO}/releases/tags/v0.4.7"
+        ))
+        .expect("an allowlisted host is within policy");
+        assert_eq!(ep.latest_redirect_url(), None);
+
+        let mut ep = Endpoints::production();
+        ep.releases_url = "https://example.invalid/feed/latest".to_string();
+        ep.trusted = false;
+        assert_eq!(ep.latest_redirect_url(), None);
     }
 }
 

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -705,6 +705,7 @@ mod tests {
             endpoints: Endpoints {
                 releases_url: "http://127.0.0.1:9/release.json".to_string(),
                 download_base: "http://127.0.0.1:9".to_string(),
+                redirect_url: None,
                 trusted: false,
             },
             ..UpdateOptions::default()
@@ -760,6 +761,7 @@ mod tests {
         let untrusted = Endpoints {
             releases_url: "http://127.0.0.1:9/release.json".to_string(),
             download_base: "http://127.0.0.1:9".to_string(),
+            redirect_url: None,
             trusted: false,
         };
         for channel in [Channel::Apt, Channel::Dnf, Channel::Zypper] {

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -1,6 +1,7 @@
 //! `fresh --cmd update`, end to end.
 //!
-//! Resolve provenance, fetch the release feed, then take one of four routes
+//! Resolve provenance, resolve the release (through the `releases/latest`
+//! redirect, not the API — see [`crate::fetch`]), then take one of four routes
 //! decided entirely by [`UpdateKind`]:
 //!
 //! * **Delegated / Toolchain** — print the owning package manager's own
@@ -165,16 +166,11 @@ pub fn run(current_version: &str, opts: &UpdateOptions) -> Result<UpdateStatus, 
     );
 
     let transport = Transport::new(&opts.endpoints);
+    // Resolves through the `releases/latest` redirect on the pinned endpoints —
+    // no API budget spent, so a `--check` cannot be refused by a rate limit
+    // somebody else used up. See `crate::fetch`.
     let fetched = crate::fetch::latest(&transport, &opts.endpoints, opts.allow_prerelease)?;
-    let release = fetched.release;
-    let latest = release.version().to_string();
-    if fetched.source == crate::fetch::Source::ReleaseRedirect {
-        // Say it, rather than leaving a user to wonder why an update that just
-        // failed now works: this run knows the version but not the release's
-        // asset list, and `package` below turns that into a real answer.
-        println!("GitHub's API is rate-limited right now; read the version from the");
-        println!("release redirect instead.");
-    }
+    let latest = fetched.release.version().to_string();
 
     println!("Current version: {current_version}");
     println!("Latest version:  {latest}");
@@ -218,24 +214,7 @@ pub fn run(current_version: &str, opts: &UpdateOptions) -> Result<UpdateStatus, 
                 println!("An update is available. Run `fresh --cmd update` to fetch it.");
                 return Ok(UpdateStatus::Done);
             }
-            if !fetched.source.lists_assets() {
-                // The version came from the release redirect, which names no
-                // assets, and this channel's artifact is whichever `.deb`/`.rpm`
-                // the release actually published — a name that embeds a
-                // packaging revision we cannot derive. Saying so beats
-                // "release 0.4.8 publishes no .deb for amd64", which would be
-                // false as well as unactionable.
-                return Err(format!(
-                    "{latest} is available, but naming its {} package needs GitHub's API, \
-                     which is rate-limited right now. Wait for the limit to reset, set {} to \
-                     a personal access token, or download it from \
-                     https://github.com/{}/releases/latest",
-                    prov.channel.label(),
-                    net::TOKEN_ENVS.join(" or "),
-                    crate::endpoint::REPO,
-                ));
-            }
-            package(&prov, &release, &transport, opts)
+            package(&prov, &fetched, &transport, opts)
         }
         UpdateKind::Delegated | UpdateKind::Toolchain => {
             let cmd = plan.command.clone().unwrap_or_default();
@@ -268,9 +247,16 @@ pub fn run(current_version: &str, opts: &UpdateOptions) -> Result<UpdateStatus, 
 
 /// Fetch the release artifact for a channel whose package manager has no
 /// repository to upgrade from, and hand it to the local package tool.
+///
+/// The artifact is named the way `scripts/install.sh` names it — from the
+/// version, with no request for the release's asset list — so a `.deb`/`.rpm`
+/// update spends no API budget either. That name is a prediction, so it is
+/// checked by using it: if the release does not publish it, the feed is asked
+/// for the real one, which costs the one request the construction was there to
+/// avoid and only when it was actually wrong.
 fn package(
     prov: &Provenance,
-    release: &Release,
+    fetched: &crate::fetch::Fetched,
     transport: &Transport,
     opts: &UpdateOptions,
 ) -> Result<UpdateStatus, String> {
@@ -286,28 +272,19 @@ fn package(
     )
     .ok_or_else(|| format!("no release package is published for {}", channel.label()))?;
 
-    let asset = release.find_package(asset_spec.extension, &asset_spec.arch)?;
-    // This URL comes out of the feed rather than being built from a pinned
-    // base, so on the production endpoint it gets the full host check — a feed
-    // we did not author must not be able to point the download anywhere.
-    //
-    // An overridden endpoint is the one case where that check is wrong rather
-    // than strict: a mirror's feed necessarily names assets *on the mirror*, so
-    // enforcing the GitHub allowlist there rejects every asset and makes
-    // `--releases-url` unusable for the air-gapped case it exists for. The
-    // endpoint is already marked untrusted, and nothing is installed from it.
-    if opts.endpoints.trusted {
-        crate::endpoint::check(&asset.browser_download_url).map_err(|e| e.to_string())?;
-    }
+    let mut asset = match constructed_asset(fetched, &asset_spec, opts) {
+        Some(asset) => asset,
+        // Either the feed is already in hand, or this extension has no naming
+        // we encode. Both mean: read the name off the release.
+        None => feed_asset(&fetched.release, &asset_spec, opts)?,
+    };
 
     // Display only: whether the printed command needs a `sudo` in front of it.
     let needs_privilege = crate::plan(prov).needs_privilege;
 
     if !opts.execution.may_download() {
         // "Show the command" means exactly that: no request for the artifact,
-        // nothing written to disk. The two commands are still nameable, because
-        // the release feed — already fetched, and the same request the daily
-        // background check makes — carries the asset's URL and filename.
+        // nothing written to disk.
         let cmd = crate::registry::install_command_with(
             channel,
             Path::new(&format!("./{}", asset.name)),
@@ -323,11 +300,33 @@ fn package(
         return Ok(UpdateStatus::ActionRequired);
     }
 
-    let bytes = fetch_and_verify(
+    let bytes = match fetch_and_verify(
         transport,
         &asset.browser_download_url,
         opts.endpoints.trusted,
-    )?;
+    ) {
+        Ok(bytes) => bytes,
+        // The name we built is not what this release published — a packaging
+        // change, or a second revision of the same version. The feed knows the
+        // real one; ask it, and only now.
+        Err(DownloadError::Missing(_))
+            if fetched.source == crate::fetch::Source::ReleaseRedirect =>
+        {
+            tracing::warn!(
+                asset = %asset.name,
+                "constructed package name is not published; asking the release feed"
+            );
+            let release =
+                crate::fetch::from_feed(transport, &opts.endpoints, opts.allow_prerelease)?;
+            asset = feed_asset(&release, &asset_spec, opts)?;
+            fetch_and_verify(
+                transport,
+                &asset.browser_download_url,
+                opts.endpoints.trusted,
+            )?
+        }
+        Err(e) => return Err(e.into()),
+    };
 
     // The user installs this by hand, later, so it goes somewhere nothing
     // sweeps out from under them. (This used to be an ephemeral directory when
@@ -345,6 +344,52 @@ fn package(
     println!();
     show_command(&crate::elevate::elevated(&cmd, needs_privilege));
     Ok(UpdateStatus::ActionRequired)
+}
+
+/// The package this release should publish, named from its version and hosted
+/// under the pinned download base.
+///
+/// `None` when the release came from the feed (whose names are facts, so there
+/// is nothing to predict), when the endpoint is overridden (a mirror serves its
+/// own layout, and only its feed knows it), or when the extension has no naming
+/// we encode.
+fn constructed_asset(
+    fetched: &crate::fetch::Fetched,
+    spec: &crate::registry::PackageAsset,
+    opts: &UpdateOptions,
+) -> Option<crate::feed::Asset> {
+    if fetched.source.lists_assets() || !opts.endpoints.trusted {
+        return None;
+    }
+    let version = fetched.release.version();
+    let name = crate::feed::package_file_name(version, spec.extension, &spec.arch)?;
+    let browser_download_url = opts.endpoints.asset_url(version, &name);
+    Some(crate::feed::Asset {
+        name,
+        browser_download_url,
+    })
+}
+
+/// The package this release *does* publish, read off the feed.
+fn feed_asset(
+    release: &Release,
+    spec: &crate::registry::PackageAsset,
+    opts: &UpdateOptions,
+) -> Result<crate::feed::Asset, String> {
+    let asset = release.find_package(spec.extension, &spec.arch)?;
+    // This URL comes out of the feed rather than being built from a pinned
+    // base, so on the production endpoint it gets the full host check — a feed
+    // we did not author must not be able to point the download anywhere.
+    //
+    // An overridden endpoint is the one case where that check is wrong rather
+    // than strict: a mirror's feed necessarily names assets *on the mirror*, so
+    // enforcing the GitHub allowlist there rejects every asset and makes
+    // `--releases-url` unusable for the air-gapped case it exists for. The
+    // endpoint is already marked untrusted, and nothing is installed from it.
+    if opts.endpoints.trusted {
+        crate::endpoint::check(&asset.browser_download_url).map_err(|e| e.to_string())?;
+    }
+    Ok(asset.clone())
 }
 
 /// Verified in-place update for a self-contained install.
@@ -472,6 +517,40 @@ pub fn archive_ext(target: &str) -> &'static str {
     }
 }
 
+/// A download that did not produce verified bytes.
+///
+/// "That asset does not exist" is kept apart from every other failure because
+/// one caller can act on it: [`package`] builds a filename from a convention,
+/// and a 404 is the release telling it the convention did not hold. Everything
+/// else — a checksum mismatch, a missing attestation, a broken connection — is
+/// a failure to report, and collapsing the two would turn a tampered download
+/// into a retry against the feed.
+enum DownloadError {
+    /// The asset is not published under that name.
+    Missing(String),
+    /// Anything else, already phrased for the user.
+    Failed(String),
+}
+
+impl From<crate::net::FetchError> for DownloadError {
+    fn from(e: crate::net::FetchError) -> Self {
+        match e {
+            crate::net::FetchError::Status { status: 404, .. } => {
+                DownloadError::Missing(e.to_string())
+            }
+            other => DownloadError::Failed(other.to_string()),
+        }
+    }
+}
+
+impl From<DownloadError> for String {
+    fn from(e: DownloadError) -> String {
+        match e {
+            DownloadError::Missing(detail) | DownloadError::Failed(detail) => detail,
+        }
+    }
+}
+
 /// Download `url`, returning the bytes only if they check out at both origins.
 ///
 /// The sidecar shares an origin with the payload, so it catches corruption and
@@ -481,19 +560,25 @@ pub fn archive_ext(target: &str) -> &'static str {
 ///
 /// `trusted` tracks [`Endpoints::trusted`] — an overridden endpoint has no
 /// attestations to find, so the second check is skipped.
-fn fetch_and_verify(transport: &Transport, url: &str, trusted: bool) -> Result<Vec<u8>, String> {
+fn fetch_and_verify(
+    transport: &Transport,
+    url: &str,
+    trusted: bool,
+) -> Result<Vec<u8>, DownloadError> {
     println!("Downloading {url} ...");
-    let scratch = crate::staging::ephemeral()?;
+    let scratch = crate::staging::ephemeral().map_err(DownloadError::Failed)?;
     let tmp = scratch.path().join("payload");
     transport.download(url, &tmp, net::ASSET_MAX_BYTES)?;
-    let bytes = std::fs::read(&tmp).map_err(|e| format!("read download: {e}"))?;
+    let bytes =
+        std::fs::read(&tmp).map_err(|e| DownloadError::Failed(format!("read download: {e}")))?;
 
     println!("Verifying checksum ...");
     let sha_url = format!("{url}.sha256");
     let expected = transport
         .get_text(&sha_url, net::SIDECAR_MAX_BYTES)
-        .map_err(|e| format!("could not fetch checksum ({sha_url}): {e}"))?;
-    self_update::verify_sha256(&bytes, expected.trim()).map_err(|e| e.to_string())?;
+        .map_err(|e| DownloadError::Failed(format!("could not fetch checksum ({sha_url}): {e}")))?;
+    self_update::verify_sha256(&bytes, expected.trim())
+        .map_err(|e| DownloadError::Failed(e.to_string()))?;
 
     if trusted {
         println!("Verifying release attestation ...");
@@ -503,7 +588,7 @@ fn fetch_and_verify(transport: &Transport, url: &str, trusted: bool) -> Result<V
         let digest = self_update::sha256_hex(&bytes);
         let asset = url.rsplit('/').next().unwrap_or(url);
         crate::attestation::verify(transport, crate::endpoint::REPO, asset, &digest)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| DownloadError::Failed(e.to_string()))?;
     } else {
         println!("Release endpoint overridden — skipping the attestation check.");
     }
@@ -558,6 +643,106 @@ mod tests {
         for (target, expected) in cases {
             assert_eq!(archive_ext(target), expected, "archive_ext({target})");
         }
+    }
+
+    fn redirect_fetched(version: &str) -> crate::fetch::Fetched {
+        crate::fetch::Fetched {
+            release: Release::from_tag(format!("v{version}")),
+            source: crate::fetch::Source::ReleaseRedirect,
+        }
+    }
+
+    /// The point of the construction: a `.deb`/`.rpm` update names its
+    /// artifact from the version, so it needs no request to `api.github.com`
+    /// and cannot be refused by a rate limit somebody else used up. The URL
+    /// must land on the pinned host, exactly where `install.sh` fetches it.
+    #[test]
+    fn a_package_is_named_from_the_version_without_the_feed() {
+        let opts = UpdateOptions {
+            endpoints: Endpoints::production(),
+            ..UpdateOptions::default()
+        };
+        let spec = crate::registry::PackageAsset {
+            extension: ".deb",
+            arch: "amd64".to_string(),
+        };
+        let asset = constructed_asset(&redirect_fetched("0.4.10"), &spec, &opts)
+            .expect("a .deb name is one we encode");
+        assert_eq!(asset.name, "fresh-editor_0.4.10-1_amd64.deb");
+        assert_eq!(
+            asset.browser_download_url,
+            format!(
+                "https://github.com/{}/releases/download/v0.4.10/{}",
+                crate::endpoint::REPO,
+                asset.name
+            )
+        );
+        crate::endpoint::check(&asset.browser_download_url)
+            .expect("a constructed asset URL stays on a pinned host");
+    }
+
+    /// Two cases where predicting the name would be wrong rather than merely
+    /// unnecessary: the feed is already in hand and states the real names, or
+    /// the endpoint is a mirror whose layout we do not get to assume.
+    #[test]
+    fn a_name_is_never_predicted_when_the_release_can_be_asked() {
+        let spec = crate::registry::PackageAsset {
+            extension: ".deb",
+            arch: "amd64".to_string(),
+        };
+
+        let from_feed = crate::fetch::Fetched {
+            release: Release::from_tag("v0.4.10"),
+            source: crate::fetch::Source::Api,
+        };
+        let opts = UpdateOptions {
+            endpoints: Endpoints::production(),
+            ..UpdateOptions::default()
+        };
+        assert!(constructed_asset(&from_feed, &spec, &opts).is_none());
+
+        let opts = UpdateOptions {
+            endpoints: Endpoints {
+                releases_url: "http://127.0.0.1:9/release.json".to_string(),
+                download_base: "http://127.0.0.1:9".to_string(),
+                trusted: false,
+            },
+            ..UpdateOptions::default()
+        };
+        assert!(constructed_asset(&redirect_fetched("0.4.10"), &spec, &opts).is_none());
+    }
+
+    /// A 404 is the release saying the constructed name was wrong, and only
+    /// that failure may send the caller back to the feed. A checksum mismatch
+    /// or a missing attestation must never be retried as if it were a naming
+    /// problem.
+    #[test]
+    fn only_a_missing_asset_is_a_naming_problem() {
+        let missing: DownloadError = crate::net::FetchError::Status {
+            url: "https://github.com/x.deb".to_string(),
+            status: 404,
+        }
+        .into();
+        assert!(matches!(missing, DownloadError::Missing(_)));
+
+        for status in [403, 500, 502] {
+            let other: DownloadError = crate::net::FetchError::Status {
+                url: "https://github.com/x.deb".to_string(),
+                status,
+            }
+            .into();
+            assert!(
+                matches!(other, DownloadError::Failed(_)),
+                "HTTP {status} must not read as a naming problem"
+            );
+        }
+        let limited: DownloadError = crate::net::FetchError::RateLimited {
+            url: "https://api.github.com/x".to_string(),
+            wait: None,
+            authenticated: false,
+        }
+        .into();
+        assert!(matches!(limited, DownloadError::Failed(_)));
     }
 
     /// Windows wins over the musl check, so a hypothetical

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -615,9 +615,9 @@ fn fetch_and_verify(
     if skip_attestation {
         // Said plainly, every time, because the user gave up the check that
         // separates "these bytes are intact" from "GitHub published them".
-        println!("Skipping the release attestation check ({SKIP_ATTESTATION_FLAG}).");
-        println!("These bytes are verified only against a checksum served from the same");
-        println!("origin as the artifact, which catches corruption but not tampering.");
+        println!("Skipping the release attestation check: these bytes are verified");
+        println!("only by a checksum from the same origin, which catches corruption");
+        println!("but not tampering.");
     } else if trusted {
         println!("Verifying release attestation ...");
         // The digest is computed from the bytes on disk, never read from the
@@ -645,10 +645,7 @@ fn fetch_and_verify(
 fn attestation_failure(e: &crate::attestation::AttestationError) -> String {
     let bypass = matches!(e, crate::attestation::AttestationError::RateLimited(_));
     if bypass {
-        format!(
-            "{e}\n\nIf a checksum-only install is acceptable — the verification \
-             `install.sh` does, and no more — re-run with {SKIP_ATTESTATION_FLAG}."
-        )
+        format!("{e} Re-run later, or {SKIP_ATTESTATION_FLAG} to install on the checksum alone.")
     } else {
         e.to_string()
     }

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -43,16 +43,12 @@
 
 #![allow(clippy::let_underscore_must_use)]
 
-/// The flag that turns the attestation check off, named once so the hint in a
-/// failure and the CLI that parses it cannot drift apart.
-pub const SKIP_ATTESTATION_FLAG: &str = "--skip-attestation";
-
 use crate::endpoint::Endpoints;
 use crate::feed::Release;
 use crate::net::{self, Transport};
 use crate::provenance::Provenance;
 use crate::registry::UpdateKind;
-use crate::{self_update, Channel};
+use crate::{self_update, Channel, SKIP_ATTESTATION_FLAG};
 use std::path::{Path, PathBuf};
 
 /// Options for one run of the engine.

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -43,6 +43,10 @@
 
 #![allow(clippy::let_underscore_must_use)]
 
+/// The flag that turns the attestation check off, named once so the hint in a
+/// failure and the CLI that parses it cannot drift apart.
+pub const SKIP_ATTESTATION_FLAG: &str = "--skip-attestation";
+
 use crate::endpoint::Endpoints;
 use crate::feed::Release;
 use crate::net::{self, Transport};
@@ -65,6 +69,20 @@ pub struct UpdateOptions {
     /// Off by default, and the refusal is enforced in [`crate::feed::select`]
     /// rather than left to the endpoint: see the note there.
     pub allow_prerelease: bool,
+    /// Do not check the release attestation before installing.
+    ///
+    /// Lowers verification to the checksum sidecar alone — the same bar
+    /// `install.sh` sets, and a weaker one than this engine's default: the
+    /// sidecar is served from the same origin as the artifact, so it catches
+    /// corruption but not a release that was tampered with at the source. It
+    /// exists because the attestation lookup is the one request an update makes
+    /// to `api.github.com`, and a rate limit there is otherwise an hour's wait
+    /// with no way through.
+    ///
+    /// Deliberately a flag and not an environment variable: this is a decision
+    /// to be taken per run, not one to leave set in a shell profile where it
+    /// silently applies to every future update.
+    pub skip_attestation: bool,
     /// Run the install path even when already on the latest version.
     ///
     /// Distinct from `allow_downgrade`, which is about *which* versions are
@@ -86,6 +104,7 @@ impl Default for UpdateOptions {
             yes: false,
             allow_downgrade: false,
             allow_prerelease: false,
+            skip_attestation: false,
             force: false,
             execution: Execution::Install,
             // An out-of-policy override is refused outright in a release build,
@@ -304,6 +323,7 @@ fn package(
         transport,
         &asset.browser_download_url,
         opts.endpoints.trusted,
+        opts.skip_attestation,
     ) {
         Ok(bytes) => bytes,
         // The name we built is not what this release published — a packaging
@@ -323,6 +343,7 @@ fn package(
                 transport,
                 &asset.browser_download_url,
                 opts.endpoints.trusted,
+                opts.skip_attestation,
             )?
         }
         Err(e) => return Err(e.into()),
@@ -411,7 +432,12 @@ fn self_contained(
     let url = opts.endpoints.asset_url(latest, &asset);
 
     let bin_name = if cfg!(windows) { "fresh.exe" } else { "fresh" };
-    let archive = fetch_and_verify(transport, &url, opts.endpoints.trusted)?;
+    let archive = fetch_and_verify(
+        transport,
+        &url,
+        opts.endpoints.trusted,
+        opts.skip_attestation,
+    )?;
     let binary = if asset.ends_with(".zip") {
         crate::archive::from_zip(&archive, bin_name)?
     } else if asset.ends_with(".tar.gz") {
@@ -444,7 +470,12 @@ fn appimage(
         "AppImage install has no recorded install_root; reinstall via install.sh".to_string()
     })?;
 
-    let bytes = fetch_and_verify(transport, &url, opts.endpoints.trusted)?;
+    let bytes = fetch_and_verify(
+        transport,
+        &url,
+        opts.endpoints.trusted,
+        opts.skip_attestation,
+    )?;
 
     // Everything happens inside one private directory next to the install root
     // — same filesystem, so the final rename is atomic, and private so nothing
@@ -564,6 +595,7 @@ fn fetch_and_verify(
     transport: &Transport,
     url: &str,
     trusted: bool,
+    skip_attestation: bool,
 ) -> Result<Vec<u8>, DownloadError> {
     println!("Downloading {url} ...");
     let scratch = crate::staging::ephemeral().map_err(DownloadError::Failed)?;
@@ -580,7 +612,13 @@ fn fetch_and_verify(
     self_update::verify_sha256(&bytes, expected.trim())
         .map_err(|e| DownloadError::Failed(e.to_string()))?;
 
-    if trusted {
+    if skip_attestation {
+        // Said plainly, every time, because the user gave up the check that
+        // separates "these bytes are intact" from "GitHub published them".
+        println!("Skipping the release attestation check ({SKIP_ATTESTATION_FLAG}).");
+        println!("These bytes are verified only against a checksum served from the same");
+        println!("origin as the artifact, which catches corruption but not tampering.");
+    } else if trusted {
         println!("Verifying release attestation ...");
         // The digest is computed from the bytes on disk, never read from the
         // network — otherwise the second origin would be checking the first
@@ -588,12 +626,32 @@ fn fetch_and_verify(
         let digest = self_update::sha256_hex(&bytes);
         let asset = url.rsplit('/').next().unwrap_or(url);
         crate::attestation::verify(transport, crate::endpoint::REPO, asset, &digest)
-            .map_err(|e| DownloadError::Failed(e.to_string()))?;
+            .map_err(|e| DownloadError::Failed(attestation_failure(&e)))?;
     } else {
         println!("Release endpoint overridden — skipping the attestation check.");
     }
 
     Ok(bytes)
+}
+
+/// What to tell the user when the attestation could not be confirmed.
+///
+/// The bypass is named for a rate limit and nothing else. Every other failure
+/// here is either "GitHub does not attest to these bytes" or "something got in
+/// the way of asking" — and pointing at a flag that skips the check would be
+/// suggesting the bypass in precisely the cases the check is for. A rate limit
+/// is different in kind: GitHub answered, over TLS, that it will not answer
+/// again for a while.
+fn attestation_failure(e: &crate::attestation::AttestationError) -> String {
+    let bypass = matches!(e, crate::attestation::AttestationError::RateLimited(_));
+    if bypass {
+        format!(
+            "{e}\n\nIf a checksum-only install is acceptable — the verification \
+             `install.sh` does, and no more — re-run with {SKIP_ATTESTATION_FLAG}."
+        )
+    } else {
+        e.to_string()
+    }
 }
 
 /// Print a command for the user to run, rather than running it.
@@ -711,6 +769,40 @@ mod tests {
             ..UpdateOptions::default()
         };
         assert!(constructed_asset(&redirect_fetched("0.4.10"), &spec, &opts).is_none());
+    }
+
+    /// The bypass is offered for a rate limit and for nothing else: naming it
+    /// when GitHub says these bytes are *not* attested would be suggesting the
+    /// way around the check in the one case the check exists for.
+    #[test]
+    fn only_a_rate_limit_is_told_how_to_go_around_the_attestation() {
+        use crate::attestation::AttestationError;
+
+        let limited = AttestationError::RateLimited("rate limited".to_string());
+        let message = attestation_failure(&limited);
+        assert!(
+            message.contains(SKIP_ATTESTATION_FLAG),
+            "a rate limit must name the way through: {message}"
+        );
+
+        for e in [
+            AttestationError::NotAttested {
+                asset: "fresh-editor.tar.gz".to_string(),
+                digest: "a".repeat(64),
+            },
+            AttestationError::NameMismatch {
+                asset: "fresh-editor.tar.gz".to_string(),
+                digest: "a".repeat(64),
+            },
+            AttestationError::Malformed("not json".to_string()),
+            AttestationError::Fetch("connection reset".to_string()),
+        ] {
+            let message = attestation_failure(&e);
+            assert!(
+                !message.contains(SKIP_ATTESTATION_FLAG),
+                "{e:?} must not advertise the bypass: {message}"
+            );
+        }
     }
 
     /// A 404 is the release saying the constructed name was wrong, and only

--- a/crates/fresh-update/src/engine.rs
+++ b/crates/fresh-update/src/engine.rs
@@ -165,16 +165,16 @@ pub fn run(current_version: &str, opts: &UpdateOptions) -> Result<UpdateStatus, 
     );
 
     let transport = Transport::new(&opts.endpoints);
-    // Pre-releases are absent from `/releases/latest`, so opting in means
-    // asking the list endpoint; without the flag this is the pinned default.
-    let feed_url = if opts.allow_prerelease {
-        opts.endpoints.list_url()
-    } else {
-        opts.endpoints.releases_url.clone()
-    };
-    let body = transport.get_text(&feed_url, net::FEED_MAX_BYTES)?;
-    let release = crate::feed::select(&body, opts.allow_prerelease)?;
+    let fetched = crate::fetch::latest(&transport, &opts.endpoints, opts.allow_prerelease)?;
+    let release = fetched.release;
     let latest = release.version().to_string();
+    if fetched.source == crate::fetch::Source::ReleaseRedirect {
+        // Say it, rather than leaving a user to wonder why an update that just
+        // failed now works: this run knows the version but not the release's
+        // asset list, and `package` below turns that into a real answer.
+        println!("GitHub's API is rate-limited right now; read the version from the");
+        println!("release redirect instead.");
+    }
 
     println!("Current version: {current_version}");
     println!("Latest version:  {latest}");
@@ -217,6 +217,23 @@ pub fn run(current_version: &str, opts: &UpdateOptions) -> Result<UpdateStatus, 
             if opts.check_only {
                 println!("An update is available. Run `fresh --cmd update` to fetch it.");
                 return Ok(UpdateStatus::Done);
+            }
+            if !fetched.source.lists_assets() {
+                // The version came from the release redirect, which names no
+                // assets, and this channel's artifact is whichever `.deb`/`.rpm`
+                // the release actually published — a name that embeds a
+                // packaging revision we cannot derive. Saying so beats
+                // "release 0.4.8 publishes no .deb for amd64", which would be
+                // false as well as unactionable.
+                return Err(format!(
+                    "{latest} is available, but naming its {} package needs GitHub's API, \
+                     which is rate-limited right now. Wait for the limit to reset, set {} to \
+                     a personal access token, or download it from \
+                     https://github.com/{}/releases/latest",
+                    prov.channel.label(),
+                    net::TOKEN_ENVS.join(" or "),
+                    crate::endpoint::REPO,
+                ));
             }
             package(&prov, &release, &transport, opts)
         }

--- a/crates/fresh-update/src/feed.rs
+++ b/crates/fresh-update/src/feed.rs
@@ -21,6 +21,18 @@ use serde::Deserialize;
 /// differ, which is the distinction that broke receipt lookup once already.
 pub const PACKAGE_PREFIX: &str = "fresh-editor";
 
+/// The packaging revision in a `.deb`/`.rpm` filename: the `-1` in
+/// `fresh-editor_0.4.10-1_amd64.deb`.
+///
+/// It is a constant rather than a variable because the pipeline makes it one:
+/// `scripts/update-debian-changelog.sh` writes `(${VERSION}-1)` on every
+/// release, and `cargo generate-rpm` leaves its default release of `1`. A
+/// release that ever needs a second revision of the same version would have to
+/// change both, and this with them — which is why the name built from it is
+/// checked against the release rather than assumed (see
+/// [`package_file_name`]).
+pub const PACKAGE_REVISION: &str = "1";
+
 /// One published release asset.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct Asset {
@@ -179,6 +191,33 @@ pub fn select(json: &str, allow_prerelease: bool) -> Result<Release, String> {
     }
 }
 
+/// The filename this release publishes for `extension` and `arch`, built from
+/// the version alone.
+///
+/// This is the same construction `scripts/install.sh` does — it has no release
+/// feed either, and names `fresh-editor_${VERSION}-1_${ARCH}.deb` straight from
+/// the version — and it is what lets an update fetch a package without asking
+/// GitHub's API for the release's asset list. `None` for an extension whose
+/// naming we do not encode, which the caller must read as "ask the feed".
+///
+/// It is a *prediction*, not a fact: [`crate::engine`] downloads the name it
+/// returns and falls back to the feed if the release does not publish it, so a
+/// packaging change surfaces as one extra request rather than as a wrong
+/// answer.
+pub fn package_file_name(version: &str, extension: &str, arch: &str) -> Option<String> {
+    let rev = PACKAGE_REVISION;
+    match extension {
+        // dpkg: fresh-editor_0.4.10-1_amd64.deb
+        ".deb" => Some(format!("{PACKAGE_PREFIX}_{version}-{rev}_{arch}.deb")),
+        // rpm: fresh-editor-0.4.10-1.x86_64.rpm
+        ".rpm" => Some(format!("{PACKAGE_PREFIX}-{version}-{rev}.{arch}.rpm")),
+        // flatpak bundles carry no packaging revision:
+        // fresh-editor-0.4.10-x86_64.flatpak
+        ".flatpak" => Some(format!("{PACKAGE_PREFIX}-{version}-{arch}.flatpak")),
+        _ => None,
+    }
+}
+
 /// Whether `name` is our package artifact for `extension` and `arch`.
 ///
 /// The separator before the architecture matters: dpkg writes
@@ -254,6 +293,54 @@ mod tests {
         assert_eq!(
             release.find_package(".rpm", "x86_64").unwrap().name,
             "fresh-editor-0.4.7-1.x86_64.rpm"
+        );
+    }
+
+    /// The constructed name and the predicate that recognises one must agree:
+    /// they are the two halves of the same convention, and a release resolves
+    /// through whichever half the update path reached.
+    #[test]
+    fn a_constructed_name_is_one_the_matcher_recognises() {
+        for (extension, arch) in [
+            (".deb", "amd64"),
+            (".rpm", "x86_64"),
+            (".flatpak", "x86_64"),
+        ] {
+            let name = package_file_name("0.4.10", extension, arch).expect("a name");
+            assert!(
+                is_package_named(&name, extension, arch),
+                "built {name}, which the matcher rejects"
+            );
+        }
+        assert_eq!(
+            package_file_name("0.4.10", ".deb", "amd64").as_deref(),
+            Some("fresh-editor_0.4.10-1_amd64.deb")
+        );
+        assert_eq!(
+            package_file_name("0.4.10", ".rpm", "x86_64").as_deref(),
+            Some("fresh-editor-0.4.10-1.x86_64.rpm")
+        );
+        // An extension whose naming we do not encode must say so rather than
+        // guess: the caller asks the feed instead.
+        assert_eq!(package_file_name("0.4.10", ".pkg.tar.zst", "x86_64"), None);
+    }
+
+    /// The names in this test are the ones `scripts/install.sh` builds. If the
+    /// two ever disagree, one of them is downloading a 404.
+    #[test]
+    fn the_constructed_names_match_the_install_script() {
+        let script = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../scripts/install.sh"
+        ))
+        .expect("read install.sh");
+        assert!(
+            script.contains(r#"${BIN_NAME}_${VERSION}-1_${ARCH}.deb"#),
+            "install.sh no longer names .debs the way package_file_name does"
+        );
+        assert!(
+            script.contains(r#"${BIN_NAME}-${VERSION}-1.${ARCH}.rpm"#),
+            "install.sh no longer names .rpms the way package_file_name does"
         );
     }
 

--- a/crates/fresh-update/src/feed.rs
+++ b/crates/fresh-update/src/feed.rs
@@ -52,6 +52,21 @@ pub struct Release {
 }
 
 impl Release {
+    /// A release known only by its tag.
+    ///
+    /// This is what [`crate::fetch`] can recover when the API refuses to serve
+    /// the feed: the `releases/latest` redirect names the release and nothing
+    /// else. The empty asset list is *unknown*, not *empty*, and callers must
+    /// keep the two apart — [`crate::fetch::Source::lists_assets`] is how.
+    pub fn from_tag(tag_name: impl Into<String>) -> Self {
+        Release {
+            tag_name: tag_name.into(),
+            assets: Vec::new(),
+            prerelease: false,
+            draft: false,
+        }
+    }
+
     /// Parse a release-metadata document.
     pub fn parse(json: &str) -> Result<Self, String> {
         serde_json::from_str(json).map_err(|e| format!("could not read the release feed: {e}"))

--- a/crates/fresh-update/src/fetch.rs
+++ b/crates/fresh-update/src/fetch.rs
@@ -27,9 +27,12 @@
 //!   construction the install script does — and [`crate::engine`] falls back to
 //!   the feed if the release does not actually publish that name.
 //!
-//! An overridden endpoint (`--releases-url`, a mirror, a test server) keeps
-//! using its feed: it named a document, and reinterpreting that as "ask GitHub
-//! instead" would ignore what the caller asked for.
+//! Naming a feed (`--releases-url`, `FRESH_RELEASES_URL`) takes the redirect
+//! out of play entirely: the caller pointed at a document, and resolving the
+//! version somewhere else would ignore that. Pointing only the *downloads*
+//! elsewhere moves the redirect with them — it lives beside them, at
+//! `…/releases/latest` — so a mirror that keeps GitHub's layout keeps the
+//! cheap route too. See [`crate::endpoint::Endpoints::redirect_url`].
 //!
 //! The one request that has no second route is the attestation lookup
 //! ([`crate::attestation`]), which is a *different origin* on purpose — that is
@@ -239,10 +242,46 @@ mod server_tests {
         format!("http://127.0.0.1:{port}")
     }
 
+    /// [`serve`], plus paths that answer 200 with a body.
+    fn serve_with_bodies(routes: Vec<Route>, bodies: Vec<(&'static str, &'static str)>) -> String {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let port = server.server_addr().to_ip().expect("ip").port();
+        let (ready, started) = mpsc::channel();
+        std::thread::spawn(move || {
+            ready.send(()).expect("signal");
+            for request in server.incoming_requests() {
+                let url = request.url().to_string();
+                let response = if let Some((_, body)) =
+                    bodies.iter().find(|(path, _)| url.starts_with(path))
+                {
+                    tiny_http::Response::from_string(*body).with_status_code(200)
+                } else if let Some((_, code, headers)) =
+                    routes.iter().find(|(path, _, _)| url.starts_with(path))
+                {
+                    let mut response = tiny_http::Response::from_string("")
+                        .with_status_code(tiny_http::StatusCode(*code));
+                    for (name, value) in headers {
+                        response.add_header(
+                            tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes())
+                                .expect("header"),
+                        );
+                    }
+                    response
+                } else {
+                    tiny_http::Response::from_string("").with_status_code(404)
+                };
+                let _ = request.respond(response);
+            }
+        });
+        started.recv().expect("server start");
+        format!("http://127.0.0.1:{port}")
+    }
+
     fn endpoints_for(base: &str) -> Endpoints {
         Endpoints {
             releases_url: format!("{base}/releases/latest"),
             download_base: format!("{base}/dl"),
+            redirect_url: None,
             trusted: false,
         }
     }
@@ -281,6 +320,68 @@ mod server_tests {
     /// The regression this module exists for: `api.github.com` answering 403
     /// because the address's hourly budget is gone must be reported as the
     /// rate limit it is, with the remedy in the message.
+    /// Endpoints shaped like production against a local server: the redirect
+    /// beside the download base, and a feed nothing may reach — so if the
+    /// redirect route is not the one taken, the test fails rather than
+    /// quietly asking GitHub.
+    fn redirect_endpoints(base: &str) -> Endpoints {
+        Endpoints {
+            releases_url: "http://127.0.0.1:1/must-not-be-fetched".to_string(),
+            download_base: format!("{base}/releases/download"),
+            redirect_url: Some(format!("{base}/releases/latest")),
+            trusted: false,
+        }
+    }
+
+    /// The route every real update now takes, driven through `latest` against
+    /// a server answering the way GitHub does: 302, `Location` naming the
+    /// release page. No feed request is possible here.
+    #[test]
+    fn the_redirect_is_the_route_the_version_comes_from() {
+        let base = serve(vec![(
+            "/releases/latest",
+            302,
+            vec![(
+                "Location",
+                "https://github.com/sinelaw/fresh/releases/tag/v9.9.9".to_string(),
+            )],
+        )]);
+        let endpoints = redirect_endpoints(&base);
+        let transport = Transport::new(&endpoints).without_token();
+
+        let fetched = latest(&transport, &endpoints, false).expect("the redirect answers");
+        assert_eq!(fetched.release.version(), "9.9.9");
+        assert_eq!(fetched.source, Source::ReleaseRedirect);
+        // And the asset URL built from it lands beside the redirect, which is
+        // what makes the whole update reachable without the API.
+        assert_eq!(
+            endpoints.asset_url("9.9.9", "fresh-editor_9.9.9-1_amd64.deb"),
+            format!("{base}/releases/download/v9.9.9/fresh-editor_9.9.9-1_amd64.deb")
+        );
+    }
+
+    /// If the redirect stops answering the way we expect, the feed still can:
+    /// the same server serves a 500 there and a release document at the feed
+    /// URL, and the version comes back from the feed.
+    #[test]
+    fn a_broken_redirect_falls_through_to_the_feed() {
+        let base = serve_with_bodies(
+            vec![("/releases/latest", 500, vec![])],
+            vec![("/feed", r#"{"tag_name":"v8.8.8"}"#)],
+        );
+        let endpoints = Endpoints {
+            releases_url: format!("{base}/feed"),
+            download_base: format!("{base}/releases/download"),
+            redirect_url: Some(format!("{base}/releases/latest")),
+            trusted: false,
+        };
+        let transport = Transport::new(&endpoints).without_token();
+
+        let fetched = latest(&transport, &endpoints, false).expect("the feed answers");
+        assert_eq!(fetched.release.version(), "8.8.8");
+        assert_eq!(fetched.source, Source::Api);
+    }
+
     #[test]
     fn a_rate_limited_feed_says_so() {
         let base = serve(vec![(

--- a/crates/fresh-update/src/fetch.rs
+++ b/crates/fresh-update/src/fetch.rs
@@ -1,33 +1,48 @@
-//! Getting the release we would offer — and what to do when GitHub's API says
-//! no.
+//! Which release to offer, resolved the way the install script resolves it.
 //!
-//! The release feed lives on `api.github.com`, which gives an unauthenticated
-//! caller 60 requests an hour *per source address*. That is a budget shared
-//! with everything else on the same NAT, so `fresh --cmd update` can be
-//! refused with a 403 on a machine where `curl … install.sh | sh` works fine
-//! seconds later: the install script never touches the API at all. It asks
-//! `github.com` for the release *asset*, and GitHub serves that from the web
-//! host with no such budget.
+//! `scripts/install.sh` never touches `api.github.com`. It asks
+//! `github.com/<repo>/releases/latest`, which answers 302 with the newest
+//! release's page in its `Location` header, and builds every asset URL from
+//! the tag it reads there. That is why `curl … install.sh | sh` succeeds on a
+//! machine where `fresh --cmd update` was just refused with a 403: the API
+//! gives an unauthenticated caller 60 requests an hour *per source address*,
+//! shared with everyone behind the same NAT, and the web host has no such
+//! budget.
 //!
-//! So when the API refuses for that reason — and only that reason — the
-//! version is read the way the install script effectively reads it:
-//! `github.com/<repo>/releases/latest` is a redirect to the newest release's
-//! page, and the tag is in the `Location` header. One request, no API budget,
-//! same host allowlist, still https.
+//! So the updater resolves the version the same way: one redirect, no API
+//! budget, same host allowlist, still https. `--check`, the editor's daily
+//! background check and a self-contained update therefore spend nothing at all
+//! on the API, and cannot be refused by a limit somebody else used up.
 //!
-//! What the redirect cannot give is the release's **asset list**, which is why
-//! the source is reported alongside the release rather than hidden. Channels
-//! whose artifact is named by the feed ([`crate::registry::UpdateKind::DownloadPackage`])
-//! need that list and must say so plainly; the self-contained channels build
-//! the asset name from their own target triple and need nothing but the
-//! version. The former is the case the redirect cannot rescue, and pretending
-//! otherwise would surface as "release 0.4.8 publishes no .deb for amd64" —
-//! a sentence that is both false and unactionable.
+//! # What the redirect cannot answer, and what happens then
 //!
-//! The redirect is *not* used in place of the feed by default. It carries no
-//! `prerelease` or `draft` flag, so `select`'s guarantees would become
-//! GitHub's web behaviour again, which is the arrangement
-//! [`crate::feed::select`] exists to end.
+//! It names a tag and nothing else. Two things need more, and both fall back
+//! to the feed on `api.github.com`:
+//!
+//! * **`--pre`.** The redirect points at the newest *full* release by
+//!   definition, so a pre-release can only come from the list endpoint. This
+//!   is opt-in and rare.
+//! * **A package whose filename we cannot construct.** `.deb`/`.rpm`/`.flatpak`
+//!   names come out of [`crate::feed::package_file_name`], the same
+//!   construction the install script does — and [`crate::engine`] falls back to
+//!   the feed if the release does not actually publish that name.
+//!
+//! An overridden endpoint (`--releases-url`, a mirror, a test server) keeps
+//! using its feed: it named a document, and reinterpreting that as "ask GitHub
+//! instead" would ignore what the caller asked for.
+//!
+//! The one request that has no second route is the attestation lookup
+//! ([`crate::attestation`]), which is a *different origin* on purpose — that is
+//! the entire value it adds over the checksum sidecar. It is spent once, when
+//! an update actually installs, and never by a check.
+//!
+//! # The guarantee the flag used to carry
+//!
+//! [`crate::feed::select`] refuses a pre-release unless asked, rather than
+//! relying on `/releases/latest` to omit one. A tag carries no such flag, so
+//! that check is made against the version itself: a tag that parses as a
+//! pre-release is refused here exactly as the flag would be. Drafts need no
+//! equivalent — they are not public, so no redirect reaches one.
 
 use crate::endpoint::{self, Endpoints};
 use crate::feed::Release;
@@ -58,17 +73,66 @@ pub struct Fetched {
     pub source: Source,
 }
 
-/// The release to offer, from the feed if the API will serve it.
+/// The release to offer.
 ///
-/// Falls back to the redirect only when the API refused for rate limiting:
-/// every other failure is reported as itself, because a 404 or a TLS error is
-/// not something a second request to a different path would fix, and quietly
-/// answering a broken feed with a version from somewhere else would hide it.
+/// Tries the redirect first on the pinned endpoints, and the feed when that is
+/// not available (an override, `--pre`) or did not work. Failing over in that
+/// direction matters: the redirect is one header on a host that also serves
+/// the download, so if it stops answering, the API is still there.
 pub fn latest(
     transport: &Transport,
     endpoints: &Endpoints,
     allow_prerelease: bool,
 ) -> Result<Fetched, String> {
+    if !allow_prerelease {
+        if let Some(redirect) = endpoints.latest_redirect_url() {
+            match latest_tag(transport, &redirect) {
+                Ok(tag) => return from_redirect_tag(tag),
+                // Not fatal: the feed answers the same question, and is what
+                // every overridden endpoint uses anyway.
+                Err(e) => {
+                    tracing::warn!(error = %e, "release redirect unusable; asking the API feed")
+                }
+            }
+        }
+    }
+
+    Ok(Fetched {
+        release: from_feed(transport, endpoints, allow_prerelease)?,
+        source: Source::Api,
+    })
+}
+
+/// The release a redirect tag names, with the guarantee the feed's flag used
+/// to carry.
+///
+/// GitHub should never point `releases/latest` at a pre-release, so this is
+/// the same defence `feed::select` makes against a feed that does: the refusal
+/// is ours, derived from the version, rather than a behaviour we are trusting.
+fn from_redirect_tag(tag: String) -> Result<Fetched, String> {
+    if crate::version::is_prerelease(&tag) {
+        return Err(format!(
+            "the newest release is {}, a pre-release; pass --pre to install it",
+            tag.trim_start_matches('v')
+        ));
+    }
+    Ok(Fetched {
+        release: Release::from_tag(tag),
+        source: Source::ReleaseRedirect,
+    })
+}
+
+/// The release the API feed describes, assets and all.
+///
+/// This is the request that spends rate-limit budget, so it is called only
+/// when something actually needs what the redirect cannot give: `--pre`, an
+/// overridden endpoint, or a package filename that turned out not to be the
+/// published one.
+pub fn from_feed(
+    transport: &Transport,
+    endpoints: &Endpoints,
+    allow_prerelease: bool,
+) -> Result<Release, String> {
     // Pre-releases are absent from `/releases/latest`, so opting in means
     // asking the list endpoint; without the flag this is the pinned default.
     let feed_url = if allow_prerelease {
@@ -76,37 +140,8 @@ pub fn latest(
     } else {
         endpoints.releases_url.clone()
     };
-
-    let error = match transport.get_text(&feed_url, net::FEED_MAX_BYTES) {
-        Ok(body) => {
-            return Ok(Fetched {
-                release: crate::feed::select(&body, allow_prerelease)?,
-                source: Source::Api,
-            })
-        }
-        Err(e) => e,
-    };
-
-    // The redirect names the latest *stable* release, so it cannot answer a
-    // `--pre` run, and it only means anything against the pinned endpoints.
-    let redirect = match (error.is_rate_limited(), allow_prerelease) {
-        (true, false) => endpoints.latest_redirect_url(),
-        _ => None,
-    };
-    let Some(redirect) = redirect else {
-        return Err(error.to_string());
-    };
-
-    tracing::warn!(%error, "release feed rate-limited; reading the version from the release redirect");
-    match latest_tag(transport, &redirect) {
-        Ok(tag) => Ok(Fetched {
-            release: Release::from_tag(tag),
-            source: Source::ReleaseRedirect,
-        }),
-        // Both routes failed: report the rate limit, which is the actionable
-        // half, and name the second attempt so it is clear one was made.
-        Err(second) => Err(format!("{error}\n\nReading {redirect} instead: {second}")),
-    }
+    let body = transport.get_text(&feed_url, net::FEED_MAX_BYTES)?;
+    crate::feed::select(&body, allow_prerelease)
 }
 
 /// The tag the `releases/latest` redirect points at.
@@ -274,6 +309,26 @@ mod server_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The redirect carries no `prerelease` flag, so a stable install keeps
+    /// its guarantee only if the tag itself is read — this is that check.
+    #[test]
+    fn a_pre_release_tag_is_refused_without_the_flag() {
+        let err = from_redirect_tag("v0.4.8-rc.1".to_string()).unwrap_err();
+        assert!(err.contains("0.4.8-rc.1"), "got: {err}");
+        assert!(
+            err.contains("--pre"),
+            "the refusal must name the flag: {err}"
+        );
+
+        let fetched = from_redirect_tag("v0.4.8".to_string()).expect("a full release");
+        assert_eq!(fetched.release.version(), "0.4.8");
+        assert_eq!(fetched.source, Source::ReleaseRedirect);
+        assert!(
+            !fetched.source.lists_assets(),
+            "a tag names no assets, and callers key off that"
+        );
+    }
 
     #[test]
     fn the_tag_comes_out_of_a_release_url() {

--- a/crates/fresh-update/src/fetch.rs
+++ b/crates/fresh-update/src/fetch.rs
@@ -401,7 +401,7 @@ mod server_tests {
         assert!(err.contains("rate limit"), "got: {err}");
         assert!(err.contains("10 minutes"), "the wait must be named: {err}");
         assert!(
-            err.contains("FRESH_GITHUB_TOKEN"),
+            err.contains("GITHUB_TOKEN"),
             "the message must name the way out: {err}"
         );
     }

--- a/crates/fresh-update/src/fetch.rs
+++ b/crates/fresh-update/src/fetch.rs
@@ -1,0 +1,327 @@
+//! Getting the release we would offer — and what to do when GitHub's API says
+//! no.
+//!
+//! The release feed lives on `api.github.com`, which gives an unauthenticated
+//! caller 60 requests an hour *per source address*. That is a budget shared
+//! with everything else on the same NAT, so `fresh --cmd update` can be
+//! refused with a 403 on a machine where `curl … install.sh | sh` works fine
+//! seconds later: the install script never touches the API at all. It asks
+//! `github.com` for the release *asset*, and GitHub serves that from the web
+//! host with no such budget.
+//!
+//! So when the API refuses for that reason — and only that reason — the
+//! version is read the way the install script effectively reads it:
+//! `github.com/<repo>/releases/latest` is a redirect to the newest release's
+//! page, and the tag is in the `Location` header. One request, no API budget,
+//! same host allowlist, still https.
+//!
+//! What the redirect cannot give is the release's **asset list**, which is why
+//! the source is reported alongside the release rather than hidden. Channels
+//! whose artifact is named by the feed ([`crate::registry::UpdateKind::DownloadPackage`])
+//! need that list and must say so plainly; the self-contained channels build
+//! the asset name from their own target triple and need nothing but the
+//! version. The former is the case the redirect cannot rescue, and pretending
+//! otherwise would surface as "release 0.4.8 publishes no .deb for amd64" —
+//! a sentence that is both false and unactionable.
+//!
+//! The redirect is *not* used in place of the feed by default. It carries no
+//! `prerelease` or `draft` flag, so `select`'s guarantees would become
+//! GitHub's web behaviour again, which is the arrangement
+//! [`crate::feed::select`] exists to end.
+
+use crate::endpoint::{self, Endpoints};
+use crate::feed::Release;
+use crate::net::{self, Transport};
+
+/// Where the release we are about to act on came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// The release-metadata feed: full detail, assets included.
+    Api,
+    /// The `releases/latest` redirect: the version, and nothing else.
+    ReleaseRedirect,
+}
+
+impl Source {
+    /// Whether this source lists the release's published assets.
+    pub fn lists_assets(self) -> bool {
+        matches!(self, Source::Api)
+    }
+}
+
+/// A release, and how much we know about it.
+#[derive(Debug, Clone)]
+pub struct Fetched {
+    /// The release to offer.
+    pub release: Release,
+    /// Where it came from — see [`Source::lists_assets`].
+    pub source: Source,
+}
+
+/// The release to offer, from the feed if the API will serve it.
+///
+/// Falls back to the redirect only when the API refused for rate limiting:
+/// every other failure is reported as itself, because a 404 or a TLS error is
+/// not something a second request to a different path would fix, and quietly
+/// answering a broken feed with a version from somewhere else would hide it.
+pub fn latest(
+    transport: &Transport,
+    endpoints: &Endpoints,
+    allow_prerelease: bool,
+) -> Result<Fetched, String> {
+    // Pre-releases are absent from `/releases/latest`, so opting in means
+    // asking the list endpoint; without the flag this is the pinned default.
+    let feed_url = if allow_prerelease {
+        endpoints.list_url()
+    } else {
+        endpoints.releases_url.clone()
+    };
+
+    let error = match transport.get_text(&feed_url, net::FEED_MAX_BYTES) {
+        Ok(body) => {
+            return Ok(Fetched {
+                release: crate::feed::select(&body, allow_prerelease)?,
+                source: Source::Api,
+            })
+        }
+        Err(e) => e,
+    };
+
+    // The redirect names the latest *stable* release, so it cannot answer a
+    // `--pre` run, and it only means anything against the pinned endpoints.
+    let redirect = match (error.is_rate_limited(), allow_prerelease) {
+        (true, false) => endpoints.latest_redirect_url(),
+        _ => None,
+    };
+    let Some(redirect) = redirect else {
+        return Err(error.to_string());
+    };
+
+    tracing::warn!(%error, "release feed rate-limited; reading the version from the release redirect");
+    match latest_tag(transport, &redirect) {
+        Ok(tag) => Ok(Fetched {
+            release: Release::from_tag(tag),
+            source: Source::ReleaseRedirect,
+        }),
+        // Both routes failed: report the rate limit, which is the actionable
+        // half, and name the second attempt so it is clear one was made.
+        Err(second) => Err(format!("{error}\n\nReading {redirect} instead: {second}")),
+    }
+}
+
+/// The tag the `releases/latest` redirect points at.
+///
+/// Exposed for tests and for callers that want the version without the feed.
+pub fn latest_tag(transport: &Transport, url: &str) -> Result<String, String> {
+    let location = transport
+        .redirect_location(url)?
+        .ok_or_else(|| format!("{url} did not redirect to a release"))?;
+    let target = absolutize(url, &location)
+        .ok_or_else(|| format!("{url} redirected somewhere unusable: {location}"))?;
+
+    // A pinned request must land on a pinned host: a redirect is exactly the
+    // move that would otherwise walk us off the allowlist, and this one is
+    // read for a version we then build a download URL from. A request that was
+    // already off the allowlist (a test server) is left alone, as it is for
+    // asset URLs that come out of an overridden feed.
+    if endpoint::is_trusted(url) {
+        endpoint::check(&target).map_err(|e| e.to_string())?;
+    }
+
+    tag_of(&target).ok_or_else(|| format!("{url} redirected to {target}, which names no release"))
+}
+
+/// The tag in a `…/releases/tag/<tag>` URL, if it is one and the tag looks
+/// like a version rather than arbitrary text we would go on to put in a URL.
+fn tag_of(url: &str) -> Option<String> {
+    let tag = url.split("/releases/tag/").nth(1)?;
+    let tag = tag.split(['?', '#', '/']).next()?.trim();
+    let plausible = !tag.is_empty()
+        && tag.chars().any(|c| c.is_ascii_digit())
+        && tag
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+' | '_'));
+    plausible.then(|| tag.to_string())
+}
+
+/// Resolve a `Location` against the URL it came from.
+///
+/// GitHub answers with an absolute URL; a root-relative one is resolved
+/// against the request's own origin. Anything else — a path-relative hop, a
+/// `data:` URL — is refused rather than guessed at.
+fn absolutize(base: &str, location: &str) -> Option<String> {
+    if location.starts_with("https://") || location.starts_with("http://") {
+        return Some(location.to_string());
+    }
+    let rest = location.strip_prefix('/')?;
+    let scheme_end = base.find("://")? + 3;
+    let authority_len = base[scheme_end..]
+        .find('/')
+        .unwrap_or(base.len() - scheme_end);
+    Some(format!("{}/{rest}", &base[..scheme_end + authority_len]))
+}
+
+#[cfg(test)]
+mod server_tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    /// One canned answer: the path prefix it matches, its status, and the
+    /// headers that carry the part under test.
+    type Route = (&'static str, u16, Vec<(&'static str, String)>);
+
+    /// Serve one canned answer per path, and hand back the base URL.
+    fn serve(routes: Vec<Route>) -> String {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let port = server.server_addr().to_ip().expect("ip").port();
+        let (ready, started) = mpsc::channel();
+        std::thread::spawn(move || {
+            ready.send(()).expect("signal");
+            for request in server.incoming_requests() {
+                let url = request.url().to_string();
+                let route = routes
+                    .iter()
+                    .find(|(path, _, _)| url.starts_with(path))
+                    .cloned();
+                let response = match route {
+                    Some((_, code, headers)) => {
+                        let mut response = tiny_http::Response::from_string("")
+                            .with_status_code(tiny_http::StatusCode(code));
+                        for (name, value) in headers {
+                            response.add_header(
+                                tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes())
+                                    .expect("header"),
+                            );
+                        }
+                        response
+                    }
+                    None => tiny_http::Response::from_string("").with_status_code(404),
+                };
+                let _ = request.respond(response);
+            }
+        });
+        started.recv().expect("server start");
+        format!("http://127.0.0.1:{port}")
+    }
+
+    fn endpoints_for(base: &str) -> Endpoints {
+        Endpoints {
+            releases_url: format!("{base}/releases/latest"),
+            download_base: format!("{base}/dl"),
+            trusted: false,
+        }
+    }
+
+    #[test]
+    fn the_redirect_yields_the_tag_without_following_it() {
+        let base = serve(vec![(
+            "/releases/latest",
+            302,
+            vec![(
+                "Location",
+                "https://github.com/sinelaw/fresh/releases/tag/v9.9.9".to_string(),
+            )],
+        )]);
+        let transport = Transport::new(&endpoints_for(&base));
+        assert_eq!(
+            latest_tag(&transport, &format!("{base}/releases/latest")).unwrap(),
+            "v9.9.9"
+        );
+    }
+
+    /// A `Location` that names no release is a failure, not a version we make
+    /// up: whatever came back would otherwise be pasted into a download URL.
+    #[test]
+    fn a_redirect_that_names_no_release_is_refused() {
+        let base = serve(vec![(
+            "/releases/latest",
+            302,
+            vec![("Location", "https://github.com/sinelaw/fresh".to_string())],
+        )]);
+        let transport = Transport::new(&endpoints_for(&base));
+        let err = latest_tag(&transport, &format!("{base}/releases/latest")).unwrap_err();
+        assert!(err.contains("names no release"), "got: {err}");
+    }
+
+    /// The regression this module exists for: `api.github.com` answering 403
+    /// because the address's hourly budget is gone must be reported as the
+    /// rate limit it is, with the remedy in the message.
+    #[test]
+    fn a_rate_limited_feed_says_so() {
+        let base = serve(vec![(
+            "/releases",
+            403,
+            vec![
+                ("x-ratelimit-remaining", "0".to_string()),
+                ("retry-after", "600".to_string()),
+            ],
+        )]);
+        let endpoints = endpoints_for(&base);
+        let transport = Transport::new(&endpoints).without_token();
+        // An overridden feed has no redirect to fall back to — a mirror's
+        // `latest` is not this repository's — so the rate limit is reported.
+        assert_eq!(endpoints.latest_redirect_url(), None);
+        let err = latest(&transport, &endpoints, false).unwrap_err();
+        assert!(err.contains("rate limit"), "got: {err}");
+        assert!(err.contains("10 minutes"), "the wait must be named: {err}");
+        assert!(
+            err.contains("FRESH_GITHUB_TOKEN"),
+            "the message must name the way out: {err}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_tag_comes_out_of_a_release_url() {
+        assert_eq!(
+            tag_of("https://github.com/sinelaw/fresh/releases/tag/v0.4.7").as_deref(),
+            Some("v0.4.7")
+        );
+        // Query strings and trailing segments are not part of the tag.
+        assert_eq!(
+            tag_of("https://github.com/sinelaw/fresh/releases/tag/v0.4.7?a=b").as_deref(),
+            Some("v0.4.7")
+        );
+    }
+
+    /// The tag is pasted into a download URL, so it may not be arbitrary text.
+    #[test]
+    fn a_tag_that_is_not_a_version_is_refused() {
+        assert_eq!(tag_of("https://github.com/sinelaw/fresh/releases"), None);
+        assert_eq!(
+            tag_of("https://github.com/sinelaw/fresh/releases/tag/"),
+            None
+        );
+        assert_eq!(
+            tag_of("https://github.com/sinelaw/fresh/releases/tag/latest"),
+            None,
+            "a tag with no digit in it is not a version"
+        );
+        assert_eq!(
+            tag_of("https://github.com/x/y/releases/tag/v1.0%2F..%2Fevil"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_relative_location_resolves_against_the_request() {
+        assert_eq!(
+            absolutize(
+                "https://github.com/sinelaw/fresh/releases/latest",
+                "/sinelaw/fresh/releases/tag/v0.4.7"
+            )
+            .as_deref(),
+            Some("https://github.com/sinelaw/fresh/releases/tag/v0.4.7")
+        );
+        assert_eq!(
+            absolutize("https://github.com/a", "https://elsewhere.example/b").as_deref(),
+            Some("https://elsewhere.example/b")
+        );
+        // Not a hop we understand, so not a hop we follow.
+        assert_eq!(absolutize("https://github.com/a", "../b"), None);
+    }
+}

--- a/crates/fresh-update/src/lib.rs
+++ b/crates/fresh-update/src/lib.rs
@@ -87,6 +87,14 @@ pub const TARGET_TRIPLE: &str = env!("FRESH_UPDATE_TARGET");
 /// update indicator keys its `ActionRequired` state off this code.
 pub const EXIT_ACTION_REQUIRED: i32 = 2;
 
+/// The flag that turns the release-attestation check off, lowering
+/// verification to the checksum sidecar alone.
+///
+/// Lives here rather than in [`engine`] for the same reason
+/// [`EXIT_ACTION_REQUIRED`] does: it is part of the CLI's contract, and the
+/// argument parser reads it in builds compiled without the engine.
+pub const SKIP_ATTESTATION_FLAG: &str = "--skip-attestation";
+
 /// The build-time install channel embedded via `FRESH_BUILD_CHANNEL`, if any.
 /// `None` for the shared prebuilt archive and ordinary developer builds.
 pub fn embedded_channel() -> Option<&'static str> {

--- a/crates/fresh-update/src/lib.rs
+++ b/crates/fresh-update/src/lib.rs
@@ -55,6 +55,8 @@ pub mod attestation;
 #[cfg(feature = "engine")]
 pub mod engine;
 #[cfg(feature = "net")]
+pub mod fetch;
+#[cfg(feature = "net")]
 pub mod net;
 pub mod offer;
 

--- a/crates/fresh-update/src/net.rs
+++ b/crates/fresh-update/src/net.rs
@@ -127,26 +127,20 @@ impl std::fmt::Display for FetchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FetchError::RateLimited {
-                url,
+                url: _,
                 wait,
                 authenticated,
             } => {
-                write!(
-                    f,
-                    "GitHub's API rate limit is used up, so {url} was refused"
-                )?;
-                if let Some(wait) = wait {
-                    write!(f, "; it resets in about {}", humanize(*wait))?;
+                write!(f, "GitHub's API rate limit is used up")?;
+                match wait {
+                    Some(wait) => write!(f, ", resets in about {}.", humanize(*wait))?,
+                    None => write!(f, ".")?,
                 }
-                write!(f, ".")?;
                 if !authenticated {
-                    write!(
-                        f,
-                        " Unauthenticated callers get 60 requests an hour per IP address, \
-                         shared with everyone else behind it. Set {} to a personal access \
-                         token — it needs no scopes for a public repository — to get 5000.",
-                        TOKEN_ENVS.join(" or ")
-                    )?;
+                    // The limit is per address and shared with everyone behind
+                    // it, which is why it runs out; a token is the fix. The
+                    // other two variable names are in the docs.
+                    write!(f, " Set GITHUB_TOKEN to raise it from 60 an hour to 5000.")?;
                 }
                 Ok(())
             }

--- a/crates/fresh-update/src/net.rs
+++ b/crates/fresh-update/src/net.rs
@@ -20,13 +20,13 @@
 //!
 //! # Rate limiting is a distinct outcome, not a failure like any other
 //!
-//! Two of the requests an update makes — the release feed and the attestation
-//! lookup — go to `api.github.com`, which allows an unauthenticated client 60
-//! requests an hour *per source address*. That budget is shared by everyone
-//! behind the same NAT, so "403" here usually means someone else spent it. It
-//! is reported as [`FetchError::RateLimited`] rather than a bare status,
-//! because the answer ("wait, or bring a token") is nothing like the answer to
-//! a real 403, and because [`crate::fetch`] can route around it for the feed.
+//! `api.github.com` allows an unauthenticated client 60 requests an hour *per
+//! source address*, a budget shared by everyone behind the same NAT — so "403"
+//! from that host usually means someone else spent it. [`crate::fetch`] keeps
+//! the updater off the API for everything but the attestation lookup, and what
+//! is left is reported as [`FetchError::RateLimited`] rather than a bare
+//! status, because the answer ("wait, or bring a token") is nothing like the
+//! answer to a real 403.
 //!
 //! A token from the environment is attached to `api.github.com` requests only.
 //! `ureq`'s default is to drop `Authorization` across a redirect, so a hop to

--- a/crates/fresh-update/src/net.rs
+++ b/crates/fresh-update/src/net.rs
@@ -17,10 +17,24 @@
 //! A redirect between two https hosts is still followed, because GitHub's
 //! asset CDN varies. Transport strictness is not the answer to "who produced
 //! these bytes"; see [`crate::attestation`].
+//!
+//! # Rate limiting is a distinct outcome, not a failure like any other
+//!
+//! Two of the requests an update makes — the release feed and the attestation
+//! lookup — go to `api.github.com`, which allows an unauthenticated client 60
+//! requests an hour *per source address*. That budget is shared by everyone
+//! behind the same NAT, so "403" here usually means someone else spent it. It
+//! is reported as [`FetchError::RateLimited`] rather than a bare status,
+//! because the answer ("wait, or bring a token") is nothing like the answer to
+//! a real 403, and because [`crate::fetch`] can route around it for the feed.
+//!
+//! A token from the environment is attached to `api.github.com` requests only.
+//! `ureq`'s default is to drop `Authorization` across a redirect, so a hop to
+//! the asset CDN cannot carry it either.
 
-use crate::endpoint::Endpoints;
+use crate::endpoint::{self, Endpoints};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Cap on the release-metadata document. GitHub's release JSON runs to a few
 /// hundred KB with long changelogs; 8 MiB is far above that and far below
@@ -43,9 +57,133 @@ const MAX_REDIRECTS: u32 = 4;
 
 const USER_AGENT: &str = "fresh-editor-updater";
 
+/// The host whose requests count against GitHub's API rate limit — and the
+/// only host a token is ever sent to.
+const API_HOST: &str = "api.github.com";
+
+/// Environment variables consulted for a GitHub API token, in order.
+///
+/// The fresh-specific name comes first so a user can raise the updater's limit
+/// without handing it whatever token the rest of their shell is carrying; the
+/// two conventional names follow because most machines that have a token
+/// already have it under one of them.
+pub const TOKEN_ENVS: &[&str] = &["FRESH_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"];
+
+/// Why a request did not produce bytes we can use.
+///
+/// Rate limiting is called out as its own variant: it is the one failure here
+/// that is neither the user's fault nor a sign that anything is wrong, it
+/// clears by itself, and both remedies (wait, or set a token) are things only
+/// the message can convey.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FetchError {
+    /// GitHub refused the request because the API budget for this address —
+    /// or for this token — is spent.
+    RateLimited {
+        /// The request that was refused.
+        url: String,
+        /// How long until the budget resets, when GitHub said.
+        wait: Option<Duration>,
+        /// Whether a token was attached. Without one the remedy is to bring
+        /// one; with one, the limit is already the higher one and waiting is
+        /// all that is left.
+        authenticated: bool,
+    },
+    /// Any other non-2xx status.
+    Status {
+        /// The request that was refused.
+        url: String,
+        /// The status code returned.
+        status: u16,
+    },
+    /// The request never completed: DNS, TLS, timeout, connection reset.
+    Transport {
+        /// The request that failed.
+        url: String,
+        /// The transport's own description.
+        detail: String,
+    },
+    /// A response arrived but its body could not be read — most often the
+    /// size cap above.
+    Body {
+        /// The request whose body could not be read.
+        url: String,
+        /// What went wrong reading or writing it.
+        detail: String,
+    },
+}
+
+impl FetchError {
+    /// Whether this is GitHub's rate limit rather than a real failure.
+    ///
+    /// Callers with a route around the API — [`crate::fetch`] reading the
+    /// version from the release redirect instead — key off this.
+    pub fn is_rate_limited(&self) -> bool {
+        matches!(self, FetchError::RateLimited { .. })
+    }
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchError::RateLimited {
+                url,
+                wait,
+                authenticated,
+            } => {
+                write!(
+                    f,
+                    "GitHub's API rate limit is used up, so {url} was refused"
+                )?;
+                if let Some(wait) = wait {
+                    write!(f, "; it resets in about {}", humanize(*wait))?;
+                }
+                write!(f, ".")?;
+                if !authenticated {
+                    write!(
+                        f,
+                        " Unauthenticated callers get 60 requests an hour per IP address, \
+                         shared with everyone else behind it. Set {} to a personal access \
+                         token — it needs no scopes for a public repository — to get 5000.",
+                        TOKEN_ENVS.join(" or ")
+                    )?;
+                }
+                Ok(())
+            }
+            FetchError::Status { url, status } => write!(f, "HTTP {status} fetching {url}"),
+            FetchError::Transport { url, detail } => write!(f, "fetching {url}: {detail}"),
+            FetchError::Body { url, detail } => write!(f, "reading {url}: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+impl From<FetchError> for String {
+    fn from(e: FetchError) -> String {
+        e.to_string()
+    }
+}
+
+/// A duration as a person would say it, for "try again in …".
+fn humanize(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 90 {
+        return format!("{secs} seconds");
+    }
+    let mins = secs.div_ceil(60);
+    if mins < 90 {
+        format!("{mins} minutes")
+    } else {
+        format!("{} hours", mins.div_ceil(60))
+    }
+}
+
 /// An HTTP client configured for one set of release endpoints.
 pub struct Transport {
     agent: ureq::Agent,
+    /// A GitHub token from the environment, if any. Sent to [`API_HOST`] only.
+    token: Option<String>,
 }
 
 impl Transport {
@@ -66,40 +204,58 @@ impl Transport {
             .https_only(endpoints.trusted)
             .max_redirects(MAX_REDIRECTS)
             // A non-2xx must reach us as a status, not as an `Err` that hides
-            // which status it was; `status_checked` turns it back into an
-            // error with the code in the message.
+            // which status it was; `classify` turns it back into an error with
+            // the code — or the rate limit — in the message.
             .http_status_as_error(false)
             .tls_config(tls_config)
             .build()
             .new_agent();
 
-        Transport { agent }
+        Transport {
+            agent,
+            token: token_from_env(),
+        }
+    }
+
+    /// Whether a token was found, and so which rate limit applies.
+    pub fn authenticated(&self) -> bool {
+        self.token.is_some()
+    }
+
+    /// The same client with no token, whatever the environment holds.
+    ///
+    /// Tests of the unauthenticated path must not depend on whether the
+    /// machine running them happens to export a `GITHUB_TOKEN` — on CI it
+    /// usually does, and the two paths report different things.
+    #[cfg(test)]
+    pub(crate) fn without_token(mut self) -> Self {
+        self.token = None;
+        self
     }
 
     /// GET `url` and return the body as text, refusing anything over `limit`.
-    pub fn get_text(&self, url: &str, limit: u64) -> Result<String, String> {
+    pub fn get_text(&self, url: &str, limit: u64) -> Result<String, FetchError> {
         let response = self.call(url)?;
-        response
-            .into_body()
-            .into_with_config()
-            .limit(limit)
-            .read_to_string()
-            .map_err(|e| format!("reading {url}: {e}"))
+        read_text(url, response, limit)
     }
 
     /// GET `url` and stream the body into `target`, refusing anything over
     /// `limit`.
-    pub fn download(&self, url: &str, target: &Path, limit: u64) -> Result<(), String> {
+    pub fn download(&self, url: &str, target: &Path, limit: u64) -> Result<(), FetchError> {
         let response = self.call(url)?;
-        let mut file = std::fs::File::create(target)
-            .map_err(|e| format!("creating {}: {e}", target.display()))?;
+        let mut file = std::fs::File::create(target).map_err(|e| FetchError::Body {
+            url: url.to_string(),
+            detail: format!("creating {}: {e}", target.display()),
+        })?;
         let mut reader = response
             .into_body()
             .into_with_config()
             .limit(limit)
             .reader();
-        std::io::copy(&mut reader, &mut file)
-            .map_err(|e| format!("writing {}: {e}", target.display()))?;
+        std::io::copy(&mut reader, &mut file).map_err(|e| FetchError::Body {
+            url: url.to_string(),
+            detail: format!("writing {}: {e}", target.display()),
+        })?;
         Ok(())
     }
 
@@ -110,40 +266,289 @@ impl Transport {
     /// on rather than a failure to report — the attestation lookup, where a
     /// 404 means GitHub holds no attestation for that digest and the caller
     /// turns it into a specific, actionable refusal.
-    pub fn get_text_optional(&self, url: &str, limit: u64) -> Result<Option<String>, String> {
+    pub fn get_text_optional(&self, url: &str, limit: u64) -> Result<Option<String>, FetchError> {
         let response = self.send(url)?;
-        let status = response.status().as_u16();
-        if status == 404 {
+        if response.status().as_u16() == 404 {
             return Ok(None);
         }
-        if !(200..300).contains(&status) {
-            return Err(format!("HTTP {status} fetching {url}"));
+        if let Some(e) = self.classify(url, &response) {
+            return Err(e);
         }
-        response
-            .into_body()
-            .into_with_config()
-            .limit(limit)
-            .read_to_string()
-            .map(Some)
-            .map_err(|e| format!("reading {url}: {e}"))
+        read_text(url, response, limit).map(Some)
     }
 
-    fn call(&self, url: &str) -> Result<ureq::http::Response<ureq::Body>, String> {
-        let response = self.send(url)?;
+    /// GET `url` **without** following redirects, returning where it points.
+    ///
+    /// `Ok(None)` means the response was not a redirect. This exists for
+    /// [`crate::fetch`]: `github.com/<repo>/releases/latest` names the newest
+    /// release in its `Location` header, which answers "what is the latest
+    /// version?" without spending any of the API budget the feed spends.
+    pub fn redirect_location(&self, url: &str) -> Result<Option<String>, FetchError> {
+        let response = self
+            .request(url)
+            .config()
+            // 0 means "return the redirect rather than following it", which is
+            // the whole point: we want the header, not the page.
+            .max_redirects(0)
+            .build()
+            .call()
+            .map_err(|e| FetchError::Transport {
+                url: url.to_string(),
+                detail: e.to_string(),
+            })?;
         let status = response.status().as_u16();
-        if !(200..300).contains(&status) {
-            return Err(format!("HTTP {status} fetching {url}"));
+        if !(300..400).contains(&status) {
+            if let Some(e) = self.classify(url, &response) {
+                return Err(e);
+            }
+            return Ok(None);
         }
-        Ok(response)
+        Ok(response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty()))
+    }
+
+    fn call(&self, url: &str) -> Result<ureq::http::Response<ureq::Body>, FetchError> {
+        let response = self.send(url)?;
+        match self.classify(url, &response) {
+            Some(e) => Err(e),
+            None => Ok(response),
+        }
     }
 
     /// The request itself, with no opinion about the status code.
-    fn send(&self, url: &str) -> Result<ureq::http::Response<ureq::Body>, String> {
-        self.agent
+    fn send(&self, url: &str) -> Result<ureq::http::Response<ureq::Body>, FetchError> {
+        self.request(url).call().map_err(|e| FetchError::Transport {
+            url: url.to_string(),
+            detail: e.to_string(),
+        })
+    }
+
+    /// The common request shape: our headers, plus a token when — and only
+    /// when — the request is going to the API host over https.
+    fn request(&self, url: &str) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+        let request = self
+            .agent
             .get(url)
             .header("User-Agent", USER_AGENT)
-            .header("Accept", "application/vnd.github.v3+json")
-            .call()
-            .map_err(|e| format!("fetching {url}: {e}"))
+            .header("Accept", "application/vnd.github.v3+json");
+        match self.token_for(url) {
+            Some(token) => request.header("Authorization", &format!("Bearer {token}")),
+            None => request,
+        }
+    }
+
+    /// The token to send with `url`, if any.
+    ///
+    /// Pinned to the API host over https: a token is a credential, and the
+    /// asset CDN, a mirror named by `--releases-url`, or a plaintext test
+    /// server have no business seeing one. `ureq` drops `Authorization` across
+    /// redirects by default, so a hop off this host cannot carry it either.
+    fn token_for(&self, url: &str) -> Option<&str> {
+        let host = endpoint::host_of(url)?;
+        if host == API_HOST && url.starts_with("https://") {
+            self.token.as_deref()
+        } else {
+            None
+        }
+    }
+
+    /// The error this response represents, or `None` if it is a 2xx.
+    fn classify(
+        &self,
+        url: &str,
+        response: &ureq::http::Response<ureq::Body>,
+    ) -> Option<FetchError> {
+        let status = response.status().as_u16();
+        if (200..300).contains(&status) {
+            return None;
+        }
+        if let Some(wait) = rate_limit_wait(status, response.headers()) {
+            return Some(FetchError::RateLimited {
+                url: url.to_string(),
+                wait,
+                authenticated: self.authenticated(),
+            });
+        }
+        Some(FetchError::Status {
+            url: url.to_string(),
+            status,
+        })
+    }
+}
+
+fn read_text(
+    url: &str,
+    response: ureq::http::Response<ureq::Body>,
+    limit: u64,
+) -> Result<String, FetchError> {
+    response
+        .into_body()
+        .into_with_config()
+        .limit(limit)
+        .read_to_string()
+        .map_err(|e| FetchError::Body {
+            url: url.to_string(),
+            detail: e.to_string(),
+        })
+}
+
+/// `Some(wait)` when this response is GitHub saying "you have had enough".
+///
+/// Both of GitHub's limits are reported as 403 (older) or 429 (newer), so the
+/// status alone does not distinguish a rate limit from a genuine refusal. The
+/// headers do: the primary limit sets `x-ratelimit-remaining: 0` and a reset
+/// timestamp, and the secondary limit sets `retry-after`. Requiring one of
+/// those keeps a real 403 — a private repository, a bad token — reported as
+/// what it is.
+fn rate_limit_wait(status: u16, headers: &ureq::http::HeaderMap) -> Option<Option<Duration>> {
+    if status != 403 && status != 429 {
+        return None;
+    }
+    let header = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+    };
+
+    let exhausted = header("x-ratelimit-remaining") == Some("0");
+    let retry_after = header("retry-after").and_then(|v| v.parse::<u64>().ok());
+    if !exhausted && retry_after.is_none() {
+        return None;
+    }
+
+    let wait = retry_after
+        .map(Duration::from_secs)
+        .or_else(|| {
+            let reset: u64 = header("x-ratelimit-reset")?.parse().ok()?;
+            let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+            Some(Duration::from_secs(reset.saturating_sub(now)))
+        })
+        // A reset already in the past says nothing useful, and "resets in
+        // about 0 seconds" reads as a bug rather than as advice.
+        .filter(|d| !d.is_zero());
+    Some(wait)
+}
+
+/// The first non-empty token in [`TOKEN_ENVS`].
+fn token_from_env() -> Option<String> {
+    TOKEN_ENVS.iter().find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> ureq::http::HeaderMap {
+        let mut map = ureq::http::HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                ureq::http::HeaderName::from_bytes(name.as_bytes()).expect("header name"),
+                ureq::http::HeaderValue::from_str(value).expect("header value"),
+            );
+        }
+        map
+    }
+
+    /// GitHub reports both of its limits as 403/429, so the status alone must
+    /// not decide: a genuine refusal (a private repository, a bad token) has
+    /// to stay reported as a refusal.
+    #[test]
+    fn only_a_403_with_the_rate_limit_headers_is_a_rate_limit() {
+        assert_eq!(
+            rate_limit_wait(403, &headers(&[("x-ratelimit-remaining", "0")])),
+            Some(None),
+            "the primary limit is remaining=0"
+        );
+        assert_eq!(
+            rate_limit_wait(429, &headers(&[("retry-after", "120")])),
+            Some(Some(Duration::from_secs(120))),
+            "the secondary limit is retry-after"
+        );
+        assert_eq!(
+            rate_limit_wait(403, &headers(&[("x-ratelimit-remaining", "57")])),
+            None,
+            "a 403 with budget left is a real refusal"
+        );
+        assert_eq!(rate_limit_wait(403, &headers(&[])), None);
+        assert_eq!(
+            rate_limit_wait(404, &headers(&[("retry-after", "60")])),
+            None
+        );
+    }
+
+    #[test]
+    fn a_reset_timestamp_becomes_a_wait() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_secs();
+        let wait = rate_limit_wait(
+            403,
+            &headers(&[
+                ("x-ratelimit-remaining", "0"),
+                ("x-ratelimit-reset", &(now + 600).to_string()),
+            ]),
+        )
+        .expect("rate limited")
+        .expect("a wait");
+        assert!(
+            wait <= Duration::from_secs(600) && wait > Duration::from_secs(590),
+            "got {wait:?}"
+        );
+        // A reset in the past is no advice at all.
+        assert_eq!(
+            rate_limit_wait(
+                403,
+                &headers(&[("x-ratelimit-remaining", "0"), ("x-ratelimit-reset", "1"),]),
+            ),
+            Some(None)
+        );
+    }
+
+    /// A token is a credential. It goes to the API host over https and
+    /// nowhere else — not to the asset CDN a download redirects to, not to a
+    /// mirror named by `--releases-url`, not to a plaintext test server.
+    #[test]
+    fn a_token_is_only_ever_sent_to_the_api_host() {
+        let mut transport = Transport::new(&Endpoints::production());
+        transport.token = Some("secret".to_string());
+
+        assert_eq!(
+            transport.token_for("https://api.github.com/repos/x/y/releases/latest"),
+            Some("secret")
+        );
+        assert_eq!(
+            transport.token_for("https://github.com/x/y/releases/download/v1/a"),
+            None
+        );
+        assert_eq!(
+            transport.token_for("https://objects.githubusercontent.com/a"),
+            None
+        );
+        assert_eq!(transport.token_for("http://api.github.com/repos/x/y"), None);
+        // Userinfo must not smuggle the host past the check.
+        assert_eq!(
+            transport.token_for("https://api.github.com@evil.example/repos"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_wait_is_phrased_the_way_a_person_would_say_it() {
+        assert_eq!(humanize(Duration::from_secs(30)), "30 seconds");
+        assert_eq!(humanize(Duration::from_secs(600)), "10 minutes");
+        assert_eq!(humanize(Duration::from_secs(3600)), "60 minutes");
+        assert_eq!(humanize(Duration::from_secs(3600 * 5)), "5 hours");
     }
 }

--- a/crates/fresh-update/src/version.rs
+++ b/crates/fresh-update/src/version.rs
@@ -52,6 +52,19 @@ fn parse(v: &str) -> Option<Version> {
     })
 }
 
+/// `true` if `v` carries a semver pre-release suffix (`0.4.8-rc.1`).
+///
+/// The release feed states this in a `prerelease` flag; a tag on its own does
+/// not, and the tag is all the `releases/latest` redirect gives us. Reading it
+/// out of the version itself is how a stable install keeps refusing release
+/// candidates without the feed to ask — see [`crate::fetch`].
+///
+/// A tag that is not a version at all is not a pre-release; nothing else here
+/// treats it as one either.
+pub fn is_prerelease(v: &str) -> bool {
+    parse(v).is_some_and(|p| p.release_rank == 0)
+}
+
 /// `true` if `latest` is strictly newer than `current`.
 pub fn is_newer(current: &str, latest: &str) -> bool {
     match (parse(current), parse(latest)) {
@@ -63,6 +76,18 @@ pub fn is_newer(current: &str, latest: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_pre_release_is_read_out_of_the_tag() {
+        assert!(is_prerelease("0.4.8-rc.1"));
+        assert!(is_prerelease("v0.4.8-beta"));
+        assert!(!is_prerelease("0.4.8"));
+        assert!(!is_prerelease("v0.4.8"));
+        // Build metadata is not a pre-release marker.
+        assert!(!is_prerelease("0.4.8+deadbeef"));
+        // Not a version at all: not our business to call it a pre-release.
+        assert!(!is_prerelease("nightly"));
+    }
 
     #[test]
     fn newer_comparison() {

--- a/docs/internal/packaging-self-update.md
+++ b/docs/internal/packaging-self-update.md
@@ -739,15 +739,30 @@ non-goal on silent installs.
 
 ### 10.1 GitHub's API rate limit
 
-Two of the requests an update makes go to `api.github.com`: the release feed,
-and the attestation lookup (§11). That host allows an unauthenticated caller
-**60 requests an hour per source address**, shared with everything else behind
-the same NAT — so `fresh --cmd update` can be refused with a 403 on a machine
-where `curl … install.sh | sh` succeeds seconds later. The install script is
-not luckier; it never touches the API at all, fetching the asset straight from
-`github.com`.
+`api.github.com` allows an unauthenticated caller **60 requests an hour per
+source address**, shared with everything else behind the same NAT. That used to
+be enough to break `fresh --cmd update` on a machine where
+`curl … install.sh | sh` worked seconds later — the install script never
+touches the API at all.
 
-Three things follow, all in `fresh_update::net` / `fresh_update::fetch`:
+So the updater resolves releases the way the script does, and the API is now a
+fallback rather than the route:
+
+| what | how | API budget |
+| --- | --- | --- |
+| the latest version (`--check`, the daily background check, any update) | `github.com/<repo>/releases/latest` → 302, tag in `Location` | none |
+| the archive for a self-contained install | built from the target triple, fetched from `github.com` | none |
+| the `.deb`/`.rpm`/`.flatpak` for a `DownloadPackage` channel | `feed::package_file_name`, the same construction `install.sh` does | none |
+| checksum sidecars | `<asset>.sha256` on `github.com` | none |
+| a pre-release (`--pre`) | the `/releases` list endpoint | 1 |
+| a package name the release turns out not to publish | the feed, after a 404 | 1 |
+| the release attestation, when an update installs | `api.github.com/repos/<repo>/attestations/sha256:<digest>` | 1 |
+
+A check therefore spends nothing, and an install spends exactly one request —
+the attestation, which is a *second origin* on purpose (§11) and so cannot be
+moved to `github.com` without becoming the thing it exists to improve on.
+
+Three supporting pieces, in `fresh_update::net` / `fresh_update::fetch`:
 
 - **A rate limit is reported as itself.** GitHub answers both of its limits
   with a 403 (or 429), so the status alone cannot distinguish "your budget is
@@ -760,22 +775,23 @@ Three things follow, all in `fresh_update::net` / `fresh_update::fetch`:
   over https, with `ureq` configured to drop `Authorization` across redirects,
   so a hop to the asset CDN cannot carry the credential. A token needs no
   scopes for a public repository and raises the limit to 5000/hour.
-- **The version has a second route.** `github.com/<repo>/releases/latest`
-  redirects to the newest release's page, and the tag is in the `Location`
-  header: one request, same host allowlist, no API budget. When — and only when
-  — the feed was refused for rate limiting, the version is read from there
-  instead, so `--check`, the daily background check and a SelfContained update
-  all keep working. It is a fallback, never the default: the redirect carries
-  no `prerelease`/`draft` flag, and making it the default would hand those
-  guarantees back to GitHub's web behaviour, which is what `feed::select`
-  exists to stop.
+- **Predicted names are checked by using them.** `package_file_name` builds
+  `fresh-editor_0.4.10-1_amd64.deb` from the version, because the pipeline
+  fixes that shape (`update-debian-changelog.sh` writes `-1`; `generate-rpm`
+  defaults to release `1`) — but it is a prediction. The engine downloads it and
+  falls back to the feed on a 404, so a packaging change costs one request
+  rather than producing a wrong answer. A checksum or attestation failure is
+  never retried that way: only `DownloadError::Missing` reopens the question.
 
-What the redirect cannot supply is the release's **asset list**, so a
-`DownloadPackage` channel (a `.deb`/`.rpm` whose filename embeds a packaging
-revision) says exactly that rather than claiming the release publishes nothing
-for the architecture. Neither can the attestation lookup be routed around: it
-is fail-closed by design, so a rate-limited attestation stops the install and
-the message names the two remedies (wait, or set a token).
+The guarantee `feed::select` carries — a stable install never offered a
+pre-release — survives the move, because it is re-derived from the tag itself
+(`version::is_prerelease`) rather than from a flag the redirect does not carry.
+Drafts need no equivalent: they are not public, so no redirect reaches one.
+
+An overridden endpoint (`--releases-url`, a mirror, the test server in
+`self_update_spine.rs`) keeps using its feed throughout: it named a document,
+and reinterpreting that as "ask GitHub instead" would ignore what the caller
+asked for.
 
 ---
 

--- a/docs/internal/packaging-self-update.md
+++ b/docs/internal/packaging-self-update.md
@@ -724,6 +724,9 @@ convention (`daemon`, `config`, `grammar`, `init`):
 - `fresh --cmd update --check` — report status only (current, latest, channel,
   what the update command would be); exit non-zero if outdated. Scriptable.
 - `fresh --cmd update --yes` — non-interactive (CI, dotfiles).
+- `fresh --cmd update --skip-attestation` — install with checksum verification
+  only (§10.1). A flag rather than an environment variable on purpose: it is a
+  decision per run, not one to leave sitting in a shell profile.
 - `fresh --cmd config paths` — extend to print resolved provenance + receipt
   path (for debugging "why does it think I installed via X").
 
@@ -761,6 +764,13 @@ fallback rather than the route:
 A check therefore spends nothing, and an install spends exactly one request —
 the attestation, which is a *second origin* on purpose (§11) and so cannot be
 moved to `github.com` without becoming the thing it exists to improve on.
+
+If that one request is refused, the failure offers `--skip-attestation`, which
+installs on the checksum alone — exactly the verification `install.sh` does, and
+no more. The offer is made **only** for a rate limit: every other attestation
+failure is either "GitHub does not attest to these bytes" or "something got in
+the way of asking", and naming a bypass there would be advertising it in the
+cases the check exists for. Using it prints what was given up, every time.
 
 Three supporting pieces, in `fresh_update::net` / `fresh_update::fetch`:
 
@@ -829,6 +839,16 @@ test-only surface: it overrides the download base and nothing else.
   An overridden endpoint skips the attestation check — a local test server has
   no attestations and never could — which is the same line already drawn for
   privilege: bytes from an overridden endpoint never reach `sudo`.
+
+  `--skip-attestation` skips it on the pinned endpoints too, and is the one
+  place this design lets the user lower the bar. It is not a hole so much as a
+  choice made explicit: without it, a `.deb` user whose address has run out of
+  API budget is told to wait an hour or download the same artifact by hand from
+  the same URL, verifying *nothing* — which is a worse outcome reached by a
+  longer road. So the flag exists, it is offered only when the limit is what
+  blocked the check, it must be typed on the command line each time (no
+  environment variable), and every run that uses it prints which guarantee it
+  dropped. What it never skips is the checksum.
 - **No privilege escalation, because nothing is executed.** `fresh` spawns no
   package manager, so there is no `sudo` to consent to and no credential path to
   get wrong. Where root is genuinely required it appears only as the `sudo` in

--- a/docs/internal/packaging-self-update.md
+++ b/docs/internal/packaging-self-update.md
@@ -737,6 +737,46 @@ Config (`config.rs`): keep `check_for_updates` and `--no-upgrade-check`. Add
 SelfContained installs update without a prompt; **off by default** per the
 non-goal on silent installs.
 
+### 10.1 GitHub's API rate limit
+
+Two of the requests an update makes go to `api.github.com`: the release feed,
+and the attestation lookup (§11). That host allows an unauthenticated caller
+**60 requests an hour per source address**, shared with everything else behind
+the same NAT — so `fresh --cmd update` can be refused with a 403 on a machine
+where `curl … install.sh | sh` succeeds seconds later. The install script is
+not luckier; it never touches the API at all, fetching the asset straight from
+`github.com`.
+
+Three things follow, all in `fresh_update::net` / `fresh_update::fetch`:
+
+- **A rate limit is reported as itself.** GitHub answers both of its limits
+  with a 403 (or 429), so the status alone cannot distinguish "your budget is
+  gone" from "you may not have this". The headers can — `x-ratelimit-remaining:
+  0` for the primary limit, `retry-after` for the secondary — and only those
+  produce `FetchError::RateLimited`, whose message carries the wait and the way
+  out. A real 403 stays reported as a 403.
+- **A token lifts it.** `FRESH_GITHUB_TOKEN`, `GITHUB_TOKEN` or `GH_TOKEN` (in
+  that order) is attached to `api.github.com` requests — and *only* to those,
+  over https, with `ureq` configured to drop `Authorization` across redirects,
+  so a hop to the asset CDN cannot carry the credential. A token needs no
+  scopes for a public repository and raises the limit to 5000/hour.
+- **The version has a second route.** `github.com/<repo>/releases/latest`
+  redirects to the newest release's page, and the tag is in the `Location`
+  header: one request, same host allowlist, no API budget. When — and only when
+  — the feed was refused for rate limiting, the version is read from there
+  instead, so `--check`, the daily background check and a SelfContained update
+  all keep working. It is a fallback, never the default: the redirect carries
+  no `prerelease`/`draft` flag, and making it the default would hand those
+  guarantees back to GitHub's web behaviour, which is what `feed::select`
+  exists to stop.
+
+What the redirect cannot supply is the release's **asset list**, so a
+`DownloadPackage` channel (a `.deb`/`.rpm` whose filename embeds a packaging
+revision) says exactly that rather than claiming the release publishes nothing
+for the architecture. Neither can the attestation lookup be routed around: it
+is fail-closed by design, so a rate-limited attestation stops the install and
+the message names the two remedies (wait, or set a token).
+
 ---
 
 ## 11. Security

--- a/docs/internal/packaging-self-update.md
+++ b/docs/internal/packaging-self-update.md
@@ -788,10 +788,14 @@ pre-release — survives the move, because it is re-derived from the tag itself
 (`version::is_prerelease`) rather than from a flag the redirect does not carry.
 Drafts need no equivalent: they are not public, so no redirect reaches one.
 
-An overridden endpoint (`--releases-url`, a mirror, the test server in
-`self_update_spine.rs`) keeps using its feed throughout: it named a document,
-and reinterpreting that as "ask GitHub instead" would ignore what the caller
-asked for.
+The redirect URL is *derived from the download base* rather than hard-coded:
+GitHub serves `…/releases/latest` beside `…/releases/download`, and so does
+anything mirroring that layout. Naming a feed (`--releases-url`,
+`FRESH_RELEASES_URL`) clears it — the caller pointed at a document, and
+resolving the version elsewhere would ignore that — while pointing only the
+downloads elsewhere moves it with them. That is also what lets
+`self_update_spine.rs` drive the real binary through a real 302 without any
+test-only surface: it overrides the download base and nothing else.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,3 +79,32 @@ If a keybinding isn't working as expected, use **Help → Debug Keyboard Events*
 - Incorrect escape sequences from your terminal
 
 Press any key to see its code, modifiers, and event type. Press `c` to clear history, `q` or `Esc` to close.
+
+## Updating
+
+### `fresh --cmd update` fails with a 403, but the install script works
+
+`fresh --cmd update` asks `api.github.com` which release is newest, and that
+host allows an unauthenticated caller 60 requests an hour **per IP address** —
+shared with everyone else behind the same router, VPN or corporate NAT. The
+install script never touches that API, which is why
+`curl -fsSL …/install.sh | sh` can succeed seconds after an update was refused.
+
+Fresh reports this as a rate limit rather than a bare 403, tells you when it
+resets, and reads the version from GitHub's release redirect instead so
+`--check` and the in-editor indicator keep working. Installing still needs the
+API for the release attestation, which is verified fail-closed, so you have
+three options:
+
+- **Wait** for the window named in the message (at most an hour).
+- **Use a token** — a GitHub personal access token needs no scopes at all for a
+  public repository and raises the limit to 5000/hour:
+
+  ```bash
+  export FRESH_GITHUB_TOKEN=ghp_...   # or GITHUB_TOKEN / GH_TOKEN
+  fresh --cmd update
+  ```
+
+  It is sent to `api.github.com` and nowhere else.
+- **Re-run the installer**, which fetches the release directly from
+  `github.com` and verifies its published checksum.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,17 +109,11 @@ as the download. If that one is refused:
   It is sent to `api.github.com` and nowhere else.
 - **Re-run the installer**, which fetches the release directly from
   `github.com` and verifies its published checksum.
-- **Skip the attestation** for this one run, accepting the same verification
-  the installer does and no more:
-
-  ```bash
-  fresh --cmd update --yes --skip-attestation
-  ```
-
-  The download is still checked against its published SHA-256, but that
-  checksum comes from the same origin as the artifact — so it catches a
-  corrupted download, not a tampered release. Fresh prints that trade-off
-  whenever the flag is used.
+- **Skip the attestation** for this one run — `fresh --cmd update --yes
+  --skip-attestation`. The download is still checked against its published
+  SHA-256, but that checksum shares an origin with the artifact, so it catches
+  a corrupted download and not a tampered release. Fresh says so whenever the
+  flag is used.
 
 `fresh --cmd update --pre` also needs the API, because pre-releases are only
 listed there.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,19 +82,20 @@ Press any key to see its code, modifiers, and event type. Press `c` to clear his
 
 ## Updating
 
-### `fresh --cmd update` fails with a 403, but the install script works
+### `fresh --cmd update` fails with a 403 from GitHub
 
-`fresh --cmd update` asks `api.github.com` which release is newest, and that
-host allows an unauthenticated caller 60 requests an hour **per IP address** —
-shared with everyone else behind the same router, VPN or corporate NAT. The
-install script never touches that API, which is why
-`curl -fsSL …/install.sh | sh` can succeed seconds after an update was refused.
+`api.github.com` allows an unauthenticated caller 60 requests an hour **per IP
+address** — shared with everyone else behind the same router, VPN or corporate
+NAT — so a 403 from that host usually means somebody else spent the budget.
 
-Fresh reports this as a rate limit rather than a bare 403, tells you when it
-resets, and reads the version from GitHub's release redirect instead so
-`--check` and the in-editor indicator keep working. Installing still needs the
-API for the release attestation, which is verified fail-closed, so you have
-three options:
+Fresh stays off that API almost entirely: the version comes from GitHub's
+release redirect, and the archive, the package and their checksums come from
+`github.com`, exactly as `install.sh` fetches them. Checking for an update
+therefore costs nothing at all.
+
+Installing spends one API request: the release attestation, which is verified
+against a second origin on purpose and so cannot be served from the same host
+as the download. If that one is refused:
 
 - **Wait** for the window named in the message (at most an hour).
 - **Use a token** — a GitHub personal access token needs no scopes at all for a
@@ -108,3 +109,6 @@ three options:
   It is sent to `api.github.com` and nowhere else.
 - **Re-run the installer**, which fetches the release directly from
   `github.com` and verifies its published checksum.
+
+`fresh --cmd update --pre` also needs the API, because pre-releases are only
+listed there.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -109,6 +109,17 @@ as the download. If that one is refused:
   It is sent to `api.github.com` and nowhere else.
 - **Re-run the installer**, which fetches the release directly from
   `github.com` and verifies its published checksum.
+- **Skip the attestation** for this one run, accepting the same verification
+  the installer does and no more:
+
+  ```bash
+  fresh --cmd update --yes --skip-attestation
+  ```
+
+  The download is still checked against its published SHA-256, but that
+  checksum comes from the same origin as the artifact — so it catches a
+  corrupted download, not a tampered release. Fresh prints that trade-off
+  whenever the flag is used.
 
 `fresh --cmd update --pre` also needs the API, because pre-releases are only
 listed there.


### PR DESCRIPTION
`fresh --cmd update` was refused with a bare `HTTP 403 fetching …` on a machine where `curl -fsSL …/install.sh | sh` succeeded seconds later. The install script is not luckier — it never touches `api.github.com` at all. It asks `github.com/<repo>/releases/latest`, reads the tag out of the 302, and builds every asset URL from it. The API gives an unauthenticated caller **60 requests an hour per source address**, shared with everyone behind the same NAT.

So the updater now resolves releases the same way, and the API is a fallback rather than the route.

## Where the API budget goes

| step | route | API |
| --- | --- | --- |
| latest version (`--check`, the editor's daily check, any update) | `releases/latest` → 302, tag in `Location` | none |
| self-contained archive + `.sha256` | `github.com` | none |
| `.deb`/`.rpm`/`.flatpak` name and download | built from the version, `github.com` | none |
| `--pre` | `/releases` list endpoint | 1 |
| a package name the release does not publish | the feed, after a 404 | 1 |
| release attestation, on an actual install | `api.github.com/…/attestations/…` | 1 |

**A check spends nothing and can no longer be rate-limited at all. An install spends exactly one request** — the attestation, whose entire value over the `.sha256` sidecar is that it is a *different origin*, so it cannot move to `github.com` without becoming the sidecar.

## What a rate-limited install says now

```
Error: GitHub's API rate limit is used up, resets in about 34 minutes. Set
GITHUB_TOKEN to raise it from 60 an hour to 5000. The release attestation could
not be checked, so nothing was installed. Re-run later, or --skip-attestation
to install on the checksum alone.
```

Two sentences and a remedy, composed from three layers that each used to write a paragraph. The 90 characters of subject digest are gone from the URL as well — a plain HTTP status still prints its URL, where that *is* the diagnosis.

## Supporting pieces

- **A rate limit is reported as itself.** GitHub answers both of its limits with a 403 (or 429), so the status alone cannot separate "your budget is gone" from "you may not have this". The headers can — `x-ratelimit-remaining: 0` for the primary limit, `retry-after` for the secondary — and only those produce `FetchError::RateLimited`. A genuine 403 stays a 403.
- **A token lifts it.** `FRESH_GITHUB_TOKEN`, `GITHUB_TOKEN` or `GH_TOKEN` (in that order), attached to `api.github.com` requests over https and to nothing else — `ureq` drops `Authorization` across redirects, so the asset CDN never sees it.
- **`--skip-attestation`** installs on the checksum alone: what `install.sh` verifies, and no more. It is offered *only* when a rate limit is what blocked the check (naming it on `NotAttested` would advertise the bypass in the case the check exists for), it is a flag rather than an env var so it cannot sit in a shell profile, and every run that uses it prints which guarantee was dropped. The checksum is never skipped. Its name is a constant at the `fresh-update` crate root beside `EXIT_ACTION_REQUIRED` — both are the CLI's contract, and the argument parser reads them in builds compiled without the engine.
- **Predicted names are checked by using them.** `feed::package_file_name` builds `fresh-editor_0.4.10-1_amd64.deb` from the version because the pipeline fixes that shape (`update-debian-changelog.sh` writes `-1`; `generate-rpm` defaults to release `1`) — but it is a prediction, so a 404 falls back to the feed for the real name. Only `DownloadError::Missing` reopens the question; a checksum or attestation failure is never retried that way.

## What survives the move

`feed::select`'s guarantee that a stable install is never offered a pre-release: a tag carries no `prerelease` flag, so it is re-derived from the version itself (`version::is_prerelease`) — stronger than trusting GitHub's `latest` semantics, which is what `select` was written to stop. Drafts are not public, so no redirect reaches one. Naming a feed (`--releases-url`) clears the redirect entirely; pointing only the downloads elsewhere moves it with them, since it lives at `…/releases/latest` beside `…/releases/download`.

## Tests

The 302 route is what every install now takes, so it is tested through the real binary: `self_update_spine.rs` gains two cases driving `fresh --cmd update` against a server answering exactly as GitHub does — 302 with the release page in `Location`, assets beside it, **404 for everything else**, so a run that reached for a feed could not pass. One does the full swap and executes the replacement; one is `--check`. Reaching that needed no test-only surface: the redirect URL is derived from the download base, so the test overrides that and nothing else.

Two things those tests turned up, both fixed here:

- `stripped_binary()` cached the test binary with **no invalidation**, so every spine case ran whatever binary was stripped first — the new tests failed against pre-change code, and the old ones would have passed against it just as silently. The cache is now reused only while it is newer than the binary it came from.
- The attestation failure message is pinned by a test, since that is the one API request an install still makes.

Also new: unit tests for rate-limit classification (only the headers make a 403 a rate limit; a reset becomes a wait), token pinning (`api.github.com` over https and no other host, userinfo included), redirect parsing (a `Location` naming no release is refused, not turned into a version), the pre-release guard, constructed-vs-matched package names, that the constructed names still match `install.sh`, and that only a rate limit — never `NotAttested`, `NameMismatch`, `Malformed` or a transport failure — is told how to go around the attestation.

Green: 139 `fresh-update` tests, 11/11 spine tests, `cargo clippy --all-features --all-targets`, `cargo fmt --check`, and `cargo check --no-default-features --features runtime --all-targets` — the min-size build with no HTTP stack, which is the job that caught the flag constant living behind the `engine` feature gate.

Docs: §10.1 in `docs/internal/packaging-self-update.md` (the table above, plus why the attestation cannot move and what `--skip-attestation` costs), a §11 note on the one place this design lets a user lower the bar, and a troubleshooting entry for "403 on update, but the install script works".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSm1Z1KYD1BMGg3CkASrPG