### PR TITLE
Showing or focusing a sidebar section opens it

### DIFF
--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -99,6 +99,10 @@ impl Editor {
         // Exactly one chrome region wears the accent: a focused plugin
         // section gives the keyboard up to the tree.
         self.blur_sidebar_panels();
+        // A visible column is not a visible tree: open the explorer's own
+        // section if the reader had collapsed it, so the keyboard does not
+        // land in a section with no rows on screen.
+        self.reveal_file_explorer_section();
         let win = self.active_window_mut();
         // Stop routing keys to the PTY while the explorer holds focus:
         // `focused_terminal_live()` is false in any non-editor key context.
@@ -132,6 +136,35 @@ impl Editor {
     pub fn show_file_explorer(&mut self) {
         if !self.file_explorer_visible() {
             self.toggle_file_explorer();
+        } else {
+            // Already showing the column — but the tree is only on screen if
+            // its section is open, so say the second half out loud too.
+            self.reveal_file_explorer_section();
+        }
+    }
+
+    /// Open the explorer's sidebar section if the reader has collapsed it.
+    ///
+    /// The sidebar column being visible does not mean the file tree is: the
+    /// explorer is section 0 of the accordion, and a reader who collapsed it
+    /// to give a plugin section the whole column (the Markdown contents
+    /// panel, say) is left with the explorer's header row and nothing under
+    /// it. Without this, "show the file explorer" showed a column whose tree
+    /// never appeared, and toggling it off and on again could not recover:
+    /// the collapse is section state, so it outlived hiding the column.
+    ///
+    /// Routed through [`toggle_sidebar_section`](Self::toggle_sidebar_section)
+    /// so this does exactly what a press on the header does — the exclusive
+    /// accordion still gets its one open section, and the section stops being
+    /// `squeezed` because it was opened on purpose.
+    ///
+    /// A section collapsed by pressure rather than by the reader is opened
+    /// too, and it stays open: `squeeze` collapses from the bottom up, so a
+    /// column too short for every section takes the rows back from the last
+    /// one instead of from the tree the reader just asked for.
+    pub(crate) fn reveal_file_explorer_section(&mut self) {
+        if self.sidebar_sections.first().is_some_and(|s| s.collapsed) {
+            self.toggle_sidebar_section(0);
         }
     }
 

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -102,7 +102,7 @@ impl Editor {
         // A visible column is not a visible tree: open the explorer's own
         // section if the reader had collapsed it, so the keyboard does not
         // land in a section with no rows on screen.
-        self.reveal_file_explorer_section();
+        self.reveal_explorer_section();
         let win = self.active_window_mut();
         // Stop routing keys to the PTY while the explorer holds focus:
         // `focused_terminal_live()` is false in any non-editor key context.
@@ -139,32 +139,7 @@ impl Editor {
         } else {
             // Already showing the column — but the tree is only on screen if
             // its section is open, so say the second half out loud too.
-            self.reveal_file_explorer_section();
-        }
-    }
-
-    /// Open the explorer's sidebar section if the reader has collapsed it.
-    ///
-    /// The sidebar column being visible does not mean the file tree is: the
-    /// explorer is section 0 of the accordion, and a reader who collapsed it
-    /// to give a plugin section the whole column (the Markdown contents
-    /// panel, say) is left with the explorer's header row and nothing under
-    /// it. Without this, "show the file explorer" showed a column whose tree
-    /// never appeared, and toggling it off and on again could not recover:
-    /// the collapse is section state, so it outlived hiding the column.
-    ///
-    /// Routed through [`toggle_sidebar_section`](Self::toggle_sidebar_section)
-    /// so this does exactly what a press on the header does — the exclusive
-    /// accordion still gets its one open section, and the section stops being
-    /// `squeezed` because it was opened on purpose.
-    ///
-    /// A section collapsed by pressure rather than by the reader is opened
-    /// too, and it stays open: `squeeze` collapses from the bottom up, so a
-    /// column too short for every section takes the rows back from the last
-    /// one instead of from the tree the reader just asked for.
-    pub(crate) fn reveal_file_explorer_section(&mut self) {
-        if self.sidebar_sections.first().is_some_and(|s| s.collapsed) {
-            self.toggle_sidebar_section(0);
+            self.reveal_explorer_section();
         }
     }
 

--- a/crates/fresh-editor/src/app/sidebar.rs
+++ b/crates/fresh-editor/src/app/sidebar.rs
@@ -69,6 +69,17 @@ impl SidebarSection {
         }
     }
 
+    /// Whether this is the section that holds the file tree.
+    ///
+    /// The explorer is section 0 and `restore_sidebar_sections` keeps it
+    /// there, but *asking by position* spreads that invariant over every
+    /// caller. Ask what the section holds instead: the kind is the
+    /// unambiguous name for it, and it stays right if the column ever grows
+    /// a section above the tree.
+    pub(crate) fn is_explorer(&self) -> bool {
+        self.kind == SidebarSectionKind::Explorer
+    }
+
     pub(crate) fn panel_key(&self) -> Option<&PanelKey> {
         match &self.kind {
             SidebarSectionKind::Panel { key, .. } => Some(key),
@@ -277,6 +288,52 @@ impl super::Editor {
         sec.squeezed = false;
     }
 
+    /// Where the file tree's section is, by what it holds.
+    pub(crate) fn explorer_section_index(&self) -> Option<usize> {
+        self.sidebar_sections.iter().position(|s| s.is_explorer())
+    }
+
+    /// Open section `index` if it is collapsed, so what is about to be
+    /// focused, or asked for by name, is on screen.
+    ///
+    /// A visible column is not a visible section: collapsing is how a reader
+    /// gives one section's rows to another, and the collapse is section state
+    /// that outlives hiding the column. Anything that means "show me *this*"
+    /// has to say the second half out loud, or it leaves the keyboard in a
+    /// section with no rows under its header — which is what
+    /// `focus_sidebar_section` already refuses to do about the column
+    /// (`reveal_sidebar`), and had no answer for about the section.
+    ///
+    /// Routed through [`toggle_sidebar_section`](Self::toggle_sidebar_section)
+    /// so this does exactly what a press on the header does: the exclusive
+    /// accordion still ends with one open section, and the section stops
+    /// being `squeezed` because it was opened on purpose. A section collapsed
+    /// by pressure is opened too and stays open — `squeeze` collapses from
+    /// the bottom up, so a column too short for every section takes the rows
+    /// back from the last one rather than from the one just asked for.
+    pub(crate) fn reveal_sidebar_section(&mut self, index: usize) {
+        if self
+            .sidebar_sections
+            .get(index)
+            .is_some_and(|s| s.collapsed)
+        {
+            self.toggle_sidebar_section(index);
+        }
+    }
+
+    /// Open the explorer's section if the reader has collapsed it.
+    ///
+    /// The commands that show or focus the file explorer mean the tree, not
+    /// the column it lives in: a reader who collapsed the tree to give a
+    /// plugin section the column (the Markdown contents panel, say) was left
+    /// with a header row and nothing under it, and toggling the column off
+    /// and on again could not recover it.
+    pub(crate) fn reveal_explorer_section(&mut self) {
+        if let Some(i) = self.explorer_section_index() {
+            self.reveal_sidebar_section(i);
+        }
+    }
+
     /// The press that may become a divider drag: snapshot the neighbours.
     pub(crate) fn begin_sidebar_section_drag(&mut self, index: usize, y: u16) {
         let inert = self.sidebar_accordion() == Accordion::Exclusive;
@@ -334,14 +391,15 @@ impl super::Editor {
         }
     }
 
-    /// Drop section `index`. Section 0 is the explorer and is not a section
-    /// the user can close this way — its `×` hides the whole sidebar.
+    /// Drop section `index`. The explorer's section is not one the user can
+    /// close this way — its `×` hides the whole sidebar.
     ///
     /// A mounted panel is unmounted and told, with the `cancel` a closed
     /// modal fires, so the plugin can drop its own state.
     pub(crate) fn close_sidebar_section(&mut self, index: usize) {
-        if index == 0 || index >= self.sidebar_sections.len() {
-            return;
+        match self.sidebar_sections.get(index) {
+            Some(s) if !s.is_explorer() => {}
+            _ => return,
         }
         if let Some(panel) = self.sidebar_sections[index].panel.take() {
             let widget_key = self
@@ -399,8 +457,10 @@ impl super::Editor {
         }
         // Putting the keyboard in a section you cannot see is not a
         // state; this is the ask that `place_panel_in_sidebar` no longer
-        // assumes (see `reveal_sidebar`).
+        // assumes (see `reveal_sidebar`). The column and the section are two
+        // separate ways to be off screen, so focusing says both.
         self.reveal_sidebar();
+        self.reveal_sidebar_section(index);
         if self.dock.as_ref().is_some_and(|d| d.focused) {
             self.blur_floating_panel(super::PanelSlot::Dock);
         }
@@ -438,13 +498,16 @@ impl super::Editor {
         }
         let current = match self.focused_sidebar_panel() {
             Some(i) => Some(i),
-            None if self.active_window().key_context == KeyContext::FileExplorer => Some(0),
+            None if self.active_window().key_context == KeyContext::FileExplorer => {
+                self.explorer_section_index()
+            }
             None => None,
         };
-        let next = (current.map(|i| i + 1).unwrap_or(0)..self.sidebar_sections.len())
-            .find(|&i| i == 0 || self.sidebar_sections[i].panel.is_some());
+        let next = (current.map(|i| i + 1).unwrap_or(0)..self.sidebar_sections.len()).find(|&i| {
+            self.sidebar_sections[i].is_explorer() || self.sidebar_sections[i].panel.is_some()
+        });
         match (current, next) {
-            (_, Some(0)) => self.focus_file_explorer(),
+            (_, Some(i)) if self.sidebar_sections[i].is_explorer() => self.focus_file_explorer(),
             (_, Some(i)) => self.focus_sidebar_section(i),
             // Past the last section: the editor.
             (Some(_), None) => {
@@ -570,7 +633,7 @@ impl super::Editor {
         &mut self,
         index: usize,
     ) -> Option<super::FloatingWidgetState> {
-        if index == 0 || index >= self.sidebar_sections.len() {
+        if self.sidebar_sections.get(index)?.is_explorer() {
             return None;
         }
         let panel = self.sidebar_sections[index].panel.take()?;

--- a/crates/fresh-editor/tests/e2e/sidebar_sections.rs
+++ b/crates/fresh-editor/tests/e2e/sidebar_sections.rs
@@ -211,3 +211,104 @@ fn a_plugin_section_mounts_drags_collapses_and_survives_a_restore() {
         );
     }
 }
+
+/// **A collapsed explorer section is not a hidden sidebar**, and the commands
+/// that show the explorer have to say so.
+///
+/// The reader here is the one the Markdown contents panel produces: a column
+/// with two sections, the tree collapsed to its header row so the panel below
+/// has the rows. Section state is the editor's, not the column's, so it
+/// outlives hiding the sidebar — before the fix, `Ctrl+B` off and on again
+/// brought the column back with the tree still collapsed, and there was no
+/// way to reach the tree from the command at all.
+#[test]
+fn showing_the_explorer_opens_a_section_the_reader_collapsed() {
+    init_tracing_from_env();
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project = temp_dir.path().join("project");
+    fs::create_dir(&project).unwrap();
+    fs::write(project.join("a.txt"), "hello\n").unwrap();
+    install_plugin(&project);
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // An inside cell of a header row, clear of the chevron and the `×`.
+    let x = 6u16;
+
+    let mut h = launch(&project, &dir_context);
+    h.editor_mut()
+        .restore_active_window_on_launch(false)
+        .unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+    run_palette_command(&mut h, "SidebarTest: Mount");
+    h.wait_until(|h| h.screen_to_string().contains("alpha"))
+        .unwrap();
+
+    // **Collapse the explorer**, the way the reader does: a click on its
+    // header. The tree goes with its body; the plugin section keeps the rows.
+    let explorer = row_of(&h, "▼ File Explorer").expect("the explorer's header");
+    h.mouse_click(x, explorer).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("▶ File Explorer"))
+        .unwrap();
+    assert!(
+        row_of(&h, "a.txt").is_none(),
+        "the tree went with the section's body\n{}",
+        h.screen_to_string()
+    );
+    assert!(
+        row_of(&h, "alpha").is_some(),
+        "the panel still has its rows"
+    );
+
+    // **Hide the column** (`Ctrl+B`): every section goes with it.
+    h.send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.render().unwrap();
+    assert!(
+        row_of(&h, "File Explorer").is_none() && row_of(&h, "Outline").is_none(),
+        "the whole column is hidden\n{}",
+        h.screen_to_string()
+    );
+
+    // **Show it again**: the command means the tree, so the section it was
+    // collapsed into opens with it.
+    h.send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.render().unwrap();
+    assert!(
+        row_of(&h, "▼ File Explorer").is_some(),
+        "the explorer's section is open again\n{}",
+        h.screen_to_string()
+    );
+    assert!(
+        row_of(&h, "a.txt").is_some(),
+        "and the tree is on screen\n{}",
+        h.screen_to_string()
+    );
+
+    // **Collapsing it again still works**: the reveal is the command's, not
+    // a rule that the section can never be closed.
+    let explorer = row_of(&h, "▼ File Explorer").expect("the explorer's header");
+    h.mouse_click(x, explorer).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("▶ File Explorer"))
+        .unwrap();
+    assert!(
+        row_of(&h, "a.txt").is_none(),
+        "collapsed by the reader again"
+    );
+
+    // **Focusing the explorer opens it too** (`Ctrl+E`): the keyboard does
+    // not go to a section with no rows on screen. The explorer holds the
+    // focus after the collapsing click, so the first press returns it to the
+    // editor and the second asks for the tree.
+    h.send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.render().unwrap();
+    assert!(
+        row_of(&h, "a.txt").is_some(),
+        "focus put the tree back on screen\n{}",
+        h.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/sidebar_sections.rs
+++ b/crates/fresh-editor/tests/e2e/sidebar_sections.rs
@@ -312,3 +312,55 @@ fn showing_the_explorer_opens_a_section_the_reader_collapsed() {
         h.screen_to_string()
     );
 }
+
+/// The same claim for a plugin section: focusing one the reader collapsed
+/// opens it, rather than leaving the keyboard under a header with no rows.
+///
+/// `Focus Next Sidebar Section` cycles explorer → plugin sections → editor,
+/// so the second step lands on the collapsed section — and before the fix it
+/// landed there invisibly: the header wore the focus accent and every key
+/// went to a panel the reader could not see.
+#[test]
+fn focusing_a_plugin_section_opens_one_the_reader_collapsed() {
+    init_tracing_from_env();
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project = temp_dir.path().join("project");
+    fs::create_dir(&project).unwrap();
+    fs::write(project.join("a.txt"), "hello\n").unwrap();
+    install_plugin(&project);
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // An inside cell of a header row, clear of the chevron and the `×`.
+    let x = 6u16;
+
+    let mut h = launch(&project, &dir_context);
+    h.editor_mut()
+        .restore_active_window_on_launch(false)
+        .unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+    run_palette_command(&mut h, "SidebarTest: Mount");
+    h.wait_until(|h| h.screen_to_string().contains("alpha"))
+        .unwrap();
+
+    // **Collapse the plugin's section** with a click on its header.
+    let header = row_of(&h, "▼ Outline").expect("the section's header");
+    h.mouse_click(x, header).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("▶ Outline"))
+        .unwrap();
+    assert!(row_of(&h, "alpha").is_none(), "the body went with it");
+
+    // **Cycle the keyboard into it**: explorer first, then the section,
+    // which opens rather than take the keys out of sight.
+    run_palette_command(&mut h, "Focus Next Sidebar Section");
+    h.wait_until(|h| h.screen_to_string().contains("▼ File Explorer"))
+        .unwrap();
+    run_palette_command(&mut h, "Focus Next Sidebar Section");
+    h.wait_until(|h| h.screen_to_string().contains("alpha"))
+        .unwrap();
+    assert!(
+        row_of(&h, "▼ Outline").is_some(),
+        "the focused section is open\n{}",
+        h.screen_to_string()
+    );
+}


### PR DESCRIPTION
The sidebar is a column of sections, so anything in it has two ways to be off screen: the column hidden, or its own section collapsed. Every command that means "show me *this*" only said the first half, and a reader reading Markdown gets there without trying — the contents panel mounts under the tree, they collapse one of the two to give the other the column, and the commands that exist to bring it back cannot.

## Reproduction

Driven manually in tmux (100×30) against the real binary, in a project with a Markdown file open so `markdown_toc` mounts its *Contents* section under the tree.

**The tree** — collapse the explorer's section by clicking its header:

```
┌ ▶ File Explorer ─────────×─┐ notes.md ×      Ctrl+B (Toggle File Explorer) → column hidden
├ ▼ Contents ──────────────×─┤  1 │ # Title    Ctrl+B again → column back, still ▶, no tree
│▌ Title                     │  2 │
```

`Toggle File Explorer` flipped a column whose tree never appeared: the collapse is section state, not column state, so it outlived hiding the column and there was no way back to the tree from the command at all. `Focus File Explorer` was worse — the status bar said the explorer was focused while it had zero rows on screen.

**A plugin section** — collapse *Contents* instead and cycle onto it with `Focus Next Sidebar Section`: its header rendered with the focus accent (`ESC[1m ESC[38;5;16m ESC[48;5;231m ▶ Contents`) over no rows, and arrow keys moved nothing. Same shape, and one `focus_sidebar_section` already refuses about the column (`reveal_sidebar`) while having no answer about the section.

## The change

One helper, `reveal_sidebar_section(index)`, opens a collapsed section. It is called from:

* `take_focus_for_file_explorer` (so `toggle_file_explorer`'s show branch and `focus_file_explorer` both get it) and `show_file_explorer` for the already-visible case, via `reveal_explorer_section()`;
* `focus_sidebar_section`, next to the `reveal_sidebar()` that shows the column — focusing now says both halves.

It routes through `toggle_sidebar_section` so this does exactly what a press on the header does: the exclusive accordion still ends with one open section, and the section stops being `squeezed` because it was opened on purpose. A section collapsed by pressure is opened too and stays open — `squeeze` collapses from the bottom up, so a column too short for every section takes the rows back from the last one rather than from the one just asked for. Collapsing afterwards still works; the reveal belongs to the command, not to the section.

**The explorer is found by kind, not by index.** It is section 0 and `restore_sidebar_sections` keeps it there, but asking by position spread that invariant over every caller and read as a magic number where the list is otherwise addressed by what a section holds. `SidebarSection::is_explorer()` and `explorer_section_index()` ask the kind, and the three places that tested `index == 0` — closing a section, taking a panel out of one, and the focus cycle — now say what they mean. Behaviour is unchanged, and the bounds checks those guards doubled as are kept by going through `get`.

## Testing

Two e2e tests in `tests/e2e/sidebar_sections.rs`, driving only the mouse, keys and palette and asserting on rendered output:

* `showing_the_explorer_opens_a_section_the_reader_collapsed` — mount a plugin section, collapse the explorer by clicking its header, `Ctrl+B` off and on, then `Ctrl+E`. Fails with the source change stashed.
* `focusing_a_plugin_section_opens_one_the_reader_collapsed` — collapse the plugin's section, cycle the keyboard onto it with `Focus Next Sidebar Section`. Hangs waiting for rows that never appear without the change.

Both tmux flows re-driven after the change: `Ctrl+B` off/on brings back `▼ File Explorer` with the tree, `Ctrl+E` expands and focuses it, and the focus cycle opens *Contents* as it lands on it.

`cargo test -p fresh-editor --test all_tests` over `explorer` (222 passed), `dock` (160), `markdown` (180), `panel` (53), `sidebar` (15), `widget` (13); `cargo fmt --check` and `cargo clippy -p fresh-editor --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxLrW4pWggsLbnuWdq2SQ9