### PR TITLE
git plugins: pin every config knob that reshapes the parsed patch output

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -18,7 +18,7 @@ import {
   fetchCommitShow,
   fetchGitLog,
 } from "./lib/git_history.ts";
-import { type GitRepo, resolveGitRepo } from "./lib/git_repo.ts";
+import { type GitRepo, diffArgs, resolveGitRepo, withDiffArgs } from "./lib/git_repo.ts";
 import type { HintEntry, TreeNode, WidgetSpec } from "./lib/widgets.ts";
 import {
   WidgetPanel,
@@ -845,56 +845,9 @@ async function getGitStatus(): Promise<GitStatusResult> {
     };
 }
 
-/**
- * Restore git's default `a/` / `b/` path prefixes. Written as `-c` overrides
- * rather than `--src-prefix=`/`--dst-prefix=`: `git stash show` garbles those
- * two, while `-c` behaves the same for every sub-command.
- */
-const DIFF_PREFIX_CONFIG = [
-    "-c", "diff.noprefix=false",
-    "-c", "diff.mnemonicPrefix=false",
-    "-c", "diff.srcPrefix=a/",
-    "-c", "diff.dstPrefix=b/",
-];
-
-/**
- * Build the `git` argv for a diff-producing sub-command whose stdout
- * `parseDiffOutput` parses and `buildHunkPatch` rebuilds for `git apply`.
- * Each knob neutralised here is one a user may legitimately have set, and any
- * one alone leaves the parser with zero hunks: `diff.external` swaps in a
- * tool's own format, textconv diffs converted text (so hunk line numbers stop
- * addressing the real file), `color.diff=always` wraps every line in escapes,
- * and the prefix settings break the `a/`/`b/` paths it matches on.
- */
-function diffArgs(subcommand: string[], ...rest: string[]): string[] {
-    return [
-        // Top-level, so it has to precede the sub-command. `git diff`
-        // refreshes the index and writes it back under `.git/index.lock`
-        // just as `git status` does, and the watch runs both on a timer
-        // (#3126) — pinning the flag here rather than at one call site
-        // keeps the panel from racing the user's own `git` for that lock
-        // whichever sub-command the tick reaches for.
-        "--no-optional-locks",
-        ...DIFF_PREFIX_CONFIG,
-        ...subcommand,
-        "--no-ext-diff",
-        "--no-textconv",
-        "--no-color",
-        ...rest,
-    ];
-}
-
-/**
- * Route an already-assembled git argv through `diffArgs`, splitting it at its
- * first option so the leading sub-command words (`diff`, `stash show`, …) stay
- * in front. Lets callers that build the argv dynamically inherit the format
- * pinning instead of each having to repeat the flag list.
- */
-function withDiffArgs(command: string[]): string[] {
-    const firstOption = command.findIndex(a => a.startsWith("-"));
-    const cut = firstOption === -1 ? command.length : firstOption;
-    return diffArgs(command.slice(0, cut), ...command.slice(cut));
-}
+// `diffArgs` / `withDiffArgs` — the argv that pins git's patch output to the
+// shape `parseDiffOutput` and `buildHunkPatch` expect — are shared with the
+// git log plugin and live in `./lib/git_repo.ts`.
 
 /**
  * Fetch unified diffs for the given file entries.
@@ -7798,10 +7751,13 @@ async function side_by_side_diff_current_file() {
     const gitRoot = gitRootResult.stdout.trim();
 
     // Get relative path from git root using git itself (handles Windows paths correctly)
-    const relPathResult = await editor.spawnProcess("git", ["-C", fileDir, "ls-files", "--full-name", fileName]);
+    // `-z`: without it a path with non-ASCII (or `"`, `\`) bytes comes back
+    // quoted and octal-escaped, and no later git call would match it.
+    const relPathResult = await editor.spawnProcess("git", ["-C", fileDir, "ls-files", "-z", "--full-name", fileName]);
+    const relPath = relPathResult.stdout.split("\0")[0] ?? "";
     let filePath: string;
-    if (relPathResult.exit_code === 0 && relPathResult.stdout.trim()) {
-        filePath = relPathResult.stdout.trim();
+    if (relPathResult.exit_code === 0 && relPath) {
+        filePath = relPath;
     } else {
         // File might be untracked, compute relative path manually
         // Normalize paths: replace backslashes with forward slashes for comparison

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -8,6 +8,7 @@ import {
 } from "./lib/git_history.ts";
 import {
   type GitRepo,
+  diffArgs,
   git,
   resolveGitRepo,
   resolveGitRepoForPath,
@@ -385,9 +386,13 @@ function spawnGitShow(hash: string, cwd: string): ProcessHandle<SpawnResult> {
   // as flat positional args. The runtime JS wrapper also accepts an
   // `{stdoutTo}` options object in the 4th slot, but using the flat
   // form keeps the call type-checked without a cast.
+  //
+  // `diffArgs` pins the patch format: the fold ranges, `Enter` and the
+  // host's `.diff` highlighting all read this file's `diff --git` /
+  // `+++ b/` / `@@` rows, which user config can otherwise reshape.
   return editor.spawnProcess(
     "git",
-    ["show", "--stat", "--patch", hash],
+    diffArgs(["show"], "--stat", "--patch", hash),
     cwd,
     cachePathForHash(hash),
   );

--- a/crates/fresh-editor/plugins/lib/git_history.ts
+++ b/crates/fresh-editor/plugins/lib/git_history.ts
@@ -14,6 +14,8 @@
 // gateway) alongside the rest of repo resolution — import `discoverSubRepos`
 // from there.
 
+import { diffArgs } from "./git_repo.ts";
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -114,7 +116,9 @@ export async function fetchGitLog(
   const maxCommits = opts.maxCommits ?? 200;
   const cwd = opts.cwd ?? editor.getCwd();
   const format = "%H%x00%h%x00%an%x00%ae%x00%ai%x00%ar%x00%D%x00%s%x00%b%x1e";
-  const args = ["log", `--format=${format}`, `-n${maxCommits}`];
+  // `--no-show-signature`: with `log.showSignature` set, a signed commit's
+  // gpg lines precede its record and would be read as part of its hash.
+  const args = ["log", "--no-show-signature", `--format=${format}`, `-n${maxCommits}`];
   if (opts.range) args.push(opts.range);
   // `-- <path>` must come last so git treats it as a pathspec, not a
   // revision. Restricts the log to commits touching that file.
@@ -163,9 +167,11 @@ export async function fetchCommitShow(
 
   // numstat first — small output, lets us spot oversized files before
   // pulling the full diff.
+  // Through `diffArgs` so the paths come back unquoted and match the
+  // `:(exclude,top)` pathspecs built from them below.
   const numstatResult = await editor.spawnProcess(
     "git",
-    ["show", "--numstat", "--format=", hash],
+    diffArgs(["show"], "--numstat", "--format=", hash),
     workdir
   );
   const oversized: string[] = [];
@@ -189,7 +195,7 @@ export async function fetchCommitShow(
 
   // Stat + patch, excluding oversized paths. `:(exclude,top)` is rooted
   // at the repo root so it matches regardless of git's cwd.
-  const showArgs = ["show", "--stat", "--patch", hash];
+  const showArgs = diffArgs(["show"], "--stat", "--patch", hash);
   if (oversized.length > 0) {
     showArgs.push("--", ".");
     for (const p of oversized) showArgs.push(`:(exclude,top)${p}`);

--- a/crates/fresh-editor/plugins/lib/git_repo.ts
+++ b/crates/fresh-editor/plugins/lib/git_repo.ts
@@ -100,6 +100,72 @@ export function git(
 }
 
 /**
+ * User settings that reshape git's patch output, pinned back to the documented
+ * default. Written as top-level `-c` overrides rather than per-sub-command
+ * flags: `git stash show` mangles `--src-prefix=`/`--dst-prefix=`, and `-c`
+ * behaves the same for every sub-command (`diff`, `show`, `stash show`, ...).
+ * Plumbing (`diff-files -p` and friends) is no escape hatch: `core.quotePath`
+ * and `diff.suppressBlankEmpty` are honoured there too.
+ */
+const DIFF_FORMAT_CONFIG = [
+  // The `a/` / `b/` path prefixes the parsers match on.
+  "-c", "diff.noprefix=false",
+  "-c", "diff.mnemonicPrefix=false",
+  "-c", "diff.srcPrefix=a/",
+  "-c", "diff.dstPrefix=b/",
+  // Non-ASCII paths otherwise come out quoted and octal-escaped in every
+  // header (`diff --git "a/caf\303\251"`), and in `--numstat`/`--stat` rows.
+  "-c", "core.quotepath=false",
+  // Empty context lines otherwise lose their leading space, so a parser
+  // classifying rows by their first byte drops them.
+  "-c", "diff.suppressBlankEmpty=false",
+  // Paths stay repo-relative, and files outside git's cwd are not omitted.
+  "-c", "diff.relative=false",
+  // A changed submodule is one `Subproject commit` hunk, not a nested diff
+  // whose `diff --git` paths are relative to the submodule.
+  "-c", "diff.submodule=short",
+];
+
+/**
+ * Build the `git` argv for a patch-producing sub-command whose stdout a plugin
+ * parses (`diff --git` / `+++ b/` / `@@` headers, `+`/`-`/` ` rows). Every
+ * knob neutralised here is one a user may legitimately have set, and any one
+ * alone breaks the parse: `diff.external` swaps in a tool's own format,
+ * textconv diffs converted text (so hunk line numbers stop addressing the
+ * real file), `color.diff=always` wraps every line in escapes, and the
+ * config knobs above reshape the headers and rows.
+ */
+export function diffArgs(subcommand: string[], ...rest: string[]): string[] {
+  return [
+    // Top-level, so it has to precede the sub-command. `git diff` refreshes
+    // the index and writes it back under `.git/index.lock` just as
+    // `git status` does, and the review watch runs both on a timer (#3126)
+    // — pinning the flag here rather than at one call site keeps the panel
+    // from racing the user's own `git` for that lock whichever sub-command
+    // the tick reaches for.
+    "--no-optional-locks",
+    ...DIFF_FORMAT_CONFIG,
+    ...subcommand,
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-color",
+    ...rest,
+  ];
+}
+
+/**
+ * Route an already-assembled git argv through `diffArgs`, splitting it at its
+ * first option so the leading sub-command words (`diff`, `stash show`, ...)
+ * stay in front. Lets callers that build the argv dynamically inherit the
+ * format pinning instead of each having to repeat the flag list.
+ */
+export function withDiffArgs(command: string[]): string[] {
+  const firstOption = command.findIndex((a) => a.startsWith("-"));
+  const cut = firstOption === -1 ? command.length : firstOption;
+  return diffArgs(command.slice(0, cut), ...command.slice(cut));
+}
+
+/**
  * Absolute path for a repo-relative path (e.g. a line of `git ls-files` or
  * `git grep` output). In a monorepo the workspace root differs from the repo
  * root, so a repo-relative path must be joined onto the repo root to open.

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_hostile_diff_config.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_hostile_diff_config.rs
@@ -1,0 +1,222 @@
+//! The Git Log detail panel is `git show --stat --patch` streamed into a
+//! `.diff` file. Three consumers read that file's patch headers and rows —
+//! the host's `.diff` highlighting, the plugin's fold ranges, and `Enter`,
+//! which walks back from the cursor to a `+++ b/<path>` header and a `@@`
+//! hunk header to open the file at the cursor's line. User git config can
+//! reshape every one of those lines: `color.diff=always` wraps them in
+//! escapes, `diff.noprefix` strips the `b/` the header walk keys on, and
+//! `core.quotePath` quotes and octal-escapes a non-ASCII path so neither the
+//! header walk nor the follow-up `git show <hash>:<path>` can use it.
+//!
+//! The fixture switches all of those on and asserts the rendered result the
+//! way `git_log_diff_highlight_offset.rs` does — no status-bar text.
+
+use crate::common::git_test_helper::{git_command, GitTestRepo};
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use ratatui::style::Color;
+
+/// A non-ASCII path, in a subdirectory so `diff.relative` has something to
+/// strip.
+const FILE: &str = "notas/añadido.txt";
+/// The context line between the accented addition and the plain one.
+const CTX_ROW: &str = "CTX KEEP LINE";
+/// The plain (all-ASCII) added line; line 5 of the new file.
+const ADDED_ROW: &str = "PLAIN ADD ROW";
+/// A context line below the hunk, the "no diff colour here" reference.
+const CLEAN_ROW: &str = "gamma three";
+
+const BEFORE: &str = "alpha one\nbeta two\nCTX KEEP LINE\ngamma three\ndelta four\n";
+const AFTER: &str =
+    "alpha one\nbeta two\nañadido ñ·ñ·ñ\nCTX KEEP LINE\nPLAIN ADD ROW\ngamma three\ndelta four\n";
+
+/// A harness whose grammar registry can highlight the `.diff` buffer.
+fn harness_with_highlighting(
+    width: u16,
+    height: u16,
+    working_dir: std::path::PathBuf,
+) -> EditorTestHarness {
+    EditorTestHarness::create(
+        width,
+        height,
+        HarnessOptions::new()
+            .with_config(Config::default())
+            .with_working_dir(working_dir)
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry(),
+    )
+    .unwrap()
+}
+
+/// Text of screen row `y`.
+fn row_text(harness: &EditorTestHarness, y: u16) -> String {
+    let buf = harness.buffer();
+    (0..buf.area.width)
+        .map(|x| buf[(x, y)].symbol().to_string())
+        .collect()
+}
+
+/// Row index of the first screen row containing `needle`.
+fn row_containing(harness: &EditorTestHarness, needle: &str) -> Option<u16> {
+    let height = harness.buffer().area.height;
+    (0..height).find(|&y| row_text(harness, y).contains(needle))
+}
+
+/// The distinct background colours painted across the detail-panel part of
+/// row `y` — everything right of the split's `│` divider.
+fn detail_backgrounds(harness: &EditorTestHarness, y: u16) -> Vec<Color> {
+    let divider = row_text(harness, y).chars().position(|c| c == '│');
+    let first_x = divider.map(|d| d as u16 + 1).unwrap_or(0);
+    let buf = harness.buffer();
+    let mut seen: Vec<Color> = Vec::new();
+    for x in first_x..buf.area.width {
+        let bg = buf[(x, y)].style().bg.unwrap_or(Color::Reset);
+        if !seen.contains(&bg) {
+            seen.push(bg);
+        }
+    }
+    seen
+}
+
+/// Two commits on `FILE`, then every setting that reshapes `git show`'s patch.
+fn hostile_repo() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    repo.create_file(FILE, BEFORE);
+    repo.git_add(&[FILE]);
+    repo.git_commit("Add notes");
+    repo.create_file(FILE, AFTER);
+    repo.git_add(&[FILE]);
+    repo.git_commit("Add accented and plain lines");
+
+    for (key, value) in [
+        ("color.diff", "always"),
+        ("color.ui", "always"),
+        ("diff.noprefix", "true"),
+        ("diff.mnemonicPrefix", "true"),
+        ("core.quotePath", "true"),
+        ("diff.suppressBlankEmpty", "true"),
+        ("diff.relative", "true"),
+    ] {
+        let output = git_command(&repo.path)
+            .args(["config", "--local", key, value])
+            .output()
+            .expect("run git config");
+        assert!(
+            output.status.success(),
+            "git config {key} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    repo.setup_git_log_plugin();
+    repo
+}
+
+// TODO: git command output differs on Windows; the other git_log tests skip it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn git_log_detail_parses_diff_under_hostile_diff_config() {
+    let repo = hostile_repo();
+    let _guard = repo.change_to_repo_dir();
+
+    // Wide enough that no diff row wraps in the detail panel — the cursor is
+    // walked down by display rows below.
+    let mut harness = harness_with_highlighting(160, 45, repo.path.clone());
+    harness.open_file(&repo.path.join(FILE)).unwrap();
+    harness.render().unwrap();
+
+    harness.run_palette_command("Git Log").unwrap();
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane")
+                && s.contains("Author:")
+                && s.contains(CTX_ROW)
+                && s.contains(ADDED_ROW)
+                && s.contains(CLEAN_ROW)
+        })
+        .unwrap();
+    // `git show` streams into the buffer and the highlighter runs over what
+    // has arrived; let the pipeline go quiet before reading cells.
+    harness.wait_for_async_quiescence(3).unwrap();
+
+    let screen = harness.screen_to_string();
+
+    // The per-file header must carry the `b/` prefix and the unquoted path:
+    // that exact form is what `Enter`'s header walk matches.
+    let header = format!("+++ b/{FILE}");
+    assert!(
+        screen.contains(&header),
+        "the detail panel should show `{header}` whatever the prefix and \
+         quoting settings say.\nScreen:\n{screen}",
+    );
+
+    // Colour escapes in the file would defeat the `.diff` grammar: the `+`
+    // row must still be painted with a background the context row lacks.
+    let find = |needle: &str| {
+        row_containing(&harness, needle)
+            .unwrap_or_else(|| panic!("`{needle}` never rendered.\nScreen:\n{screen}"))
+    };
+    let added_y = find(ADDED_ROW);
+    let clean_y = find(CLEAN_ROW);
+    let context_bgs = detail_backgrounds(&harness, clean_y);
+    let added_bgs = detail_backgrounds(&harness, added_y);
+    let addition_only: Vec<Color> = added_bgs
+        .iter()
+        .copied()
+        .filter(|bg| !context_bgs.contains(bg))
+        .collect();
+    assert!(
+        !addition_only.is_empty(),
+        "the `+{ADDED_ROW}` row ({added_y}) should be painted with a background \
+         the context row ({clean_y}) doesn't have; saw {added_bgs:?} vs \
+         {context_bgs:?}\nScreen:\n{screen}",
+    );
+
+    // `Enter` on the `+` row opens the file at that row's line. The detail
+    // panel opens with its cursor on the `commit <sha>` line, the row above
+    // `Author:`, so the on-screen distance is the number of `Down` presses.
+    let author_y = find("Author:");
+    let first_y = author_y - 1;
+    assert!(
+        added_y > first_y,
+        "the diff should render `{ADDED_ROW}` below its `commit` header; \
+         saw rows {added_y} and {first_y}\nScreen:\n{screen}",
+    );
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    for _ in 0..(added_y - first_y) {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // git_log titles the file-at-commit view `*<hash>:<path>*`, so `:notas/`
+    // is unique to it. Fail fast on the two ways the walk gives up — a header
+    // it could not match, or a path `git show` could not resolve — rather than
+    // waiting forever for a view that will never open.
+    // The view is created with its cursor already on the target line, so once
+    // its title is up and the frame has settled the cursor is where it will
+    // stay.
+    let view_title = format!(":{FILE}");
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            if s.contains("Move cursor to a diff line") || s.contains("not found at commit") {
+                panic!("Enter on the `+{ADDED_ROW}` row did not open the file.\nScreen:\n{s}");
+            }
+            s.contains(&view_title)
+        })
+        .unwrap();
+
+    // `PLAIN ADD ROW` is line 5 of the new file: the cursor must sit at the
+    // byte where that line starts.
+    let expected: usize = AFTER.split_inclusive('\n').take(4).map(str::len).sum();
+    let screen = harness.screen_to_string();
+    assert_eq!(
+        harness.cursor_position(),
+        expected,
+        "Enter on the `+{ADDED_ROW}` row should open {FILE} at line 5.\nScreen:\n{screen}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -40,6 +40,7 @@ pub mod find_file;
 pub mod git;
 pub mod git_log_current_file;
 pub mod git_log_diff_highlight_offset;
+pub mod git_log_hostile_diff_config;
 pub mod git_log_indent_guide;
 pub mod git_log_split_tab_focus;
 pub mod git_statusbar;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -124,7 +124,6 @@ fn start_server(config: Config) {
 /// shim could never run and would protect nothing.
 #[cfg(unix)]
 fn configure_hostile_diff_output(repo: &GitTestRepo) {
-    use crate::common::git_test_helper::git_command;
     use std::os::unix::fs::PermissionsExt;
 
     // Everything the fixture installs lives under `.git/`, which git never
@@ -160,13 +159,24 @@ fn configure_hostile_diff_output(repo: &GitTestRepo) {
     // `.gitattributes` would, without adding a file to the working tree.
     repo.create_file(".git/info/attributes", "*.rs diff=fresh-test\n");
 
-    for (key, value) in [
-        ("diff.external", external.as_str()),
-        ("diff.fresh-test.textconv", textconv.as_str()),
-        ("color.diff", "always"),
-        ("diff.noprefix", "true"),
-        ("diff.mnemonicPrefix", "true"),
-    ] {
+    set_git_config(
+        repo,
+        &[
+            ("diff.external", external.as_str()),
+            ("diff.fresh-test.textconv", textconv.as_str()),
+            ("color.diff", "always"),
+            ("diff.noprefix", "true"),
+            ("diff.mnemonicPrefix", "true"),
+        ],
+    );
+}
+
+/// Write each `(key, value)` into the repo's local git config.
+#[cfg(unix)]
+fn set_git_config(repo: &GitTestRepo, pairs: &[(&str, &str)]) {
+    use crate::common::git_test_helper::git_command;
+
+    for (key, value) in pairs {
         let output = git_command(&repo.path)
             .args(["config", "--local", key, value])
             .output()
@@ -2359,6 +2369,159 @@ fn test_stash_review_ignores_external_diff_and_format_settings() {
         marker_new_line_number(&screen, "STASH_EXTERNAL_DIFF_MARKER"),
         Some(2),
         "Review Diff: Stash should number the marker by the real file. Screen:\n{screen}"
+    );
+}
+
+/// `diff.suppressBlankEmpty=true` makes git print an empty context line as
+/// `""` instead of `" "`. Review Diff classifies rows by their first byte, so
+/// such a row used to vanish from the hunk and every row below it was numbered
+/// one too low — the numbers `buildHunkPatch` then hands to `git apply`.
+#[test]
+#[cfg(unix)]
+fn test_review_diff_keeps_blank_context_lines_under_suppress_blank_empty() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    // The blank line is inside the hunk's leading context, above the change.
+    repo.create_file(
+        "src/main.rs",
+        "fn main() {\n    let a = 1;\n\n    let b = 2;\n}\n",
+    );
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    repo.create_file(
+        "src/main.rs",
+        "fn main() {\n    let a = 1;\n\n    let b = 2;\n    // BLANK_CONTEXT_MARKER\n}\n",
+    );
+    set_git_config(&repo, &[("diff.suppressBlankEmpty", "true")]);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    let screen = open_review_diff(&mut harness);
+
+    assert!(
+        screen.contains("BLANK_CONTEXT_MARKER"),
+        "Review Diff should render the hunk. Screen:\n{screen}"
+    );
+    // The marker is line 5 of the new file; with the blank context row
+    // dropped it would be counted as line 4.
+    assert_eq!(
+        marker_new_line_number(&screen, "BLANK_CONTEXT_MARKER"),
+        Some(5),
+        "Review Diff should keep the empty context line above the marker and \
+         number the marker by the real file. Screen:\n{screen}"
+    );
+}
+
+/// With `core.quotePath=true` (git's default) a non-ASCII path is quoted and
+/// octal-escaped in every diff header: `diff --git "a/src/a\303\261adido.rs"
+/// ...`. Review Diff matches the unquoted `a/`/`b/` form, so the file used to
+/// list with no hunks at all.
+#[test]
+#[cfg(unix)]
+fn test_review_diff_parses_non_ascii_paths_under_quotepath() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    repo.create_file("src/añadido.rs", "fn main() {}\n");
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    repo.create_file(
+        "src/añadido.rs",
+        "fn main() {\n    // QUOTEPATH_MARKER\n}\n",
+    );
+    // Pinned explicitly so the test keeps its meaning if git's default moves.
+    set_git_config(&repo, &[("core.quotePath", "true")]);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    let screen = open_review_diff(&mut harness);
+
+    assert!(
+        screen.contains("QUOTEPATH_MARKER"),
+        "Review Diff should render the hunk of a non-ASCII path even though \
+         git quotes it in the diff headers. Screen:\n{screen}"
+    );
+    assert_eq!(
+        marker_new_line_number(&screen, "QUOTEPATH_MARKER"),
+        Some(2),
+        "Review Diff should number the marker by the real file. Screen:\n{screen}"
+    );
+}
+
+/// Side-by-Side Diff resolves the file's repo-relative path through
+/// `git ls-files`, whose output is quoted under `core.quotePath` just like the
+/// diff headers. A quoted path matches nothing afterwards, so the file was
+/// treated as untracked and the view never opened.
+#[test]
+#[cfg(unix)]
+fn test_side_by_side_diff_parses_non_ascii_paths_under_quotepath() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    let path = repo.create_file("src/añadido.rs", "fn main() {}\n");
+    repo.git_add_all();
+    repo.git_commit("first commit");
+
+    repo.create_file(
+        "src/añadido.rs",
+        "fn main() {\n    // SIDE_BY_SIDE_QUOTEPATH_MARKER\n}\n",
+    );
+    set_git_config(&repo, &[("core.quotePath", "true")]);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        50,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+
+    harness.run_palette_command("Side-by-Side Diff").unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            // Fail fast: a failed path lookup reports the file as unchanged
+            // and never opens the view, which would otherwise be a hang.
+            if screen.contains("TypeError")
+                || screen.contains("Error:")
+                || screen.contains("Failed")
+                || screen.contains("No changes")
+            {
+                panic!("Error loading side-by-side diff. Screen:\n{screen}");
+            }
+            screen.contains("OLD (HEAD)") && screen.contains("NEW (Working)")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("SIDE_BY_SIDE_QUOTEPATH_MARKER"),
+        "Side-by-Side Diff should show the working-tree change of a non-ASCII \
+         path. Screen:\n{screen}"
     );
 }
 


### PR DESCRIPTION
## Summary

Review Diff (`audit_mode.ts`) and Git Log (`git_log.ts`) both spawn `git` and parse its stdout for `diff --git` / `+++ b/` / `@@` headers and `+`/`-`/` ` rows. Review Diff already neutralised `diff.external`, textconv, colour and the `a/`/`b/` prefix settings; Git Log's `git show --stat --patch` neutralised nothing. This PR pins the remaining knobs that can still reshape that output, in one shared helper both plugins use, and adds e2e tests that open the real panels against repos whose local git config is deliberately hostile.

## What each knob did, and to which command

| Knob | Command(s) affected | What it broke | Fix |
|---|---|---|---|
| `core.quotePath` (git's **default** is `true`) | `git diff`, `git show --patch`, `git show --numstat`, `git ls-files` | A non-ASCII path prints as `diff --git "a/caf\303\251.txt" "b/caf\303\251.txt"` / `+++ "b/caf\303\251.txt"`. Review Diff's `diff --git a\/(.+) b\/(.+)` never matched, so the file listed with no hunks. Git Log's `+++ b/` walk never matched, so `Enter` found no file to open. Side-by-Side Diff took the quoted `ls-files --full-name` output, matched nothing with it, and reported the file unchanged. `--numstat` paths (used to build `:(exclude,top)` pathspecs) were quoted too. | `-c core.quotepath=false`; `ls-files -z` with NUL-split |
| `diff.suppressBlankEmpty` | `git diff`, `git show` | An empty context line prints as `""` instead of `" "`. Review Diff classifies rows by their first byte, dropped the row, and numbered every row below it one too low — the numbers `buildHunkPatch` hands to `git apply`. | `-c diff.suppressBlankEmpty=false` |
| `diff.relative` | `git diff`, `git show` | From a subdirectory, files outside the cwd are omitted and the rest are printed cwd-relative, so they no longer match the repo-root paths from `git status --porcelain` and used by `git show <rev>:<path>`. Plugins run git at the repo root, but `-C <fileDir>` call sites exist. | `-c diff.relative=false` |
| `diff.submodule=diff` | `git diff`, `git show` | A changed submodule prints as a nested diff whose `diff --git` paths are relative to the submodule. | `-c diff.submodule=short` |
| `log.showSignature` | `git log --format=...` (`fetchGitLog`) | For a signed commit, gpg's lines print ahead of the record and would be read as part of the next hash. Reasoned from git's `log-tree.c` (`show_signature` runs for user formats too); **not covered by a test** — the harness has no gpg agent. | `--no-show-signature` |
| `color.diff` / `color.ui=always`, `diff.noprefix` / `mnemonicPrefix` / `srcPrefix` / `dstPrefix`, `diff.external`, textconv | `git show` (new); `git diff` was already pinned | Same breakage Review Diff was already guarding against, now reaching Git Log: escapes defeat the `.diff` grammar and the `startsWith` checks; no `b/` means no header match. `git show` defaults to `--no-ext-diff` but keeps textconv on, so `--no-textconv` matters there: converted text shifts the hunk line numbers `Enter` derives. | shared `diffArgs` |

## Leads examined and rejected (every shape they produce still parses)

- `diff.orderFile` — permutes whole-file sections only; Review Diff sorts hunks itself, Git Log displays them in order.
- Rename/copy detection (`diff.renames`, `status.renames`, `diff.renameLimit`) — both parsers take the `b/` side of the header; the status parser already reads `R`/`C` entries; `renames=false` yields a delete+add that parses too.
- `diff.algorithm`, `diff.context`, `diff.interHunkContext`, `diff.indentHeuristic` — hunk boundaries only; `--unified=3` already pins context where hunk ids matter. Left as user preference.
- `format.pretty`, `log.decorate` — the `git show` header is display-only; `fetchGitLog` passes an explicit `--format`, which `format.pretty` does not touch and which prints `%D` uncoloured even under `color.ui=always` (verified).
- `core.pager` — never started when stdout is a pipe (verified with `-c core.pager='echo PAGER'`).
- `core.autocrlf` / `core.eol` — a trailing CR stays inside its row; classification by first byte is unaffected.
- `diff.wordRegex`, `interactive.diffFilter` — only reached with `--word-diff` / interactive add.
- Localisation — `git status --porcelain -z` is unlocalised and unquoted by contract; the plugins do use `--porcelain -z`.

## Plumbing vs porcelain

Considered switching to `diff-files -p` / `diff-index -p` / `diff-tree -p`. Rejected: they skip the UI-level diff config (`diff.noprefix`, `diff.external`, colour) but **still honour `core.quotePath` and `diff.suppressBlankEmpty`** (both verified by running them under those settings), need an explicit `update-index --refresh` to see the working tree the way `git diff` does, and have no equivalent for `git show --stat --patch`, `git stash show -p` or `diff --no-index`. Every command shape the plugins depend on would have changed for a guarantee that would still have needed `-c` overrides on top. Porcelain plus overrides is the minimal change that is robust.

## Centralisation

`diffArgs` / `withDiffArgs` moved from `audit_mode.ts` into `lib/git_repo.ts` (the git gateway both plugins already import) and gained the new `-c` overrides. Used by Review Diff's diff/stash/range/single-file paths, Git Log's streamed `git show`, and the shared `fetchCommitShow` (branch review detail). No command shapes changed.

## Tests

All drive the real entrypoints and assert the rendered panel (no status-bar text). Each was run against master's plugin sources and failed on the assertion targeting its knob:

- `test_review_diff_keeps_blank_context_lines_under_suppress_blank_empty` — `diff.suppressBlankEmpty=true`; failed on master with the marker numbered 4 instead of 5.
- `test_review_diff_parses_non_ascii_paths_under_quotepath` — `core.quotePath=true` + `src/añadido.rs`; failed on master with no hunk rendered.
- `test_side_by_side_diff_parses_non_ascii_paths_under_quotepath` — same config, `Side-by-Side Diff` command; failed on master (file reported unchanged, view never opened).
- `git_log_detail_parses_diff_under_hostile_diff_config` — `color.diff`/`color.ui=always`, `diff.noprefix`, `diff.mnemonicPrefix`, `core.quotePath`, `diff.suppressBlankEmpty`, `diff.relative` all on, `notas/añadido.txt`. Asserts the `+++ b/notas/añadido.txt` header, the `+` row's highlight background, and that `Enter` opens the file with the cursor at line 5. Each of the three assertions was confirmed to fail independently on master by temporarily dropping the ones before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbLDaJdpD1MJLvQH3vqbpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbLDaJdpD1MJLvQH3vqbpb)_