### PR TITLE
Compose mode belongs to a pane, and a table's padding is not content

### DIFF
--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -671,6 +671,78 @@ function widthsForRow(byte: number): number[] | undefined {
   return w && w.length ? w : undefined;
 }
 
+/** How a table row is laid out across visual rows: the row texts the conceal
+ * pass draws, and the source positions the soft-break pass breaks at.
+ *
+ * One function because the two passes have to agree exactly — the conceal for
+ * visual row N covers the source between break N-1 and break N, so a break the
+ * other pass didn't pick puts a row's text on the wrong side of a fold. They
+ * were two copies of the same loop under a "must match" comment, which is how
+ * they came to disagree.
+ *
+ * Returns `null` for a row that fits on one visual line.
+ *
+ * Break positions must be spaces: a Space token carries its own source offset,
+ * while the characters inside a Text token all share the token's start, so a
+ * break asked for mid-token silently never happens. They must also be spread
+ * out — segment N+1 runs from the previous break + 1 up to this one, so two
+ * adjacent spaces leave it empty, and a conceal over an empty range renders
+ * nothing at all: the row it was carrying disappears into a blank line through
+ * the middle of the table.
+ */
+interface TableRowLayout { visualLines: string[]; breakChars: number[] }
+function tableRowLayout(
+  lineContent: string,
+  colWidths: number[],
+): TableRowLayout | null {
+  let inner = lineContent.trim();
+  if (inner.startsWith('|')) inner = inner.slice(1);
+  if (inner.endsWith('|')) inner = inner.slice(0, -1);
+  const cells = inner.split('|');
+  const numCols = Math.min(cells.length, colWidths.length);
+
+  const cellWrapped: string[][] = [];
+  let maxVisualLines = 1;
+  for (let ci = 0; ci < numCols; ci++) {
+    // 1 leading + 1 trailing space margin, matching the frame's cell padding.
+    const wrapped = wrapText(
+      concealedText(cells[ci]).trim(), Math.max(1, colWidths[ci] - 2),
+    );
+    cellWrapped.push(wrapped);
+    maxVisualLines = Math.max(maxVisualLines, wrapped.length);
+  }
+
+  // Cap to available source characters (excluding the trailing newline): each
+  // extra visual row costs one break position, and there are only so many.
+  let effLen = lineContent.length;
+  if (effLen > 0 && lineContent[effLen - 1] === '\n') effLen--;
+  if (effLen > 0 && lineContent[effLen - 1] === '\r') effLen--;
+  maxVisualLines = Math.min(maxVisualLines, effLen);
+  if (maxVisualLines <= 1) return null;
+
+  const breakChars: number[] = [];
+  let lastBreak = -1;
+  for (let i = 1; i < effLen - 1 && breakChars.length < maxVisualLines - 1; i++) {
+    if (lineContent[i] !== ' ' || i <= lastBreak + 1) continue;
+    breakChars.push(i);
+    lastBreak = i;
+  }
+  // A row with too few usable break positions renders the rows it can.
+  const rows = breakChars.length + 1;
+
+  const visualLines: string[] = [];
+  for (let vl = 0; vl < rows; vl++) {
+    let vline = '│';
+    for (let ci = 0; ci < numCols; ci++) {
+      const wrapW = Math.max(1, colWidths[ci] - 2);
+      const text = cellWrapped[ci][vl] ?? '';
+      vline += ' ' + text + ' '.repeat(Math.max(0, wrapW - displayWidth(text))) + ' │';
+    }
+    visualLines.push(vline);
+  }
+  return { visualLines, breakChars };
+}
+
 /** Whether a source line is a list item, for the inter-item spacing pass.
  * Indent widening doesn't matter here, so the measure is irrelevant. */
 function isListItemContent(content: string): boolean {
@@ -694,10 +766,19 @@ function tableCells(content: string): string[] {
 }
 
 // Viewport-constrained per-column widths from accumulated max raw widths.
+//
+// The frame's own columns come off the top: one `│` per column plus the
+// closing one. Two more go the way the thematic-break rule's do — the renderer
+// reserves an end-of-line column, and a frame that reaches it wraps its right
+// edge onto a row of its own. A table laid out at the full measure only got
+// away with it while the pane was wider than the measure; in a pane narrower
+// than the configured compose width (a vertical split, the file explorer
+// open), `effectiveComposeWidth` clamps to the pane and every border line
+// folded.
 function allocatedFor(maxW: number[]): number[] {
   const viewport = editor.getViewport();
   const composeW = effectiveComposeWidth(viewport ? viewport.width : 80);
-  const available = composeW - (maxW.length + 1);
+  const available = composeW - 2 - (maxW.length + 1);
   return distributeColumnWidths(maxW, available);
 }
 
@@ -1148,7 +1229,14 @@ function enableMarkdownCompose(bufferId: number): void {
   // Enable native line wrapping so that long lines without whitespace
   // (which the plugin can't soft-break) are force-wrapped by the Rust
   // wrapping transform at the content width.
-  editor.setLineWrap(bufferId, null, true);
+  //
+  // Scoped to THIS split, not to every split showing the buffer (which is what
+  // a `null` split id means). Compose mode is a property of one pane: a
+  // markdown buffer open in two panes, one composing and one in source, had
+  // wrap forced on in the source pane every time focus landed on the composing
+  // one — this hook runs on `buffer_activated`, so merely switching between
+  // the two rewrote the source pane's setting.
+  editor.setLineWrap(bufferId, editor.getActiveSplitId(), true);
 
   // Set layout hints for centered margins. With no explicit session choice
   // this resolves to the configured page width (default 80), so compose opens
@@ -1827,45 +1915,15 @@ function processLineConceals(
     // the wrapped rendering is the cursor-OFF variant).
     let handledByWrapping = false;
     if (colWidths && !isSeparator) {
-      const numCols = Math.min(cells.length, colWidths.length);
-      const cellWrapped: string[][] = [];
-      let maxVisualLines = 1;
-      for (let ci = 0; ci < numCols; ci++) {
-        const cellText = concealedText(cells[ci]).trim();
-        const wrapW = Math.max(1, colWidths[ci] - 2); // 1 leading + 1 trailing space margin
-        const wrapped = wrapText(cellText, wrapW);
-        cellWrapped.push(wrapped);
-        maxVisualLines = Math.max(maxVisualLines, wrapped.length);
-      }
-      // Cap to available source bytes (excluding trailing newline)
-      let effLen = lineContent.length;
-      if (effLen > 0 && lineContent[effLen - 1] === '\n') effLen--;
-      if (effLen > 0 && lineContent[effLen - 1] === '\r') effLen--;
-      maxVisualLines = Math.min(maxVisualLines, effLen);
-
-      if (maxVisualLines > 1) {
-        // Build formatted visual line for each wrapped row
-        const visualLines: string[] = [];
-        for (let vl = 0; vl < maxVisualLines; vl++) {
-          let vline = '│';
-          for (let ci = 0; ci < numCols; ci++) {
-            const wrapW = Math.max(1, colWidths[ci] - 2);
-            const wrapped = cellWrapped[ci] || [];
-            const text = vl < wrapped.length ? wrapped[vl] : '';
-            vline += ' ' + text + ' '.repeat(Math.max(0, wrapW - displayWidth(text))) + ' │';
-          }
-          visualLines.push(vline);
-        }
+      const layout = tableRowLayout(lineContent, colWidths);
+      if (layout) {
+        const { visualLines, breakChars } = layout;
 
         // Divide source bytes into segments, one per visual line.
-        // Soft breaks at segment boundaries (added by processLineSoftBreaks)
-        // create the visual line breaks; conceals replace each segment.
+        // Soft breaks at segment boundaries (added by processFlowBlock, from
+        // the same `tableRowLayout`) create the visual line breaks; conceals
+        // replace each segment.
         //
-        // IMPORTANT: break positions MUST land on Space characters.
-        // Space tokens have individual source_offset values matching their
-        // byte positions, so soft breaks will reliably trigger. Non-space
-        // characters inside Text tokens share the token's START offset,
-        // so breaks at mid-token positions silently fail.
         // The consumed space (replaced by Newline) must NOT be covered by
         // any segment's conceal range, so segment N+1 starts at spacePos+1.
         // Exclude trailing newline from segment range so the Newline token
@@ -1874,17 +1932,10 @@ function processLineConceals(
         let lineCharLen = lineContent.length;
         if (lineCharLen > 0 && lineContent[lineCharLen - 1] === '\n') lineCharLen--;
         if (lineCharLen > 0 && lineContent[lineCharLen - 1] === '\r') lineCharLen--;
-        const spacePositions: number[] = [];
-        for (let i = 1; i < lineCharLen; i++) {
-          if (lineContent[i] === ' ') spacePositions.push(i);
-        }
-        const breakChars = spacePositions.slice(0, maxVisualLines - 1);
-        // Trim visual lines if we couldn't find enough break positions
-        const actualVisualLines = breakChars.length + 1;
         // Segments: first starts at 0, subsequent start AFTER the consumed space
         const segStarts = [0, ...breakChars.map(c => c + 1)];
         const segEnds = [...breakChars, lineCharLen];
-        for (let vl = 0; vl < actualVisualLines; vl++) {
+        for (let vl = 0; vl < visualLines.length; vl++) {
           const sByteS = charToByte(lineContent, segStarts[vl], byteStart);
           const sByteE = charToByte(lineContent, segEnds[vl], byteStart);
           editor.addConceal(
@@ -1936,6 +1987,59 @@ function processLineConceals(
         }
       }
 
+      // A data cell's surrounding spaces are alignment, not content.
+      //
+      // The wrapping path above already reads a cell as `concealedText(...)
+      // .trim()` and re-lays it out as `␣content␣pad`. This path used to
+      // measure the cell verbatim, so a hand-aligned source — `|What
+      // ..........|`, which is how most people write a markdown table — read
+      // as a cell 14 columns wide, overflowed a 10-column allocation, and came
+      // out truncated to `What     -`: the header row of an otherwise fine
+      // table, mangled and a column out of step with the rows under it.
+      //
+      // So normalise here too. Concealing the cell's two whitespace RUNS
+      // rather than the whole cell is what keeps the content's own conceals
+      // and emphasis overlays alive inside it — the whole-cell replacement
+      // below is still the fallback for content that genuinely doesn't fit.
+      // `lead === 0` has no run to conceal, so its single space is appended to
+      // the *opening* pipe's replacement instead.
+      interface CellNorm {
+        charStart: number; charEnd: number;
+        lead: number; trail: number;
+        width: number;      // display width of the trimmed, concealed content
+        truncate: boolean;
+      }
+      //
+      // Only for a row that opens with a pipe, which is what makes `cells[ci]`
+      // the text between `pipePositions[ci]` and `[ci + 1]`. A row written
+      // without its leading `|` shifts that correspondence by one, and this
+      // pass conceals source rather than merely padding it — so it stands down
+      // there and the old width-only path below handles the row.
+      const cellNorms = new Map<number, CellNorm>();
+      if (colWidths && !isSeparator && trimmed.startsWith('|')) {
+        for (let ci = 0; ci < Math.min(cells.length, colWidths.length); ci++) {
+          const prevPipe = pipePositions[ci];
+          const nextPipe = pipePositions[ci + 1];
+          if (prevPipe === undefined || nextPipe === undefined) continue;
+          const charStart = prevPipe + 1;
+          const raw = lineContent.slice(charStart, nextPipe);
+          const trimmedStart = raw.trimStart();
+          // An all-whitespace cell is one run, not two: counting it twice
+          // would emit two overlapping conceals over the same bytes.
+          const lead = raw.length - trimmedStart.length;
+          const trail = trimmedStart.length === 0
+            ? 0
+            : raw.length - raw.trimEnd().length;
+          const width = displayWidth(concealedText(raw).trim());
+          cellNorms.set(ci, {
+            charStart, charEnd: nextPipe, lead, trail, width,
+            // One column goes to the leading space, so the content has
+            // `allocated - 1` to live in.
+            truncate: width > colWidths[ci] - 1,
+          });
+        }
+      }
+
       // Track which pipe index we're on (0 = leading pipe)
       let pipeIdx = 0;
       for (let i = 0; i < lineContent.length; i++) {
@@ -1957,33 +2061,70 @@ function processLineConceals(
           // stays fully visible for editing.
           let padOff = ""; // cursor elsewhere: concealed text width
           let padOn = ""; // cursor on this row: raw text width
+          // The single leading space of the cell this pipe OPENS, when that
+          // cell has no whitespace run of its own to normalise into one.
+          let leadOff = "";
           const cellIdx = pipeIdx - 1;
           if (colWidths && pipeIdx > 0 && cellIdx < cells.length && cellIdx < colWidths.length) {
-            const offText = concealedText(cells[cellIdx]);
-            const offWidth = displayWidth(offText);
             const rawWidth = displayWidth(cells[cellIdx]);
             const allocatedWidth = colWidths[cellIdx];
+            const norm = cellNorms.get(cellIdx);
 
-            if (offWidth > allocatedWidth) {
-              // Truncate (cursor-off only): conceal entire cell content and
-              // replace with truncated text. Separator rows use box-drawing ─
-              // to match the non-truncated path (per-char conceals replace
-              // source `-` with ─ and pad via pipe replacement).
-              const prevPipeCharPos = pipePositions[pipeIdx - 1];
-              const cellByteStart = charToByte(lineContent, prevPipeCharPos + 1, byteStart);
-              const cellByteEnd = pipeByte;
-              const truncated = isSeparator
-                ? '─'.repeat(allocatedWidth)
-                : offText.slice(0, allocatedWidth - 1) + '-';
+            if (norm && !norm.truncate) {
+              // Normalised: `␣` + content + pad, the two whitespace runs
+              // concealed away so the content keeps its own decorations.
+              if (norm.lead > 0) {
+                editor.addConceal(
+                  bufferId, "md-syntax",
+                  charToByte(lineContent, norm.charStart, byteStart),
+                  charToByte(lineContent, norm.charStart + norm.lead, byteStart),
+                  " ", "unless-cursor-in", byteStart, lineScopeStrictEnd,
+                );
+              }
+              if (norm.trail > 0) {
+                editor.addConceal(
+                  bufferId, "md-syntax",
+                  charToByte(lineContent, norm.charEnd - norm.trail, byteStart),
+                  pipeByte, "", "unless-cursor-in", byteStart, lineScopeStrictEnd,
+                );
+              }
+              const padCount = allocatedWidth - 1 - norm.width;
+              if (padCount > 0) padOff = " ".repeat(padCount);
+            } else if (norm) {
+              // Content too wide even trimmed: replace the whole cell, leading
+              // space included, and mark the range so the inline passes below
+              // don't decorate bytes that are no longer drawn.
+              const cellByteStart = charToByte(lineContent, norm.charStart, byteStart);
+              const content = concealedText(
+                lineContent.slice(norm.charStart, norm.charEnd),
+              ).trim();
               editor.addConceal(
-                bufferId, "md-syntax", cellByteStart, cellByteEnd, truncated,
+                bufferId, "md-syntax", cellByteStart, pipeByte,
+                " " + content.slice(0, Math.max(0, allocatedWidth - 2)) + "-",
                 "unless-cursor-in", byteStart, lineScopeStrictEnd,
               );
-              truncatedByteRanges.push({start: cellByteStart, end: cellByteEnd});
-              // padOff stays "" — the truncate conceal fills the cell.
+              truncatedByteRanges.push({start: cellByteStart, end: pipeByte});
+              // padOff stays "" — the replacement fills the cell.
             } else {
-              const padCount = allocatedWidth - offWidth;
-              if (padCount > 0) {
+              // A separator row — whose `─` fill is the whole point, so it is
+              // never normalised — or a row whose pipes and cells don't line
+              // up, which leaves the cell without a normalisation to apply.
+              // Both pad from the concealed width, as this path always did.
+              const offText = concealedText(cells[cellIdx]);
+              const offWidth = displayWidth(offText);
+              if (offWidth > allocatedWidth) {
+                const prevPipeCharPos = pipePositions[pipeIdx - 1];
+                const cellByteStart = charToByte(lineContent, prevPipeCharPos + 1, byteStart);
+                editor.addConceal(
+                  bufferId, "md-syntax", cellByteStart, pipeByte,
+                  isSeparator
+                    ? '─'.repeat(allocatedWidth)
+                    : offText.slice(0, allocatedWidth - 1) + '-',
+                  "unless-cursor-in", byteStart, lineScopeStrictEnd,
+                );
+                truncatedByteRanges.push({start: cellByteStart, end: pipeByte});
+              } else if (allocatedWidth > offWidth) {
+                const padCount = allocatedWidth - offWidth;
                 padOff = isSeparator ? "─".repeat(padCount) : " ".repeat(padCount);
               }
             }
@@ -1996,6 +2137,8 @@ function processLineConceals(
             // rawWidth > allocatedWidth: the cursor row keeps the too-wide
             // cell raw (no padding, no truncation) so it stays editable.
           }
+          const opening = cellNorms.get(pipeIdx);
+          if (opening && opening.lead === 0 && !opening.truncate) leadOff = " ";
 
           let glyph = "│";
           if (isSeparator) {
@@ -2005,12 +2148,12 @@ function processLineConceals(
             if (pipeIndex === 1) glyph = '├';
             else if (pipeIndex === totalPipes) glyph = '┤';
           }
-          if (padOff === padOn) {
+          if (padOff === padOn && leadOff === "") {
             // Same rendering in both cursor states — one always-active conceal.
             editor.addConceal(bufferId, "md-syntax", pipeByte, pipeByteEnd, padOff + glyph);
           } else {
             editor.addConceal(
-              bufferId, "md-syntax", pipeByte, pipeByteEnd, padOff + glyph,
+              bufferId, "md-syntax", pipeByte, pipeByteEnd, padOff + glyph + leadOff,
               "unless-cursor-in", byteStart, lineScopeStrictEnd,
             );
             editor.addConceal(
@@ -2678,45 +2821,18 @@ function processFlowBlock(
   // while the cursor is on the row (strict scope, matching the segment
   // conceals), where the row renders as a plain single line.
   if (parsed.type === 'table-row') {
-    const trimmedLine = lineContent.trim();
-    const isSep = /^\|[-:\s|]+\|$/.test(trimmedLine);
+    const isSep = /^\|[-:\s|]+\|$/.test(lineContent.trim());
     if (!isSep) {
       const colWidths = widthsForRow(byteStart);
-      if (colWidths) {
-        let innerLine = trimmedLine;
-        if (innerLine.startsWith('|')) innerLine = innerLine.slice(1);
-        if (innerLine.endsWith('|')) innerLine = innerLine.slice(0, -1);
-        const tableCells = innerLine.split('|');
-        let maxVisualLines = 1;
-        const numCols = Math.min(tableCells.length, colWidths.length);
-        for (let ci = 0; ci < numCols; ci++) {
-          const cellText = concealedText(tableCells[ci]).trim();
-          const wrapW = Math.max(1, colWidths[ci] - 2);
-          const wrapped = wrapText(cellText, wrapW);
-          maxVisualLines = Math.max(maxVisualLines, wrapped.length);
-        }
-        // Exclude trailing newline (same as processLineConceals)
-        let effLineLen = lineContent.length;
-        if (effLineLen > 0 && lineContent[effLineLen - 1] === '\n') effLineLen--;
-        if (effLineLen > 0 && lineContent[effLineLen - 1] === '\r') effLineLen--;
-        maxVisualLines = Math.min(maxVisualLines, effLineLen);
-
-        if (maxVisualLines > 1) {
-          // Must match the break positions from processLineConceals:
-          // pick Space chars (they have individual source_offsets that match).
-          const spacePositions: number[] = [];
-          for (let i = 1; i < effLineLen; i++) {
-            if (lineContent[i] === ' ') spacePositions.push(i);
-          }
-          const breakChars = spacePositions.slice(0, maxVisualLines - 1);
-          for (const charPos of breakChars) {
-            const breakBytePos = byteStart + editor.utf8ByteLength(lineContent.slice(0, charPos));
-            editor.addSoftBreak(
-              bufferId, "md-wrap", breakBytePos, 0,
-              "unless-cursor-in", byteStart, byteEnd,
-            );
-          }
-        }
+      // Exactly the positions `processLineConceals` cut its segments at — one
+      // layout, so a fold can never land somewhere no conceal ends.
+      const layout = colWidths ? tableRowLayout(lineContent, colWidths) : null;
+      for (const charPos of layout?.breakChars ?? []) {
+        const breakBytePos = byteStart + editor.utf8ByteLength(lineContent.slice(0, charPos));
+        editor.addSoftBreak(
+          bufferId, "md-wrap", breakBytePos, 0,
+          "unless-cursor-in", byteStart, byteEnd,
+        );
       }
     }
   }

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -351,6 +351,19 @@ impl Editor {
         // non-terminal clears terminal mode. Single restore authority.
         self.sync_terminal_mode_to_active_buffer();
 
+        // Refresh the snapshot BEFORE the hook, for the reason
+        // `set_active_buffer` gives: the handler has to see the split that is
+        // active *now*. Focus moving between two splits on the SAME buffer
+        // never reaches `set_active_buffer` (it early-returns when the buffer
+        // does not change), so without this the plugin mirror still answers
+        // with the split focus just left. `markdown_compose` reads
+        // `getBufferInfo().view_mode` here to decide whether to restore
+        // compose, and a mirror one split behind told it "compose" as focus
+        // landed on a *source* pane — which it then composed: gutter hidden,
+        // wrap forced on, view mode flipped. Whether that happened at all came
+        // down to which thread won the race.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
         // Emit buffer_activated hook for plugins
         self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
@@ -645,6 +658,10 @@ impl Editor {
         self.active_window_mut()
             .ensure_active_tab_visible(next_split, next_buf, tabs_width);
 
+        // Snapshot first, then the hook — see the note at the other
+        // split-focus site above.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
         // Emit the buffer_activated hook for plugins, matching every other
         // focus-changing command.
         self.plugin_manager.read().unwrap().run_hook(

--- a/crates/fresh-editor/src/app/tab_drag.rs
+++ b/crates/fresh-editor/src/app/tab_drag.rs
@@ -119,6 +119,31 @@ impl Editor {
         (split_id != source_split_id).then_some(TabDropZone::SplitCenter(split_id))
     }
 
+    /// The view state a dragged tab takes with it: the source split's entry
+    /// for *that buffer*, not the split's active one.
+    ///
+    /// A tab carries how it was being viewed. Dropping a composing markdown tab
+    /// into another pane used to hand it a freshly defaulted state, so the
+    /// document snapped back to source mode — with the compose plugin none the
+    /// wiser, since nothing told it the mode had changed. `BufferViewState`'s
+    /// `Clone` already carries `view_mode` and the compose settings for exactly
+    /// this reason (and resets `folds`, which are markers this split owns).
+    fn carried_view_state(
+        &self,
+        source_split_id: LeafId,
+        buffer_id: BufferId,
+    ) -> Option<crate::view::split::BufferViewState> {
+        self.windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(_, vs)| vs)
+            .expect("active window must have a populated split layout")
+            .get(&source_split_id)?
+            .keyed_states
+            .get(&buffer_id)
+            .cloned()
+    }
+
     /// Where among `tabs` a tab dropped at `col` goes: before the tab whose
     /// left half it is over, after the one whose right half, at the end past
     /// them all.
@@ -305,6 +330,18 @@ impl Editor {
         let active_id = self.active_window;
         let source_showed_buffer =
             self.split_manager().get_buffer_id(source_split_id.into()) == Some(buffer_id);
+        // The tab's own view state travels with it (see `carried_view_state`),
+        // unless the destination already has an opinion about this buffer.
+        let carried_state = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(_, vs)| vs)
+            .expect("active window must have a populated split layout")
+            .get(&target_split_id)
+            .is_none_or(|target| !target.keyed_states.contains_key(&buffer_id))
+            .then(|| self.carried_view_state(source_split_id, buffer_id))
+            .flatten();
         let mut next_buffer_for_source: Option<BufferId> = None;
         // Remove from source split's tab bar
         if let Some((mgr, vs)) = self
@@ -358,6 +395,20 @@ impl Editor {
         // `apply_event_to_state` on `keyed_states.get_mut(...).unwrap()`.
         self.active_window_mut()
             .set_pane_buffer(target_split_id, buffer_id);
+        // `set_pane_buffer` seeds a default entry for the buffer; overwrite it
+        // with the state the tab was carrying, so a composing tab keeps
+        // composing after the move.
+        if let Some(carried) = carried_state {
+            if let Some(target_view_state) = self
+                .windows
+                .get_mut(&self.active_window)
+                .and_then(|w| w.split_view_states_mut())
+                .expect("active window must have a populated split layout")
+                .get_mut(&target_split_id)
+            {
+                target_view_state.keyed_states.insert(buffer_id, carried);
+            }
+        }
         self.windows
             .get_mut(&self.active_window)
             .and_then(|w| w.split_manager_mut())
@@ -438,6 +489,7 @@ impl Editor {
         let active_id = self.active_window;
         let source_showed_buffer =
             self.split_manager().get_buffer_id(source_split_id.into()) == Some(buffer_id);
+        let carried_state = self.carried_view_state(source_split_id, buffer_id);
         let mut next_buffer_for_source: Option<BufferId> = None;
         let source_had_buffer = if let Some((mgr, vs)) = self
             .windows
@@ -512,16 +564,11 @@ impl Editor {
                     scroll_offset: self.config.editor.scroll_offset,
                 });
 
-                // Copy cursor position from source split's view state
-                if let Some(source_vs) = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.buffers.splits())
-                    .map(|(_, vs)| vs)
-                    .expect("active window must have a populated split layout")
-                    .get(&source_split_id)
-                {
-                    new_view_state.cursors = source_vs.cursors.clone();
+                // The dragged tab's own view state, cursors included — not the
+                // source split's *active* buffer's, which is a different tab
+                // whenever the drag started from an unfocused one.
+                if let Some(carried) = carried_state {
+                    new_view_state.keyed_states.insert(buffer_id, carried);
                 }
 
                 self.windows

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -701,11 +701,11 @@ impl EditorState {
     /// cursor-dependent activation is the renderer's business, and letting it
     /// reach the index would mean scroll position changed when a cursor moved.
     ///
-    /// `view_mode` decides the decorations that are mode-specific:
-    /// markdown_compose's `md-syntax` conceals, its frame lines and its code
-    /// rails are emitted whenever any split composes the buffer, so a
-    /// Source-mode split must ignore them — the same gate `build_view_data`
-    /// applies (see [`crate::view::compose_only`]).
+    /// `view_mode` decides the one namespace that is mode-specific:
+    /// markdown_compose's `md-syntax` conceals are emitted whenever any split
+    /// composes the buffer, so a Source-mode split must ignore them — the same
+    /// gate `build_view_data` applies. Compose's frame lines and code rails are
+    /// deliberately *not* gated here; see the comment on `virtual_lines`.
     /// Collapsed byte ranges for `folds`, sorted — the form the index and the
     /// renderer both want. Folds live on the split, so they arrive as an
     /// argument rather than off `self`.
@@ -758,13 +758,19 @@ impl EditorState {
             Vec::new()
         } else {
             crate::view::ui::split_rendering::transforms::resolve_inline_hints(
-                self, None, 0, end, is_compose,
+                self, None, 0, end, true,
             )
         };
 
-        // Compose's own frame lines are dropped for a Source-mode split by
-        // `inject_virtual_lines`; the index has to drop the same ones or it
-        // counts rows the renderer never draws, and scrolling clamps early.
+        // Every virtual line the buffer has, compose's frame included — and the
+        // same for the rails above. The renderer drops the compose-only ones
+        // when the split it is drawing is in source mode, but this index is not
+        // per split: scroll math asks for it under a fixed
+        // `CacheViewMode::Source` label that says nothing about any split's
+        // mode (`scrollbar_math::scroll_geometry`). Dropping them on that label
+        // took the table borders and list spacers out of the row count of a
+        // *composing* buffer, and the wheel and the scrollbar stopped short of
+        // the end of the document.
         let virtual_lines = if self.virtual_texts.is_empty() {
             Vec::new()
         } else {
@@ -772,9 +778,6 @@ impl EditorState {
                 .virtual_texts
                 .query_lines_in_range(&self.marker_list, 0, end)
                 .into_iter()
-                .filter(|(_, vt)| {
-                    is_compose || !crate::view::compose_only::is_compose_only_virtual_text(vt)
-                })
                 .map(|(pos, _)| pos)
                 .collect();
             v.sort_unstable();

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -701,10 +701,11 @@ impl EditorState {
     /// cursor-dependent activation is the renderer's business, and letting it
     /// reach the index would mean scroll position changed when a cursor moved.
     ///
-    /// `view_mode` decides the one namespace that is mode-specific:
-    /// markdown_compose's `md-syntax` conceals are emitted whenever any split
-    /// composes the buffer, so a Source-mode split must ignore them — the same
-    /// gate `build_view_data` applies.
+    /// `view_mode` decides the decorations that are mode-specific:
+    /// markdown_compose's `md-syntax` conceals, its frame lines and its code
+    /// rails are emitted whenever any split composes the buffer, so a
+    /// Source-mode split must ignore them — the same gate `build_view_data`
+    /// applies (see [`crate::view::compose_only`]).
     /// Collapsed byte ranges for `folds`, sorted — the form the index and the
     /// renderer both want. Folds live on the split, so they arrive as an
     /// argument rather than off `self`.
@@ -740,11 +741,12 @@ impl EditorState {
                 .query_viewport_rendered(0, end, &self.marker_list, &no_cursors, None)
         };
 
+        let is_compose = matches!(view_mode, CacheViewMode::Compose);
+
         let conceals = if self.conceals.is_empty() {
             Vec::new()
         } else {
-            let exclude = (!matches!(view_mode, CacheViewMode::Compose))
-                .then(|| fresh_core::overlay::OverlayNamespace::from_string("md-syntax".into()));
+            let exclude = (!is_compose).then(crate::view::compose_only::md_syntax_namespace);
             self.conceals
                 .query_viewport_excluding(0, end, &self.marker_list, exclude.as_ref(), &no_cursors)
                 .into_iter()
@@ -755,9 +757,14 @@ impl EditorState {
         let inline_hints = if self.virtual_texts.is_empty() {
             Vec::new()
         } else {
-            crate::view::ui::split_rendering::transforms::resolve_inline_hints(self, None, 0, end)
+            crate::view::ui::split_rendering::transforms::resolve_inline_hints(
+                self, None, 0, end, is_compose,
+            )
         };
 
+        // Compose's own frame lines are dropped for a Source-mode split by
+        // `inject_virtual_lines`; the index has to drop the same ones or it
+        // counts rows the renderer never draws, and scrolling clamps early.
         let virtual_lines = if self.virtual_texts.is_empty() {
             Vec::new()
         } else {
@@ -765,6 +772,9 @@ impl EditorState {
                 .virtual_texts
                 .query_lines_in_range(&self.marker_list, 0, end)
                 .into_iter()
+                .filter(|(_, vt)| {
+                    is_compose || !crate::view::compose_only::is_compose_only_virtual_text(vt)
+                })
                 .map(|(pos, _)| pos)
                 .collect();
             v.sort_unstable();

--- a/crates/fresh-editor/src/view/compose_only.rs
+++ b/crates/fresh-editor/src/view/compose_only.rs
@@ -1,0 +1,72 @@
+//! The decorations `markdown_compose` emits that belong to a Compose-mode
+//! split alone.
+//!
+//! Decorations live on the *buffer*, but compose mode is a property of a
+//! *split*: the plugin emits its frame whenever any split composes the buffer
+//! (`is_composing_in_any_split`), so a Source-mode split showing the same
+//! buffer — a sibling pane, or the same pane a moment after compose was turned
+//! off — would otherwise draw compose's chrome around raw source.
+//!
+//! Every render pass therefore drops these, and only these, when the split it
+//! is drawing is not composing. The names live here rather than at each pass so
+//! the passes cannot disagree about what "compose-only" means: a namespace
+//! suppressed in the token stream but not in the wrap index makes the index
+//! describe rows the renderer never draws.
+//!
+//! Everything else a plugin emits (git blame headers, live-diff deletions,
+//! flash's conceals, …) renders in both modes, which is why this is a list and
+//! not a blanket gate.
+
+use crate::view::virtual_text::VirtualText;
+
+/// Conceal namespace: the cell-separator / emphasis-marker conceals that turn
+/// raw `|` and `**` into the composed table, and the fence delimiters into the
+/// code block's top and bottom border.
+pub const MD_SYNTAX_NS: &str = "md-syntax";
+
+/// Overlay namespace: the styling compose paints over what it composed.
+pub const MD_EMPHASIS_NS: &str = "md-emphasis";
+
+/// Virtual-line namespace: the `┌─┬─┐` / `├─┼─┤` / `└─┴─┘` table frame.
+pub const MD_TABLE_BORDER_NS: &str = "md-tb";
+
+/// Virtual-line namespace: the blank spacer rows between list items.
+pub const MD_LIST_SPACING_NS: &str = "md-ls";
+
+/// Inline virtual-text id prefix: a fenced code block's `│` side rails.
+///
+/// A prefix rather than a namespace because only virtual *lines* carry a
+/// namespace — the inline add path keys on the id, which is also how the
+/// plugin clears them (`removeVirtualTextsByPrefix`).
+pub const MD_CODE_RAIL_ID_PREFIX: &str = "mdcr:";
+
+/// The `md-syntax` conceal namespace, as the conceal store wants it.
+pub fn md_syntax_namespace() -> fresh_core::overlay::OverlayNamespace {
+    fresh_core::overlay::OverlayNamespace::from_string(MD_SYNTAX_NS.to_string())
+}
+
+/// The `md-emphasis` overlay namespace, as the overlay store wants it.
+pub fn md_emphasis_namespace() -> fresh_core::overlay::OverlayNamespace {
+    fresh_core::overlay::OverlayNamespace::from_string(MD_EMPHASIS_NS.to_string())
+}
+
+/// Whether this virtual text is one a Source-mode split must not draw.
+///
+/// Covers both halves of the code/table frame: the virtual *lines* that cap it
+/// (matched by namespace) and the inline rails that close its sides (matched by
+/// id prefix).
+pub fn is_compose_only_virtual_text(vtext: &VirtualText) -> bool {
+    // Compared as strings rather than by building a `VirtualTextNamespace`:
+    // this runs for every virtual text in the viewport on every frame.
+    if vtext
+        .namespace
+        .as_ref()
+        .is_some_and(|ns| ns.as_str() == MD_TABLE_BORDER_NS || ns.as_str() == MD_LIST_SPACING_NS)
+    {
+        return true;
+    }
+    vtext
+        .string_id
+        .as_deref()
+        .is_some_and(|id| id.starts_with(MD_CODE_RAIL_ID_PREFIX))
+}

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -572,7 +572,7 @@ pub fn compute_line_layout(
     // width matters, not colour.
     if !state.virtual_texts.is_empty() {
         let hints = crate::view::ui::split_rendering::transforms::resolve_inline_hints(
-            state, None, line_start, line_end,
+            state, None, line_start, line_end, is_compose,
         );
         tokens = splice_inline_virtual_text(tokens, &hints);
     }

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -571,8 +571,11 @@ pub fn compute_line_layout(
     // feeds scroll-math / coordinate queries (never drawn), so only cell
     // width matters, not colour.
     if !state.virtual_texts.is_empty() {
+        // Rails included whatever `is_compose` says: this output feeds scroll
+        // math and coordinate queries, which ask under the same fixed
+        // `CacheViewMode::Source` label rather than a split's real mode.
         let hints = crate::view::ui::split_rendering::transforms::resolve_inline_hints(
-            state, None, line_start, line_end, is_compose,
+            state, None, line_start, line_end, true,
         );
         tokens = splice_inline_virtual_text(tokens, &hints);
     }

--- a/crates/fresh-editor/src/view/mod.rs
+++ b/crates/fresh-editor/src/view/mod.rs
@@ -21,6 +21,8 @@ pub mod animation;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub use fresh_editor_core::color_support;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
+pub mod compose_only;
+#[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod composite_view;
 #[cfg(any(feature = "runtime", feature = "wasm"))]
 pub mod conceal;

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -253,8 +253,7 @@ pub(crate) fn decoration_context(
     // Semantic tokens are stored as overlays so their ranges track edits.
     // Convert them into highlight spans for the render pipeline.
     let is_compose = matches!(view_mode, ViewMode::PageView);
-    let md_emphasis_ns =
-        fresh_core::overlay::OverlayNamespace::from_string("md-emphasis".to_string());
+    let md_emphasis_ns = crate::view::compose_only::md_emphasis_namespace();
     let mut semantic_token_spans = Vec::new();
     let mut viewport_overlays = Vec::new();
     for (overlay, range) in

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -14,7 +14,8 @@ use crate::state::EditorState;
 use crate::view::soft_break::SoftBreakRender;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{LineStart, ViewLine};
-use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
+use crate::view::compose_only::is_compose_only_virtual_text;
+use crate::view::virtual_text::VirtualTextPosition;
 use crate::view::wrap_machine::{WrapMachine, WrapRule};
 use fresh_core::api::{ViewTokenStyle, ViewTokenWire, ViewTokenWireKind};
 use std::collections::{HashMap, HashSet};
@@ -517,16 +518,16 @@ pub(super) fn inject_virtual_lines(
             .virtual_texts
             .query_lines_in_range(&state.marker_list, viewport_start, viewport_end);
 
-    // markdown_compose's table-border virtual lines (`md-tb`) frame the composed
-    // table and belong only to a Compose-mode split. Virtual lines live on the
-    // buffer, so in a Source-mode split sharing a buffer with a composing sibling
-    // they would otherwise draw a frame around the raw source. Drop that
-    // compose-only namespace here — mirroring the `md-syntax` conceal gate in
-    // `view_data.rs` and the `md-emphasis` overlay gate in `overlays.rs`. Every
-    // other virtual-line namespace (git blame, diff, …) renders in both modes.
+    // markdown_compose's frame lines — the table border (`md-tb`) and the
+    // spacer rows between list items (`md-ls`) — belong only to a Compose-mode
+    // split. Virtual lines live on the buffer, so in a Source-mode split
+    // sharing a buffer with a composing sibling they would otherwise draw a
+    // frame around the raw source. Drop the compose-only ones here — mirroring
+    // the `md-syntax` conceal gate in `view_data.rs` and the `md-emphasis`
+    // overlay gate in `overlays.rs`. Every other virtual-line namespace (git
+    // blame, diff, …) renders in both modes.
     if !is_compose {
-        let md_border_ns = VirtualTextNamespace::from_string("md-tb".to_string());
-        virtual_lines.retain(|(_, vt)| vt.namespace.as_ref() != Some(&md_border_ns));
+        virtual_lines.retain(|(_, vt)| !is_compose_only_virtual_text(vt));
     }
 
     if virtual_lines.is_empty() {
@@ -663,16 +664,24 @@ pub struct InlineHint {
 /// The state-dependent half of the splice, split out so the transform itself is
 /// pure. `theme` is `Some` on the draw path (so hint colours resolve) and `None`
 /// wherever the output is measured but never drawn.
+///
+/// `is_compose` gates markdown_compose's code-block side rails the same way
+/// [`inject_virtual_lines`] gates its frame lines: the rails are emitted
+/// whenever any split composes the buffer, and a Source-mode split must render
+/// the code literally rather than boxed. Every other inline hint (LSP inlay
+/// hints, git blame, …) is mode-independent.
 pub fn resolve_inline_hints(
     state: &EditorState,
     theme: Option<&Theme>,
     start: usize,
     end: usize,
+    is_compose: bool,
 ) -> Vec<InlineHint> {
     state
         .virtual_texts
         .query_inline_in_range(&state.marker_list, start, end)
         .into_iter()
+        .filter(|(_, vtext)| is_compose || !is_compose_only_virtual_text(vtext))
         .map(|(anchor, vtext)| InlineHint {
             anchor,
             text: vtext.text.clone(),

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -665,23 +665,30 @@ pub struct InlineHint {
 /// pure. `theme` is `Some` on the draw path (so hint colours resolve) and `None`
 /// wherever the output is measured but never drawn.
 ///
-/// `is_compose` gates markdown_compose's code-block side rails the same way
-/// [`inject_virtual_lines`] gates its frame lines: the rails are emitted
-/// whenever any split composes the buffer, and a Source-mode split must render
-/// the code literally rather than boxed. Every other inline hint (LSP inlay
-/// hints, git blame, …) is mode-independent.
+/// `include_compose_only` is `false` only on the *draw* path of a Source-mode
+/// split, where markdown_compose's code-block side rails must be dropped the
+/// same way [`inject_virtual_lines`] drops its frame lines: the rails are
+/// emitted whenever any split composes the buffer, and a source pane has to
+/// show the code literally.
+///
+/// Every *measuring* caller passes `true`, rails included, because the row
+/// counts they feed are not per split. Scroll math asks for its index under a
+/// fixed `CacheViewMode::Source` label that says nothing about any split's
+/// actual mode (`scrollbar_math::scroll_geometry`), so gating on it there takes
+/// compose's own decorations out of the row count of a *composing* buffer and
+/// the scrollbar stops short of the end of the document.
 pub fn resolve_inline_hints(
     state: &EditorState,
     theme: Option<&Theme>,
     start: usize,
     end: usize,
-    is_compose: bool,
+    include_compose_only: bool,
 ) -> Vec<InlineHint> {
     state
         .virtual_texts
         .query_inline_in_range(&state.marker_list, start, end)
         .into_iter()
-        .filter(|(_, vtext)| is_compose || !is_compose_only_virtual_text(vtext))
+        .filter(|(_, vtext)| include_compose_only || !is_compose_only_virtual_text(vtext))
         .map(|(anchor, vtext)| InlineHint {
             anchor,
             text: vtext.text.clone(),

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -11,10 +11,10 @@
 use super::style::{create_wrapped_virtual_lines, token_style_from_ratatui};
 use crate::primitives::display_width::str_width;
 use crate::state::EditorState;
+use crate::view::compose_only::is_compose_only_virtual_text;
 use crate::view::soft_break::SoftBreakRender;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{LineStart, ViewLine};
-use crate::view::compose_only::is_compose_only_virtual_text;
 use crate::view::virtual_text::VirtualTextPosition;
 use crate::view::wrap_machine::{WrapMachine, WrapRule};
 use fresh_core::api::{ViewTokenStyle, ViewTokenWire, ViewTokenWireKind};

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -15,18 +15,11 @@ use super::transforms::{
 };
 use super::MAX_SAFE_LINE_WIDTH;
 use crate::state::{EditorState, ViewMode};
+use crate::view::compose_only::md_syntax_namespace;
 use crate::view::folding::FoldManager;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{LineStart, ViewLine, ViewLineIterator};
 use crate::view::viewport::Viewport;
-
-/// markdown_compose's conceal namespace (`md-syntax`): the cell-separator /
-/// emphasis-marker conceals that turn raw `|`/`**` into the composed table. Only
-/// valid in a Compose-mode split; suppressed in Source mode (see the conceal
-/// pass below). Mirrors the `md-emphasis` overlay gate in `overlays.rs`.
-fn md_syntax_namespace() -> fresh_core::overlay::OverlayNamespace {
-    fresh_core::overlay::OverlayNamespace::from_string("md-syntax".to_string())
-}
 
 /// Processed view data containing display lines from the view pipeline.
 pub(super) struct ViewData {
@@ -338,7 +331,13 @@ pub(super) fn build_view_data(
             .unwrap_or(viewport.top_byte());
         tokens = splice_inline_virtual_text(
             tokens,
-            &resolve_inline_hints(state, Some(theme), viewport.top_byte(), viewport_end),
+            &resolve_inline_hints(
+                state,
+                Some(theme),
+                viewport.top_byte(),
+                viewport_end,
+                is_compose,
+            ),
         );
     }
 

--- a/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
@@ -257,12 +257,7 @@ fn wrapped_table_row_keeps_every_visual_line() {
     let screen = harness.screen_to_string();
     let top = row_of(&screen, "┌");
     let bottom = row_of(&screen, "└");
-    for (offset, line) in screen
-        .lines()
-        .skip(top)
-        .take(bottom - top + 1)
-        .enumerate()
-    {
+    for (offset, line) in screen.lines().skip(top).take(bottom - top + 1).enumerate() {
         assert!(
             line.contains('│') || line.contains('┌') || line.contains('├') || line.contains('└'),
             "row {} of the table frame is blank — a wrapped row's visual line \

--- a/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_table_structure.rs
@@ -182,3 +182,98 @@ after
          is {below:?}.\nScreen:\n{after}"
     );
 }
+
+/// A hand-aligned table — cells padded with spaces so the source lines up — is
+/// the common way people write markdown tables, and its header row used to come
+/// out mangled.
+///
+/// The two passes that render a row measured its cells differently. The
+/// wrapping path read a cell as `concealedText(...).trim()`, so a header cell
+/// written `|What          |` was four characters of content. The padding path,
+/// which handles every row short enough to fit on one line, measured it
+/// verbatim at 14 columns, decided it overflowed its 10-column allocation, and
+/// truncated it to `What     -` — no cell padding, a spurious `-`, and a header
+/// a column out of step with the rows beneath it.
+///
+/// Asserted on rendered output: the header's cells read the same way the body's
+/// do, `␣content␣…`, and nothing on the row was truncated.
+#[cfg(feature = "plugins")]
+#[test]
+fn hand_aligned_table_header_is_not_truncated() {
+    let md = "\
+# Doc
+
+|What          |Before       |After        |
+|--------------|-------------|-------------|
+|Rendering     |Direct       |Retained     |
+";
+    let (mut harness, _tmp) = compose_harness(md, 100, 30);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains('┌'))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let header = screen
+        .lines()
+        .nth(row_of(&screen, "What"))
+        .unwrap()
+        .to_string();
+    assert!(
+        header.contains("│ What"),
+        "the header's cells lost their padding: {header:?}.\nScreen:\n{screen}"
+    );
+    assert!(
+        !header.contains('-'),
+        "the header row was truncated — its padding spaces were measured as \
+         content: {header:?}.\nScreen:\n{screen}"
+    );
+}
+
+/// A row whose cells wrap must not lose a visual line to a blank row through
+/// the middle of the frame.
+///
+/// A wrapped row is drawn as one conceal per visual line, each covering the
+/// source between two chosen break positions, and the breaks have to be spaces
+/// (only a Space token carries its own source offset). The first N-1 spaces in
+/// the line were taken verbatim — and in a hand-aligned table those are a run
+/// of consecutive padding spaces, which makes every segment after the first
+/// empty. A conceal over an empty range draws nothing, so the visual line it
+/// was carrying vanished and left a blank row cutting through the table.
+#[cfg(feature = "plugins")]
+#[test]
+fn wrapped_table_row_keeps_every_visual_line() {
+    let md = "\
+# Doc
+
+|What          |Detail                                                  |
+|--------------|--------------------------------------------------------|
+|Layout        |Imperative logic per case, duplicated in multiple flows  |
+";
+    let (mut harness, _tmp) = compose_harness(md, 100, 30);
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains('┌'))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let top = row_of(&screen, "┌");
+    let bottom = row_of(&screen, "└");
+    for (offset, line) in screen
+        .lines()
+        .skip(top)
+        .take(bottom - top + 1)
+        .enumerate()
+    {
+        assert!(
+            line.contains('│') || line.contains('┌') || line.contains('├') || line.contains('└'),
+            "row {} of the table frame is blank — a wrapped row's visual line \
+             was dropped: {line:?}.\nScreen:\n{screen}",
+            top + offset,
+        );
+    }
+    // The wrapped cell's continuation must actually be on screen, not merely
+    // absent from a row that still has its edges.
+    assert!(
+        screen.contains("flows"),
+        "the wrapped row's last line never rendered.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
@@ -503,3 +503,182 @@ fn test_split_view_scroll_sync() {
         );
     }
 }
+
+/// Regression: a fenced code block must render as plain numbered lines in a
+/// Source-mode split, even while a sibling split composes the same buffer.
+///
+/// Compose frames a code block with a `┌──┐` / `└──┘` border (conceals, already
+/// gated on the split's mode) *and* with `│` side rails on every body line. The
+/// rails are inline virtual text, which lives on the buffer and had no such
+/// gate: a source split drew them around the raw code. Worse, the rails are
+/// spliced in before wrapping, so each body line came out wide enough to fold —
+/// and a folded row carries no line number, so the block's lines lost their
+/// gutter entries too. That is exactly what the bug report described: "the ```
+/// code blocks are missing the line number in the gutter and they have | |
+/// borders inserted for them".
+///
+/// Asserted on rendered output only: in the source split, each code line sits
+/// on a row that also carries its line number, and carries no rail.
+#[cfg(feature = "plugins")]
+#[test]
+fn test_code_block_renders_plain_in_source_split_while_sibling_composes() {
+    init_tracing_from_env();
+
+    let md = "\
+# Title
+
+Some text before the code.
+
+```rust
+fn main() {
+    println!(\"hello\");
+}
+```
+
+Text after the code.
+";
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+    let md_path = project_root.join("code.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    // Split first, then compose the LEFT split — so the right one, which stays
+    // in source, is the split the assertions look at.
+    run_palette_command(&mut harness, "Split Vertical");
+    harness.wait_for_async_quiescence(6).unwrap();
+    // `Split Vertical` focuses the new right pane; move back to the left one.
+    harness
+        .send_key(KeyCode::Char('['), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    run_palette_command(&mut harness, "Toggle Compose");
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains('┌'))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    // The composing split proves the frame is being emitted at all — without
+    // this the test would pass on a buffer that simply has no decorations.
+    assert!(
+        screen.contains('┌'),
+        "the composing split should frame the code block.\nScreen:\n{}",
+        screen,
+    );
+
+    // Everything right of the pane separator belongs to the source split. The
+    // separator is the first `│` on a row — in the source half a rail would be
+    // the *second*, which is precisely what must not be there.
+    for line in screen.lines() {
+        let Some(sep) = line.find('│') else { continue };
+        let right: String = line[sep + '│'.len_utf8()..].to_string();
+        if !right.contains("println!") {
+            continue;
+        }
+        assert!(
+            !right.contains('│'),
+            "the source split drew compose's code rails around the raw code.\n\
+             Source half: {right:?}\nScreen:\n{screen}",
+        );
+        // The gutter entry for this line survived, so the row was not folded
+        // by rail width. Line 7 of the document is the `println!` line.
+        assert!(
+            right.contains(" 7 "),
+            "the source split's code line lost its gutter line number.\n\
+             Source half: {right:?}\nScreen:\n{screen}",
+        );
+        return;
+    }
+    panic!("the source split never showed the code block.\nScreen:\n{screen}");
+}
+
+/// Regression: composing one split must not turn line wrap on in a sibling
+/// split showing the same buffer in source mode.
+///
+/// `enableMarkdownCompose` turns native wrap on so a long unbreakable line
+/// still folds inside the page. It used to ask for that with no split id, which
+/// the editor reads as "every split showing this buffer" — and the hook runs on
+/// `buffer_activated`, so merely moving focus onto the composing split rewrote
+/// the source split's wrap setting, undoing the user's own "Toggle Line Wrap
+/// (Current Buffer)".
+#[cfg(feature = "plugins")]
+#[test]
+fn test_composing_one_split_leaves_a_sibling_splits_line_wrap_alone() {
+    init_tracing_from_env();
+
+    // One line far wider than either pane, so wrap on / off is visible.
+    let long = "word ".repeat(60);
+    let md = format!("# Title\n\n{long}\n");
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+    let md_path = project_root.join("wrap.md");
+    std::fs::write(&md_path, &md).unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    run_palette_command(&mut harness, "Split Vertical");
+    harness.wait_for_async_quiescence(6).unwrap();
+
+    // The new right split is active: turn its wrap off, and record how much of
+    // the long line it draws as a result.
+    run_palette_command(&mut harness, "Toggle Line Wrap (Current");
+    harness.render().unwrap();
+    let unwrapped_rows = harness
+        .screen_to_string()
+        .lines()
+        .filter(|l| {
+            l.find('│')
+                .is_some_and(|sep| l[sep + '│'.len_utf8()..].contains("word"))
+        })
+        .count();
+
+    // Compose the LEFT split, then come back. Both moves fire
+    // `buffer_activated`, which is where the wrap request lives.
+    harness
+        .send_key(KeyCode::Char('['), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    run_palette_command(&mut harness, "Toggle Compose");
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("Compose"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char(']'), KeyModifiers::ALT)
+        .unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
+
+    let screen = harness.screen_to_string();
+    let rows_now = screen
+        .lines()
+        .filter(|l| {
+            l.find('│')
+                .is_some_and(|sep| l[sep + '│'.len_utf8()..].contains("word"))
+        })
+        .count();
+    assert_eq!(
+        rows_now, unwrapped_rows,
+        "composing the sibling split turned line wrap back on in the source \
+         split: its long line now occupies {rows_now} rows instead of \
+         {unwrapped_rows}.\nScreen:\n{screen}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
@@ -648,44 +648,68 @@ fn test_composing_one_split_leaves_a_sibling_splits_line_wrap_alone() {
     // One line far wider than either pane, so wrap on / off is visible as a
     // different number of rows carrying its text.
     let long = "word ".repeat(60);
-    let (mut harness, _tmp) = compose_split_harness(&format!("# Title\n\n{long}\n"), false);
+    // `## Section` is the compose signal below — deliberately not line 1, which
+    // is where the caret sits: compose reveals the markup on the caret's own
+    // row, so a heading there stays raw forever and waiting on it never ends.
+    let (mut harness, _tmp) =
+        compose_split_harness(&format!("# Title\n\n{long}\n\n## Section\n"), false);
+
+    // Rows of `pane` carrying the long line: 1 with wrap off, several with it on.
+    fn long_line_rows(harness: &EditorTestHarness, pane: fresh::model::event::LeafId) -> usize {
+        pane_rows(harness, pane)
+            .iter()
+            .filter(|r| r.contains("word"))
+            .count()
+    }
 
     run_palette_command(&mut harness, "Split Vertical");
     harness.wait_for_async_quiescence(6).unwrap();
     let source_pane = harness.editor().get_active_split();
 
-    // The new right split is active: turn its wrap off, and record how many
-    // rows of it the long line occupies as a result.
-    run_palette_command(&mut harness, "Toggle Line Wrap (Current");
-    harness.render().unwrap();
-    let rows_with_wrap_off = pane_rows(&harness, source_pane)
-        .iter()
-        .filter(|r| r.contains("word"))
-        .count();
-    assert_eq!(
-        rows_with_wrap_off, 1,
-        "wrap should be off in the source split to begin with"
-    );
+    // The new right split is active. Get its wrap *off*, whichever way
+    // `editor.line_wrap` happens to default — asserting the toggle's direction
+    // instead made this depend on the harness's config, and a render taken
+    // before the toggle had settled read the old layout and let the setup pass
+    // while leaving wrap on.
+    if long_line_rows(&harness, source_pane) != 1 {
+        run_palette_command(&mut harness, "Toggle Line Wrap (Current");
+    }
+    harness
+        .wait_until_stable(|h| long_line_rows(h, source_pane) == 1)
+        .unwrap();
 
     // Compose the LEFT split, then come back. Both moves fire
     // `buffer_activated`, which is where the wrap request lives.
     run_palette_command(&mut harness, "Previous Split");
     harness.render().unwrap();
+    let compose_pane = harness.editor().get_active_split();
+    assert_ne!(
+        compose_pane, source_pane,
+        "the test needs focus on the other split before composing"
+    );
     run_palette_command(&mut harness, "Toggle Compose");
-    harness.wait_for_async_quiescence(6).unwrap();
+    // Wait for the sibling to be *actually* composing rather than for a timer:
+    // compose conceals a heading's `##` markers, so a `Section` heading that
+    // still reads `## Section` is a pane that is not composing yet. The scenario
+    // does not exist until then, and a run where the toggle never landed would
+    // otherwise report on an invariant it never exercised.
+    harness
+        .wait_until_stable(|h| {
+            pane_rows(h, compose_pane)
+                .iter()
+                .any(|r| r.contains("Section") && !r.contains("## Section"))
+        })
+        .unwrap();
     run_palette_command(&mut harness, "Next Split");
     harness.wait_for_async_quiescence(6).unwrap();
 
-    let rows_now = pane_rows(&harness, source_pane)
-        .iter()
-        .filter(|r| r.contains("word"))
-        .count();
+    let rows_now = long_line_rows(&harness, source_pane);
     assert_eq!(
         rows_now,
-        rows_with_wrap_off,
+        1,
         "composing the sibling split turned line wrap back on in the source \
-         split: its long line now occupies {rows_now} rows instead of \
-         {rows_with_wrap_off}.\nScreen:\n{}",
+         split: its long line now occupies {rows_now} rows instead of 1.\
+         \nScreen:\n{}",
         harness.screen_to_string(),
     );
 }

--- a/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
@@ -533,10 +533,7 @@ fn pane_rows(harness: &EditorTestHarness, pane: fresh::model::event::LeafId) -> 
 /// with the default empty registry there is no classification and — correctly —
 /// no frame to assert about (see `markdown_compose_code_frame`).
 #[cfg(feature = "plugins")]
-fn compose_split_harness(
-    md: &str,
-    full_grammar: bool,
-) -> (EditorTestHarness, tempfile::TempDir) {
+fn compose_split_harness(md: &str, full_grammar: bool) -> (EditorTestHarness, tempfile::TempDir) {
     init_tracing_from_env();
 
     let temp_dir = tempfile::TempDir::new().unwrap();
@@ -684,7 +681,8 @@ fn test_composing_one_split_leaves_a_sibling_splits_line_wrap_alone() {
         .filter(|r| r.contains("word"))
         .count();
     assert_eq!(
-        rows_now, rows_with_wrap_off,
+        rows_now,
+        rows_with_wrap_off,
         "composing the sibling split turned line wrap back on in the source \
          split: its long line now occupies {rows_now} rows instead of \
          {rows_with_wrap_off}.\nScreen:\n{}",

--- a/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_markdown_compose.rs
@@ -7,7 +7,7 @@
 /// 1. Compose mode only applies to the right panel (conceals, soft breaks)
 /// 2. Line numbers visible in source panel, hidden in compose panel
 /// 3. Scroll synchronization between panels
-use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -504,6 +504,64 @@ fn test_split_view_scroll_sync() {
     }
 }
 
+/// The rows of `pane`, clipped to its own columns — so an assertion about one
+/// pane cannot be satisfied (or broken) by what its neighbour drew.
+#[cfg(feature = "plugins")]
+fn pane_rows(harness: &EditorTestHarness, pane: fresh::model::event::LeafId) -> Vec<String> {
+    let rect = harness
+        .editor()
+        .pane_content_rect(pane)
+        .expect("the shell laid the pane out");
+    harness
+        .screen_to_string()
+        .lines()
+        .skip(rect.y as usize)
+        .take(rect.height as usize)
+        .map(|line| {
+            line.chars()
+                .skip(rect.x as usize)
+                .take(rect.width as usize)
+                .collect()
+        })
+        .collect()
+}
+
+/// A project with the `markdown_compose` plugin and one markdown file, opened.
+///
+/// `full_grammar` is what the code-frame assertions need: compose frames a
+/// fenced block from the region classification the *Markdown grammar* makes, so
+/// with the default empty registry there is no classification and — correctly —
+/// no frame to assert about (see `markdown_compose_code_frame`).
+#[cfg(feature = "plugins")]
+fn compose_split_harness(
+    md: &str,
+    full_grammar: bool,
+) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+    let md_path = project_root.join("doc.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut options = HarnessOptions::new()
+        .with_working_dir(project_root.clone())
+        .without_empty_plugins_dir();
+    if full_grammar {
+        options = options.with_full_grammar_registry();
+    }
+    let mut harness = EditorTestHarness::create(160, 40, options).unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    (harness, temp_dir)
+}
+
 /// Regression: a fenced code block must render as plain numbered lines in a
 /// Source-mode split, even while a sibling split composes the same buffer.
 ///
@@ -517,13 +575,12 @@ fn test_split_view_scroll_sync() {
 /// code blocks are missing the line number in the gutter and they have | |
 /// borders inserted for them".
 ///
-/// Asserted on rendered output only: in the source split, each code line sits
-/// on a row that also carries its line number, and carries no rail.
+/// Asserted on rendered output only, and only on the source split's own
+/// columns: its code line keeps its gutter number, and nothing past the gutter
+/// is a rail.
 #[cfg(feature = "plugins")]
 #[test]
 fn test_code_block_renders_plain_in_source_split_while_sibling_composes() {
-    init_tracing_from_env();
-
     let md = "\
 # Title
 
@@ -537,69 +594,46 @@ fn main() {
 
 Text after the code.
 ";
-    let temp_dir = tempfile::TempDir::new().unwrap();
-    let project_root = temp_dir.path().join("project");
-    std::fs::create_dir(&project_root).unwrap();
-    let plugins_dir = project_root.join("plugins");
-    std::fs::create_dir(&plugins_dir).unwrap();
-    copy_plugin(&plugins_dir, "markdown_compose");
-    copy_plugin_lib(&plugins_dir);
-    let md_path = project_root.join("code.md");
-    std::fs::write(&md_path, md).unwrap();
-
-    let mut harness =
-        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
-            .unwrap();
-    harness.open_file(&md_path).unwrap();
-    harness.render().unwrap();
+    let (mut harness, _tmp) = compose_split_harness(md, true);
 
     // Split first, then compose the LEFT split — so the right one, which stays
     // in source, is the split the assertions look at.
     run_palette_command(&mut harness, "Split Vertical");
     harness.wait_for_async_quiescence(6).unwrap();
-    // `Split Vertical` focuses the new right pane; move back to the left one.
-    harness
-        .send_key(KeyCode::Char('['), KeyModifiers::ALT)
-        .unwrap();
+    let source_pane = harness.editor().get_active_split();
+
+    run_palette_command(&mut harness, "Previous Split");
     harness.render().unwrap();
     run_palette_command(&mut harness, "Toggle Compose");
     harness
         .wait_until_stable(|h| h.screen_to_string().contains('┌'))
         .unwrap();
 
-    let screen = harness.screen_to_string();
     // The composing split proves the frame is being emitted at all — without
     // this the test would pass on a buffer that simply has no decorations.
+    let screen = harness.screen_to_string();
     assert!(
         screen.contains('┌'),
-        "the composing split should frame the code block.\nScreen:\n{}",
-        screen,
+        "the composing split should frame the code block.\nScreen:\n{screen}",
     );
 
-    // Everything right of the pane separator belongs to the source split. The
-    // separator is the first `│` on a row — in the source half a rail would be
-    // the *second*, which is precisely what must not be there.
-    for line in screen.lines() {
-        let Some(sep) = line.find('│') else { continue };
-        let right: String = line[sep + '│'.len_utf8()..].to_string();
-        if !right.contains("println!") {
-            continue;
-        }
-        assert!(
-            !right.contains('│'),
-            "the source split drew compose's code rails around the raw code.\n\
-             Source half: {right:?}\nScreen:\n{screen}",
-        );
-        // The gutter entry for this line survived, so the row was not folded
-        // by rail width. Line 7 of the document is the `println!` line.
-        assert!(
-            right.contains(" 7 "),
-            "the source split's code line lost its gutter line number.\n\
-             Source half: {right:?}\nScreen:\n{screen}",
-        );
-        return;
-    }
-    panic!("the source split never showed the code block.\nScreen:\n{screen}");
+    let row = pane_rows(&harness, source_pane)
+        .into_iter()
+        .find(|r| r.contains("println!"))
+        .unwrap_or_else(|| panic!("the source split never showed the code.\nScreen:\n{screen}"));
+    let (gutter, text) = row
+        .split_once('│')
+        .unwrap_or_else(|| panic!("the source split drew no gutter: {row:?}.\nScreen:\n{screen}"));
+    assert!(
+        gutter.contains('7'),
+        "the source split's code line lost its gutter line number: {row:?}.\n\
+         Screen:\n{screen}",
+    );
+    assert!(
+        !text.contains('│'),
+        "the source split drew compose's code rails around the raw code: \
+         {row:?}.\nScreen:\n{screen}",
+    );
 }
 
 /// Regression: composing one split must not turn line wrap on in a sibling
@@ -614,71 +648,46 @@ Text after the code.
 #[cfg(feature = "plugins")]
 #[test]
 fn test_composing_one_split_leaves_a_sibling_splits_line_wrap_alone() {
-    init_tracing_from_env();
-
-    // One line far wider than either pane, so wrap on / off is visible.
+    // One line far wider than either pane, so wrap on / off is visible as a
+    // different number of rows carrying its text.
     let long = "word ".repeat(60);
-    let md = format!("# Title\n\n{long}\n");
-
-    let temp_dir = tempfile::TempDir::new().unwrap();
-    let project_root = temp_dir.path().join("project");
-    std::fs::create_dir(&project_root).unwrap();
-    let plugins_dir = project_root.join("plugins");
-    std::fs::create_dir(&plugins_dir).unwrap();
-    copy_plugin(&plugins_dir, "markdown_compose");
-    copy_plugin_lib(&plugins_dir);
-    let md_path = project_root.join("wrap.md");
-    std::fs::write(&md_path, &md).unwrap();
-
-    let mut harness =
-        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
-            .unwrap();
-    harness.open_file(&md_path).unwrap();
-    harness.render().unwrap();
+    let (mut harness, _tmp) = compose_split_harness(&format!("# Title\n\n{long}\n"), false);
 
     run_palette_command(&mut harness, "Split Vertical");
     harness.wait_for_async_quiescence(6).unwrap();
+    let source_pane = harness.editor().get_active_split();
 
-    // The new right split is active: turn its wrap off, and record how much of
-    // the long line it draws as a result.
+    // The new right split is active: turn its wrap off, and record how many
+    // rows of it the long line occupies as a result.
     run_palette_command(&mut harness, "Toggle Line Wrap (Current");
     harness.render().unwrap();
-    let unwrapped_rows = harness
-        .screen_to_string()
-        .lines()
-        .filter(|l| {
-            l.find('│')
-                .is_some_and(|sep| l[sep + '│'.len_utf8()..].contains("word"))
-        })
+    let rows_with_wrap_off = pane_rows(&harness, source_pane)
+        .iter()
+        .filter(|r| r.contains("word"))
         .count();
+    assert_eq!(
+        rows_with_wrap_off, 1,
+        "wrap should be off in the source split to begin with"
+    );
 
     // Compose the LEFT split, then come back. Both moves fire
     // `buffer_activated`, which is where the wrap request lives.
-    harness
-        .send_key(KeyCode::Char('['), KeyModifiers::ALT)
-        .unwrap();
+    run_palette_command(&mut harness, "Previous Split");
     harness.render().unwrap();
     run_palette_command(&mut harness, "Toggle Compose");
-    harness
-        .wait_until_stable(|h| h.screen_to_string().contains("Compose"))
-        .unwrap();
-    harness
-        .send_key(KeyCode::Char(']'), KeyModifiers::ALT)
-        .unwrap();
+    harness.wait_for_async_quiescence(6).unwrap();
+    run_palette_command(&mut harness, "Next Split");
     harness.wait_for_async_quiescence(6).unwrap();
 
-    let screen = harness.screen_to_string();
-    let rows_now = screen
-        .lines()
-        .filter(|l| {
-            l.find('│')
-                .is_some_and(|sep| l[sep + '│'.len_utf8()..].contains("word"))
-        })
+    let rows_now = pane_rows(&harness, source_pane)
+        .iter()
+        .filter(|r| r.contains("word"))
         .count();
     assert_eq!(
-        rows_now, unwrapped_rows,
+        rows_now, rows_with_wrap_off,
         "composing the sibling split turned line wrap back on in the source \
          split: its long line now occupies {rows_now} rows instead of \
-         {unwrapped_rows}.\nScreen:\n{screen}",
+         {rows_with_wrap_off}.\nScreen:\n{}",
+        harness.screen_to_string(),
     );
 }

--- a/crates/fresh-editor/tests/e2e/tab_drag.rs
+++ b/crates/fresh-editor/tests/e2e/tab_drag.rs
@@ -935,3 +935,139 @@ fn test_drag_tab_to_fresh_split_then_type_does_not_panic() {
         screen
     );
 }
+
+/// Run a command-palette command by typing a query and accepting the first hit.
+fn run_palette_command(harness: &mut EditorTestHarness, query: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text(query).unwrap();
+    harness.wait_for_screen_contains(query).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+}
+
+/// The screen rows of `pane`, clipped to its own columns.
+fn pane_rows(harness: &EditorTestHarness, pane: LeafId) -> Vec<String> {
+    let rect = harness
+        .editor()
+        .pane_content_rect(pane)
+        .expect("the shell laid the pane out");
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .skip(rect.y as usize)
+        .take(rect.height as usize)
+        .map(|line| {
+            line.chars()
+                .skip(rect.x as usize)
+                .take(rect.width as usize)
+                .collect()
+        })
+        .collect()
+}
+
+/// The pane currently showing `buffer_id`.
+fn pane_showing(harness: &EditorTestHarness, buffer_id: BufferId) -> LeafId {
+    harness
+        .editor()
+        .get_split_areas()
+        .iter()
+        .find(|(_, buf, ..)| *buf == buffer_id)
+        .map(|(pane, ..)| *pane)
+        .expect("the dragged buffer is on screen")
+}
+
+/// Regression: a tab dragged into a new pane keeps the view mode it was being
+/// read in.
+///
+/// A new pane's view state was built from config defaults and given only the
+/// source pane's *cursors*, so a document being read in page view (what
+/// markdown compose runs on) snapped back to source the moment it was dragged
+/// from a vertical split to a horizontal one. Nothing told the compose plugin
+/// the mode had changed either, so it kept emitting the buffer-wide decorations
+/// a composing pane wants — which the reverted pane then drew over its raw
+/// source.
+///
+/// `BufferViewState`'s `Clone` already carries `view_mode` and the compose
+/// settings for exactly this reason; the drag just has to use it.
+#[test]
+fn test_drag_tab_to_new_split_keeps_page_view() {
+    let temp_dir = TempDir::new().unwrap();
+    let doc = temp_dir.path().join("doc.md");
+    std::fs::write(&doc, "Hello\n").unwrap();
+    let other = temp_dir.path().join("other.txt");
+    std::fs::write(&other, "elsewhere\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.open_file(&other).unwrap();
+    harness.open_file(&doc).unwrap();
+    harness.render().unwrap();
+
+    let doc_buffer = harness
+        .editor()
+        .get_split_buffer(harness.editor().get_active_split().into())
+        .expect("the opened document is active");
+
+    // A digit anywhere on the `Hello` row can only be the line-number gutter.
+    let hello_row_has_gutter = |harness: &EditorTestHarness| -> bool {
+        pane_rows(harness, pane_showing(harness, doc_buffer))
+            .iter()
+            .find(|row| row.contains("Hello"))
+            .map(|row| row.chars().any(|c| c.is_ascii_digit()))
+            .expect("the document is on screen")
+    };
+    assert!(
+        hello_row_has_gutter(&harness),
+        "source mode should show the line-number gutter to begin with"
+    );
+
+    run_palette_command(&mut harness, "Toggle Page View");
+    harness.render().unwrap();
+    assert!(
+        !hello_row_has_gutter(&harness),
+        "page view should hide the line-number gutter"
+    );
+
+    // Drag the document's tab onto the bottom edge of its own pane: a
+    // horizontal split, made from the tab.
+    let tab = get_all_tabs(&harness)
+        .into_iter()
+        .find(|t| t.buffer_id == doc_buffer)
+        .expect("the document has a tab");
+    let content_rect = harness
+        .editor()
+        .pane_content_rect(tab.split_id)
+        .expect("the shell laid the only pane out");
+    let bottom_row = content_rect.y + content_rect.height - 2;
+    let centre_col = content_rect.x + content_rect.width / 2;
+    assert!(
+        matches!(
+            harness
+                .editor()
+                .compute_drop_zone(centre_col, bottom_row, tab.split_id),
+            Some(TabDropZone::SplitBottom(_))
+        ),
+        "expected the bottom edge to be a SplitBottom drop zone"
+    );
+
+    harness
+        .mouse_drag(tab.center_col(), tab.tab_row, centre_col, bottom_row)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        harness.editor().get_split_count(),
+        2,
+        "dragging to the bottom edge should create a new split"
+    );
+    assert!(
+        !hello_row_has_gutter(&harness),
+        "the dragged tab reverted to source mode in its new pane: its \
+         line-number gutter is back.\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+}


### PR DESCRIPTION
Four reported markdown bugs, each reproduced interactively in tmux against a pre-fix build and re-checked after.

### A fenced code block drew compose's rails, and lost its gutter numbers, in source mode

> in markdown files even if markdown compose mode is off (just plain source mode) the ``` code blocks are missing the line number in the gutter and they have `| |` borders inserted for them instead of just plain normal text lines

Before, in a source pane sharing a buffer with a composing one:

```
  5 │ ```rust
    │ │ fn main() {
    │                                                              │
    │ │     println!("hello");
    │                                                   │
    │ │ }
    │    │
  9 │ ```
```

Compose's decorations live on the *buffer* and the plugin emits them whenever any split composes it, so each render pass gates them on the split's own mode. The conceals, the overlays and the table border had that gate; the code block's `│` side rails (inline virtual text) and the list spacers did not. And because the rails are spliced in *before* wrapping, every body line came out wide enough to fold — and a folded row carries no line number, which is where the gutter entries went.

`view::compose_only` now names the compose-only decorations in one place, and `inject_virtual_lines` and the draw path's `resolve_inline_hints` both gate on it. After:

```
  5 │ ```rust
▾ 6 │ fn main() {
  7 │     println!("hello");
  8 │ }
  9 │ ```
```

### Dragging a tab into another pane reverted it to source mode

> when dragging a split panel with markdown that's in compose mode enabled, dragging that panel's tab using the mouse to move it from split vertical to horizontal etc it loses the compose mode

`create_split_from_tab` built the new pane's view state from config defaults and handed it only the source pane's **active** cursors — which belong to a different tab whenever the drag started from an unfocused one. It now carries the dragged buffer's own `BufferViewState`, whose `Clone` already preserves `view_mode` and the compose settings for exactly this case ("a split cloned from a composing one is composing too"). `move_tab_to_split` does the same, unless the destination already has an opinion about that buffer.

This is also how the two reports connect: nothing told the plugin the mode had changed, so it kept emitting the decorations a composing pane wants, and the reverted pane drew them over its raw source — the rails above.

### Composing one split turned line wrap on in a sibling

> if the same markdown buffer has two splits, one in source mode and another in compose mode, switching focus between them causes the source mode buffer to switch to line wrapping even if it was disabled before that

This one had **two** causes, and the second only showed up on macOS CI.

**The fan-out.** `enableMarkdownCompose` asked for wrap with no split id, which the editor reads as "every split showing this buffer" — and the hook runs on `buffer_activated`, so merely moving focus onto the composing pane rewrote the source pane's setting and undid the user's own **Toggle Line Wrap (Current Buffer)**. Scoped to the active split, like `setViewMode` and `setLayoutHints` beside it already are.

**The stale mirror.** `Editor::set_active_buffer` refreshes the plugin state snapshot before firing `buffer_activated` — *"Run it BEFORE the hook so the handler sees the new active buffer"*. But moving focus between two splits on the **same** buffer never reaches it: it early-returns when the buffer does not change, and the two split-focus paths in `split_actions.rs` fired the hook themselves without the refresh. So `markdown_compose`, whose `buffer_activated` handler reads `getBufferInfo().view_mode` to decide whether to restore compose, was answered by a mirror one split behind. It said "compose" as focus landed on a *source* pane, and the plugin composed that pane: gutter hidden, wrap forced on, view mode flipped. Which thread won the race decided whether it fired at all, which is why Linux was green and macOS was not — the failing job's screen showed *both* panes composed. Both sites now refresh first.

### A hand-aligned table rendered wrong

Two independent defects on the reported table:

```
│What     -│Before                       │After                              -│
│ Layout   │ Imperative logic per case,  │ Calculated once by the new lib     │
                    ← a blank row straight through the frame
│          │ flows                       │                                    │
```

**The header.** The two passes that render a row measured cells differently. The wrapping path reads a cell as `concealedText(...).trim()`; the padding path — which handles every row short enough to fit on one line — measured it verbatim, so `|What          |` read as 14 columns, "overflowed" its 10-column allocation and came out truncated to `What     -`. It now normalises to `␣content␣pad` by concealing the cell's two whitespace *runs* rather than the whole cell, which keeps the content's own conceals and emphasis overlays alive inside it. Only for a row that opens with a `|`, which is what makes cell *i* the text between pipes *i* and *i+1*.

**The dropped row.** A wrapped row is drawn as one conceal per visual line, each covering the source between two break positions, and the breaks have to be spaces. The first N-1 spaces in the line were taken verbatim — consecutive, in a padded table — so every segment after the first was empty, and a conceal over an empty range draws nothing. The conceal and soft-break passes now share one `tableRowLayout` instead of two copies of the loop under a "must match" comment. The frame also reserves the two end columns every other block does, so it stops folding its own right edge in a pane narrower than the compose width.

```
│ What     │ Before                      │ After                             │
│ Layout   │ Imperative logic per case,  │ Calculated once by the new lib    │
│          │ duplicated in multiple      │ from declarative clauses          │
│          │ flows                       │                                   │
```

## A regression this branch introduced, and its fix

The second commit fixes one of my own. Eight `markdown_compose_scroll_reach` tests went red on the first commit; the same tests pass on the commit before it. I had extended the source-mode gate into `index_decorations`, which builds the wrap index — but scroll math asks for that index under a hardcoded `CacheViewMode::Source` that is a naming convention, not a statement about any split ("Scroll math runs without access to the view mode; `Source` is the fixed convention", `scrollbar_math::scroll_geometry`). The gate therefore took the table borders and list spacers out of the row count of a *composing* buffer, and the scrollbar could no longer reach the end of the document. Bullets failing alongside tables is what named the virtual-line count rather than the table's width.

The gate now lives only where a split's mode is actually known — the draw path. Every measuring caller passes `include_compose_only: true`, which is also how the table border was handled before this branch.

## Tests

New regression tests, all on rendered output:

- `tab_drag::test_drag_tab_to_new_split_keeps_page_view`
- `split_view_markdown_compose::test_code_block_renders_plain_in_source_split_while_sibling_composes`
- `split_view_markdown_compose::test_composing_one_split_leaves_a_sibling_splits_line_wrap_alone`
- `markdown_compose_table_structure::hand_aligned_table_header_is_not_truncated`
- `markdown_compose_table_structure::wrapped_table_row_keeps_every_visual_line`

The split-view ones clip to each pane's `pane_content_rect` rather than slicing at the first `│`, which is the source split's own gutter separator, and the code-block one builds with the full grammar registry — compose frames a block from the Markdown grammar's region classification, so the empty registry gives nothing to assert about.

The wrap test earned a commit of its own after CI caught it reporting on a scenario it had never reached. It now drives its split to one row whichever way `editor.line_wrap` defaults, asserts focus actually moved to the other pane, and waits for the sibling to be *observably* composing — keyed on a heading below the caret, since compose reveals markup on the caret's own row and a heading there stays raw forever.

## Known, not addressed

Two pre-existing wrinkles, both reproduced identically on a pre-fix binary and outside these four reports:

- after an **in-place edit**, the edited row picks up a stray extra `│` one column left of the frame; it survives scrolling and clears on reopen, so it is a stale render leftover rather than bad source;
- clicking inside a *wrapped* composed table row puts the caret at the row's start, because that row is drawn as one whole-segment conceal and every column maps back to the segment's first byte. A second click, once the row shows raw, lands precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73BAGcWAjU28c9Netnnyi