### PR TITLE
fix(scrollbar): an empty buffer has no rows to project marks onto

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -61,7 +61,14 @@ pub(crate) fn scrollbar_line_counts(
         1
     };
 
-    if viewport.line_wrap_enabled
+    // An empty buffer is left out of the wrapped branch deliberately: it has
+    // no rows to index, so `scrollbar_visual_row_counts` takes its `(1, 0)`
+    // shortcut and returns before building one. Claiming `VisualRows` for it
+    // would hand the marker projection a basis with no index behind it
+    // (fresh#3236). One logical line and one visual row are the same single
+    // row, so the thumb reads the same on either basis.
+    if buffer_len > 0
+        && viewport.line_wrap_enabled
         && total_lines <= MAX_WRAP_SCROLLBAR_LINES
         && buffer_len <= MAX_WRAP_SCROLLBAR_BYTES
     {
@@ -213,10 +220,14 @@ pub(crate) fn resolve_scrollbar_marks(
             })
         }
         MarkerBasis::VisualRows { .. } => {
-            let index = state
-                .wrap_indices
-                .most_recent()
-                .expect("visual-row basis implies a built wrap index");
+            // The basis is only ever chosen by the branch that has just built
+            // this index, so `most_recent()` is the geometry the frame is
+            // painting. Marks are decoration on a bar, though, and no set of
+            // them is worth taking the editor down for: an unbuilt index drops
+            // them for this frame instead of panicking (fresh#3236).
+            let Some(index) = state.wrap_indices.most_recent() else {
+                return std::rc::Rc::from(Vec::new());
+            };
             let buffer = &state.buffer;
             scrollbar_marker::resolve_rows(&state.scrollbar_markers, core.as_ref(), basis, |b| {
                 index.line_first_row(buffer.get_line_number(b)) as u64
@@ -627,5 +638,120 @@ mod tests {
             1_999 * 50 + 1,
             "merging must still cover the last edit"
         );
+    }
+
+    /// fresh#3236: an empty buffer takes the `buffer_len == 0` shortcut in
+    /// `scrollbar_visual_row_counts`, which returns before building a wrap
+    /// index — so it must not be handed the visual-row basis, which the
+    /// marker projection reads that index through. One line and one row are
+    /// the same single row, so the thumb is unchanged.
+    ///
+    /// Reaching the projection at all needs a mark source, and an empty
+    /// buffer has the plainest one there is: delete every byte of a file and
+    /// the unsaved-change diff covers the deletion. That is the editor a
+    /// crash-recovery restore reopens, and the first frame used to panic on
+    /// it before any keystroke.
+    #[test]
+    fn empty_wrapped_buffer_keeps_the_thumb_off_the_visual_row_basis() {
+        let mut state = state_with_wrapping_lines(10);
+        let len = state.buffer.len();
+        state.buffer.delete(0..len);
+        assert_eq!(state.buffer.len(), 0);
+        assert!(
+            state.buffer.is_modified(),
+            "the deletion is the mark source that reaches the projection"
+        );
+
+        let vp = narrow_wrapped_viewport();
+        let (total, top, basis) = scrollbar_line_counts(
+            &mut state,
+            &vp,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES,
+            0,
+            Vec::new(),
+        );
+        assert_eq!(
+            (total, top),
+            (1, 0),
+            "an empty buffer is one row wherever it is counted"
+        );
+        assert_eq!(
+            basis,
+            MarkerBasis::LogicalLines { total: 1 },
+            "an empty buffer has no wrap index, so it cannot claim visual rows"
+        );
+
+        // The frame that used to die on `expect`. The deletion is itself an
+        // unsaved change, and a one-row basis buckets it onto the top of the
+        // track.
+        let cells = project(&mut state, basis, 20);
+        let marked: Vec<usize> = cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.is_some())
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            marked,
+            vec![0],
+            "the whole buffer is one row, so its one mark sits on the first cell"
+        );
+    }
+
+    /// The same empty buffer with a plugin marker instead of an unsaved edit —
+    /// the other way the projection is reached with nothing in the buffer.
+    #[test]
+    fn empty_wrapped_buffer_with_a_plugin_marker_projects() {
+        use crate::view::scrollbar_marker::ResolvedMarker;
+
+        let fs: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> =
+            Arc::new(crate::model::filesystem::StdFileSystem);
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            fs,
+        );
+        state.scrollbar_markers.set_markers(
+            "test",
+            vec![ResolvedMarker {
+                start: 0,
+                end: None,
+                color: fresh_core::api::OverlayColorSpec::Rgb(1, 2, 3),
+                priority: 0,
+            }],
+        );
+
+        let vp = narrow_wrapped_viewport();
+        let (_, _, basis) = scrollbar_line_counts(
+            &mut state,
+            &vp,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES,
+            0,
+            Vec::new(),
+        );
+        assert_eq!(basis, MarkerBasis::LogicalLines { total: 1 });
+        let cells = project(&mut state, basis, 20);
+        assert!(
+            cells.iter().any(Option::is_some),
+            "the marker still lands on the track"
+        );
+    }
+
+    /// And the projection itself no longer depends on that basis choice being
+    /// right: handed a visual-row basis with no index built, it drops the
+    /// frame's marks rather than the editor.
+    #[test]
+    fn visual_row_basis_without_an_index_drops_marks_instead_of_panicking() {
+        let mut state = state_with_wrapping_lines(10);
+        let len = state.buffer.len();
+        state.buffer.insert(len / 2, "an unsaved edit");
+        assert!(
+            state.wrap_indices.is_empty(),
+            "no index has been built here"
+        );
+
+        let cells = project(&mut state, MarkerBasis::VisualRows { total: 40 }, 20);
+        assert!(cells.iter().all(Option::is_none));
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -61,12 +61,9 @@ pub(crate) fn scrollbar_line_counts(
         1
     };
 
-    // An empty buffer is left out of the wrapped branch deliberately: it has
-    // no rows to index, so `scrollbar_visual_row_counts` takes its `(1, 0)`
-    // shortcut and returns before building one. Claiming `VisualRows` for it
-    // would hand the marker projection a basis with no index behind it
-    // (fresh#3236). One logical line and one visual row are the same single
-    // row, so the thumb reads the same on either basis.
+    // Empty buffers stay out: `scrollbar_visual_row_counts` shortcuts them
+    // without building the index the visual-row basis is read through
+    // (fresh#3236), and one line is one row here anyway.
     if buffer_len > 0
         && viewport.line_wrap_enabled
         && total_lines <= MAX_WRAP_SCROLLBAR_LINES
@@ -220,11 +217,8 @@ pub(crate) fn resolve_scrollbar_marks(
             })
         }
         MarkerBasis::VisualRows { .. } => {
-            // The basis is only ever chosen by the branch that has just built
-            // this index, so `most_recent()` is the geometry the frame is
-            // painting. Marks are decoration on a bar, though, and no set of
-            // them is worth taking the editor down for: an unbuilt index drops
-            // them for this frame instead of panicking (fresh#3236).
+            // Marks are decoration on a bar, so an unbuilt index costs this
+            // frame's marks rather than the editor (fresh#3236).
             let Some(index) = state.wrap_indices.most_recent() else {
                 return std::rc::Rc::from(Vec::new());
             };
@@ -640,27 +634,15 @@ mod tests {
         );
     }
 
-    /// fresh#3236: an empty buffer takes the `buffer_len == 0` shortcut in
-    /// `scrollbar_visual_row_counts`, which returns before building a wrap
-    /// index — so it must not be handed the visual-row basis, which the
-    /// marker projection reads that index through. One line and one row are
-    /// the same single row, so the thumb is unchanged.
-    ///
-    /// Reaching the projection at all needs a mark source, and an empty
-    /// buffer has the plainest one there is: delete every byte of a file and
-    /// the unsaved-change diff covers the deletion. That is the editor a
-    /// crash-recovery restore reopens, and the first frame used to panic on
-    /// it before any keystroke.
+    /// fresh#3236: the crash a recovery restore reopened into, where the
+    /// unsaved deletion is what reaches the projection.
     #[test]
     fn empty_wrapped_buffer_keeps_the_thumb_off_the_visual_row_basis() {
         let mut state = state_with_wrapping_lines(10);
         let len = state.buffer.len();
         state.buffer.delete(0..len);
         assert_eq!(state.buffer.len(), 0);
-        assert!(
-            state.buffer.is_modified(),
-            "the deletion is the mark source that reaches the projection"
-        );
+        assert!(state.buffer.is_modified());
 
         let vp = narrow_wrapped_viewport();
         let (total, top, basis) = scrollbar_line_counts(
@@ -670,20 +652,9 @@ mod tests {
             0,
             Vec::new(),
         );
-        assert_eq!(
-            (total, top),
-            (1, 0),
-            "an empty buffer is one row wherever it is counted"
-        );
-        assert_eq!(
-            basis,
-            MarkerBasis::LogicalLines { total: 1 },
-            "an empty buffer has no wrap index, so it cannot claim visual rows"
-        );
+        assert_eq!((total, top), (1, 0));
+        assert_eq!(basis, MarkerBasis::LogicalLines { total: 1 });
 
-        // The frame that used to die on `expect`. The deletion is itself an
-        // unsaved change, and a one-row basis buckets it onto the top of the
-        // track.
         let cells = project(&mut state, basis, 20);
         let marked: Vec<usize> = cells
             .iter()
@@ -691,15 +662,10 @@ mod tests {
             .filter(|(_, c)| c.is_some())
             .map(|(i, _)| i)
             .collect();
-        assert_eq!(
-            marked,
-            vec![0],
-            "the whole buffer is one row, so its one mark sits on the first cell"
-        );
+        assert_eq!(marked, vec![0], "one row, so one mark on the first cell");
     }
 
-    /// The same empty buffer with a plugin marker instead of an unsaved edit —
-    /// the other way the projection is reached with nothing in the buffer.
+    /// The other mark source that reaches the projection on an empty buffer.
     #[test]
     fn empty_wrapped_buffer_with_a_plugin_marker_projects() {
         use crate::view::scrollbar_marker::ResolvedMarker;
@@ -732,24 +698,16 @@ mod tests {
         );
         assert_eq!(basis, MarkerBasis::LogicalLines { total: 1 });
         let cells = project(&mut state, basis, 20);
-        assert!(
-            cells.iter().any(Option::is_some),
-            "the marker still lands on the track"
-        );
+        assert!(cells.iter().any(Option::is_some));
     }
 
-    /// And the projection itself no longer depends on that basis choice being
-    /// right: handed a visual-row basis with no index built, it drops the
-    /// frame's marks rather than the editor.
+    /// The projection does not depend on that basis choice being right.
     #[test]
     fn visual_row_basis_without_an_index_drops_marks_instead_of_panicking() {
         let mut state = state_with_wrapping_lines(10);
         let len = state.buffer.len();
         state.buffer.insert(len / 2, "an unsaved edit");
-        assert!(
-            state.wrap_indices.is_empty(),
-            "no index has been built here"
-        );
+        assert!(state.wrap_indices.is_empty());
 
         let cells = project(&mut state, MarkerBasis::VisualRows { total: 40 }, 20);
         assert!(cells.iter().all(Option::is_none));


### PR DESCRIPTION
Fixes #3236 — `fresh` panics on startup, before a keystroke, and again on every launch.

```
thread 'main' panicked at crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs:219:18:
visual-row basis implies a built wrap index
   4: fresh::view::ui::split_rendering::scrollbar::resolve_scrollbar_marks
   5: fresh::app::scrollbar_facts::<impl fresh::app::Editor>::settle_pane_bars::{{closure}}::{{closure}}
  10: fresh::app::render::<impl fresh::app::Editor>::shell_frame
```

## What happens

`scrollbar_visual_row_counts` shortcuts an empty buffer to `(1, 0)` and returns *before* `wrap_indices.entry()`, so no index is built — but `scrollbar_line_counts` still handed that buffer `MarkerBasis::VisualRows`. The marker projection reads its rows through that index, so the first frame that painted a bar for an empty buffer with anything to mark died on the `expect`.

Reaching the projection needs a mark source, and an empty buffer has the plainest one there is: delete every byte of a file and the unsaved-change diff covers the deletion. In a live editor the index usually survives from earlier frames with content, so it takes a buffer that is empty *and* modified on its very first frame — which is exactly what a crash-recovery restore reopens. That is why the reporter's editor was bricked rather than merely crashy: the recovery entry outlives the crash, so every subsequent launch panics on the same first frame.

## Reproduced

Against the real binary in a container, not just a test:

```bash
mkdir work && cd work && printf 'abc' > repro.txt
fresh repro.txt          # wrap is on by default (editor.line_wrap = true)
# Delete ×3 so the buffer is empty but unsaved, then Ctrl+Q -> panic
fresh                    # no arguments: panics on the first frame, every time
```

Confirmed as the trigger by toggling it: moving `~/.local/share/fresh/recovery` aside gives a clean startup, moving it back panics again. The poisoned entry is a `*.meta.json` with `"content_size": 0`. After this change the same recovery state reopens the buffer normally, unsaved marker and scrollbar mark included.

## The change

* `scrollbar_line_counts` keeps an empty buffer on the logical-line basis. Its one line and its one visual row are the same single row, so the thumb reads `(1, 0)` either way — only the basis handed to the projection changes.
* `resolve_scrollbar_marks` stops trusting that choice too. Marks are decoration on a bar, so an unbuilt index now drops the frame's marks rather than the editor.

## Tests

Three tests in `scrollbar.rs`, each failing before the change:

* `empty_wrapped_buffer_keeps_the_thumb_off_the_visual_row_basis` — the deletion path, the one the recovery restore lands on; asserts the basis, the unchanged `(1, 0)` counts, and that the deletion's own mark still buckets onto the top of the track.
* `empty_wrapped_buffer_with_a_plugin_marker_projects` — the other way the projection is reached with nothing in the buffer.
* `visual_row_basis_without_an_index_drops_marks_instead_of_panicking` — the hardening on its own.

`cargo test -p fresh-editor --lib scrollbar`: 64 passed. `cargo fmt --check` clean. The wider suite was not run at the author's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt27wSXbArwhMHZBwoRYHG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gt27wSXbArwhMHZBwoRYHG)_