### PR TITLE
terminal: a paste the child asked to be bracketed is bracketed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **LSP diagnostics no longer get stuck reporting errors you already fixed** (#3038, reported by @thedadams).
 * **Settings: `Delete` works in a text field again** in the Edit Item dialog (#2875, reported by @asukaminato0721).
 * **Dim text in the integrated terminal is dim again** (#3123, reported by @fiatcode-gh).
+* **A multi-line paste into a terminal arrives whole instead of only its last line.** Pasting several lines into a shell or an agent CLI ran every line but the tail, which was left sitting on the input line — the paste read as typing, because that is exactly what it was: fresh handed the child the raw clipboard bytes, and a line editor takes each newline in them for the Enter key. A program that asks for bracketed paste (which readline in bash/zsh/fish does, as does an agent's input box) now gets the paste wrapped in the markers that say "this is pasted text, not keystrokes", so it lands as one inert block. A program that has not asked for it still gets keystrokes, now with line breaks as the carriage return the Enter key actually produces.
 * **Quitting no longer panics** while a plugin's off-loop work is still in flight.
 * **Git and review commands are grouped under two palette prefixes**, `Review Diff:` and `Git Log:` (#3098).
 * **Review Diff works with an external difftool** instead of showing an empty diff (#3066, by @asukaminato0721).

--- a/crates/fresh-editor/src/app/action_dispatch.rs
+++ b/crates/fresh-editor/src/app/action_dispatch.rs
@@ -1729,11 +1729,14 @@ impl Editor {
                 }
             }
             Action::TerminalPaste => {
-                // Paste clipboard contents into terminal as a single batch
+                // Paste clipboard contents into terminal as a single batch.
+                // Same normalization and bracketing as the terminal route in
+                // `paste_text`: CRLF/CR → LF, then wrapped in the paste
+                // markers when the child asked for DECSET 2004.
                 if self.active_window().focused_terminal_live() {
                     if let Some(text) = self.clipboard.paste() {
-                        self.active_window_mut()
-                            .send_terminal_input(text.as_bytes());
+                        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+                        self.active_window_mut().send_terminal_paste(&normalized);
                     }
                 }
             }

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1292,10 +1292,12 @@ impl Editor {
             return;
         }
 
-        // If the focused split is a live terminal, send paste to its PTY
+        // If the focused split is a live terminal, send paste to its PTY —
+        // as a paste, bracketed when the child asked for DECSET 2004, so a
+        // multi-line paste arrives as one block instead of as a run of Enter
+        // keys that submits every line but the tail.
         if self.active_window().focused_terminal_live() {
-            self.active_window_mut()
-                .send_terminal_input(normalized.as_bytes());
+            self.active_window_mut().send_terminal_paste(&normalized);
             return;
         }
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -57,6 +57,13 @@ pub(crate) fn terminal_backing_fs() -> Arc<dyn crate::model::filesystem::FileSys
     Arc::new(crate::model::filesystem::StdFileSystem)
 }
 
+/// Bracketed-paste start marker, sent to a child that asked for DECSET 2004
+/// before the pasted text. See [`Window::send_terminal_paste`].
+const PASTE_START: &str = "\x1b[200~";
+
+/// Bracketed-paste end marker, sent after the pasted text.
+const PASTE_END: &str = "\x1b[201~";
+
 /// How often [`Window::sync_terminal_titles`] polls each terminal's
 /// foreground process group for tmux-style tab auto-naming. Frequent enough
 /// to feel responsive when a command starts/exits, infrequent enough that
@@ -2134,6 +2141,42 @@ impl Window {
                 handle.write(data);
             }
         }
+    }
+
+    /// Send `text` to this window's active terminal as a **paste**, rather
+    /// than as the keystrokes the same bytes would be.
+    ///
+    /// Which of those the child sees is its own decision, announced by
+    /// DECSET 2004: a line editor (readline in bash/zsh/fish, an agent CLI's
+    /// input box) turns bracketed paste on precisely so it can tell one from
+    /// the other, and then reads a bare `\n` as the Enter key. Handing such a
+    /// child the raw clipboard bytes therefore submits every line but the
+    /// last — the paste "only pastes the tail", because everything before it
+    /// already ran. Wrapping the text in `ESC [ 200 ~` … `ESC [ 201 ~` is what
+    /// makes it arrive as one inert block.
+    ///
+    /// `ESC` is stripped from the wrapped payload: it is what a premature
+    /// `ESC [ 201 ~` inside the clipboard would need to break out of the
+    /// brackets and have the rest of the text executed, and pasted text has
+    /// no business carrying control sequences either way.
+    ///
+    /// With the mode off the child cannot distinguish paste from typing at
+    /// all, so the honest thing is to send what the keyboard would: line
+    /// breaks become `\r`, the byte the Enter key produces.
+    pub fn send_terminal_paste(&mut self, text: &str) {
+        let bracketed = self
+            .get_active_terminal_state()
+            .is_some_and(|state| state.is_bracketed_paste());
+        let payload = if bracketed {
+            let mut out = String::with_capacity(text.len() + PASTE_START.len() + PASTE_END.len());
+            out.push_str(PASTE_START);
+            out.extend(text.chars().filter(|c| *c != '\x1b'));
+            out.push_str(PASTE_END);
+            out
+        } else {
+            text.replace("\r\n", "\r").replace('\n', "\r")
+        };
+        self.send_terminal_input(payload.as_bytes());
     }
 
     /// Send a key event to this window's active terminal. Picks

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -969,6 +969,19 @@ impl TerminalState {
         self.term.mode().contains(TermMode::APP_CURSOR)
     }
 
+    /// Check if the child asked for bracketed paste (DECSET 2004).
+    ///
+    /// Every line editor worth the name — bash/zsh/fish's readline, and the
+    /// input box of a TUI like an agent CLI — turns this on so it can tell a
+    /// paste apart from typing. Text sent to such a child *without* the
+    /// `ESC [ 200 ~` … `ESC [ 201 ~` wrapper is read as keystrokes: each
+    /// newline is an Enter that submits the line before it, so a multi-line
+    /// paste runs (or sends) every line but the last and only the tail is
+    /// left on the input line.
+    pub fn is_bracketed_paste(&self) -> bool {
+        self.term.mode().contains(TermMode::BRACKETED_PASTE)
+    }
+
     // =========================================================================
     // Incremental scrollback streaming
     // =========================================================================

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -3783,6 +3783,143 @@ fn test_bracket_paste_in_terminal_mode() {
         .send_terminal_input(b"\x04");
 }
 
+/// Spawn a terminal whose child is `sh -c <script>` rather than an interactive
+/// shell, so the test drives one known program: no prompt, no readline, and
+/// nothing that re-announces its own terminal modes between our writes.
+///
+/// Returns `None` when there is no PTY (or no `/bin/sh`) to run it on, which
+/// the paste tests below treat as "skip", like the rest of this file.
+fn harness_running_or_skip(script: &str) -> Option<EditorTestHarness> {
+    if native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_err()
+        || !std::path::Path::new("/bin/sh").exists()
+    {
+        eprintln!("Skipping terminal test: no PTY or /bin/sh in this environment");
+        return None;
+    }
+
+    let mut config = Config::default();
+    config.terminal.shell = Some(TerminalShellConfig {
+        command: "/bin/sh".to_string(),
+        args: vec!["-c".to_string(), script.to_string()],
+    });
+    EditorTestHarness::with_config(80, 24, config).ok()
+}
+
+/// A paste into a live terminal whose child asked for bracketed paste
+/// (DECSET 2004) must arrive wrapped in `ESC[200~` … `ESC[201~`.
+///
+/// Regression: fresh used to hand the child the raw clipboard bytes. A line
+/// editor that turns 2004 on — readline in bash/zsh/fish, an agent CLI's input
+/// box — then reads every embedded newline as the Enter key, so a multi-line
+/// paste ran (or submitted) every line but the last and only the tail was left
+/// on the input line.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Unix shell commands (stty/cat)
+fn test_paste_is_bracketed_when_child_requests_it() {
+    // `cat -v` renders the control bytes it reads: an ESC comes back as `^[`,
+    // so the markers are visible on screen. `-icanon` makes it echo what it
+    // reads without waiting for a line, `-echo` keeps the line discipline from
+    // re-injecting our paste into the emulator itself.
+    let Some(mut harness) = harness_running_or_skip(
+        "stty -echo -icanon; printf '\\033[?2004h'; printf 'CAT_READY\\n'; cat -v",
+    ) else {
+        return;
+    };
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    // Wait until the emulator has actually seen the DECSET — that is the state
+    // the paste path reads, and it lands only once the child's output arrives.
+    harness
+        .wait_until(|h| {
+            h.screen_to_string().contains("CAT_READY")
+                && h.editor()
+                    .active_window()
+                    .get_active_terminal_state()
+                    .is_some_and(|s| s.is_bracketed_paste())
+        })
+        .unwrap();
+
+    harness
+        .editor_mut()
+        .paste_text("PASTE_L1\nPASTE_L2".to_string());
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("PASTE_L2^[[201~"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("^[[200~PASTE_L1"),
+        "paste should reach the child wrapped in the start marker. Screen:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains("PASTE_L2^[[201~"),
+        "paste should reach the child wrapped in the end marker. Screen:\n{}",
+        screen
+    );
+
+    // Clean up: Ctrl+D to exit cat.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"\x04");
+}
+
+/// With bracketed paste *off*, the child cannot tell a paste from typing, so
+/// the paste is sent as the keystrokes it would be: line breaks become `\r`,
+/// the byte the Enter key produces (`\n` alone is not what a keyboard sends,
+/// and a raw-mode reader that only accepts CR would swallow the line break).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Unix shell commands (stty/cat)
+fn test_paste_without_bracketed_paste_sends_carriage_returns() {
+    // `-icrnl` keeps the line discipline from rewriting our CR as NL, so what
+    // `cat -v` prints (`^M`) is exactly what the child received.
+    let Some(mut harness) =
+        harness_running_or_skip("stty -echo -icanon -icrnl; printf 'CAT_READY\\n'; cat -v")
+    else {
+        return;
+    };
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("CAT_READY"))
+        .unwrap();
+
+    assert!(
+        !harness
+            .editor()
+            .active_window()
+            .get_active_terminal_state()
+            .is_some_and(|s| s.is_bracketed_paste()),
+        "plain `cat` never asks for bracketed paste"
+    );
+
+    harness.editor_mut().paste_text("P1\nP2".to_string());
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("P1^MP2"))
+        .unwrap();
+
+    harness.assert_screen_contains("P1^MP2");
+
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"\x04");
+}
+
 /// Regression test: when an alternate-screen program is *tracking the mouse*
 /// (mouse reporting enabled), wheel events must be forwarded to it as real
 /// mouse reports — never converted into arrow keys by alternate-scroll mode.

--- a/docs/internal/terminal.md
+++ b/docs/internal/terminal.md
@@ -116,6 +116,23 @@ Application-cursor mode (DECCKM) switches unmodified arrows to SS3 form, selecte
 from the terminal state at send time. Shift+Tab is emitted for both `Tab+SHIFT`
 and the `BackTab` variant.
 
+A **paste** is not key encoding and does not go through it: every route into a
+live terminal (`Ev::Paste` and the web/daemon pastes via `Editor::paste_text`,
+`Action::TerminalPaste`) ends at `Window::send_terminal_paste`, which reads the
+child's bracketed-paste mode (DECSET 2004, `TerminalState::is_bracketed_paste`)
+the same way key encoding reads DECCKM:
+
+- **2004 on** — the text is wrapped in `ESC[200~` … `ESC[201~`, with `ESC`
+  stripped from the payload so nothing inside it can close the brackets early.
+  This is what keeps a multi-line paste one block: a line editor that asked for
+  the mode reads a bare `\n` as Enter, so unwrapped text submits every line but
+  the tail.
+- **2004 off** — the child cannot tell paste from typing, so it is sent as the
+  keystrokes it would be, line breaks included: `\r`, the byte Enter produces.
+
+`Editor::send_selection_to_terminal` is deliberately *not* a paste — sending a
+selection means running it, so it stays raw and newline-terminated.
+
 ---
 
 ## 5. Incremental scrollback streaming (the core model)


### PR DESCRIPTION
Pasting several lines into an embedded terminal ran every line but the last, leaving only the tail on the input line — "sometimes it works" being the single-line pastes and the programs that guess from timing.

## Cause

fresh handed the child the raw clipboard bytes, which is the same stream typing produces, and a line editor reads each newline in it as the Enter key: bash, zsh and fish's readline, and an agent CLI's input box, all submit line by line. Those programs say so first — DECSET 2004 is exactly the announcement "tell me when text is pasted rather than typed" — and fresh tracked the mode for its own host terminal while never reading it for a child's. No paste marker was written into a PTY anywhere in the tree.

## Fix

Every paste route into a live terminal (`Ev::Paste` and the web/daemon pastes through `paste_text`, plus `Action::TerminalPaste`) now goes through `Window::send_terminal_paste`, which reads the child's mode the way key encoding already reads DECCKM:

* **2004 on** — wrap the text in `ESC[200~` … `ESC[201~`, with `ESC` stripped from the payload so nothing in the clipboard can close the brackets early and have the rest of itself executed.
* **2004 off** — the child cannot tell paste from typing either way, so send what the keyboard would: line breaks as `\r`, the byte Enter produces.

`Action::TerminalPaste` also picks up the CRLF/CR normalization the `paste_text` route already did. `send_selection_to_terminal` stays raw and newline-terminated — sending a selection to a terminal means running it, and that is not a paste.

## Changes

| File | What |
| --- | --- |
| `services/terminal/term.rs` | `TerminalState::is_bracketed_paste()`, beside the existing DECCKM / mouse-mode accessors |
| `app/terminal.rs` | `Window::send_terminal_paste` — the single paste funnel — plus the marker constants |
| `app/clipboard.rs` | the live-terminal branch of `paste_text` routes through it |
| `app/action_dispatch.rs` | `Action::TerminalPaste` normalizes, then routes through it |
| `tests/e2e/terminal.rs` | two tests, and a helper that spawns one known program as the terminal's child |
| `docs/internal/terminal.md`, `CHANGELOG.md` | the paste path next to key encoding; a 0.4.11 bug-fix entry |

## Testing

Both new e2e tests drive a real `sh -c 'stty …; cat -v'` child — no interactive shell in between, so the modes under test are the ones the test set — and read the markers back off the screen: one asserts the wrapper when the child requests 2004, one asserts `^M` when it doesn't.

* `cargo test -p fresh-editor --all-features --test all_tests -- terminal` — 169 passed, 0 failed, 5 ignored
* `cargo test -p fresh-editor --all-features --test all_tests -- paste` — 102 passed, 0 failed, 2 ignored
* `cargo fmt -- --check` clean; `cargo check -p fresh-editor --all-features` clean (only the two pre-existing dead-code warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAWUbfnPexgrEGHLVthBHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAWUbfnPexgrEGHLVthBHP)_