### PR TITLE
The Welcome page is a document: centred boxes, focus where the reader is, and a selection they can see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Settings dialog** - `Delete` works again in the Edit Item text field (#2875, reported by @asukaminato0721)
 * **Quitting** no longer panics while plugin work is still in flight
 * **Rendering fixes** - whitespace markers, indent guides, block-selection rectangles, misread angle brackets; File Explorer got a scrollbar (#3077, #3079, #3148, #3090, reported by @Korkman; #2859, reported by @asukaminato0721)
+* **The Welcome screen reads and quotes like a document** - text can be selected with `Shift`+movement or the mouse and copied with `Ctrl+C` (its mode was hiding the editor's own bindings, and a selection on it was never painted), a control takes focus only where the caret actually is instead of anywhere on its row, the framed cards sit on the page's axis, and the syntax-highlighting sample no longer grows a scrollbar over a listing that fits
 * **The block-selection highlight is exactly what a block copy takes** - the rectangle used to be painted one column wider than `Ctrl+C` copied, and a zero-width block (Alt+Shift+Down with no sideways movement) painted a column it did not select, then copied a bare newline per line (#3150, reported by @Korkman)
 * **Conceals spanning a line break** no longer crash the editor (#3139)
 * **New file/folder names with slashes** create their missing parent directories (#2640, requested by @akarinotomoshibi)

--- a/crates/fresh-editor/plugins/welcome_screen.ts
+++ b/crates/fresh-editor/plugins/welcome_screen.ts
@@ -484,20 +484,30 @@ function card(
   // page was a stack of headings and boxes at single-row spacing, which
   // reads as one dense column however well each part is set — the first
   // viewport got its rhythm and the rest of the document did not.
-  if (folded.has(id)) return col(...air(2), head);
-  if (framed) return col(...air(2), head, toCardWidth(col(...body())));
+  if (folded.has(id)) return col(...air(2), framed ? centredRow(head) : head);
+  if (framed) {
+    return col(...air(2), centredRow(head), toCardWidth(col(...body())));
+  }
   return col(...air(2), head, ...body());
 }
 
-/** Constrain a framed card to the card measure rather than the page's.
+/** Constrain a framed card to the card measure rather than the page's,
+ *  and sit it on the page's axis.
  *
  *  A box drawn to the full measure is mostly empty: the finder's paths,
  *  the git card's file names and the workspace rows are all short, so
  *  the frame ran forty columns past its own content and the card read
  *  as a room rather than a card. Prose still sets to the full measure —
- *  it is the *frames* that were too wide, not the page. */
+ *  it is the *frames* that were too wide, not the page.
+ *
+ *  **Centred, because a box is a block and the page is a column.** A
+ *  narrowed card packed to the left edge left a growing band of white
+ *  down the right of every framed section, so the boxes and the prose
+ *  they sit among disagreed about where the page was. The heading above
+ *  each one is centred with it (`card`), because a heading ruling to
+ *  its own box's width and starting somewhere else is two objects. */
 function toCardWidth(child: WidgetSpec): WidgetSpec {
-  return row(labeledSection({ child, widthCols: cardMeasure() }));
+  return centredRow(labeledSection({ child, widthCols: cardMeasure() }));
 }
 
 /** Framed cards sit inside the page's measure by a margin on each side,
@@ -1067,6 +1077,12 @@ function level2(): WidgetSpec[] {
       // it is pretending to be, and inset from the prose around it — a
       // listing, not a paragraph.
       //
+      // Centred on the page's axis like every other box, rather than
+      // packed to the left edge with the spare columns pooling on the
+      // right — the inset that did that was two columns wide and the
+      // slack was two columns wide, so the box looked centred until the
+      // measure changed under it.
+      //
       // The margin goes AROUND the widget, never inside its text: the
       // markdown renderer turns leading spaces in a code fence into
       // NBSP and paints the code background across them, so an indent
@@ -1074,8 +1090,7 @@ function level2(): WidgetSpec[] {
       // whole left margin. (The background inside the box is the
       // host's `ui.inline_code_bg`, shared with every hover popup and
       // the markdown preview, so it is not this page's to switch off.)
-      row(
-        spacer(2),
+      centredRow(
         labeledSection({
           label: "src/store.rs",
           widthCols: measure() - 4,
@@ -2175,6 +2190,22 @@ editor.defineMode(
     ...FORWARDED.map(([k, action]) => [k, `welcome_do_${action}`] as [string, string]),
   ],
   true,
+  true,
+  // **Everything this mode does not bind is still the editor's.** A mode
+  // that inherits nothing is a mode that *masks* everything, and what it
+  // was masking here is the half of the keyboard a document needs: `Left`
+  // and `Right`, `Home` and `End`, every `Shift+` movement — which is
+  // selection — and `Ctrl+A` / `Ctrl+C`. The page is a read-only buffer
+  // you read and quote, so a reader could see text they could not select
+  // and could not copy, and the fix is not to re-bind any of it here: it
+  // is to stop hiding the bindings that already exist. The built-in help
+  // viewer's `special` mode says the same thing the same way
+  // (`ensure_help_panel_mode_registered`: "keeps cursor motion / copy /
+  // search usable even though `editing_disabled` blocks edits").
+  //
+  // The bindings above still win, because a mode's own bindings are
+  // resolved first: `Up` and `Down` walk the finder's results before they
+  // move the caret, `Enter` activates, `Escape` leaves the field.
   true,
 );
 

--- a/crates/fresh-editor/src/app/chrome/splits.rs
+++ b/crates/fresh-editor/src/app/chrome/splits.rs
@@ -504,6 +504,15 @@ impl Editor {
         if self.overlay_prompt_active() {
             return Ok(());
         }
+        // **A described page sweeps its own selection.** Its pane has no
+        // screen-to-byte projection — the content is the panel's subtree, not
+        // the buffer's leaf — so the buffer's drag below could not answer
+        // where the pointer is in the text. The page's own window can, and
+        // does; this returns true for any page pane, selecting or not, so the
+        // buffer path never runs over one.
+        if self.drag_moved_the_page_selection(pane, col, row) {
+            return Ok(());
+        }
         let ms = &self.active_window().mouse_state;
         if let Some((split_id, buffer_id, ocol, orow)) = ms.terminal_drag_pending {
             // The press landed on a live terminal grid and this is the first

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -614,6 +614,7 @@ impl Editor {
             page: None,
             // Not a page, so nothing reads a page.
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: Some(hovered).filter(|k| !k.is_empty()),
             hovered_item_key: hovered_item,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -6276,6 +6276,18 @@ impl Editor {
             keyboard: false,
             page: self.page_anchors.get(&key).cloned(),
             reading: self.page_reading.get(&key).copied(),
+            // **The mirror's selection, because nothing else would show it.**
+            // The pane draws this tree and not the buffer under it, so the
+            // painter that washes a selection everywhere else in the editor
+            // never runs here — shift-arrow and drag-to-select made a range
+            // that Copy took and the reader could not see.
+            selection: match self.page_anchors.contains_key(&key) {
+                true => self.page_selection_bands(buffer),
+                // Only a page is described with a window of its own to wash;
+                // every other pane-mounted panel would compute a selection
+                // that `splits::panel_content` never reads.
+                false => Vec::new(),
+            },
             compose: self.buffer_compose_width(buffer),
             // **A mounted panel's rows light under the pointer too.** The memo
             // is the registry's rather than a `Panel` record's, because a pane
@@ -6373,6 +6385,7 @@ impl Editor {
             page: None,
             // Not a page, so nothing reads a page.
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: Some(panel.hovered_widget_key.clone()).filter(|k| !k.is_empty()),
             hovered_item_key: panel.hovered_item_key.clone(),

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -526,12 +526,23 @@ impl Editor {
         let position = self.active_window().active_cursors().primary().position;
         let st = self.active_state();
         let row = st.buffer.get_line_number(position);
+        // **A display column, not a byte one.** The page's spans come off the
+        // laid-out tree, so the reader's column has to be in the same units
+        // the tree is in — and the rows carrying controls are exactly the
+        // rows drawn in box glyphs, where three bytes are one column. The
+        // mirror is where the two meet, so the conversion belongs here and in
+        // `mirror_page_reader_into_buffer`, which does it the other way.
         let col = st
             .buffer
             .line_start_offset(row)
-            .map(|start| position.saturating_sub(start))
+            .map(|start| {
+                display_col_of(
+                    &Self::page_line(&st.buffer, row),
+                    position.saturating_sub(start),
+                )
+            })
             .unwrap_or(0);
-        let at = (row as u32, col.min(u16::MAX as usize) as u16);
+        let at = (row as u32, col);
         if self.page_reading.get(&key) == Some(&at) {
             return;
         }
@@ -1778,34 +1789,46 @@ impl Editor {
         out
     }
 
-    /// How far `col` is from a span running `[start, start + width)`: zero
-    /// inside it, and the distance to the nearer edge outside.
-    fn column_distance(start: u16, width: u16, col: u16) -> u32 {
-        let end = start.saturating_add(width);
-        match col {
-            c if c < start => (start - c) as u32,
-            c if c >= end => (c - end) as u32 + 1,
-            _ => 0,
-        }
+    /// The mirror buffer's line `row`, without its newline.
+    fn page_line(buffer: &crate::model::buffer::Buffer, row: usize) -> String {
+        buffer
+            .get_line(row)
+            .map(|b| {
+                String::from_utf8_lossy(&b)
+                    .trim_end_matches('\n')
+                    .to_string()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Does a span running `[start, start + width)` cover `col`?
+    ///
+    /// A zero-width span covers nothing, which is what a zero-width node is:
+    /// a marker, not a place.
+    fn column_covers(start: u16, width: u16, col: u16) -> bool {
+        col >= start && col < start.saturating_add(width)
     }
 
     /// The widget in `panel_key` that a reader at `(row, col)` is on, or `""`
     /// for none.
     ///
-    /// **The row is the region; the column decides which control on it.** That
-    /// is a weaker rule than "a focus region is a widget's own placed
-    /// rectangle", and the weaker one is the one that works: a reader moving
-    /// down a page keeps whatever column they were in, and on this editor's own
-    /// pages that column is very often a framed card's border or the margin
-    /// left of an inset card. Requiring containment would mean moving down
-    /// through a card focuses nothing in it — including its text field, which
-    /// then does not take what you type.
+    /// **A focus region is the control's own rectangle: the reader has to be
+    /// standing on it, in both axes.** The rule was once "the row is the
+    /// region; the column decides which control on it", with no distance cap —
+    /// so on a row carrying one control that control was the answer for every
+    /// column of the row, and a reader walking down the page's left margin lit
+    /// up, and armed Enter on, a button forty columns away that they were
+    /// plainly not pointing at. Reaching a control now means going to it.
     ///
-    /// So containment wins where it applies (distance zero), and otherwise the
-    /// nearest control **on the same row**, ties leftmost. There is no distance
-    /// cap, which has a consequence worth stating rather than discovering: on a
-    /// row carrying exactly one control, that control is the answer for every
-    /// column of the row.
+    /// **Which is why the reading column is a display column** (see
+    /// [`Self::page_follows_caret`]): the spans come off the laid-out tree, so
+    /// a byte column would put the reader two columns right of where they are
+    /// on any row whose frame is drawn in box glyphs — exactly the rows the
+    /// controls are in.
+    ///
+    /// Nested spans are decided innermost-first (narrowest, ties leftmost): a
+    /// card's own key covers every row it occupies, and a control inside it is
+    /// the more specific answer for the cells it covers.
     ///
     /// An empty string is an answer, not the absence of one: a reader on a row
     /// with no control at all means *nothing* is focused, and a caller that
@@ -1824,17 +1847,19 @@ impl Editor {
         row: u32,
         col: u16,
     ) -> String {
-        let mut best: Option<(u32, u16, String)> = None;
+        let mut best: Option<(u16, u16, String)> = None;
         for (top, rows, start, width, key) in self.page_widget_spans(panel_key) {
             if row < top || row >= top + rows.max(1) as u32 {
                 continue;
             }
-            let d = Self::column_distance(start, width, col);
+            if !Self::column_covers(start, width, col) {
+                continue;
+            }
             if best
                 .as_ref()
-                .is_none_or(|(bd, bs, _)| d < *bd || (d == *bd && start < *bs))
+                .is_none_or(|(bw, bs, _)| width < *bw || (width == *bw && start < *bs))
             {
-                best = Some((d, start, key));
+                best = Some((width, start, key));
             }
         }
         best.map(|(_, _, k)| k).unwrap_or_default()
@@ -1968,13 +1993,38 @@ impl Editor {
     }
 
     /// A press on `pane` at screen `(x, y)` moves that pane's page reader, if
-    /// it has one and the press landed inside its window.
+    /// it has one and the press landed inside its window — and arms the
+    /// selection sweep the press may turn out to have started.
     ///
-    /// Screen coordinates in, content coordinates out — the same conversion
-    /// `page_widget_spans` does, in the other direction.
+    /// Screen coordinates in, content coordinates out ([`Self::page_point_at`])
+    /// — the same conversion `page_widget_spans` does, in the other direction.
     pub(super) fn press_moved_the_page_reader(&mut self, pane: LeafId, x: u16, y: u16) {
-        let Some(panel_key) = self
-            .widget_registry
+        let Some(panel_key) = self.page_panel_of_pane(pane) else {
+            return;
+        };
+        let Some(at) = self.page_point_at(&panel_key, x, y, false) else {
+            return;
+        };
+        self.move_page_reader_to(&panel_key, at);
+        self.sync_widget_focus_to_reading_row(&panel_key);
+        // **The press is also a selection's anchor.** The page's text is the
+        // mirror's, and a reader who wants to quote a paragraph of it sweeps
+        // the pointer across it exactly as they would over a file. The caret
+        // this press just seated is collapsed, so the anchor is where it is;
+        // every move of the pointer under the same capture extends from here
+        // (`drag_moved_the_page_selection`), and the release leaves the
+        // selection standing for Copy.
+        let ms = &mut self.active_window_mut().mouse_state;
+        ms.dragging_text_selection = true;
+        ms.drag_selection_split = Some(pane);
+        ms.drag_selection_by_words = false;
+        ms.drag_selection_word_end = None;
+    }
+
+    /// The page panel a pane holds, if it holds one whose focus follows its
+    /// reader.
+    fn page_panel_of_pane(&self, pane: LeafId) -> Option<crate::widgets::PanelKey> {
+        self.widget_registry
             .panel_keys()
             .into_iter()
             .find(|k| {
@@ -1986,27 +2036,115 @@ impl Editor {
                     .get(k)
                     .is_some_and(|p| p.page && p.focus_follows_cursor)
             })
-        else {
-            return;
+    }
+
+    /// Screen `(x, y)` as a point in the page's own content, or `None` when
+    /// the point is outside its window — unless `clamp`, which pins it to the
+    /// nearest cell inside instead, because a drag that leaves the window is
+    /// still a drag to the end of what it crossed.
+    fn page_point_at(
+        &self,
+        panel_key: &crate::widgets::PanelKey,
+        x: u16,
+        y: u16,
+        clamp: bool,
+    ) -> Option<(u32, u16)> {
+        let (ui, vp) = (self.shell_ui.as_ref()?, self.page_viewport(panel_key)?);
+        let window = ui.rect_of(vp);
+        let (scroll, _) = ui.scroll(vp);
+        let (x, y) = (x as i32, y as i32);
+        let inside = x >= window.x && x < window.right() && y >= window.y && y < window.bottom();
+        if !inside && !clamp {
+            return None;
+        }
+        let x = x.clamp(window.x, window.right().saturating_sub(1).max(window.x));
+        let y = y.clamp(window.y, window.bottom().saturating_sub(1).max(window.y));
+        Some((
+            (y - window.y + scroll.y).max(0) as u32,
+            (x - window.x + scroll.x).max(0) as u16,
+        ))
+    }
+
+    /// A move of the pointer the page's press captured: the selection grows
+    /// to wherever it is now.
+    ///
+    /// Returns whether this pane is a page at all — a pane that is not takes
+    /// its drag through the buffer's own path, which needs a screen-to-byte
+    /// projection a described pane does not have.
+    pub(super) fn drag_moved_the_page_selection(&mut self, pane: LeafId, x: u16, y: u16) -> bool {
+        let Some(panel_key) = self.page_panel_of_pane(pane) else {
+            return false;
         };
-        let at = {
-            let (Some(ui), Some(vp)) = (self.shell_ui.as_ref(), self.page_viewport(&panel_key))
-            else {
-                return;
-            };
-            let window = ui.rect_of(vp);
-            let (scroll, _) = ui.scroll(vp);
-            let (x, y) = (x as i32, y as i32);
-            if x < window.x || x >= window.right() || y < window.y || y >= window.bottom() {
-                return;
+        let ms = &self.active_window().mouse_state;
+        if !ms.dragging_text_selection || ms.drag_selection_split != Some(pane) {
+            return true;
+        }
+        let Some(at) = self.page_point_at(&panel_key, x, y, true) else {
+            return true;
+        };
+        // Deliberately not `sync_widget_focus_to_reading_row`: a sweep across
+        // the page is a statement about its text, and arming every control it
+        // crosses under Enter is not part of it.
+        self.move_page_reader(&panel_key, at, true);
+        true
+    }
+
+    /// The mirror buffer's selection as bands of display columns, one per
+    /// content row — what the description washes over the page.
+    ///
+    /// Read off whichever split carries the buffer, the active one first: the
+    /// selection is a cursor's, cursors are per split, and a page shown in
+    /// two panes is one buffer with two of them.
+    pub(super) fn page_selection_bands(&self, buffer_id: BufferId) -> Vec<(u32, u16, u16)> {
+        /// A whole-page selection is thousands of rows and a handful of them
+        /// are on screen; the cap is a guard against a pathological
+        /// description, not a limit anyone can reach by selecting.
+        const MAX_BANDS: usize = 8192;
+        let window = self.windows.get(&self.active_window);
+        let Some(state) = window.and_then(|w| w.buffers.get(&buffer_id)) else {
+            return Vec::new();
+        };
+        let Some((manager, view_states)) = window.and_then(|w| w.buffers.splits()) else {
+            return Vec::new();
+        };
+        let active = manager.active_split();
+        let mut leaves = self.splits_showing_buffer(buffer_id);
+        leaves.sort_by_key(|l| *l != active);
+        let Some(vs) = leaves.first().and_then(|l| view_states.get(l)) else {
+            return Vec::new();
+        };
+        let mut ranges = vs.cursors.selections();
+        ranges.sort_by_key(|r| r.start);
+        let mut bands = Vec::new();
+        for range in ranges {
+            let first = state.buffer.get_line_number(range.start);
+            let last = state.buffer.get_line_number(range.end);
+            for row in first..=last {
+                if bands.len() >= MAX_BANDS {
+                    return bands;
+                }
+                let Some(start) = state.buffer.line_start_offset(row) else {
+                    break;
+                };
+                let line = Self::page_line(&state.buffer, row);
+                let from = match row == first {
+                    true => display_col_of(&line, range.start.saturating_sub(start)),
+                    false => 0,
+                };
+                // A row inside the selection is selected past its own text,
+                // by the one column that stands for the line break it took —
+                // the same shape the buffer painter gives a multi-line
+                // selection.
+                let to = match row == last {
+                    true => display_col_of(&line, range.end.saturating_sub(start)),
+                    false => display_col_of(&line, line.len()).saturating_add(1),
+                };
+                if to > from {
+                    bands.push((row as u32, from, to));
+                }
             }
-            (
-                (y - window.y + scroll.y).max(0) as u32,
-                (x - window.x + scroll.x).max(0) as u16,
-            )
-        };
-        self.move_page_reader_to(&panel_key, at);
-        self.sync_widget_focus_to_reading_row(&panel_key);
+        }
+        bands
     }
 
     /// Put the reader at `(row, col)` and bring that row into the window.
@@ -2014,11 +2152,23 @@ impl Editor {
     /// The reveal is minimal, which is what following is: a Tab between two
     /// controls of one card must not move the page under them.
     fn move_page_reader_to(&mut self, panel_key: &crate::widgets::PanelKey, at: (u32, u16)) {
+        self.move_page_reader(panel_key, at, false);
+    }
+
+    /// The same, saying whether the caret it seats takes the selection with
+    /// it: a drag over the page is one gesture from its press, so every move
+    /// of it extends from where the press left the anchor.
+    fn move_page_reader(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        at: (u32, u16),
+        extend: bool,
+    ) {
         self.page_reading.insert(panel_key.clone(), at);
         if let Some(anchor) = self.page_anchors.get(panel_key) {
             anchor.reveal(at.0);
         }
-        self.mirror_page_reader_into_buffer(panel_key, at);
+        self.mirror_page_reader_into_buffer(panel_key, at, extend);
         self.shell_description_stale = true;
     }
 
@@ -2038,6 +2188,7 @@ impl Editor {
         &mut self,
         panel_key: &crate::widgets::PanelKey,
         (row, col): (u32, u16),
+        extend: bool,
     ) {
         let Some(buffer_id) = self
             .widget_registry
@@ -2053,11 +2204,12 @@ impl Editor {
                 Some(next) => next.saturating_sub(1),
                 None => st.buffer.len(),
             };
-            Some((start + col as usize).min(end))
+            let line = Self::page_line(&st.buffer, row as usize);
+            Some((start + byte_at_display_col(&line, col)).min(end))
         }) else {
             return;
         };
-        self.seat_buffer_cursor(buffer_id, offset);
+        self.seat_buffer_cursor_selecting(buffer_id, offset, extend);
     }
 
     /// The other direction: the reader has landed somewhere on a
@@ -2128,6 +2280,18 @@ impl Editor {
     /// `set_buffer_cursor_in_splits` themselves, into buffers that can
     /// perfectly well carry a focus-following panel; they call this now.
     pub(super) fn seat_buffer_cursor(&mut self, buffer_id: BufferId, position: usize) {
+        self.seat_buffer_cursor_selecting(buffer_id, position, false);
+    }
+
+    /// The same, saying whether the caret drags a selection behind it. Only
+    /// the page's pointer sweep passes `true`: every other seat here is a
+    /// placement, and a placement collapses.
+    pub(super) fn seat_buffer_cursor_selecting(
+        &mut self,
+        buffer_id: BufferId,
+        position: usize,
+        extend: bool,
+    ) {
         let splits = self.splits_showing_buffer(buffer_id);
         if splits.is_empty() {
             tracing::warn!("No splits found for buffer {:?}", buffer_id);
@@ -2137,7 +2301,7 @@ impl Editor {
             return;
         }
         self.active_window_mut()
-            .set_buffer_cursor_in_splits(buffer_id, position, &splits);
+            .set_buffer_cursor_in_splits_selecting(buffer_id, position, &splits, extend);
     }
 
     /// Offer a panel-focus transition to the kinds: the widget losing
@@ -4581,4 +4745,36 @@ mod tests {
             "the dropdown owns the keyboard, so ↑/↓ drive it and not the list"
         );
     }
+}
+
+/// The display column a byte offset sits at within `line`.
+///
+/// The page's rows are text and its spans are cells, and these two are where
+/// the one becomes the other. A byte column is what a buffer cursor is; a
+/// display column is what the tree laid out, what a press lands on, and what
+/// a selection is washed across.
+fn display_col_of(line: &str, byte: usize) -> u16 {
+    use unicode_width::UnicodeWidthChar;
+    let mut cols = 0usize;
+    for (at, ch) in line.char_indices() {
+        if at >= byte {
+            break;
+        }
+        cols += ch.width().unwrap_or(0);
+    }
+    cols.min(u16::MAX as usize) as u16
+}
+
+/// The byte offset at display column `col` of `line` — the start of the
+/// character covering that cell, and the line's length past its end.
+fn byte_at_display_col(line: &str, col: u16) -> usize {
+    use unicode_width::UnicodeWidthChar;
+    let mut cols = 0usize;
+    for (at, ch) in line.char_indices() {
+        if cols >= col as usize {
+            return at;
+        }
+        cols += ch.width().unwrap_or(0);
+    }
+    line.len()
 }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1899,6 +1899,24 @@ impl Window {
         position: usize,
         splits: &[LeafId],
     ) {
+        self.set_buffer_cursor_in_splits_selecting(buffer_id, position, splits, false);
+    }
+
+    /// The same, saying whether the caret takes a selection with it.
+    ///
+    /// `extend` is the pointer sweep over a described page
+    /// (`Editor::drag_moved_the_page_selection`), which is the one caller
+    /// here that is a *gesture* rather than a placement: it anchors on the
+    /// press and every move after it grows the range. Everything else is a
+    /// jump, and a jump collapses — see the goal-column note below, which is
+    /// the same argument.
+    pub fn set_buffer_cursor_in_splits_selecting(
+        &mut self,
+        buffer_id: BufferId,
+        position: usize,
+        splits: &[LeafId],
+        extend: bool,
+    ) {
         self.buffers
             .with_buffer_and_view_states(buffer_id, |state, vs_map| {
                 let mut moved_any = false;
@@ -1907,7 +1925,7 @@ impl Window {
                         continue;
                     };
                     let cursor = view_state.cursors.primary_mut();
-                    cursor.move_to(position, false);
+                    cursor.move_to(position, extend);
                     // An absolute placement is a jump, not a vertical move,
                     // so it clears the goal column — the same thing every
                     // other jump in the editor does (`new_sticky_column:

--- a/crates/fresh-editor/src/view/shell/dock.rs
+++ b/crates/fresh-editor/src/view/shell/dock.rs
@@ -380,6 +380,7 @@ mod tests {
 
                     page: None,
                     reading: None,
+                    selection: Vec::new(),
                     compose: None,
                     hovered_key: None,
                     hovered_item_key: String::new(),
@@ -582,6 +583,7 @@ mod tests {
 
                     page: None,
                     reading: None,
+                    selection: Vec::new(),
                     compose: None,
                     hovered_key: None,
                     hovered_item_key: String::new(),

--- a/crates/fresh-editor/src/view/shell/frame.rs
+++ b/crates/fresh-editor/src/view/shell/frame.rs
@@ -1436,6 +1436,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),

--- a/crates/fresh-editor/src/view/shell/overlay_prompt.rs
+++ b/crates/fresh-editor/src/view/shell/overlay_prompt.rs
@@ -606,6 +606,7 @@ mod tests {
             keyboard: true,
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),

--- a/crates/fresh-editor/src/view/shell/panel.rs
+++ b/crates/fresh-editor/src/view/shell/panel.rs
@@ -162,6 +162,21 @@ pub struct Interior {
     /// coordinates inside the scrolled content is the caret, and it travels
     /// with the page the way every other row does.
     pub reading: Option<(u32, u16)>,
+    /// The reader's selection on that page, one band per content row:
+    /// `(row, first column, last column + 1)`, in display columns.
+    ///
+    /// **Described for the same reason the caret is.** The pane shows this
+    /// tree rather than the mirror buffer, so the buffer painter — the thing
+    /// that washes a selection everywhere else in the editor — never runs
+    /// over this text: shift-arrow and drag-to-select made a selection the
+    /// reader could not see, on a page whose whole purpose is to be read and
+    /// quoted. Each band is a wash laid over the content and scrolled with
+    /// it (`splits::page_layers`), so what is copied and what is lit are one
+    /// thing.
+    ///
+    /// Empty for every panel that is not a page, and for a page whose reader
+    /// has selected nothing.
+    pub selection: Vec<(u32, u16, u16)>,
     /// The column a composed panel is laid out and centred in
     /// (`setLayoutHints({ composeWidth })`), when it is narrower than the
     /// pane. `None` for every surface that fills the box it was given.
@@ -999,6 +1014,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),
@@ -1238,6 +1254,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),
@@ -1293,6 +1310,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),
@@ -1361,6 +1379,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),
@@ -1418,6 +1437,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),

--- a/crates/fresh-editor/src/view/shell/sidebar.rs
+++ b/crates/fresh-editor/src/view/shell/sidebar.rs
@@ -922,6 +922,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),

--- a/crates/fresh-editor/src/view/shell/splits.rs
+++ b/crates/fresh-editor/src/view/shell/splits.rs
@@ -1447,6 +1447,84 @@ fn compose_margin(width: u16, height: u16, desk_first: bool) -> Node<UiMsg> {
     }
 }
 
+/// A page's content with the two things the host draws over it: the band
+/// under the reader's selection, and the reader's caret.
+///
+/// **Both are the description's because there is nothing else on screen that
+/// could draw them.** The pane shows this tree rather than the mirror buffer,
+/// so the buffer painter — which draws a caret and washes a selection over
+/// every other text surface in the editor — never runs over this text. The
+/// caret is a zero-width marker at the reader's cell; the selection is one
+/// wash per row, in the editor's own selection ground, over the content and
+/// scrolled with it.
+///
+/// **Nothing in either layer is hittable.** A stack's children all get the
+/// whole rect and the later one is hit first, so a layer that took hits would
+/// swallow every press on the page — which is how the reader gets to a
+/// control in the first place.
+fn page_layers(
+    id: LeafId,
+    widgets: Node<UiMsg>,
+    reading: Option<(u32, u16)>,
+    selection: &[(u32, u16, u16)],
+) -> Node<UiMsg> {
+    if reading.is_none() && selection.is_empty() {
+        return widgets;
+    }
+    let mut layers = vec![widgets];
+    if !selection.is_empty() {
+        // The bands are in content rows, so the layer is a column of spacers
+        // and washes: each band skips to its own row and paints the cells
+        // between its two columns. A wash recolours what is under it and
+        // keeps the text, which is what a selection is.
+        let mut band_layer = col().pointer_mode(PointerMode::Ignore);
+        let mut at: u32 = 0;
+        for (band_row, from, to) in selection.iter().copied() {
+            if to <= from || band_row < at {
+                continue;
+            }
+            if band_row > at {
+                band_layer = band_layer
+                    .child(row().h(Sizing::Cells((band_row - at).min(u16::MAX as u32) as u16)));
+            }
+            band_layer = band_layer.child(
+                row()
+                    .h(Sizing::Cells(1))
+                    .child(row().w(Sizing::Cells(from)))
+                    .child(
+                        row()
+                            .w(Sizing::Cells(to - from))
+                            .h(Sizing::Cells(1))
+                            .theme(pair("editor.fg", "editor.selection_bg"))
+                            .wash(),
+                    ),
+            );
+            at = band_row + 1;
+        }
+        layers.push(band_layer);
+    }
+    if let Some((at_row, at_col)) = reading {
+        layers.push(
+            col()
+                .pointer_mode(PointerMode::Ignore)
+                .child(row().h(Sizing::Cells(at_row.min(u16::MAX as u32) as u16)))
+                .child(
+                    row()
+                        .h(Sizing::Cells(1))
+                        .child(row().w(Sizing::Cells(at_col)))
+                        .child(
+                            text("")
+                                .key(super::widgets::caret_key(super::widgets::Slot::Pane(id)))
+                                .w(Sizing::Cells(0))
+                                .h(Sizing::Cells(1))
+                                .cursor_byte(0),
+                        ),
+                ),
+        );
+    }
+    stack().children(layers)
+}
+
 /// A mounted plugin panel, as the pane's content.
 ///
 /// Laid out inside a `layout_reader` for both extents, and that is the point
@@ -1461,8 +1539,14 @@ fn panel_content(id: LeafId, i: super::panel::Interior, active: bool) -> Node<Ui
     // surface does. A widget the registry names is marked by `widgets::node`
     // (through `Ctx::keyboard`), and the innermost mark wins.
     let rests_here = active && !super::widgets::marks(&i.spec, &i.focus_key);
+    // Whether this panel is a page, read before the interior is moved into
+    // the layout reader: the press below captures the pointer only for one,
+    // because a page is the only pane-mounted panel whose content is text to
+    // sweep rather than a set of controls to click.
+    let is_page = i.page.is_some();
     let page = i.page.clone();
     let reading = i.reading;
+    let selection = i.selection.clone();
     let compose = i.compose;
     let body = fresh_ui::layout_reader(move |info: fresh_ui::LayoutInfo| {
         // **The whole pane, not `widget_panel_width`'s.** The runtime lays a
@@ -1540,43 +1624,7 @@ fn panel_content(id: LeafId, i: super::panel::Interior, active: bool) -> Node<Ui
             // windows itself.
             Some(anchor) => fresh_ui::viewport(
                 fresh_ui::row().children([
-                    match reading {
-                        // **A page's reader is drawn by the description**, because
-                        // there is nothing else on screen that could: the pane
-                        // shows this tree rather than the mirror buffer, so the
-                        // mirror's cursor is a report and not a caret. A
-                        // zero-width marker at the reader's cell, laid over the
-                        // content and scrolled with it, is that caret — the same
-                        // marker a focused field places, at coordinates the host
-                        // owns instead of a byte the field owns.
-                        Some((at_row, at_col)) => stack().children([
-                            widgets,
-                            // **Nothing here is hittable.** A stack's children all
-                            // get the whole rect and the later one is hit first, so
-                            // a caret layer that took hits would swallow every
-                            // press on the page — which is how the reader gets to
-                            // a control in the first place.
-                            col()
-                                .pointer_mode(PointerMode::Ignore)
-                                .child(row().h(Sizing::Cells(at_row.min(u16::MAX as u32) as u16)))
-                                .child(
-                                    row()
-                                        .h(Sizing::Cells(1))
-                                        .child(row().w(Sizing::Cells(at_col)))
-                                        .child(
-                                            text("")
-                                                .key(super::widgets::caret_key(
-                                                    super::widgets::Slot::Pane(id),
-                                                ))
-                                                .w(Sizing::Cells(0))
-                                                .h(Sizing::Cells(1))
-                                                .cursor_byte(0),
-                                        ),
-                                ),
-                        ]),
-                        None => widgets,
-                    }
-                    .w(Sizing::Cells(inner_w)),
+                    page_layers(id, widgets, reading, &selection).w(Sizing::Cells(inner_w)),
                     // **The window is wider than the page.** A viewport stretches
                     // its child to its own width, and the window reaches the
                     // pane's edge so its bar can hang there — so the page is
@@ -1671,24 +1719,61 @@ fn panel_content(id: LeafId, i: super::panel::Interior, active: bool) -> Node<Ui
     //
     // A **right** press is left alone for the reason it was before: it belongs
     // to the base surface's dismissal of the tab context menu.
-    let pressed = gesture(body).on(
-        GestureKind::Press,
-        Rc::new(move |e: &Event| {
-            if e.button != MouseButton::Left {
-                return None;
-            }
-            e.stop();
-            Some(UiMsg::Ui(UiFact::PaneContentPress {
-                pane: id,
-                // A panel has no byte to place a caret at.
-                byte: None,
-                x: e.pos.x.max(0) as u16,
-                y: e.pos.y.max(0) as u16,
-                clicks: e.clicks,
-                mods: e.mods,
-            }))
-        }),
-    );
+    //
+    // **And a page's press captures the pointer, as the buffer's does.** A
+    // page is text to read and quote, so a press that no widget claimed is
+    // the beginning of a possible sweep across it: the moves come back here
+    // as `PaneContentDrag` and the release as `PaneContentRelease`, and
+    // `Editor::drag_moved_the_page_selection` grows the mirror's selection
+    // with them. A press a control took never reaches this handler, so
+    // dragging off a button still does nothing — and a panel that is not a
+    // page never captures at all, because its content is controls rather
+    // than prose.
+    let at = |e: &Event| (e.pos.x.max(0) as u16, e.pos.y.max(0) as u16);
+    let pressed = gesture(body)
+        .on(
+            GestureKind::Press,
+            Rc::new(move |e: &Event| {
+                if e.button != MouseButton::Left {
+                    return None;
+                }
+                let (x, y) = at(e);
+                if is_page {
+                    e.capture_pointer();
+                }
+                e.stop();
+                Some(UiMsg::Ui(UiFact::PaneContentPress {
+                    pane: id,
+                    // A panel has no byte to place a caret at.
+                    byte: None,
+                    x,
+                    y,
+                    clicks: e.clicks,
+                    mods: e.mods,
+                }))
+            }),
+        )
+        .on(
+            GestureKind::Move,
+            Rc::new(move |e: &Event| {
+                // Only while this node holds the pointer its press took:
+                // bare motion over the page is the hover's business.
+                if !e.captured {
+                    return None;
+                }
+                let (x, y) = at(e);
+                Some(UiMsg::Ui(UiFact::PaneContentDrag { pane: id, x, y }))
+            }),
+        )
+        .on(
+            GestureKind::Release,
+            Rc::new(move |e: &Event| {
+                if e.button != MouseButton::Left {
+                    return None;
+                }
+                Some(UiMsg::Ui(UiFact::PaneContentRelease { pane: id }))
+            }),
+        );
     // **The panel's interior: its ring's root, its keymap, and the seam its
     // keys cross.** The same [`super::panel::interior`] the dock's is: the
     // content slot's key (`content_key`, which `interior_key(Slot::Pane)`

--- a/crates/fresh-editor/src/view/shell/widgets.rs
+++ b/crates/fresh-editor/src/view/shell/widgets.rs
@@ -2207,7 +2207,23 @@ fn node_body(spec: &WidgetSpec, width: u16, cx: &Ctx<'_>, site: Site) -> Node<Ui
             // `List::windowed` is the same window `widgets::List` gives every
             // other kind here. Its rows are one cell each, so its item scroll
             // *is* the row scroll the runtime had.
-            let rows_src = std::rc::Rc::new(out.entries.split_off(head));
+            let mut body_rows = out.entries.split_off(head);
+            // **The window is the box; the padding under a short document is
+            // not part of it.** The line count above is a guess whenever the
+            // widget is unkeyed — `value.split('\n')` counts a fenced block's
+            // ``` delimiters, which the render does not draw — and the
+            // collector pads its output to whatever height it was told, so
+            // the welcome page's nine-line sample came back eleven rows tall
+            // in a nine-row box and grew a scrollbar over a document that
+            // fits. Padding past the box is never content: it is trimmed,
+            // and never below the box's own height, so a document that
+            // really is taller still scrolls.
+            while body_rows.len() > (*rows).max(1) as usize
+                && body_rows.last().is_some_and(|e| e.text.trim().is_empty())
+            {
+                body_rows.pop();
+            }
+            let rows_src = std::rc::Rc::new(body_rows);
             let hits = std::rc::Rc::new(out.hits.clone());
             let n = rows_src.len();
             let slot = cx.slot;
@@ -7081,6 +7097,7 @@ mod tests {
 
             page: None,
             reading: None,
+            selection: Vec::new(),
             compose: None,
             hovered_key: None,
             hovered_item_key: String::new(),

--- a/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/welcome_screen.rs
@@ -672,6 +672,12 @@ fn moving_the_caret_onto_prose_disarms_the_focused_control() {
 /// Walking down the page with an arrow key onto the finder's input means
 /// the next character typed goes into the finder — no Tab count, no `/`,
 /// nothing to know. The caret is on the field, so the field has focus.
+///
+/// *Onto* it: the walk is down the field's own columns, because a control
+/// takes focus where it is and not across the whole width of its row (see
+/// `a_control_takes_focus_only_where_it_is`). A reader coming down the
+/// page's left margin passes the card without entering it, which is the
+/// point of the rule.
 #[test]
 fn the_caret_arriving_at_the_finder_field_types_into_it() {
     let (mut harness, _tmp) = harness_with_welcome();
@@ -682,6 +688,15 @@ fn the_caret_arriving_at_the_finder_field_types_into_it() {
     // makes reading its screen row unreliable.
     harness.wait_for_async_quiescence(4).unwrap();
     scroll_until(&mut harness, "find [");
+    // Start above the field, in its column: a click seats the caret, and
+    // Down keeps the column it was seated in.
+    {
+        let (col, row) = harness
+            .find_text_on_screen("find [")
+            .expect("the finder field is on screen");
+        harness.mouse_click(col + 7, row.saturating_sub(3)).unwrap();
+        harness.wait_for_async_quiescence(4).unwrap();
+    }
 
     // Down moves by *buffer* line and the gap read off the screen is in
     // *screen* rows; they agree only while nothing between them wraps
@@ -1105,5 +1120,222 @@ fn a_level_banner_has_air_before_its_description() {
          {} reads {description:?}. Screen:\n{}",
         rule_row + 2,
         harness.screen_to_string()
+    );
+}
+
+/// The page's own left and right edges on the row `needle` is on — the
+/// columns a full-measure row occupies, which is what "centred on the
+/// page" is measured against. The page is itself centred in the pane, and
+/// the pane's right margin carries the scrollbar, so the *screen* is not
+/// the frame of reference.
+fn page_edges(harness: &EditorTestHarness, needle: &str) -> (usize, usize) {
+    let screen = harness.screen_to_string();
+    let line = screen
+        .lines()
+        .find(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("{needle:?} is not on screen. Screen:\n{screen}"));
+    let cells: Vec<char> = line.chars().collect();
+    let left = cells
+        .iter()
+        .position(|c| *c != ' ')
+        .expect("a row with ink");
+    let right = cells
+        .iter()
+        .rposition(|c| *c != ' ')
+        .expect("a row with ink");
+    (left, right)
+}
+
+/// The columns of the first `╭ … ╮` box at or below `from`.
+fn box_edges(harness: &EditorTestHarness, from: u16) -> (usize, usize, u16) {
+    let screen = harness.screen_to_string();
+    for (y, line) in screen.lines().enumerate() {
+        if (y as u16) < from {
+            continue;
+        }
+        let cells: Vec<char> = line.chars().collect();
+        if let (Some(l), Some(r)) = (
+            cells.iter().position(|c| *c == '╭'),
+            cells.iter().rposition(|c| *c == '╮'),
+        ) {
+            return (l, r, y as u16);
+        }
+    }
+    panic!("no framed box below row {from}. Screen:\n{screen}");
+}
+
+/// **A box is a block, and a page is a column: the two share an axis.**
+/// The framed cards were laid out at the page's left edge and narrowed to
+/// less than the measure, so every one of them left a growing band of
+/// white down the right of the page — the boxes and the prose around them
+/// disagreeing about where the page was.
+#[test]
+fn a_framed_card_is_centred_on_the_page() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+    scroll_until(&mut harness, "find [");
+
+    // A level banner is a full-measure row, so it names the page's edges.
+    let (page_left, page_right) = page_edges(&harness, "━━━━");
+    let (_, _, top) = box_edges(&harness, 0);
+    let (box_left, box_right, _) = box_edges(&harness, top);
+    let (before, after) = (box_left - page_left, page_right - box_right);
+    assert!(
+        before.abs_diff(after) <= 1,
+        "the card sits {before} columns from the page's left edge and \
+         {after} from its right. Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// **A box is as tall as what is in it.** The code sample's box asks for
+/// exactly the rows its listing has, and the collector used to pad the
+/// document out to a row count taken from the *source* — which counts a
+/// fenced block's ``` delimiters, two rows nothing draws. The box then
+/// held eleven rows in nine and grew a scrollbar over a listing that fits.
+#[test]
+fn the_code_sample_box_holds_its_whole_listing() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+    scroll_until(&mut harness, "src/store.rs");
+
+    let (left, right, top) = box_edges(&harness, 0);
+    let rows = harness.screen_to_string().lines().count() as u16;
+    for y in top..rows.min(top + 12) {
+        for x in (left + 1)..right {
+            assert!(
+                !harness.is_scrollbar_thumb_at(x as u16, y)
+                    && !harness.is_scrollbar_track_at(x as u16, y),
+                "a scrollbar at column {x} of row {y}: the sample's box is \
+                 shorter than the sample. Screen:\n{}",
+                harness.screen_to_string()
+            );
+        }
+    }
+}
+
+/// **Focus follows the reader onto a control, not merely onto its row.**
+/// The startup switch is alone on the page's first row and right-aligned
+/// on it, so every column left of it is empty — and every one of them used
+/// to resolve to the switch, because the rule was "nearest control on the
+/// row, no distance cap". A reader walking down the page's left margin lit
+/// it up and armed Enter on it from forty columns away.
+#[test]
+fn a_control_takes_focus_only_where_it_is() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+    let (col, row) = harness
+        .find_text_on_screen("[✓] Show this screen on startup")
+        .expect("the startup switch is on the first row");
+
+    // Left of it on its own row: empty page, so nothing is focused.
+    harness.mouse_click(col.saturating_sub(20), row).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    assert!(
+        harness
+            .screen_to_string()
+            .contains("[✓] Show this screen on startup"),
+        "Enter from twenty columns left of the switch toggled it. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // And walking onto it — `End` is the editor's own binding, which this
+    // page's mode no longer hides, and one `Left` off the line's end is the
+    // switch's last cell — hands it the keyboard.
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("[ ] Show this screen on startup")
+        })
+        .expect("Enter with the caret on the switch toggles it");
+}
+
+/// **The page is text you can quote.** Its mode used to inherit no normal
+/// bindings, so `Shift+Right` — every shift-movement, in fact — reached
+/// nothing at all, and `Ctrl+C` with it: a document the reader could read
+/// and could not copy a line of. The mode inherits now, and the selection
+/// the editor makes is described over the page, because the pane draws
+/// this tree rather than the buffer under it.
+#[test]
+fn a_keyboard_selection_is_visible_and_copies() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+    let (col, row) = harness
+        .find_text_on_screen("It grows when your work does")
+        .expect("the tagline is on screen");
+    harness.mouse_click(col, row).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    for _ in 0..8 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::SHIFT)
+            .unwrap();
+    }
+    harness.wait_for_async_quiescence(4).unwrap();
+
+    let ground = harness.buffer()[(col.saturating_sub(2), row)].bg;
+    let selected = harness.buffer()[(col + 3, row)].bg;
+    assert_ne!(
+        selected,
+        ground,
+        "the selected run is painted in the page's own ground: a selection \
+         nobody can see. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    assert_eq!(
+        harness.editor_mut().clipboard_content_for_test(),
+        "It grows",
+        "Ctrl+C did not take the eight characters Shift+Right selected"
+    );
+}
+
+/// **And swept with the pointer.** A described pane has no
+/// screen-to-byte projection of its own — its content is the panel's
+/// subtree, not the buffer's leaf — so the buffer's drag path could not
+/// answer where the pointer is in the text. The page's own window can,
+/// and the selection it makes is the buffer's, not a second model.
+#[test]
+fn dragging_across_the_page_selects_what_it_crossed() {
+    let (mut harness, _tmp) = harness_with_welcome();
+    open_welcome(&mut harness);
+    let (col, row) = harness
+        .find_text_on_screen("It grows when your work does")
+        .expect("the tagline is on screen");
+
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    harness.mouse_drag(col, row, col + 8, row).unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    let ground = harness.buffer()[(col.saturating_sub(2), row)].bg;
+    let selected = harness.buffer()[(col + 3, row)].bg;
+    assert_ne!(
+        selected,
+        ground,
+        "the dragged run is not lit. Screen:\n{}",
+        harness.screen_to_string()
+    );
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_async_quiescence(4).unwrap();
+    assert_eq!(
+        harness.editor_mut().clipboard_content_for_test(),
+        "It grows",
+        "the drag selected something other than what it crossed"
     );
 }

--- a/docs/internal/retained-mode-ui.md
+++ b/docs/internal/retained-mode-ui.md
@@ -313,6 +313,30 @@ port needed, each found by driving the surface rather than by reading the diff:
   working; nothing resolves focus from it, which is what breaks the loop the
   buffer-caret version had.
 
+Two more the surface taught after the port:
+
+* **A focus region is the control's rectangle, in display columns.** The rule
+  was row-then-nearest-column with no cap, so a control alone on its row
+  answered for every column of it — the welcome page's right-aligned startup
+  switch armed Enter from the left margin. Containment needs the two sides to
+  agree on what a column *is*: the spans come off layout and the reader's came
+  off the buffer, and on any row drawn in box glyphs three bytes are one
+  column. The mirror converts in both directions (`display_col_of`,
+  `byte_at_display_col`), which is the same "the mirror is where they meet"
+  rule as above.
+* **A selection is the mirror's, and the description shows it.** The pane
+  draws the tree, so the painter that washes a selection over every other text
+  surface never runs here: shift-movement and a pointer sweep made a range
+  that `Ctrl+C` took and nobody could see. `panel::Interior::selection` is
+  that range as bands of display columns, one per content row, washed over the
+  content by `splits::page_layers` and scrolled with it — the caret's own
+  argument, applied to the other half of what a caret is. The sweep itself is
+  the pane's press capture (`panel_content`'s gesture) mapped through the
+  page's window; it moves the reader with `extend`, so what grows is the
+  buffer's own cursor. No second selection model, and none wanted: a plugin
+  that hid this behind a mode with no inherited bindings is what made it look
+  like one was missing.
+
 **L6 — A keyed geometry index.** `find_by_key` has 160 call sites in the
 editor and walks the tree. After layout the library publishes `Key → Rect`
 (and the scroll/window facts `GeomSnapshot` already carries) as an O(1)

--- a/docs/internal/welcome-screen-design.md
+++ b/docs/internal/welcome-screen-design.md
@@ -470,7 +470,8 @@ the welcome screen, is the welcome screen.
 |---|---|
 | scroll / `PgUp` / `PgDn` / mouse wheel | ordinary buffer scrolling; the depth meter follows |
 | `Tab` / `Shift+Tab` | move focus between interactive widgets — the caret comes with it |
-| arrow / page keys / a click on the text | move the caret; the control on the row it lands on takes focus, and a row with none clears it |
+| arrow / page keys / a click on the text | move the caret; the control it lands **on** takes focus, and a cell carrying none clears it |
+| `Shift`+movement, or a drag with the mouse | select the page's text; `Ctrl+C` copies it, `Ctrl+A` takes the page |
 | `Enter` | activate the focused widget — nothing, on a paragraph |
 | click on a fold arrow, or `za` on its row | fold / unfold that card |
 | typing, while the caret is in the finder | it is a real text input; it really searches |
@@ -1116,6 +1117,52 @@ Eleven things the wireframes did not know:
     index is rebuilt on the version bump regardless. The e2e test written
     for it passed with the change reverted, which is how the theory was
     caught; it is not in this PR.
+
+35. **A control took focus across the whole width of its row.** Focus
+    resolved by row and then by *nearest* column with no distance cap, so on
+    a row carrying one control that control was the answer for every column
+    of it — and the page's first row carries one right-aligned switch. A
+    reader walking down the left margin lit it up and armed Enter on it from
+    forty columns away. A focus region is the control's own rectangle now
+    (`page_focus_target_at`), which needed the reader's column to be a
+    *display* column rather than a byte one: the rows carrying controls are
+    exactly the rows drawn in box glyphs, where one column is three bytes.
+    `page_follows_caret` converts on the way out and
+    `mirror_page_reader_into_buffer` on the way back, so the mirror is still
+    where the two coordinate systems meet.
+
+36. **The mode inherited no bindings, so it masked half the keyboard.**
+    `defineMode`'s `inheritNormalBindings` defaults to false, and what it was
+    hiding here is what a *document* needs: `Left` / `Right`, `Home` / `End`,
+    every `Shift+` movement — which is selection — and `Ctrl+A` / `Ctrl+C`.
+    The page could be read and not quoted. Nothing was re-bound to fix it:
+    the mode inherits now, exactly as the built-in help viewer's `special`
+    mode does, and its own bindings still win where it has one.
+
+    The host half is that a described pane draws the tree and not the buffer
+    under it, so the painter that washes a selection everywhere else in the
+    editor never ran here — the selection existed and was invisible. The
+    description carries it now (`panel::Interior::selection`, one band per
+    row, washed by `splits::page_layers`), the way it already carried the
+    caret, and the pointer sweep is the pane's own press capture mapped
+    through the page's window (`drag_moved_the_page_selection`). Both read
+    the buffer's own cursors: there is no second selection model.
+
+37. **A box is a block, and the page is a column.** Framed cards were
+    narrowed to `cardMeasure()` and left at the page's left edge, so every
+    one of them left a band of white down the right — the boxes and the
+    prose disagreeing about where the page was. `toCardWidth` centres them
+    and `card` centres the heading with them, because a heading that rules
+    to its own box's width and starts somewhere else is two objects.
+
+38. **A markdown box was padded taller than its own document.** The
+    collector is told how many rows to emit, and for an unkeyed `Text` that
+    number came from `value.split('\n')` — which counts a fenced block's
+    ``` delimiters, two rows nothing draws. The sample's nine-line listing
+    came back eleven rows tall in a nine-row box and grew a scrollbar over a
+    document that fits. Padding past the box is never content, so the
+    description trims it (`view/shell/widgets.rs`), never below the box's own
+    height: a document that really is taller still scrolls.
 
 ### Still aspirational
 


### PR DESCRIPTION
Four things found by reading the Welcome page rather than the diff.

### Its boxes sat off the page's axis

A framed card is narrowed to `cardMeasure()` and was laid out at the page's left edge, so every one of them — the finder, git, Review Diff, the themes, the Orchestrator dock — left a growing band of white down the right, and the boxes and the prose disagreed about where the page was. `toCardWidth` centres them now and `card` centres the heading with them, because a heading that rules to its own box's width and starts somewhere else is two objects rather than one. The code sample's box is centred the same way, in place of a two-column inset that only looked centred because the slack beside it happened to be two columns wide.

### And the sample's box was shorter than the sample

The collector is told how many rows to emit, and for an unkeyed markdown `Text` that number comes from `value.split('\n')` — which counts a fenced block's ``` delimiters, two rows nothing draws. Nine lines of Rust came back eleven rows tall in a nine-row box and grew a scrollbar over a listing that fits. Padding past the box is never content, so the description trims it, and never below the box's own height: a document that really is taller still scrolls.

### A control took focus across the whole width of its row

Focus resolved by row and then by *nearest* column with no distance cap, so on a row carrying one control that control was the answer for every column of it — and the page's first row carries one right-aligned switch. A reader walking down the left margin lit it up and armed Enter on it from forty columns away. A focus region is the control's own rectangle now, in both axes.

That needed the reader's column to be a **display** column rather than a byte one: the spans come off the laid-out tree, and the rows carrying controls are exactly the rows drawn in box glyphs, where three bytes are one column. The mirror is where the two coordinate systems meet, so it converts in both directions — `page_follows_caret` out, `mirror_page_reader_into_buffer` back — which also puts a click's caret on the cell that was clicked.

### The page could be read and not quoted

`defineMode`'s `inheritNormalBindings` defaults to false, and the welcome mode took the default: `Left` and `Right`, `Home` and `End`, every `Shift+` movement — which is selection — and `Ctrl+A` / `Ctrl+C` reached nothing at all. Nothing is re-bound to fix that; the mode inherits, exactly as the built-in help viewer's `special` mode already does for the same reason, and its own bindings still win where it has one.

The host half is that a described pane draws the tree and not the buffer under it, so the painter that washes a selection over every other text surface never ran here — the range existed, and nobody could see it. The description carries it now (`panel::Interior::selection`, one band of display columns per content row, washed over the content by `splits::page_layers` and scrolled with it), which is the caret's own argument applied to the other half of what a caret is. The pointer sweep is the pane's own press capture mapped through the page's window; it moves the reader with `extend`, so what grows is the buffer's cursor. There is no second selection model, and none was wanted.

### Tests

Five new e2e tests in `welcome_screen.rs`: `a_framed_card_is_centred_on_the_page`, `the_code_sample_box_holds_its_whole_listing`, `a_control_takes_focus_only_where_it_is`, `a_keyboard_selection_is_visible_and_copies`, `dragging_across_the_page_selects_what_it_crossed`. One existing test (`the_caret_arriving_at_the_finder_field_types_into_it`) now walks down the field's own columns, which is the new rule stated from the other side.

All 4927 tests in `fresh-editor`'s suite pass, and `cargo fmt --check` and `cargo clippy --all-targets` are clean of anything this change introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xA34Gq64xbAE24KxUZrN5

---
_Generated by [Claude Code](https://claude.ai/code/session_015xA34Gq64xbAE24KxUZrN5)_