### PR TITLE
fix(viewport): the scroll margin is the user's, wrap on or off

### DIFF
--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -1400,9 +1400,9 @@ impl Viewport {
     /// anything is built.
     ///
     /// Returns whether this pass **owns vertical placement** for the frame —
-    /// not whether it moved anything. The caller forwards it to
-    /// [`Self::ensure_visible_in_layout`] as `rows_settled`, and the two must
-    /// not both apply the margin. "Decided not to scroll" is still owning the
+    /// not whether it moved anything. Every buffer that reaches here has an
+    /// index, and the byte pass defers to this one for all of them, so the
+    /// answer is always yes. "Decided not to scroll" is still owning the
     /// decision, so a `true` return with no movement is normal.
     ///
     /// The viewport keeps its `(top_byte, top_view_line_offset)` pair — a new
@@ -1463,25 +1463,23 @@ impl Viewport {
             None => index.row_of_byte(buffer, cursor_byte) as usize,
         };
 
-        // Same margin rule as the layout pass, in absolute rows — including its
-        // guard, which is `top_view_line_offset > 0`, i.e. "the viewport is
-        // parked inside a wrapped line". Not `top_row > 0`, which is true after
-        // any scroll at all: with wrap off that turns on a margin the layout
-        // pass deliberately leaves off, because there the byte-oriented
-        // pre-render `ensure_visible` has already placed the cursor and a second
-        // margin just pushes it a few rows further from the edge.
-        let apply_margin = self.line_wrap_enabled || self.top_view_line_offset() > 0;
-        let margin = if apply_margin {
-            self.scroll_offset.min(viewport_height / 2)
-        } else {
-            0
-        };
+        // The user's `scroll_offset`, in absolute rows — the same rule the byte
+        // pass applies, and unconditional like it. This pass once left the
+        // margin off unless wrap was on or the top was parked inside a line, on
+        // the grounds that the byte pass had already placed the cursor; but the
+        // byte pass hands vertical placement to this one for every buffer that
+        // has an index (`row_pass_owns_placement`), so with wrap off the margin
+        // was one nobody applied: the cursor rode the very edge of the window
+        // and the view only scrolled once it got there, with the user's
+        // `scroll_offset` doing nothing at all on any file small enough to be
+        // indexed.
+        let margin = self.scroll_offset.min(viewport_height / 2);
         let max_top = total_rows.saturating_sub(viewport_height);
 
         let in_top_margin = cursor_row < top_row + margin;
         let in_bottom_margin = cursor_row + margin + 1 > top_row + viewport_height;
         if !in_top_margin && !in_bottom_margin {
-            return apply_margin;
+            return true;
         }
 
         let target_top = if in_top_margin {
@@ -1492,7 +1490,7 @@ impl Viewport {
 
         let new_top = target_top.min(max_top);
         if new_top == top_row {
-            return apply_margin;
+            return true;
         }
 
         if delta > 0 && new_top >= exp_first && new_top < exp_first + exp_drawn {
@@ -1510,7 +1508,7 @@ impl Viewport {
             self.set_top_byte(buffer.line_start_offset(addr.line).unwrap_or(0));
             self.set_top_view_line_offset(addr.row_in_line);
         }
-        apply_margin
+        true
     }
 
     /// Horizontal placement only.

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -1400,10 +1400,8 @@ impl Viewport {
     /// anything is built.
     ///
     /// Returns whether this pass **owns vertical placement** for the frame —
-    /// not whether it moved anything. Every buffer that reaches here has an
-    /// index, and the byte pass defers to this one for all of them, so the
-    /// answer is always yes. "Decided not to scroll" is still owning the
-    /// decision, so a `true` return with no movement is normal.
+    /// not whether it moved anything. Always true: every buffer that reaches
+    /// here has an index, and the byte pass defers for all of them.
     ///
     /// The viewport keeps its `(top_byte, top_view_line_offset)` pair — a new
     /// absolute top row is converted back through `byte_of_row`, so this changes
@@ -1463,16 +1461,9 @@ impl Viewport {
             None => index.row_of_byte(buffer, cursor_byte) as usize,
         };
 
-        // The user's `scroll_offset`, in absolute rows — the same rule the byte
-        // pass applies, and unconditional like it. This pass once left the
-        // margin off unless wrap was on or the top was parked inside a line, on
-        // the grounds that the byte pass had already placed the cursor; but the
-        // byte pass hands vertical placement to this one for every buffer that
-        // has an index (`row_pass_owns_placement`), so with wrap off the margin
-        // was one nobody applied: the cursor rode the very edge of the window
-        // and the view only scrolled once it got there, with the user's
-        // `scroll_offset` doing nothing at all on any file small enough to be
-        // indexed.
+        // Unconditional, and the byte pass's own rule: that pass defers to this
+        // one for every indexed buffer, so a margin skipped here is a margin
+        // nobody applies.
         let margin = self.scroll_offset.min(viewport_height / 2);
         let max_top = total_rows.saturating_sub(viewport_height);
 

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -2693,6 +2693,57 @@ mod tests {
         assert!(set.get(&geometry(10)).is_none(), "oldest evicted");
     }
 
+    /// The scroll margin is the user's `scroll_offset` whether or not wrap is
+    /// on. This pass owns vertical placement for every indexed buffer — the
+    /// byte pass defers to it — so a margin skipped here is a margin nobody
+    /// applies, which is what left the cursor riding the bottom edge of a
+    /// wrap-off window.
+    #[test]
+    fn ensure_visible_in_rows_keeps_the_margin_with_wrap_off() {
+        use crate::view::viewport::Viewport;
+
+        // Wrap off is `Chop`: rows are logical lines until a line is
+        // pathologically long, so row 9 is line 9.
+        let text = (0..100)
+            .map(|i| format!("line_{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut buffer = Buffer::from_bytes(text.as_bytes().to_vec(), test_fs());
+        let mut index = WrapIndex::default();
+        let geometry = WrapIndexGeometry {
+            fold_signature: 0,
+            rule: WrapRule::Chop { chars: 1000 },
+            view_mode: CacheViewMode::Source,
+        };
+        index.ensure_built(
+            &mut buffer,
+            geometry,
+            inputs(0),
+            LineEnding::LF,
+            &IndexDecorations::default(),
+        );
+
+        let height = 10usize;
+        let mut viewport = Viewport::new(20, height as u16);
+        viewport.line_wrap_enabled = false;
+        viewport.set_scroll_offset(3);
+        viewport.set_top_byte(0);
+        viewport.set_top_view_line_offset(0);
+
+        // The cursor on the window's last row is three rows inside the bottom
+        // margin, so the view scrolls until it is three rows clear of the edge.
+        let cursor_byte = buffer.line_start_offset(height - 1).unwrap();
+        viewport.ensure_visible_in_rows(&index, &buffer, cursor_byte, None);
+
+        let top_line = buffer.get_line_number(viewport.top_byte());
+        assert_eq!(
+            top_line, 3,
+            "wrap-off placement must keep `scroll_offset` rows below the cursor: \
+             expected top line 3, got {top_line}"
+        );
+        assert_eq!(viewport.top_view_line_offset(), 0);
+    }
+
     /// Row-space `ensure_visible` matches the Python model's rule exactly
     /// (`tests/wrap_model/wrap_model/viewport.py::Viewport.ensure_visible`):
     /// scroll the minimum that puts the cursor's row inside the margin, clamped

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -2693,17 +2693,13 @@ mod tests {
         assert!(set.get(&geometry(10)).is_none(), "oldest evicted");
     }
 
-    /// The scroll margin is the user's `scroll_offset` whether or not wrap is
-    /// on. This pass owns vertical placement for every indexed buffer — the
-    /// byte pass defers to it — so a margin skipped here is a margin nobody
-    /// applies, which is what left the cursor riding the bottom edge of a
-    /// wrap-off window.
+    /// The margin is the user's `scroll_offset` with wrap off too — skipping it
+    /// here skips it everywhere, leaving the cursor on the window's last row.
     #[test]
     fn ensure_visible_in_rows_keeps_the_margin_with_wrap_off() {
         use crate::view::viewport::Viewport;
 
-        // Wrap off is `Chop`: rows are logical lines until a line is
-        // pathologically long, so row 9 is line 9.
+        // Wrap off is `Chop`, so row 9 is line 9.
         let text = (0..100)
             .map(|i| format!("line_{i}"))
             .collect::<Vec<_>>()
@@ -2730,8 +2726,7 @@ mod tests {
         viewport.set_top_byte(0);
         viewport.set_top_view_line_offset(0);
 
-        // The cursor on the window's last row is three rows inside the bottom
-        // margin, so the view scrolls until it is three rows clear of the edge.
+        // On the last row: three rows inside the margin, so the view scrolls by 3.
         let cursor_byte = buffer.line_start_offset(height - 1).unwrap();
         viewport.ensure_visible_in_rows(&index, &buffer, cursor_byte, None);
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -276,6 +276,7 @@ pub mod restored_terminal_focus;
 pub mod save_as_language_detection;
 pub mod save_nonexistent_directory;
 pub mod scroll_clearing;
+pub mod scroll_offset_wrap_off;
 #[cfg(feature = "plugins")]
 pub mod scrollbar_markers;
 pub mod scrolling;

--- a/crates/fresh-editor/tests/e2e/scroll_offset_wrap_off.rs
+++ b/crates/fresh-editor/tests/e2e/scroll_offset_wrap_off.rs
@@ -1,0 +1,92 @@
+//! `editor.scroll_offset` keeps its rows of context with soft wrap **off**.
+//!
+//! The setting is a reading margin: the cursor stops that many rows short of
+//! the window's edge and the file scrolls under it instead. With wrap off the
+//! margin went missing — the cursor walked to the very last row of the pane and
+//! only then did the view move, one row per key press, whatever
+//! `scroll_offset` said.
+//!
+//! It looked like a per-file-type bug because the wrap index that owns
+//! placement has size ceilings: past them no index is built, the byte-oriented
+//! pass stays the vertical authority, and it always applied the margin. So a
+//! 200-line source file rode the edge while a 6000-line one in the same window,
+//! with the same config, kept its context rows.
+//!
+//! The test drives `Down` and `Up` and reads only rendered output — the
+//! hardware cursor's row against the pane's own first and last row.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+/// Deliberately not the default (3), so the assertions below can only pass if
+/// the configured value reached the placement pass.
+const SCROLL_OFFSET: usize = 5;
+
+/// Comfortably more than the walk below covers, so the document never runs out
+/// underneath the cursor and the margin is owed at every step.
+const LINES: usize = 300;
+
+/// Small enough to stay well inside the wrap index's ceilings, which is the
+/// case that lost the margin.
+fn wrap_off_config() -> Config {
+    let mut config = Config::default();
+    config.editor.line_wrap = false;
+    config.editor.scroll_offset = SCROLL_OFFSET;
+    config
+}
+
+#[test]
+fn scroll_offset_holds_the_cursor_off_the_edge_with_wrap_off() {
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(80, 24, wrap_off_config()).unwrap();
+
+    let path = harness.project_dir().unwrap().join("lines.ts");
+    let text = (1..=LINES)
+        .map(|i| format!("const v{i} = {i};"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, text).unwrap();
+
+    harness.open_file(&path).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("const v1 = 1;"))
+        .unwrap();
+
+    let (first_row, last_row) = harness.content_area_rows();
+
+    // Down through several screenfuls. Every line the cursor lands on has 100+
+    // more below it, so the view owes it `SCROLL_OFFSET` rows of what is
+    // coming; a cursor closer than that to the bottom means the view stopped
+    // scrolling ahead of it.
+    for step in 1..=120 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let (_, cursor_row) = harness.screen_cursor_position();
+        assert!(
+            cursor_row as usize + SCROLL_OFFSET <= last_row,
+            "Down #{step}: the cursor is on screen row {cursor_row}, {} rows from \
+             the pane's last row ({last_row}), with the rest of the file still \
+             below it. `scroll_offset` is {SCROLL_OFFSET}, so the view must \
+             scroll while the cursor is still that far from the edge.\n{}",
+            last_row.saturating_sub(cursor_row as usize),
+            harness.screen_to_string(),
+        );
+    }
+
+    // And the same margin above the cursor on the way back up, stopping short
+    // of the first line so there is always more document overhead.
+    for step in 1..=80 {
+        harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let (_, cursor_row) = harness.screen_cursor_position();
+        assert!(
+            cursor_row as usize >= first_row + SCROLL_OFFSET,
+            "Up #{step}: the cursor is on screen row {cursor_row}, {} rows from \
+             the pane's first row ({first_row}), with more of the file above \
+             it. `scroll_offset` is {SCROLL_OFFSET}.\n{}",
+            (cursor_row as usize).saturating_sub(first_row),
+            harness.screen_to_string(),
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/scroll_offset_wrap_off.rs
+++ b/crates/fresh-editor/tests/e2e/scroll_offset_wrap_off.rs
@@ -1,34 +1,21 @@
 //! `editor.scroll_offset` keeps its rows of context with soft wrap **off**.
 //!
-//! The setting is a reading margin: the cursor stops that many rows short of
-//! the window's edge and the file scrolls under it instead. With wrap off the
-//! margin went missing — the cursor walked to the very last row of the pane and
-//! only then did the view move, one row per key press, whatever
-//! `scroll_offset` said.
-//!
-//! It looked like a per-file-type bug because the wrap index that owns
-//! placement has size ceilings: past them no index is built, the byte-oriented
-//! pass stays the vertical authority, and it always applied the margin. So a
-//! 200-line source file rode the edge while a 6000-line one in the same window,
-//! with the same config, kept its context rows.
-//!
-//! The test drives `Down` and `Up` and reads only rendered output — the
-//! hardware cursor's row against the pane's own first and last row.
+//! The margin went missing in the hand-off between the two placement passes,
+//! which no single pass can see — hence an e2e test rather than a unit one.
+//! It read as a per-file-type bug because the wrap index that owns placement
+//! has size ceilings, and past them the byte pass (which kept the margin) is
+//! the authority.
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 
-/// Deliberately not the default (3), so the assertions below can only pass if
-/// the configured value reached the placement pass.
+/// Not the default (3), so this can only pass if the configured value arrived.
 const SCROLL_OFFSET: usize = 5;
 
-/// Comfortably more than the walk below covers, so the document never runs out
-/// underneath the cursor and the margin is owed at every step.
+/// More than the walk below covers, so the margin is owed at every step.
 const LINES: usize = 300;
 
-/// Small enough to stay well inside the wrap index's ceilings, which is the
-/// case that lost the margin.
 fn wrap_off_config() -> Config {
     let mut config = Config::default();
     config.editor.line_wrap = false;
@@ -38,6 +25,7 @@ fn wrap_off_config() -> Config {
 
 #[test]
 fn scroll_offset_holds_the_cursor_off_the_edge_with_wrap_off() {
+    // Small enough to be indexed, which is the case that lost the margin.
     let mut harness =
         EditorTestHarness::with_temp_project_and_config(80, 24, wrap_off_config()).unwrap();
 
@@ -55,10 +43,6 @@ fn scroll_offset_holds_the_cursor_off_the_edge_with_wrap_off() {
 
     let (first_row, last_row) = harness.content_area_rows();
 
-    // Down through several screenfuls. Every line the cursor lands on has 100+
-    // more below it, so the view owes it `SCROLL_OFFSET` rows of what is
-    // coming; a cursor closer than that to the bottom means the view stopped
-    // scrolling ahead of it.
     for step in 1..=120 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
         harness.render().unwrap();
@@ -74,8 +58,7 @@ fn scroll_offset_holds_the_cursor_off_the_edge_with_wrap_off() {
         );
     }
 
-    // And the same margin above the cursor on the way back up, stopping short
-    // of the first line so there is always more document overhead.
+    // Back up, stopping short of the first line so there is always more above.
     for step in 1..=80 {
         harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
         harness.render().unwrap();


### PR DESCRIPTION
Closes #3249.

## Motivation

Reported as "scroll offset doesn't work on a `.ts` file, but works on a `.json` one": the cursor walked to the very last row of the pane and only then did the file start scrolling, one row per key press, whatever `editor.scroll_offset` said.

The file type is a coincidence. **`scroll_offset` was ignored for every file with soft wrap off that is small enough to be indexed.**

`ensure_visible_in_rows` — the row-space placement pass — applied the margin only when wrap was on or the top was parked inside a wrapped line:

```rust
let apply_margin = self.line_wrap_enabled || self.top_view_line_offset() > 0;
```

Its comment justified that by saying the byte-oriented `ensure_visible` had already placed the cursor, so a second margin would only push it further from the edge. But that pass hands vertical placement to this one for every buffer that has a wrap index — it reads `row_pass_owns_placement` and reports the cursor visible without scrolling. So with wrap off the margin was one nobody applied.

It looked per-file-type because the index has size ceilings (`MAX_WRAP_SCROLLBAR_LINES` = 5000, `MAX_WRAP_SCROLLBAR_BYTES` = 2 MB). Past them no index is built, the byte pass stays the vertical authority, and it always applied the margin. A 200-line source file rode the edge; a 6000-line JSON in the same window, with the same config, kept its context rows.

## Change

The margin in `ensure_visible_in_rows` is now unconditional and is the same rule the byte pass uses (`scroll_offset.min(height / 2)`), so the two agree on the frames where both run. `apply_margin` was also the function's return value; it means "this pass owns vertical placement", which is now always true (every buffer reaching it has an index), and no caller reads it outside tests.

## Reproduction / testing

Manual, in tmux at 100×30 with `scroll_offset: 5`, `line_wrap: false` — before the fix, the cursor reached line 27 (the last visible row) and the view then crawled one row per press; the same 6000-line JSON scrolled at line 23, as configured. After the fix, `.ts` and `.json`, small file and 6000-line file, wrap on and wrap off, all begin scrolling at line 23, in both directions, with Ctrl+End/Ctrl+Home clamps unchanged.

Two tests, both verified to fail on the parent commit and pass with the fix:

- `view::wrap_index::tests::ensure_visible_in_rows_keeps_the_margin_with_wrap_off` — the placement pass in isolation, wrap-off (`Chop`) geometry.
- `e2e::scroll_offset_wrap_off::scroll_offset_holds_the_cursor_off_the_edge_with_wrap_off` — drives `Down` and `Up` over a 300-line file with `scroll_offset = 5` (deliberately not the default) and asserts only on rendered output: the hardware cursor's row against the pane's first and last row. This is the one that covers the actual defect, which is an interaction between two passes that neither can see alone.

Checks run: `cargo fmt --check`, `cargo clippy --all-features --all-targets` (no errors), `cargo check --all-targets`, `cargo test -p fresh-editor --lib` (2514 passed), `cargo test --test all_tests` (4798 passed, 1 failure: `test_plugin_i18n::test_plugin_i18n_loading_and_translation`, which passes in isolation — shared-process global locale state under plain `cargo test`; CI runs nextest with a process per test).

No GUI code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLriqhn6c3XqTiZ6igateP