### PR TITLE
Support Rust 1.98 in CI without unpinning 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,29 @@ jobs:
       - name: Check build without plugins feature
         run: cargo check --no-default-features --features runtime --all-targets
 
+  # 1.95 stays the default for everything else here; this is the standing
+  # check that the tree still compiles on current stable. Pinned rather than
+  # `stable` so a Rust release cannot turn it red on its own. RUSTUP_TOOLCHAIN
+  # is the only override rust-toolchain.toml respects, and keys rust-cache
+  # separately. No fmt or clippy: both differ between versions.
+  newer-toolchain:
+    name: rust 1.98 (non-default)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: "1.98"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Rust 1.98
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable branch
+        with:
+          toolchain: "1.98"
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - name: Check
+        run: cargo check --workspace --all-targets --all-features
+
   # install.sh is the entry point for `curl ... | sh`, and it is the one script
   # here whose failure modes users hit before they have anything else installed.
   # shellcheck's own job below lints workflow `run:` blocks only, so the

--- a/crates/fresh-editor/src/app/lsp_status.rs
+++ b/crates/fresh-editor/src/app/lsp_status.rs
@@ -52,15 +52,17 @@ fn centered(s: &str) -> String {
 /// in `status_bar::element_style`; the text is what's rendered inside the
 /// segment.  Priority:
 ///
-///     0. Buffer-level skip (large file, binary, per-buffer toggle)
-///                       — "LSP (n/a)",              state = OffDismissed
-///     1. Progress       — detailed progress string, state = On
-///     2. Error          — "LSP (error)",            state = Error
-///     2b. Unresponsive  — "LSP (stuck)",            state = Warning
-///     3. Running        — "LSP (on)",               state = On
-///     4. Configured-but-not-running (either auto_start or opt-in dormant)
-///                       — "LSP (off)",              state = Off / OffDismissed
-///     5. Nothing        — empty,                    state = None
+/// ```text
+/// 0. Buffer-level skip (large file, binary, per-buffer toggle)
+///                   — "LSP (n/a)",              state = OffDismissed
+/// 1. Progress       — detailed progress string, state = On
+/// 2. Error          — "LSP (error)",            state = Error
+/// 2b. Unresponsive  — "LSP (stuck)",            state = Warning
+/// 3. Running        — "LSP (on)",               state = On
+/// 4. Configured-but-not-running (either auto_start or opt-in dormant)
+///                   — "LSP (off)",              state = Off / OffDismissed
+/// 5. Nothing        — empty,                    state = None
+/// ```
 ///
 /// The buffer-level skip only wins over running language state: showing
 /// "LSP (on)" while LSP is actively skipping this buffer (e.g. rust-

--- a/crates/fresh-editor/src/input/input_history.rs
+++ b/crates/fresh-editor/src/input/input_history.rs
@@ -22,7 +22,7 @@
 //! ## Usage Example
 //!
 //! ```
-//! use fresh::input_history::InputHistory;
+//! use fresh::input::input_history::InputHistory;
 //!
 //! let mut history = InputHistory::new();
 //!
@@ -116,7 +116,7 @@ impl InputHistory {
     ///
     /// # Example
     /// ```
-    /// # use fresh::input_history::InputHistory;
+    /// # use fresh::input::input_history::InputHistory;
     /// let mut history = InputHistory::new();
     /// history.push("first".to_string());
     /// history.push("second".to_string());
@@ -161,7 +161,7 @@ impl InputHistory {
     ///
     /// # Example
     /// ```
-    /// # use fresh::input_history::InputHistory;
+    /// # use fresh::input::input_history::InputHistory;
     /// let mut history = InputHistory::new();
     /// history.push("first".to_string());
     /// history.push("second".to_string());
@@ -211,7 +211,7 @@ impl InputHistory {
     ///
     /// # Example
     /// ```
-    /// # use fresh::input_history::InputHistory;
+    /// # use fresh::input::input_history::InputHistory;
     /// let mut history = InputHistory::new();
     /// history.push("first".to_string());
     /// history.push("second".to_string());
@@ -267,7 +267,7 @@ impl InputHistory {
     ///
     /// # Example
     /// ```
-    /// # use fresh::input_history::InputHistory;
+    /// # use fresh::input::input_history::InputHistory;
     /// let mut history = InputHistory::new();
     /// history.push("last search".to_string());
     /// assert_eq!(history.last(), Some("last search"));
@@ -284,7 +284,7 @@ impl InputHistory {
     ///
     /// # Example
     /// ```
-    /// # use fresh::input_history::InputHistory;
+    /// # use fresh::input::input_history::InputHistory;
     /// let mut history = InputHistory::new();
     /// history.push("first".to_string());
     /// history.push("second".to_string());

--- a/crates/fresh-editor/src/view/line_wrap_cache.rs
+++ b/crates/fresh-editor/src/view/line_wrap_cache.rs
@@ -34,8 +34,10 @@
 //!
 //! Structural invariants maintained at all times:
 //!
-//!     self.map.len() == self.order.len()
-//!     self.current_bytes <= self.byte_budget  (after any insert)
+//! ```text
+//! self.map.len() == self.order.len()
+//! self.current_bytes <= self.byte_budget  (after any insert)
+//! ```
 
 use crate::state::EditorState;
 use crate::view::ui::split_rendering::base_tokens::build_base_tokens;

--- a/crates/fresh-editor/src/view/prompt.rs
+++ b/crates/fresh-editor/src/view/prompt.rs
@@ -517,7 +517,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Search: ".to_string(), PromptType::Search);
     /// prompt.set_input_plain("current".to_string());
     /// prompt.set_cursor_byte(7);
@@ -744,7 +744,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Find: ".to_string(), PromptType::OpenFile);
     /// prompt.set_input_plain("hello world".to_string());
     /// prompt.set_cursor_byte(0); // At start of "hello"
@@ -766,7 +766,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Find: ".to_string(), PromptType::OpenFile);
     /// prompt.set_input_plain("hello world".to_string());
     /// prompt.set_cursor_byte(5); // After "hello"
@@ -788,7 +788,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Find: ".to_string(), PromptType::OpenFile);
     /// prompt.set_input_plain("hello world".to_string());
     /// prompt.set_cursor_byte(5); // After "hello"
@@ -819,7 +819,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Search: ".to_string(), PromptType::Search);
     /// prompt.set_input_plain("test query".to_string());
     /// assert_eq!(prompt.get_text(), "test query");
@@ -834,7 +834,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Find: ".to_string(), PromptType::OpenFile);
     /// prompt.set_input_plain("some text".to_string());
     /// prompt.set_cursor_byte(9);
@@ -855,7 +855,7 @@ impl Prompt {
     ///
     /// # Example
     /// ```
-    /// # use fresh::prompt::{Prompt, PromptType};
+    /// # use fresh::view::prompt::{Prompt, PromptType};
     /// let mut prompt = Prompt::new("Command: ".to_string(), PromptType::QuickOpen);
     /// prompt.set_input_plain("save".to_string());
     /// prompt.set_cursor_byte(4);


### PR DESCRIPTION
A CI job that compiles the tree on 1.98 (current stable, 1.98.1). `rust-toolchain.toml` is untouched — 1.95 stays the default everywhere.

The workspace already compiled clean on 1.98 (check, clippy, fmt, doc; same warnings as 1.95). The actual compile errors were in the doctests, and they fail identically on 1.95 — nothing catches them because nextest can't run doctests. Fixed: stale module paths in `prompt.rs` / `input_history.rs`, and indented prose in `lsp_status.rs` / `line_wrap_cache.rs` that rustdoc compiles as Rust. 16/16 doctests pass on both toolchains.

Verified locally on 1.95 and 1.98: `cargo check --workspace --all-targets --all-features`, clippy, `fmt --check`, `cargo doc`, `cargo test --doc -p fresh-editor --all-features`. Not exercised: the full suite under 1.98, and the release/min-size profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YAhTDJTy4kRFj18g4DP4t