### PR TITLE
Two panels that outlived what they painted into

### DIFF
--- a/crates/fresh-editor/plugins/git_gutter.ts
+++ b/crates/fresh-editor/plugins/git_gutter.ts
@@ -76,6 +76,27 @@ interface BufferGitState {
 /** Git state per buffer */
 const bufferStates: Map<number, BufferGitState> = new Map();
 
+/** A buffer's starting state, in one place because six handlers need one.
+ *
+ *  It was six hand-written object literals, and the one in
+ *  `after_file_revert` left both baseline fields out. That is `undefined`,
+ *  not `null`, so `ensureBaselines` read them as *already registered*,
+ *  skipped registration, and `refreshDiffBaseline(undefined)` rejected with
+ *  `Error converting from js 'undefined' into type 'f64'` — a reverted
+ *  buffer (an external `git checkout` of the open file, say) lost its gutter
+ *  until it was reopened. A literal that omits a required field is a type
+ *  error `check-types.sh` reports; a constructor is one that cannot be
+ *  written. */
+function newBufferState(filePath: string): BufferGitState {
+  return {
+    filePath,
+    hunks: [],
+    updating: false,
+    diskBaselineId: null,
+    headBaselineId: null,
+  };
+}
+
 
 // =============================================================================
 // Hunk mapping (host-side diff)
@@ -333,13 +354,7 @@ function git_gutter_refresh() : void {
 
   // Ensure state exists
   if (!bufferStates.has(bufferId)) {
-    bufferStates.set(bufferId, {
-      filePath,
-      hunks: [],
-      updating: false,
-      diskBaselineId: null,
-      headBaselineId: null,
-    });
+    bufferStates.set(bufferId, newBufferState(filePath));
   }
 
   // Force immediate update
@@ -367,13 +382,7 @@ editor.on("after_file_open", (args) => {
   }
 
   // Initialize state for this buffer
-  bufferStates.set(bufferId, {
-    filePath,
-    hunks: [],
-    updating: false,
-    diskBaselineId: null,
-    headBaselineId: null,
-  });
+  bufferStates.set(bufferId, newBufferState(filePath));
 
   // Update immediately (no debounce for file open)
   updateGitGutter(bufferId);
@@ -387,13 +396,7 @@ editor.on("buffer_activated", (args) => {
   if (!bufferStates.has(bufferId)) {
     const filePath = editor.getBufferPath(bufferId);
     if (filePath && filePath !== "") {
-      bufferStates.set(bufferId, {
-        filePath,
-        hunks: [],
-        updating: false,
-        diskBaselineId: null,
-        headBaselineId: null,
-      });
+      bufferStates.set(bufferId, newBufferState(filePath));
       updateGitGutter(bufferId);
     }
   }
@@ -414,13 +417,7 @@ editor.on("after_file_save", (args) => {
       releaseBaselines(state);
     }
   } else {
-    bufferStates.set(bufferId, {
-      filePath: args.path,
-      hunks: [],
-      updating: false,
-      diskBaselineId: null,
-      headBaselineId: null,
-    });
+    bufferStates.set(bufferId, newBufferState(args.path));
   }
 
   // Update immediately after save (no debounce)
@@ -440,11 +437,7 @@ editor.on("after_file_revert", (args) => {
   if (state) {
     state.filePath = args.path;
   } else {
-    bufferStates.set(bufferId, {
-      filePath: args.path,
-      hunks: [],
-      updating: false,
-    });
+    bufferStates.set(bufferId, newBufferState(args.path));
   }
 
   updateGitGutter(bufferId);
@@ -468,13 +461,7 @@ editor.registerCommand(
 const initBufferId = editor.getActiveBufferId();
 const initPath = editor.getBufferPath(initBufferId);
 if (initPath && initPath !== "") {
-  bufferStates.set(initBufferId, {
-    filePath: initPath,
-    hunks: [],
-    updating: false,
-    diskBaselineId: null,
-    headBaselineId: null,
-  });
+  bufferStates.set(initBufferId, newBufferState(initPath));
   updateGitGutter(initBufferId);
 }
 

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -457,6 +457,9 @@ impl Editor {
     /// logs, semantic-token bookkeeping, the panel-id mapping, and each
     /// split's open-buffers / focus-history lists.
     fn purge_buffer_state(&mut self, id: BufferId) {
+        // Widget panels painting into this buffer go with it — they are
+        // editor-level state, so nothing below would have touched them.
+        self.drop_widget_panels_for_buffer(id);
         self.windows
             .get_mut(&self.active_window)
             .map(|w| &mut w.buffers)

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -790,6 +790,38 @@ impl Editor {
         }
     }
 
+    /// Forget every panel mounted into `buffer_id`, because that buffer is
+    /// being closed.
+    ///
+    /// **The registry is the editor's and the buffer is the window's, and
+    /// nothing else joined those two lifetimes.** A panel whose buffer went
+    /// away — the tab's `×`, `Ctrl+W`, closing the workspace's last file —
+    /// stayed mounted, so every later sweep over the registry kept trying to
+    /// paint it: a resize re-renders *all* of them, and each attempt wrote
+    /// its rows into a buffer that no longer exists. That is the
+    /// `rerender_widget_panel(welcome_screen:1) failed: Buffer not found`
+    /// that appeared in the log on every terminal resize after the welcome
+    /// page's tab was closed.
+    ///
+    /// The plugin learns of the close from the `buffer_closed` hook and drops
+    /// its own handle; this is the host's half of the same teardown, and it
+    /// mirrors what `handle_unmount_widget_panel` does when the plugin
+    /// unmounts a panel itself.
+    pub(crate) fn drop_widget_panels_for_buffer(&mut self, buffer_id: BufferId) {
+        for panel_key in self.widget_registry.panels_for_buffer(buffer_id) {
+            self.page_anchors.remove(&panel_key);
+            self.widget_panel_render_heights.remove(&panel_key);
+            self.widget_registry.unmount(&panel_key);
+            // The description names the panels, so losing one changes it.
+            self.shell_description_stale = true;
+            tracing::debug!(
+                "Dropped widget panel {} with its buffer {:?}",
+                panel_key,
+                buffer_id
+            );
+        }
+    }
+
     /// Re-render an existing widget panel after an in-host state
     /// change (focus advance, scroll move, etc.) without the plugin
     /// re-emitting the spec. Reads the panel's current spec from
@@ -4265,6 +4297,40 @@ mod tests {
             "a pane-mounted panel is the tree's as well: {} boxes, {} painted windows",
             panel.boxes.len(),
             panel.painted.len()
+        );
+    }
+
+    /// **A panel dies with the buffer it paints into.**
+    ///
+    /// Closing the tab is the reader's move, not the plugin's, and nothing
+    /// joined the editor-level registry to the window's buffer map: the panel
+    /// stayed mounted over a buffer that had been freed, and every later
+    /// sweep over the registry — a resize re-renders every panel key — failed
+    /// against it with `Buffer not found`, once per resize, for the rest of
+    /// the session.
+    #[test]
+    fn closing_a_buffer_unmounts_the_panels_mounted_into_it() {
+        let (mut editor, _t) = make_editor();
+        let panel_key = crate::widgets::PanelKey::new("welcome_screen", 1);
+        let buffer = editor.active_buffer();
+        mount_list_panel(&mut editor, &panel_key, buffer);
+        editor.record_widget_panel_render_height(&panel_key, Some(20));
+        assert!(
+            editor.widget_registry.get(&panel_key).is_some(),
+            "mounted to begin with"
+        );
+
+        editor
+            .close_buffer(buffer)
+            .expect("an unmodified buffer closes");
+
+        assert!(
+            editor.widget_registry.get(&panel_key).is_none(),
+            "the panel went with its buffer"
+        );
+        assert!(
+            !editor.widget_panel_render_heights.contains_key(&panel_key),
+            "and so did the row budget it was last rendered against"
         );
     }
 


### PR DESCRIPTION
Both errors came out of one session's log.

## `rerender_widget_panel(welcome_screen:1) failed: Buffer not found`

The widget registry is the editor's, the buffer a panel paints into is the window's, and nothing joined those two lifetimes. Close the welcome page's tab and its panel stayed mounted over the freed buffer, so every later sweep over the registry tried to paint it — and `relayout` re-renders *every* panel key, which is why the line repeated once per terminal resize for the rest of the session.

`purge_buffer_state` now drops the panels mounted into the buffer it is purging, along with the page anchor and the recorded render height that were born with each. That is the host's half of the teardown the plugin already does from the `buffer_closed` hook (`welcome_screen.ts` drops its own handle there).

Guarded by `closing_a_buffer_unmounts_the_panels_mounted_into_it`.

## `Unhandled Promise rejection: Error converting from js 'undefined' into type 'f64'` in `updateGitGutter`

Five of the six handlers in `git_gutter.ts` that build a `BufferGitState` set both baseline ids to `null`; `after_file_revert` left them out entirely. `undefined` is not `null`, so `ensureBaselines` read them as already registered, skipped registration, and passed `undefined` to `refreshDiffBaseline`, whose host signature takes a `u64`.

The effect: a buffer that was reverted rather than saved — an external `git checkout` of the open file, an explicit revert — lost its gutter and its scrollbar marks until it was reopened.

The six object literals are now one `newBufferState()`. `plugins/check-types.sh` does flag the missing fields (`TS2739`, verified by restoring the old literal), but nothing in `.github/workflows/` runs it — worth wiring up separately.

## Testing

- `cargo test -p fresh-editor --lib` — 2499 passed, 0 failed (includes the new test)
- `plugins/check-types.sh git_gutter.ts` — passes
- `cargo fmt --check`, `cargo clippy -p fresh-editor --lib` — clean (the remaining clippy warnings are pre-existing and elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYdXderYZgr1RLrPn3mtAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYdXderYZgr1RLrPn3mtAQ)_