### PR TITLE
Update CHANGELOG.md for 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.5.1
+
+For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
+
+> Most config options below can be changed in the **Settings UI** - run **Open Settings** from the command palette (`Ctrl+P`).
+
+### Bug Fixes
+
+* **Startup crash on an empty buffer with unsaved changes** - hit crash-recovery restores where the deletion itself was the unsaved change, panicking on every launch (#3236, reported by @CC-Hsu)
+* **A closed Welcome tab's panel no longer keeps trying to repaint itself** on every resize
+* **Git gutter survives an external revert** of the open file instead of going stale until the buffer is reopened
+
 ## 0.5.0
 
 For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).


### PR DESCRIPTION
## Summary

- Adds a `## 0.5.1` section to CHANGELOG.md covering everything merged since the `v0.5.0` tag.
- Audited the existing `0.5.0` and older sections against `v0.5.0..HEAD` - no tampering found, they're untouched.

## Bug Fixes covered

- Startup crash on an empty buffer carrying an unsaved deletion (e.g. a crash-recovery restore), reported in #3236 by @CC-Hsu and fixed by #3237.
- A closed Welcome tab's widget panel no longer stays registered and repaints itself on every subsequent resize.
- Git gutter no longer goes stale after an external revert of the open file.

## Test plan

- [x] `git diff v0.5.0..HEAD -- CHANGELOG.md` shows changes only inside the new `## 0.5.1` section.
- [x] Every `#NNNN` cited corresponds to a fix actually present in `v0.5.0..HEAD`.
- [x] No attribution to `sinelaw` or `claude` in the new section.
- [x] No mention of the Web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eSTEqVTnQcKoujdp9WWRL

---
_Generated by [Claude Code](https://claude.ai/code/session_011eSTEqVTnQcKoujdp9WWRL)_