### PR TITLE
Editing a huge single-line file costs the screen, not the line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,12 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
     * A multi-line paste now arrives whole instead of only its last line (#3215)
     * A killed editor leaves it usable instead of exiting straight out of raw mode and the alternate screen (#3197)
     * No longer loses recent scrollback (#3151)
-* **Opening large files**
-    * Huge single-line files (tens of MB) no longer loop or stall for cursor movement, scrolling and paging (#1806)
+* **Large single-line files (minified JSON and friends)**
+    * Opening one no longer loops or stalls for cursor movement, scrolling and paging (#1806)
     * Very large binary/zip files open instantly instead of freezing or risking an out-of-memory crash (#3142, reported by @mommysgoodpuppy)
+    * **Editing one is no longer slow.** A frame, a keystroke and an arrow press now cost the size of the screen rather than the size of the line: on a 19 MB one-line JSON a frame reads ~150 KB instead of ~12 MB, and a keystroke ~180 KB instead of ~14 MB. The scans behind that — where a line starts, where it ends, how many lines are below this one — are bounded, and a stretch already found to hold no line break is remembered rather than re-walked on every frame
+    * With **soft wrap off**, a logical line is now one visual row, so a file with no line breaks draws one row and `Down` has nowhere to go — turn soft wrap on to read such a file vertically. Rows used to be chopped at a fixed 10,000 columns, which put ~400,000 characters through layout to draw ~4,800 and left the viewport and the renderer counting rows differently
+    * Plugin decorations that consume source lines (blame, live diff, compose reflow) are bounded to the visible text on such a file, so a plugin can no longer make a frame read the line
 * **Wave screensaver** now ends when you return to the window (or the GUI window), not just on the next keypress (#3204)
 * **`deno.json`** no longer disables TypeScript on a project without Deno (#2981, reported by @atk)
 * **Keymap chords** - a single-key binding on a chord prefix now fires, and deleting a keybinding frees the key (#3171)

--- a/crates/fresh-editor-core/src/config.rs
+++ b/crates/fresh-editor-core/src/config.rs
@@ -1163,9 +1163,15 @@ pub struct EditorConfig {
     /// from its background, the one inside it two thirds, and the third
     /// row in normally. Constant, not animated — the same rows are
     /// shaded whether the view is moving or still, so scrolling is a
-    /// plain shift of the text through a fixed gradient. The top edge
-    /// only shades when there is something above it, so the first lines
-    /// of a file are not dimmed for no reason.
+    /// plain shift of the text through a fixed gradient.
+    ///
+    /// An edge shades only where there is something beyond it to trail off
+    /// into, so the first and last lines of a file are not dimmed for no
+    /// reason, and neither is a file that fits its pane. An edge whose facts
+    /// are missing — a pane with no scrollbar, or a file too large to count
+    /// lines on — is left alone rather than shaded on a guess. So is the edge
+    /// the cursor is sitting in: the shading helps reading, and the line being
+    /// edited is the one line the reader is certainly looking at.
     #[serde(default = "default_true")]
     #[schemars(extend("x-section" = "Display"))]
     pub viewport_edge_fade: bool,

--- a/crates/fresh-editor-core/src/counters.rs
+++ b/crates/fresh-editor-core/src/counters.rs
@@ -1,8 +1,12 @@
-//! Global performance counters for observability and testing.
+//! Performance counters for observability and testing.
 //!
-//! Atomic counters that can be incremented from anywhere and read/reset in tests.
-//! All operations use relaxed ordering — these are best-effort metrics, not
-//! synchronization primitives.
+//! Two kinds, for two different questions:
+//!
+//! * [`Counters`] — process-global atomics for I/O that happens on whatever
+//!   thread does it (disk reads, recovery chunks). Relaxed ordering: these are
+//!   best-effort metrics, not synchronization primitives.
+//! * [`work`] — per-thread counters for the layout path, where a test needs to
+//!   measure exactly the work *it* caused.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::LazyLock;
@@ -53,5 +57,70 @@ impl Counters {
 
     pub fn get_disk_bytes_read(&self) -> u64 {
         self.disk_bytes_read.load(Ordering::Relaxed)
+    }
+}
+
+/// Per-thread work counters for the layout path.
+///
+/// The question these answer is "did this operation stay bounded by the
+/// screen?": a frame, a keystroke or a scroll step should touch a few
+/// screenfuls of text whatever the file's size, and a figure that tracks the
+/// file instead is the signature of a per-line or whole-file scan — the cost
+/// the large-file paths exist to avoid. Tests assert on these rather than on
+/// the clock, so they mean the same on a loaded CI runner as on an idle
+/// laptop.
+///
+/// **Per thread, not global**, unlike [`Counters`] above. Editing and
+/// rendering are synchronous on the thread that drives them, so a test that
+/// resets and reads these observes exactly its own work — no interference
+/// from tests running beside it in the same process under `cargo test`, and
+/// no atomic in a path that runs once per token.
+pub mod work {
+    use std::cell::Cell;
+
+    thread_local! {
+        static BUFFER_BYTES_READ: Cell<u64> = const { Cell::new(0) };
+        static TEXT_BYTES_SEGMENTED: Cell<u64> = const { Cell::new(0) };
+        static TEXT_BYTES_MEASURED: Cell<u64> = const { Cell::new(0) };
+    }
+
+    /// Bytes handed out by `TextBuffer`'s range reads on this thread.
+    pub fn buffer_bytes_read() -> u64 {
+        BUFFER_BYTES_READ.with(|c| c.get())
+    }
+
+    /// Bytes put through UAX #29 grapheme segmentation by the view pipeline
+    /// on this thread. Text that reaches the segmenter but never reaches the
+    /// screen is per-frame waste.
+    pub fn text_bytes_segmented() -> u64 {
+        TEXT_BYTES_SEGMENTED.with(|c| c.get())
+    }
+
+    /// Bytes whose display width the wrap machine measured on this thread
+    /// ([`visual_layout::visual_width`](crate::primitives::visual_layout::visual_width)).
+    /// Measuring the same run twice is pure waste, and on a long token it is
+    /// the frame's second-largest cost after the split itself.
+    pub fn text_bytes_measured() -> u64 {
+        TEXT_BYTES_MEASURED.with(|c| c.get())
+    }
+
+    pub fn add_text_bytes_measured(n: u64) {
+        TEXT_BYTES_MEASURED.with(|c| c.set(c.get().wrapping_add(n)));
+    }
+
+    pub fn add_buffer_bytes_read(n: u64) {
+        BUFFER_BYTES_READ.with(|c| c.set(c.get().wrapping_add(n)));
+    }
+
+    pub fn add_text_bytes_segmented(n: u64) {
+        TEXT_BYTES_SEGMENTED.with(|c| c.set(c.get().wrapping_add(n)));
+    }
+
+    /// Zero this thread's counters. Call immediately before the operation
+    /// under measurement.
+    pub fn reset() {
+        BUFFER_BYTES_READ.with(|c| c.set(0));
+        TEXT_BYTES_SEGMENTED.with(|c| c.set(0));
+        TEXT_BYTES_MEASURED.with(|c| c.set(0));
     }
 }

--- a/crates/fresh-editor-core/src/model/buffer/mod.rs
+++ b/crates/fresh-editor-core/src/model/buffer/mod.rs
@@ -1031,11 +1031,11 @@ impl TextBuffer {
             return self.piece_tree.cursor_at_offset(offset);
         }
 
-        // Mark as modified (updates version)
-        self.mark_content_modified();
-
         // Count line feeds in the text to insert
         let line_feed_cnt = Some(text.iter().filter(|&&b| b == b'\n').count());
+
+        // Mark as modified (updates version)
+        self.mark_content_modified();
 
         // Optimization: try to append to existing buffer if insertion is at piece boundary
         let (buffer_location, buffer_offset, text_len) =
@@ -1336,6 +1336,7 @@ impl TextBuffer {
             }
         }
 
+        crate::counters::work::add_buffer_bytes_read(result.len() as u64);
         Some(result)
     }
 
@@ -1452,6 +1453,7 @@ impl TextBuffer {
             );
         }
 
+        crate::counters::work::add_buffer_bytes_read(result.len() as u64);
         Ok(result)
     }
 
@@ -3292,6 +3294,281 @@ impl TextBuffer {
         }
 
         len
+    }
+
+    /// Fill in the piece tree's line-feed count for `view`, if it is unknown
+    /// and the piece's bytes are already in hand, and report what is known.
+    ///
+    /// The tree carries a count of `\n` per piece — that is what makes
+    /// `line_count` and line-number lookup possible — and leaves it `None`
+    /// for a piece nobody has read. The scans below read pieces as they walk,
+    /// so they are exactly the place to answer the question the tree is
+    /// missing: counting a resident piece costs one pass over bytes that were
+    /// loaded anyway, and every later frame that reaches this piece gets its
+    /// answer from metadata instead of walking it again. Knowledge recorded
+    /// this way also survives editing, because the tree already maintains
+    /// these counts across inserts and deletes.
+    ///
+    /// `None` means still unknown, and unknown is never treated as zero: a
+    /// piece that is not loaded, that reaches past its buffer, or that is too
+    /// large to sweep in one go is left alone for the bounded scan to handle.
+    fn index_piece_line_feeds(&mut self, view: &PieceView) -> Option<usize> {
+        if let Some(known) = view.line_feed_cnt {
+            return Some(known);
+        }
+        // A piece larger than a load chunk is a region nobody has faulted in
+        // yet; sweeping it would be the unbounded read this whole path exists
+        // to avoid.
+        if view.bytes == 0 || view.bytes > LOAD_CHUNK_SIZE {
+            return None;
+        }
+        let lo = view.buffer_offset;
+        let hi = lo.checked_add(view.bytes)?;
+        let count = {
+            let data = self
+                .buffers
+                .get(view.location.buffer_id())
+                .and_then(|b| b.get_data())?;
+            if hi > data.len() {
+                return None;
+            }
+            crate::counters::work::add_buffer_bytes_read(view.bytes as u64);
+            data[lo..hi].iter().filter(|&&b| b == b'\n').count()
+        };
+        self.piece_tree
+            .set_leaf_line_feeds_at(view.doc_offset, view.bytes, count);
+        Some(count)
+    }
+
+    /// Byte just past the next `\n` at or after `from`, searching at most `cap`
+    /// bytes — the start of the next line, without reading the line.
+    ///
+    /// `None` means no line break within `cap` bytes (or the buffer ends
+    /// first). The cap is not optional: on a file that is one enormous line an
+    /// unbounded search is a scan of the whole file, and the callers here —
+    /// scroll clamping, row counting, cursor visibility — run several times per
+    /// keystroke.
+    ///
+    /// Scans the piece tree's own storage rather than copying a range out of
+    /// it, so answering "where does this line end" costs the bytes it walks and
+    /// nothing else. A lazily-loaded chunk is loaded as the scan reaches it,
+    /// exactly as a read would, and no further. Pieces the tree already knows
+    /// to hold no line feed are stepped over without reading them at all, and
+    /// pieces it does not know about are counted on the way past — so on a file
+    /// that is one enormous line this search stops repeating itself.
+    pub fn next_line_start_within(&mut self, from: usize, cap: usize) -> Option<usize> {
+        let total = self.total_bytes();
+        if from >= total || cap == 0 {
+            return None;
+        }
+        let end = from.saturating_add(cap).min(total);
+        let mut pos = from;
+
+        while pos < end {
+            let mut advanced = false;
+            for view in self.piece_tree.iter_pieces_in_range(pos, end) {
+                let piece_start = view.doc_offset;
+                let piece_end = piece_start + view.bytes;
+
+                // Already answered by the tree: step over the piece without
+                // reading a byte of it, and without faulting it in.
+                if view.line_feed_cnt == Some(0) {
+                    if piece_end > pos {
+                        pos = piece_end;
+                        advanced = true;
+                    }
+                    continue;
+                }
+
+                let buffer_id = view.location.buffer_id();
+                let needs_loading = self
+                    .buffers
+                    .get(buffer_id)
+                    .map(|b| !b.is_loaded())
+                    .unwrap_or(false);
+                if needs_loading {
+                    // Splitting invalidates the piece list; restart the walk
+                    // from where it got to, as `get_text_range_mut` does.
+                    match self.chunk_split_and_load(&view, pos) {
+                        Ok(true) => {
+                            advanced = true;
+                            break;
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::warn!("next_line_start_within: load failed: {e}");
+                            return None;
+                        }
+                    }
+                }
+
+                if self.index_piece_line_feeds(&view) == Some(0) {
+                    if piece_end > pos {
+                        pos = piece_end;
+                        advanced = true;
+                    }
+                    continue;
+                }
+
+                let scan_start = pos.max(piece_start);
+                let scan_end = end.min(piece_end);
+                if scan_end <= scan_start {
+                    continue;
+                }
+                let Some(data) = self.buffers.get(buffer_id).and_then(|b| b.get_data()) else {
+                    continue;
+                };
+                let lo = view.buffer_offset + (scan_start - piece_start);
+                let hi = view.buffer_offset + (scan_end - piece_start);
+                if hi > data.len() {
+                    continue;
+                }
+                crate::counters::work::add_buffer_bytes_read((hi - lo) as u64);
+                if let Some(i) = data[lo..hi].iter().position(|&b| b == b'\n') {
+                    return Some(scan_start + i + 1);
+                }
+                pos = scan_end;
+                advanced = true;
+            }
+            if !advanced {
+                break;
+            }
+        }
+
+        None
+    }
+
+    /// Start of the line containing `from`, searching back at most `cap` bytes.
+    ///
+    /// `None` means the line began more than `cap` bytes above — on the files
+    /// this exists for, that means "further up than anything you are about to
+    /// draw or measure". The forward twin is
+    /// [`next_line_start_within`](Self::next_line_start_within); like it, this
+    /// scans the piece tree's storage rather than copying a range out of it,
+    /// steps over pieces already known to hold no line feed, and records what
+    /// it learns about the ones it does read.
+    pub fn prev_line_start_within(&mut self, from: usize, cap: usize) -> Option<usize> {
+        let from = from.min(self.total_bytes());
+        if from == 0 {
+            return Some(0);
+        }
+        let floor = from.saturating_sub(cap);
+        let mut pos = from;
+
+        while pos > floor {
+            let mut advanced = false;
+            // Collected front-to-back, walked back-to-front: the line start is
+            // the *last* newline before `pos`.
+            let views: Vec<_> = self.piece_tree.iter_pieces_in_range(floor, pos).collect();
+            for view in views.into_iter().rev() {
+                let piece_start = view.doc_offset;
+
+                if view.line_feed_cnt == Some(0) {
+                    if piece_start < pos {
+                        pos = piece_start.max(floor);
+                        advanced = true;
+                    }
+                    continue;
+                }
+
+                let buffer_id = view.location.buffer_id();
+                let needs_loading = self
+                    .buffers
+                    .get(buffer_id)
+                    .map(|b| !b.is_loaded())
+                    .unwrap_or(false);
+                if needs_loading {
+                    match self.chunk_split_and_load(&view, view.doc_offset.max(floor)) {
+                        Ok(true) => {
+                            advanced = true;
+                            break;
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            tracing::warn!("prev_line_start_within: load failed: {e}");
+                            return None;
+                        }
+                    }
+                }
+
+                if self.index_piece_line_feeds(&view) == Some(0) {
+                    if piece_start < pos {
+                        pos = piece_start.max(floor);
+                        advanced = true;
+                    }
+                    continue;
+                }
+
+                let scan_start = floor.max(piece_start);
+                let scan_end = pos.min(piece_start + view.bytes);
+                if scan_end <= scan_start {
+                    continue;
+                }
+                let Some(data) = self.buffers.get(buffer_id).and_then(|b| b.get_data()) else {
+                    continue;
+                };
+                let lo = view.buffer_offset + (scan_start - piece_start);
+                let hi = view.buffer_offset + (scan_end - piece_start);
+                if hi > data.len() {
+                    continue;
+                }
+                crate::counters::work::add_buffer_bytes_read((hi - lo) as u64);
+                if let Some(i) = data[lo..hi].iter().rposition(|&b| b == b'\n') {
+                    return Some(scan_start + i + 1);
+                }
+                pos = scan_start;
+                advanced = true;
+            }
+            if !advanced {
+                break;
+            }
+        }
+
+        (floor == 0).then_some(0)
+    }
+
+    /// Whether the piece tree already knows `range` holds no `\n`.
+    ///
+    /// Answered from the per-piece line-feed counts the tree maintains, so it
+    /// reads no buffer data and faults in no lazily-loaded chunk; a piece
+    /// whose count is unknown makes the answer `false` rather than a guess.
+    /// The counts are filled in by whatever walked the region first — see
+    /// [`next_line_start_within`](Self::next_line_start_within) — which is why
+    /// this is worth asking at all on a file that is one enormous line.
+    ///
+    /// Public so the probes that only have `&Buffer` — the fold and
+    /// indentation-guide line scans — can skip a region the render path has
+    /// already been through.
+    pub fn known_newline_free(&self, range: Range<usize>) -> bool {
+        range.start < range.end && self.piece_tree.range_line_feed_free(range.start, range.end)
+    }
+
+    /// Walk `lines` line starts forward from `from`, spending at most
+    /// `total_cap` bytes of scanning, and report the byte reached.
+    ///
+    /// The question "where does the window starting here end" — asked by
+    /// cursor-visibility clamping and by anything that highlights the visible
+    /// region — answered without materialising a single line. A walk that runs
+    /// out of budget or line breaks returns as far as it looked, which is the
+    /// honest answer for a file whose next line break is megabytes away: the
+    /// window extends at least that far.
+    pub fn advance_lines_within(&mut self, from: usize, lines: usize, total_cap: usize) -> usize {
+        let total = self.total_bytes();
+        let mut pos = from.min(total);
+        let mut budget = total_cap;
+        for _ in 0..lines {
+            if budget == 0 {
+                break;
+            }
+            match self.next_line_start_within(pos, budget) {
+                Some(next) => {
+                    budget = budget.saturating_sub(next - pos);
+                    pos = next;
+                }
+                None => return pos.saturating_add(budget).min(total),
+            }
+        }
+        pos
     }
 
     /// Create a line iterator starting at the given byte position

--- a/crates/fresh-editor-core/src/model/buffer/property_tests.rs
+++ b/crates/fresh-editor-core/src/model/buffer/property_tests.rs
@@ -429,3 +429,129 @@ fn test_detect_binary_executable_formats() {
     let pe_header: &[u8] = &[0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00];
     assert!(is_detected_as_binary(pe_header));
 }
+
+/// Where a naive scan of the bytes says the next line starts, under the exact
+/// contract of [`TextBuffer::next_line_start_within`].
+fn shadow_next_line_start(text: &[u8], from: usize, cap: usize) -> Option<usize> {
+    if from >= text.len() || cap == 0 {
+        return None;
+    }
+    let end = from.saturating_add(cap).min(text.len());
+    text[from..end]
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|i| from + i + 1)
+}
+
+/// The backward twin, under the contract of
+/// [`TextBuffer::prev_line_start_within`]: the buffer start is a line start,
+/// and out of reach is `None`.
+fn shadow_prev_line_start(text: &[u8], from: usize, cap: usize) -> Option<usize> {
+    let from = from.min(text.len());
+    if from == 0 {
+        return Some(0);
+    }
+    let floor = from.saturating_sub(cap);
+    if let Some(i) = text[floor..from].iter().rposition(|&b| b == b'\n') {
+        return Some(floor + i + 1);
+    }
+    (floor == 0).then_some(0)
+}
+
+proptest! {
+    /// The line-feed counts the bounded searches write into the piece tree
+    /// agree with the bytes, after any sequence of edits.
+    ///
+    /// These searches do not only read the tree's per-piece line-feed counts,
+    /// they fill them in — the same counts `line_count` and line-number lookup
+    /// are computed from. So a count recorded from a piece and then carried
+    /// across an edit is now load-bearing for correctness, not just for speed,
+    /// and a wrong one is silent: line numbering drifts, or a search reports no
+    /// line break in a stretch that has one.
+    ///
+    /// The searches are run *between* the edits as well as after them, because
+    /// a count that is never recorded can never be stale — the bug this guards
+    /// against needs the buffer to have learnt something first.
+    #[test]
+    fn prop_recorded_line_feed_counts_agree_with_the_bytes(
+        operations in operation_strategy(),
+        probes in prop::collection::vec((0usize..300, 1usize..300), 1..8),
+        forget_counts in any::<bool>(),
+    ) {
+        let mut buffer = TextBuffer::from_bytes(b"line1\nline2\nline3".to_vec(), test_fs());
+
+        // A buffer built from memory knows every piece's line-feed count
+        // already, so the searches only ever *read* the tree — the recording
+        // path, which is the new one, would never run. Splitting the leaves
+        // puts the tree in the state a lazily-loaded file is in: many small
+        // pieces, none of them counted, exactly what the searches are there to
+        // fill in.
+        if forget_counts {
+            buffer.piece_tree.split_leaves_to_chunk_size(8);
+        }
+
+        // One round of probing before any edit, so the tree has counts to carry.
+        for &(from, cap) in &probes {
+            let _ = buffer.next_line_start_within(from, cap);
+            let _ = buffer.prev_line_start_within(from, cap);
+        }
+
+        for op in operations {
+            match op {
+                Operation::Insert { offset, text } => {
+                    let offset = offset.min(buffer.total_bytes());
+                    buffer.insert_bytes(offset, text);
+                }
+                Operation::Delete { offset, bytes } => {
+                    buffer.delete_bytes(offset, bytes);
+                }
+            }
+
+            let text = buffer.get_all_text().expect("in-memory buffer is loaded");
+
+            // The tree's own line index, which the searches write into. It is
+            // allowed not to know — a piece nobody has read has no count — but
+            // when it claims to, it has to be right.
+            let newlines = text.iter().filter(|&&b| b == b'\n').count();
+            if let Some(lines) = buffer.line_count() {
+                prop_assert_eq!(
+                    lines,
+                    newlines + 1,
+                    "line_count disagrees with the bytes after an edit"
+                );
+            }
+
+            for &(from, cap) in &probes {
+                let from = from.min(text.len());
+
+                prop_assert_eq!(
+                    buffer.next_line_start_within(from, cap),
+                    shadow_next_line_start(&text, from, cap),
+                    "next_line_start_within({}, {}) disagrees with a scan of the bytes",
+                    from,
+                    cap
+                );
+                prop_assert_eq!(
+                    buffer.prev_line_start_within(from, cap),
+                    shadow_prev_line_start(&text, from, cap),
+                    "prev_line_start_within({}, {}) disagrees with a scan of the bytes",
+                    from,
+                    cap
+                );
+
+                // Claiming a stretch holds no line break is a claim about the
+                // bytes; it may say "don't know" (false), never a falsehood.
+                let end = from.saturating_add(cap);
+                if buffer.known_newline_free(from..end) {
+                    let end = end.min(text.len());
+                    prop_assert!(
+                        !text[from..end].contains(&b'\n'),
+                        "known_newline_free({}..{}) over a stretch that has one",
+                        from,
+                        end
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/fresh-editor-core/src/model/buffer/tests.rs
+++ b/crates/fresh-editor-core/src/model/buffer/tests.rs
@@ -2121,6 +2121,135 @@ mod rebuild_pristine_saved_root_tests {
         }
     }
 
+    /// `next_line_start_within` answers where the next line begins without
+    /// reading the line — the property every scroll and row-counting caller
+    /// needs on a file whose "line" is the whole file.
+    #[test]
+    fn next_line_start_reads_only_what_it_scans() {
+        let mut buf = TextBuffer::from_str_test("one\ntwo\nthree");
+
+        assert_eq!(buf.next_line_start_within(0, 64), Some(4));
+        assert_eq!(buf.next_line_start_within(4, 64), Some(8));
+        // Scanning from inside a line finds that line's own break.
+        assert_eq!(buf.next_line_start_within(5, 64), Some(8));
+        // The last line has no terminator.
+        assert_eq!(buf.next_line_start_within(8, 64), None);
+        // Past the end.
+        assert_eq!(buf.next_line_start_within(99, 64), None);
+    }
+
+    /// The cap is the whole point: a search that runs past it reports "no line
+    /// break in reach" rather than walking the file.
+    #[test]
+    fn next_line_start_stops_at_the_cap() {
+        let mut content = "x".repeat(10_000);
+        content.push('\n');
+        content.push_str("after");
+        let mut buf = TextBuffer::from_str_test(&content);
+
+        assert_eq!(buf.next_line_start_within(0, 100), None);
+        assert_eq!(buf.next_line_start_within(0, 20_000), Some(10_001));
+
+        // And it costs what it scans, not what the line contains.
+        crate::counters::work::reset();
+        assert_eq!(buf.next_line_start_within(0, 100), None);
+        let read = crate::counters::work::buffer_bytes_read();
+        assert!(
+            read <= 100,
+            "a 100-byte capped scan read {read} bytes of a {} byte line",
+            content.len()
+        );
+    }
+
+    /// On the lazily-loaded path the scan pulls chunks as it reaches them and
+    /// no further — the same laziness a read has, without the copy.
+    #[test]
+    fn next_line_start_on_an_unloaded_buffer_loads_only_what_it_reaches() {
+        // 4 MB with a newline early on, so the answer is a long way from the
+        // end of the file.
+        let mut content = vec![b'x'; 4 * 1024 * 1024];
+        content[1000] = b'\n';
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), &content).unwrap();
+        let mut buf = large_file_buffer_unloaded(tmp.path(), content.len());
+
+        assert_eq!(buf.next_line_start_within(0, 64 * 1024), Some(1001));
+        assert!(
+            buf.resident_bytes() < content.len(),
+            "the scan pulled the whole file in ({} of {} bytes resident)",
+            buf.resident_bytes(),
+            content.len()
+        );
+
+        // No newline within the cap further in: still bounded.
+        assert_eq!(buf.next_line_start_within(2_000_000, 4096), None);
+    }
+
+    /// The backward twin: the start of the line containing a byte, bounded.
+    #[test]
+    fn prev_line_start_is_bounded_and_exact_within_the_bound() {
+        let mut buf = TextBuffer::from_str_test("one\ntwo\nthree");
+
+        assert_eq!(buf.prev_line_start_within(0, 64), Some(0));
+        assert_eq!(buf.prev_line_start_within(2, 64), Some(0));
+        assert_eq!(buf.prev_line_start_within(4, 64), Some(4));
+        assert_eq!(buf.prev_line_start_within(6, 64), Some(4));
+        assert_eq!(buf.prev_line_start_within(10, 64), Some(8));
+
+        // Out of reach: a line whose start is further back than the cap.
+        let long = "x".repeat(10_000);
+        let mut buf = TextBuffer::from_str_test(&long);
+        assert_eq!(buf.prev_line_start_within(9_000, 100), None);
+        assert_eq!(buf.prev_line_start_within(9_000, 20_000), Some(0));
+    }
+
+    /// A stretch known to hold no line break is not walked to find that out —
+    /// the question every layout pass asks about a file with no line structure
+    /// — and editing inside it does not make the editor forget.
+    ///
+    /// A buffer built from memory has its per-piece line-feed counts from the
+    /// start, so here the search never has to read anything at all; on a
+    /// lazily-loaded file it reads each piece once and then behaves like this.
+    /// Either way the answer comes from the piece tree, and the tree carries it
+    /// across edits.
+    #[test]
+    fn a_newline_free_stretch_survives_edits_that_cannot_add_a_break() {
+        let content = "x".repeat(200_000);
+        let mut buf = TextBuffer::from_str_test(&content);
+
+        crate::counters::work::reset();
+        assert_eq!(buf.next_line_start_within(0, 100_000), None);
+        assert_eq!(
+            crate::counters::work::buffer_bytes_read(),
+            0,
+            "the tree already counts the line feeds in this piece; the search \
+             must not re-derive that by reading it"
+        );
+
+        // Typing a character cannot introduce a line break, so the answer is
+        // still known — this is the keystroke case, where re-walking would cost
+        // a quarter of a megabyte per press.
+        buf.insert(10, "y");
+        crate::counters::work::reset();
+        assert_eq!(buf.next_line_start_within(0, 100_000), None);
+        assert_eq!(
+            crate::counters::work::buffer_bytes_read(),
+            0,
+            "an insertion with no newline in it must not cost a rescan"
+        );
+
+        // Deleting cannot introduce one either.
+        buf.delete(10..11);
+        crate::counters::work::reset();
+        assert_eq!(buf.next_line_start_within(0, 100_000), None);
+        assert_eq!(crate::counters::work::buffer_bytes_read(), 0);
+
+        // But an inserted newline is noticed, which is the whole correctness
+        // requirement.
+        buf.insert(50, "\n");
+        assert_eq!(buf.next_line_start_within(0, 100_000), Some(51));
+    }
+
     #[test]
     fn test_unloaded_buffer_no_edits_line_count() {
         let content = make_content(2 * 1024 * 1024);
@@ -3131,4 +3260,152 @@ fn find_all_in_range_skips_overlapping_matches() {
     assert!(buffer
         .find_all_in_range("", 0..buffer.len(), usize::MAX)
         .is_empty());
+}
+
+/// A stretch the line-break search has already walked is not walked again —
+/// and staying knowledgeable about one stretch does not cost the answer for
+/// another.
+///
+/// On a file that is one enormous line, every layout question ends in the same
+/// search ("is there a line break within reach?"), several times per frame and
+/// per keystroke, and the answer is always no. The search records what it
+/// learns on the piece tree's own per-piece line-feed counts as it crosses
+/// them, so the second frame asks the tree instead of the file. Because the
+/// record is per piece rather than one remembered span, scrolling to a distant
+/// part of the file and back does not put the first stretch back to unknown.
+#[test]
+fn a_walked_stretch_is_not_walked_twice() {
+    let file_size = LOAD_CHUNK_SIZE * 3;
+    // One line: no break anywhere in three megabytes.
+    let content = vec![b'x'; file_size];
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &content).unwrap();
+
+    let buffer = crate::model::piece_tree::StringBuffer::new_unloaded(
+        0,
+        tmp.path().to_path_buf(),
+        0,
+        file_size,
+    );
+    let piece_tree = PieceTree::new(BufferLocation::Stored(0), 0, file_size, None);
+    let saved_root = piece_tree.root();
+    let mut buf = TextBuffer {
+        piece_tree,
+        buffers: vec![buffer],
+        next_buffer_id: 1,
+        persistence: Persistence::new(
+            test_fs(),
+            Some(tmp.path().to_path_buf()),
+            saved_root,
+            Some(file_size),
+        ),
+        file_kind: BufferFileKind::new(true, false),
+        format: BufferFormat::new(LineEnding::LF, Encoding::Utf8),
+        version: 0,
+        config: BufferConfig::default(),
+    };
+
+    let cap = 256 * 1024;
+    let far = LOAD_CHUNK_SIZE * 2 + 1000;
+
+    // Walk near the start, then near the far end — two separate regions.
+    assert_eq!(buf.next_line_start_within(0, cap), None);
+    assert_eq!(buf.next_line_start_within(far, cap), None);
+
+    // Ask about the first region again. Nothing about the file has changed and
+    // nothing about it needs re-reading.
+    crate::counters::work::reset();
+    assert_eq!(buf.next_line_start_within(0, cap), None);
+    let reread = crate::counters::work::buffer_bytes_read();
+    assert_eq!(
+        reread, 0,
+        "re-asking where the first line break is read {reread} bytes; the search \
+         already walked this stretch and recorded that it holds none"
+    );
+
+    // And the far region, which was walked second.
+    crate::counters::work::reset();
+    assert_eq!(buf.next_line_start_within(far, cap), None);
+    let reread = crate::counters::work::buffer_bytes_read();
+    assert_eq!(
+        reread, 0,
+        "re-asking at the far end read {reread} bytes; both stretches are known, \
+         not just the most recent one"
+    );
+
+    // Backwards is the same search and shares the same knowledge. Starting far
+    // enough in that the search window does not reach byte 0, which is itself a
+    // line start and would end the search on structure rather than knowledge.
+    crate::counters::work::reset();
+    assert_eq!(buf.prev_line_start_within(cap * 2, cap), None);
+    let reread = crate::counters::work::buffer_bytes_read();
+    assert_eq!(
+        reread, 0,
+        "searching backwards over an already-walked stretch read {reread} bytes"
+    );
+}
+
+/// What the search learnt survives typing, including typing somewhere else.
+///
+/// Inserting text with no line break in it cannot introduce one, and the piece
+/// tree already knows how to carry line-feed counts across an edit: the pieces
+/// the insertion splits get counted from the text that made them, and every
+/// piece it did not touch keeps the count it had. So a keystroke near the top
+/// of a huge line does not make the frame rediscover the rest of it.
+#[test]
+fn typing_does_not_forget_where_the_line_breaks_are_not() {
+    let file_size = LOAD_CHUNK_SIZE * 3;
+    let content = vec![b'x'; file_size];
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), &content).unwrap();
+
+    let buffer = crate::model::piece_tree::StringBuffer::new_unloaded(
+        0,
+        tmp.path().to_path_buf(),
+        0,
+        file_size,
+    );
+    let piece_tree = PieceTree::new(BufferLocation::Stored(0), 0, file_size, None);
+    let saved_root = piece_tree.root();
+    let mut buf = TextBuffer {
+        piece_tree,
+        buffers: vec![buffer],
+        next_buffer_id: 1,
+        persistence: Persistence::new(
+            test_fs(),
+            Some(tmp.path().to_path_buf()),
+            saved_root,
+            Some(file_size),
+        ),
+        file_kind: BufferFileKind::new(true, false),
+        format: BufferFormat::new(LineEnding::LF, Encoding::Utf8),
+        version: 0,
+        config: BufferConfig::default(),
+    };
+
+    let cap = 256 * 1024;
+    // The stretch the viewport is looking at, well past the start of the file.
+    let viewport = LOAD_CHUNK_SIZE * 2 + 1000;
+    assert_eq!(buf.next_line_start_within(viewport, cap), None);
+
+    // Type a character somewhere else entirely — a megabyte above.
+    buf.insert_bytes(1000, b"h".to_vec());
+
+    crate::counters::work::reset();
+    assert_eq!(buf.next_line_start_within(viewport + 1, cap), None);
+    let reread = crate::counters::work::buffer_bytes_read();
+    assert_eq!(
+        reread, 0,
+        "a keystroke a megabyte away cost the viewport {reread} bytes of \
+         rediscovering that the line it is drawing still has no break in it"
+    );
+
+    // An inserted break is found, though — knowledge is not a licence to lie.
+    buf.insert_bytes(viewport + 100, b"\n".to_vec());
+    assert_eq!(
+        buf.next_line_start_within(viewport + 1, cap),
+        Some(viewport + 101)
+    );
 }

--- a/crates/fresh-editor-core/src/model/piece_tree.rs
+++ b/crates/fresh-editor-core/src/model/piece_tree.rs
@@ -541,6 +541,89 @@ impl PieceTreeNode {
         }
     }
 
+    /// Path-copy update of a single leaf's line_feed_cnt, addressed by the
+    /// leaf's own start offset in the document.
+    ///
+    /// The by-index twin is [`update_leaf_lf_by_index`](Self::update_leaf_lf_by_index),
+    /// which costs a `count_leaves` walk per level; a caller that has just
+    /// walked the document knows *where* it was, not which leaf that was, and
+    /// this descends on `left_bytes` in O(depth) instead.
+    ///
+    /// `bytes` is checked against the leaf found there: a count learned by
+    /// reading a piece is only about that exact piece, and if the tree has
+    /// been split or rewritten since, the answer is dropped rather than
+    /// written onto a leaf it was not measured from.
+    fn set_leaf_lf_at(
+        self: &Arc<Self>,
+        doc_offset: usize,
+        bytes: usize,
+        lf_count: usize,
+    ) -> (Arc<Self>, bool) {
+        match self.as_ref() {
+            Self::Leaf {
+                location,
+                offset,
+                bytes: leaf_bytes,
+                line_feed_cnt,
+            } => {
+                if doc_offset != 0 || *leaf_bytes != bytes {
+                    return (Arc::clone(self), false);
+                }
+                if *line_feed_cnt == Some(lf_count) {
+                    // Already known; leave the node alone so structural
+                    // sharing survives.
+                    return (Arc::clone(self), false);
+                }
+                (
+                    Arc::new(Self::Leaf {
+                        location: *location,
+                        offset: *offset,
+                        bytes: *leaf_bytes,
+                        line_feed_cnt: Some(lf_count),
+                    }),
+                    true,
+                )
+            }
+            Self::Internal {
+                left_bytes,
+                lf_left,
+                left,
+                right,
+            } => {
+                if doc_offset < *left_bytes {
+                    let (new_left, found) = left.set_leaf_lf_at(doc_offset, bytes, lf_count);
+                    if !found {
+                        return (Arc::clone(self), false);
+                    }
+                    (
+                        Arc::new(Self::Internal {
+                            left_bytes: *left_bytes,
+                            lf_left: new_left.total_line_feeds(),
+                            left: new_left,
+                            right: Arc::clone(right),
+                        }),
+                        true,
+                    )
+                } else {
+                    let (new_right, found) =
+                        right.set_leaf_lf_at(doc_offset - left_bytes, bytes, lf_count);
+                    if !found {
+                        return (Arc::clone(self), false);
+                    }
+                    (
+                        Arc::new(Self::Internal {
+                            left_bytes: *left_bytes,
+                            lf_left: *lf_left,
+                            left: Arc::clone(left),
+                            right: new_right,
+                        }),
+                        true,
+                    )
+                }
+            }
+        }
+    }
+
     /// Collect all leaves in order
     pub(crate) fn collect_leaves(&self, leaves: &mut Vec<LeafData>) {
         match self {
@@ -1558,6 +1641,53 @@ impl PieceTree {
             let (new_root, _) = self.root.update_leaf_lf_by_index(idx, lf_count);
             self.root = new_root;
         }
+    }
+
+    /// Record that the leaf starting at `doc_offset` and spanning `bytes`
+    /// contains `lf_count` line feeds.
+    ///
+    /// This is how a caller that reads the document as it goes — a viewport
+    /// walking down one enormous line looking for its end — hands back what it
+    /// learned on the way. The tree already carries a line-feed count per
+    /// piece and already maintains it across edits; filling in the pieces the
+    /// reader crossed turns a repeated scan into a question the tree can
+    /// answer from metadata the next time round.
+    ///
+    /// Path-copies only the root-to-leaf path, so `Arc::ptr_eq` still holds
+    /// for every subtree it did not touch, and does nothing at all when the
+    /// count is already known — an unchanged tree is left literally unchanged.
+    /// Returns whether a leaf was updated.
+    pub fn set_leaf_line_feeds_at(
+        &mut self,
+        doc_offset: usize,
+        bytes: usize,
+        lf_count: usize,
+    ) -> bool {
+        if bytes == 0 || doc_offset >= self.total_bytes {
+            return false;
+        }
+        let (new_root, found) = self.root.set_leaf_lf_at(doc_offset, bytes, lf_count);
+        if found {
+            self.root = new_root;
+        }
+        found
+    }
+
+    /// Whether every piece overlapping `[start, end)` is known to hold no
+    /// line feed.
+    ///
+    /// Answered purely from the tree's per-piece counts: no buffer data is
+    /// read, no lazily-loaded chunk is faulted in, and an unknown count
+    /// (`None`) is never mistaken for zero. A piece that overlaps the range
+    /// only partly still settles it — a piece with no line feed anywhere in it
+    /// has none in the part that overlaps.
+    pub fn range_line_feed_free(&self, start: usize, end: usize) -> bool {
+        let end = end.min(self.total_bytes);
+        if start >= end {
+            return true;
+        }
+        self.iter_pieces_in_range(start, end)
+            .all(|p| p.line_feed_cnt == Some(0))
     }
 
     /// Get tree statistics for debugging

--- a/crates/fresh-editor-core/src/primitives/line_iterator.rs
+++ b/crates/fresh-editor-core/src/primitives/line_iterator.rs
@@ -27,6 +27,30 @@ use crate::model::buffer::TextBuffer;
 /// This is generous enough for any practical line while preventing OOM from 10MB+ lines.
 pub const MAX_LINE_BYTES: usize = 100_000;
 
+/// How far back a line start is searched for before the position is treated as
+/// a continuation of a line that began further up.
+///
+/// The search exists to answer "which line is this byte on", and it answered it
+/// exactly, by scanning back to the previous newline however far away it was.
+/// On a file that is one enormous line that is a scan of everything above the
+/// cursor — per call, and the call sites are the status bar, the arrow keys and
+/// the scroll math, i.e. several times per keystroke. Past this bound the
+/// answer stops being worth its cost: a line this long has no useful column
+/// number, its hanging indent is clamped away by the renderer as unusably deep,
+/// and the position is reported in bytes rather than line and column anyway.
+///
+/// Matches `view::row_walk::LINE_START_SEARCH_BYTES`, which bounds the same
+/// search for the same reason on the row-walking path.
+pub const LINE_START_SEARCH_BYTES: usize = 64 * 1024;
+
+/// Bytes read per step of the backward search.
+///
+/// The search used to step by the caller's `estimated_line_length` — 80 bytes
+/// at every call site — so reaching a line start 64 KB up took 800 piece-tree
+/// range queries and 800 allocations. Reading a page at a time costs the same
+/// bytes in 16 queries.
+const LINE_START_SEARCH_CHUNK: usize = 4096;
+
 pub struct LineIterator<'a> {
     buffer: &'a mut TextBuffer,
     /// Current byte position in the document (points to start of current line)
@@ -44,45 +68,72 @@ pub struct LineIterator<'a> {
 }
 
 impl<'a> LineIterator<'a> {
-    /// Scan backward from byte_pos to find the start of the line
-    /// chunk_size: suggested chunk size for loading (used as performance hint only)
-    fn find_line_start_backward(
-        buffer: &mut TextBuffer,
-        byte_pos: usize,
-        chunk_size: usize,
-    ) -> usize {
+    /// Start of the line containing `byte_pos`, searched for over at most
+    /// [`LINE_START_SEARCH_BYTES`].
+    ///
+    /// Returns the search floor when no newline is found within the bound: the
+    /// position is then read as a continuation of a line that started further
+    /// up, which is the same answer `row_walk` gives for the same question.
+    /// Everything downstream stays correct because source offsets are absolute
+    /// — only "this byte begins a line" degrades, and it degrades exactly where
+    /// a line is longer than 64 KB.
+    ///
+    /// The floor is nudged forward to a character boundary first. Where the
+    /// search succeeds the answer follows a `\n` and is a boundary by
+    /// construction; where it runs out of budget the answer is an arbitrary
+    /// byte, and callers read text from it and anchor edits at it. Approximate
+    /// about *which line* is the documented trade; approximate about *which
+    /// character* would put a replacement glyph on screen and let an edit cut a
+    /// character in half.
+    fn find_line_start_backward(buffer: &mut TextBuffer, byte_pos: usize) -> usize {
         if byte_pos == 0 {
             return 0;
         }
 
-        // Scan backward in chunks until we find a newline or reach position 0
-        // The chunk_size is just a hint for performance - we MUST find the actual line start
+        let floor = byte_pos.saturating_sub(LINE_START_SEARCH_BYTES);
         let mut search_end = byte_pos;
 
-        loop {
-            let scan_start = search_end.saturating_sub(chunk_size);
+        while search_end > floor {
+            let scan_start = search_end
+                .saturating_sub(LINE_START_SEARCH_CHUNK)
+                .max(floor);
             let scan_len = search_end - scan_start;
 
-            // Load the chunk we need to scan
             if let Ok(chunk) = buffer.get_text_range_mut(scan_start, scan_len) {
-                // Scan backward through the chunk to find the last newline
-                for i in (0..chunk.len()).rev() {
-                    if chunk[i] == b'\n' {
-                        // Found newline - line starts at the next byte
-                        return scan_start + i + 1;
-                    }
+                if let Some(i) = chunk.iter().rposition(|&b| b == b'\n') {
+                    // Found newline - line starts at the next byte
+                    return scan_start + i + 1;
                 }
             }
 
-            // No newline found in this chunk
             if scan_start == 0 {
                 // Reached the start of the buffer - line starts at 0
                 return 0;
             }
 
-            // Continue searching from earlier position
             search_end = scan_start;
         }
+
+        Self::char_boundary_at_or_after(buffer, floor)
+    }
+
+    /// `pos`, or the next character boundary after it.
+    ///
+    /// UTF-8 continuation bytes are `0b10xxxxxx` and a character is at most
+    /// four bytes, so at most three need stepping over. A read that fails
+    /// leaves `pos` alone: this is a repair, not a place to invent an answer.
+    fn char_boundary_at_or_after(buffer: &mut TextBuffer, pos: usize) -> usize {
+        if pos == 0 || pos >= buffer.len() {
+            return pos;
+        }
+        let Ok(bytes) = buffer.get_text_range_mut(pos, 4.min(buffer.len() - pos)) else {
+            return pos;
+        };
+        let step = bytes
+            .iter()
+            .position(|&b| (b & 0xC0) != 0x80)
+            .unwrap_or(bytes.len());
+        pos + step
     }
 
     pub(crate) fn new(
@@ -114,7 +165,7 @@ impl<'a> LineIterator<'a> {
             // Scan backward from byte_pos to find the start of the line
             // We scan backward looking for a newline character
             // NOTE: We previously tried to use offset_to_position() but it has bugs with column calculation
-            Self::find_line_start_backward(buffer, byte_pos, estimated_line_length)
+            Self::find_line_start_backward(buffer, byte_pos)
         };
 
         let mut pending_trailing_empty_line = false;
@@ -167,6 +218,23 @@ impl<'a> LineIterator<'a> {
             estimated_line_length,
             pending_trailing_empty_line,
             max_line_bytes: MAX_LINE_BYTES,
+        }
+    }
+
+    /// Advance to the start of the next logical line without reading the rest
+    /// of this one, scanning at most `cap` bytes for the line break.
+    ///
+    /// `false` when no break lies within `cap`: the caller has reached a line
+    /// whose end is out of reach, and there is nothing further it can place.
+    /// This is how a reader that has taken all it can draw of one line moves on
+    /// to the next without paying for the part it skipped.
+    pub fn skip_to_next_line_within(&mut self, cap: usize) -> bool {
+        match self.buffer.next_line_start_within(self.current_pos, cap) {
+            Some(next) => {
+                self.current_pos = next;
+                true
+            }
+            None => false,
         }
     }
 
@@ -416,7 +484,7 @@ impl<'a> LineIterator<'a> {
         let prev_line_start = if prev_line_end == 0 {
             0
         } else {
-            Self::find_line_start_backward(self.buffer, prev_line_end, scan_distance)
+            Self::find_line_start_backward(self.buffer, prev_line_end)
         };
 
         // Load the previous line content

--- a/crates/fresh-editor-core/src/primitives/visual_layout.rs
+++ b/crates/fresh-editor-core/src/primitives/visual_layout.rs
@@ -182,6 +182,7 @@ impl LineMappingsBuilder {
 /// This is the canonical function for visual width calculation.
 /// Use this instead of `str_width()` when the text may contain ANSI codes or tabs.
 pub fn visual_width(s: &str, start_col: usize) -> usize {
+    crate::counters::work::add_text_bytes_measured(s.len() as u64);
     if !s.contains('\x1b') && !s.contains('\t') {
         // Fast path: no special handling needed
         return crate::primitives::display_width::str_width(s);

--- a/crates/fresh-editor-core/src/wrap_machine.rs
+++ b/crates/fresh-editor-core/src/wrap_machine.rs
@@ -330,15 +330,22 @@ impl WrapMachine {
     }
 
     fn feed_word_text(&mut self, token: ViewTokenWire, eff: usize) {
-        let text = match &token.kind {
-            ViewTokenWireKind::Text(s) => s.clone(),
-            _ => return,
+        // Borrowed, not cloned: the token is only moved into the row on the
+        // path that doesn't split it, by which point the borrow is dead. A
+        // clone here copied every token of every row, once per frame.
+        let ViewTokenWireKind::Text(text) = &token.kind else {
+            return;
         };
         if self.measuring_indent {
-            self.measure_indent(&text, eff);
+            self.measure_indent(text, eff);
         }
 
-        let text_w = visual_layout::visual_width(&text, self.col);
+        // `visual_width` walks the token's graphemes, so on a long token this
+        // is the frame's second-most expensive step after the split itself.
+        // It is measured from `self.col` because a tab's width depends on
+        // where the run starts, so it is re-measured below only when the
+        // break actually moves the column — not unconditionally.
+        let mut text_w = visual_layout::visual_width(text, self.col);
 
         // Break before a token that overflows, when either it fits on a fresh
         // row (classic word wrap) or the row already carries enough content that
@@ -354,14 +361,15 @@ impl WrapMachine {
             && (text_w <= fresh_capacity || self.col >= row_floor)
         {
             self.emit_break(true);
+            text_w = visual_layout::visual_width(text, self.col);
         }
 
-        let text_w = visual_layout::visual_width(&text, self.col);
-        if self.col + text_w > eff && !ansi::contains_ansi_codes(&text) {
-            self.split_text(&token, &text, eff);
+        if self.col + text_w > eff && !ansi::contains_ansi_codes(text) {
+            self.split_text(&token, text, eff);
         } else {
+            let width = text_w;
             self.row.push(token);
-            self.col += text_w;
+            self.col += width;
         }
     }
 
@@ -1013,5 +1021,58 @@ mod tests {
         let mut sorted = seen.clone();
         sorted.sort_unstable();
         assert_eq!(seen, sorted);
+    }
+
+    /// A token's display width is measured once, not twice.
+    ///
+    /// The break decision and the split decision both need the width, and the
+    /// second measurement existed because `emit_break` moves the column, which
+    /// changes where a tab lands. It only has to be redone when the break
+    /// actually fires — measuring every token twice doubled the cost of the
+    /// wrap machine's second-hottest step on rows that never break at all.
+    #[test]
+    fn a_token_that_fits_is_measured_once() {
+        let token = "hello";
+
+        crate::counters::work::reset();
+        let out = WrapMachine::run(
+            vec![text(token, 0)],
+            WrapRule::Word {
+                content_width: 40,
+                gutter_width: 0,
+                hanging_indent: false,
+            },
+        );
+        let measured = crate::counters::work::text_bytes_measured();
+
+        assert_eq!(out.rows.len(), 1);
+        assert_eq!(
+            measured,
+            token.len() as u64,
+            "a token that fits its row was measured {measured} bytes' worth, \
+             for a {} byte token",
+            token.len()
+        );
+    }
+
+    /// When the break does fire, the width is re-measured against the new
+    /// column — a tab is as wide as the distance to the next tab stop, so
+    /// carrying the pre-break measurement across would mis-wrap the row.
+    #[test]
+    fn a_tab_is_remeasured_after_a_break() {
+        // `content_width` 10, a row already holding 8 columns, then a token
+        // whose width depends on the column it starts at.
+        let out = WrapMachine::run(
+            vec![text("12345678", 0), text("\tx", 8)],
+            WrapRule::Word {
+                content_width: 10,
+                gutter_width: 0,
+                hanging_indent: false,
+            },
+        );
+
+        // The tab token moved to a fresh row, where it is measured from
+        // column 0 rather than column 8.
+        assert_eq!(out.rows.len(), 2, "the tab token should start a new row");
     }
 }

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -404,7 +404,7 @@
           "x-section": "Display"
         },
         "viewport_edge_fade": {
-          "description": "Shade the top and bottom rows of each pane, so text meets the\nedge by fading out rather than being cut off mid-line.\n\nThe row hard against the edge is painted a third of the way up\nfrom its background, the one inside it two thirds, and the third\nrow in normally. Constant, not animated — the same rows are\nshaded whether the view is moving or still, so scrolling is a\nplain shift of the text through a fixed gradient. The top edge\nonly shades when there is something above it, so the first lines\nof a file are not dimmed for no reason.",
+          "description": "Shade the top and bottom rows of each pane, so text meets the\nedge by fading out rather than being cut off mid-line.\n\nThe row hard against the edge is painted a third of the way up\nfrom its background, the one inside it two thirds, and the third\nrow in normally. Constant, not animated — the same rows are\nshaded whether the view is moving or still, so scrolling is a\nplain shift of the text through a fixed gradient.\n\nAn edge shades only where there is something beyond it to trail off\ninto, so the first and last lines of a file are not dimmed for no\nreason, and neither is a file that fits its pane. An edge whose facts\nare missing — a pane with no scrollbar, or a file too large to count\nlines on — is left alone rather than shaded on a guess. So is the edge\nthe cursor is sitting in: the shading helps reading, and the line being\nedited is the one line the reader is certainly looking at.",
           "type": "boolean",
           "default": true,
           "x-section": "Display"

--- a/crates/fresh-editor/src/app/click_geometry.rs
+++ b/crates/fresh-editor/src/app/click_geometry.rs
@@ -294,7 +294,9 @@ pub(crate) fn fold_toggle_byte_from_position(
     }
 
     use crate::view::folding::indent_folding;
-    let line_start = indent_folding::find_line_start_byte(&state.buffer, target_position);
+    // No line start within reach: the click is inside a line too long to have
+    // foldable indentation structure, so there is no fold to toggle.
+    let line_start = indent_folding::find_line_start_byte(&state.buffer, target_position)?;
 
     // Already collapsed → allow toggling (unfold). This stays available even
     // with the indicators hidden: the collapsed line still renders its "..."

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -84,7 +84,22 @@ impl Editor {
         // IMPORTANT: Calculate LSP changes and line info BEFORE applying to buffer!
         // The byte positions in the events are relative to the ORIGINAL buffer,
         // so we must convert them to LSP positions before modifying the buffer.
-        let lsp_changes = self.active_window().collect_lsp_changes(event);
+        //
+        // Only when a server could receive them. Deriving the change set reads
+        // the line up to the cursor to convert byte offsets into LSP's UTF-16
+        // positions, and step 5's empty-set fallback snapshots the whole
+        // document; on a file that is one long line those were 18 MB and the
+        // file respectively, per keystroke, and `send_lsp_changes_for_buffer`
+        // then discarded them because the buffer has no server. Ask first.
+        let lsp_wanted = {
+            let buf = self.active_buffer();
+            self.active_window().lsp_change_could_be_sent(buf)
+        };
+        let lsp_changes = if lsp_wanted {
+            self.active_window().collect_lsp_changes(event)
+        } else {
+            Vec::new()
+        };
 
         // Calculate line info for plugin hooks (using same pre-modification buffer state)
         let line_info = self.active_window().calculate_event_line_info(event);
@@ -234,21 +249,23 @@ impl Editor {
         // collect_lsp_changes returns empty because there are no incremental byte
         // positions to convert — BulkEdit restores a tree snapshot.  Send a
         // full-document replacement so the LSP server stays in sync.
-        if lsp_changes.is_empty() && event.modifies_buffer() {
-            if let Some(full_text) = self.active_state().buffer.to_string() {
-                let full_change = vec![TextDocumentContentChangeEvent {
-                    range: None,
-                    range_length: None,
-                    text: full_text,
-                }];
+        if lsp_wanted {
+            if lsp_changes.is_empty() && event.modifies_buffer() {
+                if let Some(full_text) = self.active_state().buffer.to_string() {
+                    let full_change = vec![TextDocumentContentChangeEvent {
+                        range: None,
+                        range_length: None,
+                        text: full_text,
+                    }];
+                    let buf = self.active_buffer();
+                    self.active_window_mut()
+                        .send_lsp_changes_for_buffer(buf, full_change);
+                }
+            } else {
                 let buf = self.active_buffer();
                 self.active_window_mut()
-                    .send_lsp_changes_for_buffer(buf, full_change);
+                    .send_lsp_changes_for_buffer(buf, lsp_changes);
             }
-        } else {
-            let buf = self.active_buffer();
-            self.active_window_mut()
-                .send_lsp_changes_for_buffer(buf, lsp_changes);
         }
     }
 

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -686,7 +686,7 @@ impl crate::app::window::Window {
             state.buffer.line_start_offset(line).unwrap_or_else(|| {
                 use crate::view::folding::indent_folding;
                 let approx = line * state.buffer.estimated_line_length();
-                indent_folding::find_line_start_byte(&state.buffer, approx)
+                indent_folding::find_line_start_byte(&state.buffer, approx).unwrap_or(approx)
             })
         };
         self.toggle_fold_at_byte(buffer_id, byte_pos);
@@ -710,6 +710,7 @@ impl crate::app::window::Window {
                 let header_byte = {
                     use crate::view::folding::indent_folding;
                     indent_folding::find_line_start_byte(&state.buffer, byte_pos)
+                        .unwrap_or(byte_pos)
                 };
                 if buf_state.folds.remove_by_header_byte(
                     &state.buffer,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -42,6 +42,18 @@ struct ExplorerSection {
 /// block head.
 const FLOW_RUN_MAX_LINES: usize = 200;
 
+/// Bytes of source text one frame offers the plugins through `lines_changed`.
+///
+/// The offer covers the lines under the viewport, and a plugin can only
+/// decorate what is drawn — a screenful. Bounding the offer in bytes as well as
+/// in lines is what keeps a frame's cost the screen's size on a file whose
+/// viewport sits inside a single multi-megabyte line, where "the lines under
+/// the viewport" is one line and reading it is reading the file. Text past the
+/// bound is not offered, so a decoration that would have landed there is not
+/// drawn — the same trade the renderer already makes by drawing only the rows
+/// that fit.
+const PLUGIN_LINE_OFFER_BYTES: usize = 64 * 1024;
+
 /// Whether a line separates two runs: empty, or nothing but whitespace.
 fn line_is_blank(content: &str) -> bool {
     content.trim().is_empty()
@@ -561,6 +573,16 @@ impl Editor {
                         );
 
                         let visible_count = split_area.height as usize;
+                        // What the pane can show, in bytes at four per column:
+                        // the offer covers the visible rows, and a row holds a
+                        // pane's width. Bounding the offer by the screen rather
+                        // than by a flat constant is what keeps it screen-sized
+                        // on a file whose lines are megabytes long.
+                        let offer_budget = (split_area.width as usize)
+                            .saturating_mul(visible_count.max(1))
+                            .saturating_mul(4)
+                            .saturating_add(1024)
+                            .min(PLUGIN_LINE_OFFER_BYTES);
 
                         let top_byte = viewport_top_byte;
                         let seen_byte_ranges = seen_ranges_for_win.entry(buffer_id).or_default();
@@ -617,7 +639,19 @@ impl Editor {
 
                         let mut walked: Vec<WalkedLine> = Vec::new();
                         let mut line_number = state.buffer.get_line_number(walk_start);
-                        let mut iter = state.buffer.line_iterator(walk_start, estimated_line_length);
+                        // Capped per read *and* in total: the walk offers the
+                        // plugins the lines under the viewport, and on a file
+                        // that is one enormous line "a line" is the file. The
+                        // reader's own 100 KB piece cap still made this a
+                        // multi-megabyte read every frame — for text no plugin
+                        // can decorate, since only the first screenful of it is
+                        // ever drawn.
+                        let buffer_len = state.buffer.len();
+                        let mut iter = state
+                            .buffer
+                            .line_iterator(walk_start, estimated_line_length)
+                            .with_max_line_bytes(offer_budget);
+                        let mut walked_bytes = 0usize;
                         // End of the last line walked, so the embedded-region
                         // probe below covers exactly the lines we iterated.
                         let mut walked_end = walk_start;
@@ -631,10 +665,19 @@ impl Editor {
                             };
                             let byte_end = line_start + line_content.len();
                             walked_end = byte_end;
+                            walked_bytes += line_content.len();
                             let blank = line_is_blank(&line_content);
                             if line_start < top_byte {
                                 lead_in += 1;
                             }
+                            // A piece that stopped short of its line's own
+                            // terminator is the front of a line, not a line:
+                            // the read cap above cut it. Counting it as one
+                            // would number every line below it wrongly, and
+                            // there is nothing below it to offer anyway —
+                            // only the part that fits on screen is ever drawn.
+                            let complete =
+                                line_content.ends_with('\n') || byte_end >= buffer_len;
                             walked.push(WalkedLine {
                                 line_number,
                                 byte_start: line_start,
@@ -642,8 +685,14 @@ impl Editor {
                                 seen: seen_byte_ranges.contains(&(line_start, byte_end)),
                                 content: line_content,
                             });
+                            if !complete {
+                                break;
+                            }
                             line_number += 1;
 
+                            if walked_bytes >= offer_budget {
+                                break;
+                            }
                             if walked.len() < lead_in + rows {
                                 continue;
                             }

--- a/crates/fresh-editor/src/app/shell_host.rs
+++ b/crates/fresh-editor/src/app/shell_host.rs
@@ -322,14 +322,29 @@ impl<'a> BodyPainter<'a> {
 /// meets the edge of its pane by fading out rather than being cut off
 /// mid-line.
 ///
-/// An edge only shades when there is something beyond it to trail off into:
-/// at the top or bottom of a document the text simply ends, and dimming it
-/// there would say the opposite. A file that fits its pane gets no shading
-/// at all. Above is read off the viewport, which knows exactly. Below is the
-/// bar's fact: a thumb short of the end of its track is content past the
-/// bottom row, and a pane with no bar has no extent to read, so its bottom
-/// edge shades — the affordance is the better guess when the answer is
-/// unavailable.
+/// An edge shades only when there is something beyond it to trail off into.
+/// At the top or bottom of a document the text simply ends, and dimming it
+/// there says the opposite; a file that fits its pane gets no shading at all.
+/// The same goes for an answer nobody has: an edge whose facts are missing is
+/// left alone rather than shaded on a guess, because the guess is visible and
+/// the restraint is not.
+///
+/// It also leaves alone the edge the caret is sitting in. The shading is an
+/// affordance for reading, and dimming the line being edited trades that for
+/// the one line the reader is certainly looking at. The band is suppressed
+/// whole rather than the caret's own row: the ramp is two rows deep, and a
+/// bright row in the middle of it reads as a fault rather than as an
+/// exception.
+///
+/// Every fact here was settled for this frame before the paint — the
+/// viewport's anchor, the pane's bar, and the rows and caret the text pass
+/// left on the pane's handle — so deciding this costs no read of the buffer.
+/// Above is the anchor's, which knows exactly. Below takes the bar's thumb,
+/// but only when the bar is addressed in lines: on a file too large to count
+/// lines on, the thumb is placed by a byte fraction and says nothing about
+/// whether the last row is the last line. And a pass that drew fewer rows
+/// than the pane holds has run out of document inside it, whatever the bar
+/// rounds to.
 fn shade_pane_edges(
     editor: &Editor,
     leaf: LeafId,
@@ -353,19 +368,53 @@ fn shade_pane_edges(
     let Some(view_state) = view_states.get(&leaf) else {
         return;
     };
-    let content_below = window
-        .panes
-        .get(&leaf)
-        .and_then(|h| h.bar(fresh_ui::Axis::Vertical))
-        .is_none_or(|f| f.thumb(rect.height).1 < rect.height);
+    let pane = window.panes.get(&leaf);
+    // What the text pass left on the pane: the rows it drew and the caret's
+    // own cell, local to `rect` — so `caret.1` is this loop's `row`.
+    let view = pane.map(|h| h.view());
+    let rows_drawn = view.as_ref().map_or(0, |v| v.rows.len());
+    let caret_row = view.as_ref().and_then(|v| v.caret).map(|(_, y)| y);
+    drop(view);
+
+    let below_the_bottom_row = match pane.and_then(|h| h.bar(fresh_ui::Axis::Vertical)) {
+        // No bar: no extent to read, so nothing is known about what lies
+        // below.
+        None => false,
+        // A file too large to count lines on. The thumb is one cell placed by
+        // the offset's fraction of the bytes, which is not an answer to "is
+        // the last row the last line".
+        Some(f)
+            if matches!(
+                f.window,
+                crate::view::shell::buffer_host::BarWindow::OneCell
+            ) =>
+        {
+            false
+        }
+        Some(f) => f.thumb(rect.height).1 < rect.height,
+    };
+    // A pass that drew fewer rows than the pane holds ran out of document
+    // inside it — the rest is `~` filler, which is painted separately and
+    // leaves no row here. Exact where the thumb only rounds, and it can only
+    // ever withdraw the shading.
+    let content_below = below_the_bottom_row && rows_drawn >= rect.height as usize;
     let anchor = view_state.viewport.anchor;
     let content_above = anchor.byte > 0 || anchor.row_offset != 0;
+
+    // The band the caret is in is left alone, both of them if the pane is
+    // shallow enough for its two bands to overlap.
+    let caret_in_top = caret_row.is_some_and(|y| y < EDGE_FADE_ROWS);
+    let caret_in_bottom =
+        caret_row.is_some_and(|y| rect.height.saturating_sub(1).saturating_sub(y) < EDGE_FADE_ROWS);
+    let shade_top = content_above && !caret_in_top;
+    let shade_bottom = content_below && !caret_in_bottom;
+
     let editor_bg = editor.theme.read().unwrap().editor_bg;
     for row in 0..rect.height {
         let from_top = row;
         let from_bottom = rect.height - 1 - row;
-        let in_top = content_above && from_top < EDGE_FADE_ROWS;
-        let in_bottom = content_below && from_bottom < EDGE_FADE_ROWS;
+        let in_top = shade_top && from_top < EDGE_FADE_ROWS;
+        let in_bottom = shade_bottom && from_bottom < EDGE_FADE_ROWS;
         let distance = match (in_top, in_bottom) {
             (true, true) => from_top.min(from_bottom),
             (true, false) => from_top,

--- a/crates/fresh-editor/src/app/text_ops.rs
+++ b/crates/fresh-editor/src/app/text_ops.rs
@@ -56,17 +56,34 @@ impl Editor {
             } else {
                 // Fall back to physical-line toggle.
                 let state = self.active_state_mut();
-                let mut iter = state
+                // The line's real start. Asking the reader for it scans back on
+                // a budget and, when the budget runs out, reports how far it
+                // looked — a "line start" in the middle of the line. Home then
+                // lands there, and a second press is needed to reach the real
+                // one, which is exactly what a long line used to do.
+                let buffer_len = state.buffer.len();
+                let line_start = state
                     .buffer
-                    .line_iterator(cursor.position, estimated_line_length);
-                let Some((line_start, line_content)) = iter.next_line() else {
-                    continue;
-                };
-                let first_non_ws = line_content
-                    .chars()
-                    .take_while(|c| *c != '\n')
-                    .position(|c| !c.is_whitespace())
-                    .map(|offset| line_start + offset)
+                    .prev_line_start_within(cursor.position, buffer_len)
+                    .unwrap_or(0);
+                // Only the indent decides where Home goes, and indentation is at
+                // the front of the line — so read a page of it rather than the
+                // line, which on a minified file is the file.
+                const INDENT_SCAN_BYTES: usize = 4096;
+                let head_len = INDENT_SCAN_BYTES.min(buffer_len.saturating_sub(line_start));
+                let head = state
+                    .buffer
+                    .get_text_range_mut(line_start, head_len)
+                    .unwrap_or_default();
+                let head = String::from_utf8_lossy(&head);
+                // Byte offsets, not character counts: the two differ the moment
+                // a line is indented with anything but ASCII, and this is added
+                // to a byte position.
+                let first_non_ws = head
+                    .char_indices()
+                    .take_while(|(_, c)| *c != '\n')
+                    .find(|(_, c)| !c.is_whitespace())
+                    .map(|(offset, _)| line_start + offset)
                     .unwrap_or(line_start);
                 if cursor.position == first_non_ws {
                     line_start

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -4268,6 +4268,29 @@ impl Window {
         let _sent = self.send_lsp_changes_inner(buffer_id, changes, false);
     }
 
+    /// Whether a `didChange` for this buffer could reach a server at all.
+    ///
+    /// The side-effect-free head of [`Self::send_lsp_changes_inner`]'s guard:
+    /// the metadata exists, LSP is enabled for the buffer, it has a URI to be
+    /// named by, and its state is still around. It deliberately stops short of
+    /// `try_spawn`, which can start a server — this only answers "would that
+    /// call have anywhere to go", never causes one.
+    ///
+    /// It exists so the caller can ask *before* deriving the change set.
+    /// Building one converts byte offsets to LSP's UTF-16 positions, which
+    /// costs a read of the line up to the cursor — 18 MB per keystroke on a
+    /// file that is one long line, measured — and the empty fallback below is
+    /// worse still, since it snapshots the whole document. Both were being
+    /// paid on every edit and then dropped here.
+    pub(crate) fn lsp_change_could_be_sent(&self, buffer_id: BufferId) -> bool {
+        let Some(metadata) = self.buffer_metadata.get(&buffer_id) else {
+            return false;
+        };
+        metadata.lsp_enabled
+            && metadata.file_uri().is_some()
+            && self.buffers.get(&buffer_id).is_some()
+    }
+
     /// `resync_only` restricts the send to servers whose copy of the document
     /// is known to have diverged, so a repair pass cannot disturb servers that
     /// are still in sync (#3038).

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -58,6 +58,16 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Scanning budget for "where does the visible window end".
+///
+/// A drawn row holds at most a pane's width of text, so a screenful of lines
+/// is a few tens of kilobytes; this is generous against that and, unlike the
+/// line count alone, it bounds the answer on a file whose next line break is
+/// megabytes away. Overshooting merely widens a window that is compared
+/// against the cursor's byte, so a generous bound costs nothing but is still a
+/// bound.
+const VISIBLE_WINDOW_SCAN_BYTES: usize = 256 * 1024;
+
 /// A project-rooted unit of editor state.
 ///
 /// After Step 0b every per-subsystem field listed below is owned
@@ -4068,17 +4078,10 @@ impl Window {
 
         let visible_start = top_byte;
         let mut visible_end = top_byte;
-        {
-            let mut line_iter = state.buffer.line_iterator(top_byte, 80);
-            for _ in 0..visible_height {
-                if let Some((line_start, line_content)) = line_iter.next_line() {
-                    visible_end = line_start + line_content.len();
-                } else {
-                    break;
-                }
-            }
-        }
-        visible_end = visible_end.min(state.buffer.len());
+        visible_end = state
+            .buffer
+            .advance_lines_within(top_byte, visible_height as usize, VISIBLE_WINDOW_SCAN_BYTES)
+            .min(state.buffer.len());
         let visible_text = state.get_text_range(visible_start, visible_end);
 
         for mat in regex.find_iter(&visible_text) {

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -2269,19 +2269,40 @@ fn handle_page_up(
             calculate_visual_column(&mut state.buffer, cursor.position, estimated_line_length);
         let goal_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
-        let mut iter = state
-            .buffer
-            .line_iterator(cursor.position, estimated_line_length);
-        let mut new_pos = cursor.position;
+        // The mirror of `handle_page_down`, and bounded for the same reason:
+        // walking back through the reader's pieces measured a page in read
+        // budgets rather than in lines.
+        let mut line_start = logical_line_start(&mut state.buffer, cursor.position);
+        let mut landed = None;
+        let mut ran_out = false;
         for _ in 0..lines_to_move {
-            if let Some((line_start, line_content)) = iter.prev() {
-                let line_text = line_content.trim_end_matches('\n');
-                new_pos = line_start + byte_offset_at_visual_column(line_text, goal_column);
-            } else {
-                new_pos = 0;
+            if line_start == 0 {
+                ran_out = true;
                 break;
             }
+            match state
+                .buffer
+                .prev_line_start_within(line_start - 1, VERTICAL_MOVE_SCAN_BYTES)
+            {
+                Some(prev) => {
+                    line_start = prev;
+                    landed = Some(prev);
+                }
+                None => {
+                    ran_out = true;
+                    break;
+                }
+            }
         }
+        let new_pos = match (landed, ran_out) {
+            // Fewer lines above than a page: the first page starts at the top.
+            (Some(_), true) => 0,
+            (Some(start), false) => {
+                let text = line_text_for_column(&mut state.buffer, start, goal_column);
+                start + byte_offset_at_visual_column(text.trim_end_matches('\n'), goal_column)
+            }
+            (None, _) => cursor.position,
+        };
 
         let new_anchor = if extend_selection {
             Some(cursor.anchor.unwrap_or(cursor.position))
@@ -2319,21 +2340,43 @@ fn handle_page_down(
             calculate_visual_column(&mut state.buffer, cursor.position, estimated_line_length);
         let goal_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
-        let mut iter = state
-            .buffer
-            .line_iterator(cursor.position, estimated_line_length);
-        iter.next_line(); // consume current line
-
-        let mut new_pos = cursor.position;
+        // Logical lines, not the reader's pieces. Asking the reader for "the
+        // next line" hands back the next hundred-kilobyte piece of the line the
+        // cursor is already on, so a page down a file that is one long line
+        // walked thirty-nine pieces along it — a distance with no relation to
+        // anything on screen.
+        let mut line_start = cursor.position;
+        let mut landed = None;
+        let mut ran_out = false;
         for _ in 0..lines_to_move {
-            if let Some((line_start, line_content)) = iter.next_line() {
-                let line_text = line_content.trim_end_matches('\n');
-                new_pos = line_start + byte_offset_at_visual_column(line_text, goal_column);
-            } else {
-                new_pos = max_cursor_position(&state.buffer);
-                break;
+            match state
+                .buffer
+                .next_line_start_within(line_start, VERTICAL_MOVE_SCAN_BYTES)
+            {
+                Some(next) => {
+                    line_start = next;
+                    landed = Some(next);
+                }
+                None => {
+                    ran_out = true;
+                    break;
+                }
             }
         }
+        let new_pos = match (landed, ran_out) {
+            // Fewer lines below than a page: the last page ends at the
+            // buffer's end, which is where paging down the final screen has
+            // always landed.
+            (Some(_), true) => max_cursor_position(&state.buffer),
+            (Some(start), false) => {
+                let text = line_text_for_column(&mut state.buffer, start, goal_column);
+                start + byte_offset_at_visual_column(text.trim_end_matches('\n'), goal_column)
+            }
+            // No line below at all. On a file that is one enormous line that is
+            // the truth, and the cursor stays where it is — the same answer
+            // `Down` gives.
+            (None, _) => cursor.position,
+        };
 
         let new_anchor = if extend_selection {
             Some(cursor.anchor.unwrap_or(cursor.position))
@@ -3334,24 +3377,14 @@ pub fn action_to_events(
 
         Action::SelectLineStart => {
             select_each_cursor(cursors, &mut events, |c| {
-                state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length)
-                    .next_line()
-                    .map(|(ls, _)| ls)
-                    .unwrap_or(c.position)
+                logical_line_start(&mut state.buffer, c.position)
             });
         }
 
         Action::SelectLineEnd => {
             // Cursor lands at the first byte of line ending (LF: on \n; CRLF: on \r).
             select_each_cursor(cursors, &mut events, |c| {
-                state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length)
-                    .next_line()
-                    .map(|(ls, lc)| ls + content_len_without_line_ending(&lc))
-                    .unwrap_or(c.position)
+                logical_line_end(&mut state.buffer, c.position)
             });
         }
 

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -1291,34 +1291,37 @@ struct InsertCursorData {
 /// Find the start of the line containing `pos`, and report whether everything
 /// between it and `pos` is a space or a tab (the auto-dedent precondition).
 ///
-/// Reads in blocks rather than a byte at a time. Each `slice_bytes` call is a
-/// piece-tree range query plus a heap allocation, so walking back one byte per
-/// iteration costs one of each per column — the dominant cost of a keystroke
-/// on a long line, and one that grows the further right the cursor sits.
-/// Materialising the whole prefix to test it for whitespace has the same
-/// problem: on a single-line file that prefix can be megabytes.
-fn line_start_and_blank_prefix(state: &EditorState, pos: usize) -> (usize, bool) {
+/// Two questions, and they want different machinery.
+///
+/// *Where the line starts* is a question about structure, and the piece tree
+/// already knows where its line feeds are — so it is asked, not read. Reading
+/// backwards to find a newline costs the distance to it, which on a file that
+/// is one long line is the whole file: measured at 18 MB in 4,417 block reads
+/// for a single keystroke, the largest single cost of typing there.
+///
+/// *Whether the prefix is blank* is settled by the first non-blank byte to the
+/// left of the cursor, so the scan stops there rather than continuing to the
+/// line start. That is exact, and it costs the length of the run of blanks —
+/// the indentation itself, which is what the question is about. On a minified
+/// line the byte before the cursor already settles it.
+fn line_start_and_blank_prefix(state: &mut EditorState, pos: usize) -> (usize, bool) {
     const CHUNK: usize = 4096;
+    let buffer_len = state.buffer.len();
+    let line_start = state
+        .buffer
+        .prev_line_start_within(pos, buffer_len)
+        .unwrap_or(0);
+
     let mut end = pos;
-    let mut only_spaces = true;
-    while end > 0 {
-        let start = end.saturating_sub(CHUNK);
+    while end > line_start {
+        let start = end.saturating_sub(CHUNK).max(line_start);
         let bytes = state.buffer.slice_bytes(start..end);
-        if let Some(i) = bytes.iter().rposition(|&b| b == b'\n') {
-            if only_spaces {
-                only_spaces = bytes[i + 1..].iter().all(|&b| b == b' ' || b == b'\t');
-            }
-            return (start + i + 1, only_spaces);
-        }
-        // Once a non-blank byte is seen the answer is settled, but the scan
-        // still has to reach the line start — `line_start` is returned either
-        // way.
-        if only_spaces {
-            only_spaces = bytes.iter().all(|&b| b == b' ' || b == b'\t');
+        if !bytes.iter().all(|&b| b == b' ' || b == b'\t') {
+            return (line_start, false);
         }
         end = start;
     }
-    (0, only_spaces)
+    (line_start, true)
 }
 
 /// Collect cursor data needed for character insertion.
@@ -6813,21 +6816,21 @@ mod tests {
 
     #[test]
     fn blank_prefix_finds_line_start_after_newline() {
-        let state = state_with("abc\n    ");
-        assert_eq!(line_start_and_blank_prefix(&state, 8), (4, true));
+        let mut state = state_with("abc\n    ");
+        assert_eq!(line_start_and_blank_prefix(&mut state, 8), (4, true));
     }
 
     #[test]
     fn blank_prefix_is_false_with_text_before_cursor() {
-        let state = state_with("abc\nfoo ");
-        assert_eq!(line_start_and_blank_prefix(&state, 8), (4, false));
+        let mut state = state_with("abc\nfoo ");
+        assert_eq!(line_start_and_blank_prefix(&mut state, 8), (4, false));
     }
 
     #[test]
     fn blank_prefix_at_buffer_start() {
-        let state = state_with("hello");
-        assert_eq!(line_start_and_blank_prefix(&state, 0), (0, true));
-        assert_eq!(line_start_and_blank_prefix(&state, 5), (0, false));
+        let mut state = state_with("hello");
+        assert_eq!(line_start_and_blank_prefix(&mut state, 0), (0, true));
+        assert_eq!(line_start_and_blank_prefix(&mut state, 5), (0, false));
     }
 
     /// The scan reads in blocks, so a line longer than one block has to keep
@@ -6836,18 +6839,18 @@ mod tests {
     #[test]
     fn blank_prefix_spans_multiple_scan_blocks() {
         let indent = " ".repeat(10_000);
-        let state = state_with(&format!("first\n{indent}"));
+        let mut state = state_with(&format!("first\n{indent}"));
         assert_eq!(
-            line_start_and_blank_prefix(&state, 6 + indent.len()),
+            line_start_and_blank_prefix(&mut state, 6 + indent.len()),
             (6, true)
         );
 
         let mut long_line = " ".repeat(10_000);
         long_line.push('x');
         long_line.push_str(&" ".repeat(10_000));
-        let state = state_with(&format!("first\n{long_line}"));
+        let mut state = state_with(&format!("first\n{long_line}"));
         assert_eq!(
-            line_start_and_blank_prefix(&state, 6 + long_line.len()),
+            line_start_and_blank_prefix(&mut state, 6 + long_line.len()),
             (6, false)
         );
     }
@@ -6857,8 +6860,11 @@ mod tests {
     #[test]
     fn blank_prefix_on_single_line_file() {
         let text = "x".repeat(200_000);
-        let state = state_with(&text);
-        assert_eq!(line_start_and_blank_prefix(&state, text.len()), (0, false));
+        let mut state = state_with(&text);
+        assert_eq!(
+            line_start_and_blank_prefix(&mut state, text.len()),
+            (0, false)
+        );
     }
 
     // ========================================================================

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -30,24 +30,189 @@ enum BlockDirection {
 
 /// Calculate the visual column (display width) at the cursor position.
 /// Returns (visual_column, byte_column_within_line).
+/// How far the vertical motions search for a line boundary.
+///
+/// Down asks "where does the next line start", Up asks "where did this one",
+/// and the column math asks "how wide is the text before the cursor". Each is a
+/// bounded question about the neighbourhood of the cursor; unbounded, each is a
+/// scan of everything above or below it on a file that is one long line, paid
+/// per keypress. Past the bound there is no line above or below to move to,
+/// which is the truth for such a file.
+///
+/// Sized at the chunk the file is loaded in, so the search costs at most one
+/// chunk's worth of scanning over bytes that had to be read anyway — and the
+/// piece tree remembers what each chunk holds, so asking twice costs once. A
+/// tighter bound is not free: a file of hundred-kilobyte lines — minified
+/// JavaScript, a log with embedded payloads — has real lines above and below
+/// the cursor, and a search that stops short of them makes the arrow keys do
+/// nothing at all.
+const VERTICAL_MOVE_SCAN_BYTES: usize = fresh_editor_core::model::buffer::LOAD_CHUNK_SIZE;
+
+/// How much of the target line is read to place a column on it.
+///
+/// Separate from the search bound above because this one materialises text.
+/// A goal column is a screen column, so four bytes each plus a terminator
+/// covers any of them; the cap only binds when something has asked for a
+/// column further right than any pane can show.
+const VERTICAL_MOVE_READ_BYTES: usize = 64 * 1024;
+
+/// The next logical line after `pos`: its start, and as much of its text as a
+/// goal column that far along could need.
+///
+/// `None` when no line break lies within [`VERTICAL_MOVE_SCAN_BYTES`] — there
+/// is no line below, so a downward motion has nowhere to go.
+fn next_logical_line(
+    buffer: &mut Buffer,
+    pos: usize,
+    goal_visual_column: usize,
+) -> Option<(usize, String)> {
+    let start = buffer.next_line_start_within(pos, VERTICAL_MOVE_SCAN_BYTES)?;
+    Some((
+        start,
+        line_text_for_column(buffer, start, goal_visual_column),
+    ))
+}
+
+/// Start of the logical line containing `pos`.
+///
+/// Unbounded, deliberately, and unlike every other line-boundary search on
+/// this path. The bounded ones answer questions about layout — "is there a row
+/// below", "how far down is the cursor" — where "not within reach" is a usable
+/// answer and the budget keeps a keypress off the whole file. `Home` is not
+/// that question. It names a position, that position exists, and an answer
+/// bounded by how far the search felt like looking is simply wrong: it puts the
+/// caret in the middle of the line and takes a second press to leave.
+///
+/// The cost is a scan of the line above the cursor, once. The piece tree
+/// records what the scan crosses, so asking again is answered from metadata.
+fn logical_line_start(buffer: &mut Buffer, pos: usize) -> usize {
+    // A cap of the whole buffer cannot run out, so `None` is unreachable here
+    // — the search returns 0 once its floor reaches the start of the buffer.
+    buffer
+        .prev_line_start_within(pos, buffer.len())
+        .unwrap_or(0)
+}
+
+/// The byte `End` rests on for the line containing `pos`: the first byte of the
+/// line's terminator, or the end of the buffer for a line that has none.
+///
+/// Unbounded for the same reason as [`logical_line_start`]. It is also why this
+/// does not go through the line *reader*: that hands back a long line in
+/// hundred-kilobyte pieces, and a piece boundary is a read budget, not the end
+/// of anything — `End` on a file that is one long line landed on byte 100,000,
+/// which is the cap's value and no part of the document's structure.
+fn logical_line_end(buffer: &mut Buffer, pos: usize) -> usize {
+    let len = buffer.len();
+    let Some(next_line) = buffer.next_line_start_within(pos, len) else {
+        // No line break between here and the end of the buffer, so the line
+        // ends where the buffer does. Unambiguous only because the cap was the
+        // whole buffer: a smaller one could not tell this from "didn't reach".
+        return len;
+    };
+    // `next_line` is one past the terminator. Step back over it — over both
+    // bytes of a CRLF pair — so the caret rests on the terminator's first byte.
+    let mut end = next_line.saturating_sub(1);
+    if end > 0
+        && buffer
+            .get_text_range_mut(end.saturating_sub(1), 1)
+            .is_ok_and(|b| b.first() == Some(&b'\r'))
+    {
+        end -= 1;
+    }
+    end
+}
+
+/// What lies above the cursor's line, for a vertical motion.
+enum LineAbove {
+    /// Start of the line above, and as much of its text as a goal column that
+    /// far along could need.
+    Found(usize, String),
+    /// The cursor is on the first line of the buffer; there is nothing above.
+    TopOfBuffer,
+    /// The line above begins further back than [`VERTICAL_MOVE_SCAN_BYTES`].
+    /// Not the top of the buffer, and not somewhere a keypress can afford to
+    /// go looking for.
+    OutOfReach,
+}
+
+/// The logical line before `pos`.
+///
+/// The mirror of [`next_logical_line`], and bounded for the same reason: asking
+/// the line iterator to walk back to the previous line reads the previous line,
+/// and on a file whose lines are hundreds of kilobytes that is the whole cost
+/// of an arrow key.
+fn previous_logical_line(buffer: &mut Buffer, pos: usize, goal_visual_column: usize) -> LineAbove {
+    let Some(this_line) = buffer.prev_line_start_within(pos, VERTICAL_MOVE_SCAN_BYTES) else {
+        return LineAbove::OutOfReach;
+    };
+    if this_line == 0 {
+        return LineAbove::TopOfBuffer;
+    }
+    // One byte back from this line's start is its predecessor's terminator, so
+    // the same search from there lands on the line above.
+    match buffer.prev_line_start_within(this_line - 1, VERTICAL_MOVE_SCAN_BYTES) {
+        Some(start) => LineAbove::Found(
+            start,
+            line_text_for_column(buffer, start, goal_visual_column),
+        ),
+        None => LineAbove::OutOfReach,
+    }
+}
+
+/// As much of the line at `line_start` as landing on `goal_visual_column`
+/// needs: the column in bytes at worst four bytes per column, plus room for the
+/// terminator. A caller mapping a column onto a line never looks past that, and
+/// on a line of millions of columns reading the rest is the whole cost.
+fn line_text_for_column(
+    buffer: &mut Buffer,
+    line_start: usize,
+    goal_visual_column: usize,
+) -> String {
+    let want = goal_visual_column
+        .saturating_mul(4)
+        .saturating_add(8)
+        .min(VERTICAL_MOVE_READ_BYTES);
+    let end = line_start.saturating_add(want).min(buffer.len());
+    // A read that loads. `slice_bytes` hands back nothing at all for a region
+    // that has not been faulted in yet — which, on the lazily-loaded large
+    // files this bound exists for, is most of the file — and an empty line maps
+    // every goal column to zero.
+    let bytes = buffer
+        .get_text_range_mut(line_start, end.saturating_sub(line_start))
+        .unwrap_or_default();
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    match text.find('\n') {
+        Some(i) => text[..=i].to_string(),
+        None => text,
+    }
+}
+
 fn calculate_visual_column(
     buffer: &mut Buffer,
     cursor_position: usize,
-    estimated_line_length: usize,
+    _estimated_line_length: usize,
 ) -> (usize, usize) {
-    let mut iter = buffer.line_iterator(cursor_position, estimated_line_length);
-    let current_line_start = iter.current_position();
+    // Only the text *before* the cursor decides its column, so read that and
+    // nothing else. Asking the line iterator for "the line" read a 100 KB piece
+    // of it — on every arrow key, several times per press.
+    let Some(current_line_start) =
+        buffer.prev_line_start_within(cursor_position, VERTICAL_MOVE_SCAN_BYTES)
+    else {
+        // The line began further back than the scan: no column worth
+        // reporting, and the caller only uses it as a goal to preserve.
+        return (0, 0);
+    };
     let byte_column = cursor_position.saturating_sub(current_line_start);
-
-    if let Some((_, line_content)) = iter.next_line() {
-        if byte_column > 0 && byte_column <= line_content.len() {
-            (str_width(&line_content[..byte_column]), byte_column)
-        } else {
-            (byte_column, byte_column) // Fallback for edge cases
-        }
-    } else {
-        (byte_column, byte_column) // Fallback
+    if byte_column == 0 {
+        return (0, 0);
     }
+    // Loading, for the same reason: a prefix read as empty reports column 0,
+    // and the column is what the next Up or Down aims at.
+    let prefix = buffer
+        .get_text_range_mut(current_line_start, byte_column)
+        .unwrap_or_default();
+    let prefix = String::from_utf8_lossy(&prefix);
+    (str_width(&prefix), byte_column)
 }
 
 /// Pattern for matching line ending characters (\r and \n)
@@ -1942,8 +2107,8 @@ fn handle_vertical_up(
             calculate_visual_column(&mut state.buffer, from_pos, estimated_line_length);
         let goal_visual_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
-        let mut iter = state.buffer.line_iterator(from_pos, estimated_line_length);
-        if let Some((prev_line_start, prev_line_content)) = iter.prev() {
+        let above = previous_logical_line(&mut state.buffer, from_pos, goal_visual_column);
+        if let LineAbove::Found(prev_line_start, prev_line_content) = above {
             let prev_line_text = prev_line_content.trim_end_matches('\n');
             let byte_offset = byte_offset_at_visual_column(prev_line_text, goal_visual_column);
             let mut new_pos = prev_line_start + byte_offset;
@@ -1967,11 +2132,17 @@ fn handle_vertical_up(
                 old_sticky_column: cursor.sticky_column,
                 new_sticky_column: Some(goal_visual_column),
             });
-        } else if extend_selection && cursor.position > 0 {
+        } else if matches!(above, LineAbove::TopOfBuffer) && extend_selection && cursor.position > 0
+        {
             // No line above: the cursor sits on the first line. Shift+Up still
             // extends the selection head to the very start of the buffer
             // (VSCode/Sublime behaviour, issue #3006). The goal column is kept
             // so a later Shift+Down returns to the original column.
+            //
+            // Only when the buffer really does start above the cursor. A line
+            // that merely begins further back than the search reaches is not
+            // the first line, and taking the selection to byte 0 on the
+            // strength of it would swallow the file.
             events.push(Event::MoveCursor {
                 cursor_id,
                 old_position: cursor.position,
@@ -2014,22 +2185,13 @@ fn handle_vertical_down(
             calculate_visual_column(&mut state.buffer, from_pos, estimated_line_length);
         let goal_visual_column = cursor.sticky_column.unwrap_or(current_visual_column);
 
-        let mut iter = state.buffer.line_iterator(from_pos, estimated_line_length);
-        iter.next_line(); // consume current line
-
-        // `next_line` yields an over-long logical line in `MAX_LINE_BYTES`
-        // pieces, so on a file that is one enormous line the "next line" is the
-        // next read *piece* of the line the cursor is already on — a byte
-        // behind it. Taking it threw the cursor back to byte 100,000 (or
-        // 200,000) from the last row, and the view followed, so walking down
-        // such a file looped instead of stopping at the end (issue #1806).
-        //
-        // A genuine next line always starts after the cursor, which is the one
-        // thing every caller of this can rely on; anything else is this line
-        // continuing, and there is no line below.
-        let next = iter
-            .next_line()
-            .filter(|(next_line_start, _)| *next_line_start > from_pos);
+        // The next *logical* line, found by scanning for the line break rather
+        // than by reading the line. `next_line` yields an over-long line in
+        // `MAX_LINE_BYTES` pieces, so asking it for "the next line" on a file
+        // that is one enormous line hands back the next read *piece* of the
+        // line the cursor is already on, and the cursor jumps 100 KB down a
+        // line it never left (issue #1806). A line break or nothing.
+        let next = next_logical_line(&mut state.buffer, from_pos, goal_visual_column);
 
         if let Some((next_line_start, next_line_content)) = next {
             let next_line_text = next_line_content.trim_end_matches('\n');
@@ -3004,24 +3166,14 @@ pub fn action_to_events(
 
         Action::MoveLineStart => {
             move_each_cursor(cursors, &mut events, |c| {
-                state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length)
-                    .next_line()
-                    .map(|(ls, _)| ls)
-                    .unwrap_or(c.position)
+                logical_line_start(&mut state.buffer, c.position)
             });
         }
 
         Action::MoveLineEnd => {
             // Cursor lands at the first byte of line ending (LF: on \n; CRLF: on \r).
             move_each_cursor(cursors, &mut events, |c| {
-                state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length)
-                    .next_line()
-                    .map(|(ls, lc)| ls + content_len_without_line_ending(&lc))
-                    .unwrap_or(c.position)
+                logical_line_end(&mut state.buffer, c.position)
             });
         }
 
@@ -3753,6 +3905,76 @@ mod tests {
     use crate::model::cursor::Cursors;
     use crate::model::event::{CursorId, Event};
     use crate::state::EditorState;
+
+    /// A vertical motion finds the line above as well as the line below, and
+    /// finds them on lines that are long.
+    ///
+    /// Both directions are bounded, because unbounded each is a scan of
+    /// everything above or below the cursor on a file that is one enormous
+    /// line, paid per keypress. A bound is also a claim — "past here there is
+    /// no line" — and a bound sized for the pathological file makes the claim
+    /// falsely on the merely-long one: a file of hundred-kilobyte lines has
+    /// real lines above and below, and `k` and `j` do nothing at all.
+    ///
+    /// The upward search is the one that had no bound of its own: it read the
+    /// previous line through the line iterator, which scans back a few hundred
+    /// bytes for the line's break and gives up silently when the line is longer
+    /// than that.
+    #[test]
+    fn vertical_motion_finds_the_line_above_and_below_on_long_lines() {
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        let mut cursors = Cursors::new();
+
+        // Three lines, each far longer than any per-keypress scan should be
+        // sized for, and far longer than the line iterator's own look-back.
+        let width = 200 * 1024;
+        let text: String = (0..3).map(|_| format!("{}\n", "x".repeat(width))).collect();
+        let second_line = width + 1;
+        state.apply(
+            &mut cursors,
+            &Event::Insert {
+                position: 0,
+                text,
+                cursor_id: CursorId(0),
+            },
+        );
+
+        // Down, from the first line to the second.
+        assert_eq!(
+            next_logical_line(&mut state.buffer, 0, 0).map(|(start, _)| start),
+            Some(second_line),
+            "no line below a {width}-byte line: `j` does nothing"
+        );
+
+        // And back up.
+        match previous_logical_line(&mut state.buffer, second_line, 0) {
+            LineAbove::Found(start, _) => assert_eq!(
+                start, 0,
+                "the line above the second one starts at the top of the buffer"
+            ),
+            LineAbove::TopOfBuffer => {
+                panic!("the second line is not the first: there is a line above it")
+            }
+            LineAbove::OutOfReach => {
+                panic!("no line above a {width}-byte line: `k` does nothing")
+            }
+        }
+
+        // The first line really is the first: nothing above it, and that is a
+        // different answer from "further than I looked".
+        assert!(
+            matches!(
+                previous_logical_line(&mut state.buffer, 0, 0),
+                LineAbove::TopOfBuffer
+            ),
+            "the first line has nothing above it"
+        );
+    }
 
     #[test]
     fn test_backspace_deletes_newline() {

--- a/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
+++ b/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
@@ -350,6 +350,20 @@ impl BracketHighlightOverlay {
             0
         };
 
+        // A match the frame cannot draw changes nothing on screen, so the
+        // search covers the drawn span plus a screenful either side and stops
+        // there. Unbounded by the viewport it was a megabyte of scanning per
+        // keystroke on a file that is one long line — for a bracket that could
+        // not have been highlighted wherever it turned out to be.
+        let margin = viewport_end
+            .saturating_sub(viewport_start)
+            .max(BRACKET_SCAN_CHUNK);
+        let search_bound = if forward {
+            viewport_end.saturating_add(margin)
+        } else {
+            viewport_start.saturating_sub(margin)
+        };
+
         // Find matching bracket
         let matching_pos = self.find_matching_bracket(
             buffer,
@@ -358,6 +372,7 @@ impl BracketHighlightOverlay {
             closing,
             forward,
             skip_ranges,
+            search_bound,
         );
 
         // Determine color based on depth
@@ -446,6 +461,10 @@ impl BracketHighlightOverlay {
     ///
     /// Brackets inside `skip_ranges` (comments/strings) are ignored so the
     /// match reflects only structural punctuation (issue #2405).
+    /// The match for the bracket at `position`, searched for no further than
+    /// `search_bound` (an absolute byte, ahead of `position` when `forward` and
+    /// behind it otherwise).
+    #[allow(clippy::too_many_arguments)]
     fn find_matching_bracket(
         &self,
         buffer: &Buffer,
@@ -454,6 +473,7 @@ impl BracketHighlightOverlay {
         closing: char,
         forward: bool,
         skip_ranges: &[Range<usize>],
+        search_bound: usize,
     ) -> Option<usize> {
         let buffer_len = buffer.len();
         let open = opening as u8;
@@ -461,7 +481,9 @@ impl BracketHighlightOverlay {
         let mut depth: i32 = 1;
 
         if forward {
-            let search_limit = (position + 1 + MAX_BRACKET_SEARCH_BYTES).min(buffer_len);
+            let search_limit = (position + 1 + MAX_BRACKET_SEARCH_BYTES)
+                .min(buffer_len)
+                .min(search_bound.max(position + 1));
             let mut pos = position + 1;
             while pos < search_limit {
                 let chunk_end = (pos + BRACKET_SCAN_CHUNK).min(search_limit);
@@ -482,7 +504,9 @@ impl BracketHighlightOverlay {
                 pos = chunk_end;
             }
         } else {
-            let search_limit = position.saturating_sub(MAX_BRACKET_SEARCH_BYTES);
+            let search_limit = position
+                .saturating_sub(MAX_BRACKET_SEARCH_BYTES)
+                .max(search_bound.min(position));
             let mut pos = position;
             while pos > search_limit {
                 let chunk_start = pos.saturating_sub(BRACKET_SCAN_CHUNK).max(search_limit);
@@ -900,7 +924,7 @@ mod tests {
         let buffer = Buffer::from_str_test("(hello)");
         let overlay = BracketHighlightOverlay::new();
 
-        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]);
+        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[], usize::MAX);
         assert_eq!(result, Some(6));
     }
 
@@ -909,7 +933,7 @@ mod tests {
         let buffer = Buffer::from_str_test("(hello)");
         let overlay = BracketHighlightOverlay::new();
 
-        let result = overlay.find_matching_bracket(&buffer, 6, '(', ')', false, &[]);
+        let result = overlay.find_matching_bracket(&buffer, 6, '(', ')', false, &[], 0);
         assert_eq!(result, Some(0));
     }
 
@@ -919,11 +943,11 @@ mod tests {
         let overlay = BracketHighlightOverlay::new();
 
         // Outer opening bracket should match outer closing
-        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]);
+        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[], usize::MAX);
         assert_eq!(result, Some(8));
 
         // Inner opening bracket should match inner closing
-        let result = overlay.find_matching_bracket(&buffer, 1, '(', ')', true, &[]);
+        let result = overlay.find_matching_bracket(&buffer, 1, '(', ')', true, &[], usize::MAX);
         assert_eq!(result, Some(7));
     }
 
@@ -1004,14 +1028,14 @@ mod tests {
 
         // Without skipping, `(` at 0 matches the `)` at 2.
         assert_eq!(
-            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]),
+            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[], usize::MAX),
             Some(2)
         );
 
         // Treat byte 2 (the first `)`) as inside a comment: it should be
         // skipped, so the match becomes the `)` at 4.
         assert_eq!(
-            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[2..3]),
+            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[2..3], usize::MAX),
             Some(4)
         );
     }

--- a/crates/fresh-editor/src/view/folding.rs
+++ b/crates/fresh-editor/src/view/folding.rs
@@ -62,7 +62,10 @@ pub struct CollapsedFoldLineRange {
 /// enforce the same invariant from opposite ends: a blank line never owns a
 /// fold, whether it got there by an edit or by stale saved coordinates.
 fn header_line_is_blank(buffer: &Buffer, line_start: usize) -> bool {
-    let line_end = indent_folding::find_line_end_byte(buffer, line_start);
+    // A line whose end is out of reach is far too long to be blank.
+    let Some(line_end) = indent_folding::find_line_end_byte(buffer, line_start) else {
+        return false;
+    };
     let bytes = buffer.slice_bytes(line_start..line_end);
     indent_folding::slice_indent(&bytes, 1).1
 }
@@ -105,10 +108,10 @@ impl FoldManager {
         }
 
         // All right gravity, like every `MarkerList::create` marker.
-        let header_marker = marker_list.create(indent_folding::find_line_start_byte(
-            buffer,
-            start.saturating_sub(1),
-        ));
+        let header_marker = marker_list.create(
+            indent_folding::find_line_start_byte(buffer, start.saturating_sub(1))
+                .unwrap_or(start.saturating_sub(1)),
+        );
         let start_marker = marker_list.create(start);
         let end_marker = marker_list.create(end);
 
@@ -499,36 +502,79 @@ pub mod indent_folding {
     /// the scans effectively memchr-speed.
     const LINE_SCAN_CHUNK: usize = 4096;
 
-    /// Find the byte offset of the start of the line containing `pos`.
-    /// Scans backward for `\n` (or returns 0).
-    pub fn find_line_start_byte(buffer: &Buffer, pos: usize) -> usize {
+    /// How far either scan looks before giving up.
+    ///
+    /// These run per rendered frame — the active indentation guide probes the
+    /// cursor's line on every one — and they answer a question about
+    /// *indentation structure*. A line longer than this has none worth
+    /// drawing: no guide, no fold, no header. Scanning on regardless is how a
+    /// frame on a file that is one 19 MB line came to walk the file twice
+    /// looking for a newline that isn't there.
+    ///
+    /// Matches `primitives::line_iterator::LINE_START_SEARCH_BYTES`, which
+    /// bounds the same search on the text-reading path.
+    const LINE_SCAN_LIMIT: usize = 64 * 1024;
+
+    /// Byte offset of the start of the line containing `pos`, or `None` when
+    /// no line start lies within [`LINE_SCAN_LIMIT`] bytes above it.
+    pub fn find_line_start_byte(buffer: &Buffer, pos: usize) -> Option<usize> {
         let mut end = pos.min(buffer.len());
-        while end > 0 {
-            let start = end.saturating_sub(LINE_SCAN_CHUNK);
+        let floor = end.saturating_sub(LINE_SCAN_LIMIT);
+        if floor > 0 && buffer.known_newline_free(floor..end) {
+            return None;
+        }
+        while end > floor {
+            let start = end.saturating_sub(LINE_SCAN_CHUNK).max(floor);
             let bytes = buffer.slice_bytes(start..end);
             if let Some(i) = bytes.iter().rposition(|&b| b == b'\n') {
-                return start + i + 1;
+                return Some(start + i + 1);
+            }
+            if start == 0 {
+                return Some(0);
             }
             end = start;
         }
-        0
+        (floor == 0).then_some(0)
     }
 
-    /// Find the exclusive byte offset just past the line containing `pos`
-    /// (i.e. one byte past its terminating `\n`, or the buffer length if the
-    /// line has no trailing newline). Scans forward for `\n`.
-    pub fn find_line_end_byte(buffer: &Buffer, pos: usize) -> usize {
+    /// [`find_line_start_byte`], falling back to the far end of the search
+    /// window when no line start is within reach.
+    ///
+    /// For callers that want a *range* rather than a structural decision — the
+    /// current-line highlight, a margin key — where "as far back as we looked"
+    /// is a serviceable answer and `None` is not.
+    pub fn line_start_byte_or_floor(buffer: &Buffer, pos: usize) -> usize {
+        find_line_start_byte(buffer, pos).unwrap_or_else(|| pos.saturating_sub(LINE_SCAN_LIMIT))
+    }
+
+    /// [`find_line_end_byte`], falling back to the far end of the search window.
+    pub fn line_end_byte_or_ceiling(buffer: &Buffer, pos: usize) -> usize {
+        find_line_end_byte(buffer, pos)
+            .unwrap_or_else(|| pos.saturating_add(LINE_SCAN_LIMIT).min(buffer.len()))
+    }
+
+    /// Exclusive byte offset just past the line containing `pos` (one byte past
+    /// its terminating `\n`, or the buffer length if the line ends the buffer),
+    /// or `None` when the line runs past [`LINE_SCAN_LIMIT`].
+    pub fn find_line_end_byte(buffer: &Buffer, pos: usize) -> Option<usize> {
         let buf_len = buffer.len();
         let mut start = pos.min(buf_len);
-        while start < buf_len {
-            let end = (start + LINE_SCAN_CHUNK).min(buf_len);
+        let ceiling = start.saturating_add(LINE_SCAN_LIMIT).min(buf_len);
+        // A stretch this buffer has already walked and found no break in is not
+        // walked again: on a file with no line structure this scan runs every
+        // frame and always fails.
+        if ceiling < buf_len && buffer.known_newline_free(start..ceiling) {
+            return None;
+        }
+        while start < ceiling {
+            let end = (start + LINE_SCAN_CHUNK).min(ceiling);
             let bytes = buffer.slice_bytes(start..end);
             if let Some(i) = bytes.iter().position(|&b| b == b'\n') {
-                return start + i + 1;
+                return Some(start + i + 1);
             }
             start = end;
         }
-        buf_len
+        (ceiling == buf_len).then_some(buf_len)
     }
 
     /// Measure leading indent of a line. The slice may carry its trailing line
@@ -674,10 +720,9 @@ pub mod indent_folding {
         Some(header_byte + byte_offset)
     }
 
-    /// Find the byte offset of the start of the *next* line after `pos`.
-    /// Scans forward for `\n` and returns the byte after it. If no `\n` is
-    /// found, returns `buffer.len()`.
-    pub fn find_next_line_start_byte(buffer: &Buffer, pos: usize) -> usize {
+    /// Byte offset of the start of the *next* line after `pos`, or `None` when
+    /// the line containing `pos` runs past the scan limit.
+    pub fn find_next_line_start_byte(buffer: &Buffer, pos: usize) -> Option<usize> {
         find_line_end_byte(buffer, pos)
     }
 
@@ -702,15 +747,17 @@ pub mod indent_folding {
         max_scan_bytes: usize,
         max_upward_lines: usize,
     ) -> Option<(usize, usize, usize)> {
-        let mut header_byte = find_line_start_byte(buffer, target_byte);
+        // No line start within reach means no indentation structure to fold:
+        // the position sits inside a line longer than the scan limit.
+        let mut header_byte = find_line_start_byte(buffer, target_byte)?;
 
         for _ in 0..=max_upward_lines {
             if let Some(fold_end_byte) =
                 indent_fold_end_byte(buffer, header_byte, tab_size, max_scan_bytes)
             {
                 if fold_end_byte >= target_byte {
-                    let eb = find_next_line_start_byte(buffer, fold_end_byte);
-                    let sb = find_next_line_start_byte(buffer, header_byte);
+                    let eb = find_next_line_start_byte(buffer, fold_end_byte)?;
+                    let sb = find_next_line_start_byte(buffer, header_byte)?;
                     if sb < eb {
                         return Some((header_byte, sb, eb));
                     }
@@ -719,7 +766,7 @@ pub mod indent_folding {
             if header_byte == 0 {
                 break;
             }
-            header_byte = find_line_start_byte(buffer, header_byte.saturating_sub(1));
+            header_byte = find_line_start_byte(buffer, header_byte.saturating_sub(1))?;
         }
 
         None

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -571,7 +571,9 @@ pub fn compute_line_layout(
         line_ending,
         &[], // no fold skip ranges — folds affect what's rendered, not per-line wrap count
         // No character budget: callers ask this for the line's *total* visual
-        // row count, so a viewport-sized read would under-report it.
+        // row count, so a viewport-sized read would under-report it — and for
+        // the same reason the line is not cut short either.
+        None,
         None,
         false,
     );

--- a/crates/fresh-editor/src/view/row_walk.rs
+++ b/crates/fresh-editor/src/view/row_walk.rs
@@ -239,6 +239,9 @@ fn walk_rows(
         line_ending,
         folds,
         Some(budget),
+        // The rule decides where rows end here; the total budget above is what
+        // bounds the read.
+        None,
         // Read from `from` itself rather than its line start: that walk back is
         // the cost this module removes.
         true,

--- a/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
@@ -43,6 +43,210 @@ fn line_terminator_offset(
     Some(line_start + idx)
 }
 
+/// Build the rows a horizontally scrolled pane draws, reading only the window
+/// each row shows rather than the line that leads up to it.
+///
+/// With soft wrap off on a large file a logical line is one visual row, and the
+/// pane draws a screenful of columns somewhere along it. Building that row as a
+/// *prefix* — every column from the line's start out to the right-hand edge —
+/// makes both the cost and the reach of a frame scale with how far right the
+/// view is scrolled: reading 50 MB to draw 160 columns, and, past the point
+/// where the read gives up, drawing nothing at all. `End` on a one-line file
+/// left an empty row and the caret in the gutter for exactly that reason.
+///
+/// So the window is read where it is. `window_byte` is how far into each
+/// logical line the row starts, which is the horizontal offset the viewport
+/// maintains — in bytes, as every column measurement on this path already is.
+/// Source offsets stay absolute, so a row that begins mid-line still says which
+/// bytes it shows, and the mapping the click and caret paths use is built from
+/// the drawn cells either way.
+///
+/// A line shorter than the offset draws nothing, which is what a line scrolled
+/// off the left edge looks like.
+pub(super) fn build_windowed_tokens(
+    buffer: &mut Buffer,
+    top_byte: usize,
+    visible_count: usize,
+    line_ending: LineEnding,
+    fold_skip: &[std::ops::Range<usize>],
+    window_byte: usize,
+    window_chars: usize,
+) -> Vec<ViewTokenWire> {
+    let mut tokens = Vec::new();
+    let buffer_len = buffer.len();
+    // Four bytes per character covers any UTF-8 scalar, plus room for the
+    // terminator the window may carry.
+    let read_bytes = window_chars.saturating_mul(4).saturating_add(16);
+    let mut line_start = top_byte.min(buffer_len);
+    let mut rows = 0usize;
+
+    while rows < visible_count {
+        // A line inside a collapsed fold is not drawn; step over the fold.
+        if let Some(r) = fold_skip.iter().find(|r| r.contains(&line_start)) {
+            line_start = r.end;
+            continue;
+        }
+        if line_start > buffer_len {
+            break;
+        }
+
+        // Where this line ends, when that is within reach. Out of reach means
+        // the line runs past anything a row could show, so the window is
+        // certainly inside it.
+        let next_line = buffer.next_line_start_within(line_start, LINE_SKIP_SCAN_BYTES);
+        let line_end = next_line.map(|n| n.saturating_sub(1)).unwrap_or(buffer_len);
+
+        let read_from = line_start.saturating_add(window_byte).min(line_end);
+        let take = (line_end.saturating_sub(read_from)).min(read_bytes);
+        let raw = buffer
+            .get_text_range_mut(read_from, take)
+            .unwrap_or_default();
+        let text = String::from_utf8_lossy(&raw);
+        // The end-of-line search is bounded, so `line_end` can be the buffer's
+        // end for a line whose break is merely far away. Stopping at the first
+        // break in what was read keeps a row to one line regardless.
+        let text = match text.find('\n') {
+            Some(i) => &text[..=i],
+            None => &text[..],
+        };
+
+        emit_line_text(&mut tokens, read_from, text, line_ending, window_chars);
+
+        // End the row. A window carrying the line's own terminator ends on a
+        // byte the document has; one that does not is a break the layout is
+        // inventing, and says so by carrying no source byte.
+        let terminator = line_terminator_offset(text.as_bytes(), read_from, line_ending);
+        let more_below = next_line.is_some_and(|n| n < buffer_len);
+        if !more_below {
+            break;
+        }
+        tokens.push(ViewTokenWire {
+            source_offset: terminator,
+            kind: ViewTokenWireKind::Newline,
+            style: None,
+        });
+
+        rows += 1;
+        match next_line {
+            Some(n) => line_start = n,
+            // No break within reach: this line is the last row there is.
+            None => break,
+        }
+    }
+
+    tokens
+}
+
+/// Emit one run of a line's text as tokens, anchored at `text_start`.
+///
+/// Shared by the two ways a row gets its text: reading a line from its start,
+/// and reading only the window of it that a horizontally scrolled pane draws.
+/// Source offsets are absolute either way, which is what lets the second exist
+/// — a row that begins mid-line still says which bytes it is showing.
+///
+/// Returns how many characters were emitted, and whether it stopped on
+/// `max_chars` with text still to come. The caller owns what that means: on a
+/// frame budget there is no room for another row, on a row budget there is.
+fn emit_line_text(
+    tokens: &mut Vec<ViewTokenWire>,
+    text_start: usize,
+    text: &str,
+    line_ending: LineEnding,
+    max_chars: usize,
+) -> (usize, bool) {
+    let content_bytes = text.as_bytes();
+    let mut byte_offset = 0usize;
+    let mut skip_next_lf = false; // Track if we should skip \n after \r in CRLF
+    let mut emitted = 0usize;
+
+    for ch in text.chars() {
+        if emitted >= max_chars {
+            return (emitted, true);
+        }
+        emitted += 1;
+
+        let ch_len = ch.len_utf8();
+        let source_offset = Some(text_start + byte_offset);
+
+        match ch {
+            '\r' => {
+                // In CRLF mode with \r\n: emit Newline at \r position, skip the \n.
+                // In LF/Unix files, ANY \r is unusual and should be shown as <0D>.
+                let is_crlf_file = line_ending == LineEnding::CRLF;
+                let next_byte = content_bytes.get(byte_offset + 1);
+                if is_crlf_file && next_byte == Some(&b'\n') {
+                    tokens.push(ViewTokenWire {
+                        source_offset,
+                        kind: ViewTokenWireKind::Newline,
+                        style: None,
+                    });
+                    skip_next_lf = true;
+                    byte_offset += ch_len;
+                    continue;
+                }
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::BinaryByte(ch as u8),
+                    style: None,
+                });
+            }
+            '\n' if skip_next_lf => {
+                skip_next_lf = false;
+                byte_offset += ch_len;
+                continue;
+            }
+            '\n' => {
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::Newline,
+                    style: None,
+                });
+            }
+            ' ' => {
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::Space,
+                    style: None,
+                });
+            }
+            '\t' => {
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::Text(ch.to_string()),
+                    style: None,
+                });
+            }
+            _ if is_control_char(ch) => {
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::BinaryByte(ch as u8),
+                    style: None,
+                });
+            }
+            _ => {
+                if let Some(last) = tokens.last_mut() {
+                    if let ViewTokenWireKind::Text(ref mut s) = last.kind {
+                        let expected_offset = last.source_offset.map(|o| o + s.len());
+                        if expected_offset == Some(text_start + byte_offset) {
+                            s.push(ch);
+                            byte_offset += ch_len;
+                            continue;
+                        }
+                    }
+                }
+                tokens.push(ViewTokenWire {
+                    source_offset,
+                    kind: ViewTokenWireKind::Text(ch.to_string()),
+                    style: None,
+                });
+            }
+        }
+        byte_offset += ch_len;
+    }
+
+    (emitted, false)
+}
+
 /// Build tokens from a text buffer starting at `top_byte`, stopping roughly
 /// after `visible_count` visual lines. Honors CRLF / LF line endings and
 /// renders unsafe control characters as `BinaryByte` tokens.
@@ -161,105 +365,35 @@ pub(crate) fn build_base_tokens(
             if next_fold_start.is_some_and(|s| line_start >= s) {
                 break;
             }
-            let mut byte_offset = 0usize;
             let content_bytes = line_content.as_bytes();
-            let mut skip_next_lf = false; // Track if we should skip \n after \r in CRLF
-            let mut chars_this_line = 0usize;
-            let mut cut_line = false;
-            for ch in line_content.chars() {
-                // Stop once the viewport's rows are covered. Unlike the
-                // `lines_seen` bound this fires inside a single long line,
-                // which is the only place it can fire at all.
-                if char_budget.is_some_and(|budget| chars_seen >= budget) {
-                    break 'segments;
-                }
-                // The rest of *this* line cannot be drawn, but the lines under
-                // it can: end the row here and move on to them.
-                if line_char_budget.is_some_and(|budget| chars_this_line >= budget) {
-                    cut_line = true;
-                    break;
-                }
-                chars_seen += 1;
-                chars_this_line += 1;
-
-                let ch_len = ch.len_utf8();
-                let source_offset = Some(line_start + byte_offset);
-
-                match ch {
-                    '\r' => {
-                        // In CRLF mode with \r\n: emit Newline at \r position, skip the \n.
-                        // In LF/Unix files, ANY \r is unusual and should be shown as <0D>.
-                        let is_crlf_file = line_ending == LineEnding::CRLF;
-                        let next_byte = content_bytes.get(byte_offset + 1);
-                        if is_crlf_file && next_byte == Some(&b'\n') {
-                            tokens.push(ViewTokenWire {
-                                source_offset,
-                                kind: ViewTokenWireKind::Newline,
-                                style: None,
-                            });
-                            skip_next_lf = true;
-                            byte_offset += ch_len;
-                            continue;
-                        }
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::BinaryByte(ch as u8),
-                            style: None,
-                        });
-                    }
-                    '\n' if skip_next_lf => {
-                        skip_next_lf = false;
-                        byte_offset += ch_len;
-                        continue;
-                    }
-                    '\n' => {
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::Newline,
-                            style: None,
-                        });
-                    }
-                    ' ' => {
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::Space,
-                            style: None,
-                        });
-                    }
-                    '\t' => {
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::Text(ch.to_string()),
-                            style: None,
-                        });
-                    }
-                    _ if is_control_char(ch) => {
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::BinaryByte(ch as u8),
-                            style: None,
-                        });
-                    }
-                    _ => {
-                        if let Some(last) = tokens.last_mut() {
-                            if let ViewTokenWireKind::Text(ref mut s) = last.kind {
-                                let expected_offset = last.source_offset.map(|o| o + s.len());
-                                if expected_offset == Some(line_start + byte_offset) {
-                                    s.push(ch);
-                                    byte_offset += ch_len;
-                                    continue;
-                                }
-                            }
-                        }
-                        tokens.push(ViewTokenWire {
-                            source_offset,
-                            kind: ViewTokenWireKind::Text(ch.to_string()),
-                            style: None,
-                        });
-                    }
-                }
-                byte_offset += ch_len;
+            // Two budgets bound this line: the frame's remaining characters,
+            // which ends the whole build, and the row's own width, which ends
+            // only this line. Whichever is smaller stops the emission; which
+            // one it was decides what happens next.
+            let remaining_global = char_budget.map(|b| b.saturating_sub(chars_seen));
+            let line_cap = match (remaining_global, line_char_budget) {
+                (Some(g), Some(l)) => g.min(l),
+                (Some(g), None) => g,
+                (None, Some(l)) => l,
+                (None, None) => usize::MAX,
+            };
+            if remaining_global == Some(0) {
+                break 'segments;
             }
+            let (emitted, stopped_short) = emit_line_text(
+                &mut tokens,
+                line_start,
+                &line_content,
+                line_ending,
+                line_cap,
+            );
+            chars_seen += emitted;
+            // Stopped on the frame's budget rather than the row's: there is no
+            // room for another row, so nothing below this one can be drawn.
+            if stopped_short && remaining_global.is_some_and(|g| emitted >= g) {
+                break 'segments;
+            }
+            let cut_line = stopped_short;
             if cut_line {
                 // The rest of the line is off the right-hand edge of the pane,
                 // but the row still has to end and the lines under it still

--- a/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
@@ -5,8 +5,43 @@
 //! render-time "mega struct" is required.
 
 use super::MAX_SAFE_LINE_WIDTH;
+
+/// How far the builder scans for the end of a line it had to cut short.
+///
+/// Reaching the next line means finding this line's break, and on a file that
+/// is one enormous line there isn't one — so the search is bounded and a
+/// failure means "there is nothing below this row to draw", which is the truth
+/// for such a file. Sized to skip over any line a person wrote and to stop long
+/// before the cost shows up in a frame.
+const LINE_SKIP_SCAN_BYTES: usize = 256 * 1024;
 use crate::model::buffer::{Buffer, LineEnding};
 use fresh_core::api::{ViewTokenWire, ViewTokenWireKind};
+
+/// Byte offset of the line's own terminator, when the piece just read carries
+/// it.
+///
+/// A reader hands back at most a fixed number of bytes at a time, so a piece
+/// that ends without a terminator may be either the end of the document or the
+/// middle of a line that continues past the read. Telling the two apart is what
+/// keeps a row that was cut short from stepping over the line below it.
+///
+/// The offset is the terminator's *first* byte, so a CRLF pair reports the
+/// `\r` — the same anchor the character loop above gives a `Newline` token it
+/// emits itself.
+fn line_terminator_offset(
+    content: &[u8],
+    line_start: usize,
+    line_ending: LineEnding,
+) -> Option<usize> {
+    if content.last() != Some(&b'\n') {
+        return None;
+    }
+    let mut idx = content.len() - 1;
+    if line_ending == LineEnding::CRLF && idx > 0 && content[idx - 1] == b'\r' {
+        idx -= 1;
+    }
+    Some(line_start + idx)
+}
 
 /// Build tokens from a text buffer starting at `top_byte`, stopping roughly
 /// after `visible_count` visual lines. Honors CRLF / LF line endings and
@@ -20,6 +55,15 @@ use fresh_core::api::{ViewTokenWire, ViewTokenWireKind};
 /// would ask for 54 "lines" and tokenise megabytes to fill rows that hold a few
 /// thousand characters. Callers that know the width a row wraps at pass roughly
 /// `rows × width`; pass `None` to bound by source lines only.
+///
+/// `line_char_budget` bounds a *single* line the same way: once a line has
+/// contributed this many characters the rest of it is skipped and the build
+/// moves to the next line, with an injected `Newline` ending the row. This is
+/// what soft-wrap-off needs, where one logical line is one visual row and the
+/// only part of it that can ever be drawn is the columns the pane shows —
+/// `left_column + width`. Without it a file of a few enormous lines fills its
+/// whole budget on the first of them and leaves the rest of the screen blank.
+/// `None` means a line is bounded only by the total budget above.
 ///
 /// `start_mid_line` means `top_byte` is a *visual row* start rather than a
 /// logical line start — the caller obtained it from the wrap index — so the read
@@ -35,6 +79,7 @@ pub(crate) fn build_base_tokens(
     line_ending: LineEnding,
     fold_skip: &[std::ops::Range<usize>],
     char_budget: Option<usize>,
+    line_char_budget: Option<usize>,
     start_mid_line: bool,
 ) -> Vec<ViewTokenWire> {
     let mut tokens = Vec::new();
@@ -96,12 +141,13 @@ pub(crate) fn build_base_tokens(
         } else {
             buffer.line_iterator(cursor, estimated_line_length)
         };
-        if let Some(budget) = char_budget {
-            // Bytes, not characters — UTF-8 runs to 4 bytes per character — so
-            // the first piece the iterator yields always covers the whole
-            // budget and the loop below never asks for a second one. Without
-            // this the iterator reads and UTF-8-decodes 100 KB of a long line
-            // to hand back text we stop consuming after a few thousand chars.
+        // Bytes, not characters — UTF-8 runs to 4 bytes per character — so the
+        // first piece the iterator yields always covers the whole budget and
+        // the loop below never asks for a second one. Without this the iterator
+        // reads and UTF-8-decodes 100 KB of a long line to hand back text we
+        // stop consuming after a few thousand chars. The per-line budget binds
+        // it tighter still: nothing past it is ever emitted.
+        if let Some(budget) = line_char_budget.or(char_budget) {
             iter = iter.with_max_line_bytes(budget.saturating_mul(4).saturating_add(1024));
         }
         while lines_seen < max_lines {
@@ -118,6 +164,8 @@ pub(crate) fn build_base_tokens(
             let mut byte_offset = 0usize;
             let content_bytes = line_content.as_bytes();
             let mut skip_next_lf = false; // Track if we should skip \n after \r in CRLF
+            let mut chars_this_line = 0usize;
+            let mut cut_line = false;
             for ch in line_content.chars() {
                 // Stop once the viewport's rows are covered. Unlike the
                 // `lines_seen` bound this fires inside a single long line,
@@ -125,7 +173,14 @@ pub(crate) fn build_base_tokens(
                 if char_budget.is_some_and(|budget| chars_seen >= budget) {
                     break 'segments;
                 }
+                // The rest of *this* line cannot be drawn, but the lines under
+                // it can: end the row here and move on to them.
+                if line_char_budget.is_some_and(|budget| chars_this_line >= budget) {
+                    cut_line = true;
+                    break;
+                }
                 chars_seen += 1;
+                chars_this_line += 1;
 
                 let ch_len = ch.len_utf8();
                 let source_offset = Some(line_start + byte_offset);
@@ -204,6 +259,44 @@ pub(crate) fn build_base_tokens(
                     }
                 }
                 byte_offset += ch_len;
+            }
+            if cut_line {
+                // The rest of the line is off the right-hand edge of the pane,
+                // but the row still has to end and the lines under it still
+                // have to be drawn. Where the rest of the line lies decides how.
+                match line_terminator_offset(content_bytes, line_start, line_ending) {
+                    // This piece already carried the line's own terminator, so
+                    // the iterator is standing on the next line and the break is
+                    // a real one at a byte the document has. Skipping here would
+                    // step over that next line and drop it from the frame
+                    // entirely — which is what happens to every other line of a
+                    // large file whose lines are merely wider than the pane.
+                    Some(offset) => {
+                        tokens.push(ViewTokenWire {
+                            source_offset: Some(offset),
+                            kind: ViewTokenWireKind::Newline,
+                            style: None,
+                        });
+                    }
+                    // The line runs past what was read. Step over the remainder
+                    // without reading it — and if its end is out of reach, stop
+                    // rather than scan the file for it: the row is left
+                    // unterminated, which is what it is, and no row follows.
+                    None => {
+                        if !iter.skip_to_next_line_within(LINE_SKIP_SCAN_BYTES) {
+                            break 'segments;
+                        }
+                        // The break carries no source byte, because the line's
+                        // own newline is somewhere past the part that could be
+                        // drawn; the row after it starts a genuinely new logical
+                        // line, which is what `AfterInjectedNewline` says.
+                        tokens.push(ViewTokenWire {
+                            source_offset: None,
+                            kind: ViewTokenWireKind::Newline,
+                            style: None,
+                        });
+                    }
+                }
             }
             lines_seen += 1;
         }
@@ -404,6 +497,7 @@ mod tests {
             LineEnding::LF,
             &[],
             None,
+            None,
             false,
         );
         assert!(
@@ -422,6 +516,7 @@ mod tests {
             LineEnding::LF,
             &[],
             Some(50 * 200),
+            None,
             false,
         );
         let budgeted_chars = char_count(&budgeted);
@@ -454,6 +549,7 @@ mod tests {
             LineEnding::LF,
             &[],
             None,
+            None,
             false,
         );
         let budgeted = build_base_tokens(
@@ -465,6 +561,7 @@ mod tests {
             LineEnding::LF,
             &[],
             Some(30 * 200),
+            None,
             false,
         );
 
@@ -488,6 +585,7 @@ mod tests {
             LineEnding::LF,
             &[],
             Some(0),
+            None,
             false,
         );
         assert!(
@@ -513,6 +611,7 @@ mod tests {
             LineEnding::LF,
             &[],
             None,
+            None,
             false,
         );
         let budgeted = build_base_tokens(
@@ -524,6 +623,7 @@ mod tests {
             LineEnding::LF,
             &[],
             Some(4_000),
+            None,
             false,
         );
 
@@ -592,6 +692,7 @@ pub(crate) fn build_line_tokens_from(
         false,
         line_ending,
         fold_skip,
+        None,
         None,
         start.is_some(),
     );

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -267,7 +267,7 @@ pub(super) fn diff_indicators_for_viewport(
             continue;
         }
 
-        let line_start = indent_folding::find_line_start_byte(&state.buffer, lo);
+        let line_start = indent_folding::find_line_start_byte(&state.buffer, lo).unwrap_or(lo);
         if line_start >= viewport_start && line_start < viewport_end {
             indicators
                 .entry(line_start)

--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -288,13 +288,15 @@ pub(super) fn calculate_compose_layout(
     }
 }
 
-/// A line whose content reaches this many bytes is treated as "over-long": it
-/// already fills (far past) the visible row, and with horizontal scrolling
-/// (line-wrap off) it occupies a single screen row. `LineIterator` also splits
-/// such lines into chunks of `MAX_LINE_BYTES` (100 KB) and yields each chunk as
-/// a separate "line", so without a guard `calculate_viewport_end` would walk
-/// chunk-by-chunk hundreds of KB into the line. Kept in step with that limit.
-const OVERLONG_LINE_BYTES: usize = 100_000;
+/// How far [`calculate_viewport_end`] scans for one line's end.
+///
+/// It needs the end only to clamp a window that the byte budget already caps at
+/// a few screenfuls, so a line whose end is further away than this is treated
+/// as running to the end of the buffer — which, for the files where that
+/// happens, it does. It is also where the walk stops: a line this long already
+/// fills (far past) its single unwrapped row, and there is nothing below it on
+/// screen to walk to.
+const VIEWPORT_END_SCAN_BYTES: usize = 64 * 1024;
 
 /// Compute the byte offset just past the last visible line of the viewport.
 ///
@@ -323,29 +325,39 @@ pub(super) fn calculate_viewport_end(
     // clamp so we keep the previous full-line behavior.
     let visible_byte_budget = left_column.saturating_add(viewport_width).saturating_mul(4);
 
-    let mut iter_temp = state
-        .buffer
-        .line_iterator(viewport_start, estimated_line_length);
+    // Line *starts* walked, not lines read: the window's end only needs each
+    // line's position and the byte budget above. Reading the lines meant
+    // pulling a 100 KB piece per row of a file that is one long line, every
+    // frame, to compute a bound the budget already caps.
+    let _ = estimated_line_length;
     let mut viewport_end = viewport_start;
+    let mut line_start = viewport_start;
+    let buffer_len = state.buffer.len();
     for _ in 0..visible_count {
-        let Some((line_start, line_content)) = iter_temp.next_line() else {
-            break;
+        let next = state
+            .buffer
+            .next_line_start_within(line_start, VIEWPORT_END_SCAN_BYTES);
+        let line_end = match next {
+            // The next line starts where this one ends — after its terminator,
+            // which is what the reader's own `line_start + content.len()` gave.
+            Some(next) => next,
+            None => buffer_len,
         };
-        let line_len = line_content.len();
-        let line_end = line_start + line_len;
 
         if visible_byte_budget == 0 {
             viewport_end = line_end;
-            continue;
+        } else {
+            viewport_end = line_end.min(line_start.saturating_add(visible_byte_budget));
         }
 
-        let clamped_end = line_end.min(line_start.saturating_add(visible_byte_budget));
-        viewport_end = clamped_end;
-
-        // An over-long line fills its single (unwrapped) screen row and may be
-        // yielded as multiple 100 KB chunks; the clamp above already covers the
-        // visible window, so stop rather than walking the rest of the line.
-        if line_len >= OVERLONG_LINE_BYTES {
+        // No line break within reach is the over-long line this walk used to
+        // guard against by measuring: the clamp above already covers the
+        // visible window, and there is nothing below such a line to walk to.
+        let Some(next) = next else {
+            break;
+        };
+        line_start = next;
+        if line_start >= buffer_len {
             break;
         }
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -831,6 +831,7 @@ pub(crate) fn build_base_tokens_for_hook(
         // The hook hands this stream to a plugin, which may wrap it at a width
         // of its own choosing; budget by source lines only.
         None,
+        None,
         false,
     )
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -298,10 +298,12 @@ pub(crate) fn decoration_context(
         .iter()
         .filter_map(|(overlay, range)| {
             if overlay.namespace.as_ref() == Some(&diagnostic_ns) {
-                return Some(indent_folding::find_line_start_byte(
-                    &state.buffer,
-                    range.start,
-                ));
+                // A diagnostic inside a line too long to find the start of is
+                // placed at its own byte: the row it lands on is still drawn.
+                return Some(
+                    indent_folding::find_line_start_byte(&state.buffer, range.start)
+                        .unwrap_or(range.start),
+                );
             }
             None
         })
@@ -315,7 +317,8 @@ pub(crate) fn decoration_context(
                 continue;
             }
             if let Some(ref message) = overlay.message {
-                let line_start = indent_folding::find_line_start_byte(&state.buffer, range.start);
+                let line_start = indent_folding::find_line_start_byte(&state.buffer, range.start)
+                    .unwrap_or(range.start);
                 let priority = overlay.priority;
                 let dominated = by_line
                     .get(&line_start)
@@ -341,6 +344,7 @@ pub(crate) fn decoration_context(
             .margins
             .get_indicators_for_viewport(viewport_start, viewport_end, |byte_offset| {
                 indent_folding::find_line_start_byte(&state.buffer, byte_offset)
+                    .unwrap_or(byte_offset)
             });
 
     // Merge native diff-since-saved indicators (cornflower blue │ for unsaved edits).

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -327,12 +327,29 @@ pub(crate) fn compute_buffer_layout(
     // value here — the frame is drawn with it, and the pane's paint stores
     // it afterwards (`reconcile::settle_pane`).
     let primary = *cursors.primary();
-    let left_column = viewport.layout_column_scroll(
-        &view_data.lines,
-        &primary,
-        render_area.width as usize,
-        gutter_width,
-    );
+    // Rows built as a window already begin where the view is scrolled to, so
+    // there is no column to place: re-deriving one from rows that are only a
+    // screenful wide would answer nearly zero and, stored back by the pane's
+    // paint, would scroll the view home on the next frame. The horizontal
+    // position is `ensure_visible`'s to keep in that mode.
+    let windowed = view_data.line_window_byte > 0;
+    let left_column = if windowed {
+        viewport.left_column
+    } else {
+        viewport.layout_column_scroll(
+            &view_data.lines,
+            &primary,
+            render_area.width as usize,
+            gutter_width,
+        )
+    };
+    // What the row rendering skips. A windowed row is already the window, so
+    // skipping into it again would drop the columns it was built to show —
+    // which is the same empty pane, arrived at from the other side. The
+    // unwindowed row still starts at its line's start and is skipped as
+    // before. Everything else below keeps the real column: a ruler names an
+    // absolute one, and the pane stores it as its scroll position.
+    let row_left_column = if windowed { 0 } else { left_column };
 
     let view_anchor = calculate_view_anchor(&view_data.lines, viewport.top_byte());
 
@@ -401,7 +418,7 @@ pub(crate) fn compute_buffer_layout(
                 viewport_start,
                 estimated_line_length,
                 adjusted_visible_count,
-                left_column,
+                row_left_column,
                 render_area.width as usize,
             );
             (viewport_start, viewport_end)
@@ -464,7 +481,7 @@ pub(crate) fn compute_buffer_layout(
         is_active,
         line_wrap,
         estimated_lines,
-        left_column,
+        left_column: row_left_column,
         relative_line_numbers,
         session_mode,
         software_cursor_only,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -171,8 +171,10 @@ impl ActiveIndentationGuide {
         // fold whose last hidden line starts at or after the target, so probing
         // with the raw cursor byte would miss the enclosing block whenever the
         // cursor sits past the indentation of that block's last line.
+        // No line start within reach means the cursor sits inside a line with
+        // no foldable indentation structure — nothing to draw a guide for.
         let target_byte =
-            indent_folding::find_line_start_byte(&state.buffer, primary_cursor_position);
+            indent_folding::find_line_start_byte(&state.buffer, primary_cursor_position)?;
         let (header_byte, body_start_byte, body_end_byte) =
             indent_folding::find_fold_range_at_byte(
                 &state.buffer,
@@ -361,7 +363,9 @@ fn prime_guide_stack_from_buffer(
         if line_start == 0 {
             break;
         }
-        let prev_line_start = find_line_start_byte(buffer, line_start - 1);
+        let Some(prev_line_start) = find_line_start_byte(buffer, line_start - 1) else {
+            break;
+        };
         // Slice the previous line's content *excluding* its trailing `\n` (at
         // `line_start - 1`) so a whitespace-only line is correctly classified
         // as blank rather than as content ending in a newline.
@@ -510,8 +514,11 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     let primary_cursor_position = selection.primary_cursor_position;
 
     // Compute cursor line start byte — universal key for cursor line highlight
+    // Or-floor rather than the exact start: on a line longer than the scan
+    // window the highlight covers the window instead of the whole line, which
+    // is what is on screen anyway.
     let cursor_line_start_byte =
-        indent_folding::find_line_start_byte(&state.buffer, primary_cursor_position);
+        indent_folding::line_start_byte_or_floor(&state.buffer, primary_cursor_position);
 
     // Exclusive end of the cursor's logical line. A view sub-row whose first
     // source byte falls in `[cursor_line_start_byte, cursor_line_end_byte)`
@@ -522,7 +529,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     // so it doesn't depend on the cached `primary_cursor_line_number` being
     // in sync with the cursor position.
     let cursor_line_end_byte =
-        indent_folding::find_line_end_byte(&state.buffer, primary_cursor_position);
+        indent_folding::line_end_byte_or_ceiling(&state.buffer, primary_cursor_position);
 
     let active_indentation_guide = ActiveIndentationGuide::for_view_lines(
         indentation_guide,
@@ -556,12 +563,15 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             .flatten()
             .find_map(|line| line.source_start_byte);
         let stack = match first_visible_source {
-            Some(src) => prime_guide_stack_from_buffer(
-                &state.buffer,
-                indent_folding::find_line_start_byte(&state.buffer, src),
-                state.buffer_settings.tab_size,
-                crate::config::INDENT_FOLD_MAX_UPWARD_SCAN,
-            ),
+            Some(src) => match indent_folding::find_line_start_byte(&state.buffer, src) {
+                Some(line_start) => prime_guide_stack_from_buffer(
+                    &state.buffer,
+                    line_start,
+                    state.buffer_settings.tab_size,
+                    crate::config::INDENT_FOLD_MAX_UPWARD_SCAN,
+                ),
+                None => Vec::new(),
+            },
             None => Vec::new(),
         };
         GuideColumnScanner { stack }

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -59,7 +59,9 @@ pub(super) struct BuildAnchor {
 /// Wrapping is always applied for safety, but with different thresholds. When
 /// line_wrap is on: wrap at viewport width (or `wrap_column` if set). When
 /// line_wrap is off: wrap at `MAX_SAFE_LINE_WIDTH` to prevent memory
-/// exhaustion from extremely long lines.
+/// exhaustion from extremely long lines — except on the large-file path, where
+/// a line is one row and the caller widens this to the row's own span (see
+/// `build_view_data`), because a chop inside the drawn columns is a blank pane.
 ///
 /// When wrapping is on, reserve the last content column so the end-of-line
 /// cursor never lands on top of the vertical scrollbar. The cursor sits one
@@ -95,6 +97,65 @@ fn effective_wrap_width(
     base.saturating_sub(1).max(1)
 }
 
+/// Columns of a logical line a pane can put on screen, and therefore the most
+/// of it worth reading.
+///
+/// With wrapping on, that is the row width: the rest of the line is on further
+/// rows, which are read as their own rows. With wrapping off, a logical line is
+/// one row and only the columns from the horizontal scroll offset to the right
+/// edge are drawn — so the read needs the line's first `left_column + width`
+/// columns and nothing beyond. The slack is a screen's worth, so that scrolling
+/// sideways a little does not re-read on every frame.
+///
+/// The window is measured from the further right of two things: where the view
+/// is now (`left_column`), and where the *cursor* sits along its own line. They
+/// are not the same, because one frame can move both — `End` on a long line
+/// puts the cursor at its end and the horizontal scroll follows it in the same
+/// frame — and a build sized by the old `left_column` alone would hand the
+/// renderer a row that stops short of the columns it is about to draw. The
+/// vertical budget already reaches for the cursor for exactly this reason;
+/// this is that, sideways.
+///
+/// Bytes stand in for columns in the cursor term, which can only over-estimate
+/// (a column is at least one byte) — the safe direction for a read budget.
+///
+/// [`MAX_SAFE_LINE_WIDTH`] caps it: that constant stops being the routine row
+/// width and goes back to being what its name says, a bound on how much of one
+/// line can ever be materialised.
+fn visible_line_span(
+    buffer: &mut crate::model::buffer::Buffer,
+    viewport: &Viewport,
+    content_width: usize,
+    cursor_positions: &[usize],
+) -> usize {
+    let width = content_width.max(1);
+    let furthest_cursor_column = cursor_positions
+        .iter()
+        .filter_map(|&pos| {
+            let line_start = buffer.prev_line_start_within(pos, CURSOR_COLUMN_SCAN_BYTES)?;
+            Some(pos.saturating_sub(line_start))
+        })
+        .max()
+        .unwrap_or(0);
+    // The cap bounds the *extent* — how much of one line past the window may be
+    // materialised — and not the window's position. Clamping the total is how
+    // scrolling a long line sideways came to blank it: the renderer skips
+    // `left_column` characters of the row it is given and draws what follows,
+    // so a row built as the line's first 10,000 columns has nothing under a
+    // view scrolled to column 100,000, and no cell to put the caret in either.
+    viewport
+        .left_column
+        .max(furthest_cursor_column)
+        .saturating_add(width.saturating_mul(2).min(MAX_SAFE_LINE_WIDTH))
+        .max(1)
+}
+
+/// How far back the cursor's own line start is looked for when sizing that
+/// window. A cursor deeper into its line than this is past the point where a
+/// column number means anything, and the window falls back to the view's own
+/// position.
+const CURSOR_COLUMN_SCAN_BYTES: usize = 64 * 1024;
+
 /// Character budget for [`build_base_tokens`], or `None` to bound the read by
 /// source lines alone.
 ///
@@ -105,28 +166,17 @@ fn effective_wrap_width(
 /// single-line file (`lines_seen` advances only once per `MAX_SAFE_LINE_WIDTH`
 /// characters, so the line bound never fires inside one long line).
 ///
-/// With wrapping off there is no budget to give: a long line is chopped into
-/// rows of `MAX_SAFE_LINE_WIDTH` columns each, so covering the viewport's rows
-/// genuinely costs `rows × MAX_SAFE_LINE_WIDTH` characters.
+/// With wrapping off a logical line is one visual row, so the rows the
+/// renderer can draw are covered by `rows × ` [`visible_line_span`] — the
+/// columns a row can actually show, not the safety chop it would be broken at
+/// if one line ever reached it.
 fn base_char_budget(
-    line_wrap_enabled: bool,
-    effective_width: usize,
+    row_span: usize,
     adjusted_visible_count: usize,
     cursor_positions: &[usize],
     rows_before_window: usize,
     start_byte: usize,
 ) -> Option<usize> {
-    // Wrap off still wraps, at the `MAX_SAFE_LINE_WIDTH` safety chop, so it has
-    // a real budget: rows × that width. It used to be `None` because the read
-    // was bounded instead by a `Break` the token build injected at the same
-    // interval — removed, since it placed row boundaries relative to wherever
-    // the read started, so no two reads of a line agreed on them.
-    let effective_width = if line_wrap_enabled {
-        effective_width
-    } else {
-        MAX_SAFE_LINE_WIDTH
-    };
-
     // Rows the build must cover: the window, plus whatever precedes it. With an
     // anchor that prefix is the walk-back to a resumable row — usually zero.
     // Without one it is every row of the logical line above the viewport.
@@ -141,7 +191,7 @@ fn base_char_budget(
     // generously rather than trying to be exact — over-reading a little is
     // free next to the 50× the budget saves.
     let mut budget = rows
-        .saturating_mul(effective_width.max(1))
+        .saturating_mul(row_span.max(1))
         .saturating_mul(2)
         .saturating_add(1024);
 
@@ -157,7 +207,7 @@ fn base_char_budget(
     {
         budget = budget.max(
             (furthest - start_byte)
-                .saturating_add(effective_width.saturating_mul(2))
+                .saturating_add(row_span.saturating_mul(2))
                 .saturating_add(1024),
         );
     }
@@ -225,6 +275,43 @@ pub(super) fn build_view_data(
     // rather than just before `apply_wrapping_transform` — because it also
     // sizes the token build's character budget (see `base_char_budget`).
     let effective_width = effective_wrap_width(viewport, line_wrap_enabled, content_width);
+    // What a row can show, which with wrapping off is not what a row is
+    // *chopped* at: the chop is a safety bound no real line reaches, while this
+    // is the handful of columns the pane draws.
+    // Sizing a row by the pane's own window applies to the files it exists for:
+    // the ones too large to read whole. Below the large-file threshold a line
+    // costs nothing to read in full, and reading it in full is what keeps every
+    // *other* consumer of these rows correct — a diff pane scrolls sideways on a
+    // viewport of its own (`CompositeViewState::get_pane_viewport`) that this
+    // build cannot see, and would draw past the end of a row cut to the split's
+    // `left_column`.
+    let bounded_rows = !line_wrap_enabled && state.buffer.is_large_file();
+    let row_span = if bounded_rows {
+        visible_line_span(&mut state.buffer, viewport, content_width, cursor_positions)
+    } else if line_wrap_enabled {
+        effective_width
+    } else {
+        MAX_SAFE_LINE_WIDTH
+    };
+    // With wrap off on a large file a logical line is one visual row, so in
+    // that mode the line is not chopped at all — the build already stopped it
+    // at `row_span`, and the row carries every column from the line's start to
+    // there so the renderer can skip to `left_column` and draw from it.
+    //
+    // A chop here is a chop inside the drawn columns, and both ways of getting
+    // it wrong are visible: at `MAX_SAFE_LINE_WIDTH` the columns a view
+    // scrolled past 10,000 wants are on a row the viewport never reaches, so
+    // `End` on a long line blanks the pane, caret and all; at `row_span` — a
+    // read budget, roughly two screens — the line breaks into screen-wide rows
+    // and `Down` walks them, which is soft wrap by another name and exactly
+    // what this mode exists not to do. So: a bound no row can reach. Twice the
+    // characters the build may emit, since no character is wider than two
+    // columns.
+    let effective_width = if bounded_rows {
+        row_span.saturating_mul(2).saturating_add(1024)
+    } else {
+        effective_width
+    };
 
     // Build base token stream from source, skipping any source-byte range
     // that falls inside a collapsed fold.
@@ -245,13 +332,18 @@ pub(super) fn build_view_data(
         line_ending,
         &fold_skip,
         base_char_budget(
-            line_wrap_enabled,
-            effective_width,
+            row_span,
             adjusted_visible_count,
             cursor_positions,
             rows_before_window,
             start_byte,
         ),
+        // With wrapping off one logical line is one visual row, so a line
+        // contributes only the columns the pane can show. With it on the wrap
+        // machine already breaks the line into rows, and cutting it here would
+        // hide rows the viewport wants. Below the large-file threshold nothing
+        // is cut at all: see `bounded_rows` above.
+        bounded_rows.then_some(row_span),
         anchor.is_some(),
     );
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -5,7 +5,7 @@
 //! `transforms`, `folding`, and `style` — its only dependencies are the
 //! (also self-contained) sibling modules and a few editor state types.
 
-use super::base_tokens::build_base_tokens;
+use super::base_tokens::{build_base_tokens, build_windowed_tokens};
 use super::folding::{apply_folding, fold_adjusted_visible_count, fold_skip_set};
 use super::style::fold_placeholder_style;
 use super::transforms::{
@@ -38,6 +38,15 @@ pub(super) struct ViewData {
     /// discarded everything above the viewport — the O(scroll-depth) cost this
     /// replaces.
     pub first_drawn: usize,
+    /// How far into each logical line these rows start, in bytes.
+    ///
+    /// Zero for every ordinary build: the rows begin at their lines' starts and
+    /// the renderer skips `left_column` characters of them. Non-zero when the
+    /// rows *are* the window a horizontally scrolled pane draws, in which case
+    /// the renderer must skip nothing — see `build_windowed_tokens`. Carried
+    /// with the rows rather than recomputed downstream, because a build and a
+    /// renderer that disagree about this draw an empty pane.
+    pub line_window_byte: usize,
 }
 
 /// Where the build starts, when the caller could resolve a resumable row.
@@ -96,65 +105,6 @@ fn effective_wrap_width(
     };
     base.saturating_sub(1).max(1)
 }
-
-/// Columns of a logical line a pane can put on screen, and therefore the most
-/// of it worth reading.
-///
-/// With wrapping on, that is the row width: the rest of the line is on further
-/// rows, which are read as their own rows. With wrapping off, a logical line is
-/// one row and only the columns from the horizontal scroll offset to the right
-/// edge are drawn — so the read needs the line's first `left_column + width`
-/// columns and nothing beyond. The slack is a screen's worth, so that scrolling
-/// sideways a little does not re-read on every frame.
-///
-/// The window is measured from the further right of two things: where the view
-/// is now (`left_column`), and where the *cursor* sits along its own line. They
-/// are not the same, because one frame can move both — `End` on a long line
-/// puts the cursor at its end and the horizontal scroll follows it in the same
-/// frame — and a build sized by the old `left_column` alone would hand the
-/// renderer a row that stops short of the columns it is about to draw. The
-/// vertical budget already reaches for the cursor for exactly this reason;
-/// this is that, sideways.
-///
-/// Bytes stand in for columns in the cursor term, which can only over-estimate
-/// (a column is at least one byte) — the safe direction for a read budget.
-///
-/// [`MAX_SAFE_LINE_WIDTH`] caps it: that constant stops being the routine row
-/// width and goes back to being what its name says, a bound on how much of one
-/// line can ever be materialised.
-fn visible_line_span(
-    buffer: &mut crate::model::buffer::Buffer,
-    viewport: &Viewport,
-    content_width: usize,
-    cursor_positions: &[usize],
-) -> usize {
-    let width = content_width.max(1);
-    let furthest_cursor_column = cursor_positions
-        .iter()
-        .filter_map(|&pos| {
-            let line_start = buffer.prev_line_start_within(pos, CURSOR_COLUMN_SCAN_BYTES)?;
-            Some(pos.saturating_sub(line_start))
-        })
-        .max()
-        .unwrap_or(0);
-    // The cap bounds the *extent* — how much of one line past the window may be
-    // materialised — and not the window's position. Clamping the total is how
-    // scrolling a long line sideways came to blank it: the renderer skips
-    // `left_column` characters of the row it is given and draws what follows,
-    // so a row built as the line's first 10,000 columns has nothing under a
-    // view scrolled to column 100,000, and no cell to put the caret in either.
-    viewport
-        .left_column
-        .max(furthest_cursor_column)
-        .saturating_add(width.saturating_mul(2).min(MAX_SAFE_LINE_WIDTH))
-        .max(1)
-}
-
-/// How far back the cursor's own line start is looked for when sizing that
-/// window. A cursor deeper into its line than this is past the point where a
-/// column number means anything, and the window falls back to the view's own
-/// position.
-const CURSOR_COLUMN_SCAN_BYTES: usize = 64 * 1024;
 
 /// Character budget for [`build_base_tokens`], or `None` to bound the read by
 /// source lines alone.
@@ -286,8 +236,30 @@ pub(super) fn build_view_data(
     // build cannot see, and would draw past the end of a row cut to the split's
     // `left_column`.
     let bounded_rows = !line_wrap_enabled && state.buffer.is_large_file();
+    // How far into each logical line these rows begin.
+    //
+    // Only this mode can have an offset: with wrap off on a large file a row is
+    // a *window* into a line rather than the line's opening, and the window's
+    // position is the horizontal scroll the viewport maintains — in bytes, as
+    // every column measurement on this path already is. Reading the window
+    // where it is, instead of reading up to it, is what keeps a frame's cost
+    // and its reach independent of how far right the view has been scrolled.
+    // Not for a binary buffer: its rows are built byte-by-byte by a reader of
+    // its own, and a window into a line means nothing to a view already showing
+    // bytes rather than columns.
+    let line_window_byte = if bounded_rows && !is_binary {
+        viewport.left_column
+    } else {
+        0
+    };
     let row_span = if bounded_rows {
-        visible_line_span(&mut state.buffer, viewport, content_width, cursor_positions)
+        // The row is the window: its own width and a screen of slack, and
+        // nothing to do with how far along the line it sits.
+        content_width
+            .max(1)
+            .saturating_mul(2)
+            .min(MAX_SAFE_LINE_WIDTH)
+            .max(1)
     } else if line_wrap_enabled {
         effective_width
     } else {
@@ -323,29 +295,43 @@ pub(super) fn build_view_data(
         Some(a) => (a.byte, Some(a.carry), a.skip),
         None => (viewport.top_byte(), None, viewport.top_view_line_offset()),
     };
-    let base_tokens = build_base_tokens(
-        &mut state.buffer,
-        start_byte,
-        estimated_line_length,
-        adjusted_visible_count,
-        is_binary,
-        line_ending,
-        &fold_skip,
-        base_char_budget(
-            row_span,
-            adjusted_visible_count,
-            cursor_positions,
-            rows_before_window,
+    let base_tokens = if line_window_byte > 0 {
+        // The rows are the window. Nothing before it is read, so none of the
+        // budgets below apply — the read is a screenful by construction.
+        build_windowed_tokens(
+            &mut state.buffer,
             start_byte,
-        ),
-        // With wrapping off one logical line is one visual row, so a line
-        // contributes only the columns the pane can show. With it on the wrap
-        // machine already breaks the line into rows, and cutting it here would
-        // hide rows the viewport wants. Below the large-file threshold nothing
-        // is cut at all: see `bounded_rows` above.
-        bounded_rows.then_some(row_span),
-        anchor.is_some(),
-    );
+            adjusted_visible_count,
+            line_ending,
+            &fold_skip,
+            line_window_byte,
+            row_span,
+        )
+    } else {
+        build_base_tokens(
+            &mut state.buffer,
+            start_byte,
+            estimated_line_length,
+            adjusted_visible_count,
+            is_binary,
+            line_ending,
+            &fold_skip,
+            base_char_budget(
+                row_span,
+                adjusted_visible_count,
+                cursor_positions,
+                rows_before_window,
+                start_byte,
+            ),
+            // With wrapping off one logical line is one visual row, so a line
+            // contributes only the columns the pane can show. With it on the wrap
+            // machine already breaks the line into rows, and cutting it here would
+            // hide rows the viewport wants. Below the large-file threshold nothing
+            // is cut at all: see `bounded_rows` above.
+            bounded_rows.then_some(row_span),
+            anchor.is_some(),
+        )
+    };
 
     let mut tokens = base_tokens;
 
@@ -527,5 +513,6 @@ pub(super) fn build_view_data(
     ViewData {
         lines,
         first_drawn: rows_before_window,
+        line_window_byte,
     }
 }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -597,8 +597,14 @@ const CURSOR_COL_RESERVE: usize = 3;
 /// — rather than bytes or code points — keeps the reported column consistent
 /// with the editor's grapheme-based cursor movement.
 fn cursor_column(buffer: &mut crate::model::buffer::TextBuffer, cursor_position: usize) -> usize {
-    let mut iter = buffer.line_iterator(cursor_position, 80);
-    let line_start = iter.current_position();
+    // The line's real start, not the reader's guess at one. The reader's
+    // backward scan is bounded, and past that bound it reports how far it
+    // looked — which is a column of 65,537 for a cursor anywhere beyond 64 KB
+    // into its line, the same wrong number for every position past it.
+    let line_start = buffer
+        .prev_line_start_within(cursor_position, buffer.len())
+        .unwrap_or(0);
+    let mut iter = buffer.line_iterator(line_start, 80);
     let byte_col = cursor_position.saturating_sub(line_start);
     if byte_col == 0 {
         return 0;

--- a/crates/fresh-editor/src/view/ui/view_pipeline.rs
+++ b/crates/fresh-editor/src/view/ui/view_pipeline.rs
@@ -337,10 +337,23 @@ impl<'a> ViewLineIterator<'a> {
             // profile at 7.81% self, on text that is almost always ASCII.
             //
             // Excludes control bytes (so tab, ESC and the unprintables still
-            // take the general path), binary mode, and any token being watched
-            // by an ANSI parser.
+            // take the general path), binary mode, and a run the ANSI parser
+            // is part-way through.
+            //
+            // The parser's presence is not itself a reason to segment. It is
+            // constructed whenever the pipeline is `ansi_aware`, which every
+            // production caller sets to `!is_binary` — so testing it for
+            // `is_none()` here meant "binary mode", which the first condition
+            // already excludes, and the fast path never ran outside its own
+            // unit tests. What the parser actually needs is the bytes of an
+            // escape sequence: an ESC is a control byte and already excluded,
+            // and a sequence *opened by an earlier token* is the only way
+            // plain bytes can still belong to one. `parse_char` returns the
+            // current style unchanged for every other character, so skipping
+            // it over a run with no ESC in it is exactly equivalent.
+            let mid_escape = ansi_parser.as_ref().is_some_and(|p| p.in_escape());
             let ascii_fast = !self.binary_mode
-                && ansi_parser.is_none()
+                && !mid_escape
                 && valid.is_ascii()
                 && !valid.bytes().any(|b| b < 0x20 || b == 0x7f);
             if ascii_fast {
@@ -352,6 +365,7 @@ impl<'a> ViewLineIterator<'a> {
             }
 
             let mut segmented_bytes = 0usize;
+            fresh_editor_core::counters::work::add_text_bytes_segmented(valid.len() as u64);
             for (g_byte_offset, grapheme) in valid.grapheme_indices(true) {
                 segmented_bytes = g_byte_offset + grapheme.len();
 
@@ -810,6 +824,7 @@ impl Layout {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fresh_editor_core::counters::work;
 
     fn make_text_token(text: &str, source_offset: Option<usize>) -> ViewTokenWire {
         ViewTokenWire {
@@ -1381,6 +1396,78 @@ mod tests {
             lines[1].source_byte_at_visual_col(2),
             Some(6),
             "Line 2 col 2 (newline)"
+        );
+    }
+
+    /// The ASCII fast path has to be reachable in the configuration the
+    /// editor actually renders in.
+    ///
+    /// Every production caller builds the pipeline with `ansi_aware =
+    /// !is_binary`, so the parser exists for all text buffers. Gating the fast
+    /// path on the parser being *absent* therefore meant "binary mode", which
+    /// the same condition excludes — the path ran only in its own unit tests,
+    /// which passed `ansi_aware = false`, while real frames put every
+    /// character of every row through UAX #29 segmentation (12% of a frame's
+    /// self time on a minified-JSON buffer).
+    #[test]
+    fn plain_ascii_skips_segmentation_when_ansi_aware() {
+        let tokens = vec![make_text_token("plain ascii, no escapes here", Some(0))];
+
+        work::reset();
+        let lines: Vec<_> = ViewLineIterator::new(&tokens, false, true, 4, false).collect();
+        let segmented = work::text_bytes_segmented();
+
+        assert_eq!(
+            segmented, 0,
+            "plain ASCII was segmented ({segmented} bytes) with an ANSI parser \
+             present — the fast path is unreachable in the production config"
+        );
+        assert_eq!(lines[0].text, "plain ascii, no escapes here");
+    }
+
+    /// And it produces exactly what the general path produces.
+    #[test]
+    fn ascii_fast_path_matches_the_general_path() {
+        let tokens = vec![
+            make_text_token("abc", Some(0)),
+            make_newline_token(Some(3)),
+            make_text_token("de", Some(4)),
+        ];
+
+        let fast: Vec<_> = ViewLineIterator::new(&tokens, false, true, 4, false).collect();
+        let general: Vec<_> = ViewLineIterator::new(&tokens, true, true, 4, false).collect();
+
+        assert_eq!(fast.len(), general.len());
+        for (f, g) in fast.iter().zip(general.iter()) {
+            assert_eq!(f.text, g.text);
+            assert_eq!(f.char_source_bytes, g.char_source_bytes);
+            assert_eq!(f.char_visual_cols, g.char_visual_cols);
+            assert_eq!(f.visual_to_char, g.visual_to_char);
+        }
+    }
+
+    /// An escape sequence split across two tokens still hides its tail.
+    ///
+    /// The second token is plain ASCII, so it is exactly what the fast path
+    /// would claim — but its bytes are the body of a sequence the first token
+    /// opened, and they must stay invisible and zero-width. This is why the
+    /// fast path asks whether the parser is *part-way through* a sequence
+    /// rather than whether it exists.
+    #[test]
+    fn a_split_escape_sequence_stays_invisible() {
+        let tokens = vec![
+            make_text_token("\x1b[", Some(0)),
+            make_text_token("31mhello", Some(2)),
+        ];
+
+        let lines: Vec<_> = ViewLineIterator::new(&tokens, false, true, 4, false).collect();
+
+        assert_eq!(
+            lines[0].visual_width(),
+            "hello".len(),
+            "only `hello` is visible; `31m` completes the sequence opened by \
+             the previous token, got {:?}",
+            lines[0].text
         );
     }
 }

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -771,13 +771,23 @@ impl Viewport {
             self.scroll_up_visual(buffer, soft_breaks, virtual_lines, hidden_ranges, lines);
         } else {
             let new_position = if hidden_ranges.is_empty() {
-                let mut iter = buffer.line_iterator(self.top_byte(), 80);
+                // With wrap off a row is a logical line, so scrolling by rows
+                // is walking line starts. Walking the *reader* instead hands
+                // back the previous piece of the line the viewport is already
+                // on, and its backward search gives up after 64 KB — so a page
+                // up on a file that is one long line moved the top by that
+                // bound rather than by a screenful of anything.
+                let mut pos = self.top_byte();
                 for _ in 0..lines {
-                    if iter.prev().is_none() {
+                    if pos == 0 {
                         break;
                     }
+                    match buffer.prev_line_start_within(pos - 1, CLAMP_SCAN_BYTES) {
+                        Some(prev) => pos = prev,
+                        None => break,
+                    }
                 }
-                iter.current_position()
+                pos
             } else {
                 Self::walk_up_visible_lines(buffer, hidden_ranges, self.top_byte(), lines)
             };
@@ -869,13 +879,19 @@ impl Viewport {
             self.scroll_down_visual(buffer, soft_breaks, virtual_lines, hidden_ranges, lines);
         } else {
             let new_position = if hidden_ranges.is_empty() {
-                let mut iter = buffer.line_iterator(self.top_byte(), 80);
+                // The mirror of `scroll_up`: line starts, not the reader's
+                // pieces. A piece boundary is a read budget, so paging down a
+                // file that is one long line moved the viewport a hundred
+                // kilobytes per row — the pane's height times a constant, and
+                // nothing to do with the document.
+                let mut pos = self.top_byte();
                 for _ in 0..lines {
-                    if iter.next_line().is_none() {
-                        break;
+                    match buffer.next_line_start_within(pos, CLAMP_SCAN_BYTES) {
+                        Some(next) => pos = next,
+                        None => break,
                     }
                 }
-                iter.current_position()
+                pos
             } else {
                 Self::walk_down_visible_lines(buffer, hidden_ranges, self.top_byte(), lines)
             };
@@ -2164,15 +2180,39 @@ impl Viewport {
         // Horizontal scrolling (disabled when wrapping — all columns visible via wrap).
         if !self.line_wrap_enabled {
             let cursor_column = cursor.position.saturating_sub(cursor_line_start) + virtual_columns;
-            let mut line_iter = buffer.line_iterator(cursor_line_start, 80);
-            let line_length = if let Some((_, content)) = line_iter.next_line() {
-                content.trim_end_matches('\n').len()
-            } else {
-                0
+            // The line's length, and only when its end is within reach.
+            //
+            // The clamp this feeds keeps the view from scrolling into the empty
+            // space past a line's end. Measuring the line by *reading* it gives
+            // back a hundred-kilobyte piece on a long one, so the old code took
+            // the larger of that and the cursor's own column — which on a line
+            // longer than either makes the length equal to the cursor's column,
+            // and the clamp then says the cursor must be the last visible
+            // column. Every step left dragged the window left with it, the
+            // caret pinned to the right-hand edge.
+            //
+            // Zero disables the clamp, which is the right answer when the end is
+            // out of reach: a line that runs past the search is far longer than
+            // the window, so there is no empty space beyond it to scroll into.
+            let buffer_len = buffer.len();
+            let searched_to_eof = cursor_line_start.saturating_add(CLAMP_SCAN_BYTES) >= buffer_len;
+            let line_end = match buffer.next_line_start_within(cursor_line_start, CLAMP_SCAN_BYTES)
+            {
+                Some(next) => Some(next.saturating_sub(1)),
+                // No break found. If the search reached the end of the buffer
+                // there is nothing left to find and the last line ends there;
+                // otherwise the end is simply beyond reach.
+                None if searched_to_eof => Some(buffer_len),
+                None => None,
             };
-            // In virtual space the cursor column exceeds the line length;
-            // widen the scroll limit so the viewport can follow it.
-            let line_length = line_length.max(cursor_column);
+            let line_length = line_end
+                .map(|end| {
+                    end.saturating_sub(cursor_line_start)
+                        // In virtual space the cursor column exceeds the line
+                        // length; widen the limit so the view can follow it.
+                        .max(cursor_column)
+                })
+                .unwrap_or(0);
             self.ensure_column_visible(cursor_column, line_length, buffer);
         } else {
             self.left_column = 0;

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -151,6 +151,49 @@ pub struct Viewport {
     pub(crate) wrap_row_cache: crate::view::line_wrap_cache::RowCountCache,
 }
 
+/// Scanning budget for the unwrapped scroll clamp.
+///
+/// The clamp asks how many rows lie below a candidate top, and with soft wrap
+/// off a row is a line — so on a file whose next line break is megabytes away
+/// the honest answer is "not many, and finding out costs what we let it". A
+/// screenful of ordinary lines is a few tens of kilobytes; past this the clamp
+/// concludes the rows are not there, which for such a file is correct.
+const CLAMP_SCAN_BYTES: usize = 256 * 1024;
+
+/// How much scanning a row-counting walk gets per row it is counting.
+///
+/// The question is "how many rows lie between these two bytes", and with soft
+/// wrap off a row is a line, so the answer costs the line breaks between them.
+/// Budgeting per row rather than for the walk as a whole is what makes the
+/// bound scale with the pane: a forty-row viewport over a file of ten-kilobyte
+/// lines must look at four hundred kilobytes to count its own rows, and under a
+/// flat quarter-megabyte budget it gives up two thirds of the way down and
+/// concludes the rows are not there — a viewport that refuses to scroll where
+/// it was pointed.
+///
+/// Each individual search is still capped at [`CLAMP_SCAN_BYTES`]: a line
+/// longer than that has no row below it worth finding, and the piece tree
+/// remembers what it walked, so a second frame over the same region asks the
+/// tree instead of the file.
+const ROW_SCAN_BYTES_PER_ROW: usize = 64 * 1024;
+
+/// Start of the line above the one containing `byte`, or `None` at the start of
+/// the buffer / when no line start is within reach.
+///
+/// Bounded like every other line-start search: a file that is one long line has
+/// no previous line, and discovering that must not cost the file.
+fn previous_line_start(buffer: &mut Buffer, byte: usize) -> Option<usize> {
+    if byte == 0 {
+        return None;
+    }
+    // The buffer's own bounded search, which faults in the chunks it crosses.
+    // The `&Buffer` probes in `folding` read through `slice_bytes`, which is
+    // silent about a region that has not been loaded — on a lazily-loaded large
+    // file that reads as "no line break here", and the clamp would place the
+    // viewport on the strength of it.
+    buffer.prev_line_start_within(byte.saturating_sub(1), CLAMP_SCAN_BYTES)
+}
+
 impl Viewport {
     /// Byte the viewport starts at.
     ///
@@ -239,7 +282,7 @@ impl Viewport {
             if start == 0 {
                 return 0;
             }
-            p = crate::view::folding::indent_folding::find_line_start_byte(buffer, start - 1);
+            p = crate::view::folding::indent_folding::line_start_byte_or_floor(buffer, start - 1);
         }
         p
     }
@@ -1788,72 +1831,62 @@ impl Viewport {
         proposed_top_byte: usize,
         viewport_height: usize,
     ) {
-        let mut iter = buffer.line_iterator(proposed_top_byte, 80);
-        let mut lines_visible = 0;
-
-        while iter.next_line().is_some() {
-            lines_visible += 1;
-            if lines_visible >= viewport_height {
-                // We have a full viewport of content, use proposed position
-                tracing::trace!(
-                    "DEBUG: Full viewport available, setting top_byte={}",
-                    proposed_top_byte
-                );
-                self.set_top_byte(proposed_top_byte);
-                return;
+        // With soft wrap off a logical line is one visual row, so "can this
+        // position fill the viewport" is "are there this many line starts below
+        // it" — a question about structure, answered by walking line starts
+        // rather than by reading the lines. Reading them meant materialising
+        // `viewport_height` × 100 KB of a file that is one long line, per
+        // scroll event, only to count to forty.
+        let buffer_len = buffer.len();
+        let mut rows_below = 0usize;
+        let mut pos = proposed_top_byte.min(buffer_len);
+        let mut budget = viewport_height
+            .max(1)
+            .saturating_mul(ROW_SCAN_BYTES_PER_ROW);
+        // Whether the count stopped because it ran out of scanning rather than
+        // out of lines — the difference between "there are no more rows below"
+        // and "I did not finish looking".
+        let mut unfinished = false;
+        while rows_below < viewport_height {
+            if budget == 0 {
+                unfinished = true;
+                break;
+            }
+            match buffer.next_line_start_within(pos, budget.min(CLAMP_SCAN_BYTES)) {
+                Some(next) => {
+                    budget = budget.saturating_sub(next - pos);
+                    pos = next;
+                    rows_below += 1;
+                }
+                None => break,
             }
         }
+        // The row the position itself sits on counts.
+        let rows_from_here = rows_below.saturating_add(1);
 
-        tracing::trace!(
-            "DEBUG: After iteration, lines_visible={}, viewport_height={}",
-            lines_visible,
-            viewport_height
-        );
-
-        // If we have enough lines to fill the viewport, we're good
-        if lines_visible >= viewport_height {
-            tracing::trace!(
-                "DEBUG: Enough lines to fill viewport, setting top_byte={}",
-                proposed_top_byte
-            );
+        // Backing up moves the viewport away from where the caller pointed it,
+        // so it takes a finished count to justify. An unfinished one means
+        // there are at least this many rows below and probably more; leave the
+        // position alone rather than yank it upward on a half-answer.
+        if unfinished || rows_from_here >= viewport_height {
             self.set_top_byte(proposed_top_byte);
             return;
         }
 
-        // We don't have enough lines to fill the viewport from proposed_top_byte
-        // Calculate how many lines we're short and scroll back
-        let lines_short = viewport_height - lines_visible;
-        tracing::trace!("DEBUG: lines_short={}, scrolling back", lines_short);
-
-        let mut backtrack_iter = buffer.line_iterator(proposed_top_byte, 80);
-        tracing::trace!(
-            "DEBUG: Backtracking from byte {}",
-            backtrack_iter.current_position()
-        );
-        for i in 0..lines_short {
-            let pos_before = backtrack_iter.current_position();
-            if backtrack_iter.prev().is_none() {
-                tracing::trace!(
-                    "DEBUG: Hit beginning of buffer at backtrack iteration {}",
-                    i
-                );
-                break; // Hit the beginning of the buffer
+        // Not enough rows below: back up so the last row still rests at the
+        // bottom. Each step is one line start above the current one.
+        let short_by = viewport_height - rows_from_here;
+        let mut top = proposed_top_byte;
+        for _ in 0..short_by {
+            let Some(prev) = previous_line_start(buffer, top) else {
+                break;
+            };
+            if prev == top {
+                break;
             }
-            let pos_after = backtrack_iter.current_position();
-            tracing::trace!(
-                "DEBUG: Backtrack iteration {}: {} -> {}",
-                i,
-                pos_before,
-                pos_after
-            );
+            top = prev;
         }
-
-        let final_top_byte = backtrack_iter.current_position();
-        tracing::trace!(
-            "DEBUG: After backtracking, setting top_byte={}",
-            final_top_byte
-        );
-        self.set_top_byte(final_top_byte);
+        self.set_top_byte(top);
     }
 
     /// Scroll to a specific line (byte-based)
@@ -2038,7 +2071,26 @@ impl Viewport {
             return;
         }
 
-        let cursor_line_start = buffer.line_iterator(cursor.position, 80).current_position();
+        // The cursor's line start, exactly — not bounded like the walks that
+        // count rows.
+        //
+        // Those answer "is there a row above / below", where "not within reach"
+        // is a usable answer. This one is the origin the cursor's *column* is
+        // measured from, and the column decides how far right the view scrolls
+        // and therefore what is drawn. Substituting the cursor's own position
+        // when the search runs out reports column 0 for a cursor a megabyte
+        // into its line: the view then scrolls vertically into the middle of
+        // that line, as if its rows were addressed by byte, and stays at column
+        // 0 horizontally. `End` on a long line lands nowhere near the end of it
+        // — 64 KB short, that being how far the search looked.
+        //
+        // Costs a scan back to the line start, once: the piece tree records the
+        // pieces the scan crosses, so the next cursor move on the same line is
+        // answered from metadata. A cursor at the start of its line — every
+        // cursor on a file with ordinary lines — answers immediately.
+        let cursor_line_start = buffer
+            .prev_line_start_within(cursor.position, buffer.len())
+            .unwrap_or(0);
         let effective_offset = self.scroll_offset.min(viewport_lines / 2);
 
         let (cursor_is_visible, cursor_near_top) = if self.row_pass_owns_placement {
@@ -2432,22 +2484,30 @@ impl Viewport {
         effective_offset: usize,
         hidden_ranges: &[(usize, usize)],
     ) -> (bool, bool) {
-        let mut iter = buffer.line_iterator(self.top_byte(), 80);
+        // How many rows down from the top the cursor's line sits — with soft
+        // wrap off a row is a line, so this counts line starts. Walking them
+        // rather than reading the lines is what keeps it a screenful of work on
+        // a file whose lines are megabytes.
+        let mut pos = self.top_byte();
         let mut lines_from_top: usize = 0;
+        let mut budget = viewport_lines.max(1).saturating_mul(ROW_SCAN_BYTES_PER_ROW);
 
-        while iter.current_position() < cursor_line_start && lines_from_top < viewport_lines {
-            let pos = iter.current_position();
+        while pos < cursor_line_start && lines_from_top < viewport_lines {
             if let Some((_, end)) = Self::containing_hidden_range(hidden_ranges, pos) {
-                while iter.current_position() < end && iter.current_position() < cursor_line_start {
-                    if iter.next_line().is_none() {
-                        break;
-                    }
-                }
+                // A collapsed body draws as its header's single row: step over
+                // it without counting the lines inside.
+                pos = end.min(cursor_line_start);
                 continue;
             }
-            if iter.next_line().is_none() {
+            if budget == 0 {
                 break;
             }
+            let Some(next) = buffer.next_line_start_within(pos, budget.min(CLAMP_SCAN_BYTES))
+            else {
+                break;
+            };
+            budget = budget.saturating_sub(next - pos);
+            pos = next;
             lines_from_top += 1;
         }
 
@@ -2874,6 +2934,44 @@ mod tests {
     use super::*;
     use crate::model::buffer::Buffer;
     use crate::model::cursor::Cursor;
+
+    /// The scroll clamp leaves the viewport where it was pointed when it
+    /// cannot finish counting the rows below.
+    ///
+    /// With soft wrap off a row is a line, so the clamp asks "are there a
+    /// screenful of line starts below this position" and backs the viewport up
+    /// when there are not. The walk that answers is bounded — it has to be, on
+    /// a file whose next line break is megabytes away — but a budget for the
+    /// walk as a whole rather than per row it counts runs out partway down a
+    /// pane of ten-kilobyte lines. The clamp then reads an unfinished count as
+    /// "no more rows" and hauls the position back up, and the file will not
+    /// scroll past its first screen.
+    #[test]
+    fn the_clamp_does_not_back_up_on_a_count_it_could_not_finish() {
+        // Forty rows of ten-kilobyte lines is four hundred kilobytes to count,
+        // well past any single flat budget the walk would carry.
+        let width = 10 * 1024;
+        let lines = 200;
+        let content: String = (0..lines)
+            .map(|_| format!("{}\n", "x".repeat(width - 1)))
+            .collect();
+        let mut buffer = Buffer::from_str_test(&content);
+
+        let mut vp = Viewport::new(120, 40); // wrap off by default
+                                             // A position near the top, with hundreds of lines below it: the clamp
+                                             // has no reason to move it.
+        let proposed = width * 5;
+        vp.set_top_byte_with_limit(&mut buffer, &[], &[], proposed);
+
+        assert_eq!(
+            vp.top_byte(),
+            proposed,
+            "the clamp pulled the viewport back from byte {proposed} to {} with \
+             {} lines still below it",
+            vp.top_byte(),
+            lines - 5
+        );
+    }
 
     /// The capped count agrees with the plain one whenever it does not
     /// saturate — the guarantee that lets scroll math use it everywhere.

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -2676,6 +2676,11 @@ impl EditorTestHarness {
         self.editor.active_viewport().top_view_line_offset()
     }
 
+    /// The viewport's horizontal scroll offset, in columns.
+    pub fn left_column(&self) -> usize {
+        self.editor.active_viewport().left_column
+    }
+
     /// Get the viewport height (number of content lines that can be displayed)
     pub fn viewport_height(&self) -> usize {
         self.editor.active_viewport().height as usize

--- a/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
+++ b/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
@@ -544,3 +544,51 @@ fn end_reaches_the_end_of_a_long_line_and_home_comes_back() {
         "the start of the line should be back on screen:\n{screen}"
     );
 }
+
+#[test]
+fn stepping_left_from_the_end_of_a_long_line_moves_the_caret_not_the_view() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, _, bytes) = write_pair(dir.path());
+
+    let mut harness = opened(&path, false);
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        bytes,
+        "End reaches the line's end"
+    );
+
+    let settled = harness.left_column();
+    assert!(
+        settled > 0,
+        "End should have scrolled the view along the line"
+    );
+
+    // Ten steps, all of them well inside a 120-column pane: the caret has room
+    // to walk left without the view needing to move at all.
+    //
+    // The view is clamped so it never scrolls into the empty space past a
+    // line's end, and that clamp needs the line's length. Measuring the line by
+    // reading it stops at the reader's cap, so the length came back as the
+    // cursor's own column — which makes the clamp say the cursor *is* the last
+    // visible column. Every Left then dragged the window left with it and the
+    // caret stayed pinned to the right-hand edge, which is not stepping left,
+    // it is scrolling.
+    for step in 1..=10 {
+        harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        assert_eq!(
+            harness.cursor_position(),
+            bytes - step,
+            "Left must step the caret back one byte"
+        );
+        assert_eq!(
+            harness.left_column(),
+            settled,
+            "the view must hold still while the caret has room to move in it \
+             (step {step}):\n{}",
+            harness.screen_to_string()
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
+++ b/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
@@ -592,3 +592,60 @@ fn stepping_left_from_the_end_of_a_long_line_moves_the_caret_not_the_view() {
         );
     }
 }
+
+/// Typing costs the same wherever the caret sits on a line.
+///
+/// It did not. An edit at the far end of a 19 MB line read the line twice —
+/// 38 MB per keystroke, 2.3 s in a debug build — while the identical edit at
+/// byte 0 of the same file read a few hundred kilobytes. Two unrelated callers,
+/// each asking for the text between the line's start and the caret:
+///
+/// * `line_start_and_blank_prefix` walked backwards to find the line start,
+///   which on a file that is one line is the whole file.
+/// * `collect_lsp_changes` converted the edit's byte offsets into LSP's UTF-16
+///   positions, which needs the line prefix counted — and the send path then
+///   threw the result away, because the buffer has no language server.
+///
+/// Stated as a ratio against the same edit near the line's start rather than as
+/// an absolute figure: the claim is that the caret's column does not enter into
+/// what a keystroke costs, and that holds whatever the fixture's size.
+#[test]
+fn an_edit_costs_the_same_at_either_end_of_a_long_line() {
+    let dir = tempfile::tempdir().unwrap();
+    let (single_path, _, file_bytes) = write_pair(dir.path());
+    let mut harness = opened(&single_path, false);
+
+    let at_start = bytes_read(&mut harness, |h| {
+        h.send_key(KeyCode::Char('X'), KeyModifiers::NONE).unwrap();
+        h.render().unwrap();
+    });
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        file_bytes,
+        "the caret should be at the line's far end"
+    );
+
+    let at_end = bytes_read(&mut harness, |h| {
+        h.send_key(KeyCode::Char('X'), KeyModifiers::NONE).unwrap();
+        h.render().unwrap();
+    });
+
+    eprintln!(
+        "edit at byte 0: {at_start} bytes, at byte {file_bytes}: {at_end} bytes \
+         (file is {file_bytes})"
+    );
+    let budget = (at_start * 8).max(4 * 1024 * 1024);
+    assert!(
+        at_end < budget,
+        "typing at byte {file_bytes} of a {file_bytes}-byte line read {at_end} \
+         bytes against {at_start} for the same keystroke at byte 0 (budget \
+         {budget}) — the caret's column is back in the cost of a keystroke"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
+++ b/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
@@ -476,6 +476,12 @@ fn a_pane_of_long_lines_scrolls() {
 ///   looked, not where the line starts — so it takes two presses to get back,
 ///   and the first one lands in the middle of the line.
 ///
+/// The file has to be this big. The row a pane draws with wrap off is a
+/// *window* into its line, and a file whose far end sits within a screenful of
+/// its start exercises none of that — it draws either way. Past the large-file
+/// threshold, with an end megabytes from the start, it is the window or
+/// nothing.
+///
 /// Asserts on rendered output (CONTRIBUTING §2). The cursor's byte is read
 /// from the editor rather than the status bar, because reaching the end of the
 /// line necessarily walks the rest of it — and the piece tree records what that
@@ -485,17 +491,25 @@ fn a_pane_of_long_lines_scrolls() {
 #[test]
 fn end_reaches_the_end_of_a_long_line_and_home_comes_back() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("one_line.json");
-
-    // Comfortably past the reader's 100,000-byte piece cap and the 64 KB
-    // line-start search, and past the large-file threshold this config sets.
-    let (single, _) = single_line_and_control(400_000);
-    let bytes = single.len();
-    assert!(bytes > 2 * 1024 * 1024, "{bytes} is too small to show this");
-    std::fs::File::create(&path)
-        .unwrap()
-        .write_all(single.as_bytes())
-        .unwrap();
+    // The module's own ~19 MB fixture, and it has to be that big.
+    //
+    // The row a pane draws is built as a *prefix* of the line — every column
+    // from its start to the right-hand edge of the view — so how far right the
+    // view can be scrolled and still have something to draw is bounded by how
+    // much of one line the build will read. A file whose far end sits inside
+    // that reach exercises none of this: it draws, and the test passes without
+    // touching the case that fails. Past the reach the row is built short, the
+    // view is scrolled beyond what it contains, and the pane goes blank.
+    //
+    // It also has to be past the large-file threshold, which is 10 MB by
+    // default — below it a wrap-off row is chopped at `MAX_SAFE_LINE_WIDTH`
+    // and the same blank appears from a different direction.
+    let (path, _, bytes) = write_pair(dir.path());
+    assert!(
+        bytes > 10 * 1024 * 1024,
+        "{bytes} is inside the build's reach, so this would pass without \
+         testing anything"
+    );
 
     let mut harness = opened(&path, false);
     assert_eq!(harness.cursor_position(), 0, "the file opens at its start");

--- a/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
+++ b/crates/fresh-editor/tests/e2e/large_file_edit_bounded.rs
@@ -1,0 +1,532 @@
+//! Editing and moving in a file that is one enormous line must cost the
+//! screen, not the file.
+//!
+//! #3162 made *opening* such a file bounded. What it left behind is everything
+//! that happens next: a frame, a keystroke and an arrow press each re-asked
+//! questions whose answers scale with the line — "where does this line start",
+//! "where does it end", "how many lines are below this one" — and answered them
+//! by reading the line. On a 50 MB single-line JSON that is megabytes of
+//! reading per keypress, which is what "editing is still incredibly slow" was.
+//!
+//! Pinned on **bytes read from the buffer**, not on the clock, so these mean
+//! the same on a loaded CI runner as on an idle laptop (CONTRIBUTING §3). Each
+//! bound is stated against the byte-identical multi-line control: same bytes,
+//! different shape, so a gap between the two is the shape costing something.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use fresh_editor_core::counters::work;
+use std::io::Write;
+
+const W: u16 = 120;
+const H: u16 = 40;
+
+fn config(line_wrap: bool) -> Config {
+    let mut config = Config::default();
+    config.editor.line_wrap = line_wrap;
+    // Far under both files, so this is the lazily-loaded large-file path.
+    config.editor.large_file_threshold_bytes = 1024 * 1024;
+    config
+}
+
+/// `[0,1,2,...]` on one line — no whitespace anywhere, the shape of a minified
+/// JSON array — plus the byte-identical control with every comma turned into a
+/// newline.
+fn single_line_and_control(values: usize) -> (String, String) {
+    let mut single = String::from("[");
+    for i in 0..values {
+        if i > 0 {
+            single.push(',');
+        }
+        single.push_str(&i.to_string());
+    }
+    single.push(']');
+    let control = single.replace(',', "\n");
+    (single, control)
+}
+
+/// ~19 MB each: large enough that reading a line is unmistakable against the
+/// bounds below, small enough to write in well under a second.
+const VALUES: usize = 2_600_000;
+
+fn write_pair(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf, usize) {
+    let (single, control) = single_line_and_control(VALUES);
+    let bytes = single.len();
+    assert_eq!(control.len(), bytes, "the control must be byte-identical");
+
+    let single_path = dir.join("one_line.json");
+    std::fs::File::create(&single_path)
+        .unwrap()
+        .write_all(single.as_bytes())
+        .unwrap();
+    let control_path = dir.join("many_lines.txt");
+    std::fs::File::create(&control_path)
+        .unwrap()
+        .write_all(control.as_bytes())
+        .unwrap();
+    (single_path, control_path, bytes)
+}
+
+/// Bytes the buffer handed out while `f` ran, on this thread.
+fn bytes_read(harness: &mut EditorTestHarness, f: impl FnOnce(&mut EditorTestHarness)) -> u64 {
+    work::reset();
+    f(harness);
+    work::buffer_bytes_read()
+}
+
+fn opened(path: &std::path::Path, line_wrap: bool) -> EditorTestHarness {
+    let mut harness = EditorTestHarness::with_config(W, H, config(line_wrap)).unwrap();
+    harness.open_file(path).unwrap();
+    // Two frames: the first settles the viewport, the second is steady state.
+    harness.render().unwrap();
+    harness.render().unwrap();
+    harness
+}
+
+/// A steady-state frame reads a screenful, whatever shape the file is in.
+#[test]
+fn a_frame_on_a_single_line_file_reads_no_more_than_on_the_control() {
+    for line_wrap in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let (single_path, control_path, file_bytes) = write_pair(dir.path());
+
+        let mut control = opened(&control_path, line_wrap);
+        let control_read = bytes_read(&mut control, |h| h.render().unwrap());
+
+        let mut single = opened(&single_path, line_wrap);
+        let single_read = bytes_read(&mut single, |h| h.render().unwrap());
+
+        eprintln!(
+            "[wrap={line_wrap}] frame: single-line {single_read} bytes, \
+             control {control_read} bytes (file is {file_bytes})"
+        );
+        let budget = (control_read * 20).max(1024 * 1024);
+        assert!(
+            single_read < budget,
+            "a frame on a {file_bytes}-byte single-line file read {single_read} bytes \
+             against {control_read} on the byte-identical multi-line control \
+             (budget {budget}) — per-line work is back"
+        );
+    }
+}
+
+/// So does a keystroke. This is the reported bug: the file opens, and then
+/// every character typed costs the line.
+#[test]
+fn typing_a_character_reads_no_more_than_on_the_control() {
+    for line_wrap in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let (single_path, control_path, file_bytes) = write_pair(dir.path());
+
+        let mut control = opened(&control_path, line_wrap);
+        let control_read = bytes_read(&mut control, |h| h.type_text("x").unwrap());
+
+        let mut single = opened(&single_path, line_wrap);
+        let single_read = bytes_read(&mut single, |h| h.type_text("x").unwrap());
+
+        eprintln!(
+            "[wrap={line_wrap}] keystroke: single-line {single_read} bytes, \
+             control {control_read} bytes (file is {file_bytes})"
+        );
+        let budget = (control_read * 20).max(1024 * 1024);
+        assert!(
+            single_read < budget,
+            "typing one character into a {file_bytes}-byte single-line file read \
+             {single_read} bytes against {control_read} on the byte-identical \
+             multi-line control (budget {budget})"
+        );
+    }
+}
+
+/// And an arrow press, which additionally must not walk to the line's start to
+/// work out which column it is in.
+#[test]
+fn arrow_keys_read_no_more_than_on_the_control() {
+    for line_wrap in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let (single_path, control_path, file_bytes) = write_pair(dir.path());
+
+        let press = |h: &mut EditorTestHarness| {
+            for _ in 0..10 {
+                h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+            }
+            h.render().unwrap();
+        };
+
+        let mut control = opened(&control_path, line_wrap);
+        let control_read = bytes_read(&mut control, press);
+
+        let mut single = opened(&single_path, line_wrap);
+        let single_read = bytes_read(&mut single, press);
+
+        eprintln!(
+            "[wrap={line_wrap}] ten Downs: single-line {single_read} bytes, \
+             control {control_read} bytes (file is {file_bytes})"
+        );
+        let budget = (control_read * 20).max(4 * 1024 * 1024);
+        assert!(
+            single_read < budget,
+            "ten Down presses in a {file_bytes}-byte single-line file read \
+             {single_read} bytes against {control_read} on the byte-identical \
+             multi-line control (budget {budget})"
+        );
+    }
+}
+
+/// A frame draws what it can show and segments no more than that.
+///
+/// With soft wrap off a row used to be chopped at 10,000 columns — a constant
+/// with no relation to the pane — so a 40-row frame put ~400,000 characters
+/// through Unicode segmentation and width measurement to draw ~4,800.
+#[test]
+fn a_frame_segments_what_it_draws_and_not_the_chop_width() {
+    let dir = tempfile::tempdir().unwrap();
+    let (single_path, _, _) = write_pair(dir.path());
+
+    let mut harness = opened(&single_path, false);
+    work::reset();
+    harness.render().unwrap();
+    let measured = work::text_bytes_measured();
+
+    // A generous multiple of what the pane can hold (120 columns × 40 rows),
+    // and far under the old row-chop cost.
+    let budget = (W as u64) * (H as u64) * 4;
+    assert!(
+        measured < budget,
+        "a frame measured {measured} bytes' width for a {W}×{H} pane (budget \
+         {budget}) — rows are being laid out at the safety chop again"
+    );
+}
+
+/// With soft wrap off, a logical line is one visual row.
+///
+/// So a file with no line breaks in it draws exactly one row of text and
+/// nothing below, and `Down` has nowhere to go. Reading such a file vertically
+/// is what soft wrap is for; inventing rows by chopping the line at a fixed
+/// column made the pane's contents depend on a constant, and left the viewport
+/// and the renderer disagreeing about how many rows there were.
+///
+/// Asserts on rendered output (CONTRIBUTING §2).
+#[test]
+fn soft_wrap_off_draws_one_row_for_a_file_with_no_line_breaks() {
+    let dir = tempfile::tempdir().unwrap();
+    let (single_path, _, _) = write_pair(dir.path());
+
+    let mut harness = opened(&single_path, false);
+    let screen = harness.screen_to_string();
+
+    // The first row of the file is drawn...
+    assert!(
+        screen.contains("[0,1,2,3,4"),
+        "the file's first row should be on screen:\n{screen}"
+    );
+    // ...and the rows below it are empty-buffer filler, not more of the line.
+    let filler = screen
+        .lines()
+        .filter(|l| l.trim_start().starts_with('~'))
+        .count();
+    assert!(
+        filler > H as usize / 2,
+        "a file of one logical line should draw one row and filler below it, \
+         got {filler} filler rows:\n{screen}"
+    );
+
+    // Down has nowhere to go: the cursor stays where it is.
+    let byte_before = status_bar_byte(&screen);
+    for _ in 0..5 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+    let after = harness.screen_to_string();
+    assert_eq!(
+        status_bar_byte(&after),
+        byte_before,
+        "with soft wrap off there is no row below the only row, so Down must \
+         not move the cursor:\n{after}"
+    );
+}
+
+/// With soft wrap on, the same file is readable: rows are pane-width and the
+/// cursor walks down them.
+#[test]
+fn soft_wrap_on_walks_down_the_same_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let (single_path, _, _) = write_pair(dir.path());
+
+    let mut harness = opened(&single_path, true);
+    let before = status_bar_byte(&harness.screen_to_string());
+
+    for _ in 0..10 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    let after = status_bar_byte(&screen);
+
+    assert!(
+        after > before,
+        "ten Down presses with soft wrap on should walk into the line \
+         (byte {before:?} -> {after:?}):\n{screen}"
+    );
+}
+
+/// The cursor offset the status bar reports in large-file mode (`Byte N`).
+fn status_bar_byte(screen: &str) -> Option<usize> {
+    let at = screen.find("Byte ")?;
+    screen[at + "Byte ".len()..]
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()
+}
+
+/// A line wider than the pane costs its own right-hand end, not the line below
+/// it.
+///
+/// With soft wrap off a logical line is one row, and a row stops at the
+/// columns the pane can show. Cutting it there leaves the rest of the line to
+/// be stepped over — but only when there is a rest: the reader hands back whole
+/// lines when they are short enough, terminator included, and stepping again
+/// from there walks past the *next* line and drops it from the frame. On a
+/// large file whose lines are merely wider than the window — a log, a CSV,
+/// pretty-printed JSON — that is every second line missing from the screen.
+///
+/// Asserts on rendered output (CONTRIBUTING §2).
+#[test]
+fn every_wide_line_is_drawn_not_every_other_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wide_lines.txt");
+
+    // Lines several times the pane's width, in a file big enough to take the
+    // lazily-loaded large-file path.
+    let width = W as usize * 4;
+    let mut content = String::new();
+    let mut line = 0usize;
+    while content.len() < 12 * 1024 * 1024 {
+        let tag = format!("L{line:06}");
+        content.push_str(&tag);
+        content.extend(std::iter::repeat_n('.', width - tag.len()));
+        content.push('\n');
+        line += 1;
+    }
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+
+    let mut harness = opened(&path, false);
+    let screen = harness.screen_to_string();
+
+    // Every line from the top of the file, in order, one per row.
+    let drawn: Vec<usize> = screen
+        .lines()
+        .filter_map(|row| {
+            let i = row.find('L')?;
+            row.get(i + 1..i + 7)?.parse::<usize>().ok()
+        })
+        .collect();
+
+    assert!(
+        drawn.len() >= 10,
+        "expected the pane to be full of lines, got {drawn:?}:\n{screen}"
+    );
+    let expected: Vec<usize> = (0..drawn.len()).collect();
+    assert_eq!(
+        drawn, expected,
+        "lines wider than the pane are being skipped: the frame drew {drawn:?} \
+         where the file's lines run 0, 1, 2, …\n{screen}"
+    );
+}
+
+/// A file of long lines is still a file of lines: the arrow keys move between
+/// them.
+///
+/// Every line-boundary search here is bounded, which is what keeps a keypress
+/// on a 19 MB single line from scanning the file. A bound is a claim, though —
+/// "past here there is no line" — and on a file whose lines are merely long,
+/// the claim is false and the motion stops working: nothing above, nothing
+/// below, and the cursor stuck on whichever line it landed on.
+///
+/// End-to-end coverage of the ground between the two files the rest of this
+/// module uses — one endless line, or lines shorter than a screen — on the path
+/// the arrow keys actually take, which is the rendered view's own rows. The
+/// byte-based motions underneath are pinned separately, in
+/// `input::actions::tests::vertical_motion_finds_the_line_above_and_below_on_long_lines`.
+///
+/// Asserts on rendered output (CONTRIBUTING §2).
+#[test]
+fn arrows_move_between_lines_that_are_merely_long() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("long_lines.txt");
+
+    // Well past the 64 KB that the line-start search used to stop at, and well
+    // inside what a line-structured file can ask for.
+    let width = 200 * 1024;
+    let mut content = String::new();
+    for line in 0..64 {
+        let tag = format!("L{line:06}");
+        content.push_str(&tag);
+        content.extend(std::iter::repeat_n('.', width - tag.len()));
+        content.push('\n');
+    }
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+
+    for line_wrap in [false, true] {
+        let mut harness = opened(&path, line_wrap);
+        let start = status_bar_byte(&harness.screen_to_string());
+
+        // Down onto the next line, then back up onto the first.
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let down = status_bar_byte(&harness.screen_to_string());
+        assert!(
+            down > start,
+            "[wrap={line_wrap}] Down did not move off the first line \
+             (byte {start:?} -> {down:?}); a {width}-byte line is long, not endless"
+        );
+
+        harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let up = status_bar_byte(&harness.screen_to_string());
+        assert_eq!(
+            up, start,
+            "[wrap={line_wrap}] Up did not come back (byte {down:?} -> {up:?})"
+        );
+    }
+}
+
+/// A viewport over long lines scrolls where it is pointed.
+///
+/// With soft wrap off a row is a line, so the scroll clamp asks "are there a
+/// screenful of line starts below this position" and backs the viewport up when
+/// there are not. The walk that answers is bounded — it has to be, on a file
+/// whose next line break is megabytes away — but a budget for the walk as a
+/// whole rather than per row it is counting runs out partway down a pane full
+/// of ten-kilobyte lines. The clamp then concludes the rows are not there and
+/// hauls the viewport back up every time it is moved, and the file will not
+/// scroll.
+///
+/// Asserts on rendered output (CONTRIBUTING §2).
+#[test]
+fn a_pane_of_long_lines_scrolls() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("ten_k_lines.txt");
+
+    // Lines long enough that a screenful of them is more than a flat
+    // quarter-megabyte budget, in a file big enough for the large-file path.
+    let width = 10 * 1024;
+    let mut content = String::new();
+    let mut line = 0usize;
+    while content.len() < 12 * 1024 * 1024 {
+        let tag = format!("L{line:06}");
+        content.push_str(&tag);
+        content.extend(std::iter::repeat_n('.', width - tag.len()));
+        content.push('\n');
+        line += 1;
+    }
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(content.as_bytes())
+        .unwrap();
+
+    let mut harness = opened(&path, false);
+    let top_of = |screen: &str| -> Option<usize> {
+        screen.lines().find_map(|row| {
+            let i = row.find('L')?;
+            row.get(i + 1..i + 7)?.parse::<usize>().ok()
+        })
+    };
+
+    let first = top_of(&harness.screen_to_string());
+    assert_eq!(first, Some(0), "the file opens at its first line");
+
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::PageDown, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    let after = top_of(&screen);
+
+    assert!(
+        after.is_some_and(|l| l >= H as usize),
+        "three PageDowns over {width}-byte lines left the pane at line {after:?}; \
+         a viewport that cannot count its own rows refuses to scroll:\n{screen}"
+    );
+}
+
+/// `End` goes to the end of the line, shows it, and `Home` comes back.
+///
+/// Three separate faults meet on one keypress, and each shows up as a number
+/// that is a constant rather than a position in the document:
+///
+/// * `End` lands on the reader's per-piece read cap — a budget, not the line's
+///   end — so the cursor stops 100,000 bytes into a line that is megabytes
+///   long.
+/// * The row is built as the line's first *n* columns rather than as the
+///   columns the pane is scrolled to, so once the view scrolls past that
+///   prefix the row is drawn from text the build never produced: an empty row,
+///   and no cell to put the caret in. The line and the cursor both vanish.
+/// * `Home` then lands on the backward line-start search's floor — how far it
+///   looked, not where the line starts — so it takes two presses to get back,
+///   and the first one lands in the middle of the line.
+///
+/// Asserts on rendered output (CONTRIBUTING §2). The cursor's byte is read
+/// from the editor rather than the status bar, because reaching the end of the
+/// line necessarily walks the rest of it — and the piece tree records what that
+/// walk crosses, so the file ends up line-indexed and the status bar switches
+/// from a byte offset to a line and column. That is the honest report of what
+/// the editor now knows; it just is not a fixed string to scrape.
+#[test]
+fn end_reaches_the_end_of_a_long_line_and_home_comes_back() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("one_line.json");
+
+    // Comfortably past the reader's 100,000-byte piece cap and the 64 KB
+    // line-start search, and past the large-file threshold this config sets.
+    let (single, _) = single_line_and_control(400_000);
+    let bytes = single.len();
+    assert!(bytes > 2 * 1024 * 1024, "{bytes} is too small to show this");
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(single.as_bytes())
+        .unwrap();
+
+    let mut harness = opened(&path, false);
+    assert_eq!(harness.cursor_position(), 0, "the file opens at its start");
+
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+
+    assert_eq!(
+        harness.cursor_position(),
+        bytes,
+        "End must reach the end of the line, not the reader's read cap:\n{screen}"
+    );
+    assert!(
+        screen.contains(']'),
+        "End scrolled the view to the end of the line but the row was built \
+         from the line's start, so nothing is drawn:\n{screen}"
+    );
+
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+
+    assert_eq!(
+        harness.cursor_position(),
+        0,
+        "one Home must return to the start of the line, not to how far the \
+         search looked:\n{screen}"
+    );
+    assert!(
+        screen.contains("[0,1,2"),
+        "the start of the line should be back on screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/large_file_open_bounded.rs
+++ b/crates/fresh-editor/tests/e2e/large_file_open_bounded.rs
@@ -331,8 +331,9 @@ fn arrow_down_walks_deep_into_one_enormous_line() {
 /// piece and clamped the row index into it, pinning the cursor at that piece's
 /// last row — and a cursor off the drawn window cannot be moved at all.
 ///
-/// Asserts on rendered output (CONTRIBUTING §2): the status bar reports the
-/// cursor's byte offset in large-file mode.
+/// Asserts on rendered output (CONTRIBUTING §2): the status bar reports where
+/// the cursor is, as a byte offset or — once the walk has indexed the file — as
+/// a line and column.
 #[test]
 fn paging_down_one_long_line_carries_the_cursor_past_the_read_boundary() {
     use crossterm::event::{KeyCode, KeyModifiers};
@@ -365,12 +366,13 @@ fn paging_down_one_long_line_carries_the_cursor_past_the_read_boundary() {
     harness.render().unwrap();
 
     let screen = harness.screen_to_string();
-    let cursor_byte = status_bar_byte(&screen)
-        .expect("large-file mode reports the cursor's byte offset in the status bar");
+    let cursor_byte =
+        status_bar_cursor_byte(&screen).expect("the status bar reports the cursor's position");
     assert!(
         cursor_byte > READ_PIECE_BYTES,
         "after 40 PageDown presses the cursor should be well past byte \
-         {READ_PIECE_BYTES} of the line, but the status bar reads Byte {cursor_byte} — it is \
+         {READ_PIECE_BYTES} of the line, but the status bar puts it at byte \
+         {cursor_byte} — it is \
          pinned to the end of the first read piece while the view scrolled \
          on:\n{screen}"
     );
@@ -384,6 +386,30 @@ fn status_bar_byte(screen: &str) -> Option<usize> {
         .next()?
         .parse()
         .ok()
+}
+
+/// The cursor's byte, however the status bar is currently spelling it.
+///
+/// Large-file mode reports `Byte N` only while the file has not been indexed.
+/// A walk down one of these files indexes it as it goes — the line-boundary
+/// searches record the line-feed counts of every piece they cross — so partway
+/// through the walk the editor knows how many lines the file has and the bar
+/// switches to `Ln 1, Col N`. On a file that is one line of ASCII the two say
+/// the same thing: column N is byte N - 1.
+///
+/// A walk that reads only one of the two forms mistakes that switch for the
+/// cursor vanishing, which is what it did.
+fn status_bar_cursor_byte(screen: &str) -> Option<usize> {
+    if let Some(byte) = status_bar_byte(screen) {
+        return Some(byte);
+    }
+    let at = screen.find("Ln 1, Col ")?;
+    let column: usize = screen[at + "Ln 1, Col ".len()..]
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()?;
+    Some(column.saturating_sub(1))
 }
 
 /// Issue #1806, reported against this branch: holding `Down` eventually stopped
@@ -435,7 +461,8 @@ fn arrow_down_never_revisits_a_row_across_the_read_boundary() {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
         harness.render().unwrap();
         let screen = harness.screen_to_string();
-        let at = status_bar_byte(&screen).expect("the status bar reports the cursor's byte");
+        let at =
+            status_bar_cursor_byte(&screen).expect("the status bar reports the cursor's position");
         assert!(
             at > previous,
             "press {press} moved the cursor from byte {previous} to {at} — it is not \
@@ -572,7 +599,8 @@ fn arrow_down_at_the_last_row_does_not_jump_back_to_a_read_boundary() {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
         harness.render().unwrap();
         let screen = harness.screen_to_string();
-        let at = status_bar_byte(&screen).expect("the status bar reports the cursor's byte");
+        let at =
+            status_bar_cursor_byte(&screen).expect("the status bar reports the cursor's position");
         assert!(
             at >= previous,
             "press {press} moved the cursor backwards, from byte {previous} to {at}. \

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -144,6 +144,7 @@ pub mod close_buffer_shared_split_cursor;
 pub mod finder_preview;
 pub mod keybinding_editor;
 pub mod language_features_e2e;
+pub mod large_file_edit_bounded;
 pub mod large_file_inplace_write_bug;
 pub mod large_file_mode;
 pub mod large_file_open_bounded;

--- a/crates/fresh-editor/tests/semantic/scroll_edges.rs
+++ b/crates/fresh-editor/tests/semantic/scroll_edges.rs
@@ -13,6 +13,7 @@
 //! `EditorTestApi` projection.
 
 use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 use ratatui::style::Color;
 
@@ -485,4 +486,64 @@ fn one_wheel_notch_scrolls_the_configured_number_of_lines() {
 
     assert_eq!(top_after_one_notch(1), 2, "one line puts line 002 on top");
     assert_eq!(top_after_one_notch(5), 6, "five lines puts line 006 on top");
+}
+
+/// The edge the cursor is sitting in is not shaded.
+///
+/// The shading is an affordance for reading, and the line being edited is the
+/// one line the reader is certainly looking at — dimming it trades the
+/// affordance away for the thing it was meant to help. The whole band goes
+/// rather than the cursor's own row: the ramp is two rows deep, and a bright
+/// row in the middle of one reads as a fault rather than as an exception.
+///
+/// The opposite edge is unaffected, which is what says this suppresses a band
+/// and not the shading.
+#[test]
+fn the_edge_the_cursor_sits_in_is_not_shaded() {
+    const LINES: usize = 200;
+    const TEXT_COL: u16 = 20;
+    let mut config = edge_config();
+    // The viewport otherwise keeps three rows between the cursor and the edge,
+    // so the cursor never reaches a shaded row for this to be about.
+    config.editor.scroll_offset = 0;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(80, 24, config).unwrap();
+    let path = harness.project_dir().unwrap().join("long.txt");
+    std::fs::write(&path, numbered_lines(LINES)).unwrap();
+    harness.open_file(&path).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("line 001"))
+        .unwrap();
+
+    // Walk the cursor down until it rests on the pane's bottom row, with the
+    // document carrying on below it — the state in which that row shades.
+    for _ in 0..60 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    let (first, last) = text_rows(&harness, LINES);
+    let painted = colors_at(&harness, TEXT_COL, first + 6).0;
+
+    assert_eq!(
+        colors_at(&harness, TEXT_COL, last).0,
+        painted,
+        "the cursor's own row must be fully painted, screen:\n{}",
+        harness.screen_to_string()
+    );
+    assert_eq!(
+        colors_at(&harness, TEXT_COL, last - 1).0,
+        painted,
+        "and so must the rest of its band, or the ramp has a hole in it, \
+         screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // The top edge still has content above it and no cursor in it.
+    assert!(
+        level(&harness, TEXT_COL, first, painted) < 1.0,
+        "the other edge still shades: suppressing one band is not turning the \
+         shading off, screen:\n{}",
+        harness.screen_to_string()
+    );
 }


### PR DESCRIPTION
Follows #3162, which made *opening* a huge single-line file bounded. Everything that happens afterwards was not.

## The problem

On a 19 MB one-line JSON, measured by attributing every buffer read in a frame to its call site:

| | before |
| --- | --- |
| steady-state frame (wrap off) | **12.6 MB read** |
| one keystroke | **13.7 MB** |
| one `Down` press | **12.7 MB** |
| width measured per frame | 801 KB |

The file, several times over, per keypress. On the reported 50 MB file that is unusable, and `Down` stopped at the bottom of the first screen and never went further.

Two causes, the same shape at different layers.

**The layout unit was a constant, not the pane.** With soft wrap off a row was chopped at `MAX_SAFE_LINE_WIDTH` — 10,000 columns, ~83× the pane — so a 40-row frame built ~400,000 characters to draw ~4,800. It also left the viewport counting rows one way while the renderer drew them another, which is why the cursor could walk the rows on screen and then stop.

**Structural questions were answered by reading text.** "Where does this line start", "where does it end", "how many lines are below this one" — asked several times per keystroke by the scroll clamp, the visibility check, the viewport-end calculation, the fold and indentation-guide probes, and the vertical motions — each answered by reading the line, in 100 KB pieces, on a file whose line is the file.

## Results

| | before | after |
| --- | --- | --- |
| frame, wrap off | 12.6 MB | **150 KB** |
| keystroke, wrap off | 13.7 MB | **178 KB** |
| `Down`, wrap off | 12.7 MB | **300 KB** |
| frame, wrap on | 8.1 MB | **222 KB** |
| keystroke, wrap on | 9.2 MB | **268 KB** |
| width measured per frame | 801 KB | **238 bytes** |
| edit at a far column of a long line | 38.5 MB | **2.3 MB** |

Verified interactively on the reported 50 MB file, in a debug build, not only in tests:

| | before | after |
| --- | --- | --- |
| cursor step at byte 52,428,800 | — | 51–63 ms |
| `End` from byte 0 | no-op | 1137 ms (indexes the line) |
| `Home` back, `Ctrl+End`, `Ctrl+Home` after that | — | 50–57 ms |
| insert one char at byte 52,428,804 | 2287 ms | **30–34 ms** |
| backspace there | 3602 ms | **30–41 ms** |

Swept there for regressions across click, drag-select, shift-wheel, menu, go-to-line, find, and type/undo at a far column, plus the same sweep with wheel and scrollbar drag on an ordinary multi-line file.

## The commits

**`core: answer where a line begins and ends without reading the line`** — three primitives that walk the piece tree's own storage instead of copying text out of it, all with a mandatory cap, where `None` means "not within reach" rather than "not there". They also *fill in* the tree's per-piece line-feed count as they cross a piece, so the second search of a region is answered from metadata; that count already survives edits, so typing does not discard it. `LineIterator` gains a bounded backward search whose result is snapped to a character boundary, and `counters::work` gives every test a clock-free budget in bytes read. Also fixes the wrap machine measuring every token's width twice, and adds a property test holding the counts these searches write against the bytes.

**`The row a pane draws is the pane's width, and structure is walked not read`** — one logical line is one visual row with wrap off on a large file; every line-boundary search in the layout and movement paths goes through the primitives above, and the ones that cannot answer say so rather than guessing. Four places had read a budget that ran out as an answer: the scroll clamp (which dragged the viewport to byte 0 on a pane of ten-kilobyte lines), a cut row that stepped over the line below it, the window-end walk, and the plugin line offer. Bracket matching and the `lines_changed` offer are sized by the frame rather than by the file, and the ASCII fast path — dead code, gated on a condition no production caller met — is reachable again. Includes the `Home`/`End` fixes: both name a position, so neither may answer with a budget.

**`Viewport edge shading: not over the caret, and not on a guess`** — an edge no longer shades the band the caret sits in, nor shades on a fact the editor does not have (a pane with no scrollbar, or a file too large to count lines on, where the thumb is placed by a byte fraction).

**`A row a pane draws is a window into its line, not the line up to it`** — the row was built as a *prefix*, every column from the line's start out to the right edge, so a frame's cost and its reach both scaled with how far right the view had scrolled. It now reads only the window it shows. See below.

**`Paging, selecting and the horizontal clamp count lines, not read pieces`** — the last callers still asking the reader for "the next line" and getting back the next 100 KB piece of the line the cursor is already on. Page up/down walked pieces, so a page on a one-line file moved thirty-nine pieces along it; select-to-line-start/end selected to a piece boundary; scrolling by rows with wrap off moved the top by the backward search's 64 KB bound. All four now walk logical line starts. The visible one was the horizontal clamp: it needs the line's length to keep the view out of the empty space past a line's end, and measuring by reading returned a piece — so the code took the larger of that and the cursor's own column, which on a longer line makes the length *equal* the cursor's column and the clamp then states that the cursor is the last visible column. Every press of Left dragged the window one column with it and pinned the caret to the right-hand edge.

**`A keystroke costs the same at either end of a line`** — cursor movement at a far column was fixed by the commits above, but *typing* there still took 2.3 s and backspace 3.6 s, while the same keystroke at byte 0 of the same file took 48 ms. Attributed rather than guessed, by tagging every buffer read with its caller: one insert read the line **twice**, from two unrelated places. `line_start_and_blank_prefix` walked backwards in 4 KB blocks to find the line start (18 MB in 4,417 reads) — it now asks `prev_line_start_within` instead, and settles its blank-prefix question at the first non-blank byte to the left of the caret, which is exact and costs only the indentation. And `collect_lsp_changes` converted the edit's byte offsets into LSP's UTF-16 positions — which needs the line counted from its start — on every buffer-modifying event, after which the send path discarded the result because the buffer has no server. A log on that path confirmed it fired twice for two keystrokes. The side-effect-free head of that same guard is now asked *before* the changes are built.

## Two things worth a reviewer's attention

**The `End` bug was found by running the editor, not by the tests.** The test covering it passed while the editor failed: it used a 2.6 MB file with the large-file threshold moved to 1 MB, which is the one window where neither of the two bounds bites. The build stops a line at `max_lines × MAX_LINE_BYTES` (~4.4 MB, because it counts 100 KB read *pieces* rather than lines), and below the 10 MB threshold the row is chopped at `MAX_SAFE_LINE_WIDTH` instead — 4.4 MB is under 10 MB, so with default settings no file size could draw a scrolled-away column. The test now runs on the module's 19 MB fixture, past both bounds, and lands together with its fix in the fourth commit.

**Guarding the LSP conversion had to wrap the send step whole, not just the collection.** Skipping only the conversion leaves an empty change set, and the empty-set branch exists to snapshot the *entire document* for the BulkEdit case — so guarding the cheap half alone would have replaced an 18 MB read with a 50 MB one.

**Reaching the end of a line indexes the file.** The walk records what it crosses, so afterwards the status bar switches from `Byte N` to `Ln/Col`. That is an honest report of what the editor now knows, but it is a visible change.

## Behaviour changes worth a decision

**With soft wrap off, a large file with no line breaks draws one row and `Down` has nowhere to go.** That is what the setting means on such a file, and soft wrap — which walks it row by row and is unaffected — is what reading one vertically is for. The alternative was to keep inventing rows by chopping the line at a fixed column, which is a worse version of what soft wrap already does and is what left the viewport and the renderer disagreeing.

**On a file too big to index, plugin decorations that consume source lines** (blame, live diff, compose reflow) see only the visible text. A row injected with no source byte of its own cannot be placed by a byte walk; teaching the walk the whole transform stage stays open and nothing here blocks it.

**Known gap:** a long-line file *below* the large-file threshold keeps the old wrap-off row cost and the 10,000-column chop. The bounded searches and the bracket and plugin bounds still apply to it; only the row-width change is scoped out.

**Known gap:** the bracket overlay still reads 2 MB per keystroke — the bulk of what remains after the last commit. Its match search is already viewport-bounded, but on a single-line file `viewport_start .. viewport_end` spans the whole line, so the margin degenerates and the 1 MB cap is what binds. Bounding it by what is actually *drawn* needs the pane's cell window plumbed into the overlay, and tightening the rainbow nesting depth — already approximate at 1 MB — changes visible colours. That is a separate change with its own decision to make, not a bound swap.

**Scope notes:** the windowed row is skipped for binary buffers, whose rows are built byte-wise by a different reader. The byte/column conflation it relies on predates this branch — exact for ASCII, approximate for wide characters, as before.

## Tests

Every cost claim is pinned on **bytes read from the buffer**, not on the clock, so they mean the same on a loaded CI runner as on an idle laptop (CONTRIBUTING §3), and each bound is stated against a byte-identical multi-line control — same bytes, different shape, so a gap between the two is the shape costing something. The row model, `Down`, the dropped lines, the arrow keys on long-line files, the reported `End`/`Home` sequence, stepping left from the end of a long line, and the shading are asserted on rendered output (§2).

The edit-cost test states its invariant as a *ratio* — what a keystroke costs does not depend on the caret's column — rather than as an absolute figure, so it keeps its meaning if the fixture changes. Without its fix it reads 39,671,146 bytes against 128,375 for the same keystroke at byte 0.

Where a fix lives on a path the rendered view does not take — the byte-based vertical motions, the scroll clamp — the failing test is a unit test on that function rather than an end-to-end one that would pass either way; the e2e tests over those areas are labelled as the coverage they are.

Twelve e2e tests in `large_file_edit_bounded.rs`, the shading tests in `semantic/scroll_edges.rs`, and unit tests for the new primitives, the leaf-count property, the repaired fast path (including that an escape sequence split across two tokens stays invisible), and the single width measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEmagq6rum6Fs9RyqJXgGn