### PR TITLE
Harden CI, the dependency graph, and what the repo says about its own limits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Inert until branch protection is set to require review from Code Owners.
+
+*                                   @sinelaw
+
+# Release automation and the publishing secrets it carries.
+/.github/                           @sinelaw
+/scripts/install.sh                 @sinelaw
+/scripts/verify-release-assets.sh   @sinelaw
+/scripts/verify-staged-artifacts.sh @sinelaw
+/dist-workspace.toml                @sinelaw
+
+/Cargo.lock                         @sinelaw
+/Cargo.toml                         @sinelaw
+/deny.toml                          @sinelaw
+
+# The security boundaries: the updater, the trust gate, the agent capability
+# channel, and the unauthenticated web bridge.
+/crates/fresh-update/               @sinelaw
+/crates/fresh-editor/src/services/workspace_trust.rs @sinelaw
+/crates/fresh-editor/src/server/command_access.rs    @sinelaw
+/crates/fresh-editor/src/webui/                      @sinelaw

--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -3,6 +3,9 @@
 
 name: AppImage Build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -52,7 +52,7 @@ jobs:
           cat aur-repo/PKGBUILD
 
       - name: Publish AUR package (fresh-editor-bin)
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: fresh-editor-bin
           pkgbuild: ./aur-repo/PKGBUILD
@@ -87,7 +87,7 @@ jobs:
           cat aur-repo/PKGBUILD
 
       - name: Publish AUR package (fresh-editor)
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: fresh-editor
           pkgbuild: ./aur-repo/PKGBUILD

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -2,6 +2,9 @@
 
 name: Publish AUR Package
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -2,6 +2,9 @@
 
 name: Publish to crates.io
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
 
       - name: Remove unpublishable gui dep from fresh-editor
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:
@@ -17,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# Every checkout here sets `persist-credentials: false`: these jobs compile and
+# run the pull request's own code — a build.rs, a proc macro, a test — and the
+# default checkout leaves the job token in `.git/config` for that code to read.
 jobs:
   fmt:
     name: fmt
@@ -24,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: check formatting
@@ -34,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       # Plain `cargo clippy` fails the build only on error-level diagnostics
@@ -52,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: Run cargo doc
@@ -63,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: Generate schema
@@ -75,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: Check build without plugins feature
@@ -90,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Lint install.sh
         run: shellcheck -S warning -s sh scripts/install.sh
       - name: Failure modes
@@ -110,6 +128,8 @@ jobs:
       # - run: vcpkg install openssl:x64-windows-static-md
       #   if: runner.os == 'Windows'
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo dependencies
@@ -155,6 +175,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install actionlint
         env:
           VERSION: 1.7.7
@@ -168,3 +190,17 @@ jobs:
         env:
           SHELLCHECK_OPTS: -S warning
         run: ./actionlint -no-color -oneline -shellcheck shellcheck
+
+  supply-chain:
+    name: supply-chain audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: Check advisories, sources and licenses
+        run: cargo deny --all-features check advisories sources licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: check formatting
         run: cargo fmt -- --check
   clippy:
@@ -45,7 +45,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # Plain `cargo clippy` fails the build only on error-level diagnostics
       # (deny-by-default lints, the crate's `#![deny(clippy::let_underscore_must_use)]`,
       # or compile errors) — clippy *warnings* do not fail it. The previous
@@ -65,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@be39649afda95dbf70f87cce95f68b8d5797b296 # nightly branch
       - name: Run cargo doc
         run: cargo doc --no-deps --all-features
         env:
@@ -78,7 +78,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Generate schema
         run: cargo run --features dev-bins --bin generate_schema > /tmp/config-schema.json
       - name: Check schema is up-to-date
@@ -92,7 +92,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Check build without plugins feature
         run: cargo check --no-default-features --features runtime --all-targets
 
@@ -131,11 +131,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2
         with:
           tool: cargo-nextest
       # Install Vulkan + Xvfb for headless GPU testing (Linux only).
@@ -199,7 +199,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2
         with:
           tool: cargo-deny
       - name: Check advisories, sources and licenses

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,10 +12,10 @@ on:
 
   workflow_dispatch:
 
+# The Pages grants belong to the deploy job alone; the build job runs the site's
+# own toolchain and must not be able to publish a deployment itself.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Setup Pages
         uses: actions/configure-pages@v6
@@ -48,6 +48,9 @@ jobs:
           path: dist
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -3,6 +3,9 @@
 
 name: Flatpak Build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -63,7 +63,7 @@ jobs:
           cp scripts/write-install-receipt.sh crates/fresh-editor/scripts/
 
       - name: Build Flatpak
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@79327416609af08178ad73b352877e51450790b3 # v6
         with:
           manifest-path: crates/fresh-editor/flatpak/io.github.sinelaw.fresh.yml
           bundle: fresh-editor-${{ inputs.version }}-x86_64.flatpak

--- a/.github/workflows/freebsd-builds.yml
+++ b/.github/workflows/freebsd-builds.yml
@@ -1,5 +1,8 @@
 name: FreeBSD Builds
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/freebsd-builds.yml
+++ b/.github/workflows/freebsd-builds.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build in FreeBSD
         id: build
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@8b0f1a8fc0ea0def307835c258940ca358fe6480 # v1
         with:
           usesh: true
           # rsync is the default, ensuring target/ and archives come back to the host

--- a/.github/workflows/gui-builds.yml
+++ b/.github/workflows/gui-builds.yml
@@ -3,6 +3,9 @@
 
 name: GUI Builds
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/gui-builds.yml
+++ b/.github/workflows/gui-builds.yml
@@ -46,7 +46,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -39,5 +39,7 @@ jobs:
         distro: [ubuntu, debian, fedora, alpine, arch]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install and run
         run: ./scripts/test-install-e2e.sh ${{ matrix.distro }}

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -2,6 +2,9 @@
 
 name: Linux Packages
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -53,7 +53,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
           targets: ${{ matrix.target }}
 
@@ -572,7 +572,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
 
       - name: Sync debian/changelog with Cargo.toml version
         run: ./scripts/update-debian-changelog.sh

--- a/.github/workflows/min-size-build.yml
+++ b/.github/workflows/min-size-build.yml
@@ -12,6 +12,9 @@
 
 name: Min-size Build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/min-size-build.yml
+++ b/.github/workflows/min-size-build.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/musl-builds.yml
+++ b/.github/workflows/musl-builds.yml
@@ -4,6 +4,9 @@
 
 name: Musl Builds
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -44,8 +47,11 @@ jobs:
           sudo apt-get install -y musl-tools
           # For aarch64 cross-compilation
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-            # Install cross for easier cross-compilation
-            cargo install cross --git https://github.com/cross-rs/cross
+            # `--locked` so a patch release of one of cross's own dependencies
+            # cannot enter the toolchain that builds our release binaries. The
+            # revision itself is still the default branch; pinning it needs
+            # someone to confirm which one aarch64 requires.
+            cargo install cross --locked --git https://github.com/cross-rs/cross
           fi
 
       - name: Build release binary

--- a/.github/workflows/musl-builds.yml
+++ b/.github/workflows/musl-builds.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,17 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.publishing == 'true' }}
     runs-on: ubuntu-22.04
+    # Narrower than the workflow default: this job only builds, so it does not
+    # get the release-publishing grants the jobs below it need.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -120,7 +124,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/theme-screenshots.yml
+++ b/.github/workflows/theme-screenshots.yml
@@ -6,6 +6,9 @@ name: Theme screenshots
 #
 # See docs/theme-screenshot-diff.md for objectives & criteria.
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -32,6 +35,7 @@ jobs:
       - name: Checkout (full history for base diff)
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Fetch PR base branch

--- a/.github/workflows/theme-screenshots.yml
+++ b/.github/workflows/theme-screenshots.yml
@@ -42,13 +42,13 @@ jobs:
         run: git fetch --no-tags origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
 
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063 # v2
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -1,5 +1,8 @@
 name: Web UI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -38,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo dependencies
@@ -51,6 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo dependencies

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Run scene parity test
         run: cargo test -p fresh-editor --features web --test scene_parity
 
@@ -59,9 +59,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
       - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -2,6 +2,9 @@
 
 name: Publish to winget
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,37 @@ tests/wrap_model/.venv/
 tests/wrap_model/.hypothesis/
 __pycache__/
 *.pyc
+
+# Secrets and key material
+# `.envrc` itself is tracked (it holds only `use flake`); what tools write
+# beside it is not.
+.env
+.env.*
+!.env.example
+.envrc.local
+.direnv/
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa
+id_ed25519
+secrets.json
+credentials.json
+.npmrc
+.cargo/credentials
+.cargo/credentials.toml
+
+# Editor / AI-assistant workspace state
+.vscode/
+!.vscode/extensions.json
+.idea/
+.cursor/
+.claude/settings.local.json
+.claude/*.local.json
+.aider*
+.mcp.local.json
+
+# Machine-local editor session state (the project config layer beside it,
+# .fresh/config.json, is committed deliberately or not at all).
+.fresh/session.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4301,9 +4301,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,72 @@
+# Supply-chain gate. CI runs exactly:
+#
+#     cargo deny --all-features check advisories sources licenses
+
+[graph]
+# Every platform we publish for: an advisory in a Windows- or macOS-only
+# dependency is invisible to a Linux runner otherwise.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+# Every entry carries why it does not reach a user, so an exception is not
+# indistinguishable from a silenced finding. Re-check on dependency bumps.
+ignore = [
+    # Fix is in quick-xml 0.40 — a semver bump wayland-scanner has to make first.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml is build-time only, via wayland-scanner's proc-macro" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml is build-time only, via wayland-scanner's proc-macro" },
+
+    # Unmaintained, not vulnerable; each waits on the crate that pulls it in.
+    { id = "RUSTSEC-2024-0320", reason = "yaml-rust, via syntect; blocked on syntect moving to yaml-rust2" },
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error, build-time only, transitive" },
+    { id = "RUSTSEC-2024-0436", reason = "paste, build-time only, transitive" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode, transitive; no defect, only maintenance" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser, via winit's sctk-adwaita and ratatui-wgpu (GUI build only)" },
+    { id = "RUSTSEC-2026-0206", reason = "rustybuzz, via ratatui-wgpu (GUI build only)" },
+]
+
+[sources]
+# Catches the shapes dependency-confusion needs to reach a build: a git
+# dependency on a moving branch, a vendored fork, an alternative registry.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[licenses]
+# Fresh is GPL-2.0, so permissive and weak-copyleft dependencies are compatible.
+version = 2
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "GPL-2.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Deliberately not in the CI command above: duplicate versions in a tree this
+# size are a maintenance question, not a security one. Here for local use.
+multiple-versions = "allow"
+wildcards = "deny"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -232,7 +232,9 @@ download_verified() {
     # wrong and fatal: a throttled request killed the install outright, skipping
     # the fallback chain, and told the user the release was unsigned. Only a 404
     # is that claim; everything else returns and lets a fallback method run.
-    _sum_code=$(curl -SL -w '%{http_code}' "$1.sha256" -o "$2.sha256") || _sum_code=000
+    # -s here where the artifact above has a progress meter: 112 bytes of
+    # checksum render one, which reads as a second download failing to start.
+    _sum_code=$(curl -sSL -w '%{http_code}' "$1.sha256" -o "$2.sha256") || _sum_code=000
     case "$_sum_code" in
         2??) ;;
         403|429) log_warn "GitHub is rate limiting downloads from this network (HTTP $_sum_code); retry shortly."; rm -f "$2.sha256"; return 1 ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,8 +227,22 @@ download_verified() {
         *)       log_warn "Download of $(basename "$1") failed (HTTP $_dl)."; return 1 ;;
     esac
 
-    sums=$(curl -fsSL "$1.sha256" 2>/dev/null || true)
-    [ -n "$sums" ] || log_error "no .sha256 published for $(basename "$1"); refusing to install unverified bytes."
+    # The sidecar is metered exactly like the artifact above, so it gets the same
+    # status handling. Collapsing every failure into "not published" was both
+    # wrong and fatal: a throttled request killed the install outright, skipping
+    # the fallback chain, and told the user the release was unsigned. Only a 404
+    # is that claim; everything else returns and lets a fallback method run.
+    _sum_code=$(curl -SL -w '%{http_code}' "$1.sha256" -o "$2.sha256") || _sum_code=000
+    case "$_sum_code" in
+        2??) ;;
+        403|429) log_warn "GitHub is rate limiting downloads from this network (HTTP $_sum_code); retry shortly."; rm -f "$2.sha256"; return 1 ;;
+        404)     log_error "no .sha256 published for $(basename "$1"); refusing to install unverified bytes." ;;
+        000)     log_warn "Could not reach GitHub for the checksum of $(basename "$1")."; rm -f "$2.sha256"; return 1 ;;
+        *)       log_warn "Checksum fetch for $(basename "$1") failed (HTTP $_sum_code)."; rm -f "$2.sha256"; return 1 ;;
+    esac
+    sums=$(cat "$2.sha256")
+    rm -f "$2.sha256"
+    [ -n "$sums" ] || log_error "the .sha256 for $(basename "$1") is empty; refusing to install unverified bytes."
 
     expected=$(printf '%s\n' "$sums" | awk 'NR==1 {print $1}')
     actual=$(sha256_of "$2") || log_error "need sha256sum or shasum to verify the download; install coreutils and retry."

--- a/scripts/test-install-failure-modes.sh
+++ b/scripts/test-install-failure-modes.sh
@@ -44,7 +44,11 @@ for tool in sh mktemp chmod tar awk grep cut tr head sed ln mkdir rm cp mv uname
 done
 
 # $1 = status the download endpoints report ("ok" serves them)
+# $2 = status the .sha256 sidecar reports; defaults to $1. Separate because the
+#      sidecar shares the artifact's URL shape, so without its own knob the
+#      artifact always fails first and the sidecar's handling is never reached.
 make_curl_shim() {
+    SIDECAR_STATUS="${2:-$1}"
     cat > "$BINDIR/curl" <<EOF
 #!/bin/sh
 # Records every request so the assertions can inspect what was asked for, then
@@ -66,6 +70,17 @@ for a in "\$@"; do
       fi
       case " \$* " in *" -w "*) printf '' ;; esac
       exit 22 ;;
+    */releases/latest/download/*.sha256)
+      if [ "$SIDECAR_STATUS" = "ok" ]; then
+        case " \$* " in *" -w "*) printf '200' ;; esac
+        exit 0
+      fi
+      case " \$* " in *" -w "*) printf '%s' "$SIDECAR_STATUS" ;; esac
+      case " \$* " in
+        *" -f"*|*"-fsSL"*|*"-fSL"*) exit 22 ;;
+      esac
+      if [ "$SIDECAR_STATUS" = "000" ]; then exit 7; fi
+      exit 0 ;;
     */releases/latest/download/*)
       if [ "$1" = "ok" ]; then
         case " \$* " in *" -w "*) printf '200' ;; esac
@@ -163,6 +178,42 @@ if grep -qi 'rate limiting downloads' <<<"$OUT"; then
     pass "a refused download is reported as rate limiting, not as a missing asset"
 else
     fail "a refused download is not diagnosed as rate limiting"
+fi
+
+# --- The artifact arrives but its checksum request is throttled. The sidecar is
+# --- metered like anything else, so this says nothing about whether the release
+# --- published one: reporting it as "no .sha256 published" accuses the publisher
+# --- of shipping unsigned bytes, and being fatal about it skips the fallback
+# --- methods that could still complete the install. ---
+make_curl_shim ok 403
+OUT="$(run_install sidecar-ratelimited --method=tarball)"
+assert_ran "checksum 403" "$OUT"
+assert_no_bad_url "checksum 403" "$OUT"
+if grep -qi 'rate limiting downloads' <<<"$OUT"; then
+    pass "a throttled checksum is reported as rate limiting"
+else
+    fail "a throttled checksum is not diagnosed as rate limiting"
+fi
+if grep -qi 'no .sha256 published' <<<"$OUT"; then
+    fail "a throttled checksum is misreported as a missing sidecar"
+else
+    pass "a throttled checksum is not misreported as a missing sidecar"
+fi
+if grep -qi 'Checking fallback methods' <<<"$OUT"; then
+    pass "a throttled checksum leaves the fallback chain reachable"
+else
+    fail "a throttled checksum killed the install before any fallback ran"
+fi
+
+# --- The sidecar genuinely is not there: that IS an unsigned artifact, and the
+# --- install must stop rather than fall back to installing it unverified. ---
+make_curl_shim ok 404
+OUT="$(run_install sidecar-missing --method=tarball)"
+assert_no_bad_url "checksum 404" "$OUT"
+if grep -qi 'no .sha256 published' <<<"$OUT"; then
+    pass "a missing sidecar is reported as a missing sidecar"
+else
+    fail "a missing sidecar is not distinguished from a throttled one"
 fi
 
 # --- The asset genuinely is not there. ---


### PR DESCRIPTION
Closes the gaps an audit of the repository's CI, dependency handling and installer turned up.

## Objective

Make CI unable to leak its own credentials, make the dependency graph something a gate reads rather than something nobody checks, stop referring to third-party code by pointers its authors can move, and stop the installer's verification gate from failing for reasons that are not verification failures.

## Decisions

**Least privilege, declared everywhere.** 13 of 17 workflows had no `permissions:` block, so they ran on the repository's default token — including five that build and run pull-request code. All now declare `contents: read`, except the three that publish. Every PR-facing checkout sets `persist-credentials: false` so the token is not left in `.git/config` for that code to read. Verified sufficient: none of the 13 calls `gh`, creates a release, comments on a PR, or fetches artifacts across runs.

**Third-party actions pinned to commit SHAs.** 29 call sites across 9 actions were on mutable tags, two of them on *branches*. Each now names a 40-character commit with the version in a trailing comment, so Dependabot still proposes bumps and each one arrives as a reviewable diff. `actions/*` stays on tags — a compromise there is a platform event, not an account takeover, and pinning it would triple the diff.

**Two jobs stopped lending privilege they never used.** The nix smoke-test job in `release.yml` inherited `contents: write` + `id-token: write`; `deploy-docs.yml` granted `pages: write` + `id-token: write` workflow-wide, putting them in the job that runs the docs site's npm tree. Both narrowed; the Pages grants now sit only on the deploy job.

**`cargo-deny` in CI, with every exception justified.** It found an invalid pointer dereference in `crossbeam-epoch` and an unsoundness in `anyhow` — both fixed here by patch bump. The rest are accepted in `deny.toml`, each recording why it does not reach a user and which dependency has to move before it can be dropped. The gate also enforces crates.io as the only source and license compatibility.

**The installer's checksum gate no longer fails spuriously.** `install.sh` treats a throttled download of an artifact as rate limiting, but collapsed every failure of the `.sha256` sidecar fetch into one fatal "no .sha256 published". GitHub meters anonymous downloads, so that routine case was reported as the release having shipped unsigned bytes — and because it was fatal, it killed the install before any fallback method could run. The sidecar now gets the same status handling as the artifact it verifies: only a 404 claims nothing was published. Fail-closed is unchanged; nothing installs without a verified checksum. The failure-mode suite grows the cases that pin this, including a shim fix that made the sidecar's handling reachable at all.

**`.gitignore` and `CODEOWNERS`.** Credential patterns and assistant-local state are now excluded — nothing is leaked today, and that is the point. `CODEOWNERS` puts the release pipeline, the installer and the lockfile under explicit review; it takes effect once branch protection requires Code Owner review.

## Verification

- `cargo check --workspace --locked` — clean
- `actionlint` — clean (the repo's own check)
- `cargo deny --all-features check advisories sources licenses` — `advisories ok, licenses ok, sources ok`
- `shellcheck -S warning -s sh scripts/install.sh` — clean (CI's exact invocation)
- `scripts/test-install-failure-modes.sh` — 28 checks pass; the 3 new assertions were confirmed to fail against the unpatched script
- Web UI Playwright suite run locally on this branch — 182 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWM7mbwtM1ki6Z44GF2Pws