### PR TITLE
Scrolling by scrollbar leaves the cursor where it is (#3192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Search & Replace results scroll horizontally** to reveal a long match, accept a pasted query, and `Ctrl`+arrow no longer moves a hidden buffer cursor (#3154, #3184; #1960, reported by @mandolyte; #1580, #3186)
 * **More keys can be bound by name** - numpad, media and modifier keys now parse, fixing `asterisk`/`kp_multiply` bindings that silently failed before (#1128, reported by @michelpado)
 * **Shift+wheel scrolls sideways** everywhere, instead of scrolling vertically like a plain wheel notch (#1580)
+* **Dragging the scrollbar** leaves the text cursor where it is, like the wheel already did - it no longer silently relocates to the top of the scrolled view, so the next character you type still lands where you were (#3192, reported by @akarinotomoshibi)
 * **Daemon locale** now follows `config.json` instead of the environment (#3149, reported by @kirinriki7777-sys)
 * **`Ctrl+C`/`kill`** end the editor promptly instead of occasionally deadlocking or crashing
 * **Piped-in text** (`... | fresh -`) no longer leaves a temp file behind in `/tmp` (#3134, reported by @Korkman)

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -1,8 +1,7 @@
 //! Click and scroll-position helpers on `Editor`.
 //!
-//! - `move_cursor_to_visible_area` and `calculate_max_scroll_position`:
-//!   small helpers that fix up cursor position after scroll-driven moves
-//!   so the user keeps a visible cursor.
+//! - `calculate_max_scroll_position`: the small helper that caps a
+//!   scroll-driven move so the last line lands at the bottom of the view.
 //! - `fold_toggle_line_at_screen_position`: maps a click in the gutter to
 //!   the byte to fold/unfold (uses the pure helper from
 //!   `super::click_geometry`).
@@ -22,9 +21,7 @@ use crate::services::plugins::hooks::HookArgs;
 use super::Editor;
 
 impl Editor {
-    // `move_cursor_to_visible_area` and `calculate_max_scroll_position`
-    // live on `impl Window` — call them via
-    // `self.active_window_mut().move_cursor_to_visible_area(...)` and
+    // `calculate_max_scroll_position` lives on `impl Window` — call it via
     // `Window::calculate_max_scroll_position(buffer, viewport_height)`.
 
     pub(super) fn fold_toggle_line_at_screen_position(

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -195,6 +195,12 @@ impl crate::app::window::Window {
     }
 
     /// Handle scrollbar drag with relative movement (when dragging from thumb)
+    ///
+    /// Moves the viewport only: the cursor stays where the user left it, as
+    /// it does for the wheel. `skip_ensure_visible` keeps the render pass
+    /// from yanking the viewport back to an off-screen cursor, and the next
+    /// key press clears the flag so cursor motion scrolls the view again
+    /// (sinelaw/fresh#3192).
     pub(super) fn handle_scrollbar_drag_relative(
         &mut self,
         row: u16,
@@ -408,13 +414,13 @@ impl crate::app::window::Window {
             view_state.viewport.set_skip_ensure_visible();
         }
 
-        // Move cursor to be visible in the new viewport (after releasing the state borrow)
-        self.move_cursor_to_visible_area(split_id, buffer_id);
-
         Ok(())
     }
 
     /// Handle scrollbar jump (clicking on track or absolute positioning)
+    ///
+    /// Like the thumb drag, this scrolls without touching the cursor
+    /// (sinelaw/fresh#3192).
     pub(super) fn handle_scrollbar_jump(
         &mut self,
         _col: u16,
@@ -591,9 +597,6 @@ impl crate::app::window::Window {
             // Skip ensure_visible so the scroll position isn't undone during render
             view_state.viewport.set_skip_ensure_visible();
         }
-
-        // Move cursor to be visible in the new viewport (after releasing the state borrow)
-        self.move_cursor_to_visible_area(split_id, buffer_id);
 
         Ok(())
     }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -3719,49 +3719,6 @@ impl Window {
         }
     }
 
-    /// Move the cursor to a visible position within the current viewport.
-    /// Called after scrollbar operations to ensure the cursor is in view.
-    pub fn move_cursor_to_visible_area(&mut self, split_id: LeafId, buffer_id: BufferId) {
-        let (top_byte, viewport_height) =
-            if let Some(view_state) = self.buffers.splits().and_then(|(_, vs)| vs.get(&split_id)) {
-                (
-                    view_state.viewport.top_byte(),
-                    view_state.viewport.height as usize,
-                )
-            } else {
-                return;
-            };
-
-        if let Some(state) = self.buffers.get_mut(&buffer_id) {
-            let buffer_len = state.buffer.len();
-
-            let mut iter = state.buffer.line_iterator(top_byte, 80);
-            let mut bottom_byte = buffer_len;
-
-            for _ in 0..viewport_height {
-                if let Some((pos, line)) = iter.next_line() {
-                    bottom_byte = pos + line.len();
-                } else {
-                    bottom_byte = buffer_len;
-                    break;
-                }
-            }
-
-            if let Some(view_state) = self
-                .split_view_states_mut()
-                .and_then(|vs| vs.get_mut(&split_id))
-            {
-                let cursor_pos = view_state.cursors.primary().position;
-                if cursor_pos < top_byte || cursor_pos > bottom_byte {
-                    let cursor = view_state.cursors.primary_mut();
-                    cursor.position = top_byte;
-                    // Keep the existing sticky_column value so vertical
-                    // navigation preserves column.
-                }
-            }
-        }
-    }
-
     /// Calculate the maximum allowed scroll position so the last line
     /// is always at the bottom unless the buffer is smaller than the
     /// viewport. Pure function on `Buffer`; lives on `Window` so the

--- a/crates/fresh-editor/tests/e2e/issue_3192_scrollbar_drag_cursor.rs
+++ b/crates/fresh-editor/tests/e2e/issue_3192_scrollbar_drag_cursor.rs
@@ -1,0 +1,150 @@
+//! Regression tests for issue #3192: dragging the vertical scrollbar
+//! relocated the text cursor.
+//!
+//! `handle_scrollbar_drag_relative` and `handle_scrollbar_jump` finished by
+//! calling `move_cursor_to_visible_area`, which pulled the cursor to the
+//! first line of the freshly scrolled viewport whenever the scroll had left
+//! it off-screen. The wheel path never did that, which is the asymmetry the
+//! issue reports: scrolling is a viewport operation and must not mutate the
+//! buffer's cursor.
+//!
+//! The relocation was invisible until the next keypress — the status bar
+//! still read the old `Ln`/`Col` — so the first character typed after a drag
+//! landed on a line the user never navigated to, and a save wrote it there.
+//! That is what these tests observe: after the scroll, type and look at
+//! *which rendered line the text joined* (CONTRIBUTING.md Testing §2 — the
+//! assertions read the screen, not the model). Asserting on the status bar
+//! alone would pass on the broken build, because the stale status bar is
+//! precisely half the bug.
+//!
+//! Each scroll path gets its own test — thumb drag, track jump, and the
+//! mouse wheel as the control that was always correct — and all three make
+//! the same assertion, which is the parity the fix restores.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Lines in the fixture — far more than the viewport, so a scroll of any
+/// size leaves line 10 off-screen.
+const LINES: usize = 1000;
+
+/// Terminal geometry. The vertical scrollbar is the rightmost column.
+const WIDTH: u16 = 80;
+const HEIGHT: u16 = 24;
+const SCROLLBAR_COL: u16 = WIDTH - 1;
+
+/// A harness on `LINES` numbered lines with the cursor parked at the start
+/// of line 10, which is where every test below expects to find it again.
+fn harness_with_cursor_on_line_10() -> EditorTestHarness {
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    let content: String = (1..=LINES).map(|i| format!("line {i:04}\n")).collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 9)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.screen_to_string().contains("line 0010"),
+        "setup: line 10 should be on screen before scrolling"
+    );
+    harness
+}
+
+/// The topmost row of the scrollbar thumb, which is what a user grabs.
+fn thumb_top_row(harness: &EditorTestHarness) -> u16 {
+    let (first_row, last_row) = harness.content_area_rows();
+    (first_row..=last_row)
+        .map(|r| r as u16)
+        .find(|&r| harness.is_scrollbar_thumb_at(SCROLLBAR_COL, r))
+        .expect("a 1000-line buffer in a 24-row terminal must render a thumb")
+}
+
+/// Type three characters and require that they joined line 10 — the line the
+/// cursor was on before the scroll — and not whatever line the scroll left at
+/// the top of the viewport. The keypress clears `skip_ensure_visible`, so the
+/// view scrolls back to the cursor and the edited line is on screen to read.
+fn assert_typing_lands_on_line_10(harness: &mut EditorTestHarness, scrolled_from: &str) {
+    harness.type_text("ZZZ").unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("ZZZline 0010"),
+        "{scrolled_from} moved the cursor: text typed afterwards should join \
+         line 10, but line 10 does not carry it. Screen:\n{screen}"
+    );
+    assert_eq!(
+        screen.matches("ZZZ").count(),
+        1,
+        "{scrolled_from}: line 10 should be the only line carrying the typed \
+         text. Screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("Ln 10, Col 4"),
+        "{scrolled_from}: the status bar should report the cursor still on \
+         line 10, one column past the typed text. Screen:\n{screen}"
+    );
+}
+
+/// Require that the scroll actually left line 10 off-screen — without that,
+/// the cursor was never out of the viewport and the test proves nothing.
+fn assert_line_10_scrolled_away(harness: &EditorTestHarness, scrolled_from: &str) {
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("line 0010"),
+        "{scrolled_from} should have scrolled line 10 out of view. Screen:\n{screen}"
+    );
+}
+
+/// Dragging the thumb scrolls the view and leaves the cursor alone.
+#[test]
+fn scrollbar_thumb_drag_does_not_move_the_cursor() {
+    let mut harness = harness_with_cursor_on_line_10();
+
+    let (_, last_row) = harness.content_area_rows();
+    let start_row = thumb_top_row(&harness);
+    // `mouse_drag` interpolates one motion event per row, so this is the
+    // dense event stream a real mouse produces, not a couple of jumps.
+    harness
+        .mouse_drag(SCROLLBAR_COL, start_row, SCROLLBAR_COL, last_row as u16)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert_line_10_scrolled_away(&harness, "a scrollbar thumb drag");
+    assert_typing_lands_on_line_10(&mut harness, "a scrollbar thumb drag");
+}
+
+/// Clicking the track jumps the view and leaves the cursor alone — the same
+/// ruling, on the other scrollbar handler that called the cursor fixup.
+#[test]
+fn scrollbar_track_jump_does_not_move_the_cursor() {
+    let mut harness = harness_with_cursor_on_line_10();
+
+    let (_, last_row) = harness.content_area_rows();
+    // A press below the thumb lands on the track, which jumps rather than
+    // drags.
+    harness.mouse_click(SCROLLBAR_COL, last_row as u16).unwrap();
+    harness.render().unwrap();
+
+    assert_line_10_scrolled_away(&harness, "a scrollbar track jump");
+    assert_typing_lands_on_line_10(&mut harness, "a scrollbar track jump");
+}
+
+/// The control: the wheel was always correct, and the scrollbar now matches
+/// it. If this one ever fails, the ruling itself changed.
+#[test]
+fn mouse_wheel_scroll_does_not_move_the_cursor() {
+    let mut harness = harness_with_cursor_on_line_10();
+
+    let (first_row, _) = harness.content_area_rows();
+    for _ in 0..20 {
+        harness.mouse_scroll_down(10, first_row as u16).unwrap();
+    }
+    harness.render().unwrap();
+
+    assert_line_10_scrolled_away(&harness, "a mouse-wheel scroll");
+    assert_typing_lands_on_line_10(&mut harness, "a mouse-wheel scroll");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -127,6 +127,7 @@ pub mod issue_3077_tab_padding_markers;
 pub mod issue_3079_guide_and_tab_marker;
 pub mod issue_3090_angle_brackets_not_rainbow;
 pub mod issue_3148_block_selection_tabs;
+pub mod issue_3192_scrollbar_drag_cursor;
 pub mod issue_623_prompt_dropdown_scrollbar;
 pub mod issue_722_inlay_hint_split_drift;
 pub mod issue_779_after_eof_shade;

--- a/crates/fresh-editor/tests/e2e/mouse.rs
+++ b/crates/fresh-editor/tests/e2e/mouse.rs
@@ -609,12 +609,18 @@ fn extract_scrollbar_thumb_info(
     }
 }
 
-/// Test that dragging the scrollbar updates the cursor position
-/// Bug: When dragging the scrollbar, the cursor stays at its old position
-/// even though the viewport has scrolled. The cursor should be moved to
-/// somewhere within the newly visible area.
+/// Test that dragging the scrollbar scrolls the viewport and leaves the
+/// cursor where the user left it.
+///
+/// This test used to assert the opposite - that the drag pulled the cursor
+/// to the new `top_byte` - which is the behaviour issue #3192 reports as a
+/// bug: the wheel never moved the cursor, and the relocation was invisible
+/// until the next keypress typed onto a line the user never navigated to.
+/// Scrolling is a viewport operation; the ruling is now the wheel's.
+/// `e2e::issue_3192_scrollbar_drag_cursor` covers the same ground from
+/// rendered output.
 #[test]
-fn test_scrollbar_drag_updates_cursor_position() {
+fn test_scrollbar_drag_leaves_cursor_alone() {
     // Initialize tracing
     use tracing_subscriber::EnvFilter;
     let _ = tracing_subscriber::fmt()
@@ -666,19 +672,18 @@ fn test_scrollbar_drag_updates_cursor_position() {
         "Viewport should have scrolled down significantly (was line {initial_top_line}, now line {top_line_after_drag})"
     );
 
-    // VERIFY: Cursor should have moved to be within the visible area
-    // The cursor should no longer be at the beginning of the file
-    // It should be somewhere near the scrolled viewport position
-    assert!(
-        cursor_pos_after_drag > initial_cursor_pos,
-        "Cursor should have moved from position {initial_cursor_pos} after scrollbar drag, but is still at {cursor_pos_after_drag}"
+    // VERIFY: the cursor has not moved. The scroll left it off-screen, which
+    // is exactly the case the old fixup fired on and the wheel never did.
+    assert_eq!(
+        cursor_pos_after_drag, initial_cursor_pos,
+        "Scrollbar drag should leave the cursor at {initial_cursor_pos}, but it moved to {cursor_pos_after_drag}"
     );
 
-    // VERIFY: Cursor should be at the top of the visible area (or close to it)
-    // When scrollbar is dragged, the cursor is moved to top_byte
-    assert_eq!(
+    // VERIFY: and it was not pulled to the top of the new viewport - the
+    // specific relocation #3192 reports.
+    assert_ne!(
         cursor_pos_after_drag, top_byte_after_drag,
-        "Cursor position {cursor_pos_after_drag} should be at the top of the viewport (top_byte={top_byte_after_drag})"
+        "Cursor should not have been relocated to the viewport top (top_byte={top_byte_after_drag})"
     );
 }
 


### PR DESCRIPTION
Fixes #3192.

## The asymmetry

Dragging the vertical scrollbar thumb — or clicking its track — relocated the text cursor to the first line of the freshly scrolled viewport whenever the scroll had left it off-screen. The mouse wheel never did: `scroll_split_by_lines` moves the viewport, sets `skip_ensure_visible`, and stops there.

Both scrollbar handlers finished by calling `move_cursor_to_visible_area`, and that call is the whole of the difference. Scrolling is a viewport operation; it does not get to mutate the buffer's cursor.

The relocation was also silent. The status bar keeps reporting the old `Ln`/`Col` until the next keypress, so the first character typed after a drag joined a line the user never navigated to — and a save wrote it there.

## The change

Both call sites are removed. `move_cursor_to_visible_area` had no other callers anywhere in the workspace, so it goes with them, along with the two comments in `click_handlers.rs` that pointed at it.

`skip_ensure_visible` was already being set immediately before each call, and now does the work it was set for: the render pass leaves the scrolled viewport alone, and the next key press clears the flag (`app/input.rs`) so cursor motion scrolls the view back — exactly what happens after a wheel scroll today.

## Correction to the reported root cause

The issue analysis named lines 412 and 596 as `handle_scrollbar_drag_relative` and `handle_composite_scrollbar_drag_relative`. Line 596 is actually the tail of **`handle_scrollbar_jump`** (the track click). The composite-buffer handlers never called the cursor fixup at all, so composite/diff views were already behaving like the wheel. Both regular-buffer paths are fixed here; the track jump gets its own regression test.

## Tests

`crates/fresh-editor/tests/e2e/issue_3192_scrollbar_drag_cursor.rs` drives the thumb drag, the track jump, and the wheel as the control that was always correct. All three make the same assertion: scroll until line 10 is off-screen, type, and read *which rendered line the text joined*. Asserting on the status bar alone would pass on the broken build, since the stale status bar is half the bug.

Against `master` the two scrollbar tests fail (the typed text lands on line 982) and the wheel control passes; with the fix all three pass.

**One existing test asserted the old ruling and is inverted, not deleted.** `e2e::mouse::test_scrollbar_drag_updates_cursor_position` existed to require that a drag pulls the cursor to the new `top_byte`, and its doc comment framed the *wheel's* behaviour as the bug ("the cursor stays at its old position … should be moved to somewhere within the newly visible area"). #3192 settles that the other way, so the test now drives the same drag, still requires the viewport to scroll, and requires the cursor to stay put and specifically not to land on `top_byte`. Renamed `test_scrollbar_drag_leaves_cursor_alone`. It was the only test in the suite encoding the old behaviour — CI's first run reported it as the single failure out of 9775.

## Manual verification (tmux, 100x30, `--no-restore`, 1000-line file)

Cursor on `Ln 10`, thumb dragged down, then `ZZZ` + `Ctrl+S`:

| | top line after drag | status bar | `grep -n ZZZ long.txt` |
|---|---|---|---|
| before | 564 | `Ln 10, Col 1` | `563:ZZZline 0563` |
| after | 564 | `Ln 10, Col 1` | `10:ZZZline 0010` |

After the fix the view returns to the cursor on the keypress (top line 8), which is what the wheel control does with the same file: wheel down 60 notches → top line 182, type → top line 8, `10:WWWline 0010`.

Also confirmed with a dense drag (one motion event per row, 35 events including up/down jitter, ~40 ms apart) rather than the five synthetic events in the report: view lands on line 939, cursor stays on line 10, typed text lands on line 10.

## Checks

`cargo fmt --all -- --check` clean, `cargo clippy -p fresh-editor --all-targets` 0 errors, and all 116 tests matching `scrollbar` plus the whole `e2e::mouse` module (45) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MskrzCr84nWPxvotGKACtY