### PR TITLE
A block selection's highlight is what a block copy takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Settings dialog** - `Delete` works again in the Edit Item text field (#2875, reported by @asukaminato0721)
 * **Quitting** no longer panics while plugin work is still in flight
 * **Rendering fixes** - whitespace markers, indent guides, block-selection rectangles, misread angle brackets; File Explorer got a scrollbar (#3077, #3079, #3148, #3090, reported by @Korkman; #2859, reported by @asukaminato0721)
+* **The block-selection highlight is exactly what a block copy takes** - the rectangle used to be painted one column wider than `Ctrl+C` copied, and a zero-width block (Alt+Shift+Down with no sideways movement) painted a column it did not select, then copied a bare newline per line (#3150, reported by @Korkman)
 * **Conceals spanning a line break** no longer crash the editor (#3139)
 * **New file/folder names with slashes** create their missing parent directories (#2640, requested by @akarinotomoshibi)
 * **`fresh --cmd update`** no longer fails on GitHub's shared API rate limit - resolves releases the way `install.sh` does, honours `GITHUB_TOKEN`, and adds `--skip-attestation` as a fallback (#3198)

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -258,9 +258,22 @@ impl Editor {
                 }
             }
 
-            // Calculate column bounds (min and max columns for the rectangle)
+            // Calculate column bounds (min and max columns for the rectangle).
+            // The span is half-open — `min_col..max_col` — the same unit the
+            // painter and `convert_block_selection_to_cursors` use.
             let min_col = block_anchor.column.min(cursor_2d.column);
             let max_col = block_anchor.column.max(cursor_2d.column);
+
+            // A zero-width rectangle selects no text. It is a legitimate
+            // gesture — Alt+Shift+Down with no horizontal movement is how you
+            // ask for a vertical column of cursors — and it paints nothing on
+            // screen, so it must copy nothing too. Extracting from it used to
+            // yield one empty string per line, which the join below turned
+            // into a column of bare newlines that a later paste inserted as
+            // blank lines (issue #3150).
+            if min_col == max_col {
+                continue;
+            }
 
             // Calculate line bounds using byte positions
             let start_byte = anchor_byte.min(cursor_byte);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -883,7 +883,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 .block_rects
                 .iter()
                 .filter(|(start_line, _, end_line, end_col)| {
-                    *start_line <= gutter_num && gutter_num <= *end_line && *end_col >= row_len
+                    *start_line <= gutter_num && gutter_num <= *end_line && *end_col > row_len
                 })
                 .map(|(_, start_col, _, end_col)| ((*start_col).max(row_len), *end_col))
                 .fold(None::<(usize, usize)>, |acc, (s, e)| match acc {
@@ -903,9 +903,10 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                     );
                     rendered_cols += gap;
                 }
-                // Match the per-cell sweep: block columns are inclusive.
-                let sel_len =
-                    (sel_end + 1 - sel_start).min(content_cols.saturating_sub(rendered_cols));
+                // Match the per-cell sweep: block columns are half-open,
+                // so the rectangle is `sel_end - sel_start` wide — exactly
+                // what `copy_block_selection_text` pads a short line to.
+                let sel_len = (sel_end - sel_start).min(content_cols.saturating_sub(rendered_cols));
                 if sel_len > 0 {
                     push_span_with_map(
                         &mut line_spans,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/selection_sweep.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/selection_sweep.rs
@@ -16,6 +16,12 @@
 //!   `gutter_num` advances; each cell tests its own byte column in the
 //!   line against the rect's column span.
 //!
+//!   The line span is closed (`start_line..=end_line`: both the anchor's
+//!   row and the cursor's row are in the block), the column span is
+//!   half-open (`start_col..end_col`). That asymmetry is not an
+//!   oversight — it is what the rest of the block machinery means by a
+//!   rectangle, see [`SelectionActiveSet::contains`].
+//!
 //! Net: the cell loop just calls `contains(byte_pos, line_column)`.
 
 use std::ops::Range;
@@ -128,6 +134,22 @@ impl<'a> SelectionActiveSet<'a> {
     /// 3, i.e. `tab_size - 1` cells to its left (issue #3148). The cursor
     /// is the one telling the truth about what a block copy takes, and a
     /// column in the line is what both of them now count.
+    ///
+    /// The column span is **half-open** — `start_col..end_col`, the
+    /// cursor's own column excluded. Every other consumer of a block
+    /// rectangle already reads it that way: `copy_block_selection_text`
+    /// takes `max_col - min_col` characters per line, and
+    /// `convert_block_selection_to_cursors` gives each line the selection
+    /// `min_col..max_col`. Testing `col <= end_col` here painted one
+    /// column more than either of them touched, so a block copy silently
+    /// transferred something narrower than the highlight (issue #3150).
+    ///
+    /// Two things follow, both of them wanted. Extending the block to the
+    /// right leaves the cursor just past the rectangle's right edge, which
+    /// is how a one-column block reads as one column rather than two. And
+    /// a zero-width block (`start_col == end_col`, e.g. Alt+Shift+Down with
+    /// no horizontal movement) paints nothing at all: it is a column of
+    /// cursors, not a selection, and a copy of it takes no text.
     pub(super) fn contains(
         &mut self,
         buffer_byte: Option<usize>,
@@ -140,7 +162,7 @@ impl<'a> SelectionActiveSet<'a> {
         let block = line_column.is_some_and(|col| {
             self.active_block.iter().any(|&i| {
                 let (_, start_col, _, end_col) = self.blocks[i];
-                col >= start_col && col <= end_col
+                col >= start_col && col < end_col
             })
         });
         linear || block

--- a/crates/fresh-editor/tests/e2e/issue_3148_block_selection_tabs.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3148_block_selection_tabs.rs
@@ -5,6 +5,11 @@
 //! tab as its whole expansion. With one leading tab and `tab_size: 4` the
 //! highlight stopped `tab_size - 1` cells to the left of the cursor — and the
 //! cursor is the one telling the truth about what a block copy takes.
+//!
+//! The column span is half-open (issue #3150), so "where the cursor is" means
+//! the rectangle's right edge is the cell *before* the cursor's: a block copy
+//! takes `min_col..max_col`, the cursor's own column excluded. The tab is
+//! still wholly in or wholly out, which is the claim this file exists for.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -67,23 +72,23 @@ fn block_selection_ends_at_the_cursor_with_a_leading_tab() {
     );
     assert_eq!(
         selected.last().copied(),
-        Some(cursor_x),
-        "the rectangle's right edge is the cursor's cell, not {} cells left of it\n{}",
+        Some(cursor_x - 1),
+        "the rectangle's right edge is the cell before the cursor's, not {} cells left of it\n{}",
         cursor_x.saturating_sub(selected.last().copied().unwrap_or(0)),
         harness.screen_to_string()
     );
-    // Tab expansion (4 cells) + `abc`: the tab is wholly in or wholly out,
-    // which is what a block copy of column range 0..=3 takes.
+    // Tab expansion (4 cells) + `ab`: the tab is wholly in or wholly out,
+    // which is what a block copy of column range 0..3 takes.
     assert_eq!(
         selected.len(),
-        7,
-        "expected the tab's four cells plus `abc`\n{}",
+        6,
+        "expected the tab's four cells plus `ab`\n{}",
         harness.screen_to_string()
     );
     assert_eq!(
         harness.get_cell(cursor_x, cursor_y).as_deref(),
         Some("c"),
-        "the cursor sits on the last character the block covers\n{}",
+        "the cursor sits just past the last character the block covers\n{}",
         harness.screen_to_string()
     );
 }
@@ -96,11 +101,11 @@ fn block_selection_without_a_tab_is_unchanged() {
     let (cursor_x, cursor_y) = harness.screen_cursor_position();
     let selected = selected_columns(&harness, cursor_y);
 
-    assert_eq!(selected.last().copied(), Some(cursor_x));
+    assert_eq!(selected.last().copied(), Some(cursor_x - 1));
     assert_eq!(
         selected.len(),
-        4,
-        "`Zabc` — one cell per character\n{}",
+        3,
+        "`Zab` — one cell per character\n{}",
         harness.screen_to_string()
     );
 }

--- a/crates/fresh-editor/tests/e2e/issue_3150_block_selection_offset.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3150_block_selection_offset.rs
@@ -1,0 +1,209 @@
+//! Issue #3150 — the block-selection highlight and the block copy disagreed
+//! by one column.
+//!
+//! The rectangle's column span is half-open, `min_col..max_col`: that is what
+//! `copy_block_selection_text` takes from each line and what
+//! `convert_block_selection_to_cursors` gives each line as a selection. The
+//! painter tested `col <= end_col`, so it lit one column more than either of
+//! them touched — the user saw `abcd` highlighted and pasted `abc`.
+//!
+//! Two consequences are pinned here besides the widths matching:
+//!
+//! * Extending the block rightward leaves the cursor just past the
+//!   rectangle's right edge, so a one-column block reads as one column.
+//! * A zero-width block (Alt+Shift+Down with no horizontal movement) is a
+//!   column of cursors, not a selection: it paints nothing and copies
+//!   nothing. It used to paint one column — indistinguishable from a
+//!   one-column block — and copy a bare newline per line, which a later
+//!   paste inserted as blank lines.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+const LINES: usize = 3;
+
+/// `abcdef` on three lines, cursor parked at 1:1.
+fn harness() -> EditorTestHarness {
+    let mut harness = EditorTestHarness::new(100, 20).unwrap();
+    harness
+        .load_buffer_from_text(&"abcdef\n".repeat(LINES))
+        .unwrap();
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+}
+
+fn press(harness: &mut EditorTestHarness, code: KeyCode, times: usize) {
+    for _ in 0..times {
+        harness
+            .send_key(code, KeyModifiers::ALT | KeyModifiers::SHIFT)
+            .unwrap();
+    }
+    harness.render().unwrap();
+}
+
+/// The characters on `row` whose cell carries the selection background.
+fn highlighted(harness: &EditorTestHarness, row: u16) -> String {
+    let selection_bg = harness.editor().theme().selection_bg;
+    let width = harness.buffer().area.width;
+    (0..width)
+        .filter(|&x| {
+            harness
+                .get_cell_style(x, row)
+                .is_some_and(|s| s.bg == Some(selection_bg))
+        })
+        .filter_map(|x| harness.get_cell(x, row))
+        .collect()
+}
+
+/// The highlighted text of each of the buffer's `LINES` rows.
+fn highlighted_rows(harness: &EditorTestHarness) -> Vec<String> {
+    let (first, _) = harness.content_area_rows();
+    (0..LINES)
+        .map(|i| highlighted(harness, first as u16 + i as u16))
+        .collect()
+}
+
+fn copy(harness: &mut EditorTestHarness) -> String {
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.editor_mut().clipboard_content_for_test()
+}
+
+/// Case 1 from the report: Alt+Shift+Right ×3 from 1:1 highlighted `abcd`
+/// but copied `abc`.
+#[test]
+fn highlight_width_matches_copy_width() {
+    let mut harness = harness();
+    press(&mut harness, KeyCode::Down, 2);
+    press(&mut harness, KeyCode::Right, 3);
+
+    let rows = highlighted_rows(&harness);
+    assert_eq!(
+        rows,
+        vec!["abc".to_string(); LINES],
+        "three Alt+Shift+Rights from column 0 cover columns 0..3\n{}",
+        harness.screen_to_string()
+    );
+
+    let clipboard = copy(&mut harness);
+    assert_eq!(clipboard, "abc\nabc\nabc");
+    for (row, copied) in rows.iter().zip(clipboard.lines()) {
+        assert_eq!(row, copied, "the highlight is what the copy takes");
+    }
+}
+
+/// A single-line block behaves the same — this is the exact gesture in the
+/// report (no vertical movement at all).
+#[test]
+fn single_line_highlight_matches_copy() {
+    let mut harness = harness();
+    press(&mut harness, KeyCode::Right, 3);
+
+    let (first, _) = harness.content_area_rows();
+    assert_eq!(highlighted(&harness, first as u16), "abc");
+    assert_eq!(copy(&mut harness), "abc");
+}
+
+/// The reporter's suggestion: once the block is at least one column wide the
+/// cursor sits outside the rectangle, so one column of highlight means one
+/// column of text.
+#[test]
+fn cursor_sits_just_past_the_rectangle() {
+    let mut harness = harness();
+    press(&mut harness, KeyCode::Right, 1);
+
+    let (cursor_x, cursor_y) = harness.screen_cursor_position();
+    assert_eq!(
+        highlighted(&harness, cursor_y),
+        "a",
+        "one Alt+Shift+Right covers exactly column 0\n{}",
+        harness.screen_to_string()
+    );
+    assert_eq!(
+        harness.get_cell(cursor_x, cursor_y).as_deref(),
+        Some("b"),
+        "the cursor is outside the rectangle, on the first cell past it\n{}",
+        harness.screen_to_string()
+    );
+    assert_eq!(copy(&mut harness), "a");
+}
+
+/// Extending leftward puts the cursor on the rectangle's left edge, which is
+/// inside it — the span is `cursor_col..anchor_col` there.
+#[test]
+fn extending_left_keeps_the_widths_matching() {
+    let mut harness = harness();
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    press(&mut harness, KeyCode::Left, 3);
+
+    let (cursor_x, cursor_y) = harness.screen_cursor_position();
+    assert_eq!(highlighted(&harness, cursor_y), "abc");
+    assert_eq!(
+        harness.get_cell(cursor_x, cursor_y).as_deref(),
+        Some("a"),
+        "extending left, the cursor is the rectangle's left edge\n{}",
+        harness.screen_to_string()
+    );
+    assert_eq!(copy(&mut harness), "abc");
+}
+
+/// Case 2 from the report: a zero-width block painted column 0 on every line,
+/// which looked exactly like a one-column-wide block.
+#[test]
+fn zero_width_block_paints_nothing() {
+    let mut harness = harness();
+    press(&mut harness, KeyCode::Down, 2);
+
+    assert_eq!(
+        highlighted_rows(&harness),
+        vec![String::new(); LINES],
+        "a zero-width block is a column of cursors, not a selection\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// …and copying it took a bare newline per line, which pasting turned into
+/// blank lines. It must take nothing and leave the clipboard alone.
+#[test]
+fn zero_width_block_copies_nothing() {
+    let mut harness = harness();
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("untouched".to_string());
+    press(&mut harness, KeyCode::Down, 2);
+
+    assert_eq!(
+        copy(&mut harness),
+        "untouched",
+        "a zero-width block selects no text, so Ctrl+C is a no-op"
+    );
+}
+
+/// A zero-width block reached by going right and back again is still
+/// zero-width: nothing painted, nothing copied.
+#[test]
+fn block_collapsed_back_to_zero_width_paints_nothing() {
+    let mut harness = harness();
+    press(&mut harness, KeyCode::Down, 1);
+    press(&mut harness, KeyCode::Right, 2);
+    assert_eq!(highlighted_rows(&harness)[0], "ab");
+
+    press(&mut harness, KeyCode::Left, 2);
+    assert_eq!(
+        highlighted_rows(&harness),
+        vec![String::new(); LINES],
+        "back to zero width\n{}",
+        harness.screen_to_string()
+    );
+    assert_eq!(copy(&mut harness), "");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -127,6 +127,7 @@ pub mod issue_3077_tab_padding_markers;
 pub mod issue_3079_guide_and_tab_marker;
 pub mod issue_3090_angle_brackets_not_rainbow;
 pub mod issue_3148_block_selection_tabs;
+pub mod issue_3150_block_selection_offset;
 pub mod issue_3192_scrollbar_drag_cursor;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_722_inlay_hint_split_drift;

--- a/crates/fresh-editor/tests/e2e/virtual_space.rs
+++ b/crates/fresh-editor/tests/e2e/virtual_space.rs
@@ -325,8 +325,10 @@ fn test_block_copy_stays_ragged_when_off() {
     let clipboard = harness.editor_mut().clipboard_content_for_test();
     // Without virtual space, the block column collapses to the short middle
     // line's width as the selection passes through it (pre-existing
-    // behavior), so the copy comes out empty rather than rectangular.
-    assert_eq!(clipboard, "\n\n", "columns collapse without virtual space");
+    // behavior), leaving a zero-width rectangle. A zero-width rectangle
+    // paints nothing and selects nothing, so the copy takes nothing — it used
+    // to yield a bare `"\n\n"` that a paste turned into blank lines (#3150).
+    assert_eq!(clipboard, "", "columns collapse without virtual space");
 }
 
 /// Typing with a block selection whose left edge is past a short line pads


### PR DESCRIPTION
Fixes #3150.

## The disagreement

A block rectangle's column span is half-open — `min_col..max_col`. That is what `copy_block_selection_text` takes from each line, and what `convert_block_selection_to_cursors` hands each line as a selection when the block is typed over. The painter tested `col <= end_col`, one column wider than either, so what the reader saw selected and what `Ctrl+C` took were never the same rectangle.

The cursor is the one telling the truth about what a block copy takes, so the painter is the side that moves. Two things follow, both of them the reporter's own suggestion:

* Extending the block rightward now leaves the cursor **just past** the rectangle's right edge, which is how a one-column block reads as one column rather than two.
* A **zero-width** block — `Alt+Shift+Down` with no sideways movement, the legitimate way to ask for a vertical column of cursors — paints nothing at all, where it used to paint the cursor's own column and so looked exactly like a one-column-wide selection. `selection_context` already documented that case as painting nothing; now it does.

## Changes

* `selection_sweep.rs` — `col >= start_col && col < end_col`, plus docs for the closed-line-span / half-open-column-span asymmetry.
* `clipboard.rs` — copying a zero-width block took a bare newline per line. Extracting `min_col..max_col` from each line yielded an empty string, and the `join("\n")` under it turned three of those into `"\n\n"` — a clipboard whose source the reader could not see, which a later paste inserted as blank lines. A rectangle with no width selects no text, so the copy skips it, and `copy_selection`'s existing non-empty guard leaves the clipboard alone.
* `render_line/mod.rs` — the virtual-space padding path carried the same `+ 1` twice. With `virtual_space` set to `block`, the part of a rectangle floating past a short line's end is painted as spaces so the on-screen rectangle matches what a block copy pads that line out to; both the filter admitting a row (`end_col >= row_len`) and the width it painted (`sel_end + 1 - sel_start`) counted the excluded column, so a rect ending exactly at a line's end painted one cell past it.

## Tests

New `e2e/issue_3150_block_selection_offset.rs`: highlight width matches copy width (multi-line and single-line), the cursor sits just past the rectangle, extending left keeps the widths matching, and the zero-width block paints nothing / copies nothing / still paints nothing when collapsed back to zero width.

Two existing tests pinned the old behaviour and move with it. `issue_3148_block_selection_tabs.rs` keeps its claim untouched — the tab is wholly in or wholly out of the rectangle, because the columns are counted in the line rather than in the view row — and only its counts move by one. `virtual_space.rs::test_block_copy_stays_ragged_when_off` asserted `"\n\n"` while its own comment called that copy empty; it is empty now.

## Before / after

Reproduced in tmux at 100x20 on `abcdef` ×3, reading the cell backgrounds with `capture-pane -p -e` (the selection background is SGR `48;5;17`) rather than eyeballing them, and confirming the copy by pasting, saving and `cat -A`:

| | before | after |
|---|---|---|
| `Alt+Shift+Right` ×3 (`Ln 1, Col 4`) | `48;5;17` over `abcd`, paste yields `abc` | `48;5;17` over `abc`, paste yields `abc` |
| `Alt+Shift+Down` ×2 (`Ln 3, Col 1`) | `48;5;17` over `a` on all three lines; copy → paste → save added two empty lines | no `48;5;17` anywhere; file unchanged after copy → paste → save |

Also checked after the fix: one `Alt+Shift+Right` paints exactly `a` with the cursor at `Col 2` (outside the rectangle), and extending left from column 3 paints `abc` with the cursor at `Col 1` (the rectangle's left edge, inside it).

## Note

The `48;5;239` background visible in those captures is the occurrence / cursor-word highlight, not the block rectangle — incidental corroboration, since in case 1 it already painted three cells (`abc`, driven by the same cursor's linear range) on lines 2–3 while the block rectangle painted four on line 1, in the same screenshot.

I did not add a new affordance for zero-width blocks. With the half-open convention they are already distinguishable from a one-column block (which paints one cell with the caret to its right), and that is what the reporter proposed. Painting a caret on every line of a zero-width block would be nicer still, but that is multi-caret rendering during block mode — a feature, not this bug.

Local `cargo fmt -- --check` passed and the block-selection / virtual-space tests passed (64 tests); the full suite and clippy are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQrP4NBtvVPfFbATJfpCQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQrP4NBtvVPfFbATJfpCQi)_